### PR TITLE
Bug Fix: Test Server Connectivity URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Use the official OCI image from GHCR with **Docker** *or* **Podman**.
 docker run -d --name mcpgateway \
   -p 4444:4444 \
   -e MCPGATEWAY_UI_ENABLED=true \
-  -e MCPGATEWAY_ADMIN_API_ENABLED=true \  
+  -e MCPGATEWAY_ADMIN_API_ENABLED=true \
   -e HOST=0.0.0.0 \
   -e JWT_SECRET_KEY=my-test-key \
   -e BASIC_AUTH_USER=admin \
@@ -410,7 +410,7 @@ docker run -d --name mcpgateway \
   -p 4444:4444 \
   -v $(pwd)/data:/data \
   -e MCPGATEWAY_UI_ENABLED=true \
-  -e MCPGATEWAY_ADMIN_API_ENABLED=true \  
+  -e MCPGATEWAY_ADMIN_API_ENABLED=true \
   -e DATABASE_URL=sqlite:////data/mcp.db \
   -e HOST=0.0.0.0 \
   -e JWT_SECRET_KEY=my-test-key \
@@ -435,7 +435,7 @@ chmod 777 $(pwd)/data
 docker run -d --name mcpgateway \
   --network=host \
   -e MCPGATEWAY_UI_ENABLED=true \
