### PR TITLE
Hover tooltips

### DIFF
--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -8,7 +8,6 @@
   border: 1px solid #ebccd1;
 }
 
-
 /* CSS for the spinner */
 .spinner {
   border: 4px solid #f3f3f3;
@@ -27,6 +26,26 @@
   display: block;
 
   /* Ensures it behaves like a block-level element */
+}
+
+/* CSS for the tooltip */
+.tooltip {
+  position: fixed;
+  z-index: 9999;
+  background-color: #1f2937; /* Tailwind's gray-800 */
+  color: white;
+  font-size: 0.875rem; /* text-sm */
+  border-radius: 0.5rem; /* Increased rounded corners */
+  padding: 0.75rem 1rem; /* More padding */
+  pointer-events: none;
+  transition: transform 0.2s ease, opacity 0.3s ease; /* Added smooth transition */
+  opacity: 0;
+  transform: scale(0.8); /* Tooltip starts slightly smaller */
+}
+
+.tooltip.show {
+  opacity: 1;
+  transform: scale(1); /* Scales up smoothly */
 }
 
 @keyframes spin {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4071,6 +4071,95 @@ if (window.performance && window.performance.mark) {
 }
 
 // ===================================================================
+// Tool Tips for components with Alpine.js
+// ===================================================================
+
+/* global Alpine */
+function setupTooltipsWithAlpine() {
+    document.addEventListener("alpine:init", () => {
+        console.log("Initializing Alpine tooltip directive...");
+
+        Alpine.directive("tooltip", (el, { expression }, { evaluate }) => {
+            let tooltipEl = null;
+
+            const showTooltip = (event) => {
+                const text = evaluate(expression);
+                if (!text) return;
+
+                tooltipEl = document.createElement("div");
+                tooltipEl.textContent = text;
+                tooltipEl.setAttribute("role", "tooltip");
+                tooltipEl.className =
+                    "fixed z-50 max-w-xs px-3 py-2 text-sm text-white bg-black/80 rounded-lg shadow-lg pointer-events-none opacity-0 transition-opacity duration-200";
+
+                document.body.appendChild(tooltipEl);
+
+                // Position tooltip
+                if (event?.clientX && event?.clientY) {
+                    moveTooltip(event);
+                    el.addEventListener("mousemove", moveTooltip);
+                } else {
+                    const rect = el.getBoundingClientRect();
+                    const scrollY = window.scrollY || window.pageYOffset;
+                    const scrollX = window.scrollX || window.pageXOffset;
+                    tooltipEl.style.left = `${rect.left + scrollX}px`;
+                    tooltipEl.style.top = `${rect.bottom + scrollY + 10}px`;
+                }
+
+                requestAnimationFrame(() => {
+                    tooltipEl.style.opacity = "1";
+                });
+            };
+
+            const moveTooltip = (e) => {
+                if (!tooltipEl) return;
+
+                const paddingX = 12;
+                const paddingY = 20;
+                const tipRect = tooltipEl.getBoundingClientRect();
+
+                let left = e.clientX + paddingX;
+                let top = e.clientY + paddingY;
+
+                if (left + tipRect.width > window.innerWidth - 8) {
+                    left = e.clientX - tipRect.width - paddingX;
+                }
+                if (top + tipRect.height > window.innerHeight - 8) {
+                    top = e.clientY - tipRect.height - paddingY;
+                }
+
+                tooltipEl.style.left = `${left}px`;
+                tooltipEl.style.top = `${top}px`;
+            };
+
+            const hideTooltip = () => {
+                if (!tooltipEl) return;
+                tooltipEl.style.opacity = "0";
+                el.removeEventListener("mousemove", moveTooltip);
+                setTimeout(() => {
+                    tooltipEl?.remove();
+                    tooltipEl = null;
+                }, 200);
+            };
+
+            // Mouse
+            el.addEventListener("mouseenter", showTooltip);
+            el.addEventListener("mouseleave", hideTooltip);
+
+            // Keyboard
+            el.addEventListener("focus", showTooltip);
+            el.addEventListener("blur", hideTooltip);
+
+            // Optional: hide on scroll or resize
+            window.addEventListener("scroll", hideTooltip, { passive: true });
+            window.addEventListener("resize", hideTooltip, { passive: true });
+        });
+    });
+}
+
+setupTooltipsWithAlpine();
+
+// ===================================================================
 // SINGLE CONSOLIDATED INITIALIZATION SYSTEM
 // ===================================================================
 
@@ -4078,6 +4167,8 @@ document.addEventListener("DOMContentLoaded", () => {
     console.log("🔐 DOM loaded - initializing secure admin interface...");
 
     try {
+        // initializeTooltips();
+
         // 1. Initialize CodeMirror editors first
         initializeCodeMirrorEditors();
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4084,7 +4084,9 @@ function setupTooltipsWithAlpine() {
 
             const showTooltip = (event) => {
                 const text = evaluate(expression);
-                if (!text) return;
+                if (!text) {
+                    return;
+                }
 
                 tooltipEl = document.createElement("div");
                 tooltipEl.textContent = text;
@@ -4112,7 +4114,9 @@ function setupTooltipsWithAlpine() {
             };
 
             const moveTooltip = (e) => {
-                if (!tooltipEl) return;
+                if (!tooltipEl) {
+                    return;
+                }
 
                 const paddingX = 12;
                 const paddingY = 20;
@@ -4133,7 +4137,9 @@ function setupTooltipsWithAlpine() {
             };
 
             const hideTooltip = () => {
-                if (!tooltipEl) return;
+                if (!tooltipEl) {
+                    return;
+                }
                 tooltipEl.style.opacity = "0";
                 el.removeEventListener("mousemove", moveTooltip);
                 setTimeout(() => {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4083,7 +4083,9 @@ function setupTooltipsWithAlpine() {
             let tooltipEl = null;
 
             const moveTooltip = (e) => {
-                if (!tooltipEl) return;
+                if (!tooltipEl) {
+                    return;
+                }
 
                 const paddingX = 12;
                 const paddingY = 20;
@@ -4133,9 +4135,12 @@ function setupTooltipsWithAlpine() {
                 requestAnimationFrame(() => {
                     tooltipEl.style.opacity = "1";
                 });
-
-                window.addEventListener("scroll", hideTooltip, { passive: true });
-                window.addEventListener("resize", hideTooltip, { passive: true });
+                window.addEventListener("scroll", hideTooltip, {
+                    passive: true,
+                });
+                window.addEventListener("resize", hideTooltip, {
+                    passive: true,
+                });
             };
 
             const hideTooltip = () => {
@@ -4148,20 +4153,15 @@ function setupTooltipsWithAlpine() {
                 window.removeEventListener("scroll", hideTooltip);
                 window.removeEventListener("resize", hideTooltip);
                 el.addEventListener("click", hideTooltip);
-
-
                 const toRemove = tooltipEl;
                 tooltipEl = null;
-
                 setTimeout(() => toRemove.remove(), 200);
             };
-
             el.addEventListener("mouseenter", showTooltip);
             el.addEventListener("mouseleave", hideTooltip);
             el.addEventListener("focus", showTooltip);
             el.addEventListener("blur", hideTooltip);
             el.addEventListener("click", hideTooltip);
-
         });
     });
 }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -16,6 +16,7 @@
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/javascript/javascript.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{{ root_path }}/static/admin.js"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.css" rel="stylesheet" />
@@ -190,19 +191,21 @@
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   {% if server.isActive %}
                   <form method="POST" action="{{ root_path }}/admin/servers/{{ server.id }}/toggle" class="inline mr-2"
-                    title="Deactivate: This will temporarily disable the server without deleting it."
                     onsubmit="return handleToggleSubmit(event, 'servers')">
                     <input type="hidden" name="activate" value="false" />
-                    <button type="submit" class="text-yellow-600 hover:text-yellow-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Temporarily disable this item (can be re-activated).'"
+                      class="text-yellow-600 hover:text-yellow-900">
                       Deactivate
                     </button>
                   </form>
                   {% else %}
                   <form method="POST" action="{{ root_path }}/admin/servers/{{ server.id }}/toggle" class="inline mr-2"
-                    title="Activate: This will re-enable the server."
                     onsubmit="return handleToggleSubmit(event, 'servers')">
                     <input type="hidden" name="activate" value="true" />
-                    <button type="submit" class="text-blue-600 hover:text-blue-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Re-enable an inactive item.'"
+                      class="text-blue-600 hover:text-blue-900">
                       Activate
                     </button>
                   </form>
@@ -216,7 +219,9 @@
                   </button>
                   <form method="POST" action="{{ root_path }}/admin/servers/{{ server.id }}/delete" class="inline"
                     onsubmit="return handleSubmitWithConfirmation(event, 'servers')">
-                    <button type="submit" class="text-red-600 hover:text-red-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Permanently delete this item – cannot be undone.'"
+                      class="text-red-600 hover:text-red-900">
                       Delete
                     </button>
                   </form>
@@ -280,6 +285,7 @@
           </div>
           <div class="mt-6">
             <button type="submit"
+              x-tooltip="'💡Creates a new Virtual Server by combining Tools, Resources & Prompts from global catalogs.'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Server
             </button>
@@ -463,22 +469,26 @@
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   <button onclick="testTool('{{ tool.id }}')" class="text-purple-600 hover:text-purple-900 mr-2"
-                    title="Test this tool">
+                    x-tooltip="'💡Execute this Tool with sample inputs.'">
                     Test
                   </button>
                   {% if tool.enabled %}
                   <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="inline mr-2"
-                    title="Deactivate" onsubmit="return handleToggleSubmit(event, 'tools')">
+                    onsubmit="return handleToggleSubmit(event, 'tools')">
                     <input type="hidden" name="activate" value="false" />
-                    <button type="submit" class="text-yellow-600 hover:text-yellow-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Temporarily disable this item (can be re-activated).'"
+                      class="text-yellow-600 hover:text-yellow-900">
                       Deactivate
                     </button>
                   </form>
                   {% else %}
                   <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="inline mr-2"
-                    title="Activate" onsubmit="return handleToggleSubmit(event, 'tools')">
+                    onsubmit="return handleToggleSubmit(event, 'tools')">
                     <input type="hidden" name="activate" value="true" />
-                    <button type="submit" class="text-blue-600 hover:text-blue-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Re-enable an inactive item.'"
+                      class="text-blue-600 hover:text-blue-900">
                       Activate
                     </button>
                   </form>
@@ -492,7 +502,9 @@
                   </button>
                   <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/delete" class="inline"
                     onsubmit="return handleSubmitWithConfirmation(event, 'tools')">
-                    <button type="submit" class="text-red-600 hover:text-red-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Permanently delete this item – cannot be undone.'"
+                      class="text-red-600 hover:text-red-900">
                       Delete
                     </button>
                   </form>
@@ -619,6 +631,7 @@
           </div>
           <div class="mt-6">
             <button type="submit"
+              x-tooltip="'💡	Registers a new Tool from an existing REST or MCP endpoint.'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Tool
             </button>
@@ -706,19 +719,22 @@
                   {% if resource.isActive %}
                   <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle"
                     class="inline mr-2"
-                    title="Deactivate: This will temporarily disable the resource without deleting it."
                     onsubmit="return handleToggleSubmit(event, 'resources')">
                     <input type="hidden" name="activate" value="false" />
-                    <button type="submit" class="text-yellow-600 hover:text-yellow-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Temporarily disable this item (can be re-activated).'"
+                      class="text-yellow-600 hover:text-yellow-900">
                       Deactivate
                     </button>
                   </form>
                   {% else %}
                   <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle"
-                    class="inline mr-2" title="Activate: This will re-enable the resource."
+                    class="inline mr-2" 
                     onsubmit="return handleToggleSubmit(event, 'resources')">
                     <input type="hidden" name="activate" value="true" />
-                    <button type="submit" class="text-blue-600 hover:text-blue-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Re-enable an inactive item.'"
+                      class="text-blue-600 hover:text-blue-900">
                       Activate
                     </button>
                   </form>
@@ -732,7 +748,9 @@
                   </button>
                   <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.uri }}/delete" class="inline"
                     onsubmit="return handleSubmitWithConfirmation(event, 'resources')">
-                    <button type="submit" class="text-red-600 hover:text-red-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Permanently delete this item – cannot be undone.'"
+                      class="text-red-600 hover:text-red-900">
                       Delete
                     </button>
                   </form>
@@ -780,6 +798,7 @@
           </div>
           <div class="mt-6">
             <button type="submit"
+              x-tooltip="'💡Uploads or links a reusable data asset (file, URI, or text).'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Resource
             </button>
@@ -856,19 +875,21 @@
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   {% if prompt.isActive %}
                   <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.id }}/toggle" class="inline mr-2"
-                    title="Deactivate: This will temporarily disable the prompt without deleting it."
                     onsubmit="return handleToggleSubmit(event, 'prompts')">
                     <input type="hidden" name="activate" value="false" />
-                    <button type="submit" class="text-yellow-600 hover:text-yellow-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Temporarily disable this item (can be re-activated).'"
+                      class="text-yellow-600 hover:text-yellow-900">
                       Deactivate
                     </button>
                   </form>
                   {% else %}
                   <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.id }}/toggle" class="inline mr-2"
-                    title="Activate: This will re-enable the prompt."
                     onsubmit="return handleToggleSubmit(event, 'prompts')">
                     <input type="hidden" name="activate" value="true" />
-                    <button type="submit" class="text-blue-600 hover:text-blue-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Re-enable an inactive item.'"
+                      class="text-blue-600 hover:text-blue-900">
                       Activate
                     </button>
                   </form>
@@ -882,7 +903,9 @@
                   </button>
                   <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.name }}/delete" class="inline"
                     onsubmit="return handleSubmitWithConfirmation(event, 'prompts')">
-                    <button type="submit" class="text-red-600 hover:text-red-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Permanently delete this item – cannot be undone.'"
+                      class="text-red-600 hover:text-red-900">
                       Delete
                     </button>
                   </form>
@@ -925,6 +948,7 @@
           </div>
           <div class="mt-6">
             <button type="submit"
+              x-tooltip="'💡Creates a reusable message template with parameters.'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Prompt
             </button>
@@ -1054,19 +1078,22 @@
                   {% if gateway.enabled %}
                   <form method="POST" action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
                     class="inline mr-2"
-                    title="Deactivate: This will temporarily disable the gateway without deleting it."
                     onsubmit="return handleToggleSubmit(event, 'gateways')">
                     <input type="hidden" name="activate" value="false" />
-                    <button type="submit" class="text-yellow-600 hover:text-yellow-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Temporarily disable this item (can be re-activated).'"
+                      class="text-yellow-600 hover:text-yellow-900">
                       Deactivate
                     </button>
                   </form>
                   {% else %}
                   <form method="POST" action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
-                    class="inline mr-2" title="Activate: This will re-enable the gateway."
+                    class="inline mr-2" 
                     onsubmit="return handleToggleSubmit(event, 'gateways')">
                     <input type="hidden" name="activate" value="true" />
-                    <button type="submit" class="text-blue-600 hover:text-blue-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Re-enable an inactive item.'"
+                      class="text-blue-600 hover:text-blue-900">
                       Activate
                     </button>
                   </form>
@@ -1080,7 +1107,9 @@
                   </button>
                   <form method="POST" action="{{ root_path }}/admin/gateways/{{ gateway.id }}/delete" class="inline"
                     onsubmit="return handleSubmitWithConfirmation(event, 'gateways')">
-                    <button type="submit" class="text-red-600 hover:text-red-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Permanently delete this item – cannot be undone.'"
+                      class="text-red-600 hover:text-red-900">
                       Delete
                     </button>
                   </form>
@@ -1168,6 +1197,7 @@
           </div>
           <div class="mt-6">
             <button type="submit"
+              x-tooltip="'💡Registers an external MCP server and imports its catalogs - Tools, Prompts, Resources, etc.'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Gateway
             </button>
@@ -1235,7 +1265,9 @@
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   <form method="POST" action="{{ root_path }}/admin/roots/{{ root.uri }}/delete" class="inline"
                     onsubmit="return handleSubmitWithConfirmation(event, 'roots')">
-                    <button type="submit" class="text-red-600 hover:text-red-900">
+                    <button type="submit" 
+                      x-tooltip="'💡Permanently delete this item – cannot be undone.'"
+                      class="text-red-600 hover:text-red-900">
                       Delete
                     </button>
                   </form>
@@ -1268,6 +1300,7 @@
           </div>
           <div class="mt-6">
             <button type="submit"
