### PR TITLE
Fix headers for basic auth and clear tool test result on closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [0.2.0] - 2025-06-08 (pending)
+
+### Fixed
+
+* Fixed errors related to deleting gateways when metrics are associated with their tools
+* Fixed gateway addition errors when tools overlap. We add the missing tools when tool names overlap.
+* Improved logging by capturing ExceptionGroups correctly and showing specific errors
+* Fixed headers for basic authorization in tools and gateways
+
 ## [0.1.0] - 2025‑06‑01
 
 ### Added

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -545,7 +545,7 @@ async def admin_add_tool(
     """
     logger.debug(f"User {user} is adding a new tool")
     form = await request.form()
-    logger.info(f"Received form data: {dict(form)}")
+    logger.debug(f"Received form data: {dict(form)}")
 
     tool_data = {
         "name": form["name"],
@@ -563,10 +563,10 @@ async def admin_add_tool(
         "auth_header_key": form.get("auth_header_key", ""),
         "auth_header_value": form.get("auth_header_value", ""),
     }
-    logger.info(f"Tool data built: {tool_data}")
+    logger.debug(f"Tool data built: {tool_data}")
     try:
         tool = ToolCreate(**tool_data)
-        logger.info(f"Validated tool data: {tool.dict()}")
+        logger.debug(f"Validated tool data: {tool.dict()}")
         await tool_service.register_tool(db, tool)
         return JSONResponse(
             content={"message": "Tool registered successfully!", "success": True},

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -20,6 +20,7 @@ gateway-specific extensions for federation support.
 """
 
 import json
+import base64
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -318,7 +319,8 @@ class ToolCreate(BaseModelWithConfig):
         auth_type = values.get("auth_type")
         if auth_type:
             if auth_type.lower() == "basic":
-                encoded_auth = encode_auth({"username": values.get("auth_username", ""), "password": values.get("auth_password", "")})
+                creds = base64.b64encode(f'{values.get("auth_username", "")}:{values.get("auth_password", "")}'.encode("utf-8")).decode()
+                encoded_auth = encode_auth({"Authorization": f"Basic {creds}"})
                 values["auth"] = {"auth_type": "basic", "auth_value": encoded_auth}
             elif auth_type.lower() == "bearer":
                 encoded_auth = encode_auth({"Authorization": f"Bearer {values.get('auth_token', '')}"})
@@ -376,7 +378,8 @@ class ToolUpdate(BaseModelWithConfig):
         auth_type = values.get("auth_type")
         if auth_type:
             if auth_type.lower() == "basic":
-                encoded_auth = encode_auth({"username": values.get("auth_username", ""), "password": values.get("auth_password", "")})
+                creds = base64.b64encode(f'{values.get("auth_username", "")}:{values.get("auth_password", "")}'.encode("utf-8")).decode()
+                encoded_auth = encode_auth({"Authorization": f"Basic {creds}"})
                 values["auth"] = {"auth_type": "basic", "auth_value": encoded_auth}
             elif auth_type.lower() == "bearer":
                 encoded_auth = encode_auth({"Authorization": f"Bearer {values.get('auth_token', '')}"})
@@ -715,7 +718,8 @@ class GatewayCreate(BaseModelWithConfig):
             if not username or not password:
                 raise ValueError("For 'basic' auth, both 'auth_username' and 'auth_password' must be provided.")
 
-            return encode_auth({"username": username, "password": password})
+            creds = base64.b64encode(f'{username}:{password}'.encode("utf-8")).decode()
+            return encode_auth({"Authorization": f"Basic {creds}"})
 
         if auth_type == "bearer":
             # For bearer authentication, only token is required
@@ -824,7 +828,8 @@ class GatewayUpdate(BaseModelWithConfig):
             if not username or not password:
                 raise ValueError("For 'basic' auth, both 'auth_username' and 'auth_password' must be provided.")
 
-            return encode_auth({"username": username, "password": password})
+            creds = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode()
+            return encode_auth({"Authorization": f"Basic {creds}"})
 
         if auth_type == "bearer":
             # For bearer authentication, only token is required

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -19,8 +19,8 @@ The schemas ensure proper validation according to the MCP specification while ad
 gateway-specific extensions for federation support.
 """
 
-import json
 import base64
+import json
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -718,7 +718,7 @@ class GatewayCreate(BaseModelWithConfig):
             if not username or not password:
                 raise ValueError("For 'basic' auth, both 'auth_username' and 'auth_password' must be provided.")
 
-            creds = base64.b64encode(f'{username}:{password}'.encode("utf-8")).decode()
+            creds = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode()
             return encode_auth({"Authorization": f"Basic {creds}"})
 
         if auth_type == "bearer":

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -15,6 +15,7 @@ It handles:
 """
 
 import asyncio
+import base64
 import json
 import logging
 import time
@@ -125,10 +126,12 @@ class ToolService:
 
         decoded_auth_value = decode_auth(tool.auth_value)
         if tool.auth_type == "basic":
+            decoded_bytes = base64.b64decode(decoded_auth_value["Authorization"].split("Basic ")[1])
+            username, password = decoded_bytes.decode("utf-8").split(":")
             tool_dict["auth"] = {
                 "auth_type": "basic",
-                "username": decoded_auth_value["username"],
-                "password": "********" if decoded_auth_value["password"] else None,
+                "username": username,
+                "password": "********" if password else None,
             }
         elif tool.auth_type == "bearer":
             tool_dict["auth"] = {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1636,7 +1636,6 @@ function openModal(modalId) {
 }
 
 function closeModal(modalId, clearId=null) {
-  // document.getElementById(modalId).classList.add('hidden');
   const modal = document.getElementById(modalId);
 
   if (clearId) {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1610,21 +1610,20 @@ async function runToolTest() {
     .then((response) => response.json())
     .then((result) => {
       const resultStr = JSON.stringify(result, null, 2);
-      // If the CodeMirror editor exists, update its value; otherwise, create one.
-      if (toolTestResultEditor) {
-        toolTestResultEditor.setValue(resultStr);
-      } else {
-        toolTestResultEditor = window.CodeMirror(
-          document.getElementById("tool-test-result"),
-          {
-            value: resultStr,
-            mode: "application/json",
-            theme: "monokai",
-            readOnly: true,
-            lineNumbers: true,
-          },
-        );
-      }
+
+      const container = document.getElementById("tool-test-result");
+      container.innerHTML = '';        // clear any old editor
+
+      toolTestResultEditor = window.CodeMirror(
+        document.getElementById("tool-test-result"),
+        {
+          value: resultStr,
+          mode: "application/json",
+          theme: "monokai",
+          readOnly: true,
+          lineNumbers: true,
+        },
+      );
     })
     .catch((error) => {
       document.getElementById("tool-test-result").innerText = "Error: " + error;
@@ -1636,8 +1635,17 @@ function openModal(modalId) {
   document.getElementById(modalId).classList.remove("hidden");
 }
 
-function closeModal(modalId) {
-  document.getElementById(modalId).classList.add("hidden");
+function closeModal(modalId, clearId=null) {
+  // document.getElementById(modalId).classList.add('hidden');
+  const modal = document.getElementById(modalId);
+
+  if (clearId) {
+    // Look up by id string
+    const resultEl = document.getElementById(clearId);
+    if (resultEl) resultEl.innerHTML = '';
+  }
+
+  modal.classList.add('hidden');
 }
 
 const integrationRequestMap = {

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1726,7 +1726,7 @@
           <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
             <button
               type="button"
-              onclick="closeModal('tool-test-modal')"
+              onclick="closeModal('tool-test-modal', 'tool-test-result')"
               class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
             >
               Close

--- a/mcpgateway/wrapper2.py
+++ b/mcpgateway/wrapper2.py
@@ -314,7 +314,7 @@ async def handle_list_tools() -> List[types.Tool]:
         RuntimeError: If an error occurs during fetching or processing.
     """
     try:
-        tool_ids = ["0"] if SERVER_CATALOG_URLS[0]==BASE_URL else await get_tools_from_mcp_server(SERVER_CATALOG_URLS)
+        tool_ids = ["0"] if SERVER_CATALOG_URLS[0] == BASE_URL else await get_tools_from_mcp_server(SERVER_CATALOG_URLS)
         metadata = await tools_metadata(tool_ids)
         tools = []
         for tool in metadata:
@@ -393,7 +393,7 @@ async def handle_list_resources() -> List[types.Resource]:
         RuntimeError: If an error occurs during fetching or processing.
     """
     try:
-        ids = ["0"] if SERVER_CATALOG_URLS[0]==BASE_URL else await get_resources_from_mcp_server(SERVER_CATALOG_URLS)
+        ids = ["0"] if SERVER_CATALOG_URLS[0] == BASE_URL else await get_resources_from_mcp_server(SERVER_CATALOG_URLS)
         meta = await resources_metadata(ids)
         resources = []
         for r in meta:
@@ -456,7 +456,7 @@ async def handle_list_prompts() -> List[types.Prompt]:
         RuntimeError: If an error occurs during fetching or processing.
     """
     try:
-        ids = ["0"] if SERVER_CATALOG_URLS[0]==BASE_URL else await get_prompts_from_mcp_server(SERVER_CATALOG_URLS)
+        ids = ["0"] if SERVER_CATALOG_URLS[0] == BASE_URL else await get_prompts_from_mcp_server(SERVER_CATALOG_URLS)
         meta = await prompts_metadata(ids)
         prompts = []
         for p in meta:


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
- Fix the authorization headers for basic authorization in tools and gateways
- Clear tool test results while closing the test tool dialog

## 🔁 Reproduction Steps
- Add REST tool with url https://basic-routes.onrender.com/marks, basic auth with username rishi and password amrm and test

## 🐞 Root Cause
- Basic authorization headers are being passed as {"username": username, "password": password}
- closeModal in admin.js not clearing test-tool-result element before closing


## 💡 Fix Description
- Pass basic authorization headers as {"Authorization": "Basic base64 encoded value of username:password"}
- Clear test-tool-result element before hiding element in closeModal and set the result correctly in runTestTool correctly.

## ⚠️ Breaking Changes
- Older Basic auth tools will crash the UI since the decode_auth section changed

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed