### PR TITLE
Fix version template location in pip install

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -774,7 +774,7 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
             return RedirectResponse(f"{root_path}/admin#gateways", status_code=400)
         if isinstance(ex, RuntimeError):
             return RedirectResponse(f"{root_path}/admin#gateways", status_code=500)
-        
+
         return RedirectResponse(f"{root_path}/admin#gateways", status_code=500)
 
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -495,19 +495,20 @@ class ToolService:
 
                 # Build the payload based on integration type.
                 payload = arguments.copy()
-                
+
                 # Handle URL path parameter substitution
                 final_url = tool.url
-                if '{' in tool.url and '}' in tool.url:
+                if "{" in tool.url and "}" in tool.url:
                     # Extract path parameters from URL template and arguments
                     import re
-                    url_params = re.findall(r'\{(\w+)\}', tool.url)
+
+                    url_params = re.findall(r"\{(\w+)\}", tool.url)
                     url_substitutions = {}
-                    
+
                     for param in url_params:
                         if param in payload:
                             url_substitutions[param] = payload.pop(param)  # Remove from payload
-                            final_url = final_url.replace(f'{{{param}}}', str(url_substitutions[param]))
+                            final_url = final_url.replace(f"{{{param}}}", str(url_substitutions[param]))
                         else:
                             raise ToolInvocationError(f"Required URL parameter '{param}' not found in arguments")
 
@@ -518,7 +519,7 @@ class ToolService:
                 else:
                     response = await self._http_client.request(method, final_url, json=payload, headers=headers)
                 response.raise_for_status()
-                
+
                 # Handle 204 No Content responses that have no body
                 if response.status_code == 204:
                     tool_result = ToolResult(content=[TextContent(type="text", text="Request completed successfully (No Content)")])

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -909,8 +909,8 @@ async function viewGateway(gatewayId) {
           <p><strong>Name:</strong> ${gateway.name}</p>
           <p><strong>URL:</strong> ${gateway.url}</p>
           <p><strong>Description:</strong> ${gateway.description || "N/A"}</p>
-          <p><strong>Transport:</strong> 
-            ${gateway.transport === "STREAMABLEHTTP" ? "Streamable HTTP" : 
+          <p><strong>Transport:</strong>
+            ${gateway.transport === "STREAMABLEHTTP" ? "Streamable HTTP" :
               gateway.transport === "SSE" ? "SSE" : "N/A"}
           </p>
           <p><strong>Status:</strong>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1758,7 +1758,7 @@
       </div>
     </div>
 
-    
+
 
 
     <!-- Tool Edit Modal -->

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -396,7 +396,7 @@ async def version_endpoint(
         # Return partial HTML fragment for HTMX embedding
         from fastapi.templating import Jinja2Templates
 
-        templates = Jinja2Templates(directory="mcpgateway/templates")
+        templates = Jinja2Templates(directory=str(settings.templates_dir))
         return templates.TemplateResponse("version_info_partial.html", {"request": request, "payload": payload})
     wants_html = fmt == "html" or "text/html" in request.headers.get("accept", "")
     if wants_html:


### PR DESCRIPTION
Fix version template location in pip install. When calling `mcpgateway` it looks for the `mcpgateway/templates/version_info_partial.html` in the current directory instead of the path relative to the module location.