### PR TITLE
Add /ready endpoint for Kubernetes readiness checks with tests

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1968,6 +1968,27 @@ async def healthcheck(db: Session = Depends(get_db)):
     return {"status": "healthy"}
 
 
+@app.get("/ready")
+async def readiness_check(db: Session = Depends(get_db)):
+    """
+    Perform a readiness check to verify if the application is ready to receive traffic.
+
+    Args:
+        db: SQLAlchemy session dependency.
+
+    Returns:
+        JSONResponse with status 200 if ready, 503 if not.
+    """
+    try:
+        # Run the blocking DB check in a thread to avoid blocking the event loop
+        await asyncio.to_thread(db.execute, text("SELECT 1"))
+        return JSONResponse(content={"status": "ready"}, status_code=200)
+    except Exception as e:
+        error_message = f"Readiness check failed: {str(e)}"
+        logger.error(error_message)
+        return JSONResponse(content={"status": "not ready", "error": error_message}, status_code=503)
+
+
 # Mount static files
 app.mount("/static", StaticFiles(directory=str(settings.static_dir)), name="static")
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -47,6 +47,13 @@ class TestAPIEndpoints:
         assert response.status_code == 200
         assert response.json()["status"] == "healthy"
 
+    def test_ready_check(self, test_client):
+        """Test the readiness check endpoint."""
+        response = test_client.get("/ready")
+        # The readiness check returns 200 if DB is reachable
+        assert response.status_code == 200
+        assert response.json()["status"] == "ready"
+
     def test_root_redirect(self, test_client):
         """Test root path redirects to admin."""
         response = test_client.get("/", allow_redirects=False)


### PR DESCRIPTION
Closes #27 

- Implemented a new `/ready` HTTP GET endpoint__ in `mcpgateway/main.py` to serve as a Kubernetes readiness probe.
- The `/ready` endpoint performs a non-blocking database connectivity check by running a simple `SELECT 1` query in a thread to avoid blocking the event loop.
- Returns HTTP 200 with JSON `{"status": "ready"}` when the application is ready to receive traffic.
- Returns HTTP 503 with JSON `{"status": "not ready", "error": "<error details>"}` if the database connection fails or the application is not ready.
- Added a corresponding test case in `tests/unit/mcpgateway/test_main.py` to verify the `/ready` endpoint returns the expected status and response.
- The new endpoint complements the existing `/health` endpoint by providing a readiness-specific check suitable for Kubernetes readiness probes.
- No changes were made to existing functionality or the MCP protocol.
- The implementation follows existing project conventions for asynchronous endpoints, logging, and error handling.
