### PR TITLE
Streamablehttp server wise connection

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -319,7 +319,7 @@ class ToolCreate(BaseModelWithConfig):
         auth_type = values.get("auth_type")
         if auth_type:
             if auth_type.lower() == "basic":
-                creds = base64.b64encode(f'{values.get("auth_username", "")}:{values.get("auth_password", "")}'.encode("utf-8")).decode()
+                creds = base64.b64encode(f"{values.get('auth_username', '')}:{values.get('auth_password', '')}".encode("utf-8")).decode()
                 encoded_auth = encode_auth({"Authorization": f"Basic {creds}"})
                 values["auth"] = {"auth_type": "basic", "auth_value": encoded_auth}
             elif auth_type.lower() == "bearer":
@@ -378,7 +378,7 @@ class ToolUpdate(BaseModelWithConfig):
         auth_type = values.get("auth_type")
         if auth_type:
             if auth_type.lower() == "basic":
-                creds = base64.b64encode(f'{values.get("auth_username", "")}:{values.get("auth_password", "")}'.encode("utf-8")).decode()
+                creds = base64.b64encode(f"{values.get('auth_username', '')}:{values.get('auth_password', '')}".encode("utf-8")).decode()
                 encoded_auth = encode_auth({"Authorization": f"Basic {creds}"})
                 values["auth"] = {"auth_type": "basic", "auth_value": encoded_auth}
             elif auth_type.lower() == "bearer":

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -306,13 +306,6 @@ async def streamable_http_auth(scope, receive, send):
         scheme, credentials = get_authorization_scheme_param(authorization)
         if scheme.lower() == "bearer" and credentials:
             token = credentials
-
-    # # If no Bearer token in Authorization header, just allow (no auth)
-    # if not token:
-    #     return True
-
-    # If token is present, verify it
-    print("TOKEN::::", token)
     try:
         await verify_credentials(token)
     except Exception:

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -109,16 +109,13 @@ def mock_request():
     )
 
     # Basic template rendering stub
-    request.app = MagicMock()           # ensure .app exists
-    request.app.state = MagicMock()     # ensure .app.state exists
+    request.app = MagicMock()  # ensure .app exists
+    request.app.state = MagicMock()  # ensure .app.state exists
     request.app.state.templates = MagicMock()
-    request.app.state.templates.TemplateResponse.return_value = HTMLResponse(
-        content="<html></html>"
-    )
+    request.app.state.templates.TemplateResponse.return_value = HTMLResponse(content="<html></html>")
 
     request.query_params = {"include_inactive": "false"}
     return request
-
 
 
 class TestAdminServerRoutes:
@@ -216,6 +213,7 @@ class TestAdminServerRoutes:
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
         assert "/admin#catalog" in result.headers["location"]
+
 
 class TestAdminToolRoutes:
     """Test admin routes for tool management."""
@@ -602,6 +600,7 @@ class TestAdminGatewayRoutes:
         assert result.status_code == 303
         assert "/admin#gateways" in result.headers["location"]
 
+
 class TestAdminRootRoutes:
     """Test admin routes for root management."""
 
@@ -625,6 +624,7 @@ class TestAdminRootRoutes:
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
         assert "/admin#roots" in result.headers["location"]
+
 
 class TestAdminMetricsRoutes:
     """Test admin routes for metrics management."""


### PR DESCRIPTION
# ✨ Feature / Enhancement PR
---

## 🚀 Summary (1–2 sentences)
Connect to individual servers listed in server catalogs using streamable HTTP. 

To test this with MCP inspector:
1. Create a server in server catalog with required tools in the gateway.
2. Use this url- `http://localhost:4444/servers/1/mcp` and corresponding auth token.
3. Here `1` is the server id from the server catalogs, replace it with any valid server id.
4. Connect to individual servers.

-  `http://localhost:4444/mcp` works as it is (connects to the entire gateway)


---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)
