### PR TITLE
Fix/redis import lazy

### DIFF
--- a/mcpgateway/utils/redis_isready.py
+++ b/mcpgateway/utils/redis_isready.py
@@ -54,7 +54,6 @@ Python ::
     wait_for_redis_ready(sync=True)        # synchronous / blocking
 """
 
-
 # Standard
 import argparse
 import asyncio
@@ -65,19 +64,7 @@ import time
 from typing import Any, Optional
 
 # First Party imports
-from mcpgateway.config import settings  
-
-
-# ---------------------------------------------------------------------------
-# Third-party imports - abort early if redis is missing
-# ---------------------------------------------------------------------------
-if settings.cache_type == "redis":
-    try:
-        # Third-Party
-        from redis import Redis
-    except ImportError:  # pragma: no cover - handled at runtime for the CLI
-        sys.stderr.write("redis library not installed - aborting (pip install redis)\n")
-        sys.exit(2)
+from mcpgateway.config import settings
 
 # Environment variables
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
@@ -144,12 +131,12 @@ def wait_for_redis_ready(
         Raises:
             RuntimeError: Forwarded after exhausting ``max_retries`` attempts.
         """
-        # try:
-        #     # Third-Party
-        #     from redis import Redis
-        # except ImportError:  # pragma: no cover - handled at runtime for the CLI
-        #     sys.stderr.write("redis library not installed - aborting (pip install redis)\n")
-        #     sys.exit(2)
+        try:
+            # Import redis here to avoid dependency issues if not used
+            from redis import Redis
+        except ImportError:  # pragma: no cover - handled at runtime for the CLI
+            sys.stderr.write("redis library not installed - aborting (pip install redis)\n")
+            sys.exit(2)
 
         redis_client = Redis.from_url(redis_url)
         for attempt in range(1, max_retries + 1):

--- a/mcpgateway/utils/redis_isready.py
+++ b/mcpgateway/utils/redis_isready.py
@@ -64,15 +64,20 @@ import sys
 import time
 from typing import Any, Optional
 
+# First Party imports
+from mcpgateway.config import settings  
+
+
 # ---------------------------------------------------------------------------
 # Third-party imports - abort early if redis is missing
 # ---------------------------------------------------------------------------
-try:
-    # Third-Party
-    from redis import Redis
-except ImportError:  # pragma: no cover - handled at runtime for the CLI
-    sys.stderr.write("redis library not installed - aborting (pip install redis)\n")
-    sys.exit(2)
+if settings.cache_type == "redis":
+    try:
+        # Third-Party
+        from redis import Redis
+    except ImportError:  # pragma: no cover - handled at runtime for the CLI
+        sys.stderr.write("redis library not installed - aborting (pip install redis)\n")
+        sys.exit(2)
 
 # Environment variables
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
@@ -139,6 +144,13 @@ def wait_for_redis_ready(
         Raises:
             RuntimeError: Forwarded after exhausting ``max_retries`` attempts.
         """
+        # try:
+        #     # Third-Party
+        #     from redis import Redis
+        # except ImportError:  # pragma: no cover - handled at runtime for the CLI
+        #     sys.stderr.write("redis library not installed - aborting (pip install redis)\n")
+        #     sys.exit(2)
+
         redis_client = Redis.from_url(redis_url)
         for attempt in range(1, max_retries + 1):
             try:
@@ -220,4 +232,9 @@ def main() -> None:  # pragma: no cover
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    if settings.cache_type == "redis":
+        # Ensure Redis is ready before proceeding
+        main()
+    else:
+        # If not using Redis, just exit with success
+        sys.exit(0)

--- a/tests/unit/mcpgateway/utils/test_redis_isready.py
+++ b/tests/unit/mcpgateway/utils/test_redis_isready.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 Authors: Reeve Barreto, Mihai Criveti
 
 """
+
 # Standard
 import asyncio
 from unittest.mock import patch
@@ -84,7 +85,7 @@ def test_wait_for_redis_ready_success(monkeypatch):
 
     monkeypatch.setattr(redis_isready.time, "sleep", lambda *_: None)
 
-    with patch("mcpgateway.utils.redis_isready.Redis", MockRedis):
+    with patch("redis.Redis", MockRedis):
         redis_isready.wait_for_redis_ready(
             redis_url="redis://localhost:6379/0",
             max_retries=3,
@@ -113,7 +114,7 @@ def test_wait_for_redis_ready_retries(monkeypatch):
         def from_url(cls, url):
             return mock
 
-    with patch("mcpgateway.utils.redis_isready.Redis", MockRedisWithFromUrl):
+    with patch("redis.Redis", MockRedisWithFromUrl):
         redis_isready.wait_for_redis_ready(
             redis_url="redis://localhost:6379/0",
             max_retries=5,
@@ -137,7 +138,7 @@ def test_wait_for_redis_ready_fails(monkeypatch):
         def from_url(cls, url):
             return mock
 
-    with patch("mcpgateway.utils.redis_isready.Redis", MockRedisWithFromUrl):
+    with patch("redis.Redis", MockRedisWithFromUrl):
         with pytest.raises(RuntimeError, match="Redis not ready after"):
             redis_isready.wait_for_redis_ready(
                 redis_url="redis://localhost:6379/0",
@@ -188,7 +189,7 @@ def test_wait_for_redis_ready_async_path(monkeypatch):
         def from_url(cls, url):
             return mock
 
-    with patch("mcpgateway.utils.redis_isready.Redis", MockRedisWithFromUrl):
+    with patch("redis.Redis", MockRedisWithFromUrl):
         redis_isready.wait_for_redis_ready(
             redis_url="redis://localhost:6379/0",
             max_retries=2,


### PR DESCRIPTION
## 📌 Summary

This PR fixes a bug where the application exited with an error even when `settings.cache_type != "redis"`, due to an unconditional top-level import of the `redis` package in `redis_isready.py`. The fix ensures Redis-related logic is only invoked and imported if the cache type is explicitly set to `redis`.

## 🔁 Reproduction Steps

Linked issue: N/A (found during dev)

Steps:
1. Set `cache_type = "memory"` or `"database"`
2. Run the application without `redis` installed in the environment
3. Observe that it crashes due to missing `redis` package, even though Redis is not required for this config

## 🐞 Root Cause

The `redis` package was imported at the top-level of `redis_isready.py`, triggering an ImportError and exiting the application even when Redis functionality was not needed. This violated the expectation that Redis would only be a required dependency when `cache_type == "redis"`.

## 💡 Fix Description

- Moved the `redis` import into the `wait_for_redis_ready()` function.
- Now, the import and Redis logic are only executed if `cache_type == "redis"`, preventing unnecessary failures when Redis is not used.
- Updated related test cases to reflect the import handling and behavior based on `cache_type`.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ⚠️ ✅ *(warnings present, but none from changed code)* |
| Unit tests                            | `make test`          | ✅     |
| Coverage ≥ 90 %                       | `make coverage`      | ✅     |
| Manual regression no longer fails     | Confirmed UI + `/version` run with all cache types | ✅     |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed