### PR TITLE
Add deployment information for Google Cloud Run - closes #30

### DIFF
--- a/.github/workflows/google-cloud-run.yml.inactive
+++ b/.github/workflows/google-cloud-run.yml.inactive
@@ -1,0 +1,142 @@
+# ===============================================================
+# ☁️  MCP Gateway ▸ Build, Cache & Deploy to Google Cloud Run
+# ===============================================================
+#
+# This workflow:
+#   • Restores / updates a local **BuildKit layer cache**  ❄️
+#   • Builds the Docker image from **Containerfile.lite**  🏗️
+#   • Pushes the image to **Google Artifact Registry**     📤
+#   • Deploys to **Google Cloud Run** with autoscale=1     🚀
+#
+# ---------------------------------------------------------------
+# Required repository **secrets**
+# ---------------------------------------------------------------
+#  ┌────────────────────────┬────────────────────────────────┐
+#  │ Secret name            │ Example value                  │
+#  ├────────────────────────┼────────────────────────────────┤
+#  │ GCP_SERVICE_KEY        │ JSON string for gcloud auth    │
+#  └────────────────────────┴────────────────────────────────┘
+#
+# ---------------------------------------------------------------
+# Required repository **variables**
+# ---------------------------------------------------------------
+#  ┌────────────────────────────┬──────────────────────────────┐
+#  │ Variable name              │ Example value                │
+#  ├────────────────────────────┼──────────────────────────────┤
+#  │ GCP_PROJECT_ID             │ my-gcp-project               │
+#  │ GCP_REGION                 │ us-central1                  │
+#  │ GAR_REPO_NAME              │ mcpgateway                   │
+#  │ IMAGE_NAME                 │ mcpgateway                   │
+#  │ CLOUD_RUN_SERVICE          │ mcpgateway                   │
+#  │ CLOUD_RUN_PORT             │ "4444"                       │
+#  └────────────────────────────┴──────────────────────────────┘
+#
+# Triggers:
+#   • Every push to `main`
+# ===============================================================
+
+name: Deploy to Google Cloud Run
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  CACHE_DIR: /tmp/.buildx-cache
+
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_REGION: ${{ vars.GCP_REGION }}
+
+  GAR_REPO_NAME: ${{ vars.GAR_REPO_NAME }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+  IMAGE_TAG: ${{ github.sha }}
+
+  CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE }}
+  CLOUD_RUN_PORT: ${{ vars.CLOUD_RUN_PORT }}
+
+jobs:
+  build-push-deploy:
+    name: 🚀 Build, Cache, Push & Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      # -----------------------------------------------------------
+      # 0️⃣  Checkout repository
+      # -----------------------------------------------------------
+      - name: ⬇️  Checkout source
+        uses: actions/checkout@v4
+
+      # -----------------------------------------------------------
+      # 1️⃣  Authenticate to Google Cloud
+      # -----------------------------------------------------------
+      - name: 🔐  Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_KEY }}
+
+      - name: 🧰  Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          install_components: gcloud, docker
+          export_default_credentials: true
+
+      # -----------------------------------------------------------
+      # 2️⃣  Set up Docker Buildx + cache
+      # -----------------------------------------------------------
+      - name: 🛠️  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🔄  Restore BuildKit cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      # -----------------------------------------------------------
+      # 3️⃣  Configure Docker to use gcloud auth
+      # -----------------------------------------------------------
+      - name: 🔧  Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
+
+      # -----------------------------------------------------------
+      # 4️⃣  Build & tag image
+      # -----------------------------------------------------------
+      - name: 🏗️  Build Docker image
+        run: |
+          docker buildx build \
+            --file Containerfile.lite \
+            --tag ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+            --cache-from type=local,src=${{ env.CACHE_DIR }} \
+            --cache-to   type=local,dest=${{ env.CACHE_DIR }},mode=max \
+            --load \
+            .
+
+      # -----------------------------------------------------------
+      # 5️⃣  Push image to Artifact Registry
+      # -----------------------------------------------------------
+      - name: 📤  Push image to GAR
+        run: |
+          docker push ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      # -----------------------------------------------------------
+      # 6️⃣  Deploy to Cloud Run
+      # -----------------------------------------------------------
+      - name: 🚀  Deploy to Cloud Run
+        run: |
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --image $GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$GAR_REPO_NAME/$IMAGE_NAME:$IMAGE_TAG \
+            --region "$GCP_REGION" \
+            --platform managed \
+            --allow-unauthenticated \
+            --port "$CLOUD_RUN_PORT" \
+            --cpu=2 \
+            --memory=2Gi \
+            --max-instances=1 \
+            --set-env-vars=JWT_SECRET_KEY=your-secret,BASIC_AUTH_USER=admin,BASIC_AUTH_PASSWORD=changeme,AUTH_REQUIRED=true

--- a/docs/docs/deployment/.pages
+++ b/docs/docs/deployment/.pages
@@ -7,6 +7,7 @@ nav:
   - kubernetes.md
   - openshift.md
   - minikube.md
+  - google-cloud-run.md
   - ibm-code-engine.md
   - aws.md
   - azure.md

--- a/docs/docs/deployment/aws.md
+++ b/docs/docs/deployment/aws.md
@@ -1,4 +1,4 @@
-# AWS Deployment
+# 🟧 AWS
 
 MCP Gateway can be deployed to AWS using multiple container-based services:
 

--- a/docs/docs/deployment/azure.md
+++ b/docs/docs/deployment/azure.md
@@ -1,4 +1,4 @@
-# Azure Deployment
+# 🔷 Azure
 
 MCP Gateway can be deployed on Azure in multiple ways:
 

--- a/docs/docs/deployment/compose.md
+++ b/docs/docs/deployment/compose.md
@@ -1,4 +1,4 @@
-# 🚀 Docker Compose
+# 🧩 Docker Compose
 
 Running **MCP Gateway** with **Compose** spins up a full stack (Gateway, Postgres, Redis, optional MPC servers) behind a single YAML file.
 The Makefile detects Podman or Docker automatically, and you can override it with `COMPOSE_ENGINE=`.

--- a/docs/docs/deployment/container.md
+++ b/docs/docs/deployment/container.md
@@ -1,4 +1,4 @@
-# Container Deployment
+# 📦 Container Deployment
 
 You can run MCP Gateway as a fully self-contained container. This is the recommended method for production or platform-agnostic deployments.
 

--- a/docs/docs/deployment/google-cloud-run.md
+++ b/docs/docs/deployment/google-cloud-run.md
@@ -1,0 +1,188 @@
+# ☁️ Google Cloud Run
+
+MCP Gateway can be deployed to [Google Cloud Run](https://cloud.google.com/run), a fully managed, autoscaling platform for containers with built-in HTTPS, identity, and integration with other GCP services like Cloud SQL and Memorystore.
+
+This guide walks through provisioning a PostgreSQL and Redis backend, deploying the container, injecting secrets, and verifying access using JWT.
+
+---
+
+## ✅ Overview
+
+Cloud Run is ideal for MCP Gateway use cases:
+
+- **Serverless and cost-efficient** (scale to zero)
+- **Public HTTPS endpoints** with zero config
+- Built-in **integration with Cloud SQL (PostgreSQL)** and **Memorystore (Redis)**
+- Compatible with public container registries like GitHub’s `ghcr.io`
+
+You can deploy the public image directly:
+
+```text
+ghcr.io/ibm/mcp-context-forge:latest
+````
+
+---
+
+## 🛠 Prerequisites
+
+* Google Cloud project with billing enabled
+
+* `gcloud` CLI authenticated (`gcloud init`)
+
+* Enabled APIs:
+
+  ```bash
+  gcloud services enable run.googleapis.com sqladmin.googleapis.com redis.googleapis.com
+  ```
+
+* Docker (for local testing or JWT token generation)
+
+* `.env` values for:
+
+  * `JWT_SECRET_KEY`
+  * `DATABASE_URL`
+  * `REDIS_URL`
+  * `AUTH_REQUIRED`, `BASIC_AUTH_USER`, etc.
+
+---
+
+## ⚙️ Setup Steps
+
+### 1. 🗄️ Provision Cloud SQL (PostgreSQL)
+
+```bash
+gcloud sql instances create mcpgw-db \
+  --database-version=POSTGRES_14 \
+  --cpu=2 --memory=4GiB \
+  --region=us-central1
+
+gcloud sql users set-password postgres \
+  --instance=mcpgw-db --password=mysecretpassword
+
+gcloud sql databases create mcpgw --instance=mcpgw-db
+```
+
+Find the IP address:
+
+```bash
+gcloud sql instances describe mcpgw-db \
+  --format="value(ipAddresses.ipAddress)"
+```
+
+---
+
+### 2. ⚡ Provision Memorystore (Redis)
+
+```bash
+gcloud redis instances create mcpgw-redis \
+  --region=us-central1 \
+  --tier=STANDARD_HA \
+  --size=1
+```
+
+Get the Redis IP:
+
+```bash
+gcloud redis instances describe mcpgw-redis \
+  --region=us-central1 \
+  --format="value(host)"
+```
+
+---
+
+### 3. 🚀 Deploy to Google Cloud Run
+
+```bash
+gcloud run deploy mcpgateway \
+  --image=ghcr.io/ibm/mcp-context-forge:latest \
+  --region=us-central1 \
+  --platform=managed \
+  --allow-unauthenticated \
+  --port=4444 \
+  --cpu=2 \
+  --memory=2Gi \
+  --max-instances=1 \
+  --set-env-vars=\
+JWT_SECRET_KEY=your-secret,\
+BASIC_AUTH_USER=admin,\
+BASIC_AUTH_PASSWORD=changeme,\
+AUTH_REQUIRED=true,\
+DATABASE_URL=postgresql://postgres:mysecretpassword@<SQL_IP>:5432/mcpgw,\
+REDIS_URL=redis://<REDIS_IP>:6379/0,\
+CACHE_TYPE=redis
+```
+
+> 🔐 Be sure to replace `<SQL_IP>` and `<REDIS_IP>` with the actual addresses you retrieved.
+
+---
+
+## 🔒 Auth & Access
+
+### Generate a Bearer Token
+
+You can use the official container to generate a token:
+
+```bash
+docker run -it --rm ghcr.io/ibm/mcp-context-forge:latest \
+  python3 -m mcpgateway.utils.create_jwt_token -u admin
+```
+
+Export it:
+
+```bash
+export MCPGATEWAY_BEARER_TOKEN=<paste-token-here>
+```
+
+### Smoke Test
+
+```bash
+curl -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
+     https://<your-cloud-run-url>/health
+
+curl -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
+     https://<your-cloud-run-url>/tools
+```
+
+---
+
+## 📦 GitHub Actions Deployment (Optional)
+
+You can automate builds and deployments using GitHub Actions. See:
+
+```
+.github/workflows/deploy-gcr.yml
+```
+
+It builds from `Containerfile.lite`, pushes to Artifact Registry, and deploys to Cloud Run with `--max-instances=1`.
+
+---
+
+## 📘 Notes & Tips
+
+* Cloud Run endpoints are public HTTPS by default
+* Add a custom domain via Cloud Run settings (optional)
+* Use Secret Manager or env vars for sensitive values
+* To avoid cold starts, you can enable **minimum instance = 1**
+* Logs and metrics available via Cloud Console
+
+---
+
+## 🧩 Summary
+
+| Feature              | Supported               |
+| -------------------- | ----------------------- |
+| HTTPS (built-in)     | ✅                      |
+| Custom domains       | ✅                      |
+| Postgres (Cloud SQL) | ✅                      |
+| Redis (Memorystore)  | ✅                      |
+| Auto-scaling         | ✅                      |
+| Scale-to-zero        | ✅                      |
+| Max instance limit   | ✅                      |
+
+---
+
+## 🧠 Resources
+
+* [Cloud Run documentation](https://cloud.google.com/run/docs)
+* [Cloud SQL connection tips](https://cloud.google.com/sql/docs/postgres/connect-run)
+* [Memorystore overview](https://cloud.google.com/memorystore/docs/redis)

--- a/docs/docs/deployment/google-cloud-run.md
+++ b/docs/docs/deployment/google-cloud-run.md
@@ -150,7 +150,7 @@ curl -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 You can automate builds and deployments using GitHub Actions. See:
 
 ```
-.github/workflows/deploy-gcr.yml
+.github/workflows/google-cloud-run.yml
 ```
 
 It builds from `Containerfile.lite`, pushes to Artifact Registry, and deploys to Cloud Run with `--max-instances=1`.

--- a/docs/docs/deployment/ibm-code-engine.md
+++ b/docs/docs/deployment/ibm-code-engine.md
@@ -1,4 +1,4 @@
-# Deploying MCP Gateway to IBM Code Engine
+# ⚙️ IBM Code Engine
 
 This guide covers two supported deployment paths for the **MCP Gateway**:
 

--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -1,4 +1,4 @@
-# Kubernetes / OpenShift Deployment
+# ☸️ Kubernetes / OpenShift Deployment
 
 You can deploy MCP Gateway to any K8s-compliant platform — including vanilla Kubernetes, OpenShift, and managed clouds like GKE, AKS, and EKS.
 

--- a/docs/docs/deployment/local.md
+++ b/docs/docs/deployment/local.md
@@ -1,4 +1,4 @@
-# Local Deployment
+# 🐍 Local Deployment
 
 This guide walks you through running MCP Gateway on your local machine using a virtual environment or directly via Python.
 


### PR DESCRIPTION
# 📚 Documentation PR

Added a **Google Cloud Run** deployment guide for MCP Gateway. This includes:

* ✅ Introduction with platform overview and feature highlights
* 🗄️ Step-by-step provisioning for **Cloud SQL (PostgreSQL)** and **Memorystore (Redis)** using `gcloud` CLI
* 🚀 Updated deployment instructions using the **public container image** and `gcloud run deploy`
* 🔐 Clear examples for **JWT-based authentication**, including token generation and smoke tests
* ⚙️ Explanation of required `.env` variables and secret handling
* 📦 Callout to GitHub Actions CI/CD support with a reference to the `.github/workflows/google-cloud-run.yml` workflow
* 📘 Additional notes, tips, and links to official GCP documentation

## 🔗 Related Issue / Epic

Closes #30

## ✏️ Type of Change

* [x] New page or major rewrite
