### PR TITLE
UI reload issue

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -763,7 +763,6 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
         auth_header_key=form.get("auth_header_key", ""),
         auth_header_value=form.get("auth_header_value", ""),
     )
-    root_path = request.scope.get("root_path", "")
     try:
         await gateway_service.register_gateway(db, gateway)
         return JSONResponse(
@@ -779,7 +778,6 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
         if isinstance(ex, RuntimeError):
             return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
         return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
-
 
 
 @admin_router.post("/gateways/{gateway_id}/edit")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -733,7 +733,7 @@ async def admin_get_gateway(gateway_id: int, db: Session = Depends(get_db), user
 
 
 @admin_router.post("/gateways")
-async def admin_add_gateway(request: Request, db: Session = Depends(get_db), user: str = Depends(require_auth)) -> RedirectResponse:
+async def admin_add_gateway(request: Request, db: Session = Depends(get_db), user: str = Depends(require_auth)) -> JSONResponse:
     """Add a gateway via the admin UI.
 
     Expects form fields:
@@ -766,16 +766,20 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
     root_path = request.scope.get("root_path", "")
     try:
         await gateway_service.register_gateway(db, gateway)
-        return RedirectResponse(f"{root_path}/admin#gateways", status_code=303)
+        return JSONResponse(
+            content={"message": "Gateway registered successfully!", "success": True},
+            status_code=200,
+        )
+
     except Exception as ex:
         if isinstance(ex, GatewayConnectionError):
-            return RedirectResponse(f"{root_path}/admin#gateways", status_code=502)
+            return JSONResponse(content={"message": str(ex), "success": False}, status_code=502)
         if isinstance(ex, ValueError):
-            return RedirectResponse(f"{root_path}/admin#gateways", status_code=400)
+            return JSONResponse(content={"message": str(ex), "success": False}, status_code=400)
         if isinstance(ex, RuntimeError):
-            return RedirectResponse(f"{root_path}/admin#gateways", status_code=500)
+            return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
-        return RedirectResponse(f"{root_path}/admin#gateways", status_code=500)
 
 
 @admin_router.post("/gateways/{gateway_id}/edit")

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -147,43 +147,42 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
 
-  document
-  .getElementById("add-gateway-form")
-  .addEventListener("submit", (e) => {
-    e.preventDefault();
+    document.getElementById("add-gateway-form")
+      .addEventListener("submit", async (e) => {
+        e.preventDefault();
 
-    const form = e.target;
-    const formData = new FormData(form);
+        const form = e.target;
+        const formData = new FormData(form);
 
-    const status = document.getElementById("status-gateways");
-    const loading = document.getElementById("add-gateway-loading");
+        const status = document.getElementById("status-gateways");
+        const loading = document.getElementById("add-gateway-loading");
 
-    // Show loading and clear previous status
-    loading.style.display = "block";
-    status.textContent = "";
-    status.classList.remove("error-status");
+        // Show loading and clear previous status
+        loading.style.display = "block";
+        status.textContent = "";
+        status.classList.remove("error-status");
 
-    fetch(`${window.ROOT_PATH}/admin/gateways`, {
-      method: "POST",
-      body: formData,
-    })
-      .then((response) => {
-        if (!response.ok) {
-          status.textContent = "Connection failed!";
+        try {
+          const response = await fetch(`${window.ROOT_PATH}/admin/gateways`, {
+            method: "POST",
+            body: formData,
+          });
+
+          let result = await response.json();
+            if (!result.success) {
+              alert(result.message || "An error occurred");
+            } else {
+              window.location.href = `${window.ROOT_PATH}/admin#gateways`; // Redirect on success
+            }
+
+        } catch (error) {
+          console.error("Error:", error);
+          status.textContent = error.message || "An error occurred!";
           status.classList.add("error-status");
-        } else {
-          location.reload(); // Will exit before hiding spinner
+        } finally {
+          loading.style.display = "none"; // Hide loading spinner
         }
-      })
-      .catch((error) => {
-        console.error("Error:", error);
-        status.textContent = "An error occurred!";
-        status.classList.add("error-status");
-      })
-      .finally(() => {
-        loading.style.display = "none"; // Hide loading
       });
-  });
 
 
   document
@@ -305,7 +304,7 @@ document.addEventListener("DOMContentLoaded", function () {
         if (!result.success) {
           alert(result.message || "An error occurred");
         } else {
-          window.location.href = "/admin#tools"; // Redirect on success
+          window.location.href = `${window.ROOT_PATH}/admin#tools`; // Redirect on success
         }
       } catch (error) {
         console.error("Fetch error:", error);

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -563,7 +563,6 @@ class TestAdminGatewayRoutes:
         mock_register_gateway.assert_called_once()
         assert isinstance(result, JSONResponse) 
         assert result.status_code == 200
-        assert "/admin#gateways" in result.headers["location"]
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway(self, mock_update_gateway, mock_request, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -561,7 +561,7 @@ class TestAdminGatewayRoutes:
 
         # Assert
         mock_register_gateway.assert_called_once()
-        assert isinstance(result, RedirectResponse) #JSONResponse
+        assert isinstance(result, JSONResponse) 
         assert result.status_code == 303
         assert "/admin#gateways" in result.headers["location"]
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -561,7 +561,7 @@ class TestAdminGatewayRoutes:
 
         # Assert
         mock_register_gateway.assert_called_once()
-        assert isinstance(result, RedirectResponse)
+        assert isinstance(result, RedirectResponse) #JSONResponse
         assert result.status_code == 303
         assert "/admin#gateways" in result.headers["location"]
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -562,7 +562,7 @@ class TestAdminGatewayRoutes:
         # Assert
         mock_register_gateway.assert_called_once()
         assert isinstance(result, JSONResponse) 
-        assert result.status_code == 303
+        assert result.status_code == 200
         assert "/admin#gateways" in result.headers["location"]
 
     @patch.object(GatewayService, "update_gateway")


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            – passes `ruff`, `mypy`, `pylint`
2. `make test`            – all unit + integration tests green
3. `make coverage`        – ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
The tools and gateway registration UI did not reload after registration. 
This behaviour only applies to deployed instances with postgresql.

## 🔁 Reproduction Steps
1. `Applicable for deployed versions only.` 
a. Access the tool registration UI. Register a tool. The tool is added in the DB but the UI is not redirected to the correct url is ROOT_PATH is set.
b. Access the gateway registration UI. Register a gateway. In deployed versions, the gateway is added in the DB but the UI shows an error after registration due to a delayed fetch process.

## 🐞 Root Cause
The registration tool UI did not redirect to the ROOT_PATH URL, causing the redirect failure. Additionally, the fetch process failed when the gateway took time to be added to the database.

## 💡 Fix Description
Added ROOT_PATH when tool are added and the UI is redirected. Converted the JS code to async and replaced RedirectResponse with JSONResponse containing a status message to handle delayed fetch properly. 
Both local and deployed instances were tested, and the issue was resolved.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed