### PR TITLE
Added doctests to utility modules

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -7,6 +7,21 @@ Authors: Mihai Criveti
 
 This module provides a registry for SSE sessions with support for distributed deployment
 using Redis or SQLAlchemy as optional backends for shared state between workers.
+
+Doctest examples (memory backend only)
+--------------------------------------
+>>> from mcpgateway.cache.session_registry import SessionRegistry
+>>> class DummyTransport:
+...     pass
+>>> reg = SessionRegistry(backend='memory')
+>>> import asyncio
+>>> asyncio.run(reg.add_session('sid', DummyTransport()))
+>>> t = asyncio.run(reg.get_session('sid'))
+>>> isinstance(t, DummyTransport)
+True
+>>> asyncio.run(reg.remove_session('sid'))
+>>> asyncio.run(reg.get_session('sid')) is None
+True
 """
 
 # Standard
@@ -106,7 +121,8 @@ class SessionBackend:
 
 
 class SessionRegistry(SessionBackend):
-    """Registry for SSE sessions with optional distributed state.
+    """
+    Registry for SSE sessions with optional distributed state.
 
     Supports three backend modes:
     - memory: In-memory storage (default, no dependencies)
@@ -115,6 +131,20 @@ class SessionRegistry(SessionBackend):
 
     In distributed mode (redis/database), session existence is tracked in the shared
     backend while transports themselves remain local to each worker process.
+
+    Doctest (memory backend only):
+    >>> from mcpgateway.cache.session_registry import SessionRegistry
+    >>> class DummyTransport:
+    ...     pass
+    >>> reg = SessionRegistry(backend='memory')
+    >>> import asyncio
+    >>> asyncio.run(reg.add_session('sid', DummyTransport()))
+    >>> t = asyncio.run(reg.get_session('sid'))
+    >>> isinstance(t, DummyTransport)
+    True
+    >>> asyncio.run(reg.remove_session('sid'))
+    >>> asyncio.run(reg.get_session('sid')) is None
+    True
     """
 
     def __init__(

--- a/mcpgateway/utils/create_jwt_token.py
+++ b/mcpgateway/utils/create_jwt_token.py
@@ -16,12 +16,24 @@ CLI (default secret, default payload):
     $ python3 jwt_cli.py
 
 Library:
-```python
-from mcpgateway.utils.create_jwt_token import create_jwt_token, get_jwt_token
+    from mcpgateway.utils.create_jwt_token import create_jwt_token, get_jwt_token
 
-# inside async context
-jwt = await create_jwt_token({"username": "alice"})
-```
+    # inside async context
+    jwt = await create_jwt_token({"username": "alice"})
+
+Doctest examples
+----------------
+>>> from mcpgateway.utils import create_jwt_token as jwt_util
+>>> jwt_util.settings.jwt_secret_key = 'secret'
+>>> jwt_util.settings.jwt_algorithm = 'HS256'
+>>> token = jwt_util._create_jwt_token({'sub': 'alice'}, expires_in_minutes=1, secret='secret', algorithm='HS256')
+>>> import jwt
+>>> jwt.decode(token, 'secret', algorithms=['HS256'])['sub'] == 'alice'
+True
+>>> import asyncio
+>>> t = asyncio.run(jwt_util.create_jwt_token({'sub': 'bob'}, expires_in_minutes=1, secret='secret', algorithm='HS256'))
+>>> jwt.decode(t, 'secret', algorithms=['HS256'])['sub'] == 'bob'
+True
 """
 
 # Future
@@ -67,7 +79,8 @@ def _create_jwt_token(
     secret: str = DEFAULT_SECRET,
     algorithm: str = DEFAULT_ALGO,
 ) -> str:
-    """Return a signed JWT string (synchronous, timezone-aware).
+    """
+    Return a signed JWT string (synchronous, timezone-aware).
 
     Args:
         data: Dictionary containing payload data to encode in the token.
@@ -78,6 +91,15 @@ def _create_jwt_token(
 
     Returns:
         The JWT token string.
+
+    Doctest:
+    >>> from mcpgateway.utils import create_jwt_token as jwt_util
+    >>> jwt_util.settings.jwt_secret_key = 'secret'
+    >>> jwt_util.settings.jwt_algorithm = 'HS256'
+    >>> token = jwt_util._create_jwt_token({'sub': 'alice'}, expires_in_minutes=1, secret='secret', algorithm='HS256')
+    >>> import jwt
+    >>> jwt.decode(token, 'secret', algorithms=['HS256'])['sub'] == 'alice'
+    True
     """
     payload = data.copy()
     if expires_in_minutes > 0:
@@ -98,7 +120,8 @@ async def create_jwt_token(
     secret: str = DEFAULT_SECRET,
     algorithm: str = DEFAULT_ALGO,
 ) -> str:
-    """Async facade for historic code. Internally synchronous-almost instant.
+    """
+    Async facade for historic code. Internally synchronous-almost instant.
 
     Args:
         data: Dictionary containing payload data to encode in the token.
@@ -109,6 +132,16 @@ async def create_jwt_token(
 
     Returns:
         The JWT token string.
+
+    Doctest:
+    >>> from mcpgateway.utils import create_jwt_token as jwt_util
+    >>> jwt_util.settings.jwt_secret_key = 'secret'
+    >>> jwt_util.settings.jwt_algorithm = 'HS256'
+    >>> import asyncio
+    >>> t = asyncio.run(jwt_util.create_jwt_token({'sub': 'bob'}, expires_in_minutes=1, secret='secret', algorithm='HS256'))
+    >>> import jwt
+    >>> jwt.decode(t, 'secret', algorithms=['HS256'])['sub'] == 'bob'
+    True
     """
     return _create_jwt_token(data, expires_in_minutes, secret, algorithm)
 

--- a/mcpgateway/utils/services_auth.py
+++ b/mcpgateway/utils/services_auth.py
@@ -5,6 +5,31 @@ Copyright 2025
 SPDX-License-Identifier: Apache-2.0
 Authors: Mihai Criveti
 
+Doctest examples
+----------------
+>>> import os
+>>> from mcpgateway.utils import services_auth
+>>> os.environ['AUTH_ENCRYPTION_SECRET'] = 'doctest-secret'
+>>> services_auth.settings.auth_encryption_secret = 'doctest-secret'
+>>> key = services_auth.get_key()
+>>> isinstance(key, bytes)
+True
+>>> d = {'user': 'alice'}
+>>> token = services_auth.encode_auth(d)
+>>> isinstance(token, str)
+True
+>>> services_auth.decode_auth(token) == d
+True
+>>> services_auth.encode_auth(None) is None
+True
+>>> services_auth.decode_auth(None) == {}
+True
+>>> services_auth.settings.auth_encryption_secret = ''
+>>> try:
+...     services_auth.get_key()
+... except ValueError as e:
+...     print('error')
+error
 """
 
 # Standard
@@ -29,6 +54,21 @@ def get_key() -> bytes:
 
     Raises:
         ValueError: If the passphrase is not set or empty.
+
+    Doctest:
+    >>> import os
+    >>> from mcpgateway.utils import services_auth
+    >>> os.environ['AUTH_ENCRYPTION_SECRET'] = 'doctest-secret'
+    >>> services_auth.settings.auth_encryption_secret = 'doctest-secret'
+    >>> key = services_auth.get_key()
+    >>> isinstance(key, bytes)
+    True
+    >>> services_auth.settings.auth_encryption_secret = ''
+    >>> try:
+    ...     services_auth.get_key()
+    ... except ValueError as e:
+    ...     print('error')
+    error
     """
     passphrase = settings.auth_encryption_secret
     if not passphrase:
@@ -45,6 +85,17 @@ def encode_auth(auth_value: dict) -> str:
 
     Returns:
         str: A base64-url-safe encrypted string representing the dictionary, or None if input is None.
+
+    Doctest:
+    >>> import os
+    >>> from mcpgateway.utils import services_auth
+    >>> os.environ['AUTH_ENCRYPTION_SECRET'] = 'doctest-secret'
+    >>> services_auth.settings.auth_encryption_secret = 'doctest-secret'
+    >>> token = services_auth.encode_auth({'user': 'alice'})
+    >>> isinstance(token, str)
+    True
+    >>> services_auth.encode_auth(None) is None
+    True
     """
     if not auth_value:
         return None
@@ -67,6 +118,18 @@ def decode_auth(encoded_value: str) -> dict:
 
     Returns:
         dict: The decrypted authentication dictionary, or empty dict if input is None.
+
+    Doctest:
+    >>> import os
+    >>> from mcpgateway.utils import services_auth
+    >>> os.environ['AUTH_ENCRYPTION_SECRET'] = 'doctest-secret'
+    >>> services_auth.settings.auth_encryption_secret = 'doctest-secret'
+    >>> d = {'user': 'alice'}
+    >>> token = services_auth.encode_auth(d)
+    >>> services_auth.decode_auth(token) == d
+    True
+    >>> services_auth.decode_auth(None) == {}
+    True
     """
     if not encoded_value:
         return {}


### PR DESCRIPTION
## Phase 2: Doctest Coverage for Utility Modules

Doctests were added to:
```
mcpgateway/utils/redis_isready.py
mcpgateway/utils/db_isready.py
mcpgateway/utils/services_auth.py
mcpgateway/utils/verify_credentials.py
mcpgateway/utils/create_jwt_token.py
mcpgateway/cache/resource_cache.py
mcpgateway/cache/session_registry.py (memory backend, public API)
```

Coverage includes:

- All public functions and methods, with edge cases and error handling.
- Async and sync usage where relevant.
- Memory-only examples for cache/session modules to keep doctests fast and dependency-light.
- Usage and error examples in module-level docstrings for CLI/utility scripts.