### PR TITLE
Fix: Correctly parse array inputs in Test Tool UI

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3507,19 +3507,53 @@ async function runToolTest() {
                 }
                 let value;
                 if (prop.type === "array") {
-                    value = formData.getAll(key);
-                    if (prop.items && prop.items.type === "number") {
-                        value = value.map((v) => (v === "" ? null : Number(v)));
-                    } else if (prop.items && prop.items.type === "boolean") {
-                        value = value.map((v) => v === "true" || v === true);
+                    let inputValues = formData.getAll(key);
+                    try {
+                        // Convert values based on the items schema type
+                        if (prop.items && prop.items.type) {
+                            switch (prop.items.type) {
+                                case "object":
+                                    value = inputValues.map(v => {
+                                        try {
+                                            const parsed = JSON.parse(v);
+                                            if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+                                                throw new Error(`Value must be an object, got ${typeof parsed}`);
+                                            }
+                                            return parsed;
+                                        } catch (e) {
+                                            console.error(`Error parsing object for ${key}:`, e);
+                                            throw new Error(`Invalid object format for ${key}. Each item must be a valid JSON object.`);
+                                        }
+                                    });
+                                    break;
+                                case "number":
+                                    value = inputValues.map(v => v === "" ? null : Number(v));
+                                    break;
+                                case "boolean":
+                                    value = inputValues.map(v => v === "true" || v === true);
+                                    break;
+                                default:
+                                    // For other types (like strings), use raw values
+                                    value = inputValues;
+                            }
+                        } else {
+                            // If no items type specified, use raw values
+                            value = inputValues;
+                        }
+
+                        // Handle empty values
+                        if (value.length === 0 || (value.length === 1 && value[0] === "")) {
+                            if (schema.required && schema.required.includes(key)) {
+                                params[keyValidation.value] = [];
+                            }
+                            continue;
+                        }
+                        params[keyValidation.value] = value;
+                    } catch (error) {
+                        console.error(`Error parsing array values for ${key}:`, error);
+                        showErrorMessage(`Invalid input format for ${key}. Please check the values are in correct format.`);
+                        throw error;
                     }
-                    if (
-                        value.length === 0 ||
-                        (value.length === 1 && value[0] === "")
-                    ) {
-                        continue;
-                    }
-                    params[keyValidation.value] = value;
                 } else {
                     value = formData.get(key);
                     if (value === null || value === undefined || value === "") {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3507,30 +3507,44 @@ async function runToolTest() {
                 }
                 let value;
                 if (prop.type === "array") {
-                    let inputValues = formData.getAll(key);
+                    const inputValues = formData.getAll(key);
                     try {
                         // Convert values based on the items schema type
                         if (prop.items && prop.items.type) {
                             switch (prop.items.type) {
                                 case "object":
-                                    value = inputValues.map(v => {
+                                    value = inputValues.map((v) => {
                                         try {
                                             const parsed = JSON.parse(v);
-                                            if (typeof parsed !== 'object' || Array.isArray(parsed)) {
-                                                throw new Error(`Value must be an object, got ${typeof parsed}`);
+                                            if (
+                                                typeof parsed !== "object" ||
+                                                Array.isArray(parsed)
+                                            ) {
+                                                throw new Error(
+                                                    `Value must be an object, got ${typeof parsed}`,
+                                                );
                                             }
                                             return parsed;
                                         } catch (e) {
-                                            console.error(`Error parsing object for ${key}:`, e);
-                                            throw new Error(`Invalid object format for ${key}. Each item must be a valid JSON object.`);
+                                            console.error(
+                                                `Error parsing object for ${key}:`,
+                                                e,
+                                            );
+                                            throw new Error(
+                                                `Invalid object format for ${key}. Each item must be a valid JSON object.`,
+                                            );
                                         }
                                     });
                                     break;
                                 case "number":
-                                    value = inputValues.map(v => v === "" ? null : Number(v));
+                                    value = inputValues.map((v) =>
+                                        v === "" ? null : Number(v),
+                                    );
                                     break;
                                 case "boolean":
-                                    value = inputValues.map(v => v === "true" || v === true);
+                                    value = inputValues.map(
+                                        (v) => v === "true" || v === true,
+                                    );
                                     break;
                                 default:
                                     // For other types (like strings), use raw values
@@ -3542,16 +3556,27 @@ async function runToolTest() {
                         }
 
                         // Handle empty values
-                        if (value.length === 0 || (value.length === 1 && value[0] === "")) {
-                            if (schema.required && schema.required.includes(key)) {
+                        if (
+                            value.length === 0 ||
+                            (value.length === 1 && value[0] === "")
+                        ) {
+                            if (
+                                schema.required &&
+                                schema.required.includes(key)
+                            ) {
                                 params[keyValidation.value] = [];
                             }
                             continue;
                         }
                         params[keyValidation.value] = value;
                     } catch (error) {
-                        console.error(`Error parsing array values for ${key}:`, error);
-                        showErrorMessage(`Invalid input format for ${key}. Please check the values are in correct format.`);
+                        console.error(
+                            `Error parsing array values for ${key}:`,
+                            error,
+                        );
+                        showErrorMessage(
+                            `Invalid input format for ${key}. Please check the values are in correct format.`,
+                        );
                         throw error;
                     }
                 } else {


### PR DESCRIPTION
📌 Summary
This PR resolves Issue #620 by updating the Test Tool UI to correctly handle array-type inputs using schema-aware logic. It ensures that structured arrays (e.g., arrays of objects) are parsed and validated properly before submission.

🐞 Root Cause
The UI was treating array inputs as raw strings from text fields, and passing them as single stringified values instead of structured arrays. This broke validation for tools expecting array<object> or other structured formats.

🔁 Reproduction Steps
Refer to: #620 

💡 Fix Description
- Removed static text input logic for array types.
- Used formData.getAll(key) to retrieve all user inputs for array fields.
- Dynamically parsed values based on items. Type:
  - object: Parsed with JSON.parse, validated for structure.
  - number: Mapped to numeric values.
  - boolean: Converted to true/false.
  - Fallback: Used raw input as string.
- Improved error handling and validation messages.
- Set empty required array inputs to [] where appropriate.