### PR TITLE
Add web linters to Makefile and lint-web.yml GitHub Actions

### DIFF
--- a/.github/workflows/lint-web.yml
+++ b/.github/workflows/lint-web.yml
@@ -1,0 +1,166 @@
+# ===============================================================
+# 🕸️  Web Lint & Static Analysis - Frontend Code Quality Gate
+# ===============================================================
+# Author: Mihai Criveti
+#   - runs each web linter in its own matrix job for visibility
+#   - mirrors the actual CLI commands used locally (no `make`)
+#   - ensures fast-failure isolation: one failure doesn't hide others
+#   - each job installs Node.js and required npm packages
+#   - logs are grouped and plain-text for readability
+# ---------------------------------------------------------------
+
+name: Web Lint & Static Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-web:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # -------------------------------------------------------
+          # 🧼 HTML/CSS/JS Linters & Validators
+          # -------------------------------------------------------
+          - id: htmlhint
+            setup: npm install --no-save htmlhint
+            cmd: |
+              npx htmlhint "mcpgateway/templates/**/*.html"
+
+          - id: stylelint
+            setup: |
+              npm install --no-save \
+                stylelint \
+                stylelint-config-standard \
+                @stylistic/stylelint-config \
+                stylelint-order
+            cmd: |
+              npx stylelint "mcpgateway/static/**/*.css"
+
+          - id: eslint
+            setup: |
+              npm install --no-save \
+                eslint \
+                eslint-config-standard
+            cmd: |
+              npx eslint "mcpgateway/static/**/*.js"
+
+          # -------------------------------------------------------
+          # 🔒 Security Scanners
+          # -------------------------------------------------------
+          - id: retire
+            setup: npm install --no-save retire
+            cmd: |
+              npx retire --path mcpgateway/static
+
+          - id: npm-audit
+            setup: |
+              # Initialize package.json if needed for audit
+              if [ ! -f package.json ]; then
+                npm init -y >/dev/null
+              fi
+            cmd: |
+              npm audit --audit-level=high
+
+          # -------------------------------------------------------
+          # 🔍 Additional Code Quality Tools
+          # -------------------------------------------------------
+          - id: jshint
+            setup: npm install --no-save jshint
+            cmd: |
+              if [ -f .jshintrc ]; then
+                npx jshint --config .jshintrc "mcpgateway/static/**/*.js"
+              else
+                npx jshint --esversion=11 "mcpgateway/static/**/*.js"
+              fi
+
+          - id: jscpd
+            setup: npm install --no-save jscpd
+            cmd: |
+              npx jscpd "mcpgateway/static/" "mcpgateway/templates/"
+
+          - id: markuplint
+            setup: npm install --no-save markuplint
+            cmd: |
+              npx markuplint mcpgateway/templates/*
+
+    name: ${{ matrix.id }}
+    runs-on: ubuntu-latest
+
+    steps:
+      # -----------------------------------------------------------
+      # 0️⃣  Checkout
+      # -----------------------------------------------------------
+      - name: ⬇️  Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # -----------------------------------------------------------
+      # 1️⃣  Node.js Setup
+      # -----------------------------------------------------------
+      - name: 📦  Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      # -----------------------------------------------------------
+      # 2️⃣  Install Tool-Specific Requirements
+      # -----------------------------------------------------------
+      - name: 🔧  Install tool - ${{ matrix.id }}
+        run: ${{ matrix.setup }}
+
+      # -----------------------------------------------------------
+      # 3️⃣  Run Linter / Validator
+      # -----------------------------------------------------------
+      - name: 🔍  Run ${{ matrix.id }}
+        run: ${{ matrix.cmd }}
+
+  # -------------------------------------------------------
+  # 🐍 Python-based JS Security Scanner (separate job)
+  # -------------------------------------------------------
+  nodejsscan:
+    name: nodejsscan
+    runs-on: ubuntu-latest
+
+    steps:
+      # -----------------------------------------------------------
+      # 0️⃣  Checkout
+      # -----------------------------------------------------------
+      - name: ⬇️  Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # -----------------------------------------------------------
+      # 1️⃣  Python Setup
+      # -----------------------------------------------------------
+      - name: 🐍  Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # -----------------------------------------------------------
+      # 2️⃣  Install nodejsscan
+      # -----------------------------------------------------------
+      - name: 🔧  Install nodejsscan
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install nodejsscan
+
+      # -----------------------------------------------------------
+      # 3️⃣  Run nodejsscan
+      # -----------------------------------------------------------
+      - name: 🔒  Run nodejsscan
+        run: |
+          nodejsscan --directory ./mcpgateway/static

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,13 @@
+{
+  "esversion": 11,
+  "browser": true,
+  "devel": true,
+  "string": true,
+  "globals": {
+    "console": true,
+    "window": true,
+    "document": true,
+    "fetch": true,
+    "URLSearchParams": true
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -714,11 +714,14 @@ tomllint:                         ## 📑 TOML validation (tomlcheck)
 # 🕸️  WEBPAGE LINTERS & STATIC ANALYSIS
 # =============================================================================
 # help: 🕸️  WEBPAGE LINTERS & STATIC ANALYSIS (HTML/CSS/JS lint + security scans + formatting)
-# help: install-web-linters  - Install HTMLHint, Stylelint, ESLint, Retire.js & Prettier via npm
+# help: install-web-linters  - Install HTMLHint, Stylelint, ESLint, Retire.js, Prettier, JSHint, jscpd & markuplint via npm
 # help: nodejsscan           - Run nodejsscan for JS security vulnerabilities
 # help: lint-web             - Run HTMLHint, Stylelint, ESLint, Retire.js, nodejsscan and npm audit
+# help: jshint               - Run JSHint for additional JavaScript analysis
+# help: jscpd                - Detect copy-pasted code in JS/HTML/CSS files
+# help: markuplint           - Modern HTML linting with markuplint
 # help: format-web           - Format HTML, CSS & JS files with Prettier
-.PHONY: install-web-linters nodejsscan lint-web format-web
+.PHONY: install-web-linters nodejsscan lint-web jshint jscpd markuplint format-web
 
 install-web-linters:
 	@echo "🔧 Installing HTML/CSS/JS lint, security & formatting tools..."
@@ -731,7 +734,10 @@ install-web-linters:
 		stylelint stylelint-config-standard @stylistic/stylelint-config stylelint-order \
 		eslint eslint-config-standard \
 		retire \
-		prettier
+		prettier \
+		jshint \
+		jscpd \
+		markuplint
 
 nodejsscan:
 	@echo "🔒 Running nodejsscan for JavaScript security vulnerabilities..."
@@ -753,6 +759,24 @@ lint-web: install-web-linters nodejsscan
 	else \
 	  echo "⚠️  Skipping npm audit: no package.json found"; \
 	fi
+
+jshint: install-web-linters
+	@echo "🔍 Running JSHint for JavaScript analysis..."
+	@if [ -f .jshintrc ]; then \
+	  echo "📋 Using .jshintrc configuration"; \
+	  npx jshint --config .jshintrc mcpgateway/static/*.js || true; \
+	else \
+	  echo "📋 No .jshintrc found, using defaults with ES11"; \
+	  npx jshint --esversion=11 mcpgateway/static/*.js || true; \
+	fi
+
+jscpd: install-web-linters
+	@echo "🔍 Detecting copy-pasted code with jscpd..."
+	@npx jscpd "mcpgateway/static/" "mcpgateway/templates/" || true
+
+markuplint: install-web-linters
+	@echo "🔍 Running markuplint for modern HTML validation..."
+	@npx markuplint mcpgateway/templates/* || true
 
 format-web: install-web-linters
 	@echo "🎨 Formatting HTML, CSS & JS with Prettier..."


### PR DESCRIPTION
Add lint-web to CI/CD and add additional linters to Makefile (jshint jscpd markuplint) - closes #390

Add web linting to our CI/CD pipeline to ensure frontend code quality and security. This includes creating a new GitHub workflow (`lint-web.yml`) that runs HTML, CSS, and JavaScript linters in parallel jobs, similar to our existing Python lint workflow.

**Tasks:**
- [X] Create `.github/workflows/lint-web.yml` with matrix jobs for:
  - htmlhint (HTML validation)
  - stylelint (CSS linting)
  - eslint (JavaScript linting)
  - retire (vulnerability scanning)
  - npm audit (dependency security)
  - jshint (Additional JS analysis with ES11 support)
  - jscpd (Copy/paste detection across JS/HTML/CSS)
  - markuplint (Modern HTML validation)
  - nodejsscan (JS security analysis - separate Python job)
- [X] Add new linter targets to Makefile:
  - `jshint` - Additional JS analysis with ES11 support
  - `jscpd` - Copy/paste detection across JS/HTML/CSS
  - `markuplint` - Modern HTML validation
- [X] Update `install-web-linters` target to include new tools
- [X] Create `.jshintrc` config file for consistent JS standards

**Benefits:**
- Automated frontend code quality checks on every PR
- Early detection of security vulnerabilities
- Consistent code standards across HTML/CSS/JS
- Reduced technical debt through duplicate code detection
- Comprehensive coverage with 9 different linting tools

