### PR TITLE
Feat/test mcp server

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1366,6 +1366,9 @@ async def admin_test_gateway(request: GatewayTestRequest, user: str = Depends(re
 
     Returns:
         GatewayTestResponse: The response from the gateway, including status code, latency, and body
+
+    Raises:
+        HTTPException: If the gateway request fails (e.g., connection error, timeout).
     """
     full_url = str(request.base_url).rstrip("/") + "/" + request.path.lstrip("/")
     logger.debug(f"User {user} testing server at {request.base_url}.")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1355,6 +1355,17 @@ async def admin_reset_metrics(db: Session = Depends(get_db), user: str = Depends
 
 @admin_router.post("/gateways/test", response_model=GatewayTestResponse)
 async def admin_test_gateway(request: GatewayTestRequest, user: str = Depends(require_auth)) -> GatewayTestResponse:
+    """
+    Test a gateway by sending a request to its URL.
+    This endpoint allows administrators to test the connectivity and response
+
+    Args:
+        request (GatewayTestRequest): The request object containing the gateway URL and request details.
+        user (str): Authenticated user dependency.
+    
+    Returns:
+        GatewayTestResponse: The response from the gateway, including status code, latency, and body
+    """
     full_url = str(request.base_url).rstrip("/") + "/" + request.path.lstrip("/")
     logger.debug(f"User {user} testing server at {request.base_url}.")
     try:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1245,6 +1245,10 @@ class ServerRead(BaseModelWithConfigDict):
 
 
 class GatewayTestRequest(BaseModelWithConfigDict):
+    """Schema for testing gateway connectivity.
+
+    Includes the HTTP method, base URL, path, optional headers, and body.
+    """
     method: str = Field(..., description="HTTP method to test (GET, POST, etc.)")
     base_url: AnyHttpUrl = Field(..., description="Base URL of the gateway to test")
     path: str = Field(..., description="Path to append to the base URL")
@@ -1253,6 +1257,13 @@ class GatewayTestRequest(BaseModelWithConfigDict):
 
 
 class GatewayTestResponse(BaseModelWithConfigDict):
+    """Schema for the response from a gateway test request.
+
+    Contains:
+    - HTTP status code
+    - Latency in milliseconds
+    - Optional response body, which can be a string or JSON object
+    """
     status_code: int = Field(..., description="HTTP status code returned by the gateway")
     latency_ms: int = Field(..., description="Latency of the request in milliseconds")
     body: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Response body, can be a string or JSON object")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1249,6 +1249,7 @@ class GatewayTestRequest(BaseModelWithConfigDict):
 
     Includes the HTTP method, base URL, path, optional headers, and body.
     """
+
     method: str = Field(..., description="HTTP method to test (GET, POST, etc.)")
     base_url: AnyHttpUrl = Field(..., description="Base URL of the gateway to test")
     path: str = Field(..., description="Path to append to the base URL")
@@ -1264,6 +1265,7 @@ class GatewayTestResponse(BaseModelWithConfigDict):
     - Latency in milliseconds
     - Optional response body, which can be a string or JSON object
     """
+
     status_code: int = Field(..., description="HTTP status code returned by the gateway")
     latency_ms: int = Field(..., description="Latency of the request in milliseconds")
     body: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Response body, can be a string or JSON object")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1242,3 +1242,17 @@ class ServerRead(BaseModelWithConfigDict):
         if "associated_prompts" in values and values["associated_prompts"]:
             values["associated_prompts"] = [prompt.id if hasattr(prompt, "id") else prompt for prompt in values["associated_prompts"]]
         return values
+
+
+class GatewayTestRequest(BaseModelWithConfigDict):
+    method: str = Field(..., description="HTTP method to test (GET, POST, etc.)")
+    base_url: AnyHttpUrl = Field(..., description="Base URL of the gateway to test")
+    path: str = Field(..., description="Path to append to the base URL")
+    headers: Optional[Dict[str, str]] = Field(None, description="Optional headers for the request")
+    body: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Optional body for the request, can be a string or JSON object")
+
+
+class GatewayTestResponse(BaseModelWithConfigDict):
+    status_code: int = Field(..., description="HTTP status code returned by the gateway")
+    latency_ms: int = Field(..., description="Latency of the request in milliseconds")
+    body: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Response body, can be a string or JSON object")

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1146,6 +1146,30 @@ async function viewGateway(gatewayId) {
   }
 }
 
+async function testGateway() {
+  try {
+    openModal("gateway-test-modal");
+
+    headersEditor = CodeMirror.fromTextArea(document.getElementById('headers-json'), {
+      mode: "application/json",
+      theme: "monokai",
+      lineNumbers: true,
+    });
+    headersEditor.setSize(null, 100);
+    bodyEditor = CodeMirror.fromTextArea(document.getElementById('body-json'), {
+      mode: "application/json",
+      theme: "monokai",
+      lineNumbers: true
+    });
+    bodyEditor.setSize(null, 100);
+
+    
+  } catch (error) {
+    console.error("Error testing gateway:", error);
+    alert("Failed to test gateway");
+  }
+}
+
 async function editGateway(gatewayId) {
   try {
     const response = await fetch(`${window.ROOT_PATH}/admin/gateways/${gatewayId}`);

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1227,14 +1227,14 @@ async function testGateway(gatewayURL) {
 
   // Close the modal and reset the form when the close button is clicked
   document.getElementById("gateway-test-close").addEventListener("click", function () {
-    closeModal("gateway-test-modal");
-
     // Reset the form and CodeMirror editors
     document.getElementById("gateway-test-form").reset();
     headersEditor.setValue('');
     bodyEditor.setValue('');
     document.getElementById("response-json").textContent = '';
     document.getElementById("test-result").classList.add("hidden");
+
+    closeModal("gateway-test-modal");
   })
 }
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1146,6 +1146,9 @@ async function viewGateway(gatewayId) {
   }
 }
 
+// Function to test a gateway by sending a request to it
+// This function opens a modal where the user can input the request details
+// and see the response from the gateway.
 let headersEditor, bodyEditor;
 async function testGateway(gatewayURL) {
   openModal("gateway-test-modal");

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -162,7 +162,7 @@ document.addEventListener("DOMContentLoaded", function () {
         status.textContent = "";
         status.classList.remove("error-status");
 
-        const is_inactive_checked = isInactiveChecked('gateways');  
+        const is_inactive_checked = isInactiveChecked('gateways');
         formData.append("is_inactive_checked", is_inactive_checked);
 
         try {
@@ -301,8 +301,8 @@ document.addEventListener("DOMContentLoaded", function () {
       }
 
       let formData = new FormData(this);
-      const is_inactive_checked = isInactiveChecked('tools');  
-      formData.append("is_inactive_checked", is_inactive_checked); 
+      const is_inactive_checked = isInactiveChecked('tools');
+      formData.append("is_inactive_checked", is_inactive_checked);
       try {
         let response = await fetch(`${window.ROOT_PATH}/admin/tools`, {
           method: "POST",
@@ -560,7 +560,7 @@ function handleToggleSubmit(event, type) {
   event.preventDefault();
 
   // Get the value of 'is_inactive_checked' from the function
-  const is_inactive_checked = isInactiveChecked(type);  
+  const is_inactive_checked = isInactiveChecked(type);
 
   // Dynamically add the 'is_inactive_checked' value to the form
   const form = event.target;

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1171,7 +1171,6 @@ async function testGateway(gatewayURL) {
 
     // Show loading
     document.getElementById("loading").classList.remove("hidden");
-    document.getElementById("test-result").textContent = "";
 
     const form = e.target;
     const url = form.action;
@@ -1188,7 +1187,8 @@ async function testGateway(gatewayURL) {
       bodyParsed = bodyRaw ? JSON.parse(bodyRaw) : undefined;
     } catch (err) {
       document.getElementById("loading").classList.add("hidden");
-      document.getElementById("test-result").textContent = "❌ Invalid JSON in headers or body";
+      document.getElementById("response-json").textContent = `❌ Invalid JSON: ${err.message}`;
+      document.getElementById("test-result").classList.remove("hidden");
       return;
     }
 
@@ -1199,7 +1199,7 @@ async function testGateway(gatewayURL) {
       headers: headersParsed,
       body: bodyParsed,
     };
-    console.log("Testing gateway with payload:", payload);
+
     try {
       const response = await fetch(url, {
         method: "POST",
@@ -1208,13 +1208,13 @@ async function testGateway(gatewayURL) {
       });
 
       const result = await response.json();
-
-      document.getElementById("test-result").textContent =
-        `✅ Status: ${result.status_code}\n⏱ Latency: ${result.latency_ms}ms\n📦 Body:\n${JSON.stringify(result.body, null, 2)}`;
+      console.log("Test result:", result);
+      document.getElementById("response-json").textContent = JSON.stringify(result);
     } catch (err) {
-      document.getElementById("test-result").textContent = "❌ Error connecting to server";
+      document.getElementById("response-json").textContent = `❌ Error: ${err.message}`;
     } finally {
       document.getElementById("loading").classList.add("hidden");
+      document.getElementById("test-result").classList.remove("hidden");
     }
   });
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1488,6 +1488,11 @@
                       View
                     </button>
                     <button
+                      onclick="testGateway()"
+                      class="text-stone-600 hover:text-stone-900 mr-2">
+                      Test
+                    </button>
+                    <button
                       onclick="editGateway('{{ gateway.id }}')"
                       class="text-green-600 hover:text-green-900 mr-2"
                     >
@@ -2395,6 +2400,62 @@
         </div>
       </div>
     </div>
+
+    <!-- Test Gateway Modal -->
+    <div 
+      id="gateway-test-modal" 
+      class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden">
+      <div  class="bg-white dark:bg-gray-900 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg shadow-lg p-6">
+        <h2 class="text-xl font-bold mb-4 text-gray-800 dark:text-gray-100">Test Server Connectivity</h2>
+
+        <form id="gateway-test-form" class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Method</label>
+            <select 
+              name="method" id="method-select"
+              class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"
+              >
+              <option>GET</option>
+              <option>POST</option>
+              <option>PUT</option>
+              <option>DELETE</option>
+              <option>PATCH</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Path</label>
+            <input name="path" type="text" placeholder="/health"
+                  class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Headers (JSON)</label>
+            <textarea id="headers-json" class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"></textarea>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Body (JSON)</label>
+            <textarea id="body-json" class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"></textarea>
+          </div>
+
+          <button type="button" onclick="submitTest()"
+                  class="w-full text-center px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+            Send
+          </button>
+        </form>
+
+        <div id="loading" class="mt-4 hidden">
+          <div class="spinner border-t-4 border-blue-600 w-6 h-6 rounded-full animate-spin"></div>
+        </div>
+
+        <div id="test-result" class="mt-4 bg-gray-100 p-3 rounded text-sm overflow-auto text-gray-800" style="height: 220px;"></div>
+
+        <div class="mt-6 text-right">
+          <button onclick="closeModal('gateway-test-modal')" class="px-3 py-1 border rounded bg-white text-gray-700 hover:bg-gray-50">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>    
 
     <!-- Gateway Edit Modal -->
     <div

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -331,9 +331,9 @@
         </div>
         <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
           <h3 class="text-lg font-bold mb-4 dark:text-gray-200">Add New Server</h3>
-          <form method="POST" 
-                action="{{ root_path }}/admin/servers" 
-                id="add-server-form" 
+          <form method="POST"
+                action="{{ root_path }}/admin/servers"
+                id="add-server-form"
                 onsubmit="return handleToggleSubmit(event, 'servers')"
                 onreset="document.getElementById('associatedTools').selectedIndex = -1;">
             <div class="grid grid-cols-1 gap-6">
@@ -2402,8 +2402,8 @@
     </div>
 
     <!-- Test Gateway Modal -->
-    <div 
-      id="gateway-test-modal" 
+    <div
+      id="gateway-test-modal"
       class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden">
       <div  class="bg-white dark:bg-gray-900 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg shadow-lg p-6">
         <h2 class="text-xl font-bold mb-4 text-gray-800 dark:text-gray-100">Test Server Connectivity</h2>
@@ -2417,7 +2417,7 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Method</label>
-            <select 
+            <select
               name="method" id="gateway-test-method"
               class="mt-1 block w-full rounded-md shadow-sm p-1"
               >
@@ -2464,7 +2464,7 @@
           <div class="spinner border-t-4 border-blue-600 w-6 h-6 rounded-full animate-spin"></div>
         </div>
       </div>
-    </div>    
+    </div>
 
     <!-- Gateway Edit Modal -->
     <div

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1488,7 +1488,7 @@
                       View
                     </button>
                     <button
-                      onclick="testGateway()"
+                      onclick="testGateway('{{ gateway.url }}')"
                       class="text-stone-600 hover:text-stone-900 mr-2">
                       Test
                     </button>
@@ -2410,9 +2410,15 @@
 
         <form id="gateway-test-form" class="space-y-4">
           <div>
+            <label class="block text-sm font-medium text-gray-700">Server URL</label>
+            <input name="url" type="text" disabled
+                  id="gateway-test-url"
+                  class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1" />
+          </div>
+          <div>
             <label class="block text-sm font-medium text-gray-700">Method</label>
             <select 
-              name="method" id="method-select"
+              name="method" id="gateway-test-method"
               class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"
               >
               <option>GET</option>
@@ -2424,7 +2430,7 @@
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Path</label>
-            <input name="path" type="text" placeholder="/health"
+            <input id="gateway-test-path" name="path" type="text" placeholder="/health"
                   class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1" />
           </div>
           <div>
@@ -2437,7 +2443,7 @@
             <textarea id="body-json" class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"></textarea>
           </div>
 
-          <button type="button" onclick="submitTest()"
+          <button type="submit" id="gateway-test-submit"
                   class="w-full text-center px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
             Send
           </button>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1448,6 +1448,11 @@
                     gateway.lastSeen else 'Never' }}
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                    <button
+                      onclick="testGateway('{{ gateway.url }}')"
+                      class="text-stone-600 hover:text-stone-900 mr-2">
+                      Test
+                    </button>
                     {% if gateway.enabled %}
                     <form
                       method="POST"
@@ -1486,11 +1491,6 @@
                       class="text-indigo-600 dark:text-indigo-500 hover:text-indigo-900 mr-2"
                     >
                       View
-                    </button>
-                    <button
-                      onclick="testGateway('{{ gateway.url }}')"
-                      class="text-stone-600 hover:text-stone-900 mr-2">
-                      Test
                     </button>
                     <button
                       onclick="editGateway('{{ gateway.id }}')"
@@ -2413,13 +2413,13 @@
             <label class="block text-sm font-medium text-gray-700">Server URL</label>
             <input name="url" type="text"
                   id="gateway-test-url"
-                  class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1" />
+                  class="mt-1 block w-full rounded-md shadow-sm p-1" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Method</label>
             <select 
               name="method" id="gateway-test-method"
-              class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"
+              class="mt-1 block w-full rounded-md shadow-sm p-1"
               >
               <option>GET</option>
               <option>POST</option>
@@ -2431,16 +2431,16 @@
           <div>
             <label class="block text-sm font-medium text-gray-700">Path</label>
             <input id="gateway-test-path" name="path" type="text" placeholder="/health"
-                  class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1" />
+                  class="mt-1 block w-full rounded-md shadow-sm p-1" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Headers (JSON)</label>
-            <textarea id="headers-json" class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"></textarea>
+            <textarea id="headers-json" class="mt-1 block w-full rounded-md shadow-sm p-1"></textarea>
           </div>
 
           <div>
             <label class="block text-sm font-medium text-gray-700">Body (JSON)</label>
-            <textarea id="body-json" class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"></textarea>
+            <textarea id="body-json" class="mt-1 block w-full rounded-md shadow-sm p-1"></textarea>
           </div>
 
           <div class="flex">

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2443,22 +2443,25 @@
             <textarea id="body-json" class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1"></textarea>
           </div>
 
-          <button type="submit" id="gateway-test-submit"
-                  class="w-full text-center px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
-            Send
-          </button>
+          <div class="flex">
+            <button type="submit" id="gateway-test-submit"
+                    class="w-full text-center px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+              Send
+            </button>
+            <p class="p-1"></p>
+            <button onclick="closeModal('gateway-test-modal')" class="w-full text-center px-3 py-1 border rounded bg-white text-gray-700 hover:bg-gray-50">
+              Close
+            </button>
+          </div>
+
+          <div id="test-result" class="hidden">
+            <label class="block text-sm font-medium text-gray-700">Response</label>
+            <pre id="response-json" class="bg-gray-100 p-2 rounded overflow-auto text-sm text-gray-800 max-h-64"></pre>
+          </div>
         </form>
 
         <div id="loading" class="mt-4 hidden">
           <div class="spinner border-t-4 border-blue-600 w-6 h-6 rounded-full animate-spin"></div>
-        </div>
-
-        <div id="test-result" class="mt-4 bg-gray-100 p-3 rounded text-sm overflow-auto text-gray-800" style="height: 220px;"></div>
-
-        <div class="mt-6 text-right">
-          <button onclick="closeModal('gateway-test-modal')" class="px-3 py-1 border rounded bg-white text-gray-700 hover:bg-gray-50">
-            Close
-          </button>
         </div>
       </div>
     </div>    

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2411,7 +2411,7 @@
         <form id="gateway-test-form" class="space-y-4">
           <div>
             <label class="block text-sm font-medium text-gray-700">Server URL</label>
-            <input name="url" type="text" disabled
+            <input name="url" type="text"
                   id="gateway-test-url"
                   class="mt-1 block w-full border border-gray-700 rounded-md shadow-sm p-1" />
           </div>
@@ -2449,7 +2449,7 @@
               Send
             </button>
             <p class="p-1"></p>
-            <button onclick="closeModal('gateway-test-modal')" class="w-full text-center px-3 py-1 border rounded bg-white text-gray-700 hover:bg-gray-50">
+            <button id="gateway-test-close" type="button" class="w-full text-center px-3 py-1 border rounded bg-white text-gray-700 hover:bg-gray-50">
               Close
             </button>
           </div>


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue  
_Link to the epic or parent issue:_  
Closes [#181](https://github.com/IBM/mcp-context-forge/issues/181)

---

## 🚀 Summary (1-2 sentences)  
Adds a new **Test Gateway Connectivity** tool to the Admin UI, allowing admins to send custom HTTP requests to a gateway server and inspect the response directly from the frontend.

---

## 🧪 Checks

- [x] `make lint` passes  
- [x] `make test` passes  
- [ ] CHANGELOG updated (if user-facing) _Note: not quite sure what needs to be changed here._

---

## 📓 Notes (optional)

This feature allows testing a server's availability and debugging connectivity issues from the UI itself. It supports setting the method, path, headers, and body in JSON format.

Response is displayed in a pretty-printed JSON format with latency and status indicators.

## Frontend Flow:

```mermaid
flowchart TD
    A[Admin User] -->|"Click Test"| B[Open Modal]
    B --> C["Fill Form (method, path, headers, body)"]
    C --> D[Submit Form]
    D --> E[POST /admin/gateways/test]
    E --> F[Server makes outbound HTTP request]
    F --> G[Response received]
    G --> H["Show result in modal (status, latency, body)"]
```

## Modal Screenshot
![image](https://github.com/user-attachments/assets/8e28b049-5311-4984-a8e9-f41cf3560e5a)

