### PR TITLE
fix: Update server ID regex to support hexadecimal UUIDs in virtual server paths

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -517,7 +517,7 @@ class SessionManagerWrapper:
         """
 
         path = scope["modified_path"]
-        match = re.search(r"/servers/(?P<server_id>\d+)/mcp", path)
+        match = re.search(r"/servers/(?P<server_id>[a-fA-F0-9\-]+)/mcp", path)
 
         if match:
             server_id = match.group("server_id")


### PR DESCRIPTION
Update server ID regex to support hexadecimal UUIDs in virtual server paths

- Changed regex pattern from `\d+` (digits only) to `[a-fA-F0-9\-]+` 
- Now correctly matches hexadecimal server IDs like f6f588706c754dd7b8699d3193e8dda9
- Fixes virtual server routing for paths like /servers/{hex-id}/mcp
- Enables proper server context setting for tool filtering in virtual servers

This resolves the issue where virtual MCP servers with hex-based UUIDs 
were not being properly identified, causing all tools to be returned 
instead of the filtered subset for the specific virtual server.