### PR TITLE
minor bug in gateway health check

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -118,6 +118,8 @@ class GatewayService:
             self._redis_client = None
             self._lock_path = settings.filelock_path
             self._file_lock = FileLock(self._lock_path)
+        else:
+            self._redis_client = None
 
     async def initialize(self) -> None:
         """Initialize the service and start health check if this instance is the leader."""


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Fixed a minor issue in the gateway health check by properly handling redis_client assignment when Redis is not in use.

## 🐞 Root Cause
_redis_client was being referenced without proper initialization when Redis was disabled.

## 💡 Fix Description
Assigned redis_client = None when Redis is not in use to ensure safe reference.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed