### PR TITLE
Fixes for pytest warnings

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -101,7 +101,7 @@ async def admin_list_servers(
     """
     logger.debug(f"User {user} requested server list")
     servers = await server_service.list_servers(db, include_inactive=include_inactive)
-    return [server.dict(by_alias=True) for server in servers]
+    return [server.model_dump(by_alias=True) for server in servers]
 
 
 @admin_router.get("/servers/{server_id}", response_model=ServerRead)
@@ -316,7 +316,7 @@ async def admin_list_resources(
     """
     logger.debug(f"User {user} requested resource list")
     resources = await resource_service.list_resources(db, include_inactive=include_inactive)
-    return [resource.dict(by_alias=True) for resource in resources]
+    return [resource.model_dump(by_alias=True) for resource in resources]
 
 
 @admin_router.get("/prompts", response_model=List[PromptRead])
@@ -342,7 +342,7 @@ async def admin_list_prompts(
     """
     logger.debug(f"User {user} requested prompt list")
     prompts = await prompt_service.list_prompts(db, include_inactive=include_inactive)
-    return [prompt.dict(by_alias=True) for prompt in prompts]
+    return [prompt.model_dump(by_alias=True) for prompt in prompts]
 
 
 @admin_router.get("/gateways", response_model=List[GatewayRead])
@@ -368,7 +368,7 @@ async def admin_list_gateways(
     """
     logger.debug(f"User {user} requested gateway list")
     gateways = await gateway_service.list_gateways(db, include_inactive=include_inactive)
-    return [gateway.dict(by_alias=True) for gateway in gateways]
+    return [gateway.model_dump(by_alias=True) for gateway in gateways]
 
 
 @admin_router.post("/gateways/{gateway_id}/toggle")
@@ -486,7 +486,7 @@ async def admin_list_tools(
     """
     logger.debug(f"User {user} requested tool list")
     tools = await tool_service.list_tools(db, include_inactive=include_inactive)
-    return [tool.dict(by_alias=True) for tool in tools]
+    return [tool.model_dump(by_alias=True) for tool in tools]
 
 
 @admin_router.get("/tools/{tool_id}", response_model=ToolRead)
@@ -570,7 +570,7 @@ async def admin_add_tool(
     logger.debug(f"Tool data built: {tool_data}")
     try:
         tool = ToolCreate(**tool_data)
-        logger.debug(f"Validated tool data: {tool.dict()}")
+        logger.debug(f"Validated tool data: {tool.model_dump(by_alias=True)}")
         await tool_service.register_tool(db, tool)
         return JSONResponse(
             content={"message": "Tool registered successfully!", "success": True},
@@ -733,7 +733,7 @@ async def admin_get_gateway(gateway_id: str, db: Session = Depends(get_db), user
     """
     logger.debug(f"User {user} requested details for gateway ID {gateway_id}")
     gateway = await gateway_service.get_gateway(db, gateway_id)
-    return gateway.dict(by_alias=True)
+    return gateway.model_dump(by_alias=True)
 
 
 @admin_router.post("/gateways")
@@ -868,7 +868,7 @@ async def admin_get_resource(uri: str, db: Session = Depends(get_db), user: str 
     logger.debug(f"User {user} requested details for resource URI {uri}")
     resource = await resource_service.get_resource_by_uri(db, uri)
     content = await resource_service.read_resource(db, uri)
-    return {"resource": resource.dict(by_alias=True), "content": content}
+    return {"resource": resource.model_dump(by_alias=True), "content": content}
 
 
 @admin_router.post("/resources")
@@ -1023,7 +1023,7 @@ async def admin_get_prompt(name: str, db: Session = Depends(get_db), user: str =
     prompt_details = await prompt_service.get_prompt_details(db, name)
 
     prompt = PromptRead.model_validate(prompt_details)
-    return prompt.dict(by_alias=True)
+    return prompt.model_dump(by_alias=True)
 
 
 @admin_router.post("/prompts")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -444,6 +444,7 @@ async def admin_ui(
     roots = [root.model_dump(by_alias=True) for root in await root_service.list_roots()]
     root_path = settings.app_root_path
     response = request.app.state.templates.TemplateResponse(
+        request,
         "admin.html",
         {
             "request": request,

--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -95,7 +95,6 @@ class SessionBackend:
 
             self._redis = Redis.from_url(redis_url)
             self._pubsub = self._redis.pubsub()
-            self._pubsub.subscribe("mcp_session_events")
 
         elif self._backend == "database":
             if not SQLALCHEMY_AVAILABLE:
@@ -152,6 +151,9 @@ class SessionRegistry(SessionBackend):
             self._cleanup_task = asyncio.create_task(self._db_cleanup_task())
             logger.info("Database cleanup task started")
 
+        elif self._backend == "redis":
+            await self._pubsub.subscribe("mcp_session_events")
+
         elif self._backend == "none":
             # Nothing to initialize for none backend
             pass
@@ -179,8 +181,8 @@ class SessionRegistry(SessionBackend):
         # Close Redis connections
         if self._backend == "redis":
             try:
-                self._pubsub.close()
-                self._redis.close()
+                await self._pubsub.aclose()
+                await self._redis.aclose()
             except Exception as e:
                 logger.error(f"Error closing Redis connection: {e}")
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -49,20 +49,14 @@ class Settings(BaseSettings):
     """MCP Gateway configuration settings."""
 
     # Basic Settings
-    app_name: str = Field("MCP_Gateway", env="APP_NAME")
-    host: str = Field("127.0.0.1", env="HOST")
-    port: int = Field(4444, env="PORT")
+    app_name: str = "MCP_Gateway"
+    host: str = "127.0.0.1"
+    port: int = 4444
     database_url: str = "sqlite:///./mcp.db"
     templates_dir: Path = Path("mcpgateway/templates")
     # Absolute paths resolved at import-time (still override-able via env vars)
-    templates_dir: Path = Field(
-        default=files("mcpgateway") / "templates",
-        env="TEMPLATES_DIR",
-    )
-    static_dir: Path = Field(
-        default=files("mcpgateway") / "static",
-        env="STATIC_DIR",
-    )
+    templates_dir: Path = files("mcpgateway") / "templates"
+    static_dir: Path = files("mcpgateway") / "static"
     app_root_path: str = ""
 
     # Protocol

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -41,7 +41,7 @@ from fastapi import HTTPException
 import jq
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import JSONPath
-from pydantic import Field, field_validator
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -105,11 +105,13 @@ engine = create_engine(
     connect_args=connect_args,
 )
 
+
 # ---------------------------------------------------------------------------
 # 6. Function to return UTC timestamp
 # ---------------------------------------------------------------------------
 def utc_now():
     return datetime.now(timezone.utc)
+
 
 # Session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -105,6 +105,12 @@ engine = create_engine(
     connect_args=connect_args,
 )
 
+# ---------------------------------------------------------------------------
+# 6. Function to return UTC timestamp
+# ---------------------------------------------------------------------------
+def utc_now():
+    return datetime.now(timezone.utc)
+
 # Session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
@@ -181,7 +187,7 @@ class ToolMetric(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     tool_id: Mapped[str] = mapped_column(String, ForeignKey("tools.id"), nullable=False)
-    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -207,7 +213,7 @@ class ResourceMetric(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     resource_id: Mapped[int] = mapped_column(Integer, ForeignKey("resources.id"), nullable=False)
-    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -233,7 +239,7 @@ class ServerMetric(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     server_id: Mapped[str] = mapped_column(String, ForeignKey("servers.id"), nullable=False)
-    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -259,7 +265,7 @@ class PromptMetric(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     prompt_id: Mapped[int] = mapped_column(Integer, ForeignKey("prompts.id"), nullable=False)
-    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -312,8 +318,8 @@ class Tool(Base):
     headers: Mapped[Optional[Dict[str, str]]] = mapped_column(JSON)
     input_schema: Mapped[Dict[str, Any]] = mapped_column(JSON)
     annotations: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, default=lambda: {})
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     is_active: Mapped[bool] = mapped_column(default=True)
     jsonpath_filter: Mapped[str] = mapped_column(default="")
 
@@ -557,8 +563,8 @@ class Resource(Base):
     mime_type: Mapped[Optional[str]]
     size: Mapped[Optional[int]]
     template: Mapped[Optional[str]]  # URI template for parameterized resources
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     is_active: Mapped[bool] = mapped_column(default=True)
     metrics: Mapped[List["ResourceMetric"]] = relationship("ResourceMetric", back_populates="resource", cascade="all, delete-orphan")
 
@@ -714,7 +720,7 @@ class ResourceSubscription(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     resource_id: Mapped[int] = mapped_column(ForeignKey("resources.id"))
     subscriber_id: Mapped[str]  # Client identifier
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     last_notification: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
     resource: Mapped["Resource"] = relationship(back_populates="subscriptions")
@@ -745,8 +751,8 @@ class Prompt(Base):
     description: Mapped[Optional[str]]
     template: Mapped[str] = mapped_column(Text)
     argument_schema: Mapped[Dict[str, Any]] = mapped_column(JSON)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     is_active: Mapped[bool] = mapped_column(default=True)
     metrics: Mapped[List["PromptMetric"]] = relationship("PromptMetric", back_populates="prompt", cascade="all, delete-orphan")
 
@@ -894,8 +900,8 @@ class Server(Base):
     name: Mapped[str] = mapped_column(unique=True)
     description: Mapped[Optional[str]]
     icon: Mapped[Optional[str]]
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     is_active: Mapped[bool] = mapped_column(default=True)
     metrics: Mapped[List["ServerMetric"]] = relationship("ServerMetric", back_populates="server", cascade="all, delete-orphan")
 
@@ -1014,8 +1020,8 @@ class Gateway(Base):
     description: Mapped[Optional[str]]
     transport: Mapped[str] = mapped_column(default="SSE")
     capabilities: Mapped[Dict[str, Any]] = mapped_column(JSON)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     is_active: Mapped[bool] = mapped_column(default=True)
     last_seen: Mapped[Optional[datetime]]
 
@@ -1086,8 +1092,8 @@ class SessionRecord(Base):
     __tablename__ = "mcp_sessions"
 
     session_id: Mapped[str] = mapped_column(primary_key=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))  # pylint: disable=not-callable
-    last_accessed: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))  # pylint: disable=not-callable
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)  # pylint: disable=not-callable
+    last_accessed: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)  # pylint: disable=not-callable
     data: Mapped[str] = mapped_column(String, nullable=True)
 
     messages: Mapped[List["SessionMessageRecord"]] = relationship("SessionMessageRecord", back_populates="session", cascade="all, delete-orphan")
@@ -1101,8 +1107,8 @@ class SessionMessageRecord(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     session_id: Mapped[str] = mapped_column(ForeignKey("mcp_sessions.session_id"))
     message: Mapped[str] = mapped_column(String, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))  # pylint: disable=not-callable
-    last_accessed: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))  # pylint: disable=not-callable
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)  # pylint: disable=not-callable
+    last_accessed: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)  # pylint: disable=not-callable
 
     session: Mapped["SessionRecord"] = relationship("SessionRecord", back_populates="messages")
 

--- a/mcpgateway/federation/discovery.py
+++ b/mcpgateway/federation/discovery.py
@@ -16,7 +16,7 @@ It supports multiple discovery mechanisms:
 # Standard
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import os
 import socket
@@ -205,7 +205,7 @@ class DiscoveryService(LocalDiscoveryService):
         # Skip if already known
         if url in self._discovered_peers:
             peer = self._discovered_peers[url]
-            peer.last_seen = datetime.utcnow()
+            peer.last_seen = datetime.now(timezone.utc)
             return False
 
         try:
@@ -218,8 +218,8 @@ class DiscoveryService(LocalDiscoveryService):
                 name=name,
                 protocol_version=PROTOCOL_VERSION,
                 capabilities=capabilities,
-                discovered_at=datetime.utcnow(),
-                last_seen=datetime.utcnow(),
+                discovered_at=datetime.now(timezone.utc),
+                last_seen=datetime.now(timezone.utc),
                 source=source,
             )
 
@@ -253,7 +253,7 @@ class DiscoveryService(LocalDiscoveryService):
         try:
             capabilities = await self._get_gateway_info(url)
             self._discovered_peers[url].capabilities = capabilities
-            self._discovered_peers[url].last_seen = datetime.utcnow()
+            self._discovered_peers[url].last_seen = datetime.now(timezone.utc)
             return True
         except Exception as e:
             logger.warning(f"Failed to refresh peer {url}: {e}")
@@ -303,7 +303,7 @@ class DiscoveryService(LocalDiscoveryService):
         """Periodically clean up stale peers."""
         while True:
             try:
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
                 stale_urls = [url for url, peer in self._discovered_peers.items() if now - peer.last_seen > timedelta(minutes=10)]
                 for url in stale_urls:
                     await self.remove_peer(url)

--- a/mcpgateway/federation/discovery.py
+++ b/mcpgateway/federation/discovery.py
@@ -363,7 +363,7 @@ class DiscoveryService(LocalDiscoveryService):
         if result.get("protocol_version") != PROTOCOL_VERSION:
             raise ValueError(f"Unsupported protocol version: {result.get('protocol_version')}")
 
-        return ServerCapabilities.parse_obj(result["capabilities"])
+        return ServerCapabilities.model_validate(result["capabilities"])
 
     async def _exchange_peers(self) -> None:
         """Exchange peer lists with known gateways."""

--- a/mcpgateway/federation/forward.py
+++ b/mcpgateway/federation/forward.py
@@ -15,7 +15,7 @@ It handles:
 
 # Standard
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -233,7 +233,7 @@ class ForwardingService:
                     result = response.json()
 
                     # Update last seen
-                    gateway.last_seen = datetime.utcnow()
+                    gateway.last_seen = datetime.now(timezone.utc)
 
                     # Handle response
                     if "error" in result:
@@ -316,7 +316,7 @@ class ForwardingService:
         Returns:
             True if request allowed
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Clean old history
         self._request_history[gateway_url] = [t for t in self._request_history.get(gateway_url, []) if (now - t).total_seconds() < 60]

--- a/mcpgateway/federation/manager.py
+++ b/mcpgateway/federation/manager.py
@@ -234,7 +234,7 @@ class FederationManager:
         try:
             # Get tool list
             tools = await self.forward_request(gateway, "tools/list")
-            return [Tool.parse_obj(t) for t in tools]
+            return [Tool.model_validate(t) for t in tools]
 
         except Exception as e:
             raise FederationError(f"Failed to get tools from {gateway.name}: {str(e)}")
@@ -259,7 +259,7 @@ class FederationManager:
         try:
             # Get resource list
             resources = await self.forward_request(gateway, "resources/list")
-            return [Resource.parse_obj(r) for r in resources]
+            return [Resource.model_validate(r) for r in resources]
 
         except Exception as e:
             raise FederationError(f"Failed to get resources from {gateway.name}: {str(e)}")
@@ -284,7 +284,7 @@ class FederationManager:
         try:
             # Get prompt list
             prompts = await self.forward_request(gateway, "prompts/list")
-            return [Prompt.parse_obj(p) for p in prompts]
+            return [Prompt.model_validate(p) for p in prompts]
 
         except Exception as e:
             raise FederationError(f"Failed to get prompts from {gateway.name}: {str(e)}")
@@ -422,7 +422,7 @@ class FederationManager:
                 headers=self._get_auth_headers(),
             )
             response.raise_for_status()
-            result = InitializeResult.parse_obj(response.json())
+            result = InitializeResult.model_validate(response.json())
 
             # Verify protocol version
             if result.protocol_version != PROTOCOL_VERSION:

--- a/mcpgateway/federation/manager.py
+++ b/mcpgateway/federation/manager.py
@@ -157,7 +157,7 @@ class FederationManager:
             gateway = DbGateway(
                 name=gateway_name,
                 url=url,
-                capabilities=capabilities.dict(),
+                capabilities=capabilities,
                 last_seen=datetime.now(timezone.utc),
             )
             db.add(gateway)
@@ -350,7 +350,7 @@ class FederationManager:
                     try:
                         # Update capabilities
                         capabilities = await self._initialize_gateway(gateway.url)
-                        gateway.capabilities = capabilities.dict()
+                        gateway.capabilities = capabilities
                         gateway.last_seen = datetime.now(timezone.utc)
                         gateway.is_active = True
 

--- a/mcpgateway/federation/manager.py
+++ b/mcpgateway/federation/manager.py
@@ -18,7 +18,7 @@ operations, coordinating with discovery, sync and forwarding components.
 
 # Standard
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import os
 from typing import Any, Dict, List, Optional, Set
@@ -158,7 +158,7 @@ class FederationManager:
                 name=gateway_name,
                 url=url,
                 capabilities=capabilities.dict(),
-                last_seen=datetime.utcnow(),
+                last_seen=datetime.now(timezone.utc),
             )
             db.add(gateway)
             db.commit()
@@ -195,7 +195,7 @@ class FederationManager:
 
             # Remove gateway
             gateway.is_active = False
-            gateway.updated_at = datetime.utcnow()
+            gateway.updated_at = datetime.now(timezone.utc)
 
             # Remove associated tools
             db.execute(select(DbTool).where(DbTool.gateway_id == gateway_id)).delete()
@@ -315,7 +315,7 @@ class FederationManager:
             result = response.json()
 
             # Update last seen
-            gateway.last_seen = datetime.utcnow()
+            gateway.last_seen = datetime.now(timezone.utc)
 
             # Handle response
             if "error" in result:
@@ -351,7 +351,7 @@ class FederationManager:
                         # Update capabilities
                         capabilities = await self._initialize_gateway(gateway.url)
                         gateway.capabilities = capabilities.dict()
-                        gateway.last_seen = datetime.utcnow()
+                        gateway.last_seen = datetime.now(timezone.utc)
                         gateway.is_active = True
 
                     except Exception as e:
@@ -383,7 +383,7 @@ class FederationManager:
                     except Exception as e:
                         logger.warning(f"Health check failed for {gateway.name}: {e}")
                         # Mark inactive if not seen recently
-                        if datetime.utcnow() - gateway.last_seen > timedelta(minutes=5):
+                        if datetime.now(timezone.utc) - gateway.last_seen > timedelta(minutes=5):
                             gateway.is_active = False
                             self._active_gateways.discard(gateway.url)
 

--- a/mcpgateway/handlers/sampling.py
+++ b/mcpgateway/handlers/sampling.py
@@ -71,7 +71,7 @@ class SamplingHandler:
             # Extract request parameters
             messages = request.get("messages", [])
             max_tokens = request.get("maxTokens")
