### PR TITLE
Use non TTY docker with translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Copy [.env.example](.env.example) to `.env` and tweak any of the settings (or us
 ```bash
 # 1️⃣  Spin up the sample GO MCP time server using mcpgateway.translate & docker
 python3 -m mcpgateway.translate \
-     --stdio "docker run --rm -it -p 8888:8080 ghcr.io/ibm/fast-time-server:latest -transport=stdio" \
+     --stdio "docker run --rm -i -p 8888:8080 ghcr.io/ibm/fast-time-server:latest -transport=stdio" \
      --port 8003
 
 # Or using the official mcp-server-git using uvx:


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Fixes documentation to spin up the sample GO MCP time server using mcpgateway.translate & docker

## 🐞 Root Cause
The docker command earlier tried to start container with terminal from translate, but that was failing.

## 💡 Fix Description
Starting container without terminal

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
