### PR TITLE
Pylint improvements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -81,7 +81,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_pydantic
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -22,6 +22,11 @@ import json
 import logging
 from typing import Any, Dict, List, Union
 
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
@@ -58,11 +63,6 @@ from mcpgateway.services.tool_service import (
 )
 from mcpgateway.utils.create_jwt_token import get_jwt_token
 from mcpgateway.utils.verify_credentials import require_auth, require_basic_auth
-
-# Third-Party
-from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
-from sqlalchemy.orm import Session
 
 # Initialize services
 server_service = ServerService()

--- a/mcpgateway/cli.py
+++ b/mcpgateway/cli.py
@@ -41,11 +41,11 @@ import os
 import sys
 from typing import List
 
-# First-Party
-from mcpgateway import __version__
-
 # Third-Party
 import uvicorn
+
+# First-Party
+from mcpgateway import __version__
 
 # ---------------------------------------------------------------------------
 # Configuration defaults (overridable via environment variables)

--- a/mcpgateway/federation/discovery.py
+++ b/mcpgateway/federation/discovery.py
@@ -23,14 +23,14 @@ import socket
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
-# First-Party
-from mcpgateway.config import settings
-from mcpgateway.types import ServerCapabilities
-
 # Third-Party
 import httpx
 from zeroconf import ServiceInfo, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.types import ServerCapabilities
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/federation/forward.py
+++ b/mcpgateway/federation/forward.py
@@ -19,16 +19,16 @@ from datetime import datetime, timezone
 import logging
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
+# Third-Party
+import httpx
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.types import ToolResult
-
-# Third-Party
-import httpx
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/federation/manager.py
+++ b/mcpgateway/federation/manager.py
@@ -23,6 +23,11 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Set
 
+# Third-Party
+import httpx
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
@@ -38,11 +43,6 @@ from mcpgateway.types import (
     ServerCapabilities,
     Tool,
 )
-
-# Third-Party
-import httpx
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/handlers/sampling.py
+++ b/mcpgateway/handlers/sampling.py
@@ -13,11 +13,12 @@ It handles model selection, sampling preferences, and message generation.
 import logging
 from typing import Any, Dict, List
 
+# Third-Party
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.types import CreateMessageResult, ModelPreferences, Role, TextContent
 
-# Third-Party
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,7 @@ class SamplingHandler:
                 if not self._validate_message(msg):
                     raise SamplingError(f"Invalid message format: {msg}")
 
+            # pylint: disable=fixme
             # TODO: Sample from selected model
             # For now return mock response
             response = self._mock_sample(messages=messages)
@@ -160,6 +162,7 @@ class SamplingHandler:
         Returns:
             Messages with added context
         """
+        # pylint: disable=fixme
         # TODO: Implement context gathering based on type
         # For now return original messages
         return messages

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -26,6 +26,9 @@ import json
 import logging
 from typing import Any, Dict, List, Literal, Optional, Union
 
+# Third-Party
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator, ValidationInfo
+
 # First-Party
 from mcpgateway.types import ImageContent
 from mcpgateway.types import Prompt as MCPPrompt
@@ -33,9 +36,6 @@ from mcpgateway.types import Resource as MCPResource
 from mcpgateway.types import ResourceContent, TextContent
 from mcpgateway.types import Tool as MCPTool
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
-
-# Third-Party
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator, ValidationInfo
 
 logger = logging.getLogger(__name__)
 
@@ -276,6 +276,7 @@ class ToolCreate(BaseModelWithConfigDict):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
 
     @model_validator(mode="before")
+    # pylint: disable=no-self-argument
     def assemble_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Assemble authentication information from separate keys if provided.
@@ -335,6 +336,7 @@ class ToolUpdate(BaseModelWithConfigDict):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
 
     @model_validator(mode="before")
+    # pylint: disable=no-self-argument
     def assemble_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Assemble authentication information from separate keys if provided.
@@ -517,7 +519,17 @@ class ResourceNotification(BaseModelWithConfigDict):
 
     @field_serializer("timestamp")
     def serialize_timestamp(self, dt: datetime) -> str:
-        # now returns ISO string with Z
+        """Serialize the `timestamp` field as an ISO 8601 string with UTC timezone.
+
+        Converts the given datetime to UTC and returns it in ISO 8601 format,
+        replacing the "+00:00" suffix with "Z" to indicate UTC explicitly.
+
+        Args:
+            dt (datetime): The datetime object to serialize.
+
+        Returns:
+            str: ISO 8601 formatted string in UTC, ending with 'Z'.
+        """
         return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
@@ -646,6 +658,7 @@ class GatewayCreate(BaseModelWithConfigDict):
     auth_value: Optional[str] = Field(None, validate_default=True)
 
     @field_validator("url", mode="before")
+    # pylint: disable=no-self-argument
     def ensure_url_scheme(cls, v: str) -> str:
         """
         Ensure URL has an http/https scheme.
@@ -662,6 +675,7 @@ class GatewayCreate(BaseModelWithConfigDict):
         return v
 
     @field_validator("auth_value", mode="before")
+    # pylint: disable=no-self-argument
     def create_auth_value(cls, v, info):
         """
         This validator will run before the model is fully instantiated (mode="before")
@@ -760,6 +774,7 @@ class GatewayUpdate(BaseModelWithConfigDict):
     auth_value: Optional[str] = Field(None, validate_default=True)
 
     @field_validator("url", mode="before")
+    # pylint: disable=no-self-argument
     def ensure_url_scheme(cls, v: Optional[str]) -> Optional[str]:
         """
         Ensure URL has an http/https scheme.
@@ -775,6 +790,7 @@ class GatewayUpdate(BaseModelWithConfigDict):
         return v
 
     @field_validator("auth_value", mode="before")
+    # pylint: disable=no-self-argument
     def create_auth_value(cls, v, info):
         """
         This validator will run before the model is fully instantiated (mode="before")
@@ -894,6 +910,7 @@ class GatewayRead(BaseModelWithConfigDict):
 
     # This will be the main method to automatically populate fields
     @model_validator(mode="after")
+    # pylint: disable=no-self-argument
     def _populate_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         auth_type = values.auth_type
         auth_value_encoded = values.auth_value
@@ -1015,7 +1032,18 @@ class EventMessage(BaseModelWithConfigDict):
 
     @field_serializer("timestamp")
     def serialize_timestamp(self, dt: datetime) -> str:
-        # now returns ISO string with Z
+        """
+        Serialize the `timestamp` field as an ISO 8601 string with UTC timezone.
+
+        Converts the given datetime to UTC and returns it in ISO 8601 format,
+        replacing the "+00:00" suffix with "Z" to indicate UTC explicitly.
+
+        Args:
+            dt (datetime): The datetime object to serialize.
+
+        Returns:
+            str: ISO 8601 formatted string in UTC, ending with 'Z'.
+        """
         return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
@@ -1035,6 +1063,7 @@ class AdminToolCreate(BaseModelWithConfigDict):
     input_schema: Optional[str] = None  # JSON string
 
     @field_validator("headers", "input_schema")
+    # pylint: disable=no-self-argument
     def validate_json(cls, v: Optional[str]) -> Optional[Dict[str, Any]]:
         """
         Validate and parse JSON string inputs.
@@ -1120,6 +1149,7 @@ class ServerCreate(BaseModelWithConfigDict):
     associated_prompts: Optional[List[str]] = Field(None, description="Comma-separated prompt IDs")
 
     @field_validator("associated_tools", "associated_resources", "associated_prompts", mode="before")
+    # pylint: disable=no-self-argument
     def split_comma_separated(cls, v):
         """
         Splits a comma-separated string into a list of strings if needed.
@@ -1149,6 +1179,7 @@ class ServerUpdate(BaseModelWithConfigDict):
     associated_prompts: Optional[List[str]] = Field(None, description="Comma-separated prompt IDs")
 
     @field_validator("associated_tools", "associated_resources", "associated_prompts", mode="before")
+    # pylint: disable=no-self-argument
     def split_comma_separated(cls, v):
         """
         Splits a comma-separated string into a list of strings if needed.
@@ -1188,6 +1219,7 @@ class ServerRead(BaseModelWithConfigDict):
     metrics: ServerMetrics
 
     @model_validator(mode="before")
+    # pylint: disable=no-self-argument
     def populate_associated_ids(cls, values):
         """
         Pre-validation method that converts associated objects to their 'id'.

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -276,7 +276,6 @@ class ToolCreate(BaseModelWithConfigDict):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
 
     @model_validator(mode="before")
-    # pylint: disable=no-self-argument
     def assemble_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Assemble authentication information from separate keys if provided.
@@ -336,7 +335,6 @@ class ToolUpdate(BaseModelWithConfigDict):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
 
     @model_validator(mode="before")
-    # pylint: disable=no-self-argument
     def assemble_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Assemble authentication information from separate keys if provided.
@@ -658,7 +656,6 @@ class GatewayCreate(BaseModelWithConfigDict):
     auth_value: Optional[str] = Field(None, validate_default=True)
 
     @field_validator("url", mode="before")
-    # pylint: disable=no-self-argument
     def ensure_url_scheme(cls, v: str) -> str:
         """
         Ensure URL has an http/https scheme.
@@ -675,7 +672,6 @@ class GatewayCreate(BaseModelWithConfigDict):
         return v
 
     @field_validator("auth_value", mode="before")
-    # pylint: disable=no-self-argument
     def create_auth_value(cls, v, info):
         """
         This validator will run before the model is fully instantiated (mode="before")
@@ -774,7 +770,6 @@ class GatewayUpdate(BaseModelWithConfigDict):
     auth_value: Optional[str] = Field(None, validate_default=True)
 
     @field_validator("url", mode="before")
-    # pylint: disable=no-self-argument
     def ensure_url_scheme(cls, v: Optional[str]) -> Optional[str]:
         """
         Ensure URL has an http/https scheme.
@@ -790,7 +785,6 @@ class GatewayUpdate(BaseModelWithConfigDict):
         return v
 
     @field_validator("auth_value", mode="before")
-    # pylint: disable=no-self-argument
     def create_auth_value(cls, v, info):
         """
         This validator will run before the model is fully instantiated (mode="before")
@@ -910,7 +904,6 @@ class GatewayRead(BaseModelWithConfigDict):
 
     # This will be the main method to automatically populate fields
     @model_validator(mode="after")
-    # pylint: disable=no-self-argument
     def _populate_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         auth_type = values.auth_type
         auth_value_encoded = values.auth_value
@@ -1063,7 +1056,6 @@ class AdminToolCreate(BaseModelWithConfigDict):
     input_schema: Optional[str] = None  # JSON string
 
     @field_validator("headers", "input_schema")
-    # pylint: disable=no-self-argument
     def validate_json(cls, v: Optional[str]) -> Optional[Dict[str, Any]]:
         """
         Validate and parse JSON string inputs.
@@ -1149,7 +1141,6 @@ class ServerCreate(BaseModelWithConfigDict):
     associated_prompts: Optional[List[str]] = Field(None, description="Comma-separated prompt IDs")
 
     @field_validator("associated_tools", "associated_resources", "associated_prompts", mode="before")
-    # pylint: disable=no-self-argument
     def split_comma_separated(cls, v):
         """
         Splits a comma-separated string into a list of strings if needed.
@@ -1179,7 +1170,6 @@ class ServerUpdate(BaseModelWithConfigDict):
     associated_prompts: Optional[List[str]] = Field(None, description="Comma-separated prompt IDs")
 
     @field_validator("associated_tools", "associated_resources", "associated_prompts", mode="before")
-    # pylint: disable=no-self-argument
     def split_comma_separated(cls, v):
         """
         Splits a comma-separated string into a list of strings if needed.
@@ -1219,7 +1209,6 @@ class ServerRead(BaseModelWithConfigDict):
     metrics: ServerMetrics
 
     @model_validator(mode="before")
-    # pylint: disable=no-self-argument
     def populate_associated_ids(cls, values):
         """
         Pre-validation method that converts associated objects to their 'id'.

--- a/mcpgateway/services/completion_service.py
+++ b/mcpgateway/services/completion_service.py
@@ -13,14 +13,14 @@ It handles completion suggestions for prompt arguments and resource URIs.
 import logging
 from typing import Any, Dict, List
 
+# Third-Party
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.db import Prompt as DbPrompt
 from mcpgateway.db import Resource as DbResource
 from mcpgateway.types import CompleteResult
-
-# Third-Party
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -21,17 +21,17 @@ import logging
 from string import Formatter
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set
 
-# First-Party
-from mcpgateway.db import Prompt as DbPrompt
-from mcpgateway.db import PromptMetric, server_prompt_association
-from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate
-from mcpgateway.types import Message, PromptResult, Role, TextContent
-
 # Third-Party
 from jinja2 import Environment, meta, select_autoescape
 from sqlalchemy import delete, func, not_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import Prompt as DbPrompt
+from mcpgateway.db import PromptMetric, server_prompt_association
+from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate
+from mcpgateway.types import Message, PromptResult, Role, TextContent
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -23,6 +23,12 @@ import re
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
+# Third-Party
+import parse
+from sqlalchemy import delete, func, not_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.db import Resource as DbResource
 from mcpgateway.db import ResourceMetric
@@ -36,12 +42,6 @@ from mcpgateway.schemas import (
     ResourceUpdate,
 )
 from mcpgateway.types import ResourceContent, ResourceTemplate, TextContent
-
-# Third-Party
-import parse
-from sqlalchemy import delete, func, not_, select
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -18,6 +18,12 @@ from datetime import datetime, timezone
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
+# Third-Party
+import httpx
+from sqlalchemy import delete, func, not_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import Prompt as DbPrompt
@@ -26,12 +32,6 @@ from mcpgateway.db import Server as DbServer
 from mcpgateway.db import ServerMetric
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.schemas import ServerCreate, ServerMetrics, ServerRead, ServerUpdate
-
-# Third-Party
-import httpx
-from sqlalchemy import delete, func, not_, select
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -24,6 +24,15 @@ import re
 import time
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
+# Third-Party
+import httpx
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamablehttp_client
+from sqlalchemy import case, delete, func, literal, not_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
@@ -38,15 +47,6 @@ from mcpgateway.schemas import (
 from mcpgateway.types import TextContent, ToolResult
 from mcpgateway.utils.create_slug import slugify
 from mcpgateway.utils.services_auth import decode_auth
-
-# Third-Party
-import httpx
-from mcp import ClientSession
-from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
-from sqlalchemy import case, delete, func, literal, not_, select
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 
 # Local
 from ..config import extract_using_jq

--- a/mcpgateway/transports/sse_transport.py
+++ b/mcpgateway/transports/sse_transport.py
@@ -17,13 +17,13 @@ import logging
 from typing import Any, AsyncGenerator, Dict
 import uuid
 
-# First-Party
-from mcpgateway.config import settings
-from mcpgateway.transports.base import Transport
-
 # Third-Party
 from fastapi import Request
 from sse_starlette.sse import EventSourceResponse
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.transports.base import Transport
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -26,12 +26,6 @@ import re
 from typing import List, Union
 from uuid import uuid4
 
-# First-Party
-from mcpgateway.config import settings
-from mcpgateway.db import SessionLocal
-from mcpgateway.services.tool_service import ToolService
-from mcpgateway.utils.verify_credentials import verify_credentials
-
 # Third-Party
 from fastapi.security.utils import get_authorization_scheme_param
 from mcp import types
@@ -49,6 +43,13 @@ from starlette.datastructures import Headers
 from starlette.responses import JSONResponse
 from starlette.status import HTTP_401_UNAUTHORIZED
 from starlette.types import Receive, Scope, Send
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import SessionLocal
+from mcpgateway.services.tool_service import ToolService
+from mcpgateway.utils.verify_credentials import verify_credentials
+
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -128,7 +129,7 @@ class InMemoryEventStore(EventStore):
         self,
         last_event_id: EventId,
         send_callback: EventCallback,
-    ) -> StreamId | None:
+    ) -> Union[StreamId, None]:
         """
         Replays events that occurred after the specified event ID.
 

--- a/mcpgateway/transports/websocket_transport.py
+++ b/mcpgateway/transports/websocket_transport.py
@@ -14,12 +14,12 @@ import asyncio
 import logging
 from typing import Any, AsyncGenerator, Dict, Optional
 
+# Third-Party
+from fastapi import WebSocket, WebSocketDisconnect
+
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.transports.base import Transport
-
-# Third-Party
-from fastapi import WebSocket, WebSocketDisconnect
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -30,16 +30,16 @@ import time
 from typing import Any, Dict, Optional
 from urllib.parse import urlsplit, urlunsplit
 
-# First-Party
-from mcpgateway.config import settings
-from mcpgateway.db import engine
-from mcpgateway.utils.verify_credentials import require_auth
-
 # Third-Party
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import text
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import engine
+from mcpgateway.utils.verify_credentials import require_auth
 
 # Optional runtime dependencies
 try:

--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -41,9 +41,6 @@ import sys
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-# First-Party
-from mcpgateway import __version__
-
 # Third-Party
 import httpx
 from mcp import types
@@ -51,6 +48,9 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 import mcp.server.stdio
 from pydantic import AnyUrl
+
+# First-Party
+from mcpgateway import __version__
 
 # -----------------------------------------------------------------------------
 # Configuration


### PR DESCRIPTION
Cleanup code based on Pylint recommendations using `make pylint`.

Important notes:
- Pylint doesn't seem to recognize Pydantic V2. Will look into migrating to pylint-pydantic instead -> FIXED in Commit https://github.com/IBM/mcp-context-forge/pull/239/commits/7879638494a080cacac4c08857ac5ec23a013d63

- Running `isort file.py` will re-order third-party imports and place them **after** first-party imports. This upsets pylint, which requires third-party imports to be placed **before** first-party imports. Unsure how to change the order in isort from documentation, must investigate further.
