### PR TITLE
Do not restrict connection to clients of a specific MCP protocol version

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -657,11 +657,7 @@ class SessionRegistry(SessionBackend):
             )
 
         if protocol_version != settings.protocol_version:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unsupported protocol version: {protocol_version}",
-                headers={"MCP-Error-Code": "-32003"},
-            )
+            logger.warning(f"Using non default protocol version: {protocol_version}")
 
         return InitializeResult(
             protocolVersion=settings.protocol_version,

--- a/tests/unit/mcpgateway/cache/test_session_registry.py
+++ b/tests/unit/mcpgateway/cache/test_session_registry.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 # Standard
 import asyncio
 import json
+import logging
 import re
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, Mock, patch
@@ -480,11 +481,13 @@ async def test_handle_initialize_missing_version_error(registry: SessionRegistry
 
 
 @pytest.mark.asyncio
-async def test_handle_initialize_unsupported_version_error(registry: SessionRegistry):
+async def test_handle_initialize_unsupported_version_warning(registry: SessionRegistry, caplog):
+    caplog.set_level(logging.WARNING, logger="mcpgateway.cache.session_registry")
     body = {"protocol_version": "999"}
-    with pytest.raises(HTTPException) as exc:
-        await registry.handle_initialize_logic(body)
-    assert exc.value.headers["MCP-Error-Code"] == "-32003"
+
+    await registry.handle_initialize_logic(body)
+
+    assert "Using non default protocol version: 999" in caplog.text
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
- Allow connection from client protocol versions not set in `settings.protocol_version`.
- Show a warning in logs instead of throwing a HTTPException

## 🔁 Reproduction Steps
_Link the issue and minimal steps to reproduce the bug._

## 🐞 Root Cause
- Most recent protocol version is 2025-06-18. This brings additional changes such as support for OAuth, elicitation. [CHANGELOG](https://modelcontextprotocol.io/specification/2025-06-18/changelog)
- We have reviewed changes till 2025-03-26, where Streamable HTTP was added, but not the latest version. So, this not updated in settings.protocol_version.
- Earlier code was throwing a HTTPException disallowing connection from latest MCP Inspector v0.16.0
- To allow connection, allowing connection with warning instead of throwing an exception.

## 💡 Fix Description
- Replace HTTPException throw with a warning log
- Update test case to check if warning has message instead of checking for HTTPException

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
