### PR TITLE
Updated error handling for bad requests in test gateway

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1366,9 +1366,6 @@ async def admin_test_gateway(request: GatewayTestRequest, user: str = Depends(re
 
     Returns:
         GatewayTestResponse: The response from the gateway, including status code, latency, and body
-
-    Raises:
-        HTTPException: If the gateway request fails (e.g., connection error, timeout).
     """
     full_url = str(request.base_url).rstrip("/") + "/" + request.path.lstrip("/")
     full_url = full_url.rstrip("/")

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3346,7 +3346,7 @@ async function handleGatewayTestSubmit(e) {
         // Validate URL
         const urlValidation = validateUrl(baseUrl);
         if (!urlValidation.valid) {
-            return new Error(`Invalid URL: ${urlValidation.error}`);
+            throw new Error(`Invalid URL: ${urlValidation.error}`);
         }
 
         // Get CodeMirror content safely

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3319,6 +3319,7 @@ async function handleGatewayTestSubmit(e) {
     const loading = safeGetElement("gateway-test-loading");
     const responseDiv = safeGetElement("gateway-test-response-json");
     const resultDiv = safeGetElement("gateway-test-result");
+    const testButton = safeGetElement("gateway-test-submit")
 
     try {
         // Show loading
@@ -3327,6 +3328,10 @@ async function handleGatewayTestSubmit(e) {
         }
         if (resultDiv) {
             resultDiv.classList.add("hidden");
+        }
+        if (testButton) {
+            testButton.disabled = true;
+            testButton.textContent = "Testing...";
         }
 
         const form = e.target;
@@ -3341,7 +3346,7 @@ async function handleGatewayTestSubmit(e) {
         // Validate URL
         const urlValidation = validateUrl(baseUrl);
         if (!urlValidation.valid) {
-            throw new Error(`Invalid URL: ${urlValidation.error}`);
+            return new Error(`Invalid URL: ${urlValidation.error}`);
         }
 
         // Get CodeMirror content safely
@@ -3393,31 +3398,28 @@ async function handleGatewayTestSubmit(e) {
 
         const result = await response.json();
 
-        if (responseDiv) {
-            // Display result safely
-            responseDiv.innerHTML = `
-                <div class="alert alert-success">
-                    <h4>✅ Connection Successful</h4>
-                    <p><strong>Status Code:</strong> ${result.statusCode}</p>
-                    <p><strong>Response Time:</strong> ${result.latencyMs}ms</p>
-                    ${
-                        result.body
-                            ? `<details>
-                        <summary class='cursor-pointer'>Response Body</summary>
-                        <pre class="text-sm px-4 max-h-96 dark:bg-gray-800 dark:text-gray-100 overflow-auto">${JSON.stringify(result.body, null, 2)}</pre>
-                    </details>`
-                            : ""
-                    }
-                </div>
-            `;
-        } else {
-            responseDiv.innerHTML = `
-            <div class="alert alert-error">
-                <h4>❌ Connection Failed</h4>
-                <p>${result.error || "Unable to connect to the server"}</p>
-            </div>
+        const isSuccess = result.statusCode && result.statusCode >= 200 && result.statusCode < 300;
+
+        const alertType = isSuccess ? "success" : "error";
+        const icon = isSuccess ? "✅" : "❌";
+        const title = isSuccess ? "Connection Successful" : "Connection Failed";
+        const statusCode = result.statusCode || "Unknown";
+        const latency = result.latencyMs != null ? `${result.latencyMs}ms` : "NA";
+        const body = result.body
+        ? `<details open>
+                <summary class='cursor-pointer'><strong>Response Body</strong></summary>
+                <pre class="text-sm px-4 max-h-96 dark:bg-gray-800 dark:text-gray-100 overflow-auto">${JSON.stringify(result.body, null, 2)}</pre>
+            </details>`
+        : "";
+
+        responseDiv.innerHTML = `
+        <div class="alert alert-${alertType}">
+            <h4><strong>${icon} ${title}</strong></h4>
+            <p><strong>Status Code:</strong> ${statusCode}</p>
+            <p><strong>Response Time:</strong> ${latency}</p>
+            ${body}
+        </div>
         `;
-        }
     } catch (error) {
         console.error("Gateway test error:", error);
         if (responseDiv) {
@@ -3434,6 +3436,9 @@ async function handleGatewayTestSubmit(e) {
         if (resultDiv) {
             resultDiv.classList.remove("hidden");
         }
+
+        testButton.disabled = false;
+        testButton.textContent = "Test";
     }
 }
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3319,7 +3319,7 @@ async function handleGatewayTestSubmit(e) {
     const loading = safeGetElement("gateway-test-loading");
     const responseDiv = safeGetElement("gateway-test-response-json");
     const resultDiv = safeGetElement("gateway-test-result");
-    const testButton = safeGetElement("gateway-test-submit")
+    const testButton = safeGetElement("gateway-test-submit");
 
     try {
         // Show loading
@@ -3398,19 +3398,23 @@ async function handleGatewayTestSubmit(e) {
 
         const result = await response.json();
 
-        const isSuccess = result.statusCode && result.statusCode >= 200 && result.statusCode < 300;
+        const isSuccess =
+            result.statusCode &&
+            result.statusCode >= 200 &&
+            result.statusCode < 300;
 
         const alertType = isSuccess ? "success" : "error";
         const icon = isSuccess ? "✅" : "❌";
         const title = isSuccess ? "Connection Successful" : "Connection Failed";
         const statusCode = result.statusCode || "Unknown";
-        const latency = result.latencyMs != null ? `${result.latencyMs}ms` : "NA";
+        const latency =
+            result.latencyMs != null ? `${result.latencyMs}ms` : "NA";
         const body = result.body
-        ? `<details open>
+            ? `<details open>
                 <summary class='cursor-pointer'><strong>Response Body</strong></summary>
                 <pre class="text-sm px-4 max-h-96 dark:bg-gray-800 dark:text-gray-100 overflow-auto">${JSON.stringify(result.body, null, 2)}</pre>
             </details>`
-        : "";
+            : "";
 
         responseDiv.innerHTML = `
         <div class="alert alert-${alertType}">

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1709,11 +1709,11 @@
         <form id="gateway-test-form" class="space-y-4">
           <div>
             <label for="gateway-test-url" class="block text-sm font-medium text-gray-700">Server URL</label>
-            <input name="url" type="text" id="gateway-test-url" class="mt-1 block w-full rounded-md shadow-sm p-1" />
+            <input required name="url" type="text" id="gateway-test-url" class="mt-1 block w-full rounded-md shadow-sm p-1" />
           </div>
           <div>
             <label for="gateway-test-method" class="block text-sm font-medium text-gray-700">Method</label>
-            <select name="method" id="gateway-test-method" class="mt-1 block w-full rounded-md shadow-sm p-1">
+            <select required name="method" id="gateway-test-method" class="mt-1 block w-full rounded-md shadow-sm p-1">
               <option>GET</option>
               <option>POST</option>
               <option>PUT</option>
@@ -1739,7 +1739,7 @@
           <div class="flex">
             <button type="submit" id="gateway-test-submit"
               class="w-full text-center px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700">
-              Send
+              Test
             </button>
             <p class="p-1"></p>
             <button id="gateway-test-close" type="button"


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Fixes broken UI and API behavior when attempting to test a gateway with an invalid or unreachable URL. Ensures better error handling and prevents flooding the server with multiple test requests.


## 🔁 Reproduction Steps
Closes [#396](https://github.com/IBM/mcp-context-forge/issues/396)

1. Go to the admin gateway UI.
2. Click on "Test" for a gateway with an invalid or unreachable URL.
3. Observe that the UI doesn’t provide feedback, and multiple requests can be fired in parallel.


## 🐞 Root Cause
- The backend was not returning informative errors when a request to the test endpoint failed due to bad URL or network errors.
- The frontend did not prevent multiple test submissions or handle error responses clearly.


## 💡 Fix Description
- Updated the `/admin/gateways/test` endpoint to catch and return structured error responses (`502`) when the test fails.
- Frontend:
  - Updated the result display section to reduce redundancy. 
  - Disables the "Send" button while a test request is in-flight.
  - Re-enables the button once the response (or error) is received.
  - Displays clear error messages if the backend returns a failure.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Manual regression no longer fails     | Tested invalid URL, double-click prevention, success path | ✅ |


## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients


## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
