### PR TITLE
support multiline text input in test tool panel

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3417,39 +3417,44 @@ async function testTool(toolId) {
                     fieldDiv.appendChild(arrayContainer);
                     fieldDiv.appendChild(addBtn);
                 } else {
-                    // Input field with validation
-                    const input = document.createElement("input");
-                    input.name = keyValidation.value;
-                    input.required =
-                        schema.required && schema.required.includes(key);
-                    input.className =
-                        "mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 text-gray-700 dark:text-gray-300 dark:border-gray-700 dark:focus:border-indigo-400 dark:focus:ring-indigo-400";
-                    // Add validation based on type
-                    if (prop.type === "text") {
-                        input.type = "text";
-                    } else if (
-                        prop.type === "number" ||
-                        prop.type === "integer"
-                    ) {
-                        input.type = "number";
-                    } else if (prop.type === "boolean") {
-                        input.type = "checkbox";
-                        input.className =
-                            "mt-1 h-4 w-4 text-indigo-600 dark:text-indigo-200 border border-gray-300 rounded";
+                    // Input field with validation (with multiline support)
+                    let fieldInput;
+                    const isTextType = prop.type === "text";
+                    if (isTextType) {
+                        fieldInput = document.createElement("textarea");
+                        fieldInput.rows = 4;
                     } else {
-                        input.type = "text";
-                    }
-
-                    // Set default values here
-                    if (prop.default !== undefined) {
-                        if (input.type === "checkbox") {
-                            input.checked = prop.default === true;
+                        fieldInput = document.createElement("input");
+                        if (prop.type === "number" || prop.type === "integer") {
+                            fieldInput.type = "number";
+                        } else if (prop.type === "boolean") {
+                            fieldInput.type = "checkbox";
                         } else {
-                            input.value = prop.default;
+                            fieldInput = document.createElement("textarea");
+                            fieldInput.rows = 1;
                         }
                     }
 
-                    fieldDiv.appendChild(input);
+                    fieldInput.name = keyValidation.value;
+                    fieldInput.required =
+                        schema.required && schema.required.includes(key);
+                    fieldInput.className =
+                        prop.type === "boolean"
+                            ? "mt-1 h-4 w-4 text-indigo-600 dark:text-indigo-200 border border-gray-300 rounded"
+                            : "mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 text-gray-700 dark:text-gray-300 dark:border-gray-700 dark:focus:border-indigo-400 dark:focus:ring-indigo-400";
+
+                    // Set default values here
+                    if (prop.default !== undefined) {
+                        if (fieldInput.type === "checkbox") {
+                            fieldInput.checked = prop.default === true;
+                        } else if (isTextType) {
+                            fieldInput.value = prop.default;
+                        } else {
+                            fieldInput.value = prop.default;
+                        }
+                    }
+
+                    fieldDiv.appendChild(fieldInput);
                 }
 
                 container.appendChild(fieldDiv);


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
The test tool panel did not support multiline input. As a result, cases requiring multiline input such as code with newlines/indentations were passed as a single line, causing the tool to fail.

## 🔁 Reproduction Steps
1. Pass code with more than one line to a tool in the test tool panel.
2. Observe the tool failure due to incorrect formatting.

## 🐞 Root Cause
The test tool panel lacked support for multiline or properly formatted input, resulting in broken inputs for formats that rely on structure, such as Python or Mermaid.

## 💡 Fix Description
Enabled support for multiline input in the test tool panel ensuring that text blocks with indentation, new lines are passed and interpreted correctly.

### Example Input for Mermaid tool: 
```
graph TD
  A[Start] --> B{Is it working?}
  B -- Yes --> C[Great!]
  B -- No --> D[Check the config]
  D --> B
```

**Earlier Behaviour:**
The input passed to the tool would be :
```
graph TD  A[Start] --> B{Is it working?}  B -- Yes --> C[Great!]  B -- No --> D[Check the config] D --> B
```
Causing tool call failure because of invalid code.

**Current behaviour:**
The string entered in the text box is passed exactly with new lines:
```
graph TD
  A[Start] --> B{Is it working?}
  B -- Yes --> C[Great!]
  B -- No --> D[Check the config]
  D --> B
```


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
