### PR TITLE
fix: update run-gunicorn.sh script to activate virtual env if not already active

### DIFF
--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -2,6 +2,24 @@
 # Author: Mihai Criveti
 # Description: Run Gunicorn production server (optionally with TLS)
 
+# Determine script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Attempt to activate a venv if not already active
+if [[ -z "$VIRTUAL_ENV" ]]; then
+  # If a known venv path exists (like your custom .venv location), activate it
+  if [[ -f "${HOME}/.venv/mcpgateway/bin/activate" ]]; then
+    echo "🔧  Activating virtual environment: ${HOME}/.venv/mcpgateway"
+    source "${HOME}/.venv/mcpgateway/bin/activate"
+  elif [[ -f "${SCRIPT_DIR}/.venv/bin/activate" ]]; then
+    echo "🔧  Activating virtual environment in script directory"
+    source "${SCRIPT_DIR}/.venv/bin/activate"
+  else
+    echo "⚠️  No virtual environment found! Please activate manually."
+    exit 1
+  fi
+fi
+
 cat << "EOF"
 ███╗   ███╗ ██████╗██████╗      ██████╗  █████╗ ████████╗███████╗██╗    ██╗ █████╗ ██╗   ██╗
 ████╗ ████║██╔════╝██╔══██╗    ██╔════╝ ██╔══██╗╚══██╔══╝██╔════╝██║    ██║██╔══██╗╚██╗ ██╔╝


### PR DESCRIPTION
# 📝 Pull Request Template Selection

Thank you for contributing! To help us review your pull request effectively, please select the appropriate template:

- **Bug Fix**: [Use the Bug Fix Template](?template=bug_fix.md)
run-gunicorn.sh fails because it expects virtual env to be already initialized but it should actively initialize it before executing the script.
