### PR TITLE
423RedundantConditionalExpression

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -268,10 +268,7 @@ FILELOCK_NAME=gateway_healthcheck_init.lock
 #####################################
 
 # Enable dev mode features (e.g. schema debug)
-#DEV_MODE=false
-DEV_MODE=true
-FEATURES_DOCS_ENABLED=true
-
+DEV_MODE=false
 
 # Reload app on code changes (dev only)
 RELOAD=false

--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,7 @@ TOKEN_EXPIRY=10080
 # Require all JWT tokens to have expiration claims (true or false)
 REQUIRE_TOKEN_EXPIRATION=false
 
+
 # Used to derive an AES encryption key for secure auth storage
 # Must be a non-empty string (e.g. passphrase or random secret)
 AUTH_ENCRYPTION_SECRET=my-test-salt
@@ -267,7 +268,10 @@ FILELOCK_NAME=gateway_healthcheck_init.lock
 #####################################
 
 # Enable dev mode features (e.g. schema debug)
-DEV_MODE=false
+#DEV_MODE=false
+DEV_MODE=true
+FEATURES_DOCS_ENABLED=true
+
 
 # Reload app on code changes (dev only)
 RELOAD=false

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1413,6 +1413,10 @@ async def create_resource(
         raise HTTPException(status_code=409, detail=str(e))
     except ResourceError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except ValidationError as e:
+        # Handle validation errors from Pydantic
+        return JSONResponse(content=ErrorFormatter.format_validation_error(e), status_code=422)
+
 
 
 @resource_router.get("/{uri:path}")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1418,7 +1418,6 @@ async def create_resource(
         return JSONResponse(content=ErrorFormatter.format_validation_error(e), status_code=422)
 
 
-
 @resource_router.get("/{uri:path}")
 async def read_resource(uri: str, db: Session = Depends(get_db), user: str = Depends(require_auth)) -> ResourceContent:
     """

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -999,15 +999,13 @@ class ResourceCreate(BaseModel):
 
         if isinstance(v, bytes):
             try:
-                v_str = v.decode("utf-8")
-
-                if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, v_str if isinstance(v, bytes) else v, re.IGNORECASE):
-                    raise ValueError("Content contains HTML tags that may cause display issues")
+                text = v.decode("utf-8")
             except UnicodeDecodeError:
                 raise ValueError("Content must be UTF-8 decodable")
         else:
-            if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, v if isinstance(v, bytes) else v, re.IGNORECASE):
-                raise ValueError("Content contains HTML tags that may cause display issues")
+            text = v
+        if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, text, re.IGNORECASE):
+            raise ValueError("Content contains HTML tags that may cause display issues")
 
         return v
 
@@ -1094,15 +1092,13 @@ class ResourceUpdate(BaseModelWithConfigDict):
 
         if isinstance(v, bytes):
             try:
-                v_str = v.decode("utf-8")
-
-                if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, v_str if isinstance(v, bytes) else v, re.IGNORECASE):
-                    raise ValueError("Content contains HTML tags that may cause display issues")
+                text = v.decode("utf-8")
             except UnicodeDecodeError:
                 raise ValueError("Content must be UTF-8 decodable")
         else:
-            if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, v if isinstance(v, bytes) else v, re.IGNORECASE):
-                raise ValueError("Content contains HTML tags that may cause display issues")
+            text = v
+        if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, text, re.IGNORECASE):
+            raise ValueError("Content contains HTML tags that may cause display issues")
 
         return v
 


### PR DESCRIPTION

---

## 📌 Summary
_What problem does this PR fix and **why**?_
Redundant conditional expression in the content validation logic that performs unnecessary checks, impacting code maintainability and readability

## 💡 Fix Description
_How did you solve it?  Key design points._
Refactored redundant conditionals by normalizing input to a str once before validation.
This eliminates repeated isinstance checks and ternary logic, improving clarity.
Validation logic remains unchanged, ensuring consistent behavior and test coverage.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | pass   |
| Unit tests                            | `make test`          | pass   |


## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
