### PR TITLE
Consistency in acceptable length of Tool Names

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1326,6 +1326,7 @@ async def admin_ui(
     gateways = [gateway.model_dump(by_alias=True) for gateway in await gateway_service.list_gateways(db, include_inactive=include_inactive)]
     roots = [root.model_dump(by_alias=True) for root in await root_service.list_roots()]
     root_path = settings.app_root_path
+    max_name_length = settings.validation_max_name_length
     response = request.app.state.templates.TemplateResponse(
         request,
         "admin.html",
@@ -1339,6 +1340,7 @@ async def admin_ui(
             "roots": roots,
             "include_inactive": include_inactive,
             "root_path": root_path,
+            "max_name_length": max_name_length,
             "gateway_tool_name_separator": settings.gateway_tool_name_separator,
         },
     )

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -69,10 +69,10 @@ function validateInputName(name, type = "input") {
         return { valid: false, error: `${type} name cannot be empty` };
     }
 
-    if (cleaned.length > 100) {
+    if (cleaned.length > window.MAX_NAME_LENGTH) {
         return {
             valid: false,
-            error: `${type} name must be 100 characters or less`,
+            error: `${type} name must be ${window.MAX_NAME_LENGTH} characters or less`,
         };
     }
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3308,6 +3308,7 @@
 
       window.ROOT_PATH = {{ root_path | tojson }};
       window.GATEWAY_TOOL_NAME_SEPARATOR = {{ gateway_tool_name_separator | tojson }};
+      window.MAX_NAME_LENGTH = {{ max_name_length | tojson }};
     </script>
   </body>
 </html>


### PR DESCRIPTION
- **Bug Fix**: Fixes issue #631 .
🐞 Bug Summary
Inconsistency in acceptable tool name length for tools created via UI and via cURL command
Tool Names for tools created on UI are restricted to 100 characters.
Whereas, the tool names of tools created via cURL command can have up to 255 characters.

