### PR TITLE
fix: added db retry mechanism to mcpgateway/db.py

### DIFF
--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -25,6 +25,7 @@ import uuid
 from mcpgateway.config import settings
 from mcpgateway.types import ResourceContent
 from mcpgateway.utils.create_slug import slugify
+from mcpgateway.utils.db_isready import wait_for_db_ready
 
 # Third-Party
 import jsonschema
@@ -1220,4 +1221,11 @@ def init_db():
 
 
 if __name__ == "__main__":
+    # Wait for database to be ready before initializing
+    wait_for_db_ready(
+        max_tries=int(settings.db_max_retries),
+        interval=int(settings.db_retry_interval_ms) / 1000,
+        sync=True
+    )
+
     init_db()


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue  
Closes #179
[Feature Request]: Configurable Connection Retries for DB and Redis

---

## 🚀 Summary (1–2 sentences)  
Adds a configurable database connection retry mechanism to `mcpgateway/db.py`. It ensures that the database initialisation waits and retries according to environment variables before failing, improving startup resilience in containerized deployments.

---

## 🧪 Checks

- [x] `make lint` passes  
- [ ] `make test` passes  

---

## 📓 Notes (optional)  
- Implements retry logic in the database initialisation script (`db.py`) with configurable retry count and interval via environment variables.  
- Logs each retry attempt and aborts after exhausting retries with a clear error message.  
- Complements existing retry logic added in `main.py`.  
- Tested with a non-running DB to verify retry behaviour and failure exit.

---