+              x-tooltip="'💡Registers a base directory that MCP servers can browse for files.'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Root
             </button>
@@ -1975,7 +2008,7 @@
     window.ROOT_PATH = {{ root_path | tojson }};
     window.GATEWAY_TOOL_NAME_SEPARATOR = {{ gateway_tool_name_separator | tojson }};
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  
 </body>
 
 </html>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -458,11 +458,11 @@
                     <div
                       class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">
                       {% if not enabled %}
-                      Tool is Manually Deactivated.
+                      💡Tool is Manually Deactivated.
                       {% elif not reachable %}
-                      The host gateway for this tool is unreachable.
+                      💡The host gateway for this tool is unreachable.
                       {% else %}
-                      Everything stable.
+                      💡Everything stable.
                       {% endif %}
                     </div>
                   </div>
@@ -1058,11 +1058,11 @@
                     <div
                       class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">
                       {% if not enabled %}
-                      Gateway is Manually Deactivated
+                      💡Gateway is Manually Deactivated
                       {% elif not reachable %}
-                      Gateway is Not Reachable
+                      💡Gateway is Not Reachable
                       {% else %}
-                      Everything stable.
+                      💡Everything stable.
                       {% endif %}
                     </div>
                   </div>


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #233

---

## 🚀 Summary (1-2 sentences)
Added contextual hover tips for elements in UI. 

To add more tips : x-tooltip="'💡<your tip>'"

Example:
```
<button type="submit" 
  x-tooltip="'💡Temporarily disable this item (can be re-activated).'"
  class="text-yellow-600 hover:text-yellow-900">
  Deactivate
</button>
```
---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

