### PR TITLE
Fix close button for tool parameters

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -254,7 +254,6 @@ document.addEventListener("DOMContentLoaded", function () {
     </div>
     `;
     parametersContainer.appendChild(paramDiv);
-    attachListeners(paramDiv);
     updateSchemaPreview();
 
     // Delete parameter functionality


### PR DESCRIPTION
## 📌 Summary
The close button for the adding parameters section of the Global Tools tab does not work

## 🔁 Reproduction Steps
Related issue with steps to reproduce: https://github.com/IBM/mcp-context-forge/issues/189

## 🐞 Root Cause
The [attachListeners(paramDiv)](https://github.com/IBM/mcp-context-forge/blob/86804bb1ba67b9a9252e0d09d6398427ae7a3a00/mcpgateway/static/admin.js#L257) function was undefined so the subsequent code never ran

## 💡 Fix Description
Removed the function as it was not needed

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   ✅     |
| Unit tests                            | `make test`          |     ✅   |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |     ✅   |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
