### PR TITLE
feat: added configurable connection retries for DB and Redis readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,12 @@ DB_POOL_TIMEOUT=30
 # Recycle database connections after N seconds
 DB_POOL_RECYCLE=3600
 
+# Maximum number of times to boot database connection for cold start
+DB_MAX_RETRIES=3
+
+# Interval time for next retry of database connection
+DB_RETRY_INTERVAL_MS=2000
+
 #####################################
 # Cache Backend
 #####################################
@@ -57,6 +63,12 @@ SESSION_TTL=3600
 
 # TTL for ephemeral messages (like completions) in seconds
 MESSAGE_TTL=600
+
+# Maximum number of times to boot redis connection for cold start
+REDIS_MAX_RETRIES=3
+
+# Interval time for next retry of redis connection
+REDIS_RETRY_INTERVAL_MS=2000
 
 #####################################
 # Protocol Settings

--- a/README.md
+++ b/README.md
@@ -970,20 +970,24 @@ You can get started by copying the provided [.env.example](.env.example) to `.en
 
 ### Database
 
-| Setting           | Description                     | Default | Options |
-| ----------------- | ------------------------------- | ------- | ------- |
-| `DB_POOL_SIZE`    | SQLAlchemy connection pool size | `200`   | int > 0 |
-| `DB_MAX_OVERFLOW` | Extra connections beyond pool   | `10`    | int ≥ 0 |
-| `DB_POOL_TIMEOUT` | Wait for connection (secs)      | `30`    | int > 0 |
-| `DB_POOL_RECYCLE` | Recycle connections (secs)      | `3600`  | int > 0 |
+| Setting                 | Description                     | Default | Options |
+| ----------------------- | ------------------------------- | ------- | ------- |
+| `DB_POOL_SIZE`   .      | SQLAlchemy connection pool size | `200`   | int > 0 |
+| `DB_MAX_OVERFLOW`.      | Extra connections beyond pool   | `10`    | int ≥ 0 |
+| `DB_POOL_TIMEOUT`.      | Wait for connection (secs)      | `30`    | int > 0 |
+| `DB_POOL_RECYCLE`.      | Recycle connections (secs)      | `3600`  | int > 0 |
+| `DB_MAX_RETRIES` .      | Max Retry Attempts              | `3`     | int > 0 |
+| `DB_RETRY_INTERVAL_MS`  | Retry Interval (ms)             | `2000`  | int > 0 |
 
 ### Cache Backend
 
-| Setting        | Description                | Default  | Options                  |
-| -------------- | -------------------------- | -------- | ------------------------ |
-| `CACHE_TYPE`   | Backend (`memory`/`redis`) | `memory` | `none`, `memory`,`redis` |
-| `REDIS_URL`    | Redis connection URL       | (none)   | string or empty          |
-| `CACHE_PREFIX` | Key prefix                 | `mcpgw:` | string                   |
+| Setting                   | Description                | Default  | Options                  |
+| ------------------------- | -------------------------- | -------- | ------------------------ |
+| `CACHE_TYPE`              | Backend (`memory`/`redis`) | `memory` | `none`, `memory`,`redis` |
+| `REDIS_URL`               | Redis connection URL       | (none)   | string or empty          |
+| `CACHE_PREFIX`            | Key prefix                 | `mcpgw:` | string                   |
+| `REDIS_MAX_RETRIES`       | Max Retry Attempts         | `3`      | int > 0                  |
+| `REDIS_RETRY_INTERVAL_MS` | Retry Interval (ms)        | `2000`   | int > 0                  |
 
 > 🧠 `none` disables caching entirely. Use `memory` for dev, `database` for persistence, or `redis` for distributed caching.
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -179,6 +179,8 @@ class Settings(BaseSettings):
     db_max_overflow: int = 10
     db_pool_timeout: int = 30
     db_pool_recycle: int = 3600
+    db_max_retries: int = 3
+    db_retry_interval_ms: int = 2000
 
     # Cache
     cache_type: str = "database"  # memory or redis or database
@@ -186,6 +188,8 @@ class Settings(BaseSettings):
     cache_prefix: str = "mcpgw:"
     session_ttl: int = 3600
     message_ttl: int = 600
+    redis_max_retries: int = 3
+    redis_retry_interval_ms: int = 2000
 
     # streamable http transport
     use_stateful_sessions: bool = False  # Set to False to use stateless sessions without event store

--- a/mcpgateway/utils/redis_isready.py
+++ b/mcpgateway/utils/redis_isready.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""redis_isready - Wait until Redis is ready and accepting connections
+======================================================================
+This helper blocks until the given **Redis** server (defined by a connection URL)
+successfully responds to a `PING` command. It is intended to delay application startup until Redis is online.
+
+It can be used both **synchronously** or **asynchronously**, and will retry
+connections with a configurable interval and number of attempts.
+
+Features
+--------
+* Supports any valid Redis URL supported by :pypi:`redis`.
+* Retry settings are configurable via *environment variables*.
+* Works both **synchronously** (blocking) and **asynchronously**.
+
+Environment variables
+---------------------
+These environment variables can be used to configure retry behavior and Redis connection.
+
++-----------------------------+-----------------------------------------------+-----------------------------+
+| Name                        | Description                                   | Default                     |
++=============================+===============================================+=============================+
+| ``REDIS_URL``               | Redis connection URL                          | ``redis://localhost:6379/0``|
+| ``REDIS_MAX_RETRIES``       | Maximum retry attempts before failing         | ``3``                       |
+| ``REDIS_RETRY_INTERVAL_MS`` | Delay between retries *(milliseconds)*        | ``2000``                    |
+| ``LOG_LEVEL``               | Log verbosity when not set via ``--log-level``| ``INFO``                    |
++-----------------------------+-----------------------------------------------+-----------------------------+
+
+Usage examples
+--------------
+Shell ::
+
+    python redis_isready.py
+    python redis_isready.py --redis-url "redis://localhost:6379/0" \
+                            --max-retries 5 --retry-interval-ms 500
+
+Python ::
+
+    from redis_isready import wait_for_redis_ready
+
+    await wait_for_redis_ready()           # asynchronous
+    wait_for_redis_ready(sync=True)        # synchronous / blocking
+"""
+
+
+import os
+import time
+import logging
+import asyncio
+from typing import Optional
+try:
+    # Third-Party
+    from redis import Redis
+    REDIS_AVAILABLE = True
+except ImportError:
+    REDIS_AVAILABLE = False
+
+# Environment variables
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+REDIS_MAX_RETRIES = int(os.getenv("REDIS_MAX_RETRIES", "3"))
+REDIS_RETRY_INTERVAL_MS = int(os.getenv("REDIS_RETRY_INTERVAL_MS", "2000"))
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
+def wait_for_redis_ready(
+    *,
+    redis_url: str = REDIS_URL,
+    max_retries: int = REDIS_MAX_RETRIES,
+    retry_interval_ms: int = REDIS_RETRY_INTERVAL_MS,
+    logger: Optional[logging.Logger] = None,
+    sync: bool = False,
+) -> None:
+    """
+    Wait until a Redis server is ready to accept connections.
+
+    This function attempts to connect to Redis and issue a `PING` command,
+    retrying if the connection fails. It can run synchronously (blocking)
+    or asynchronously using an executor. Intended for use during service
+    startup to ensure Redis is reachable before proceeding.
+
+    Args:
+        redis_url : str
+            Redis connection URL. Defaults to the value of the `REDIS_URL` environment variable.
+        max_retries : int
+            Maximum number of connection attempts before failing.
+        retry_interval_ms : int
+            Delay between retry attempts, in milliseconds.
+        logger : logging.Logger, optional
+            Logger instance to use. If not provided, a default logger is configured.
+        sync : bool
+            If True, runs the probe synchronously. If False (default), runs it asynchronously.
+
+    Raises:
+        RuntimeError
+            If Redis does not respond successfully after all retry attempts.
+    """
+
+    log = logger or logging.getLogger("redis_isready")
+    if not log.handlers: # basicConfig **once** - respects *log.setLevel* later
+        logging.basicConfig(
+            level=getattr(logging, LOG_LEVEL, logging.INFO),
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+
+    if max_retries < 1 or retry_interval_ms <= 0:
+        raise RuntimeError("Invalid max_retries or retry_interval_ms values")
+
+    def _probe() -> None:
+        """
+        Inner synchronous probe running in either the current or a thread.
+
+        Returns:
+            None - the function exits successfully once the DB answers.
+
+        Raises:
+            RuntimeError: Forwarded after exhausting ``max_tries`` attempts.
+        """
+        
+        redis = Redis.from_url(redis_url)
+        for attempt in range(1, max_retries + 1):
+            try:
+                redis.ping()
+                log.info(f"Redis ready (attempt {attempt})")
+                return
+            except ConnectionError as e:
+                log.warning(f"Redis connection failed (attempt {attempt}/{max_retries}) - retrying in {retry_interval_ms} ms")
+                time.sleep(retry_interval_ms / 1000.0)
+        raise RuntimeError(f"Redis not ready after {max_retries} attempts")
+
+    if sync:
+        _probe()
+    else:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(loop.run_in_executor(None, _probe))
+

--- a/tests/unit/mcpgateway/utils/test_redis_isready.py
+++ b/tests/unit/mcpgateway/utils/test_redis_isready.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+# Standard
+import asyncio
+
+# Third-Party
+import pytest
+from unittest.mock import patch
+
+# First-Party
+import mcpgateway.utils.redis_isready as redis_isready
+
+
+# ---------------------------------------------------------------------------
+# Mock Redis
+# ---------------------------------------------------------------------------
+
+class MockRedis:
+    """Mock Redis client for testing Redis backend."""
+
+    def __init__(self):
+        self.data = {}
+        self.published = []
+        self.should_fail = False
+        self.attempts = 0
+
+    @classmethod
+    def from_url(cls, url):
+        return cls()
+
+    def ping(self):
+        self.attempts += 1
+        if self.should_fail:
+            raise ConnectionError("Redis not ready")
+        return True
+
+    # Async methods — included for compatibility with other parts of codebase
+    async def setex(self, key, ttl, value):
+        if self.should_fail:
+            raise Exception("Redis connection failed")
+        self.data[key] = {"value": value, "ttl": ttl}
+
+    async def exists(self, key):
+        if self.should_fail:
+            raise Exception("Redis connection failed")
+        return key in self.data
+
+    async def delete(self, key):
+        if self.should_fail:
+            raise Exception("Redis connection failed")
+        self.data.pop(key, None)
+
+    async def expire(self, key, ttl):
+        if self.should_fail:
+            raise Exception("Redis connection failed")
+        if key in self.data:
+            self.data[key]["ttl"] = ttl
+
+    async def publish(self, channel, message):
+        if self.should_fail:
+            raise Exception("Redis connection failed")
+        self.published.append({"channel": channel, "message": message})
+
+    def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_wait_for_redis_ready_success(monkeypatch):
+    """A healthy Redis instance should succeed on the first attempt."""
+
+    mock = MockRedis()
+    mock.should_fail = False
+
+    monkeypatch.setattr(redis_isready.time, "sleep", lambda *_: None)
+
+    with patch("mcpgateway.utils.redis_isready.Redis", MockRedis):
+        redis_isready.wait_for_redis_ready(
+            redis_url="redis://localhost:6379/0",
+            max_retries=3,
+            retry_interval_ms=10,
+            sync=True,
+        )
+
+
+def test_wait_for_redis_ready_retries(monkeypatch):
+    """Redis should fail a few times before succeeding."""
+
+    mock = MockRedis()
+    mock.attempts = 0 
+
+    def failing_then_succeeding_ping():
+        mock.attempts += 1
+        if mock.attempts < 3:
+            raise ConnectionError("Redis not ready")
+        return True
+
+    mock.ping = failing_then_succeeding_ping
+    monkeypatch.setattr(redis_isready.time, "sleep", lambda *_: None)
+
+    class MockRedisWithFromUrl:
+        @classmethod
+        def from_url(cls, url):
+            return mock
+
+    with patch("mcpgateway.utils.redis_isready.Redis", MockRedisWithFromUrl):
+        redis_isready.wait_for_redis_ready(
+            redis_url="redis://localhost:6379/0",
+            max_retries=5,
+            retry_interval_ms=10,
+            sync=True,
+        )
+
+    assert mock.attempts == 3
+
+
+def test_wait_for_redis_ready_fails(monkeypatch):
+    """After max_retries, should raise RuntimeError."""
+
+    mock = MockRedis()
+    mock.should_fail = True
+
+    monkeypatch.setattr(redis_isready.time, "sleep", lambda *_: None)
+
+    class MockRedisWithFromUrl:
+        @classmethod
+        def from_url(cls, url):
+            return mock
+
+    with patch("mcpgateway.utils.redis_isready.Redis", MockRedisWithFromUrl):
+        with pytest.raises(RuntimeError, match="Redis not ready after"):
+            redis_isready.wait_for_redis_ready(
+                redis_url="redis://localhost:6379/0",
+                max_retries=3,
+                retry_interval_ms=10,
+                sync=True,
+            )
+
+
+def test_wait_for_redis_ready_invalid_params():
+    """Zero or negative retry parameters are rejected immediately."""
+
+    with pytest.raises(RuntimeError):
+        redis_isready.wait_for_redis_ready(max_retries=0)
+
+    with pytest.raises(RuntimeError):
+        redis_isready.wait_for_redis_ready(retry_interval_ms=0)
+
+
+def test_wait_for_redis_ready_async_path(monkeypatch):
+    """Async path should offload probe into executor."""
+
+    mock = MockRedis()
+    mock.attempts = 0
+
+    def ping():
+        mock.attempts += 1
+        return True
+
+    mock.ping = ping
+    monkeypatch.setattr(redis_isready.time, "sleep", lambda *_: None)
+
+    # Create a dedicated loop so we can patch run_in_executor cleanly
+    loop = asyncio.new_event_loop()
+
+    async def fake_run_in_executor(_executor, func, *args):
+        # Execute the probe synchronously (no thread) then return dummy future
+        func(*args)
+        fut = loop.create_future()
+        fut.set_result(None)
+        return fut
+
+    monkeypatch.setattr(asyncio, "get_event_loop", lambda: loop)
+    loop.run_in_executor = fake_run_in_executor
+
+    class MockRedisWithFromUrl:
+        @classmethod
+        def from_url(cls, url):
+            return mock
+
+    with patch("mcpgateway.utils.redis_isready.Redis", MockRedisWithFromUrl):
+        redis_isready.wait_for_redis_ready(
+            redis_url="redis://localhost:6379/0",
+            max_retries=2,
+            retry_interval_ms=10,
+            sync=False,
+        )
+
+    assert mock.attempts == 1


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue  
Closes [#179](https://github.com/IBM/mcp-context-forge/issues/179)
[Feature Request]: Configurable Connection Retries for DB and Redis

---

## 🚀 Summary (1–2 sentences)  
Adds configurable connection retry logic for both Redis and the database on application startup. This ensures the services wait for dependencies to be ready, improving robustness during cold starts or in containerized environments.

---

## 🧪 Checks

- [ ] `make lint` passes  
- [ ] `make test` passes  

---

## 📓 Notes (optional)  
- Introduced `redis_isready.py`, modeled after `db_isready.py`, to handle Redis readiness.  
- Updated `main.py` to call both `wait_for_db_ready()` and `wait_for_redis_ready()` before starting the app.  
- Added unit tests for Redis readiness logic (`tests/unit/mcpgateway/utils/test_redis_isready.py`).  

```mermaid
flowchart TD
    A["main.py"] --> B["wait_for_db_ready()"]
    B --> C["wait_for_redis_ready()"]
    B -->|ping| D[(Database)]
    C -->|ping| E[(Redis)]
```