-            model_prefs = ModelPreferences.parse_obj(request.get("modelPreferences", {}))
+            model_prefs = ModelPreferences.model_validate(request.get("modelPreferences", {}))
             include_context = request.get("includeContext", "none")
             request.get("metadata", {})
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -812,7 +812,7 @@ async def server_get_tools(
     """
     logger.debug(f"User: {user} has listed tools for the server_id: {server_id}")
     tools = await tool_service.list_server_tools(db, server_id=server_id, include_inactive=include_inactive)
-    return [tool.dict(by_alias=True) for tool in tools]
+    return [tool.model_dump(by_alias=True) for tool in tools]
 
 
 @server_router.get("/{server_id}/resources", response_model=List[ResourceRead])
@@ -840,7 +840,7 @@ async def server_get_resources(
     """
     logger.debug(f"User: {user} has listed resources for the server_id: {server_id}")
     resources = await resource_service.list_server_resources(db, server_id=server_id, include_inactive=include_inactive)
-    return [resource.dict(by_alias=True) for resource in resources]
+    return [resource.model_dump(by_alias=True) for resource in resources]
 
 
 @server_router.get("/{server_id}/prompts", response_model=List[PromptRead])
@@ -868,7 +868,7 @@ async def server_get_prompts(
     """
     logger.debug(f"User: {user} has listed prompts for the server_id: {server_id}")
     prompts = await prompt_service.list_server_prompts(db, server_id=server_id, include_inactive=include_inactive)
-    return [prompt.dict(by_alias=True) for prompt in prompts]
+    return [prompt.model_dump(by_alias=True) for prompt in prompts]
 
 
 #############

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -443,13 +443,6 @@ class ToolRead(BaseModelWithConfigDict):
     gateway_slug: str
     original_name_slug: str
 
-    # class Config(BaseModelWithConfigDict.Config):
-    #     """
-    #     A configuration class that inherits from BaseModelWithConfigDict.Config.
-    #     This class may be used to define specific configurations, extending
-    #     the base functionality of BaseModelWithConfigDict.
-    #     """
-
 
 class ToolInvocation(BaseModelWithConfigDict):
     """Schema for tool invocation requests.
@@ -576,20 +569,6 @@ class PromptArgument(BaseModelWithConfigDict):
         **BaseModelWithConfigDict.model_config,   # carry over the base settings
         schema_extra = {"example": {"name": "language", "description": "Programming language", "required": True}}
     )
-
-    # class Config(BaseModelWithConfigDict.Config):
-    #     """
-    #     A configuration class that inherits from BaseModelWithConfigDict.Config.
-
-    #     This class defines an example schema for configuration, which includes:
-    #     - 'name': A string representing the name of the configuration (e.g., "language").
-    #     - 'description': A brief description of the configuration (e.g., "Programming language").
-    #     - 'required': A boolean indicating if the configuration is mandatory (e.g., True).
-
-    #     The `schema_extra` attribute provides an example of how the configuration should be structured.
-    #     """
-
-    #     schema_extra = {"example": {"name": "language", "description": "Programming language", "required": True}}
 
 
 class PromptCreate(BaseModelWithConfigDict):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -21,7 +21,7 @@ gateway-specific extensions for federation support.
 
 # Standard
 import base64
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -542,7 +542,7 @@ class ResourceNotification(BaseModelWithConfig):
 
     uri: str
     content: ResourceContent
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 # --- Prompt Schemas ---
@@ -893,10 +893,10 @@ class GatewayRead(BaseModelWithConfig):
     description: Optional[str] = Field(None, description="Gateway description")
     transport: str = Field(default="SSE", description="Transport used by MCP server: SSE or STREAMABLEHTTP")
     capabilities: Dict[str, Any] = Field(default_factory=dict, description="Gateway capabilities")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
-    updated_at: datetime = Field(default_factory=datetime.utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Creation timestamp")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Last update timestamp")
     is_active: bool = Field(default=True, description="Is the gateway active?")
-    last_seen: Optional[datetime] = Field(default_factory=datetime.utcnow, description="Last seen timestamp")
+    last_seen: Optional[datetime] = Field(default_factory=lambda: datetime.now(timezone.utc), description="Last seen timestamp")
 
     # Authorizations
     auth_type: Optional[str] = Field(None, description="auth_type: basic, bearer, headers or None")
@@ -1030,7 +1030,7 @@ class EventMessage(BaseModelWithConfig):
 
     type: str = Field(..., description="Event type (tool_added, resource_updated, etc)")
     data: Dict[str, Any] = Field(..., description="Event payload")
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class AdminToolCreate(BaseModelWithConfig):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -42,6 +42,7 @@ from pydantic import (
     model_validator,
     root_validator,
     validator,
+    ConfigDict
 )
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ def encode_datetime(v: datetime) -> str:
 
 
 # --- Base Model ---
-class BaseModelWithConfig(BaseModel):
+class BaseModelWithConfigDict(BaseModel):
     """Base model with common configuration.
 
     Provides:
@@ -91,29 +92,39 @@ class BaseModelWithConfig(BaseModel):
     - Automatic conversion from snake_case to camelCase for output
     """
 
-    class Config:
-        """
-        A configuration class that provides default behaviors for how to handle serialization,
-        alias generation, enum values, and extra fields when working with models.
+    model_config = ConfigDict(
+        from_attributes=True,
+        alias_generator=to_camel_case,
+        populate_by_name=True,
+        json_encoders={datetime: encode_datetime},
+        use_enum_values=True,
+        extra="ignore",
+        json_schema_extra={"nullable": True},
+    )
 
-        Attributes:
-            from_attributes (bool): Flag to indicate if attributes should be taken from model fields.
-            alias_generator (callable): Function used to generate aliases for field names (e.g., converting to camelCase).
-            populate_by_name (bool): Flag to specify whether to populate fields by name during initialization.
-            json_encoders (dict): Custom JSON encoders for specific types, such as datetime encoding.
-            use_enum_values (bool): Flag to determine if enum values should be serialized or the enum type itself.
-            extra (str): Defines behavior for extra fields in models. The "ignore" option means extra fields are ignored.
-            json_schema_extra (dict): Additional schema information, e.g., specifying that fields can be nullable.
+    # class Config:
+    #     """
+    #     A configuration class that provides default behaviors for how to handle serialization,
+    #     alias generation, enum values, and extra fields when working with models.
 
-        """
+    #     Attributes:
+    #         from_attributes (bool): Flag to indicate if attributes should be taken from model fields.
+    #         alias_generator (callable): Function used to generate aliases for field names (e.g., converting to camelCase).
+    #         populate_by_name (bool): Flag to specify whether to populate fields by name during initialization.
+    #         json_encoders (dict): Custom JSON encoders for specific types, such as datetime encoding.
+    #         use_enum_values (bool): Flag to determine if enum values should be serialized or the enum type itself.
+    #         extra (str): Defines behavior for extra fields in models. The "ignore" option means extra fields are ignored.
+    #         json_schema_extra (dict): Additional schema information, e.g., specifying that fields can be nullable.
 
-        from_attributes = True
-        alias_generator = to_camel_case
-        populate_by_name = True
-        json_encoders = {datetime: encode_datetime}
-        use_enum_values = True
-        extra = "ignore"
-        json_schema_extra = {"nullable": True}
+    #     """
+
+    #     from_attributes = True
+    #     alias_generator = to_camel_case
+    #     populate_by_name = True
+    #     json_encoders = {datetime: encode_datetime}
+    #     use_enum_values = True
+    #     extra = "ignore"
+    #     json_schema_extra = {"nullable": True}
 
     def to_dict(self, use_alias: bool = False) -> Dict[str, Any]:
         """
@@ -136,7 +147,7 @@ class BaseModelWithConfig(BaseModel):
 # --- Metrics Schemas ---
 
 
-class ToolMetrics(BaseModelWithConfig):
+class ToolMetrics(BaseModelWithConfigDict):
     """
     Represents the performance and execution statistics for a tool.
 
@@ -161,7 +172,7 @@ class ToolMetrics(BaseModelWithConfig):
     last_execution_time: Optional[datetime] = Field(None, description="Timestamp of the most recent invocation")
 
 
-class ResourceMetrics(BaseModelWithConfig):
+class ResourceMetrics(BaseModelWithConfigDict):
     """
     Represents the performance and execution statistics for a resource.
 
@@ -186,7 +197,7 @@ class ResourceMetrics(BaseModelWithConfig):
     last_execution_time: Optional[datetime] = Field(None, description="Timestamp of the most recent invocation")
 
 
-class ServerMetrics(BaseModelWithConfig):
+class ServerMetrics(BaseModelWithConfigDict):
     """
     Represents the performance and execution statistics for a server.
 
@@ -211,7 +222,7 @@ class ServerMetrics(BaseModelWithConfig):
     last_execution_time: Optional[datetime] = Field(None, description="Timestamp of the most recent invocation")
 
 
-class PromptMetrics(BaseModelWithConfig):
+class PromptMetrics(BaseModelWithConfigDict):
     """
     Represents the performance and execution statistics for a prompt.
 
@@ -239,7 +250,7 @@ class PromptMetrics(BaseModelWithConfig):
 # --- JSON Path API modifier Schema
 
 
-class JsonPathModifier(BaseModelWithConfig):
+class JsonPathModifier(BaseModelWithConfigDict):
     """Schema for JSONPath queries.
 
     Provides the structure for parsing JSONPath queries and optional mapping.
@@ -251,7 +262,7 @@ class JsonPathModifier(BaseModelWithConfig):
 
 # --- Tool Schemas ---
 # Authentication model
-class AuthenticationValues(BaseModelWithConfig):
+class AuthenticationValues(BaseModelWithConfigDict):
     """Schema for all Authentications.
     Provides the authentication values for different types of authentication.
     """
@@ -267,7 +278,7 @@ class AuthenticationValues(BaseModelWithConfig):
     auth_header_value: str = Field("", description="Value for custom headers authentication")
 
 
-class ToolCreate(BaseModelWithConfig):
+class ToolCreate(BaseModelWithConfigDict):
     """Schema for creating a new tool.
 
     Supports both MCP-compliant tools and REST integrations. Validates:
@@ -338,7 +349,7 @@ class ToolCreate(BaseModelWithConfig):
         return values
 
 
-class ToolUpdate(BaseModelWithConfig):
+class ToolUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing tool.
 
     Similar to ToolCreate but all fields are optional to allow partial updates.
@@ -398,7 +409,7 @@ class ToolUpdate(BaseModelWithConfig):
         return values
 
 
-class ToolRead(BaseModelWithConfig):
+class ToolRead(BaseModelWithConfigDict):
     """Schema for reading tool information.
 
     Includes all tool fields plus:
@@ -432,15 +443,15 @@ class ToolRead(BaseModelWithConfig):
     gateway_slug: str
     original_name_slug: str
 
-    class Config(BaseModelWithConfig.Config):
-        """
-        A configuration class that inherits from BaseModelWithConfig.Config.
-        This class may be used to define specific configurations, extending
-        the base functionality of BaseModelWithConfig.
-        """
+    # class Config(BaseModelWithConfigDict.Config):
+    #     """
+    #     A configuration class that inherits from BaseModelWithConfigDict.Config.
+    #     This class may be used to define specific configurations, extending
+    #     the base functionality of BaseModelWithConfigDict.
+    #     """
 
 
-class ToolInvocation(BaseModelWithConfig):
+class ToolInvocation(BaseModelWithConfigDict):
     """Schema for tool invocation requests.
 
     Captures:
@@ -452,7 +463,7 @@ class ToolInvocation(BaseModelWithConfig):
     arguments: Dict[str, Any] = Field(default_factory=dict, description="Arguments matching tool's input schema")
 
 
-class ToolResult(BaseModelWithConfig):
+class ToolResult(BaseModelWithConfigDict):
     """Schema for tool invocation results.
 
     Supports:
@@ -466,7 +477,7 @@ class ToolResult(BaseModelWithConfig):
     error_message: Optional[str] = None
 
 
-class ResourceCreate(BaseModelWithConfig):
+class ResourceCreate(BaseModelWithConfigDict):
     """Schema for creating a new resource.
 
     Supports:
@@ -483,7 +494,7 @@ class ResourceCreate(BaseModelWithConfig):
     content: Union[str, bytes] = Field(..., description="Resource content (text or binary)")
 
 
-class ResourceUpdate(BaseModelWithConfig):
+class ResourceUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing resource.
 
     Similar to ResourceCreate but URI is not required and all fields are optional.
@@ -496,7 +507,7 @@ class ResourceUpdate(BaseModelWithConfig):
     content: Optional[Union[str, bytes]] = Field(None, description="Resource content (text or binary)")
 
 
-class ResourceRead(BaseModelWithConfig):
+class ResourceRead(BaseModelWithConfigDict):
     """Schema for reading resource information.
 
     Includes all resource fields plus:
@@ -519,7 +530,7 @@ class ResourceRead(BaseModelWithConfig):
     metrics: ResourceMetrics
 
 
-class ResourceSubscription(BaseModelWithConfig):
+class ResourceSubscription(BaseModelWithConfigDict):
     """Schema for resource subscriptions.
 
     Tracks:
@@ -531,7 +542,7 @@ class ResourceSubscription(BaseModelWithConfig):
     subscriber_id: str = Field(..., description="Unique subscriber identifier")
 
 
-class ResourceNotification(BaseModelWithConfig):
+class ResourceNotification(BaseModelWithConfigDict):
     """Schema for resource update notifications.
 
     Contains:
@@ -548,7 +559,7 @@ class ResourceNotification(BaseModelWithConfig):
 # --- Prompt Schemas ---
 
 
-class PromptArgument(BaseModelWithConfig):
+class PromptArgument(BaseModelWithConfigDict):
     """Schema for prompt template arguments.
 
     Defines:
@@ -561,22 +572,27 @@ class PromptArgument(BaseModelWithConfig):
     description: Optional[str] = Field(None, description="Argument description")
     required: bool = Field(default=False, description="Whether argument is required")
 
-    class Config(BaseModelWithConfig.Config):
-        """
-        A configuration class that inherits from BaseModelWithConfig.Config.
-
-        This class defines an example schema for configuration, which includes:
-        - 'name': A string representing the name of the configuration (e.g., "language").
-        - 'description': A brief description of the configuration (e.g., "Programming language").
-        - 'required': A boolean indicating if the configuration is mandatory (e.g., True).
-
-        The `schema_extra` attribute provides an example of how the configuration should be structured.
-        """
-
+    model_config: ConfigDict = ConfigDict(
+        **BaseModelWithConfigDict.model_config,   # carry over the base settings
         schema_extra = {"example": {"name": "language", "description": "Programming language", "required": True}}
+    )
+
+    # class Config(BaseModelWithConfigDict.Config):
+    #     """
+    #     A configuration class that inherits from BaseModelWithConfigDict.Config.
+
+    #     This class defines an example schema for configuration, which includes:
+    #     - 'name': A string representing the name of the configuration (e.g., "language").
+    #     - 'description': A brief description of the configuration (e.g., "Programming language").
+    #     - 'required': A boolean indicating if the configuration is mandatory (e.g., True).
+
+    #     The `schema_extra` attribute provides an example of how the configuration should be structured.
+    #     """
+
+    #     schema_extra = {"example": {"name": "language", "description": "Programming language", "required": True}}
 
 
-class PromptCreate(BaseModelWithConfig):
+class PromptCreate(BaseModelWithConfigDict):
     """Schema for creating a new prompt template.
 
     Includes:
@@ -591,7 +607,7 @@ class PromptCreate(BaseModelWithConfig):
     arguments: List[PromptArgument] = Field(default_factory=list, description="List of arguments for the template")
 
 
-class PromptUpdate(BaseModelWithConfig):
+class PromptUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing prompt.
 
     Similar to PromptCreate but all fields are optional to allow partial updates.
@@ -603,7 +619,7 @@ class PromptUpdate(BaseModelWithConfig):
     arguments: Optional[List[PromptArgument]] = Field(None, description="List of arguments for the template")
 
 
-class PromptRead(BaseModelWithConfig):
+class PromptRead(BaseModelWithConfigDict):
     """Schema for reading prompt information.
 
     Includes all prompt fields plus:
@@ -624,7 +640,7 @@ class PromptRead(BaseModelWithConfig):
     metrics: PromptMetrics
 
 
-class PromptInvocation(BaseModelWithConfig):
+class PromptInvocation(BaseModelWithConfigDict):
     """Schema for prompt invocation requests.
 
     Contains:
@@ -639,7 +655,7 @@ class PromptInvocation(BaseModelWithConfig):
 # --- Gateway Schemas ---
 
 
-class GatewayCreate(BaseModelWithConfig):
+class GatewayCreate(BaseModelWithConfigDict):
     """Schema for registering a new federation gateway.
 
     Captures:
@@ -756,7 +772,7 @@ class GatewayCreate(BaseModelWithConfig):
         raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, or headers.")
 
 
-class GatewayUpdate(BaseModelWithConfig):
+class GatewayUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing federation gateway.
 
     Similar to GatewayCreate but all fields are optional to allow partial updates.
@@ -867,7 +883,7 @@ class GatewayUpdate(BaseModelWithConfig):
         raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, or headers.")
 
 
-class GatewayRead(BaseModelWithConfig):
+class GatewayRead(BaseModelWithConfigDict):
     """Schema for reading gateway information.
 
     Includes all gateway fields plus:
@@ -940,7 +956,7 @@ class GatewayRead(BaseModelWithConfig):
         return values
 
 
-class FederatedTool(BaseModelWithConfig):
+class FederatedTool(BaseModelWithConfigDict):
     """Schema for tools provided by federated gateways.
 
     Contains:
@@ -954,7 +970,7 @@ class FederatedTool(BaseModelWithConfig):
     gateway_url: str
 
 
-class FederatedResource(BaseModelWithConfig):
+class FederatedResource(BaseModelWithConfigDict):
     """Schema for resources from federated gateways.
 
     Contains:
@@ -968,7 +984,7 @@ class FederatedResource(BaseModelWithConfig):
     gateway_url: str
 
 
-class FederatedPrompt(BaseModelWithConfig):
+class FederatedPrompt(BaseModelWithConfigDict):
     """Schema for prompts from federated gateways.
 
     Contains:
@@ -985,7 +1001,7 @@ class FederatedPrompt(BaseModelWithConfig):
 # --- RPC Schemas ---
 
 
-class RPCRequest(BaseModelWithConfig):
+class RPCRequest(BaseModelWithConfigDict):
     """Schema for JSON-RPC 2.0 requests.
 
     Validates:
@@ -1001,7 +1017,7 @@ class RPCRequest(BaseModelWithConfig):
     id: Optional[Union[int, str]] = None
 
 
-class RPCResponse(BaseModelWithConfig):
+class RPCResponse(BaseModelWithConfigDict):
     """Schema for JSON-RPC 2.0 responses.
 
     Contains:
@@ -1019,7 +1035,7 @@ class RPCResponse(BaseModelWithConfig):
 # --- Event and Admin Schemas ---
 
 
-class EventMessage(BaseModelWithConfig):
+class EventMessage(BaseModelWithConfigDict):
     """Schema for SSE event messages.
 
     Includes:
@@ -1033,7 +1049,7 @@ class EventMessage(BaseModelWithConfig):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
-class AdminToolCreate(BaseModelWithConfig):
+class AdminToolCreate(BaseModelWithConfigDict):
     """Schema for creating tools via admin UI.
 
     Handles:
@@ -1070,7 +1086,7 @@ class AdminToolCreate(BaseModelWithConfig):
             raise ValueError("Invalid JSON")
 
 
-class AdminGatewayCreate(BaseModelWithConfig):
+class AdminGatewayCreate(BaseModelWithConfigDict):
     """Schema for creating gateways via admin UI.
 
     Captures:
@@ -1087,13 +1103,13 @@ class AdminGatewayCreate(BaseModelWithConfig):
 # --- New Schemas for Status Toggle Operations ---
 
 
-class StatusToggleRequest(BaseModelWithConfig):
+class StatusToggleRequest(BaseModelWithConfigDict):
     """Request schema for toggling active status."""
 
     activate: bool = Field(..., description="Whether to activate (true) or deactivate (false) the item")
 
 
-class StatusToggleResponse(BaseModelWithConfig):
+class StatusToggleResponse(BaseModelWithConfigDict):
     """Response schema for status toggle operations."""
 
     id: int
@@ -1105,7 +1121,7 @@ class StatusToggleResponse(BaseModelWithConfig):
 # --- Optional Filter Parameters for Listing Operations ---
 
 
-class ListFilters(BaseModelWithConfig):
+class ListFilters(BaseModelWithConfigDict):
     """Filtering options for list operations."""
 
     include_inactive: bool = Field(False, description="Whether to include inactive items in the results")
@@ -1114,7 +1130,7 @@ class ListFilters(BaseModelWithConfig):
 # --- Server Schemas ---
 
 
-class ServerCreate(BaseModelWithConfig):
+class ServerCreate(BaseModelWithConfigDict):
     """Schema for creating a new server.
 
     Attributes:
@@ -1149,7 +1165,7 @@ class ServerCreate(BaseModelWithConfig):
         return v
 
 
-class ServerUpdate(BaseModelWithConfig):
+class ServerUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing server.
 
     All fields are optional to allow partial updates.
@@ -1178,7 +1194,7 @@ class ServerUpdate(BaseModelWithConfig):
         return v
 
 
-class ServerRead(BaseModelWithConfig):
+class ServerRead(BaseModelWithConfigDict):
     """Schema for reading server information.
 
     Includes all server fields plus:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -35,16 +35,7 @@ from mcpgateway.types import Tool as MCPTool
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 
 # Third-Party
-from pydantic import (
-    AnyHttpUrl,
-    BaseModel,
-    Field,
-    model_validator,
-    ConfigDict,
-    field_serializer,
-    field_validator,
-    ValidationInfo
-)
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator, ValidationInfo
 
 logger = logging.getLogger(__name__)
 
@@ -546,7 +537,6 @@ class PromptArgument(BaseModelWithConfigDict):
     description: Optional[str] = Field(None, description="Argument description")
     required: bool = Field(default=False, description="Whether argument is required")
 
-
     model_config: ConfigDict = ConfigDict(
         **{
             # start with every key from the base
@@ -555,9 +545,9 @@ class PromptArgument(BaseModelWithConfigDict):
             "json_schema_extra": {
                 **BaseModelWithConfigDict.model_config.get("json_schema_extra", {}),
                 "example": {
-                    "name":        "language",
+                    "name": "language",
                     "description": "Programming language",
-                    "required":    True,
+                    "required": True,
                 },
             },
         }
@@ -702,7 +692,7 @@ class GatewayCreate(BaseModelWithConfigDict):
         This method is called based on the selected auth_type.
 
         Args:
-            values: Dict containing auth fields
+            info: ValidationInfo containing auth fields
 
         Returns:
             Dict with encoded auth
@@ -792,7 +782,7 @@ class GatewayUpdate(BaseModelWithConfigDict):
 
         Args:
             v: Input URL
-            values: Dict containing auth_type
+            info: ValidationInfo containing auth_type
 
         Returns:
             str: Auth value or URL

--- a/mcpgateway/services/logging_service.py
+++ b/mcpgateway/services/logging_service.py
@@ -11,7 +11,7 @@ It supports RFC 5424 severity levels, log level management, and log event subscr
 
 # Standard
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -106,7 +106,7 @@ class LoggingService:
             "data": {
                 "level": level,
                 "data": data,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             },
         }
         if logger_name:

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -16,7 +16,7 @@ It handles:
 
 # Standard
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from string import Formatter
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set
@@ -377,7 +377,7 @@ class PromptService:
                     argument_schema["properties"][arg.name] = schema
                 prompt.argument_schema = argument_schema
 
-            prompt.updated_at = datetime.utcnow()
+            prompt.updated_at = datetime.now(timezone.utc)
             db.commit()
             db.refresh(prompt)
 
@@ -409,7 +409,7 @@ class PromptService:
                 raise PromptNotFoundError(f"Prompt not found: {prompt_id}")
             if prompt.is_active != activate:
                 prompt.is_active = activate
-                prompt.updated_at = datetime.utcnow()
+                prompt.updated_at = datetime.now(timezone.utc)
                 db.commit()
                 db.refresh(prompt)
                 if activate:
@@ -602,7 +602,7 @@ class PromptService:
                 "description": prompt.description,
                 "is_active": prompt.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -621,7 +621,7 @@ class PromptService:
                 "description": prompt.description,
                 "is_active": prompt.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -635,7 +635,7 @@ class PromptService:
         event = {
             "type": "prompt_activated",
             "data": {"id": prompt.id, "name": prompt.name, "is_active": True},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -649,7 +649,7 @@ class PromptService:
         event = {
             "type": "prompt_deactivated",
             "data": {"id": prompt.id, "name": prompt.name, "is_active": False},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -663,7 +663,7 @@ class PromptService:
         event = {
             "type": "prompt_deleted",
             "data": prompt_info,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -677,7 +677,7 @@ class PromptService:
         event = {
             "type": "prompt_removed",
             "data": {"id": prompt.id, "name": prompt.name, "is_active": False},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -16,7 +16,7 @@ It handles:
 
 # Standard
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import mimetypes
 import re
@@ -316,7 +316,7 @@ class ResourceService:
             # Update status if it's different
             if resource.is_active != activate:
                 resource.is_active = activate
-                resource.updated_at = datetime.utcnow()
+                resource.updated_at = datetime.now(timezone.utc)
                 db.commit()
                 db.refresh(resource)
 
@@ -443,7 +443,7 @@ class ResourceService:
                 )
                 resource.size = len(resource_update.content)
 
-            resource.updated_at = datetime.utcnow()
+            resource.updated_at = datetime.now(timezone.utc)
             db.commit()
             db.refresh(resource)
 
@@ -553,7 +553,7 @@ class ResourceService:
                 "name": resource.name,
                 "is_active": True,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(resource.uri, event)
 
@@ -572,7 +572,7 @@ class ResourceService:
                 "name": resource.name,
                 "is_active": False,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(resource.uri, event)
 
@@ -586,7 +586,7 @@ class ResourceService:
         event = {
             "type": "resource_deleted",
             "data": resource_info,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(resource_info["uri"], event)
 
@@ -605,7 +605,7 @@ class ResourceService:
                 "name": resource.name,
                 "is_active": False,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(resource.uri, event)
 
@@ -762,7 +762,7 @@ class ResourceService:
                 "description": resource.description,
                 "is_active": resource.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(resource.uri, event)
 
@@ -781,7 +781,7 @@ class ResourceService:
                 "content": resource.content,
                 "is_active": resource.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(resource.uri, event)
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -14,7 +14,7 @@ It also publishes event notifications for server changes.
 
 # Standard
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -350,7 +350,7 @@ class ServerService:
                     if prompt_obj:
                         server.prompts.append(prompt_obj)
 
-            server.updated_at = datetime.utcnow()
+            server.updated_at = datetime.now(timezone.utc)
             db.commit()
             db.refresh(server)
             # Force loading relationships
@@ -400,7 +400,7 @@ class ServerService:
 
             if server.is_active != activate:
                 server.is_active = activate
-                server.updated_at = datetime.utcnow()
+                server.updated_at = datetime.now(timezone.utc)
                 db.commit()
                 db.refresh(server)
                 if activate:
@@ -500,7 +500,7 @@ class ServerService:
                 "associated_prompts": associated_prompts,
                 "is_active": server.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -526,7 +526,7 @@ class ServerService:
                 "associated_prompts": associated_prompts,
                 "is_active": server.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -544,7 +544,7 @@ class ServerService:
                 "name": server.name,
                 "is_active": True,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -562,7 +562,7 @@ class ServerService:
                 "name": server.name,
                 "is_active": False,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -576,7 +576,7 @@ class ServerService:
         event = {
             "type": "server_deleted",
             "data": server_info,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -434,7 +434,7 @@ class ToolService:
                     response = await self._http_client.get(final_url, params=payload, headers=headers)
                 else:
                     response = await self._http_client.request(method, final_url, json=payload, headers=headers)
-                response.raise_for_status()
+                await response.raise_for_status()
 
                 # Handle 204 No Content responses that have no body
                 if response.status_code == 204:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -17,7 +17,7 @@ It handles:
 # Standard
 import asyncio
 import base64
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
 import re
@@ -357,7 +357,7 @@ class ToolService:
                 raise ToolNotFoundError(f"Tool not found: {tool_id}")
             if tool.is_active != activate:
                 tool.is_active = activate
-                tool.updated_at = datetime.utcnow()
+                tool.updated_at = datetime.now(timezone.utc)
                 db.commit()
                 db.refresh(tool)
                 if activate:
@@ -574,7 +574,7 @@ class ToolService:
             else:
                 tool.auth_type = None
 
-            tool.updated_at = datetime.utcnow()
+            tool.updated_at = datetime.now(timezone.utc)
             db.commit()
             db.refresh(tool)
             await self._notify_tool_updated(tool)
@@ -600,7 +600,7 @@ class ToolService:
                 "description": tool.description,
                 "is_active": tool.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -614,7 +614,7 @@ class ToolService:
         event = {
             "type": "tool_activated",
             "data": {"id": tool.id, "name": tool.name, "is_active": True},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -628,7 +628,7 @@ class ToolService:
         event = {
             "type": "tool_deactivated",
             "data": {"id": tool.id, "name": tool.name, "is_active": False},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -642,7 +642,7 @@ class ToolService:
         event = {
             "type": "tool_deleted",
             "data": tool_info,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -677,7 +677,7 @@ class ToolService:
                 "description": tool.description,
                 "is_active": tool.is_active,
             },
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 
@@ -691,7 +691,7 @@ class ToolService:
         event = {
             "type": "tool_removed",
             "data": {"id": tool.id, "name": tool.name, "is_active": False},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         await self._publish_event(event)
 

--- a/mcpgateway/translate.py
+++ b/mcpgateway/translate.py
@@ -382,11 +382,14 @@ async def _run_sse_to_stdio(url: str, oauth2_bearer: Optional[str], log_level: s
 
         await asyncio.gather(read_stdout(), pump_sse_to_stdio())
 
+
 def start_stdio(cmd, port, log_level, cors):
     return asyncio.run(_run_stdio_to_sse(cmd, port, log_level, cors))
 
+
 def start_sse(url, bearer, log_level):
     return asyncio.run(_run_sse_to_stdio(url, bearer, log_level))
+
 
 def main(argv: Optional[Sequence[str]] | None = None) -> None:  # entry-point
     args = _parse_args(argv or sys.argv[1:])

--- a/mcpgateway/translate.py
+++ b/mcpgateway/translate.py
@@ -382,6 +382,11 @@ async def _run_sse_to_stdio(url: str, oauth2_bearer: Optional[str], log_level: s
 
         await asyncio.gather(read_stdout(), pump_sse_to_stdio())
 
+def start_stdio(cmd, port, log_level, cors):
+    return asyncio.run(_run_stdio_to_sse(cmd, port, log_level, cors))
+
+def start_sse(url, bearer, log_level):
+    return asyncio.run(_run_sse_to_stdio(url, bearer, log_level))
 
 def main(argv: Optional[Sequence[str]] | None = None) -> None:  # entry-point
     args = _parse_args(argv or sys.argv[1:])
@@ -391,9 +396,9 @@ def main(argv: Optional[Sequence[str]] | None = None) -> None:  # entry-point
     )
     try:
         if args.stdio:
-            asyncio.run(_run_stdio_to_sse(args.stdio, args.port, args.logLevel, args.cors))
+            return start_stdio(args.stdio, args.port, args.logLevel, args.cors)
         elif args.sse:
-            asyncio.run(_run_sse_to_stdio(args.sse, args.oauth2Bearer, args.logLevel))
+            return start_sse(args.sse, args.oauth2Bearer, args.logLevel)
     except KeyboardInterrupt:
         print("")  # restore shell prompt
         sys.exit(0)

--- a/mcpgateway/types.py
+++ b/mcpgateway/types.py
@@ -22,7 +22,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
 # Third-Party
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, ConfigDict
 
 
 class Role(str, Enum):
@@ -258,16 +258,21 @@ class InitializeRequest(BaseModel):
     capabilities: ClientCapabilities
     client_info: Implementation = Field(..., alias="clientInfo")
 
-    class Config:
-        """Configuration for InitializeRequest.
+    model_config = ConfigDict(
+        populate_by_name=True,
+        allow_population_by_field_name=True,
+    )
 
-        Attributes:
-            populate_by_name (bool): Enables population by field name.
-            allow_population_by_field_name (bool): Allows backward compatibility with older Pydantic versions.
-        """
+    # class Config:
+    #     """Configuration for InitializeRequest.
 
-        populate_by_name = True
-        allow_population_by_field_name = True  # Use this for backward compatibility with older Pydantic versions
+    #     Attributes:
+    #         populate_by_name (bool): Enables population by field name.
+    #         allow_population_by_field_name (bool): Allows backward compatibility with older Pydantic versions.
+    #     """
+
+    #     populate_by_name = True
+    #     allow_population_by_field_name = True  # Use this for backward compatibility with older Pydantic versions
 
 
 class InitializeResult(BaseModel):
@@ -285,15 +290,20 @@ class InitializeResult(BaseModel):
     server_info: Implementation = Field(..., alias="serverInfo")
     instructions: Optional[str] = Field(None, alias="instructions")
 
-    class Config:
-        """
-        Configuration class for Pydantic models.
+    model_config = ConfigDict(
+        populate_by_name=True,
+        allow_population_by_field_name=True,
+    )
 
-        Enables population of model fields by name and by field name.
-        """
+    # class Config:
+    #     """
+    #     Configuration class for Pydantic models.
 
-        populate_by_name = True
-        allow_population_by_field_name = True
+    #     Enables population of model fields by name and by field name.
+    #     """
+
+    #     populate_by_name = True
+    #     allow_population_by_field_name = True
 
 
 # Message types
@@ -474,11 +484,16 @@ class ListResourceTemplatesResult(BaseModel):
     next_cursor: Optional[str] = Field(None, description="An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.")
     resource_templates: List[ResourceTemplate] = Field(default_factory=list, description="List of resource templates available on the server")
 
-    class Config:
-        """Configuration for model serialization."""
+    model_config = ConfigDict(
+        populate_by_name=True,
+        allow_population_by_field_name=True,
+    )
 
-        populate_by_name = True
-        allow_population_by_field_name = True
+    # class Config:
+    #     """Configuration for model serialization."""
+
+    #     populate_by_name = True
+    #     allow_population_by_field_name = True
 
 
 # Root types

--- a/mcpgateway/types.py
+++ b/mcpgateway/types.py
@@ -22,7 +22,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
 # Third-Party
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, ConfigDict
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field
 
 
 class Role(str, Enum):
@@ -282,6 +282,7 @@ class InitializeResult(BaseModel):
         populate_by_name=True,
     )
 
+
 # Message types
 class Message(BaseModel):
     """A message in a conversation.
@@ -463,6 +464,7 @@ class ListResourceTemplatesResult(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+
 
 # Root types
 class FileUrl(AnyUrl):

--- a/mcpgateway/types.py
+++ b/mcpgateway/types.py
@@ -260,19 +260,7 @@ class InitializeRequest(BaseModel):
 
     model_config = ConfigDict(
         populate_by_name=True,
-        allow_population_by_field_name=True,
     )
-
-    # class Config:
-    #     """Configuration for InitializeRequest.
-
-    #     Attributes:
-    #         populate_by_name (bool): Enables population by field name.
-    #         allow_population_by_field_name (bool): Allows backward compatibility with older Pydantic versions.
-    #     """
-
-    #     populate_by_name = True
-    #     allow_population_by_field_name = True  # Use this for backward compatibility with older Pydantic versions
 
 
 class InitializeResult(BaseModel):
@@ -292,19 +280,7 @@ class InitializeResult(BaseModel):
 
     model_config = ConfigDict(
         populate_by_name=True,
-        allow_population_by_field_name=True,
     )
-
-    # class Config:
-    #     """
-    #     Configuration class for Pydantic models.
-
-    #     Enables population of model fields by name and by field name.
-    #     """
-
-    #     populate_by_name = True
-    #     allow_population_by_field_name = True
-
 
 # Message types
 class Message(BaseModel):
@@ -486,15 +462,7 @@ class ListResourceTemplatesResult(BaseModel):
 
     model_config = ConfigDict(
         populate_by_name=True,
-        allow_population_by_field_name=True,
     )
-
-    # class Config:
-    #     """Configuration for model serialization."""
-
-    #     populate_by_name = True
-    #     allow_population_by_field_name = True
-
 
 # Root types
 class FileUrl(AnyUrl):

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -402,7 +402,7 @@ async def version_endpoint(
     if partial:
         # Return partial HTML fragment for HTMX embedding
         templates = Jinja2Templates(directory=str(settings.templates_dir))
-        return templates.TemplateResponse("version_info_partial.html", {"request": request, "payload": payload})
+        return templates.TemplateResponse(request, "version_info_partial.html", {"request": request, "payload": payload})
     wants_html = fmt == "html" or "text/html" in request.headers.get("accept", "")
     if wants_html:
         return HTMLResponse(_render_html(payload))

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -20,7 +20,7 @@ Features:
 from __future__ import annotations
 
 # Standard
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import os
 import platform
@@ -253,7 +253,7 @@ def _build_payload(
     """
     db_ver, db_ok = _database_version()
     return {
-        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
         "host": HOSTNAME,
         "uptime_seconds": int(time.time() - START_TIME),
         "app": {

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -253,7 +253,7 @@ def _build_payload(
     """
     db_ver, db_ok = _database_version()
     return {
-        "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "host": HOSTNAME,
         "uptime_seconds": int(time.time() - START_TIME),
         "app": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,9 @@ minversion = "6.0"
 addopts = "-ra -q --cov=mcpgateway"
 testpaths = [ "tests",]
 asyncio_mode = "auto"
+filterwarnings = [
+  "ignore:Passing 'msg' argument to .*\\.cancel\\(\\) is deprecated:DeprecationWarning",
+]
 
 # ── fawltydeps ─────────────────────────────────────────────────────
 [tool.fawltydeps]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,7 +312,7 @@ addopts = "-ra -q --cov=mcpgateway"
 testpaths = [ "tests",]
 asyncio_mode = "auto"
 filterwarnings = [
-  "ignore:Passing 'msg' argument to .*\\.cancel\\(\\) is deprecated:DeprecationWarning",
+  "ignore:Passing 'msg' argument to .*\\.cancel\\(\\) is deprecated:DeprecationWarning", # From 3rd party libraries
 ]
 
 # ── fawltydeps ─────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from mcpgateway.db import Base
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from mcpgateway import translate
 
 
 @pytest.fixture(scope="session")
@@ -96,3 +97,13 @@ def mock_websocket():
     mock.receive_json = AsyncMock()
     mock.close = AsyncMock()
     return mock
+
+# @pytest.fixture(scope="session", autouse=True)
+# def _patch_stdio_first():
+#     """
+#     Runs once, *before* the test session collects other modules,
+#     so no rogue coroutine can be created.
+#     """
+#     import mcpgateway.translate as translate
+#     translate._run_stdio_to_sse = AsyncMock(return_value=None)
+#     translate._run_sse_to_stdio = AsyncMock(return_value=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import os
 from unittest.mock import AsyncMock, patch
 
 # First-Party
+from mcpgateway import translate
 from mcpgateway.config import Settings
 from mcpgateway.db import Base
 
@@ -20,7 +21,6 @@ from mcpgateway.db import Base
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from mcpgateway import translate
 
 
 @pytest.fixture(scope="session")
@@ -97,6 +97,7 @@ def mock_websocket():
     mock.receive_json = AsyncMock()
     mock.close = AsyncMock()
     return mock
+
 
 # @pytest.fixture(scope="session", autouse=True)
 # def _patch_stdio_first():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import os
 from unittest.mock import AsyncMock, patch
 
 # First-Party
-from mcpgateway import translate
 from mcpgateway.config import Settings
 from mcpgateway.db import Base
 

--- a/tests/unit/mcpgateway/handlers/test_sampling.py
+++ b/tests/unit/mcpgateway/handlers/test_sampling.py
@@ -213,7 +213,7 @@ def test_validate_message(handler):
 async def test_create_message_success(monkeypatch, handler):
     # Patch ModelPreferences.parse_obj to return neutral prefs (no hints)
     neutral_prefs = _t.SimpleNamespace(hints=[], cost_priority=0.33, speed_priority=0.33, intelligence_priority=0.34)
-    monkeypatch.setattr(sp.ModelPreferences, "parse_obj", lambda _x: neutral_prefs)
+    monkeypatch.setattr(sp.ModelPreferences, "model_validate", lambda _x: neutral_prefs)
 
     request = {
         "messages": [
@@ -231,7 +231,7 @@ async def test_create_message_success(monkeypatch, handler):
 
 @pytest.mark.asyncio
 async def test_create_message_no_messages(monkeypatch, handler):
-    monkeypatch.setattr(sp.ModelPreferences, "parse_obj", lambda _x: _t.SimpleNamespace(hints=[], cost_priority=0, speed_priority=0, intelligence_priority=0))
+    monkeypatch.setattr(sp.ModelPreferences, "model_validate", lambda _x: _t.SimpleNamespace(hints=[], cost_priority=0, speed_priority=0, intelligence_priority=0))
 
     request = {"messages": [], "maxTokens": 5, "modelPreferences": {}}
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -17,7 +17,7 @@ This suite provides complete test coverage for:
 
 # Standard
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # First-Party
@@ -72,8 +72,8 @@ def mock_resource():
     resource.binary_content = None
     resource.size = 12
     resource.is_active = True
-    resource.created_at = datetime.utcnow()
-    resource.updated_at = datetime.utcnow()
+    resource.created_at = datetime.now(timezone.utc)
+    resource.updated_at = datetime.now(timezone.utc)
     resource.metrics = []
 
     # .content property stub
@@ -104,8 +104,8 @@ def mock_inactive_resource():
     resource.binary_content = None
     resource.size = 0
     resource.is_active = False
-    resource.created_at = datetime.utcnow()
-    resource.updated_at = datetime.utcnow()
+    resource.created_at = datetime.now(timezone.utc)
+    resource.updated_at = datetime.now(timezone.utc)
     resource.metrics = []
 
     # .content property stub
@@ -185,8 +185,8 @@ class TestResourceRegistration:
                 mime_type="text/plain",
                 size=len(sample_resource_create.content),
                 is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -296,8 +296,8 @@ class TestResourceRegistration:
                 mime_type="application/octet-stream",
                 size=len(binary_resource.content),
                 is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -448,8 +448,8 @@ class TestResourceManagement:
                 mime_type=mock_inactive_resource.mime_type or "text/plain",
                 size=mock_inactive_resource.size or 0,
                 is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -482,8 +482,8 @@ class TestResourceManagement:
                 mime_type=mock_resource.mime_type,
                 size=mock_resource.size,
                 is_active=False,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -528,8 +528,8 @@ class TestResourceManagement:
                 mime_type=mock_resource.mime_type,
                 size=mock_resource.size,
                 is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -567,8 +567,8 @@ class TestResourceManagement:
                 mime_type="text/plain",
                 size=15,  # length of "Updated content"
                 is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -636,8 +636,8 @@ class TestResourceManagement:
                 mime_type="application/octet-stream",
                 size=len(b"new binary content"),
                 is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 template=None,
                 metrics={
                     "total_executions": 0,
@@ -1019,7 +1019,7 @@ class TestResourceMetrics:
             MagicMock(scalar=MagicMock(return_value=0.1)),  # min_response_time
             MagicMock(scalar=MagicMock(return_value=2.5)),  # max_response_time
             MagicMock(scalar=MagicMock(return_value=1.2)),  # avg_response_time
-            MagicMock(scalar=MagicMock(return_value=datetime.utcnow())),  # last_execution_time
+            MagicMock(scalar=MagicMock(return_value=datetime.now(timezone.utc))),  # last_execution_time
         ]
 
         result = await resource_service.aggregate_metrics(mock_db)
@@ -1107,7 +1107,7 @@ class TestUtilityMethods:
         metric1, metric2 = MagicMock(), MagicMock()
         metric1.is_success, metric1.response_time = True, 1.0
         metric2.is_success, metric2.response_time = False, 2.0
-        metric1.timestamp = metric2.timestamp = datetime.utcnow()
+        metric1.timestamp = metric2.timestamp = datetime.now(timezone.utc)
         mock_resource.metrics = [metric1, metric2]
 
         result = resource_service._convert_resource_to_read(mock_resource)

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -136,9 +136,9 @@ class TestAdminServerRoutes:
         """Test listing servers through admin UI."""
         # Setup
         mock_server1 = MagicMock()
-        mock_server1.dict.return_value = {"id": 1, "name": "Server 1"}
+        mock_server1.model_dump.return_value = {"id": 1, "name": "Server 1"}
         mock_server2 = MagicMock()
-        mock_server2.dict.return_value = {"id": 2, "name": "Server 2"}
+        mock_server2.model_dump.return_value = {"id": 2, "name": "Server 2"}
         mock_list_servers.return_value = [mock_server1, mock_server2]
 
         # Execute
@@ -235,9 +235,9 @@ class TestAdminToolRoutes:
         """Test listing tools through admin UI."""
         # Setup
         mock_tool1 = MagicMock()
-        mock_tool1.dict.return_value = {"id": 1, "name": "Tool 1"}
+        mock_tool1.model_dump.return_value = {"id": 1, "name": "Tool 1"}
         mock_tool2 = MagicMock()
-        mock_tool2.dict.return_value = {"id": 2, "name": "Tool 2"}
+        mock_tool2.model_dump.return_value = {"id": 2, "name": "Tool 2"}
         mock_list_tools.return_value = [mock_tool1, mock_tool2]
 
         # Execute
@@ -347,9 +347,9 @@ class TestAdminResourceRoutes:
         """Test listing resources through admin UI."""
         # Setup
         mock_resource1 = MagicMock()
-        mock_resource1.dict.return_value = {"id": 1, "name": "Resource 1"}
+        mock_resource1.model_dump.return_value = {"id": 1, "name": "Resource 1"}
         mock_resource2 = MagicMock()
-        mock_resource2.dict.return_value = {"id": 2, "name": "Resource 2"}
+        mock_resource2.model_dump.return_value = {"id": 2, "name": "Resource 2"}
         mock_list_resources.return_value = [mock_resource1, mock_resource2]
 
         # Execute
@@ -367,7 +367,7 @@ class TestAdminResourceRoutes:
         """Test getting a single resource through admin UI."""
         # Setup
         mock_resource = MagicMock()
-        mock_resource.dict.return_value = {"id": 1, "name": "Resource 1"}
+        mock_resource.model_dump.return_value = {"id": 1, "name": "Resource 1"}
         mock_get_resource.return_value = mock_resource
         mock_read_resource.return_value = {"type": "resource", "text": "content"}
 
@@ -435,9 +435,9 @@ class TestAdminPromptRoutes:
         """Test listing prompts through admin UI."""
         # Setup
         mock_prompt1 = MagicMock()
-        mock_prompt1.dict.return_value = {"id": 1, "name": "Prompt 1"}
+        mock_prompt1.model_dump.return_value = {"id": 1, "name": "Prompt 1"}
         mock_prompt2 = MagicMock()
-        mock_prompt2.dict.return_value = {"id": 2, "name": "Prompt 2"}
+        mock_prompt2.model_dump.return_value = {"id": 2, "name": "Prompt 2"}
         mock_list_prompts.return_value = [mock_prompt1, mock_prompt2]
 
         # Execute
@@ -537,9 +537,9 @@ class TestAdminGatewayRoutes:
         """Test listing gateways through admin UI."""
         # Setup
         mock_gateway1 = MagicMock()
-        mock_gateway1.dict.return_value = {"id": 1, "name": "Gateway 1"}
+        mock_gateway1.model_dump.return_value = {"id": 1, "name": "Gateway 1"}
         mock_gateway2 = MagicMock()
-        mock_gateway2.dict.return_value = {"id": 2, "name": "Gateway 2"}
+        mock_gateway2.model_dump.return_value = {"id": 2, "name": "Gateway 2"}
         mock_list_gateways.return_value = [mock_gateway1, mock_gateway2]
 
         # Execute
@@ -556,7 +556,7 @@ class TestAdminGatewayRoutes:
         """Test getting a single gateway through admin UI."""
         # Setup
         mock_gateway = MagicMock()
-        mock_gateway.dict.return_value = {"id": 1, "name": "Gateway 1"}
+        mock_gateway.model_dump.return_value = {"id": 1, "name": "Gateway 1"}
         mock_get_gateway.return_value = mock_gateway
 
         # Execute

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -850,7 +850,9 @@ class TestRPCEndpoints:
 
     def test_rpc_invalid_json(self, test_client, auth_headers):
         """Test RPC error handling for malformed JSON."""
-        response = test_client.post("/rpc/", data="invalid json", headers=auth_headers)
+        headers = auth_headers
+        headers["content-type"] = "application/json"
+        response = test_client.post("/rpc/", content="invalid json", headers=headers)
         assert response.status_code == 200  # Returns error response, not HTTP error
         body = response.json()
         assert "error" in body
@@ -1011,7 +1013,9 @@ class TestErrorHandling:
 
     def test_invalid_json_body(self, test_client, auth_headers):
         """Test handling of malformed JSON in request bodies."""
-        response = test_client.post("/protocol/initialize", data="invalid json", headers=auth_headers)
+        headers = auth_headers
+        headers["content-type"] = "application/json"
+        response = test_client.post("/protocol/initialize", content="invalid json", headers=headers)
         assert response.status_code == 400  # body cannot be parsed, so 400
 
     @patch("mcpgateway.main.server_service.get_server")

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -39,7 +39,7 @@ MOCK_METRICS = {
     "min_response_time": 0.1,
     "max_response_time": 2.5,
     "avg_response_time": 1.2,
-    "last_execution_time": "2023-01-01T00:00:00",
+    "last_execution_time": "2023-01-01T00:00:00+00:00",
 }
 
 MOCK_SERVER_READ = {
@@ -47,8 +47,8 @@ MOCK_SERVER_READ = {
     "name": "test_server",
     "description": "A test server",
     "icon": "server-icon",
-    "created_at": "2023-01-01T00:00:00",
-    "updated_at": "2023-01-01T00:00:00",
+    "created_at": "2023-01-01T00:00:00+00:00",
+    "updated_at": "2023-01-01T00:00:00+00:00",
     "is_active": True,
     "associated_tools": ["101"],
     "associated_resources": [201],
@@ -69,8 +69,8 @@ MOCK_TOOL_READ = {
     "annotations": {},
     "jsonpathFilter": None,
     "auth": {"auth_type": "none"},
-    "createdAt": "2023-01-01T00:00:00",
-    "updatedAt": "2023-01-01T00:00:00",
+    "createdAt": "2023-01-01T00:00:00+00:00",
+    "updatedAt": "2023-01-01T00:00:00+00:00",
     "isActive": True,
     "gatewayId": "gateway-1",
     "executionCount": 5,
@@ -115,8 +115,8 @@ MOCK_RESOURCE_READ = {
     "description": "A test resource",
     "mime_type": "text/plain",
     "size": 12,
-    "created_at": "2023-01-01T00:00:00",
-    "updated_at": "2023-01-01T00:00:00",
+    "created_at": "2023-01-01T00:00:00+00:00",
+    "updated_at": "2023-01-01T00:00:00+00:00",
     "is_active": True,
     "metrics": MOCK_METRICS,
 }
@@ -127,8 +127,8 @@ MOCK_PROMPT_READ = {
     "description": "A test prompt",
     "template": "Hello {name}",
     "arguments": [],
-    "created_at": "2023-01-01T00:00:00",
-    "updated_at": "2023-01-01T00:00:00",
+    "created_at": "2023-01-01T00:00:00+00:00",
+    "updated_at": "2023-01-01T00:00:00+00:00",
     "is_active": True,
     "metrics": MOCK_METRICS,
 }
@@ -140,8 +140,8 @@ MOCK_GATEWAY_READ = {
     "description": "A test gateway",
     "transport": "SSE",
     "auth_type": "none",
-    "created_at": "2023-01-01T00:00:00",
-    "updated_at": "2023-01-01T00:00:00",
+    "created_at": "2023-01-01T00:00:00+00:00",
+    "updated_at": "2023-01-01T00:00:00+00:00",
     "is_active": True,
 }
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -387,7 +387,7 @@ class TestServerEndpoints:
     def test_server_get_tools(self, mock_list_tools, test_client, auth_headers):
         """Test listing tools associated with a server."""
         mock_tool = MagicMock()
-        mock_tool.dict.return_value = MOCK_TOOL_READ
+        mock_tool.model_dump.return_value = MOCK_TOOL_READ
         mock_list_tools.return_value = [mock_tool]
 
         response = test_client.get("/servers/1/tools", headers=auth_headers)
@@ -400,7 +400,7 @@ class TestServerEndpoints:
     def test_server_get_resources(self, mock_list_resources, test_client, auth_headers):
         """Test listing resources associated with a server."""
         mock_resource = MagicMock()
-        mock_resource.dict.return_value = MOCK_RESOURCE_READ
+        mock_resource.model_dump.return_value = MOCK_RESOURCE_READ
         mock_list_resources.return_value = [mock_resource]
 
         response = test_client.get("/servers/1/resources", headers=auth_headers)

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -10,7 +10,7 @@ defined in the types.py module.
 """
 
 # Standard
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import os
 from unittest.mock import Mock
@@ -588,7 +588,7 @@ class TestEventAndAdminSchemas:
 
     def test_event_message(self):
         """Test EventMessage model."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         event = EventMessage(
             type="resource_updated",
@@ -744,7 +744,7 @@ class TestServerSchemas:
 
     def test_server_read(self):
         """Test ServerRead model."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
 
         server = ServerRead(

--- a/tests/unit/mcpgateway/test_translate.py
+++ b/tests/unit/mcpgateway/test_translate.py
@@ -42,11 +42,13 @@ import sys
 import types
 from typing import Sequence
 from unittest.mock import AsyncMock, Mock
-# import inspect
 
 # Third-Party
 from fastapi.testclient import TestClient
 import pytest
+
+# import inspect
+
 
 # ---------------------------------------------------------------------------#
 # Pytest fixtures                                                            #
@@ -253,7 +255,11 @@ async def test_fastapi_message_endpoint_invalid_json(translate):
     app = translate._build_fastapi(ps, stdio)
     client = TestClient(app)
 
-    response = client.post("/message", content="invalid json", headers={"content-type": "application/json"},)
+    response = client.post(
+        "/message",
+        content="invalid json",
+        headers={"content-type": "application/json"},
+    )
     assert response.status_code == 400
     assert "Invalid JSON payload" in response.text
 

--- a/tests/unit/mcpgateway/test_translate.py
+++ b/tests/unit/mcpgateway/test_translate.py
@@ -42,6 +42,7 @@ import sys
 import types
 from typing import Sequence
 from unittest.mock import AsyncMock, Mock
+# import inspect
 
 # Third-Party
 from fastapi.testclient import TestClient
@@ -252,7 +253,7 @@ async def test_fastapi_message_endpoint_invalid_json(translate):
     app = translate._build_fastapi(ps, stdio)
     client = TestClient(app)
 
-    response = client.post("/message", data="invalid json")
+    response = client.post("/message", content="invalid json", headers={"content-type": "application/json"},)
     assert response.status_code == 400
     assert "Invalid JSON payload" in response.text
 
@@ -792,7 +793,6 @@ def test_main_function_sse(monkeypatch, translate):
             pass
         return None
 
-    monkeypatch.setattr(translate, "_run_sse_to_stdio", _fake_sse_runner)
     monkeypatch.setattr(translate.asyncio, "run", _fake_asyncio_run)
 
     translate.main(["--sse", "http://example.com/sse"])
@@ -817,6 +817,12 @@ def test_main_function_keyboard_interrupt(monkeypatch, translate, capsys):
 
 def test_main_function_not_implemented_error(monkeypatch, translate, capsys):
     """Test main() function handles NotImplementedError."""
+
+    # def _raise_not_implemented(coro, *a, **kw):
+    #     # close the coroutine if the autouse fixture didn't remove it
+    #     if hasattr(coro, "close"):
+    #         coro.close()
+    #     raise NotImplementedError("Test error message")
 
     def _raise_not_implemented(*args):
         raise NotImplementedError("Test error message")

--- a/tests/unit/mcpgateway/utils/test_verify_credentials.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials.py
@@ -23,7 +23,7 @@ and detail.
 from __future__ import annotations
 
 # Standard
-import datetime as _dt
+from datetime import datetime, timedelta, timezone
 
 # First-Party
 from mcpgateway.utils import verify_credentials as vc  # module under test
@@ -44,7 +44,7 @@ ALGO = "HS256"
 def _token(payload: dict, *, exp_delta: int | None = None, secret: str = SECRET) -> str:
     """Return a signed JWT with optional expiry offset (minutes)."""
     if exp_delta is not None:
-        expire = _dt.datetime.utcnow() + _dt.timedelta(minutes=exp_delta)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=exp_delta)
         payload = payload | {"exp": int(expire.timestamp())}
     return jwt.encode(payload, secret, algorithm=ALGO)
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
- Fixed 220+ warnings.
- 180 warnings were related to deprecation of Task.cancel() and Future.cancel() in Python 3.14. These are not in our code, so filtered them by adding a filter under [tool.pytest.ini_options] in pyproject.toml
- One warning related to translate.py is pending.
  - The warning indicates that `_run_stdio_to_sse` is not awaited, but it is in the code. So, some of the tests seem to be triggering this condition themselves.


## 🔁 Reproduction Steps
Run `make test`

## Passes
[x] `make test`
[x] `make smoketest`