### PR TITLE
Use X-Forwarded-Proto for URL correction

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -54,7 +54,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 # First-Party
 from mcpgateway import __version__

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -54,6 +54,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
 
 # First-Party
 from mcpgateway import __version__
@@ -475,6 +476,9 @@ app.add_middleware(DocsAuthMiddleware)
 
 # Add streamable HTTP middleware for /mcp routes
 app.add_middleware(MCPPathRewriteMiddleware)
+
+# Trust all proxies (or lock down with a list of host patterns)
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 
 # Set up Jinja2 templates and store in app state for later use

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -82,5 +82,6 @@ exec gunicorn -c gunicorn.config.py \
     --max-requests-jitter "${GUNICORN_MAX_REQUESTS_JITTER}" \
     --access-logfile - \
     --error-logfile - \
+    --forwarded-allow-ips="*" \
     ${SSL_ARGS} \
     "mcpgateway.main:app"


### PR DESCRIPTION
- **add proxyheaders firmware**
- **fix import**
- **update url with protocol**

# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Issue #424

## 💡 Fix Description
1. Forward X-Forwarded-Proto in gunicorn
2. Update url sent to SSETransport to have the correct protocol based on X-Forwarded-Proto header or request URL scheme

## 🧪 Verification

| Check                                 | Command              |   Status   |
|---------------------------------------|----------------------|------------|
| Lint suite                            | `make lint`          |    pass    |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
