### PR TITLE
Fix/pre commit config exclude object files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -368,6 +368,7 @@ repos:
         description: Verifies test files in tests/ directories start with `test_`.
         language: python
         files: (^|/)tests/.+\.py$
+        exclude: ^tests/.*/pages/.*\.py$  # Exclude page object files
         args: [--pytest-test-first] # `test_.*\.py`
 
   # - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
Modified this section from:

```
- id: name-tests-test
        name: 🐍 Python Tests Naming
        description: Verifies test files in tests/ directories start with `test_`.
        language: python
        files: (^|/)tests/.+\.py$
        args: [--pytest-test-first] # `test_.*\.py`
```

to:

```
- id: name-tests-test
        name: 🐍 Python Tests Naming
        description: Verifies test files in tests/ directories start with `test_`.
        language: python
        files: (^|/)tests/.+\.py$
        exclude: ^tests/.*/pages/.*\.py$  # Exclude page object files
        args: [--pytest-test-first] # `test_.*\.py`
```

The key addition is:

`exclude: ^tests/.*/pages/.*\.py$  # Exclude page object files`

This will exclude all Python files in any pages directory under tests, which covers:

```
tests/playwright/pages/admin_page.py
tests/playwright/pages/base_page.py
```