### PR TITLE
added streamablehttp as request type

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -2958,7 +2958,7 @@ function createParameterForm(parameterCount) {
 // ===================================================================
 
 const integrationRequestMap = {
-    MCP: ["SSE", "STREAMABLE", "STDIO"],
+    MCP: ["SSE", "STREAMABLEHTTP","STDIO"],
     REST: ["GET", "POST", "PUT", "PATCH", "DELETE"],
 };
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -2958,7 +2958,7 @@ function createParameterForm(parameterCount) {
 // ===================================================================
 
 const integrationRequestMap = {
-    MCP: ["SSE", "STREAMABLEHTTP","STDIO"],
+    MCP: ["SSE", "STREAMABLEHTTP", "STDIO"],
     REST: ["GET", "POST", "PUT", "PATCH", "DELETE"],
 };
 


### PR DESCRIPTION
📌 Summary
This PR updates the Admin UI to add "STREAMABLEHTTP" as a valid request type for MCP tools. This allows users to select "STREAMABLEHTTP" when creating or editing tools.

💡 Fix Description
Added "STREAMABLEHTTP" to the MCP request type options in the Admin UI

✅Validation
<img width="1342" height="469" alt="imageforfix" src="https://github.com/user-attachments/assets/c956bb60-2833-4b60-8d84-907a4f77a5e4" />

Closes #610 