### PR TITLE
fix: Fix sending true/false for boolean tool input

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3331,8 +3331,18 @@ async function testTool(toolId) {
                     input.type = "number";
                 } else if (prop.type === "boolean") {
                     input.type = "checkbox";
+                    input.value = true;
                     input.className =
                         "mt-1 h-4 w-4 text-indigo-600 dark:text-indigo-200 border border-gray-300 rounded";
+
+                    // Add a second hidden input to include `false` in the Form
+                    // will be overriden in the map generation due to the same name being used as the key
+                    const hiddenInput = document.createElement("input");
+                    hiddenInput.name = input.name;
+                    hiddenInput.required = input.required;
+                    hiddenInput.type = "hidden";
+                    hiddenInput.value = false;
+                    fieldDiv.appendChild(hiddenInput);
                 }
 
                 fieldDiv.appendChild(input);


### PR DESCRIPTION
Closes #622

Input of type checkbox per default has the value "on", setting the value explicitly to true solves this. 
Additionally unchecked checkboxes are excluded from forms completley so we add an extra hidden input to circumvent that. 
