### PR TITLE
Fix alembic_version creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2337,24 +2337,24 @@ alembic-install:
 
 db-new:
 	@echo "➜ Generating revision: $(MSG)"
-	$(ALEMBIC) revision --autogenerate -m $(MSG)
+	$(ALEMBIC) -c mcpgateway/alembic.ini revision --autogenerate -m $(MSG)
 
 db-up:
 	@echo "➜ Upgrading database to head ..."
-	$(ALEMBIC) upgrade head
+	$(ALEMBIC) -c mcpgateway/alembic.ini upgrade head
 
 db-down:
 	@echo "➜ Downgrading database → $(REV) ..."
-	$(ALEMBIC) downgrade $(REV)
+	$(ALEMBIC) -c mcpgateway/alembic.ini downgrade $(REV)
 
 db-current:
-	$(ALEMBIC) current
+	$(ALEMBIC) -c mcpgateway/alembic.ini current
 
 db-history:
-	$(ALEMBIC) history --verbose
+	$(ALEMBIC) -c mcpgateway/alembic.ini history --verbose
 
 db-revision-id:
-	@$(ALEMBIC) current --verbose | awk '/Current revision/ {print $$3}'
+	@$(ALEMBIC) -c mcpgateway/alembic.ini current --verbose | awk '/Current revision/ {print $$3}'
 
 
 # =============================================================================

--- a/mcpgateway/alembic/env.py
+++ b/mcpgateway/alembic/env.py
@@ -62,10 +62,11 @@ from mcpgateway.db import Base
 
 
 # Create config object - this is the standard way in Alembic
-if context.config is None:
-    config = Config()
-else:
-    config = context.config
+config = getattr(context, "config", None) or Config()
+
+def _inside_alembic() -> bool:
+    """Return True only when this file is running under Alembic CLI."""
+    return getattr(context, "_proxy", None) is not None
 
 config.set_main_option("script_location", str(files("mcpgateway").joinpath("alembic")))
 
@@ -145,8 +146,8 @@ def run_migrations_online() -> None:
         with context.begin_transaction():
             context.run_migrations()
 
-
-if context.is_offline_mode():
-    run_migrations_offline()
-else:
-    run_migrations_online()
+if _inside_alembic():
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()

--- a/mcpgateway/alembic/env.py
+++ b/mcpgateway/alembic/env.py
@@ -40,6 +40,7 @@ Note:
     This file is automatically executed by Alembic and should not be
     imported or run directly by application code.
 """
+
 # Standard
 from importlib.resources import files
 from logging.config import fileConfig

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 import json
 import logging
 import re
-from typing import Any, Dict, List, Literal, Optional, Union, Self
+from typing import Any, Dict, List, Literal, Optional, Self, Union
 
 # Third-Party
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator, ValidationInfo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,7 @@ import_heading_localfolder = "Local"        # header for ad-hoc scripts / tests
 ###############################################################################
 known_first_party          = ["mcpgateway"]    # treat "mcpgateway.*" as FIRSTPARTY
 known_local_folder         = ["tests", "scripts"]  # treat these folders as LOCALFOLDER
+known_third_party          = ["alembic"] # treat "alembic" as THIRDPARTY
 # src_paths                = ["src/mcpgateway"]    # uncomment only if package moves under src/
 
 ###############################################################################

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -3,6 +3,7 @@
 Playwright test configuration - Simple version without python-dotenv.
 This assumes environment variables are loaded by the Makefile.
 """
+
 # Standard
 import base64
 import os


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Fixes a regression in alembic_version table creation

## 🔁 Reproduction Steps
1. Delete mcp.db
2. Run `make serve`
3. mcp.db would be created with alembic_version table along with the latest revision

## 🐞 Root Cause
Unsure, when this broke

## 💡 Fix Description
bootstrap_db.py
1. Create connection string in bootstrap_db, set it in context

env.py
1. Read config from context if context.config is not None
2. Run offline and online migration code from bootstrap_db.py instead of only when env.py is run

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    pass    |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
