### PR TITLE
425 SECURITYFEATURE Make JWT Token Expiration Mandatory when REQUIRE_TOKEN_EXPIRATION=true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,9 @@ JWT_ALGORITHM=HS256
 # Expiry time for generated JWT tokens (in minutes; e.g. 7 days)
 TOKEN_EXPIRY=10080
 
+# Require all JWT tokens to have expiration claims (true or false)
+REQUIRE_TOKEN_EXPIRATION=false
+
 # Used to derive an AES encryption key for secure auth storage
 # Must be a non-empty string (e.g. passphrase or random secret)
 AUTH_ENCRYPTION_SECRET=my-test-salt

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -61,7 +61,8 @@ import jq
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import JSONPath
 from pydantic import field_validator
-from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict 
+from pydantic import Field
 
 logging.basicConfig(
     level=logging.INFO,
@@ -115,6 +116,11 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     auth_required: bool = True
     token_expiry: int = 10080  # minutes
+
+    require_token_expiration: bool = Field(
+    default=False,  # Default to flexible mode for backward compatibility
+    description="Require all JWT tokens to have expiration claims"
+     )
 
     #  Encryption key phrase for auth storage
     auth_encryption_secret: str = "my-test-salt"

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -60,9 +60,8 @@ from fastapi import HTTPException
 import jq
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import JSONPath
-from pydantic import field_validator
-from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict 
-from pydantic import Field
+from pydantic import Field,field_validator
+from pydantic_settings import BaseSettings,NoDecode,SettingsConfigDict 
 
 logging.basicConfig(
     level=logging.INFO,

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -60,8 +60,8 @@ from fastapi import HTTPException
 import jq
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import JSONPath
-from pydantic import Field,field_validator
-from pydantic_settings import BaseSettings,NoDecode,SettingsConfigDict 
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 logging.basicConfig(
     level=logging.INFO,
@@ -116,10 +116,7 @@ class Settings(BaseSettings):
     auth_required: bool = True
     token_expiry: int = 10080  # minutes
 
-    require_token_expiration: bool = Field(
-    default=False,  # Default to flexible mode for backward compatibility
-    description="Require all JWT tokens to have expiration claims"
-     )
+    require_token_expiration: bool = Field(default=False, description="Require all JWT tokens to have expiration claims")  # Default to flexible mode for backward compatibility
 
     #  Encryption key phrase for auth storage
     auth_encryption_secret: str = "my-test-salt"

--- a/mcpgateway/utils/create_jwt_token.py
+++ b/mcpgateway/utils/create_jwt_token.py
@@ -105,6 +105,14 @@ def _create_jwt_token(
     if expires_in_minutes > 0:
         expire = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(minutes=expires_in_minutes)
         payload["exp"] = int(expire.timestamp())
+    else:
+        # Warn about non-expiring token
+        print(
+            "⚠️  WARNING: Creating token without expiration. This is a security risk!\n"
+            "   Consider using --exp with a value > 0 for production use.\n"
+            "   Once JWT API (#425) is available, use it for automatic token renewal.",
+            file=sys.stderr
+        )    
     return jwt.encode(payload, secret, algorithm=algorithm)
 
 

--- a/mcpgateway/utils/create_jwt_token.py
+++ b/mcpgateway/utils/create_jwt_token.py
@@ -111,8 +111,8 @@ def _create_jwt_token(
             "⚠️  WARNING: Creating token without expiration. This is a security risk!\n"
             "   Consider using --exp with a value > 0 for production use.\n"
             "   Once JWT API (#425) is available, use it for automatic token renewal.",
-            file=sys.stderr
-        )    
+            file=sys.stderr,
+        )
     return jwt.encode(payload, secret, algorithm=algorithm)
 
 

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -17,6 +17,7 @@ Examples:
     ...     basic_auth_user = 'user'
     ...     basic_auth_password = 'pass'
     ...     auth_required = True
+    ...     require_token_expiration = False
     >>> vc.settings = DummySettings()
     >>> import jwt
     >>> token = jwt.encode({'sub': 'alice'}, 'secret', algorithm='HS256')
@@ -87,6 +88,7 @@ async def verify_jwt_token(token: str) -> dict:
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = 'pass'
         ...     auth_required = True
+        ...     require_token_expiration = False
         >>> vc.settings = DummySettings()
         >>> import jwt
         >>> token = jwt.encode({'sub': 'alice'}, 'secret', algorithm='HS256')
@@ -196,6 +198,7 @@ async def verify_credentials(token: str) -> dict:
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = 'pass'
         ...     auth_required = True
+        ...     require_token_expiration = False
         >>> vc.settings = DummySettings()
         >>> import jwt
         >>> token = jwt.encode({'sub': 'alice'}, 'secret', algorithm='HS256')
@@ -236,6 +239,7 @@ async def require_auth(credentials: Optional[HTTPAuthorizationCredentials] = Dep
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = 'pass'
         ...     auth_required = True
+        ...     require_token_expiration = False
         >>> vc.settings = DummySettings()
         >>> import jwt
         >>> from fastapi.security import HTTPAuthorizationCredentials
@@ -415,6 +419,7 @@ async def require_auth_override(
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = 'pass'
         ...     auth_required = True
+        ...     require_token_expiration = False
         >>> vc.settings = DummySettings()
         >>> import jwt
         >>> import asyncio

--- a/tests/security/test_rpc_endpoint_validation.py
+++ b/tests/security/test_rpc_endpoint_validation.py
@@ -39,14 +39,13 @@ class TestRPCEndpointValidation:
     @pytest.fixture
     def client(self):
         """Create a test client for the FastAPI app."""
-        return TestClient(app)   
+        return TestClient(app)
+
     @pytest.fixture
     def auth_headers(self):
         """Create authorization headers for testing."""
         # You might need to adjust this based on your auth setup
         return {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
-    
-     
 
     def test_rpc_endpoint_with_malicious_methods(self, client, auth_headers):
         """Test that malicious method names are rejected before processing.

--- a/tests/security/test_rpc_endpoint_validation.py
+++ b/tests/security/test_rpc_endpoint_validation.py
@@ -39,13 +39,14 @@ class TestRPCEndpointValidation:
     @pytest.fixture
     def client(self):
         """Create a test client for the FastAPI app."""
-        return TestClient(app)
-
+        return TestClient(app)   
     @pytest.fixture
     def auth_headers(self):
         """Create authorization headers for testing."""
         # You might need to adjust this based on your auth setup
         return {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+    
+     
 
     def test_rpc_endpoint_with_malicious_methods(self, client, auth_headers):
         """Test that malicious method names are rejected before processing.

--- a/tests/unit/mcpgateway/utils/test_verify_credentials.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials.py
@@ -48,6 +48,7 @@ ALGO = "HS256"
 #         payload = payload | {"exp": int(expire.timestamp())}
 #     return jwt.encode(payload, secret, algorithm=ALGO)
 
+
 def _token(payload: dict, *, exp_delta: int | None = 60, secret: str = SECRET) -> str:
     """Return a signed JWT with optional expiry offset (minutes)."""
     if exp_delta is not None:
@@ -63,8 +64,8 @@ def _token(payload: dict, *, exp_delta: int | None = 60, secret: str = SECRET) -
 async def test_verify_jwt_token_success(monkeypatch):
     monkeypatch.setattr(vc.settings, "jwt_secret_key", SECRET, raising=False)
     monkeypatch.setattr(vc.settings, "jwt_algorithm", ALGO, raising=False)
-    monkeypatch.setattr(vc.settings, "require_token_expiration", False, raising=False) 
-    
+    monkeypatch.setattr(vc.settings, "require_token_expiration", False, raising=False)
+
     token = _token({"sub": "abc"})
     data = await vc.verify_jwt_token(token)
 

--- a/tests/unit/mcpgateway/utils/test_verify_credentials.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials.py
@@ -41,7 +41,14 @@ SECRET = "unit-secret"
 ALGO = "HS256"
 
 
-def _token(payload: dict, *, exp_delta: int | None = None, secret: str = SECRET) -> str:
+# def _token(payload: dict, *, exp_delta: int | None = None, secret: str = SECRET) -> str:
+#     """Return a signed JWT with optional expiry offset (minutes)."""
+#     if exp_delta is not None:
+#         expire = datetime.now(timezone.utc) + timedelta(minutes=exp_delta)
+#         payload = payload | {"exp": int(expire.timestamp())}
+#     return jwt.encode(payload, secret, algorithm=ALGO)
+
+def _token(payload: dict, *, exp_delta: int | None = 60, secret: str = SECRET) -> str:
     """Return a signed JWT with optional expiry offset (minutes)."""
     if exp_delta is not None:
         expire = datetime.now(timezone.utc) + timedelta(minutes=exp_delta)
@@ -56,7 +63,8 @@ def _token(payload: dict, *, exp_delta: int | None = None, secret: str = SECRET)
 async def test_verify_jwt_token_success(monkeypatch):
     monkeypatch.setattr(vc.settings, "jwt_secret_key", SECRET, raising=False)
     monkeypatch.setattr(vc.settings, "jwt_algorithm", ALGO, raising=False)
-
+    monkeypatch.setattr(vc.settings, "require_token_expiration", False, raising=False) 
+    
     token = _token({"sub": "abc"})
     data = await vc.verify_jwt_token(token)
 


### PR DESCRIPTION
## 📌 Summary
_What problem does this PR fix and **why**?_
This PR ensures that JWT tokens must include an expiration claim (exp) when the REQUIRE_TOKEN_EXPIRATION setting is set to true

## 💡 Fix Description
_How did you solve it?  Key design points._
Added a REQUIRE_TOKEN_EXPIRATION config flag to enforce or warn on missing exp claims in JWTs.
Updated verify_jwt_token to reject or log based on this setting, and enhanced CLI to warn on non-expiring tokens.
Ensures security compliance while allowing flexibility for automation use cases.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | pass    
| Unit tests                            | `make test`          | pass    

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

