### PR TITLE
Validate prompt arguments for XSS

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -79,6 +79,7 @@ from mcpgateway.schemas import (
     GatewayUpdate,
     JsonPathModifier,
     PromptCreate,
+    PromptExecuteArgs,
     PromptRead,
     PromptUpdate,
     ResourceCreate,
@@ -1632,7 +1633,13 @@ async def get_prompt(
         Rendered prompt or metadata.
     """
     logger.debug(f"User: {user} requested prompt: {name} with args={args}")
-    return await prompt_service.get_prompt(db, name, args)
+    try:
+        PromptExecuteArgs(args=args)
+        return await prompt_service.get_prompt(db, name, args)
+    except Exception as ex:
+        logger.error(f"Error retrieving prompt {name}: {ex}")
+        if isinstance(ex, ValueError):
+            return JSONResponse(content={"message": "Prompt execution arguments contains HTML tags that may cause security issues"}, status_code=422)
 
 
 @prompt_router.get("/{name}")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1433,6 +1433,34 @@ class PromptCreate(BaseModel):
         return v
 
 
+class PromptExecuteArgs(BaseModel):
+    """
+    Schema for args executing a prompt
+
+    Attributes:
+        args (Dict[str, str]): Arguments for prompt execution.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    args: Dict[str, str] = Field(default_factory=dict, description="Arguments for prompt execution")
+
+    @field_validator("args")
+    @classmethod
+    def validate_args(cls, v: dict) -> dict:
+        """Ensure prompt arguments pass XSS validation
+
+        Args:
+            v (dict): Value to validate
+
+        Returns:
+            dict: Value if validated as safe
+        """
+        for val in v.values():
+            SecurityValidator.validate_no_xss(val, "Prompt execution arguments")
+        return v
+
+
 class PromptUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing prompt.
 

--- a/mcpgateway/validators.py
+++ b/mcpgateway/validators.py
@@ -421,6 +421,24 @@ class SecurityValidator:
         return value
 
     @classmethod
+    def validate_no_xss(cls, value: str, field_name: str) -> None:
+        """
+        Validate that a string does not contain XSS patterns.
+
+        Args:
+            value (str): Value to validate.
+            field_name (str): Name of the field being validated.
+
+        Raises:
+            ValueError: If the value contains XSS patterns.
+        """
+        if not value:
+            return  # Empty values are considered safe
+        # Check for dangerous HTML tags
+        if re.search(cls.DANGEROUS_HTML_PATTERN, value, re.IGNORECASE):
+            raise ValueError(f"{field_name} contains HTML tags that may cause security issues")
+
+    @classmethod
     def validate_json_depth(
         cls,
         obj: object,


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Fixes prompt execution part of issue #361

## 🔁 Reproduction Steps
Refer to issue #361

## 🐞 Root Cause
Prompt arguments not validated

## 💡 Fix Description
1. Add schema for PromptExecutionArgs where args are validation for XSS issues

## 🧪 Verification

| Check                                 | Command              |   Status  |
|---------------------------------------|----------------------|-----------|
| Lint suite                            | `make lint`          |   pass    |
| Unit tests                            | `make test`          |   pass    |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
