### PR TITLE
Update default .env examples to enable UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,10 +106,10 @@ AUTH_ENCRYPTION_SECRET=my-test-salt
 #####################################
 
 # Enable the visual Admin UI (true/false)
-MCPGATEWAY_UI_ENABLED=false
+MCPGATEWAY_UI_ENABLED=true
 
 # Enable the Admin API endpoints (true/false)
-MCPGATEWAY_ADMIN_API_ENABLED=false
+MCPGATEWAY_ADMIN_API_ENABLED=true
 
 #####################################
 # Security and CORS


### PR DESCRIPTION
Enable the UI in the .env.example file to make it easier to start up the application.

Enable the visual Admin UI (true/false)
MCPGATEWAY_UI_ENABLED=true

Enable the Admin API endpoints (true/false)
MCPGATEWAY_ADMIN_API_ENABLED=true

