### PR TITLE
Fix CodeMirror layout spacing and update content textarea

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4340,7 +4340,7 @@ function initializeCodeMirrorEditors() {
                     {
                         mode: config.mode,
                         theme: "monokai",
-                        lineNumbers: true,
+                        lineNumbers: false,
                         autoCloseBrackets: true,
                         matchBrackets: true,
                         tabSize: 2,

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -790,10 +790,10 @@
             <div>
               <label class="block text-sm font-medium text-gray-700 dark:text-gray-400">Content</label>
               <textarea name="content" id="resource-content-editor"
-                class="mt-1 block w-full h-48 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                style="display: none">
-                </textarea>
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                placeholder=""></textarea>
             </div>
+
             <div id="status-resources"></div>
           </div>
           <div class="mt-6">
@@ -935,9 +935,8 @@
             <div>
               <label class="block text-sm font-medium text-gray-700 dark:text-gray-400">Template</label>
               <textarea name="template" id="prompt-template-editor"
-                class="mt-1 block w-full h-48 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                style="display: none">
-                </textarea>
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                placeholder=""></textarea>
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 dark:text-gray-400">Arguments (JSON)</label>


### PR DESCRIPTION
# 🐛 Bug-fix PR
---
## 📌 Summary
fix code mirror layout spacing one for prompt template , resource content textarea.
## 🐞 Root Cause
HTML classes for textarea creating issues.
## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed