### PR TITLE
feat: Add MCP Gateway Name to the Tools Overview

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -535,6 +535,11 @@
                     S. No.
                   </th>
                   <th
+                    class="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-36"
+                  >
+                    Gateway Name
+                  </th>
+                  <th
                     class="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-24"
                   >
                     Name
@@ -587,9 +592,14 @@
                     {{ loop.index }}
                   </td>
                   <td
+                    class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-36"
+                  >
+                    {{ tool.gatewaySlug }}
+                  </td>
+                  <td
                     class="px-2 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-24 dark:text-gray-100"
                   >
-                    {{ tool.name }}
+                    {{ tool.originalNameSlug }}
                   </td>
                   <td
                     class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-24"


### PR DESCRIPTION
Closes #506

This adds another column to the tools admin page overview with the gateway/server name. The slug was already pulled in the backend - just needed to add it to the UI
