### PR TITLE
published Helm chart for Kubernetes deployment

### DIFF
--- a/charts/mcpgateway/Chart.yaml
+++ b/charts/mcpgateway/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: mcpgateway
+description: A Helm chart for deploying MCP Gateway to Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - mcp
+  - gateway
+  - kubernetes
+  - helm
+maintainers:
+  - name: MCP Team
+    email: mcp-team@example.com
+sources:
+  - https://github.com/IBM/mcp-context-forge

--- a/charts/mcpgateway/templates/_helpers.tpl
+++ b/charts/mcpgateway/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "mcpgateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "mcpgateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "mcpgateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version -}}
+{{- end }}
+
+{{- define "mcpgateway.labels" -}}
+app.kubernetes.io/name: {{ include "mcpgateway.name" . }}
+helm.sh/chart: {{ include "mcpgateway.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}

--- a/charts/mcpgateway/templates/configmap.yaml
+++ b/charts/mcpgateway/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcpgateway.fullname" . }}-config
+  labels:
+    app: {{ include "mcpgateway.name" . }}
+    chart: {{ include "mcpgateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  # Add any configuration data here as key-value pairs
+  # Example:
+  # config.yaml: |-
+  #   key: value

--- a/charts/mcpgateway/templates/deployment.yaml
+++ b/charts/mcpgateway/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcpgateway.fullname" . }}
+  labels:
+    app: {{ include "mcpgateway.name" . }}
+    chart: {{ include "mcpgateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "mcpgateway.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "mcpgateway.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: mcpgateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.env.PORT | default 4444 | int }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+{{- if and (index $.Values.secrets $key) (not (empty (index $.Values.secrets $key))) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ index $.Values.secrets $key }}
+                  key: {{ $key }}
+{{- else }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/charts/mcpgateway/templates/ingress.yaml
+++ b/charts/mcpgateway/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mcpgateway.fullname" . }}
+  labels:
+    app: {{ include "mcpgateway.name" . }}
+    chart: {{ include "mcpgateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+spec:
+  rules:
+{{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "mcpgateway.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+{{- end }}
+{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcpgateway/templates/service.yaml
+++ b/charts/mcpgateway/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcpgateway.fullname" . }}
+  labels:
+    app: {{ include "mcpgateway.name" . }}
+    chart: {{ include "mcpgateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.env.PORT | default 4444 | int }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "mcpgateway.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/mcpgateway/values.yaml
+++ b/charts/mcpgateway/values.yaml
@@ -1,0 +1,52 @@
+# Default values for mcpgateway Helm chart
+
+image:
+  repository: ghcr.io/ibm/mcp-context-forge
+  tag: local-arm64
+  pullPolicy: IfNotPresent
+
+env:
+  APP_NAME: "MCP_Gateway"
+  HOST: "0.0.0.0"
+  PORT: 4444
+  DATABASE_URL: "sqlite:///./mcp.db"
+  APP_ROOT_PATH: ""
+  CACHE_TYPE: "database"
+  REDIS_URL: "redis://redis:6379/0"
+  CACHE_PREFIX: "mcpgw:"
+  SESSION_TTL: 3600
+  MESSAGE_TTL: 600
+  BASIC_AUTH_USER: "admin"
+  BASIC_AUTH_PASSWORD: "changeme"
+  AUTH_REQUIRED: "true"
+  JWT_SECRET_KEY: "my-test-key"
+  JWT_ALGORITHM: "HS256"
+  TOKEN_EXPIRY: 10080
+  AUTH_ENCRYPTION_SECRET: "my-test-salt"
+  MCPGATEWAY_UI_ENABLED: "true"
+  MCPGATEWAY_ADMIN_API_ENABLED: "true"
+  CORS_ENABLED: "true"
+  ALLOWED_ORIGINS:
+    - "http://localhost:3000"
+  LOG_LEVEL: "INFO"
+  LOG_FORMAT: "json"
+  TRANSPORT_TYPE: "all"
+  FEDERATION_ENABLED: "true"
+  FEDERATION_DISCOVERY: "false"
+  FEDERATION_PEERS: []
+
+secrets: {}
+
+service:
+  type: ClusterIP
+  port: 4444
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: gateway.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []


### PR DESCRIPTION
# 📝 Pull Request Template Selection

Thank you for contributing! To help us review your pull request effectively, please select the appropriate template:

- **Feature / Enhancement**: [Use the Feature Template](?template=feature.md)
Fixes #24 

- Created a new Helm chart for MCP Gateway under `charts/mcpgateway` with the following:

  - `Chart.yaml` defining chart metadata.

  - `values.yaml` with default image, environment variables, service, and ingress configuration.

  - `templates/` directory containing:

    - `deployment.yaml` with support for environment variables and secret-based injection.
    - `service.yaml` defining the Kubernetes Service.
    - `ingress.yaml` supporting optional ingress configuration.
    - `configmap.yaml` as a placeholder for configuration injection.
    - `_helpers.tpl` defining Helm template helper functions for consistent naming and labeling.

