### PR TITLE
gateway registration fix

### DIFF
--- a/mcpgateway/utils/services_auth.py
+++ b/mcpgateway/utils/services_auth.py
@@ -43,7 +43,7 @@ def encode_auth(auth_value: dict) -> str:
     Returns:
         str: A base64-url-safe encrypted string representing the dictionary, or None if input is None.
     """
-    if auth_value is None:
+    if not auth_value:
         return None
     plaintext = json.dumps(auth_value)
     key = get_key()
@@ -65,7 +65,7 @@ def decode_auth(encoded_value: str) -> dict:
     Returns:
         dict: The decrypted authentication dictionary, or empty dict if input is None.
     """
-    if encoded_value is None:
+    if not encoded_value:
         return {}
     key = get_key()
     aesgcm = AESGCM(key)


### PR DESCRIPTION
When registering a gateway without authentication, a bug prevented the bypass of authentication decoding, leading to a "Connection failed!" error. 
Now, if the gateway does not require authentication, both encryption and decryption are bypassed, allowing for successful gateway registration. 
Gateways that have authentication continue to function as expected.

In the earlier implementation, the condition 'if encoded_value is None' didn't properly bypass decryption because the default value of encoded_value was {}, not None. This issue has now been resolved.