### PR TITLE
Id migration wrapper

### DIFF
--- a/mcpgateway/alembic/env.py
+++ b/mcpgateway/alembic/env.py
@@ -3,10 +3,10 @@
 from logging.config import fileConfig
 
 # Third-Party
-from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 # First-Party
+from alembic import context
 from mcpgateway.config import settings
 from mcpgateway.db import Base
 

--- a/mcpgateway/alembic/versions/b77ca9d2de7e_uuid_pk_and_slug_refactor.py
+++ b/mcpgateway/alembic/versions/b77ca9d2de7e_uuid_pk_and_slug_refactor.py
@@ -12,11 +12,11 @@ from typing import Sequence, Union
 import uuid
 
 # Third-Party
-from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 # First-Party
+from alembic import op
 from mcpgateway.config import settings
 from mcpgateway.utils.create_slug import slugify
 

--- a/mcpgateway/alembic/versions/b77ca9d2de7e_uuid_pk_and_slug_refactor.py
+++ b/mcpgateway/alembic/versions/b77ca9d2de7e_uuid_pk_and_slug_refactor.py
@@ -6,6 +6,7 @@ Revises:
 Create Date: 2025-06-26 21:29:59.117140
 
 """
+
 # Standard
 from typing import Sequence, Union
 import uuid

--- a/mcpgateway/alembic/versions/e4fc04d1a442_add_annotations_to_tables.py
+++ b/mcpgateway/alembic/versions/e4fc04d1a442_add_annotations_to_tables.py
@@ -11,8 +11,10 @@ Create Date: 2025-06-27 21:45:35.099713
 from typing import Sequence, Union
 
 # Third-Party
-from alembic import op
 import sqlalchemy as sa
+
+# First-Party
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "e4fc04d1a442"

--- a/mcpgateway/alembic/versions/e4fc04d1a442_add_annotations_to_tables.py
+++ b/mcpgateway/alembic/versions/e4fc04d1a442_add_annotations_to_tables.py
@@ -6,6 +6,7 @@ Revises: b77ca9d2de7e
 Create Date: 2025-06-27 21:45:35.099713
 
 """
+
 # Standard
 from typing import Sequence, Union
 

--- a/mcpgateway/alembic/versions/e75490e949b1_add_improved_status_to_tables.py
+++ b/mcpgateway/alembic/versions/e75490e949b1_add_improved_status_to_tables.py
@@ -10,9 +10,11 @@ Create Date: 2025-07-02 17:12:40.678256
 from typing import Sequence, Union
 
 # Third-Party
+import sqlalchemy as sa
+
+# First-Party
 # Alembic / SQLAlchemy
 from alembic import op
-import sqlalchemy as sa
 
 # Revision identifiers.
 revision: str = "e75490e949b1"

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -25,11 +25,11 @@ from importlib.resources import files
 import logging
 
 # Third-Party
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect
 
 # First-Party
+from alembic import command
 from mcpgateway.config import settings
 from mcpgateway.db import Base
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -167,7 +167,7 @@ class Settings(BaseSettings):
     # Health Checks
     health_check_interval: int = 60  # seconds
     health_check_timeout: int = 10  # seconds
-    unhealthy_threshold: int = 10
+    unhealthy_threshold: int = 5  # after this many failures, mark as Offline
 
     filelock_path: str = "tmp/gateway_service_leader.lock"
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -375,7 +375,7 @@ class ToolService:
                     await self._notify_tool_activated(tool)
                 else:
                     await self._notify_tool_deactivated(tool)
-                logger.info(f"Tool: {tool.name} is {'enabled' if activate else 'disabled'}{' and accessible' if reachable else 'but inaccessible'}")
+                logger.info(f"Tool: {tool.name} is {'enabled' if activate else 'disabled'}{' and accessible' if reachable else ' but inaccessible'}")
 
             return self._convert_tool_to_read(tool)
         except Exception as e:

--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -216,7 +216,7 @@ async def tools_metadata(tool_ids: List[str]) -> List[Dict[str, Any]]:
     if tool_ids == ["0"]:
         return data
 
-    return [tool for tool in data if tool["id"] in tool_ids]
+    return [tool for tool in data if tool["name"] in tool_ids]
 
 
 async def get_prompts_from_mcp_server(catalog_urls: List[str]) -> List[str]:

--- a/tests/unit/mcpgateway/test_wrapper.py
+++ b/tests/unit/mcpgateway/test_wrapper.py
@@ -415,12 +415,12 @@ async def test_handle_list_tools(monkeypatch, wrapper):
 async def test_get_tools_and_metadata(monkeypatch, wrapper):
     # fake catalog → two servers with associated tools
     catalog = [
-        {"id": "1", "associatedTools": ["10", "11"]},
-        {"id": "2", "associatedTools": ["20"]},
+        {"id": "1", "associatedTools": ["tool1", "tool2"]},
+        {"id": "2", "associatedTools": ["tool3"]},
     ]
     monkeypatch.setattr(wrapper, "fetch_url", _json_fetcher(catalog))
     out = await wrapper.get_tools_from_mcp_server(["https://host.com/servers/1"])
-    assert out == ["10", "11"]
+    assert out == ["tool1", "tool2"]
 
     # now cover tools_metadata *filter* & *all* paths
     tools_payload = [
@@ -428,7 +428,7 @@ async def test_get_tools_and_metadata(monkeypatch, wrapper):
         {"id": "11", "name": "B"},
     ]
     monkeypatch.setattr(wrapper, "fetch_url", _json_fetcher(tools_payload))
-    subset = await wrapper.tools_metadata(["10"])
+    subset = await wrapper.tools_metadata(["A"])
     assert subset == [{"id": "10", "name": "A"}]
 
     everything = await wrapper.tools_metadata(["0"])


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            – passes `ruff`, `mypy`, `pylint`
2. `make test`            – all unit + integration tests green
3. `make coverage`        – ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
The wrapper failed when extracting tools using Ids, as the system now associates virtual servers with tool names instead. The implementation has been updated to use tool names.



## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed