### PR TITLE
Wrapper now supports for app root path for url

### DIFF
--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -92,7 +92,12 @@ def _extract_base_url(url: str) -> str:
     parsed = urlparse(url)
     if not parsed.scheme or not parsed.netloc:
         raise ValueError(f"Invalid URL provided: {url}")
-    return f"{parsed.scheme}://{parsed.netloc}"
+
+    if "/servers/" in url:
+        before_servers = parsed.path.split('/servers')[0]
+        return f"{parsed.scheme}://{parsed.netloc}{before_servers}"
+
+    return f"{url}"
 
 
 BASE_URL: str = _extract_base_url(SERVER_CATALOG_URLS[0]) if SERVER_CATALOG_URLS else ""


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Wrapper now regards the APP_ROOT_PATH set in the env variable and extracts appropriate base url for getting all servers, tools and more from the given MCP_SERVER_CATALOG_URLS.

## 🐞 Root Cause
If APP_ROOT_PATH is set in env, the base url changes for all apis, and hence the wrapper failed to connect and get all the required info from the gateway.

## 💡 Fix Description
The base URL generated by the wrapper considers the entire URL path, then extracts the base URL. If the user provides a base URL within MCP_SERVER_CATALOG_URLS, no extraction occurs, and the provided URL is used as the base URL.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed