### PR TITLE
Fix prompt service test case

### DIFF
--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -421,12 +421,6 @@ class TestPromptService:
         assert "name" in required
         assert "code" in required
 
-    def test_get_required_arguments(self, prompt_service):
-        template = "Hello, {{ name }}! Your code is {{ code }}."
-        required = prompt_service._get_required_arguments(template)
-        assert "name" in required
-        assert "code" in required
-
     def test_render_template_fallback_and_error(self, prompt_service):
         # Patch jinja_env.from_string to raise
         prompt_service._jinja_env.from_string = Mock(side_effect=Exception("bad"))


### PR DESCRIPTION
## 📌 Summary
This small PR removes the duplicated `test_get_required_arguments` test case.

## 🔁 Reproduction Steps

## 🐞 Root Cause

## 💡 Fix Description

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     V   |
| Unit tests                            | `make test`          |     V   |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed