### PR TITLE
suppressed pydantic warnings

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -122,7 +122,7 @@ class BaseModelWithConfigDict(BaseModel):
             {'foo': 1, 'bar': 'baz'}
         """
         output = {}
-        for key, value in self.dict(by_alias=use_alias).items():
+        for key, value in self.model_dump(by_alias=use_alias).items():
             output[key] = value if not isinstance(value, BaseModel) else value.to_dict(use_alias)
         return output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,12 +362,12 @@ python_functions = ["test_*"]
 
 # Playwright browser configuration (can be overridden via CLI)
 # These are custom options that your conftest.py can read
-playwright_browser = "chromium"  # default browser
-playwright_headed = false        # run headless by default
-playwright_slow_mo = 0          # milliseconds delay between actions
-playwright_screenshot = "only-on-failure"
-playwright_video = "retain-on-failure"
-playwright_trace = "retain-on-failure"
+# playwright_browser = "chromium"  # default browser
+# playwright_headed = false        # run headless by default
+# playwright_slow_mo = 0          # milliseconds delay between actions
+# playwright_screenshot = "only-on-failure"
+# playwright_video = "retain-on-failure"
+# playwright_trace = "retain-on-failure"
 
 # ── fawltydeps ─────────────────────────────────────────────────────
 [tool.fawltydeps]


### PR DESCRIPTION
1. Pydantic Deprecation Warning Fix
- Updated the `to_dict` method in `mcpgateway/schemas.py `to use `model_dump()` instead of the deprecated `dict() `method, in compliance with Pydantic v2+.
- This resolves the PydanticDeprecatedSince20 warning during doctest and test runs.
2. Pytest Unknown Config Option Warnings
- Investigated and addressed warnings about unknown pytest config options (playwright_browser, playwright_headed, etc.).
- Determined that these options are not recognized by pytest or pytest-playwright when placed in [tool.pytest.ini_options] in pyproject.toml.
