### PR TITLE
Adds tip about venv to command example

### DIFF
--- a/docs/docs/using/mcpgateway-wrapper.md
+++ b/docs/docs/using/mcpgateway-wrapper.md
@@ -159,6 +159,14 @@ Open **File → Settings → Developer → Edit Config** and add:
 }
 ```
 
+> **Tip:** If you're using a virtual environment (venv), make sure to run the MCP client using the Python interpreter from that venv. This ensures that the `mcpgateway` module can be found and used correctly. For example:
+>
+> ```bash
+> /path/to/.venv/mcpgateway/bin/python
+> ```
+>
+> Replace `/path/to/.venv/mcpgateway/` with the actual path to your virtual environment.
+
 Restart the app; the wrapper will appear in the tool list.
 
 ---


### PR DESCRIPTION
# 📚 Documentation PR

> Run `make markdownlint spellcheck` and fix any issues.
> Preview locally with `cd docs && make serve`.
> Do **not** commit secrets or internal URLs.

---

## 🔗 Related Issue / Epic
_Link to the doc bug or epic this PR addresses:_
Closes #98 

---

## 📝 Summary (1–2 sentences)
Adds a tip below the claude desktop example to help with issues when mcpgateway is installed in a venv.

---

## ✏️ Type of Change
- [ ] Typo / formatting
- [ ] Outdated or incorrect info
- [ ] Missing explanation / example
- [x] Unclear instructions
- [ ] New page or major rewrite
- [ ] Other (describe)

---
