### PR TITLE
Persisting checkbox state

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -291,8 +291,15 @@ async def admin_delete_server(server_id: str, request: Request, db: Session = De
         await server_service.delete_server(db, server_id)
     except Exception as e:
         logger.error(f"Error deleting server: {e}")
-
+    
+    form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked", "false")
+    print("IS INACTIVE CHECKED:", is_inactive_checked)
     root_path = request.scope.get("root_path", "")
+    
+  
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
     return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
 
 
@@ -657,6 +664,8 @@ async def admin_edit_tool(
         await tool_service.update_tool(db, tool_id, tool)
 
         root_path = request.scope.get("root_path", "")
+        is_inactive_checked = form.get("is_inactive_checked", "false")
+        print("IS INACTIVE CHECKED:", is_inactive_checked)
         return RedirectResponse(f"{root_path}/admin#tools", status_code=303)
     except ToolNameConflictError as e:
         return JSONResponse(content={"message": str(e), "success": False}, status_code=400)
@@ -686,7 +695,12 @@ async def admin_delete_tool(tool_id: str, request: Request, db: Session = Depend
     logger.debug(f"User {user} is deleting tool ID {tool_id}")
     await tool_service.delete_tool(db, tool_id)
 
+    form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
+
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#tools", status_code=303)
     return RedirectResponse(f"{root_path}/admin#tools", status_code=303)
 
 
@@ -860,7 +874,12 @@ async def admin_delete_gateway(gateway_id: str, request: Request, db: Session = 
     logger.debug(f"User {user} is deleting gateway ID {gateway_id}")
     await gateway_service.delete_gateway(db, gateway_id)
 
+    form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
+    
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#gateways", status_code=303)
     return RedirectResponse(f"{root_path}/admin#gateways", status_code=303)
 
 
@@ -976,9 +995,15 @@ async def admin_delete_resource(uri: str, request: Request, db: Session = Depend
     """
     logger.debug(f"User {user} is deleting resource URI {uri}")
     await resource_service.delete_resource(db, uri)
-
+    
+    form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
+
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#resources", status_code=303)
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
+ 
 
 
 @admin_router.post("/resources/{resource_id}/toggle")
@@ -1136,7 +1161,12 @@ async def admin_delete_prompt(name: str, request: Request, db: Session = Depends
     logger.debug(f"User {user} is deleting prompt name {name}")
     await prompt_service.delete_prompt(db, name)
 
+    form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
+
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#prompts", status_code=303)
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)
 
 
@@ -1226,7 +1256,12 @@ async def admin_delete_root(uri: str, request: Request, user: str = Depends(requ
     logger.debug(f"User {user} is deleting root URI {uri}")
     await root_service.remove_root(uri)
 
+    form = await request.form()
     root_path = request.scope.get("root_path", "")
+    is_inactive_checked = form.get("is_inactive_checked", "false")
+
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#roots", status_code=303)
     return RedirectResponse(f"{root_path}/admin#roots", status_code=303)
 
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -157,7 +157,7 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
     is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         logger.debug(f"User {user} is adding a new server with name: {form['name']}")
-        
+
         server = ServerCreate(
             name=form.get("name"),
             description=form.get("description"),
@@ -213,7 +213,7 @@ async def admin_edit_server(
         RedirectResponse: A redirect to the admin dashboard catalog section with a status code of 303
     """
     form = await request.form()
-    is_inactive_checked = form.get("is_inactive_checked","false")
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         logger.debug(f"User {user} is editing server ID {server_id} with name: {form.get('name')}")
         server = ServerUpdate(
@@ -227,7 +227,7 @@ async def admin_edit_server(
         await server_service.update_server(db, server_id, server)
 
         root_path = request.scope.get("root_path", "")
-        
+
         if is_inactive_checked.lower() == "true":
             return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
         return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
@@ -303,11 +303,11 @@ async def admin_delete_server(server_id: str, request: Request, db: Session = De
         await server_service.delete_server(db, server_id)
     except Exception as e:
         logger.error(f"Error deleting server: {e}")
-    
+
     form = await request.form()
     is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
-    
+
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
     return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
@@ -892,7 +892,7 @@ async def admin_delete_gateway(gateway_id: str, request: Request, db: Session = 
     form = await request.form()
     is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
-    
+
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#gateways", status_code=303)
     return RedirectResponse(f"{root_path}/admin#gateways", status_code=303)
@@ -987,7 +987,7 @@ async def admin_edit_resource(
 
     root_path = request.scope.get("root_path", "")
     is_inactive_checked = form.get("is_inactive_checked", "false")
-    
+
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#resources", status_code=303)
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
@@ -1014,7 +1014,7 @@ async def admin_delete_resource(uri: str, request: Request, db: Session = Depend
     """
     logger.debug(f"User {user} is deleting resource URI {uri}")
     await resource_service.delete_resource(db, uri)
-    
+
     form = await request.form()
     is_inactive_checked = form.get("is_inactive_checked", "false")
     root_path = request.scope.get("root_path", "")
@@ -1022,7 +1022,6 @@ async def admin_delete_resource(uri: str, request: Request, db: Session = Depend
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#resources", status_code=303)
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
- 
 
 
 @admin_router.post("/resources/{resource_id}/toggle")
@@ -1156,7 +1155,7 @@ async def admin_edit_prompt(
 
     root_path = request.scope.get("root_path", "")
     is_inactive_checked = form.get("is_inactive_checked", "false")
-    
+
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#prompts", status_code=303)
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -154,8 +154,10 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
         RedirectResponse: A redirect to the admin dashboard catalog section
     """
     form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         logger.debug(f"User {user} is adding a new server with name: {form['name']}")
+        
         server = ServerCreate(
             name=form.get("name"),
             description=form.get("description"),
@@ -167,11 +169,15 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
         await server_service.register_server(db, server)
 
         root_path = request.scope.get("root_path", "")
+        if is_inactive_checked.lower() == "true":
+            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
         return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
     except Exception as e:
         logger.error(f"Error adding server: {e}")
 
         root_path = request.scope.get("root_path", "")
+        if is_inactive_checked.lower() == "true":
+            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
         return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
 
 
@@ -207,6 +213,7 @@ async def admin_edit_server(
         RedirectResponse: A redirect to the admin dashboard catalog section with a status code of 303
     """
     form = await request.form()
+    is_inactive_checked = form.get("is_inactive_checked","false")
     try:
         logger.debug(f"User {user} is editing server ID {server_id} with name: {form.get('name')}")
         server = ServerUpdate(
@@ -220,11 +227,16 @@ async def admin_edit_server(
         await server_service.update_server(db, server_id, server)
 
         root_path = request.scope.get("root_path", "")
+        
+        if is_inactive_checked.lower() == "true":
+            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
         return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
     except Exception as e:
         logger.error(f"Error editing server: {e}")
 
         root_path = request.scope.get("root_path", "")
+        if is_inactive_checked.lower() == "true":
+            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
         return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
 
 
@@ -294,10 +306,8 @@ async def admin_delete_server(server_id: str, request: Request, db: Session = De
     
     form = await request.form()
     is_inactive_checked = form.get("is_inactive_checked", "false")
-    print("IS INACTIVE CHECKED:", is_inactive_checked)
     root_path = request.scope.get("root_path", "")
     
-  
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
     return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
@@ -665,7 +675,8 @@ async def admin_edit_tool(
 
         root_path = request.scope.get("root_path", "")
         is_inactive_checked = form.get("is_inactive_checked", "false")
-        print("IS INACTIVE CHECKED:", is_inactive_checked)
+        if is_inactive_checked.lower() == "true":
+            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#tools", status_code=303)
         return RedirectResponse(f"{root_path}/admin#tools", status_code=303)
     except ToolNameConflictError as e:
         return JSONResponse(content={"message": str(e), "success": False}, status_code=400)
@@ -849,6 +860,10 @@ async def admin_edit_gateway(
     await gateway_service.update_gateway(db, gateway_id, gateway)
 
     root_path = request.scope.get("root_path", "")
+    is_inactive_checked = form.get("is_inactive_checked", "false")
+
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#gateways", status_code=303)
     return RedirectResponse(f"{root_path}/admin#gateways", status_code=303)
 
 
@@ -971,6 +986,10 @@ async def admin_edit_resource(
     await resource_service.update_resource(db, uri, resource)
 
     root_path = request.scope.get("root_path", "")
+    is_inactive_checked = form.get("is_inactive_checked", "false")
+    
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#resources", status_code=303)
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
 
 
@@ -1136,6 +1155,10 @@ async def admin_edit_prompt(
     await prompt_service.update_prompt(db, name, prompt)
 
     root_path = request.scope.get("root_path", "")
+    is_inactive_checked = form.get("is_inactive_checked", "false")
+    
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#prompts", status_code=303)
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)
 
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -256,12 +256,15 @@ async def admin_toggle_server(
     form = await request.form()
     logger.debug(f"User {user} is toggling server ID {server_id} with activate: {form.get('activate')}")
     activate = form.get("activate", "true").lower() == "true"
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         await server_service.toggle_server_status(db, server_id, activate)
     except Exception as e:
         logger.error(f"Error toggling server status: {e}")
 
     root_path = request.scope.get("root_path", "")
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
     return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
 
 
@@ -398,12 +401,16 @@ async def admin_toggle_gateway(
     logger.debug(f"User {user} is toggling gateway ID {gateway_id}")
     form = await request.form()
     activate = form.get("activate", "true").lower() == "true"
+    is_inactive_checked = form.get("is_inactive_checked", "false")
+
     try:
         await gateway_service.toggle_gateway_status(db, gateway_id, activate)
     except Exception as e:
         logger.error(f"Error toggling gateway status: {e}")
 
     root_path = request.scope.get("root_path", "")
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#gateways", status_code=303)
     return RedirectResponse(f"{root_path}/admin#gateways", status_code=303)
 
 
@@ -711,12 +718,15 @@ async def admin_toggle_tool(
     logger.debug(f"User {user} is toggling tool ID {tool_id}")
     form = await request.form()
     activate = form.get("activate", "true").lower() == "true"
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate)
     except Exception as e:
         logger.error(f"Error toggling tool status: {e}")
 
     root_path = request.scope.get("root_path", "")
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#tools", status_code=303)
     return RedirectResponse(f"{root_path}/admin#tools", status_code=303)
 
 
@@ -999,12 +1009,15 @@ async def admin_toggle_resource(
     logger.debug(f"User {user} is toggling resource ID {resource_id}")
     form = await request.form()
     activate = form.get("activate", "true").lower() == "true"
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         await resource_service.toggle_resource_status(db, resource_id, activate)
     except Exception as e:
         logger.error(f"Error toggling resource status: {e}")
 
     root_path = request.scope.get("root_path", "")
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#resources", status_code=303)
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
 
 
@@ -1155,12 +1168,15 @@ async def admin_toggle_prompt(
     logger.debug(f"User {user} is toggling prompt ID {prompt_id}")
     form = await request.form()
     activate = form.get("activate", "true").lower() == "true"
+    is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         await prompt_service.toggle_prompt_status(db, prompt_id, activate)
     except Exception as e:
         logger.error(f"Error toggling prompt status: {e}")
 
     root_path = request.scope.get("root_path", "")
+    if is_inactive_checked.lower() == "true":
+        return RedirectResponse(f"{root_path}/admin/?include_inactive=true#prompts", status_code=303)
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)
 
 

--- a/mcpgateway/alembic/env.py
+++ b/mcpgateway/alembic/env.py
@@ -3,10 +3,10 @@
 from logging.config import fileConfig
 
 # Third-Party
-from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 # First-Party
+from alembic import context
 from mcpgateway.config import settings
 from mcpgateway.db import Base
 

--- a/mcpgateway/alembic/versions/b77ca9d2de7e_uuid_pk_and_slug_refactor.py
+++ b/mcpgateway/alembic/versions/b77ca9d2de7e_uuid_pk_and_slug_refactor.py
@@ -6,16 +6,17 @@ Revises:
 Create Date: 2025-06-26 21:29:59.117140
 
 """
+
 # Standard
 from typing import Sequence, Union
 import uuid
 
 # Third-Party
-from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 # First-Party
+from alembic import op
 from mcpgateway.config import settings
 from mcpgateway.utils.create_slug import slugify
 

--- a/mcpgateway/alembic/versions/e4fc04d1a442_add_annotations_to_tables.py
+++ b/mcpgateway/alembic/versions/e4fc04d1a442_add_annotations_to_tables.py
@@ -6,12 +6,15 @@ Revises: b77ca9d2de7e
 Create Date: 2025-06-27 21:45:35.099713
 
 """
+
 # Standard
 from typing import Sequence, Union
 
 # Third-Party
-from alembic import op
 import sqlalchemy as sa
+
+# First-Party
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "e4fc04d1a442"

--- a/mcpgateway/alembic/versions/e75490e949b1_add_improved_status_to_tables.py
+++ b/mcpgateway/alembic/versions/e75490e949b1_add_improved_status_to_tables.py
@@ -10,9 +10,11 @@ Create Date: 2025-07-02 17:12:40.678256
 from typing import Sequence, Union
 
 # Third-Party
+import sqlalchemy as sa
+
+# First-Party
 # Alembic / SQLAlchemy
 from alembic import op
-import sqlalchemy as sa
 
 # Revision identifiers.
 revision: str = "e75490e949b1"

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -25,11 +25,11 @@ from importlib.resources import files
 import logging
 
 # Third-Party
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect
 
 # First-Party
+from alembic import command
 from mcpgateway.config import settings
 from mcpgateway.db import Base
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -532,6 +532,38 @@ function toggleInactiveItems(type) {
   window.location = url;
 }
 
+// Function to check if the "Show Inactive" checkbox is checked
+function isInactiveChecked(type) {
+  const checkbox = document.getElementById(`show-inactive-${type}`);
+  if (checkbox.checked) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function handleToggleSubmit(event, type) {
+  // Prevent form from submitting immediately
+  event.preventDefault();
+
+  // Get the value of 'is_inactive_checked' from the function
+  const is_inactive_checked = isInactiveChecked(type);  
+
+  // Dynamically add the 'is_inactive_checked' value to the form
+  const form = event.target;
+  const hiddenField = document.createElement('input');
+  hiddenField.type = 'hidden';
+  hiddenField.name = 'is_inactive_checked';
+  hiddenField.value = is_inactive_checked;
+
+  form.appendChild(hiddenField);
+
+  // Now submit the form
+  form.submit();
+}
+
+
+
 // Tool CRUD operations
 /**
  * Fetches detailed tool information from the backend and renders all properties,
@@ -2007,6 +2039,7 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 window.toggleInactiveItems = toggleInactiveItems;
+window.handleToggleSubmit = handleToggleSubmit
 window.viewTool = viewTool;
 window.editTool = editTool;
 window.testTool = testTool;

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -162,6 +162,9 @@ document.addEventListener("DOMContentLoaded", function () {
         status.textContent = "";
         status.classList.remove("error-status");
 
+        const is_inactive_checked = isInactiveChecked('gateways');  
+        formData.append("is_inactive_checked", is_inactive_checked);
+
         try {
           const response = await fetch(`${window.ROOT_PATH}/admin/gateways`, {
             method: "POST",
@@ -172,7 +175,11 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!result.success) {
               alert(result.message || "An error occurred");
             } else {
+              if (is_inactive_checked) {
+                window.location.href = `${window.ROOT_PATH}/admin?include_inactive=true#gateways`; // Redirect on success
+              } else{
               window.location.href = `${window.ROOT_PATH}/admin#gateways`; // Redirect on success
+              }
             }
 
         } catch (error) {
@@ -294,6 +301,8 @@ document.addEventListener("DOMContentLoaded", function () {
       }
 
       let formData = new FormData(this);
+      const is_inactive_checked = isInactiveChecked('tools');  
+      formData.append("is_inactive_checked", is_inactive_checked); 
       try {
         let response = await fetch(`${window.ROOT_PATH}/admin/tools`, {
           method: "POST",
@@ -303,7 +312,11 @@ document.addEventListener("DOMContentLoaded", function () {
         if (!result.success) {
           alert(result.message || "An error occurred");
         } else {
-          window.location.href = `${window.ROOT_PATH}/admin#tools`; // Redirect on success
+            if (is_inactive_checked) {
+              window.location.href = `${window.ROOT_PATH}/admin?include_inactive=true#tools`; // Redirect on success
+            } else{
+            window.location.href = `${window.ROOT_PATH}/admin#tools`; // Redirect on success
+            }
         }
       } catch (error) {
         console.error("Fetch error:", error);
@@ -758,6 +771,17 @@ async function editTool(toolId) {
     const response = await fetch(`${window.ROOT_PATH}/admin/tools/${toolId}`);
     const tool = await response.json();
 
+    const isInActiveCheckedBool = isInactiveChecked('tools');
+    let hiddenField = document.getElementById("edit-show-inactive");
+    if (!hiddenField) {
+      hiddenField = document.createElement("input");
+      hiddenField.type = "hidden";
+      hiddenField.name = "is_inactive_checked";
+      hiddenField.id = "edit-show-inactive";
+      document.getElementById("edit-tool-form").appendChild(hiddenField);
+    }
+    hiddenField.value = isInActiveCheckedBool;
+
     // Set form action and populate basic fields.
     document.getElementById("edit-tool-form").action =
       `${window.ROOT_PATH}/admin/tools/${toolId}/edit`;
@@ -910,6 +934,17 @@ async function editResource(resourceUri) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
     const data = await response.json();
+    const isInActiveCheckedBool = isInactiveChecked('resources');
+    let hiddenField = document.getElementById("edit-show-inactive");
+    if (!hiddenField) {
+      hiddenField = document.createElement("input");
+      hiddenField.type = "hidden";
+      hiddenField.name = "is_inactive_checked";
+      hiddenField.id = "edit-show-inactive";
+      document.getElementById("edit-resource-form").appendChild(hiddenField);
+    }
+    hiddenField.value = isInActiveCheckedBool;
+
     const resource = data.resource;
     // Set the form action for editing
     document.getElementById("edit-resource-form").action =
@@ -997,6 +1032,18 @@ async function editPrompt(promptName) {
       `${window.ROOT_PATH}/admin/prompts/${encodeURIComponent(promptName)}`,
     );
     const prompt = await response.json();
+
+    const isInActiveCheckedBool = isInactiveChecked('resources');
+    let hiddenField = document.getElementById("edit-show-inactive");
+    if (!hiddenField) {
+      hiddenField = document.createElement("input");
+      hiddenField.type = "hidden";
+      hiddenField.name = "is_inactive_checked";
+      hiddenField.id = "edit-show-inactive";
+      document.getElementById("edit-prompt-form").appendChild(hiddenField);
+    }
+    hiddenField.value = isInActiveCheckedBool;
+
     document.getElementById("edit-prompt-form").action =
       `${window.ROOT_PATH}/admin/prompts/${encodeURIComponent(promptName)}/edit`;
     document.getElementById("edit-prompt-name").value = prompt.name;
@@ -1103,6 +1150,18 @@ async function editGateway(gatewayId) {
   try {
     const response = await fetch(`${window.ROOT_PATH}/admin/gateways/${gatewayId}`);
     const gateway = await response.json();
+
+    const isInActiveCheckedBool = isInactiveChecked('gateways');
+    let hiddenField = document.getElementById("edit-show-inactive");
+    if (!hiddenField) {
+      hiddenField = document.createElement("input");
+      hiddenField.type = "hidden";
+      hiddenField.name = "is_inactive_checked";
+      hiddenField.id = "edit-show-inactive";
+      document.getElementById("edit-gateway-form").appendChild(hiddenField);
+    }
+    hiddenField.value = isInActiveCheckedBool;
+
     document.getElementById("edit-gateway-form").action =
       `${window.ROOT_PATH}/admin/gateways/${gatewayId}/edit`;
     document.getElementById("edit-gateway-name").value = gateway.name;
@@ -1220,6 +1279,17 @@ async function editServer(serverId) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
     const server = await response.json();
+
+    const isInActiveCheckedBool = isInactiveChecked('servers');
+    let hiddenField = document.getElementById("edit-show-inactive");
+    if (!hiddenField) {
+      hiddenField = document.createElement("input");
+      hiddenField.type = "hidden";
+      hiddenField.name = "is_inactive_checked";
+      hiddenField.id = "edit-show-inactive";
+      document.getElementById("edit-server-form").appendChild(hiddenField);
+    }
+    hiddenField.value = isInActiveCheckedBool;
     // Set the form action for editing
     document.getElementById("edit-server-form").action =
       `${window.ROOT_PATH}/admin/servers/${serverId}/edit`;

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -562,6 +562,18 @@ function handleToggleSubmit(event, type) {
   form.submit();
 }
 
+function handleSubmitWithConfirmation(event, type) {
+  event.preventDefault();
+
+  const confirmationMessage = `Are you sure you want to permanently delete this ${type}? (Deactivation is reversible, deletion is permanent)`;
+  const confirmation = confirm(confirmationMessage);
+  if (!confirmation) {
+    return false; // Prevent form submission
+  }
+
+  return handleToggleSubmit(event, type); // Proceed with your original function
+}
+
 
 
 // Tool CRUD operations
@@ -2039,7 +2051,8 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 window.toggleInactiveItems = toggleInactiveItems;
-window.handleToggleSubmit = handleToggleSubmit
+window.handleToggleSubmit = handleToggleSubmit;
+window.handleSubmitWithConfirmation = handleSubmitWithConfirmation;
 window.viewTool = viewTool;
 window.editTool = editTool;
 window.testTool = testTool;

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -313,7 +313,7 @@
                       method="POST"
                       action="{{ root_path }}/admin/servers/{{ server.id }}/delete"
                       class="inline"
-                      onsubmit="return confirm('Are you sure you want to permanently delete this server?');"
+                      onsubmit="return handleSubmitWithConfirmation(event, 'servers')"
                     >
                       <button
                         type="submit"
@@ -655,7 +655,7 @@
                       method="POST"
                       action="{{ root_path }}/admin/tools/{{ tool.id }}/delete"
                       class="inline"
-                      onsubmit="return confirm('Are you sure you want to permanently delete this tool? (Deactivation is reversible, deletion is permanent)');"
+                      onsubmit="return handleSubmitWithConfirmation(event, 'tools')"
                     >
                       <button
                         type="submit"
@@ -1020,7 +1020,7 @@
                       method="POST"
                       action="{{ root_path }}/admin/resources/{{ resource.uri }}/delete"
                       class="inline"
-                      onsubmit="return confirm('Are you sure you want to permanently delete this resource? (Deactivation is reversible, deletion is permanent)');"
+                      onsubmit="return handleSubmitWithConfirmation(event, 'resources')"
                     >
                       <button
                         type="submit"
@@ -1242,7 +1242,7 @@
                       method="POST"
                       action="{{ root_path }}/admin/prompts/{{ prompt.name }}/delete"
                       class="inline"
-                      onsubmit="return confirm('Are you sure you want to permanently delete this prompt? (Deactivation is reversible, deletion is permanent)');"
+                      onsubmit="return handleSubmitWithConfirmation(event, 'prompts')"
                     >
                       <button
                         type="submit"
@@ -1493,7 +1493,7 @@
                       method="POST"
                       action="{{ root_path }}/admin/gateways/{{ gateway.id }}/delete"
                       class="inline"
-                      onsubmit="return confirm('Are you sure you want to permanently delete this gateway? (Deactivation is reversible, deletion is permanent)');"
+                      onsubmit="return handleSubmitWithConfirmation(event, 'gateways')"
                     >
                       <button
                         type="submit"
@@ -1711,7 +1711,7 @@
                       method="POST"
                       action="{{ root_path }}/admin/roots/{{ root.uri }}/delete"
                       class="inline"
-                      onsubmit="return confirm('Are you sure you want to delete this root?');"
+                      onsubmit="return handleSubmitWithConfirmation(event, 'roots')"
                     >
                       <button type="submit" class="text-red-600 hover:text-red-900">
                         Delete

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -270,6 +270,7 @@
                       action="{{ root_path }}/admin/servers/{{ server.id }}/toggle"
                       class="inline mr-2"
                       title="Deactivate: This will temporarily disable the server without deleting it."
+                      onsubmit="return handleToggleSubmit(event, 'servers')"
                     >
                       <input type="hidden" name="activate" value="false" />
                       <button
@@ -285,6 +286,7 @@
                       action="{{ root_path }}/admin/servers/{{ server.id }}/toggle"
                       class="inline mr-2"
                       title="Activate: This will re-enable the server."
+                      onsubmit="return handleToggleSubmit(event, 'servers')"
                     >
                       <input type="hidden" name="activate" value="true" />
                       <button
@@ -610,6 +612,7 @@
                       action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle"
                       class="inline mr-2"
                       title="Deactivate"
+                      onsubmit="return handleToggleSubmit(event, 'tools')"
                     >
                       <input type="hidden" name="activate" value="false" />
                       <button
@@ -625,6 +628,7 @@
                       action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle"
                       class="inline mr-2"
                       title="Activate"
+                      onsubmit="return handleToggleSubmit(event, 'tools')"
                     >
                       <input type="hidden" name="activate" value="true" />
                       <button
@@ -973,6 +977,7 @@
                       action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle"
                       class="inline mr-2"
                       title="Deactivate: This will temporarily disable the resource without deleting it."
+                      onsubmit="return handleToggleSubmit(event, 'resources')"
                     >
                       <input type="hidden" name="activate" value="false" />
                       <button
@@ -988,6 +993,7 @@
                       action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle"
                       class="inline mr-2"
                       title="Activate: This will re-enable the resource."
+                      onsubmit="return handleToggleSubmit(event, 'resources')"
                     >
                       <input type="hidden" name="activate" value="true" />
                       <button
@@ -1193,6 +1199,7 @@
                       action="{{ root_path }}/admin/prompts/{{ prompt.id }}/toggle"
                       class="inline mr-2"
                       title="Deactivate: This will temporarily disable the prompt without deleting it."
+                      onsubmit="return handleToggleSubmit(event, 'prompts')"
                     >
                       <input type="hidden" name="activate" value="false" />
                       <button
@@ -1208,6 +1215,7 @@
                       action="{{ root_path }}/admin/prompts/{{ prompt.id }}/toggle"
                       class="inline mr-2"
                       title="Activate: This will re-enable the prompt."
+                      onsubmit="return handleToggleSubmit(event, 'prompts')"
                     >
                       <input type="hidden" name="activate" value="true" />
                       <button
@@ -1442,6 +1450,7 @@
                       action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
                       class="inline mr-2"
                       title="Deactivate: This will temporarily disable the gateway without deleting it."
+                      onsubmit="return handleToggleSubmit(event, 'gateways')"
                     >
                       <input type="hidden" name="activate" value="false" />
                       <button
@@ -1457,6 +1466,7 @@
                       action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
                       class="inline mr-2"
                       title="Activate: This will re-enable the gateway."
+                      onsubmit="return handleToggleSubmit(event, 'gateways')"
                     >
                       <input type="hidden" name="activate" value="true" />
                       <button

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -331,7 +331,11 @@
         </div>
         <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
           <h3 class="text-lg font-bold mb-4 dark:text-gray-200">Add New Server</h3>
-          <form method="POST" action="{{ root_path }}/admin/servers" id="add-server-form" onreset="document.getElementById('associatedTools').selectedIndex = -1;">
+          <form method="POST" 
+                action="{{ root_path }}/admin/servers" 
+                id="add-server-form" 
+                onsubmit="return handleToggleSubmit(event, 'servers')"
+                onreset="document.getElementById('associatedTools').selectedIndex = -1;">
             <div class="grid grid-cols-1 gap-6">
               <div>
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
@@ -1261,7 +1265,7 @@
 
         <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
           <h3 class="text-lg font-bold mb-4 dark:text-gray-200">Add New Prompt</h3>
-          <form method="POST" action="{{ root_path }}/admin/prompts" id="add-prompt-form">
+          <form method="POST" action="{{ root_path }}/admin/prompts" id="add-prompt-form" onsubmit="return handleToggleSubmit(event, 'prompts')">
             <div class="grid grid-cols-1 gap-6">
               <div>
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
@@ -1728,7 +1732,7 @@
         <!-- Add new root -------------------------------------------------------->
         <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
           <h3 class="text-lg font-bold mb-4 dark:text-gray-200">Add New Root</h3>
-          <form method="POST" action="{{ root_path }}/admin/roots" id="add-root-form">
+          <form method="POST" action="{{ root_path }}/admin/roots" id="add-root-form" onsubmit="return handleToggleSubmit(event, 'roots')">
             <div class="grid grid-cols-1 gap-6">
               <div>
                 <label class="block text-sm font-medium text-gray-700">URI</label>


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #177

---

## 🚀 Summary (1-2 sentences)
When the 'Show Inactive' button is checked, the setting persists across all sections and tabs. It also remains enabled after performing actions such as deactivating/activating, editing, or deleting any component (servers, tools, gateways, resources, prompts, etc.).

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)

**Previous Behaviour:**

https://github.com/user-attachments/assets/d564560b-0dd3-4896-8927-891197bbbc96



**Current Behaviour:**

https://github.com/user-attachments/assets/7d9e6407-0f01-4b3a-9ab0-6093b877cf9c



