### PR TITLE
Fix test tool and improve stability

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -129,9 +129,6 @@ class SessionRegistry(SessionBackend):
             database_url: Database connection URL (required for database backend)
             session_ttl: Session time-to-live in seconds
             message_ttl: Message time-to-live in seconds
-
-        Raises:
-            ValueError: If backend is invalid or required URL is missing
         """
         super().__init__(backend=backend, redis_url=redis_url, database_url=database_url, session_ttl=session_ttl, message_ttl=message_ttl)
         self._sessions: Dict[str, Any] = {}  # Local transport cache
@@ -415,6 +412,7 @@ class SessionRegistry(SessionBackend):
             server_id: Server ID
             session_id: Session ID
             user: User information
+            base_url: Base URL for the FastAPI request
 
         """
 
@@ -681,6 +679,7 @@ class SessionRegistry(SessionBackend):
             transport: Transport where message should be responded in
             server_id: Server ID
             user: User information
+            base_url: Base URL for the FastAPI request
 
         """
         result = {}

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -1086,3 +1086,6 @@ def init_db():
         Base.metadata.create_all(bind=engine)
     except SQLAlchemyError as e:
         raise Exception(f"Failed to initialize database: {str(e)}")
+
+if __name__ == "__main__":
+    init_db()

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -1087,5 +1087,6 @@ def init_db():
     except SQLAlchemyError as e:
         raise Exception(f"Failed to initialize database: {str(e)}")
 
+
 if __name__ == "__main__":
     init_db()

--- a/mcpgateway/handlers/sampling.py
+++ b/mcpgateway/handlers/sampling.py
@@ -150,9 +150,9 @@ class SamplingHandler:
         """Add context to messages.
 
         Args:
-            db: Database session
+            _db: Database session
             messages: Message list
-            context_type: Context inclusion type
+            _context_type: Context inclusion type
 
         Returns:
             Messages with added context

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -214,6 +214,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 logger.error(f"Error shutting down {service.__class__.__name__}: {str(e)}")
         logger.info("Shutdown complete")
 
+
 # Initialize FastAPI app
 app = FastAPI(
     title=settings.app_name,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -157,12 +157,70 @@ session_registry = SessionRegistry(
 # Initialize cache
 resource_cache = ResourceCache(max_size=settings.resource_cache_size, ttl=settings.resource_cache_ttl)
 
+
+####################
+# Startup/Shutdown #
+####################
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """
+    Manage the application's startup and shutdown lifecycle.
+
+    The function initialises every core service on entry and then
+    shuts them down in reverse order on exit.
+
+    Args:
+        app (FastAPI): FastAPI app
+
+    Yields:
+        None
+
+    Raises:
+        Exception: Any unhandled error that occurs during service
+            initialisation or shutdown is re-raised to the caller.
+    """
+    logger.info("Starting MCP Gateway services")
+    try:
+        await tool_service.initialize()
+        await resource_service.initialize()
+        await prompt_service.initialize()
+        await gateway_service.initialize()
+        await root_service.initialize()
+        await completion_service.initialize()
+        await logging_service.initialize()
+        await sampling_handler.initialize()
+        await resource_cache.initialize()
+        logger.info("All services initialized successfully")
+        yield
+    except Exception as e:
+        logger.error(f"Error during startup: {str(e)}")
+        raise
+    finally:
+        logger.info("Shutting down MCP Gateway services")
+        for service in [
+            resource_cache,
+            sampling_handler,
+            logging_service,
+            completion_service,
+            root_service,
+            gateway_service,
+            prompt_service,
+            resource_service,
+            tool_service,
+        ]:
+            try:
+                await service.shutdown()
+            except Exception as e:
+                logger.error(f"Error shutting down {service.__class__.__name__}: {str(e)}")
+        logger.info("Shutdown complete")
+
 # Initialize FastAPI app
 app = FastAPI(
     title=settings.app_name,
     version=__version__,
     description="A FastAPI-based MCP Gateway with federation support",
     root_path=settings.app_root_path,
+    lifespan=lifespan,
 )
 
 
@@ -1907,60 +1965,6 @@ async def healthcheck(db: Session = Depends(get_db)):
         logger.error(error_message)
         return {"status": "unhealthy", "error": error_message}
     return {"status": "healthy"}
-
-
-####################
-# Startup/Shutdown #
-####################
-@asynccontextmanager
-async def lifespan() -> AsyncIterator[None]:
-    """
-    Manage the application's startup and shutdown lifecycle.
-
-    The function initialises every core service on entry and then
-    shuts them down in reverse order on exit.
-
-    Yields:
-        None
-
-    Raises:
-        Exception: Any unhandled error that occurs during service
-            initialisation or shutdown is re-raised to the caller.
-    """
-    logger.info("Starting MCP Gateway services")
-    try:
-        await tool_service.initialize()
-        await resource_service.initialize()
-        await prompt_service.initialize()
-        await gateway_service.initialize()
-        await root_service.initialize()
-        await completion_service.initialize()
-        await logging_service.initialize()
-        await sampling_handler.initialize()
-        await resource_cache.initialize()
-        logger.info("All services initialized successfully")
-        yield
-    except Exception as e:
-        logger.error(f"Error during startup: {str(e)}")
-        raise
-    finally:
-        logger.info("Shutting down MCP Gateway services")
-        for service in [
-            resource_cache,
-            sampling_handler,
-            logging_service,
-            completion_service,
-            root_service,
-            gateway_service,
-            prompt_service,
-            resource_service,
-            tool_service,
-        ]:
-            try:
-                await service.shutdown()
-            except Exception as e:
-                logger.error(f"Error shutting down {service.__class__.__name__}: {str(e)}")
-        logger.info("Shutdown complete")
 
 
 # Mount static files

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -620,7 +620,7 @@ async def sse_endpoint(request: Request, server_id: int, user: str = Depends(req
         await session_registry.add_session(transport.session_id, transport)
         response = await transport.create_sse_response(request)
 
-        asyncio.create_task(session_registry.respond(server_id, user, session_id=transport.session_id))
+        asyncio.create_task(session_registry.respond(server_id, user, session_id=transport.session_id, base_url=base_url))
 
         tasks = BackgroundTasks()
         tasks.add_task(session_registry.remove_session, transport.session_id)
@@ -1744,7 +1744,7 @@ async def utility_sse_endpoint(request: Request, user: str = Depends(require_aut
         await transport.connect()
         await session_registry.add_session(transport.session_id, transport)
 
-        asyncio.create_task(session_registry.respond(None, user, session_id=transport.session_id))
+        asyncio.create_task(session_registry.respond(None, user, session_id=transport.session_id, base_url=base_url))
 
         response = await transport.create_sse_response(request)
         tasks = BackgroundTasks()

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import Session
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import Tool as DbTool
+from mcpgateway.db import SessionLocal
 from mcpgateway.schemas import GatewayCreate, GatewayRead, GatewayUpdate, ToolCreate
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.services_auth import decode_auth
@@ -579,7 +580,7 @@ class GatewayService:
 
     def _get_active_gateways(self) -> list[DbGateway]:
         """Sync function for database operations (runs in thread)."""
-        with Session() as db:
+        with SessionLocal() as db:
             return db.execute(select(DbGateway).where(DbGateway.is_active)).scalars().all()
     
     async def _run_health_checks(self) -> None:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -455,28 +455,29 @@ class GatewayService:
         except Exception as e:
             raise GatewayConnectionError(f"Failed to forward request to {gateway.name}: {str(e)}")
 
-    async def check_gateway_health(self, gateway: DbGateway) -> bool:
-        """Check if a gateway is healthy.
+    async def check_health_of_gateways(self, gateways: List[DbGateway]) -> bool:
+        """Health check for gateways
 
         Args:
-            gateway: Gateway to check
+            gateways: Gateways to check
 
         Returns:
             True if gateway is healthy
         """
-        if not gateway.is_active:
-            return False
+        for gateway in gateways:
+            if not gateway.is_active:
+                return False
 
-        try:
-            # Try to initialize connection
-            await self._initialize_gateway(gateway.url, gateway.auth_value)
+            try:
+                # Try to initialize connection
+                await self._initialize_gateway(gateway.url, gateway.auth_value)
 
-            # Update last seen
-            gateway.last_seen = datetime.utcnow()
-            return True
+                # Update last seen
+                gateway.last_seen = datetime.utcnow()
+                return True
 
-        except Exception:
-            return False
+            except Exception:
+                return False
 
     async def aggregate_capabilities(self, db: Session) -> Dict[str, Any]:
         """Aggregate capabilities from all gateways.
@@ -576,29 +577,24 @@ class GatewayService:
         except Exception as e:
             raise GatewayConnectionError(f"Failed to initialize gateway at {url}: {str(e)}")
 
+    def _get_active_gateways(self) -> list[DbGateway]:
+        """Sync function for database operations (runs in thread)."""
+        with Session() as db:
+            return db.execute(select(DbGateway).where(DbGateway.is_active)).scalars().all()
+    
     async def _run_health_checks(self) -> None:
-        """Run periodic health checks on all gateways."""
+        """Run health checks with sync Session in async code."""
         while True:
             try:
-                async with Session() as db:
-                    # Get active gateways
-                    gateways = db.execute(select(DbGateway).where(DbGateway.is_active)).scalars().all()
+                # Run sync database code in a thread
+                gateways = await asyncio.to_thread(self._get_active_gateways)
 
-                    # Check each gateway
-                    for gateway in gateways:
-                        try:
-                            is_healthy = await self.check_gateway_health(gateway)
-                            if not is_healthy:
-                                logger.warning(f"Gateway {gateway.name} is unhealthy")
-                        except Exception as e:
-                            logger.error(f"Health check failed for {gateway.name}: {str(e)}")
-
-                    db.commit()
+                # Async health checks (non-blocking)
+                await self.check_health_of_gateways(gateways)
 
             except Exception as e:
                 logger.error(f"Health check run failed: {str(e)}")
-
-            # Wait for next check
+            
             await asyncio.sleep(self._health_check_interval)
 
     def _get_auth_headers(self) -> Dict[str, str]:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -28,8 +28,8 @@ from sqlalchemy.orm import Session
 
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
-from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import SessionLocal
+from mcpgateway.db import Tool as DbTool
 from mcpgateway.schemas import GatewayCreate, GatewayRead, GatewayUpdate, ToolCreate
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.services_auth import decode_auth
@@ -582,7 +582,7 @@ class GatewayService:
         """Sync function for database operations (runs in thread)."""
         with SessionLocal() as db:
             return db.execute(select(DbGateway).where(DbGateway.is_active)).scalars().all()
-    
+
     async def _run_health_checks(self) -> None:
         """Run health checks with sync Session in async code."""
         while True:
@@ -595,7 +595,7 @@ class GatewayService:
 
             except Exception as e:
                 logger.error(f"Health check run failed: {str(e)}")
-            
+
             await asyncio.sleep(self._health_check_interval)
 
     def _get_auth_headers(self) -> Dict[str, str]:

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -222,9 +222,7 @@ class ResourceService:
             db (Session): The SQLAlchemy database session.
             include_inactive (bool): If True, include inactive resources in the result.
                 Defaults to False.
-            cursor (Optional[str], optional): An opaque cursor token for pagination. Currently,
-                this parameter is ignored. Defaults to None.
-
+            
         Returns:
             List[ResourceRead]: A list of resources represented as ResourceRead objects.
         """
@@ -249,8 +247,6 @@ class ResourceService:
             server_id (int): Server ID
             include_inactive (bool): If True, include inactive resources in the result.
                 Defaults to False.
-            cursor (Optional[str], optional): An opaque cursor token for pagination. Currently,
-                this parameter is ignored. Defaults to None.
 
         Returns:
             List[ResourceRead]: A list of resources represented as ResourceRead objects.

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -222,7 +222,7 @@ class ResourceService:
             db (Session): The SQLAlchemy database session.
             include_inactive (bool): If True, include inactive resources in the result.
                 Defaults to False.
-            
+
         Returns:
             List[ResourceRead]: A list of resources represented as ResourceRead objects.
         """

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -521,6 +521,9 @@ class ToolService:
                 async def connect_to_sse_server(server_url: str):
                     """
                     Connect to an MCP server running with SSE transport
+
+                    Args:
+                        server_url (str): MCP Server SSE URL
                     """
                     # Use async with directly to manage the context
                     async with sse_client(url=server_url, headers=headers) as streams:

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -218,7 +218,7 @@ document.addEventListener("DOMContentLoaded", function () {
       if (mode === "ui") {
         window.schemaEditor.setValue(generateSchema());
       }
-      // Save CodeMirror editors' contents into the underlying textareas
+      // Save CodeMirror editors’ contents into the underlying textareas
       if (window.headersEditor) {
         window.headersEditor.save();
       }
@@ -1579,7 +1579,15 @@ async function runToolTest() {
   const formData = new FormData(form);
   const params = {};
   for (const [key, value] of formData.entries()) {
-    params[key] = value;
+    if(isNaN(value)) {
+      if(value.toLowerCase() ===  "true" || value.toLowerCase() === "false") {
+        params[key] = Boolean(value.toLowerCase() ===  "true");
+      } else {
+        params[key] = value;
+      }
+    } else {
+      params[key] = Number(value);
+    }
   }
 
   // Build the JSON-RPC payload using the tool's name as the method
@@ -1591,7 +1599,7 @@ async function runToolTest() {
   };
 
   // Send the request to your /rpc endpoint
-  fetch("/rpc", {
+  fetch(`${window.ROOT_PATH}/rpc`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json", // ← make sure we include this

--- a/mcpgateway/transports/sse_transport.py
+++ b/mcpgateway/transports/sse_transport.py
@@ -126,7 +126,7 @@ class SSETransport(Transport):
         """Create SSE response for streaming.
 
         Args:
-            request: FastAPI request
+            _request: FastAPI request
 
         Returns:
             SSE response object
@@ -209,7 +209,7 @@ class SSETransport(Transport):
         """Check if client has disconnected.
 
         Args:
-            request: FastAPI Request object
+            _request: FastAPI Request object
 
         Returns:
             bool: True if client disconnected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,16 @@ postgres = [
     "psycopg2-binary>=2.9.10",
 ]
 
+# Async SQLite Driver (optional)
+aiosqlite = [
+    "aiosqlite>=0.21.0",
+]
+
+# Async PostgreSQL driver (optional)
+asyncpg = [
+    "asyncpg>=0.30.0",
+]
+
 # Optional dependency groups (development)
 dev = [
     "argparse-manpage>=4.6",

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -36,6 +36,9 @@ if [[ "${SSL}" == "true" ]]; then
     echo "✓  TLS enabled – using ${CERT_FILE} / ${KEY_FILE}"
 fi
 
+# Initialize databases
+python -m mcpgateway.db
+
 exec gunicorn -c gunicorn.config.py \
     --worker-class uvicorn.workers.UvicornWorker \
     --workers "${GUNICORN_WORKERS}" \


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
- Fixes tool testing from gateway UI for non string inputs
- Improves stability by correctly handing database session context in gateway health checks

## 🔁 Reproduction Steps
- Test google_search tool (expected integer for number of results)
- Test with hey for n1000 c100 for performance issues

## 🐞 Root Cause
- All inputs were being passed as strings instead of correct data type to the APIs in test tool screen
- Hardcoded rpc endpoint to localhost while testing
- 'async with' can be used with AsyncSession, but not with Session of sqlalchemy. Identified by pyright test.
- 

## 💡 Fix Description
- Pass correct inputs to tools with integer and boolean pass fields while testing from the test tool screen.
- Replace the hardcoded rpc endpoint (at localhost) with an endpoint based on the request's base_url in the session manager.
- Replace gateway health check's 'async with Session' fixed with 'with Session'. This makes the context manager close it correctly since Session object does not have __aexit__ implemented.
- Add lifespan to the FastAPI app
- Separate database initialization from gunicorn startup

## 🧪 Verification

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed