### PR TITLE
feat: support both /message and /messages endpoints in fast-time-server

### DIFF
--- a/mcp-servers/go/fast-time-server/go.mod
+++ b/mcp-servers/go/fast-time-server/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.10
 require github.com/mark3labs/mcp-go v0.32.0 // MCP server/runtime
 
 require (
-    github.com/google/uuid v1.6.0 // indirect
-    github.com/spf13/cast v1.7.1 // indirect
-    github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 )

--- a/mcp-servers/go/fast-time-server/main.go
+++ b/mcp-servers/go/fast-time-server/main.go
@@ -3,7 +3,7 @@
 //
 // Copyright 2025
 // SPDX-License-Identifier: Apache-2.0
-// Authors: Mihai Criveti
+// Authors: Mihai Criveti, Manav Gupta
 //
 // This file implements an MCP (Model Context Protocol) server written in Go
 // that provides time-related tools for LLM applications. The server exposes
@@ -76,7 +76,7 @@
 //
 //   DUAL Transport:
 //     SSE Events:    http://localhost:8080/sse
-//     SSE Messages:  http://localhost:8080/messages
+//     SSE Messages:  http://localhost:8080/messages and http://localhost:8080/message
 //     HTTP MCP:      http://localhost:8080/http
 //     Health:        http://localhost:8080/health
 //     Version:       http://localhost:8080/version
@@ -609,7 +609,8 @@ func main() {
 
         // Register handlers
         mux.Handle("/sse", sseHandler)
-        mux.Handle("/messages", sseHandler)
+        mux.Handle("/messages", sseHandler) // Support plural (backward compatibility)
+        mux.Handle("/message", sseHandler)  // Support singular (MCP Gateway compatibility)
         mux.Handle("/http", httpHandler)
 
         // Register health and version endpoints
@@ -617,7 +618,7 @@ func main() {
 
         logAt(logInfo, "DUAL server ready on http://%s", addr)
         logAt(logInfo, "  SSE events:       /sse")
-        logAt(logInfo, "  SSE messages:     /messages")
+        logAt(logInfo, "  SSE messages:     /messages (plural) and /message (singular)")
         logAt(logInfo, "  HTTP endpoint:    /http")
         logAt(logInfo, "  Health check:     /health")
         logAt(logInfo, "  Version info:     /version")


### PR DESCRIPTION
- Add support for /message endpoint (singular) for MCP Gateway compatibility
- Maintain backward compatibility with /messages endpoint (plural)
- Update dual transport mode to register both endpoints
- Update logging to reflect both endpoints are available

Fixes compatibility issue where MCP Gateway expects /message but server only provided /messages.

## The Problem

The time server server provides /messages (plural) endpoint while the MCP gateway looks for /message.

```
curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" -H "Content-Type: application/json" -d '{
    "name": "time_server",
    "url": "http://localhost:8899/sse",
    "description": "Fast time server MCP"
  }' http://localhost:8000/gateways
```

The error shows:

`Client error '404 Not Found' for url 'http://localhost:8899/message?sessionId=...'`

## The Fix

Modified the handler to support both /messages and /message:

```
mux.Handle("/messages", sseHandler)  // Support plural (backward compatibility)
mux.Handle("/message", sseHandler)   // Support singular (MCP Gateway compatibility)
```


## Changes made

1. Added both endpoints:

```
mux.Handle("/messages", sseHandler)  // Support plural (backward compatibility)
mux.Handle("/message", sseHandler)   // Support singular (MCP Gateway compatibility)
```

2. Updated the log message to indicate both endpoints are supported:
`logAt(logInfo, "  SSE messages:     /messages (plural) and /message (singular)")`



