### PR TITLE
gateway_servers_actions_view

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException, status
 import httpx
 
 # First-Party
+from mcpgateway import __version__
 from mcpgateway.config import settings
 from mcpgateway.db import get_db, SessionMessageRecord, SessionRecord
 from mcpgateway.models import Implementation, InitializeResult, ServerCapabilities
@@ -669,7 +670,7 @@ class SessionRegistry(SessionBackend):
                 roots={"listChanged": True},
                 sampling={},
             ),
-            serverInfo=Implementation(name=settings.app_name, version="1.0.0"),
+            serverInfo=Implementation(name=settings.app_name, version=__version__),
             instructions=("MCP Gateway providing federated tools, resources and prompts. Use /admin interface for configuration."),
         )
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -58,7 +58,6 @@ class Settings(BaseSettings):
     templates_dir: Path = files("mcpgateway") / "templates"
     static_dir: Path = files("mcpgateway") / "static"
     app_root_path: str = ""
-
     # Protocol
     protocol_version: str = "2025-03-26"
 

--- a/mcpgateway/federation/discovery.py
+++ b/mcpgateway/federation/discovery.py
@@ -29,6 +29,7 @@ from zeroconf import ServiceInfo, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
 
 # First-Party
+from mcpgateway import __version__
 from mcpgateway.config import settings
 from mcpgateway.models import ServerCapabilities
 
@@ -64,7 +65,7 @@ class LocalDiscoveryService:
             port=settings.port,
             properties={
                 "name": settings.app_name,
-                "version": "1.0.0",
+                "version": __version__,
                 "protocol": PROTOCOL_VERSION,
             },
         )
@@ -350,7 +351,7 @@ class DiscoveryService(LocalDiscoveryService):
             "params": {
                 "protocol_version": PROTOCOL_VERSION,
                 "capabilities": {"roots": {"listChanged": True}, "sampling": {}},
-                "client_info": {"name": settings.app_name, "version": "1.0.0"},
+                "client_info": {"name": settings.app_name, "version": __version__},
             },
         }
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2155,7 +2155,7 @@ else:
             dict: API info with app name, version, and UI/admin API status.
         """
         logger.info("UI disabled, serving API info at root path")
-        return {"name": settings.app_name, "version": "1.0.0", "description": f"{settings.app_name} API - UI is disabled", "ui_enabled": False, "admin_api_enabled": ADMIN_API_ENABLED}
+        return {"name": settings.app_name, "version": __version__, "description": f"{settings.app_name} API - UI is disabled", "ui_enabled": UI_ENABLED, "admin_api_enabled": ADMIN_API_ENABLED}
 
 
 # Expose some endpoints at the root level as well

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -277,13 +277,14 @@ class GatewayService:
         gateways = db.execute(query).scalars().all()
         return [GatewayRead.model_validate(g) for g in gateways]
 
-    async def update_gateway(self, db: Session, gateway_id: str, gateway_update: GatewayUpdate) -> GatewayRead:
+    async def update_gateway(self, db: Session, gateway_id: str, gateway_update: GatewayUpdate, include_inactive: bool = True) -> GatewayRead:
         """Update a gateway.
 
         Args:
             db: Database session
             gateway_id: Gateway ID to update
             gateway_update: Updated gateway data
+            include_inactive: Whether to include inactive gateways
 
         Returns:
             Updated gateway information
@@ -299,88 +300,88 @@ class GatewayService:
             if not gateway:
                 raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 
-            if not gateway.enabled:
-                raise GatewayNotFoundError(f"Gateway '{gateway.name}' exists but is inactive")
+            if gateway.enabled or include_inactive:
+                # Check for name conflicts if name is being changed
+                if gateway_update.name is not None and gateway_update.name != gateway.name:
+                    existing_gateway = db.execute(select(DbGateway).where(DbGateway.name == gateway_update.name).where(DbGateway.id != gateway_id)).scalar_one_or_none()
 
-            # Check for name conflicts if name is being changed
-            if gateway_update.name is not None and gateway_update.name != gateway.name:
-                existing_gateway = db.execute(select(DbGateway).where(DbGateway.name == gateway_update.name).where(DbGateway.id != gateway_id)).scalar_one_or_none()
+                    if existing_gateway:
+                        raise GatewayNameConflictError(
+                            gateway_update.name,
+                            enabled=existing_gateway.enabled,
+                            gateway_id=existing_gateway.id,
+                        )
 
-                if existing_gateway:
-                    raise GatewayNameConflictError(
-                        gateway_update.name,
-                        enabled=existing_gateway.enabled,
-                        gateway_id=existing_gateway.id,
-                    )
+                # Update fields if provided
+                if gateway_update.name is not None:
+                    gateway.name = gateway_update.name
+                    gateway.slug = slugify(gateway_update.name)
+                if gateway_update.url is not None:
+                    gateway.url = gateway_update.url
+                if gateway_update.description is not None:
+                    gateway.description = gateway_update.description
+                if gateway_update.transport is not None:
+                    gateway.transport = gateway_update.transport
 
-            # Update fields if provided
-            if gateway_update.name is not None:
-                gateway.name = gateway_update.name
-                gateway.slug = slugify(gateway_update.name)
-            if gateway_update.url is not None:
-                gateway.url = gateway_update.url
-            if gateway_update.description is not None:
-                gateway.description = gateway_update.description
-            if gateway_update.transport is not None:
-                gateway.transport = gateway_update.transport
+                if getattr(gateway, "auth_type", None) is not None:
+                    gateway.auth_type = gateway_update.auth_type
 
-            if getattr(gateway, "auth_type", None) is not None:
-                gateway.auth_type = gateway_update.auth_type
+                    # if auth_type is not None and only then check auth_value
+                    if getattr(gateway, "auth_value", {}) != {}:
+                        gateway.auth_value = gateway_update.auth_value
 
-                # if auth_type is not None and only then check auth_value
-                if getattr(gateway, "auth_value", {}) != {}:
-                    gateway.auth_value = gateway_update.auth_value
+                # Try to reinitialize connection if URL changed
+                if gateway_update.url is not None:
+                    try:
+                        capabilities, tools = await self._initialize_gateway(gateway.url, gateway.auth_value, gateway.transport)
+                        new_tool_names = [tool.name for tool in tools]
 
-            # Try to reinitialize connection if URL changed
-            if gateway_update.url is not None:
-                try:
-                    capabilities, tools = await self._initialize_gateway(gateway.url, gateway.auth_value, gateway.transport)
-                    new_tool_names = [tool.name for tool in tools]
-
-                    for tool in tools:
-                        existing_tool = db.execute(select(DbTool).where(DbTool.original_name == tool.name).where(DbTool.gateway_id == gateway_id)).scalar_one_or_none()
-                        if not existing_tool:
-                            gateway.tools.append(
-                                DbTool(
-                                    original_name=tool.name,
-                                    original_name_slug=slugify(tool.name),
-                                    url=gateway.url,
-                                    description=tool.description,
-                                    integration_type=tool.integration_type,
-                                    request_type=tool.request_type,
-                                    headers=tool.headers,
-                                    input_schema=tool.input_schema,
-                                    jsonpath_filter=tool.jsonpath_filter,
-                                    auth_type=gateway.auth_type,
-                                    auth_value=gateway.auth_value,
+                        for tool in tools:
+                            existing_tool = db.execute(select(DbTool).where(DbTool.original_name == tool.name).where(DbTool.gateway_id == gateway_id)).scalar_one_or_none()
+                            if not existing_tool:
+                                gateway.tools.append(
+                                    DbTool(
+                                        original_name=tool.name,
+                                        original_name_slug=slugify(tool.name),
+                                        url=gateway.url,
+                                        description=tool.description,
+                                        integration_type=tool.integration_type,
+                                        request_type=tool.request_type,
+                                        headers=tool.headers,
+                                        input_schema=tool.input_schema,
+                                        jsonpath_filter=tool.jsonpath_filter,
+                                        auth_type=gateway.auth_type,
+                                        auth_value=gateway.auth_value,
+                                    )
                                 )
-                            )
 
-                    gateway.capabilities = capabilities
-                    gateway.tools = [tool for tool in gateway.tools if tool.original_name in new_tool_names]  # keep only still-valid rows
-                    gateway.last_seen = datetime.now(timezone.utc)
+                        gateway.capabilities = capabilities
+                        gateway.tools = [tool for tool in gateway.tools if tool.original_name in new_tool_names]  # keep only still-valid rows
+                        gateway.last_seen = datetime.now(timezone.utc)
 
-                    # Update tracking with new URL
-                    self._active_gateways.discard(gateway.url)
-                    self._active_gateways.add(gateway.url)
-                except Exception as e:
-                    logger.warning(f"Failed to initialize updated gateway: {e}")
+                        # Update tracking with new URL
+                        self._active_gateways.discard(gateway.url)
+                        self._active_gateways.add(gateway.url)
+                    except Exception as e:
+                        logger.warning(f"Failed to initialize updated gateway: {e}")
 
-            gateway.updated_at = datetime.now(timezone.utc)
-            db.commit()
-            db.refresh(gateway)
+                gateway.updated_at = datetime.now(timezone.utc)
+                db.commit()
+                db.refresh(gateway)
 
-            # Notify subscribers
-            await self._notify_gateway_updated(gateway)
+                # Notify subscribers
+                await self._notify_gateway_updated(gateway)
 
-            logger.info(f"Updated gateway: {gateway.name}")
-            return GatewayRead.model_validate(gateway)
+                logger.info(f"Updated gateway: {gateway.name}")
+                return GatewayRead.model_validate(gateway)
+            else:
+                raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 
         except Exception as e:
             db.rollback()
             raise GatewayError(f"Failed to update gateway: {str(e)}")
 
-    async def get_gateway(self, db: Session, gateway_id: str, include_inactive: bool = False) -> GatewayRead:
+    async def get_gateway(self, db: Session, gateway_id: str, include_inactive: bool = True) -> GatewayRead:
         """Get a specific gateway by ID.
 
         Args:
@@ -398,10 +399,10 @@ class GatewayService:
         if not gateway:
             raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 
-        if not gateway.enabled and not include_inactive:
-            raise GatewayNotFoundError(f"Gateway '{gateway.name}' exists but is inactive")
-
-        return GatewayRead.model_validate(gateway)
+        if gateway.enabled or include_inactive:
+            return GatewayRead.model_validate(gateway)
+        else:
+            raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 
     async def toggle_gateway_status(self, db: Session, gateway_id: str, activate: bool, reachable: bool = True, only_update_reachable: bool = False) -> GatewayRead:
         """Toggle gateway active status.

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1983,12 +1983,35 @@ async function viewGateway(gatewayId) {
             statusP.appendChild(statusStrong);
 
             const statusSpan = document.createElement("span");
-            statusSpan.className = `px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                gateway.isActive
-                    ? "bg-green-100 text-green-800"
-                    : "bg-red-100 text-red-800"
-            }`;
-            statusSpan.textContent = gateway.isActive ? "Active" : "Inactive";
+            let statusText = "";
+            let statusClass = "";
+            let statusIcon = "";
+            if (!gateway.enabled) {
+                statusText = "Inactive";
+                statusClass = "bg-red-100 text-red-800";
+                statusIcon = `
+                    <svg class="ml-1 h-4 w-4 text-red-600 self-center" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M6.293 6.293a1 1 0 011.414 0L10 8.586l2.293-2.293a1 1 0 111.414 1.414L11.414 10l2.293 2.293a1 1 0 11-1.414 1.414L10 11.414l-2.293 2.293a1 1 0 11-1.414-1.414L8.586 10 6.293 7.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                      </svg>`;
+            } else if (gateway.enabled && gateway.reachable) {
+                statusText = "Active";
+                statusClass = "bg-green-100 text-green-800";
+                statusIcon = `
+                    <svg class="ml-1 h-4 w-4 text-green-600 self-center" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-4.586l5.293-5.293-1.414-1.414L9 11.586 7.121 9.707 5.707 11.121 9 14.414z" clip-rule="evenodd"></path>
+                      </svg>`;
+            } else if (gateway.enabled && !gateway.reachable) {
+                statusText = "Offline";
+                statusClass = "bg-yellow-100 text-yellow-800";
+                statusIcon = `
+                    <svg class="ml-1 h-4 w-4 text-yellow-600 self-center" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-10h2v4h-2V8zm0 6h2v2h-2v-2z" clip-rule="evenodd"></path>
+                      </svg>`;
+            }
+
+            statusSpan.className = `px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${statusClass}`;
+            statusSpan.innerHTML = `${statusText} ${statusIcon}`;
+
             statusP.appendChild(statusSpan);
             container.appendChild(statusP);
 

--- a/mcpgateway/templates/version_info_partial.html
+++ b/mcpgateway/templates/version_info_partial.html
@@ -56,7 +56,7 @@
       <svg class="h-6 w-6 mr-2 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"></path>
       </svg>
-      Platform & Runtime
+      Platform &amp; Runtime
     </h3>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div class="bg-gray-50 rounded p-4 dark:bg-gray-700">

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -267,8 +267,13 @@ class TestGatewayService:
         """Inactive gateway is not returned unless explicitly asked for."""
         mock_gateway.enabled = False
         test_db.get = Mock(return_value=mock_gateway)
+        result = await gateway_service.get_gateway(test_db, 1, include_inactive=True)
+        assert result.id == 1
+        assert result.enabled == False
+        test_db.get.reset_mock()
+        test_db.get = Mock(return_value=mock_gateway)
         with pytest.raises(GatewayNotFoundError):
-            await gateway_service.get_gateway(test_db, 1)
+            result = await gateway_service.get_gateway(test_db, 1, include_inactive=False)
 
     # ────────────────────────────────────────────────────────────────────
     # UPDATE

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 # First-Party
+from mcpgateway import __version__
 from mcpgateway.config import settings
 from mcpgateway.models import InitializeResult, ResourceContent, ServerCapabilities
 from mcpgateway.schemas import (
@@ -212,7 +213,7 @@ class TestHealthAndInfrastructure:
     def test_root_redirect(self, test_client):
         """Test that root path behavior depends on UI configuration."""
         response = test_client.get("/", follow_redirects=False)
-        
+
         # Check if UI is enabled
         if settings.mcpgateway_ui_enabled:
             # When UI is enabled, should redirect to admin
@@ -253,7 +254,7 @@ class TestProtocolEndpoints:
         mock_result = InitializeResult(
             protocolVersion=PROTOCOL_VERSION,
             capabilities=mock_capabilities,
-            serverInfo={"name": "MCP Gateway", "version": "1.0.0"},
+            serverInfo={"name": settings.app_name, "version": __version__},
             instructions="MCP Gateway providing federated tools, resources and prompts.",
         )
         mock_handle_initialize.return_value = mock_result

--- a/tests/unit/mcpgateway/test_ui_version.py
+++ b/tests/unit/mcpgateway/test_ui_version.py
@@ -67,10 +67,7 @@ def auth_headers() -> Dict[str, str]:
 #     assert "App:" in html or "Application:" in html
 
 
-@pytest.mark.skipif(
-    not settings.mcpgateway_ui_enabled,
-    reason="Admin UI tests require MCPGATEWAY_UI_ENABLED=true"
-)
+@pytest.mark.skipif(not settings.mcpgateway_ui_enabled, reason="Admin UI tests require MCPGATEWAY_UI_ENABLED=true")
 def test_admin_ui_contains_version_tab(test_client: TestClient, auth_headers: Dict[str, str]):
     """The Admin dashboard must contain the "Version & Environment Info" tab."""
     resp = test_client.get("/admin", headers=auth_headers)


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
- Updated inActive to reachable/enabled
- made fixes for Bug 382
- Gateway Servers will have 3 states - Active/Inactive/Offline
- Updated a test case that tests the gatewayInactive scenario

## 💡 Fix Description
- Gateway Servers will show status one of the following - [ Active (Green), Inactive (Red), Offline (Yellow)]
- Updated the test case - test_gateway_services.py
- Updated the version to use semantic version as in __init__.py (wherever version is being used)
- Updated isActive to use reachable and enabled 


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Unit tests                            | `make test`          |    pass    |
| Unit tests                            | `make black`          |    pass    |
| Unit tests                            | `make lint-web`          |    pass    |


## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

Signed-off-by: Satya <tsp.0713@gmail.com>