### PR TITLE
handle-duplicate-server_-name-catalog-ui

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -61,7 +61,7 @@ from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayN
 from mcpgateway.services.prompt_service import PromptNotFoundError, PromptService
 from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService
 from mcpgateway.services.root_service import RootService
-from mcpgateway.services.server_service import ServerNotFoundError, ServerService
+from mcpgateway.services.server_service import ServerError, ServerNotFoundError, ServerService
 from mcpgateway.services.tool_service import ToolError, ToolNameConflictError, ToolNotFoundError, ToolService
 from mcpgateway.utils.create_jwt_token import get_jwt_token
 from mcpgateway.utils.error_formatter import ErrorFormatter
@@ -408,7 +408,6 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
     is_inactive_checked = form.get("is_inactive_checked", "false")
     try:
         logger.debug(f"User {user} is adding a new server with name: {form['name']}")
-
         server = ServerCreate(
             name=form.get("name"),
             description=form.get("description"),
@@ -417,24 +416,39 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
             associated_resources=form.get("associatedResources"),
             associated_prompts=form.get("associatedPrompts"),
         )
-        await server_service.register_server(db, server)
+    except KeyError as e:
+        # Convert KeyError to ValidationError-like response
+        return JSONResponse(content={"message": f"Missing required field: {e}", "success": False}, status_code=422)
 
-        root_path = request.scope.get("root_path", "")
-        if is_inactive_checked.lower() == "true":
-            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
-        return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
+    try:
+        await server_service.register_server(db, server)
+        return JSONResponse(
+            content={"message": "Server created successfully!", "success": True},
+            status_code=200,
+        )
     except Exception as ex:
+        if isinstance(ex, ServerError):
+            # Custom server logic error — 500 Internal Server Error makes sense
+            return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+
+        if isinstance(ex, ValueError):
+            # Invalid input — 400 Bad Request is appropriate
+            return JSONResponse(content={"message": str(ex), "success": False}, status_code=400)
+
+        if isinstance(ex, RuntimeError):
+            # Unexpected error during runtime — 500 is suitable
+            return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+
         if isinstance(ex, ValidationError):
-            logger.info(f"ValidationError adding server: type{ex}")
+            # Pydantic or input validation failure — 422 Unprocessable Entity is correct
             return JSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
+
         if isinstance(ex, IntegrityError):
-            logger.info(f"IntegrityError adding server: type{ex}")
+            # DB constraint violation — 409 Conflict is appropriate
             return JSONResponse(status_code=409, content=ErrorFormatter.format_database_error(ex))
-        logger.info(f"Other Error adding server:{ex}")
-        root_path = request.scope.get("root_path", "")
-        if is_inactive_checked.lower() == "true":
-            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
-        return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)
+
+        # For any other unhandled error, default to 500
+        return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
 
 @admin_router.post("/servers/{server_id}/edit")

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -176,7 +176,6 @@ class ResourceService:
             'resource_read'
         """
         try:
-
             # Detect mime type if not provided
             mime_type = resource.mime_type
             if not mime_type:

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4227,6 +4227,67 @@ function handleResourceFormSubmit(e) {
         });
 }
 
+async function handleServerFormSubmit(e) {
+    e.preventDefault();
+
+    const form = e.target;
+    const formData = new FormData(form);
+    const status = safeGetElement("serverFormError");
+    const loading = safeGetElement("add-server-loading"); // Add a loading spinner if needed
+
+    try {
+        const name = formData.get("name");
+
+        // Basic validation
+        const nameValidation = validateInputName(name, "server");
+        if (!nameValidation.valid) {
+            throw new Error(nameValidation.error);
+        }
+
+        if (loading) {
+            loading.style.display = "block";
+        }
+        if (status) {
+            status.textContent = "";
+            status.classList.remove("error-status");
+        }
+
+        const isInactiveCheckedBool = isInactiveChecked("servers");
+        formData.append("is_inactive_checked", isInactiveCheckedBool);
+
+        const response = await fetchWithTimeout(
+            `${window.ROOT_PATH}/admin/servers`,
+            {
+                method: "POST",
+                body: formData,
+            },
+        );
+
+        const result = await response.json();
+        if (!result.success) {
+            console.log(result.message);
+            throw new Error(result.message || "Failed to add server.");
+        } else {
+            // Success redirect
+            const redirectUrl = isInactiveCheckedBool
+                ? `${window.ROOT_PATH}/admin?include_inactive=true#catalog`
+                : `${window.ROOT_PATH}/admin#catalog`;
+            window.location.href = redirectUrl;
+        }
+    } catch (error) {
+        console.error("Add Server Error:", error);
+        if (status) {
+            status.textContent = error.message || "An error occurred.";
+            status.classList.add("error-status");
+        }
+        showErrorMessage(error.message); // Optional if you use global popup/snackbar
+    } finally {
+        if (loading) {
+            loading.style.display = "none";
+        }
+    }
+}
+
 async function handleToolFormSubmit(event) {
     event.preventDefault();
 
@@ -4804,6 +4865,11 @@ function setupFormHandlers() {
     const resourceForm = safeGetElement("add-resource-form");
     if (resourceForm) {
         resourceForm.addEventListener("submit", handleResourceFormSubmit);
+    }
+
+    const serverForm = safeGetElement("add-server-form");
+    if (serverForm) {
+        serverForm.addEventListener("submit", handleServerFormSubmit);
     }
 
     const toolForm = safeGetElement("add-tool-form");

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -240,9 +240,7 @@
       </div>
       <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
         <h3 class="text-lg font-bold mb-4 dark:text-gray-200">Add New Server</h3>
-        <form method="POST" action="{{ root_path }}/admin/servers" id="add-server-form"
-          onsubmit="return handleToggleSubmit(event, 'servers')"
-          onreset="document.getElementById('associatedTools').selectedIndex = -1;">
+        <form method="POST" id="add-server-form" onreset="document.getElementById('associatedTools').selectedIndex = -1;">
           <div class="grid grid-cols-1 gap-6">
             <div>
               <label class="block text-sm font-medium text-gray-700 dark:text-gray-400">Name</label>
@@ -263,15 +261,13 @@
               <label for="associatedTools" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 Associated Tools
               </label>
-              <select name="associatedTools" {# same name as before (minus camelCase) #} id="associatedTools" multiple
-                {# remove if you want single-select #}
+              <select name="associatedTools" id="associatedTools" multiple
                 class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300">
                 {% for tool in tools %}
-                {# value can be tool.id, tool.slug, or any key you use later #}
                 <option value="{{ tool.id }}">{{ tool.name }}</option>
                 {% endfor %}
               </select>
-              <span id="selectedToolsPills" class="inline-flex flex-wrap gap-1 mt-2"></span> <!-- container -->
+              <span id="selectedToolsPills" class="inline-flex flex-wrap gap-1 mt-2"></span>
               <span id="selectedToolsWarning" class="block text-sm font-semibold text-red-600 mt-1"></span>
             </div>
             <div>
@@ -289,8 +285,14 @@
                 placeholder="e.g., prompt1, prompt2" />
             </div>
           </div>
+          <!-- 🔻 Error Display Span -->
+          <span id="serverFormError" class="block text-sm font-semibold text-red-600 mt-2"></span>
+
+          <!-- 🔄 Optional Loading Indicator -->
+          <div id="add-server-loading" class="hidden text-sm text-gray-500 mt-2">Submitting...</div>
+
           <div class="mt-6">
-            <button type="submit" data-testid="add-server-btn"
+            <button type="submit"
               x-tooltip="'💡Creates a new Virtual Server by combining Tools, Resources & Prompts from global catalogs.'"
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               Add Server


### PR DESCRIPTION
# 🐛 Bug-fix PR 354

---

## 📌 Summary
- made fixes to handle the bug #476 
- Error notification pops up on UI when new server with unique is not created under server catalogue
-
## 💡 Fix Description
- modified admin.py as below (review required)
# original snippet

'''
if is_inactive_checked.lower() == "true":
            return RedirectResponse(f"{root_path}/admin/?include_inactive=true#catalog", status_code=303)
        return RedirectResponse(f"{root_path}/admin#catalog", status_code=303)

'''

Changed the above to below after successful creation of server under server catalog to return a status code 200 instead of redirect (** Review required)

# updated snippet
'''
return JSONResponse(
            content={"message": "Server created successfully!", "success": True},
            status_code=200,
        )
'''
- created 'handleServerFormSubmit' similar to that of 'handleGatewayFormSubmit' and make changes in admin.html as per the form on click button - ('add-server-form')
- 

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Unit tests                            | `make test`          |    Failed for 2 scenarios|
| Unit tests                            | `make black`          |    pass    |
| Unit tests                            | `make lint-web`          |    pass    |

## Make Test Failed Cases
- 2 test cases failed when new server is added to server catalog with assert status code 303 (it is modified to 200 as per the changes in this PR) - **Review required
 
## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

Signed-off-by: Satya <tsp.0713@gmail.com>