### PR TITLE
Fix smoketest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,9 +131,12 @@ CORS_ENABLED=true
 #####################################
 
 RETRY_MAX_ATTEMPTS=3
-RETRY_BASE_DELAY=1.0  # seconds
-RETRY_MAX_DELAY=60.0  # seconds
-RETRY_JITTER_MAX=0.5  # fraction of delay
+# seconds
+RETRY_BASE_DELAY=1.0
+# seconds
+RETRY_MAX_DELAY=60.0
+# fraction of delay
+RETRY_JITTER_MAX=0.5
 
 #####################################
 # Logging
@@ -253,9 +256,8 @@ UNHEALTHY_THRESHOLD=3
 
 # This path is append with the system temp directory.
 # It is used to ensure that only one instance of the gateway health Check can run at a time.
-FILELOCK_NAME=gateway_healthcheck_init.lock   # saved dir in /tmp/gateway_healthcheck_init.lock
-# FILELOCK_NAME=somefolder/gateway_healthcheck_init.lock   # saved dir in /tmp/somefolder/gateway_healthcheck_init.lock#
-
+# saved dir in /tmp/gateway_healthcheck_init.lock
+FILELOCK_NAME=gateway_healthcheck_init.lock
 
 #####################################
 # Development Settings

--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,10 @@ clean:
 ## --- Automated checks --------------------------------------------------------
 smoketest:
 	@echo "🚀 Running smoketest..."
-	@./smoketest.py --verbose || { echo "❌ Smoketest failed!"; exit 1; }
-	@echo "✅ Smoketest passed!"
+	@bash -c '\
+		./smoketest.py --verbose || { echo "❌ Smoketest failed!"; exit 1; }; \
+		echo "✅ Smoketest passed!" \
+	'
 
 test:
 	@echo "🧪 Running tests..."
@@ -1194,7 +1196,7 @@ endef
 
 # Containerfile to use (can be overridden)
 #CONTAINER_FILE ?= Containerfile
-CONTAINER_FILE ?= $(shell [ -f "Containerfile" ] && echo "Containerfile" || echo "Dockerfile")
+CONTAINER_FILE ?= $(shell [ -f "Containerfile.lite" ] && echo "Containerfile.lite" || echo "Dockerfile")
 
 
 # Define COMMA for the conditional Z flag
@@ -1267,6 +1269,7 @@ container-run-ssl: certs container-check-image
 	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
 	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
 	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
+		-u $(id -u):$(id -g) \
 		--env-file=.env \
 		-e SSL=true \
 		-e CERT_FILE=certs/cert.pem \
@@ -1287,6 +1290,7 @@ container-run-ssl-host: certs container-check-image
 	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
 	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
 	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
+		-u $(id -u):$(id -g) \
 		--network=host \
 		--env-file=.env \
 		-e SSL=true \


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Fixes 3 issues in smoketest
1. Variable parsing from .env
2. Running npx on systems where it is not accessible system wide
3. Display correct result in make command output by returning 0 or 1 from smoketest
4. Fixed supergateway input to --stdio - had missing double quotes

## 🐞 Root Cause
- Some int or float variables set in .env.example have comments are not parsed correctly in code
- Running npx commands fails on some systems without sourcing ~/.nvm/nvm.sh
- Smoketest result not returning 0 or 1 to make command, so it always prints Smoketest passed at the end

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |  pass  |
| Unit tests                            | `make test`          |  pass  |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
