### PR TITLE
Fix Python interpreter usage in Makefile images target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,10 +274,10 @@ images:
 	@mkdir -p $(DOCS_DIR)/docs/design/images
 	@code2flow mcpgateway/ --output $(DOCS_DIR)/docs/design/images/code2flow.dot || true
 	@dot -Tsvg -Gbgcolor=transparent -Gfontname="Arial" -Nfontname="Arial" -Nfontsize=14 -Nfontcolor=black -Nfillcolor=white -Nshape=box -Nstyle="filled,rounded" -Ecolor=gray -Efontname="Arial" -Efontsize=14 -Efontcolor=black $(DOCS_DIR)/docs/design/images/code2flow.dot -o $(DOCS_DIR)/docs/design/images/code2flow.svg || true
-	@python3 -m pip install snakefood3
-	@python3 -m snakefood3 app > snakefood.dot
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && python -m pip install snakefood3"
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && python -m snakefood3 . mcpgateway > snakefood.dot"
 	@dot -Tpng -Gbgcolor=transparent -Gfontname="Arial" -Nfontname="Arial" -Nfontsize=12 -Nfontcolor=black -Nfillcolor=white -Nshape=box -Nstyle="filled,rounded" -Ecolor=gray -Efontname="Arial" -Efontsize=10 -Efontcolor=black snakefood.dot -o $(DOCS_DIR)/docs/design/images/snakefood.png || true
-	@pyreverse --colorized app || true
+	@pyreverse --colorized mcpgateway || true
 	@dot -Tsvg -Gbgcolor=transparent -Gfontname="Arial" -Nfontname="Arial" -Nfontsize=14 -Nfontcolor=black -Nfillcolor=white -Nshape=box -Nstyle="filled,rounded" -Ecolor=gray -Efontname="Arial" -Efontsize=14 -Efontcolor=black packages.dot -o $(DOCS_DIR)/docs/design/images/packages.svg || true
 	@dot -Tsvg -Gbgcolor=transparent -Gfontname="Arial" -Nfontname="Arial" -Nfontsize=14 -Nfontcolor=black -Nfillcolor=white -Nshape=box -Nstyle="filled,rounded" -Ecolor=gray -Efontname="Arial" -Efontsize=14 -Efontcolor=black classes.dot -o $(DOCS_DIR)/docs/design/images/classes.svg || true
 	@rm -f packages.dot classes.dot snakefood.dot || true


### PR DESCRIPTION
- Use virtual environment Python instead of system Python for snakefood3
- Fix snakefood3 command arguments (add missing package name)
- Update pyreverse target to use correct package name 'mcpgateway'

Fixes: #131 ( 'No module named snakefood3' error during documentation generation)

## Root Cause: 
The `Makefile`'s images target is using the system Python interpreter (python3) instead of the virtual environment's Python interpreter when running snakefood3.

## The Problem: 
@python3 -m pip install snakefood3  # Installs to system Python
@python3 -m snakefood3 app > snakefood.dot  # Tries to run from system Python

## The Fix:
Changed `.PHONY: images` target in `Makefile`

##Key changes made:
1. Fixed snakefood3 installation:

`@/bin/bash -c "source $(VENV_DIR)/bin/activate && python -m pip install snakefood3"`

2. Fixed snakefood3 execution:
`@/bin/bash -c "source $(VENV_DIR)/bin/activate && python -m snakefood3 . mcpgateway > snakefood.dot"`

3. Updated snakefood3 arguments: Changed from` app > snakefood.dot` to `. mcpgateway > snakefood.dot` to match the correct project structure.
4. Fixed pyreverse target: Changed from `app` to `mcpgateway` to match the actual package name.


## Additional Observations:
The error also shows that snakefood3 is expecting a package_name argument:
```
usage: __main__.py [-h] [-g GROUP] project_path package_name
__main__.py: error: the following arguments are required: package_name
```

This confirms that the command should be:
`bashpython -m snakefood3 . mcpgateway`
Where:

`. `is the project path (current directory)
`mcpgateway` is the package name

This fix will ensure that snakefood3 runs within the virtual environment where it's installed, resolving both the "module not found" error and the missing package name argument error.
