### PR TITLE
checkbox implementation for selection in servers panel

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -401,31 +401,64 @@
                   class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 />
               </div>
-              <div>
+              <div class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-300 dark:border-gray-700">
                 <label
+                  class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
                   for="associatedTools"
-                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
                   Associated Tools
                 </label>
-                <select
-                  name="associatedTools"
+                <div
                   id="associatedTools"
-                  multiple
-                  class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                  class="max-h-60 overflow-y-auto rounded-md border border-gray-300 dark:border-gray-700 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
                 >
                   {% for tool in tools %}
-                  <option value="{{ tool.id }}">{{ tool.name }}</option>
+                  <label
+                    class="flex items-center space-x-3 text-gray-700 dark:text-gray-300 mb-2 cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 rounded-md p-1"
+                  >
+                    <input
+                      type="checkbox"
+                      name="associatedTools"
+                      value="{{ tool.id }}"
+                      class="tool-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
+                    />
+                    <span class="select-none">{{ tool.name }}</span>
+                  </label>
                   {% endfor %}
-                </select>
-                <span
+                </div>
+                <div class="flex justify-end mt-3 gap-2">
+
+                  <button
+                  type="button"
+                  id="selectAllToolsBtn"
+                  class="px-3 py-1 text-sm font-semibold text-green-600 border border-green-600 rounded-md hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1"
+                  aria-label="Select all tools"
+                >
+                  Select All
+                </button>
+
+                <button
+                  type="button"
+                  id="clearAllToolsBtn"
+                  class="px-3 py-1 text-sm font-semibold text-red-600 border border-red-600 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1"
+                  aria-label="Clear all selected tools"
+                >
+                  Clear All
+                </button>
+                </div>
+
+                <!-- Selected pills -->
+                <div
                   id="selectedToolsPills"
-                  class="inline-flex flex-wrap gap-1 mt-2"
-                ></span>
-                <span
+                  class="mt-4 flex flex-wrap gap-2"
+                ></div>
+
+                <!-- Warning message -->
+                <div
                   id="selectedToolsWarning"
-                  class="block text-sm font-semibold text-red-600 mt-1"
-                ></span>
+                  class="mt-2 min-h-[1.25rem] text-sm font-semibold text-yellow-600"
+                  aria-live="polite"
+                ></div>
               </div>
               <div>
                 <label
@@ -3132,38 +3165,66 @@
                         class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
-                    <div>
+
+                    <div class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-600">
                       <label
                         for="edit-server-tools"
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
                       >
                         Associated Tools
                       </label>
-                      <select
+                      <div
                         id="edit-server-tools"
-                        name="associatedTools"
-                        {#
-                        same
-                        field
-                        name
-                        #}
-                        multiple
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="max-h-60 overflow-y-auto rounded-md border border-gray-600 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
                       >
                         {% for tool in tools %}
-                        <option value="{{ tool.id }}">{{ tool.name }}</option>
+                        <label
+                          class="flex items-center space-x-3 text-gray-700 dark:text-gray-300 mb-2 cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 rounded-md p-1"
+                        >
+                          <input
+                            type="checkbox"
+                            name="associatedTools"
+                            value="{{ tool.id }}"
+                            class="tool-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
+                          />
+                          <span class="select-none">{{ tool.name }}</span>
+                        </label>
                         {% endfor %}
-                      </select>
-                      <span
+                      </div>
+                      <div class="flex justify-end gap-3 mt-3">
+                        <button
+                          type="button"
+                          id="selectAllEditToolsBtn"
+                          class="px-3 py-1 text-sm font-semibold text-green-600 border border-green-600 rounded-md hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1"
+                          aria-label="Select all tools"
+                        >
+                          Select All
+                        </button>
+
+                        <button
+                          type="button"
+                          id="clearAllEditToolsBtn"
+                          class="px-3 py-1 text-sm font-semibold text-red-600 border border-red-600 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1"
+                          aria-label="Clear all selected tools"
+                        >
+                          Clear All
+                        </button>
+                      </div>
+
+                      <!-- Selected pills -->
+                      <div
                         id="selectedEditToolsPills"
-                        class="inline-flex flex-wrap gap-1 mt-2"
-                      ></span>
-                      <!-- container -->
-                      <span
+                        class="mt-4 flex flex-wrap gap-2"
+                      ></div>
+
+                      <!-- Warning message -->
+                      <div
                         id="selectedEditToolsWarning"
-                        class="block text-sm font-semibold text-red-600 mt-1"
-                      ></span>
+                        class="mt-2 min-h-[1.25rem] text-sm font-semibold text-yellow-600"
+                        aria-live="polite"
+                      ></div>
                     </div>
+
                     <div>
                       <label
                         class="block text-sm font-medium text-gray-700 dark:text-gray-300"


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #392 and #613 

---

## 🚀 Summary (1-2 sentences)
Made selecting tools easier by using checkboxes instead of Ctrl+click, plus added buttons to select or clear all tools in one go.
Fixed Linting issues.

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)

<img width="944" height="275" alt="image" src="https://github.com/user-attachments/assets/4d038822-e7cc-49a9-9787-ab1f2dc456e0" />