-  -e MCPGATEWAY_ADMIN_API_ENABLED=true \  
+  -e MCPGATEWAY_ADMIN_API_ENABLED=true \
   -e HOST=0.0.0.0 \
   -e PORT=4444 \
   -e DATABASE_URL=sqlite:////data/mcp.db \

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3251,7 +3251,7 @@ async function testGateway(gatewayURL) {
 
         // Initialize CodeMirror editors if they don't exist
         if (!gatewayTestHeadersEditor) {
-            const headersElement = safeGetElement("headers-json");
+            const headersElement = safeGetElement("gateway-test-headers");
             if (headersElement && window.CodeMirror) {
                 gatewayTestHeadersEditor = window.CodeMirror.fromTextArea(
                     headersElement,
@@ -3266,7 +3266,7 @@ async function testGateway(gatewayURL) {
         }
 
         if (!gatewayTestBodyEditor) {
-            const bodyElement = safeGetElement("body-json");
+            const bodyElement = safeGetElement("gateway-test-body");
             if (bodyElement && window.CodeMirror) {
                 gatewayTestBodyEditor = window.CodeMirror.fromTextArea(
                     bodyElement,
@@ -3316,13 +3316,14 @@ async function testGateway(gatewayURL) {
 async function handleGatewayTestSubmit(e) {
     e.preventDefault();
 
-    const loading = safeGetElement("loading");
-    const responseDiv = safeGetElement("response-json");
-    const resultDiv = safeGetElement("test-result");
+    const loading = safeGetElement("gateway-test-loading");
+    const responseDiv = safeGetElement("gateway-test-response-json");
+    const resultDiv = safeGetElement("gateway-test-result");
 
     try {
         // Show loading
         if (loading) {
+            console.log(loading)
             loading.classList.remove("hidden");
         }
         if (resultDiv) {
@@ -3395,13 +3396,26 @@ async function handleGatewayTestSubmit(e) {
 
         if (responseDiv) {
             // Display result safely
-            const pre = document.createElement("pre");
-            pre.className =
-                "bg-gray-100 p-4 rounded overflow-auto max-h-96 dark:bg-gray-800 dark:text-gray-100";
-            pre.textContent = JSON.stringify(result, null, 2);
-            responseDiv.innerHTML = "";
-            responseDiv.appendChild(pre);
+            responseDiv.innerHTML = `
+                <div class="alert alert-success">
+                    <h4>✅ Connection Successful</h4>
+                    <p><strong>Status Code:</strong> ${result.statusCode}</p>
+                    <p><strong>Response Time:</strong> ${result.latencyMs}ms</p>
+                    ${result.body ? `<details>
+                        <summary class='cursor-pointer'>Response Body</summary>
+                        <pre class="text-sm px-4 max-h-96 dark:bg-gray-800 dark:text-gray-100 overflow-auto">${JSON.stringify(result.body, null, 2)}</pre>
+                    </details>` : ''}
+                </div>
+            `;
+        } else {
+        responseDiv.innerHTML = `
+            <div class="alert alert-error">
+                <h4>❌ Connection Failed</h4>
+                <p>${result.error || 'Unable to connect to the server'}</p>
+            </div>
+        `;
         }
+        console.log("✓ Gateway test completed successfully");
     } catch (error) {
         console.error("Gateway test error:", error);
         if (responseDiv) {
@@ -3447,8 +3461,8 @@ function handleGatewayTestClose() {
         }
 
         // Clear response
-        const responseDiv = safeGetElement("response-json");
-        const resultDiv = safeGetElement("test-result");
+        const responseDiv = safeGetElement("gateway-test-response-json");
+        const resultDiv = safeGetElement("gateway-test-result");
 
         if (responseDiv) {
             responseDiv.innerHTML = "";

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3334,7 +3334,7 @@ async function handleGatewayTestSubmit(e) {
 
         // Get form data with validation
         const formData = new FormData(form);
-        const baseUrl = formData.get("gateway-test-url");
+        const baseUrl = formData.get("url");
         const method = formData.get("method");
         const path = formData.get("path");
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3323,7 +3323,6 @@ async function handleGatewayTestSubmit(e) {
     try {
         // Show loading
         if (loading) {
-            console.log(loading)
             loading.classList.remove("hidden");
         }
         if (resultDiv) {
@@ -3415,7 +3414,6 @@ async function handleGatewayTestSubmit(e) {
             </div>
         `;
         }
-        console.log("✓ Gateway test completed successfully");
     } catch (error) {
         console.error("Gateway test error:", error);
         if (responseDiv) {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3400,17 +3400,21 @@ async function handleGatewayTestSubmit(e) {
                     <h4>✅ Connection Successful</h4>
                     <p><strong>Status Code:</strong> ${result.statusCode}</p>
                     <p><strong>Response Time:</strong> ${result.latencyMs}ms</p>
-                    ${result.body ? `<details>
+                    ${
+                        result.body
+                            ? `<details>
                         <summary class='cursor-pointer'>Response Body</summary>
                         <pre class="text-sm px-4 max-h-96 dark:bg-gray-800 dark:text-gray-100 overflow-auto">${JSON.stringify(result.body, null, 2)}</pre>
-                    </details>` : ''}
+                    </details>`
+                            : ""
+                    }
                 </div>
             `;
         } else {
-        responseDiv.innerHTML = `
+            responseDiv.innerHTML = `
             <div class="alert alert-error">
                 <h4>❌ Connection Failed</h4>
-                <p>${result.error || 'Unable to connect to the server'}</p>
+                <p>${result.error || "Unable to connect to the server"}</p>
             </div>
         `;
         }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1705,15 +1705,14 @@
     <div id="gateway-test-modal"
       class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden">
       <div class="bg-white dark:bg-gray-900 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg shadow-lg p-6">
-        <h2 class="text-xl font-bold mb-4 text-gray-800 dark:text-gray-100">Test Server Connectivity</h2>
-
+        <h2 class="text-xl font-bold mb-4 text-gray-800 dark:text-gray-100">Test Gateway Connectivity</h2>
         <form id="gateway-test-form" class="space-y-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700">Server URL</label>
+            <label for="gateway-test-url" class="block text-sm font-medium text-gray-700">Server URL</label>
             <input name="url" type="text" id="gateway-test-url" class="mt-1 block w-full rounded-md shadow-sm p-1" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Method</label>
+            <label for="gateway-test-method" class="block text-sm font-medium text-gray-700">Method</label>
             <select name="method" id="gateway-test-method" class="mt-1 block w-full rounded-md shadow-sm p-1">
               <option>GET</option>
               <option>POST</option>
@@ -1723,18 +1722,18 @@
             </select>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Path</label>
+            <label for="gateway-test-path" class="block text-sm font-medium text-gray-700">Path</label>
             <input id="gateway-test-path" name="path" type="text" placeholder="/health"
               class="mt-1 block w-full rounded-md shadow-sm p-1" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Headers (JSON)</label>
-            <textarea id="headers-json" class="mt-1 block w-full rounded-md shadow-sm p-1"></textarea>
+            <label for="gateway-test-headers" class="block text-sm font-medium text-gray-700">Headers (JSON)</label>
+            <textarea id="gateway-test-headers" class="mt-1 block w-full rounded-md shadow-sm p-1"></textarea>
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">Body (JSON)</label>
-            <textarea id="body-json" class="mt-1 block w-full rounded-md shadow-sm p-1"></textarea>
+            <label for="gateway-test-body" class="block text-sm font-medium text-gray-700">Body (JSON)</label>
+            <textarea id="gateway-test-body" class="mt-1 block w-full rounded-md shadow-sm p-1"></textarea>
           </div>
 
           <div class="flex">
@@ -1749,15 +1748,16 @@
             </button>
           </div>
 
-          <div id="test-result" class="hidden">
+          <div id="gateway-test-loading" class="mt-4 hidden flex items-center justify-center">
+            <div class="spinner border-t-4 border-blue-600 w-6 h-6 rounded-full animate-spin"></div>
+          </div>
+
+          <div id="gateway-test-result" class="hidden">
             <label class="block text-sm font-medium text-gray-700">Response</label>
-            <pre id="response-json" class="bg-gray-100 p-2 rounded overflow-auto text-sm text-gray-800 max-h-64"></pre>
+            <div id="gateway-test-response-json" class="bg-gray-100 p-2 rounded overflow-auto text-sm text-gray-800 max-h-64"></pre>
           </div>
         </form>
 
-        <div id="loading" class="mt-4 hidden">
-          <div class="spinner border-t-4 border-blue-600 w-6 h-6 rounded-full animate-spin"></div>
-        </div>
       </div>
     </div>
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1754,7 +1754,8 @@
 
           <div id="gateway-test-result" class="hidden">
             <label class="block text-sm font-medium text-gray-700">Response</label>
-            <div id="gateway-test-response-json" class="bg-gray-100 p-2 rounded overflow-auto text-sm text-gray-800 max-h-64"></pre>
+            <div id="gateway-test-response-json"
+              class="bg-gray-100 p-2 rounded overflow-auto text-sm text-gray-800 max-h-64"></div>
           </div>
         </form>
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -212,7 +212,7 @@ class TestHealthAndInfrastructure:
     def test_root_redirect(self, test_client):
         """Test that root path behavior depends on UI configuration."""
         response = test_client.get("/", follow_redirects=False)
-        
+
         # Check if UI is enabled
         if settings.mcpgateway_ui_enabled:
             # When UI is enabled, should redirect to admin

--- a/tests/unit/mcpgateway/test_ui_version.py
+++ b/tests/unit/mcpgateway/test_ui_version.py
@@ -67,10 +67,7 @@ def auth_headers() -> Dict[str, str]:
 #     assert "App:" in html or "Application:" in html
 
 
-@pytest.mark.skipif(
-    not settings.mcpgateway_ui_enabled,
-    reason="Admin UI tests require MCPGATEWAY_UI_ENABLED=true"
-)
+@pytest.mark.skipif(not settings.mcpgateway_ui_enabled, reason="Admin UI tests require MCPGATEWAY_UI_ENABLED=true")
 def test_admin_ui_contains_version_tab(test_client: TestClient, auth_headers: Dict[str, str]):
     """The Admin dashboard must contain the "Version & Environment Info" tab."""
     resp = test_client.get("/admin", headers=auth_headers)


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes the Admin Gateway Test UI bug where the form submitted incorrect data and the response was not clearly displayed. Improves UI reliability and feedback when testing gateway connectivity.

---

## 🔁 Reproduction Steps

Closes [#367](https://github.com/IBM/mcp-context-forge/issues/367)

**Steps to reproduce (before fix):**
1. Open the "Test" modal for a gateway
2. Submit the form
3. Notice that the `url` is always incorrect or missing
4. Response is not clearly formatted
5. Reopening the modal sometimes duplicates editors or input fields

---

## 🐞 Root Cause

- In the form submit handler, the `name` attribute for the gateway URL input was missing or incorrect.
- As a result, `formData.get("gateway-test-url")` returned `null`, and the API received an invalid base URL.
- Modal field names were inconsistent and hard to maintain.

---

## 💡 Fix Description

- Fixed the incorrect `name` attribute for the gateway URL input field.
- Renamed and standardised modal field IDs attributes for clarity.
- Improved response UI.
- Verified gateway testing against a live MCP server with custom headers and body — all working as expected.
- Tested loading states - working fine.

---

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | [x]     |
| Unit tests                            | `make test`          | [x]     |
| Coverage ≥ 90 %                       | `make coverage`      | [ ]     |
| Manual regression no longer fails     | Tested with valid/invalid headers, method, and body | [x]     |

---

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
