### PR TITLE
Streamable http support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,18 @@ WEBSOCKET_PING_INTERVAL=30
 # SSE client retry timeout (milliseconds)
 SSE_RETRY_TIMEOUT=5000
 
+
+#####################################
+# Streamabe HTTP Transport Configuration
+#####################################
+
+# Set False to use stateless sessions without event store and True for stateful sessions
+USE_STATEFUL_SESSIONS=false  
+
+# Set true for JSON responses, false for SSE streams
+JSON_RESPONSE_ENABLED=true 
+
+
 #####################################
 # Federation
 #####################################

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It supports:
 
 * Federation across multiple MCP and REST services
 * Virtualization of legacy APIs as MCP-compliant tools and servers
-* Transport over HTTP, JSON-RPC, WebSocket, SSE, and stdio
+* Transport over HTTP, JSON-RPC, WebSocket, SSE, stdio and streamable-HTTP
 * A live Admin UI for real-time management and configuration
 * Built-in auth, observability, retries, and rate-limiting
 * Scalable deployments via Docker or PyPI, Redis-backed caching, and multi-cluster federation
@@ -688,11 +688,13 @@ You can get started by copying the provided [.env.example](.env.example) to `.en
 
 ### Transport
 
-| Setting                   | Description            | Default | Options                         |
-| ------------------------- | ---------------------- | ------- | ------------------------------- |
-| `TRANSPORT_TYPE`          | Enabled transports     | `all`   | `http`,`ws`,`sse`,`stdio`,`all` |
-| `WEBSOCKET_PING_INTERVAL` | WebSocket ping (secs)  | `30`    | int > 0                         |
-| `SSE_RETRY_TIMEOUT`       | SSE retry timeout (ms) | `5000`  | int > 0                         |
+| Setting                   | Description                        | Default | Options                         |
+| ------------------------- | ---------------------------------- | ------- | ------------------------------- |
+| `TRANSPORT_TYPE`          | Enabled transports                 | `all`   | `http`,`ws`,`sse`,`stdio`,`all` |
+| `WEBSOCKET_PING_INTERVAL` | WebSocket ping (secs)              | `30`    | int > 0                         |
+| `SSE_RETRY_TIMEOUT`       | SSE retry timeout (ms)             | `5000`  | int > 0                         |
+| `USE_STATEFUL_SESSIONS`   | streamable http config             | `false` | bool                            |
+| `JSON_RESPONSE_ENABLED`   | json/sse streams (streamable http) | `true`  | bool                            |
 
 ### Federation
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -191,6 +191,10 @@ class Settings(BaseSettings):
     session_ttl: int = 3600
     message_ttl: int = 600
 
+    # streamable http transport
+    use_stateful_sessions: bool = False  # Set to False to use stateless sessions without event store
+    json_response_enabled: bool = True  # Enable JSON responses instead of SSE streams
+
     # Development
     dev_mode: bool = False
     reload: bool = False

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1,94 +1,348 @@
-# streamablehttptransport.py
+# -*- coding: utf-8 -*-
+"""Streamable HTTP Transport Implementation.
+
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Keval Mahajan
+
+This module implements Streamable Http transport for MCP
+
+Key components include:
+- SessionManagerWrapper: Manages the lifecycle of streamable HTTP sessions
+- JWTAuthMiddlewareStreamableHttp: Middleware for JWT authentication
+- Configuration options for:
+        1. stateful/stateless operation 
+        2. JSON response mode or SSE streams
+- InMemoryEventStore: A simple in-memory event storage system for maintaining session state
+
+"""
 
 import logging
-import contextlib
-from collections.abc import AsyncIterator
-import anyio
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import List, Union
+
+from starlette.types import Receive, Scope, Send
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.datastructures import Headers
+from fastapi.security.utils import get_authorization_scheme_param
+from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.types import ASGIApp
+
 import mcp.types as types
 from mcp.server.lowlevel import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from starlette.types import Receive, Scope, Send
-from typing import Any, Dict, List, Optional, Union
 
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.db import SessionLocal
+from mcpgateway.config import settings  
+from mcpgateway.utils.verify_credentials import verify_credentials
+
+
+from collections import deque
+from dataclasses import dataclass
+from uuid import uuid4
+
+from mcp.server.streamable_http import (
+    EventCallback,
+    EventId,
+    EventMessage,
+    EventStore,
+    StreamId,
+)
+from mcp.types import JSONRPCMessage
 
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
-# This is the MCP configuration from your script's CLI options.
-# You can get these from environment variables, a config file, or hardcode them.
-JSON_RESPONSE_ENABLED = False
-
-
+# Initialize ToolService and MCP Server
 tool_service = ToolService()
+mcp_app = Server("mcp-streamable-http-stateless")
+
+## ------------------------------ Event store ------------------------------
+
+@dataclass
+class EventEntry:
+    """
+    Represents an event entry in the event store.
+    """
+
+    event_id: EventId
+    stream_id: StreamId
+    message: JSONRPCMessage
 
 
-# Initialize MCP app
-mcp_app = Server("mcp-streamable-http-stateless-demo")
+class InMemoryEventStore(EventStore):
+    """
+    Simple in-memory implementation of the EventStore interface for resumability.
+    This is primarily intended for examples and testing, not for production use
+    where a persistent storage solution would be more appropriate.
+
+    This implementation keeps only the last N events per stream for memory efficiency.
+    """
+
+    def __init__(self, max_events_per_stream: int = 100):
+        """Initialize the event store.
+
+        Args:
+            max_events_per_stream: Maximum number of events to keep per stream
+        """
+        self.max_events_per_stream = max_events_per_stream
+        # for maintaining last N events per stream
+        self.streams: dict[StreamId, deque[EventEntry]] = {}
+        # event_id -> EventEntry for quick lookup
+        self.event_index: dict[EventId, EventEntry] = {}
+
+    async def store_event(
+        self, stream_id: StreamId, message: JSONRPCMessage
+    ) -> EventId:
+        """Stores an event with a generated event ID."""
+        event_id = str(uuid4())
+        event_entry = EventEntry(
+            event_id=event_id, stream_id=stream_id, message=message
+        )
+
+        # Get or create deque for this stream
+        if stream_id not in self.streams:
+            self.streams[stream_id] = deque(maxlen=self.max_events_per_stream)
+
+        # If deque is full, the oldest event will be automatically removed
+        # We need to remove it from the event_index as well
+        if len(self.streams[stream_id]) == self.max_events_per_stream:
+            oldest_event = self.streams[stream_id][0]
+            self.event_index.pop(oldest_event.event_id, None)
+
+        # Add new event
+        self.streams[stream_id].append(event_entry)
+        self.event_index[event_id] = event_entry
+
+        return event_id
+
+    async def replay_events_after(
+        self,
+        last_event_id: EventId,
+        send_callback: EventCallback,
+    ) -> StreamId | None:
+        """Replays events that occurred after the specified event ID."""
+        if last_event_id not in self.event_index:
+            logger.warning(f"Event ID {last_event_id} not found in store")
+            return None
+
+        # Get the stream and find events after the last one
+        last_event = self.event_index[last_event_id]
+        stream_id = last_event.stream_id
+        stream_events = self.streams.get(last_event.stream_id, deque())
+
+        # Events in deque are already in chronological order
+        found_last = False
+        for event in stream_events:
+            if found_last:
+                await send_callback(EventMessage(event.message, event.event_id))
+            elif event.event_id == last_event_id:
+                found_last = True
+
+        return stream_id
+
+
+## ------------------------------ Streamable HTTP Transport ------------------------------
+
+@asynccontextmanager
+async def get_db():
+    """
+    Asynchronous context manager for database sessions.
+
+    Yields:
+        A database session instance from SessionLocal.
+    Ensures the session is closed after use.
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
 
 @mcp_app.call_tool()
 async def call_tool(name: str, arguments: dict) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
-    with SessionLocal() as db:
-        result = await tool_service.invoke_tool(db, name, arguments)
-        
-        tool_result =  [
-            types.TextContent(
-                type=result.content[0].type,
-                text=(
-                    result.content[0].text
-                ),
-            )
-        ]
-        return tool_result
-    
+    """
+    Handles tool invocation via the MCP Server.
+
+    Args:
+        name (str): The name of the tool to invoke.
+        arguments (dict): A dictionary of arguments to pass to the tool.
+
+    Returns:
+        List of content (TextContent, ImageContent, or EmbeddedResource) from the tool response.
+    Logs and returns an empty list on failure.
+    """
+    try:
+        async with get_db() as db:
+            result = await tool_service.invoke_tool(db, name, arguments)
+            if not result or not result.content:
+                logger.warning(f"No content returned by tool: {name}")
+                return []
+
+            return [
+                types.TextContent(
+                    type=result.content[0].type,
+                    text=result.content[0].text
+                )
+            ]
+    except Exception as e:
+        logger.exception(f"Error calling tool '{name}': {e}")
+        return []
+
+
 @mcp_app.list_tools()
-async def list_tools() -> list[types.Tool]:
+async def list_tools() -> List[types.Tool]:
+    """
+    Lists all tools available to the MCP Server.
 
-    with SessionLocal() as db:
-        tools = await tool_service.list_tools(db)
-        listed_tools = []
-        for tool in tools:
-            listed_tools.append(types.Tool(
-                name=tool.name,
-                description=tool.description,
-                inputSchema=tool.input_schema
-            ))
+    Returns:
+        A list of Tool objects containing metadata such as name, description, and input schema.
+    Logs and returns an empty list on failure.
+    """
+    try:
+        async with get_db() as db:
+            tools = await tool_service.list_tools(db)
+            return [
+                types.Tool(
+                    name=tool.name,
+                    description=tool.description,
+                    inputSchema=tool.input_schema
+                ) for tool in tools
+            ]
+    except Exception as e:
+        logger.exception("Error listing tools")
+        return []
 
-        return listed_tools
 
 
-# --- 2. Create and Configure MCP Session Manager ---
-session_manager = StreamableHTTPSessionManager(
-    app=mcp_app,
-    event_store=None,
-    json_response=JSON_RESPONSE_ENABLED,
-    stateless=True,
-)
+class SessionManagerWrapper:
+    """
+    Wrapper class for managing the lifecycle of a StreamableHTTPSessionManager instance.
+    Provides start, stop, and request handling methods.
+    """
 
-# This is the handler that will process requests for the mounted path.
-async def handle_streamable_http(scope: Scope, receive: Receive, send: Send) -> None:
-    await session_manager.handle_request(scope, receive, send)
+    def __init__(self) -> None:
+        """
+        Initializes the session manager and the exit stack used for managing its lifecycle.
+        """
+        
+        if settings.use_stateful_sessions:
+            event_store = InMemoryEventStore()
+            stateless=False
+        else:
+            event_store=None
+            stateless=True
 
-# --- 3. Lifespan Management to Start/Stop the Session Manager ---
-# @contextlib.asynccontextmanager
-# async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-#     """Manages the startup and shutdown of the MCP session manager."""
-#     async with session_manager.run():
-#         logger.info("Application starting with MCP StreamableHTTPSessionManager!")
-#         yield
-#     logger.info("Application shutting down...")
+        self.session_manager = StreamableHTTPSessionManager(
+            app=mcp_app,
+            event_store=event_store,
+            json_response=settings.json_response_enabled,
+            stateless=stateless,
+        )
+        self.stack = AsyncExitStack()
 
-async def start_streamablehttp():
-    # await session_manager.run()
-    # session = await session_manager.run().__aenter__()
-    # logger.info("Application starting with MCP StreamableHTTPSessionManager!")
-    async with session_manager.run():
-        logger.info("Application starting with MCP StreamableHTTPSessionManager!")
-        # yield
-    
+    async def start(self) -> None:
+        """
+        Starts the Streamable HTTP session manager context.
+        """
+        logger.info("Starting Streamable HTTP Session Manager...")
+        await self.stack.enter_async_context(self.session_manager.run())
+        
+    async def shutdown(self) -> None:
+        """
+        Gracefully shuts down the Streamable HTTP session manager.
+        """
+        logger.info("Stopping Streamable HTTP Session Manager...")
+        await self.stack.aclose()
 
-async def stop_streamablehttp():
-    # await session_manager.stop()
-    # await session_manager.run().__aexit__(None, None, None)
-    logger.info("StreamableHTTPSessionManager shutting down...")
+    async def handle_streamable_http(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """
+        Forwards an incoming ASGI request to the streamable HTTP session manager.
+
+        Args:
+            scope (Scope): ASGI scope object containing connection information.
+            receive (Receive): ASGI receive callable.
+            send (Send): ASGI send callable.
+        Logs any exceptions that occur during request handling.
+        """
+        try:
+            await self.session_manager.handle_request(scope, receive, send)
+        except Exception as e:
+            logger.exception("Error handling streamable HTTP request")
+            raise
+
+## ------------------------- FastAPI Middleware for Authentication ------------------------------
+
+class JWTAuthMiddlewareStreamableHttp(BaseHTTPMiddleware):
+    """
+    Middleware for handling JWT authentication in an ASGI application.
+    This middleware checks for JWT tokens in the authorization header or cookies
+    and verifies the credentials before allowing access to protected routes.
+    """
+    def __init__(self, app: ASGIApp):
+        """
+        Initialize the middleware with the given ASGI application.
+
+        Args:
+            app (ASGIApp): The ASGI application to wrap.
+        """
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        """
+        Dispatch the request to the appropriate handler after performing JWT authentication.
+
+        Args:
+            request (Request): The incoming request.
+            call_next: The next middleware or route handler in the chain.
+
+        Returns:
+            JSONResponse: A response indicating authentication failure if the token is invalid or missing.
+            Response: The response from the next middleware or route handler if authentication is successful.
+        """
+        # Only apply auth to /mcp path
+        if not request.url.path.startswith("/mcp"):
+            return await call_next(request)
+
+        headers = Headers(scope=request.scope)
+        authorization = headers.get("authorization")
+        cookie_header = headers.get("cookie", "")
+
+        token = None
+        if authorization:
+            scheme, credentials = get_authorization_scheme_param(authorization)
+            if scheme.lower() == "bearer" and credentials:
+                token = credentials
+
+        if not token:
+            for cookie in cookie_header.split(";"):
+                if cookie.strip().startswith("jwt_token="):
+                    token = cookie.strip().split("=", 1)[1]
+                    break
+
+        try:
+            if settings.auth_required and not token:
+                return JSONResponse(
+                    {"detail": "Not authenticated"},
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            if token:
+                await verify_credentials(token)
+
+            return await call_next(request)
+
+        except Exception as e:
+            return JSONResponse(
+                {"detail": "Authentication failed"},
+                status_code=HTTP_401_UNAUTHORIZED,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1,0 +1,94 @@
+# streamablehttptransport.py
+
+import logging
+import contextlib
+from collections.abc import AsyncIterator
+import anyio
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.types import Receive, Scope, Send
+from typing import Any, Dict, List, Optional, Union
+
+from mcpgateway.services.tool_service import ToolService
+from mcpgateway.db import SessionLocal
+
+
+logger = logging.getLogger(__name__)
+
+# This is the MCP configuration from your script's CLI options.
+# You can get these from environment variables, a config file, or hardcode them.
+JSON_RESPONSE_ENABLED = False
+
+
+tool_service = ToolService()
+
+
+# Initialize MCP app
+mcp_app = Server("mcp-streamable-http-stateless-demo")
+
+@mcp_app.call_tool()
+async def call_tool(name: str, arguments: dict) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
+    with SessionLocal() as db:
+        result = await tool_service.invoke_tool(db, name, arguments)
+        
+        tool_result =  [
+            types.TextContent(
+                type=result.content[0].type,
+                text=(
+                    result.content[0].text
+                ),
+            )
+        ]
+        return tool_result
+    
+@mcp_app.list_tools()
+async def list_tools() -> list[types.Tool]:
+
+    with SessionLocal() as db:
+        tools = await tool_service.list_tools(db)
+        listed_tools = []
+        for tool in tools:
+            listed_tools.append(types.Tool(
+                name=tool.name,
+                description=tool.description,
+                inputSchema=tool.input_schema
+            ))
+
+        return listed_tools
+
+
+# --- 2. Create and Configure MCP Session Manager ---
+session_manager = StreamableHTTPSessionManager(
+    app=mcp_app,
+    event_store=None,
+    json_response=JSON_RESPONSE_ENABLED,
+    stateless=True,
+)
+
+# This is the handler that will process requests for the mounted path.
+async def handle_streamable_http(scope: Scope, receive: Receive, send: Send) -> None:
+    await session_manager.handle_request(scope, receive, send)
+
+# --- 3. Lifespan Management to Start/Stop the Session Manager ---
+# @contextlib.asynccontextmanager
+# async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+#     """Manages the startup and shutdown of the MCP session manager."""
+#     async with session_manager.run():
+#         logger.info("Application starting with MCP StreamableHTTPSessionManager!")
+#         yield
+#     logger.info("Application shutting down...")
+
+async def start_streamablehttp():
+    # await session_manager.run()
+    # session = await session_manager.run().__aenter__()
+    # logger.info("Application starting with MCP StreamableHTTPSessionManager!")
+    async with session_manager.run():
+        logger.info("Application starting with MCP StreamableHTTPSessionManager!")
+        # yield
+    
+
+async def stop_streamablehttp():
+    # await session_manager.stop()
+    # await session_manager.run().__aexit__(None, None, None)
+    logger.info("StreamableHTTPSessionManager shutting down...")

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -250,7 +250,7 @@ class SessionManagerWrapper:
         """
         Starts the Streamable HTTP session manager context.
         """
-        logger.info("Starting Streamable HTTP Session Manager...")
+        logger.info("Initializing Streamable HTTP service")
         await self.stack.enter_async_context(self.session_manager.run())
         
     async def shutdown(self) -> None:


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
https://github.com/IBM/mcp-context-forge/issues/109
Closes #109

---

## 🚀 Summary (1–2 sentences)
Implemented streamable HTTP transport to enable client communication with the MCP gateway with authentication.

Added new variables in env:
- **USE_STATEFUL_SESSIONS**  
  Set to `False` to use stateless sessions without an event store.  
  Set to `True` for stateful sessions.

- **JSON_RESPONSE_ENABLED**  
  Set to `True` to enable JSON responses.  
  Set to `False` to enable SSE streams. 

To test this out:
1. Open the MCP Inspector and Select "Streamable HTTP" as the transport option.
2. Enter the URL: [http://localhost:4444/mcp/](http://localhost:4444/mcp/)
3. Paste the Bearer authentication token for the gateway. Click on "Connect."
---

## 🧪 Checks

- [x] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---
