### PR TITLE
744 dns resolution normalization fix

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -256,7 +256,7 @@ class GatewayService:
     def normalize_url(url: str) -> str:
         """
         Normalize a URL by ensuring it's properly formatted.
-        
+
         Special handling for localhost to prevent duplicates:
         - Converts 127.0.0.1 to localhost for consistency
         - Preserves all other domain names as-is for CDN/load balancer support
@@ -275,11 +275,12 @@ class GatewayService:
             >>> GatewayService.normalize_url('https://example.com/api')
             'https://example.com/api'
         """
+        # Standard
         from urllib.parse import urlparse, urlunparse
-        
+
         parsed = urlparse(url)
         hostname = parsed.hostname
-        
+
         # Special case: normalize 127.0.0.1 to localhost to prevent duplicates
         # but preserve all other domains as-is for CDN/load balancer support
         if hostname == "127.0.0.1":
@@ -288,7 +289,7 @@ class GatewayService:
                 netloc += f":{parsed.port}"
             normalized = parsed._replace(netloc=netloc)
             return urlunparse(normalized)
-        
+
         # For all other URLs, preserve the domain name
         return url
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -42,11 +42,9 @@ import asyncio
 from datetime import datetime, timezone
 import logging
 import os
-import socket
 import tempfile
 import time
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set, TYPE_CHECKING
-from urllib.parse import urlparse, urlunparse
 import uuid
 
 # Third-Party
@@ -257,29 +255,42 @@ class GatewayService:
     @staticmethod
     def normalize_url(url: str) -> str:
         """
-        Normalize a URL by resolving the hostname to its IP address.
+        Normalize a URL by ensuring it's properly formatted.
+        
+        Special handling for localhost to prevent duplicates:
+        - Converts 127.0.0.1 to localhost for consistency
+        - Preserves all other domain names as-is for CDN/load balancer support
 
         Args:
             url (str): The URL to normalize.
 
         Returns:
-            str: The normalized URL with the hostname replaced by its IP address.
+            str: The normalized URL.
 
         Examples:
             >>> GatewayService.normalize_url('http://localhost:8080/path')
-            'http://127.0.0.1:8080/path'
+            'http://localhost:8080/path'
+            >>> GatewayService.normalize_url('http://127.0.0.1:8080/path')
+            'http://localhost:8080/path'
+            >>> GatewayService.normalize_url('https://example.com/api')
+            'https://example.com/api'
         """
+        from urllib.parse import urlparse, urlunparse
+        
         parsed = urlparse(url)
         hostname = parsed.hostname
-        try:
-            ip = socket.gethostbyname(hostname)
-        except Exception:
-            ip = hostname
-        netloc = ip
-        if parsed.port:
-            netloc += f":{parsed.port}"
-        normalized = parsed._replace(netloc=netloc)
-        return urlunparse(normalized)
+        
+        # Special case: normalize 127.0.0.1 to localhost to prevent duplicates
+        # but preserve all other domains as-is for CDN/load balancer support
+        if hostname == "127.0.0.1":
+            netloc = "localhost"
+            if parsed.port:
+                netloc += f":{parsed.port}"
+            normalized = parsed._replace(netloc=netloc)
+            return urlunparse(normalized)
+        
+        # For all other URLs, preserve the domain name
+        return url
 
     async def _validate_gateway_url(self, url: str, headers: dict, transport_type: str, timeout: Optional[int] = None):
         """

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -45,6 +45,7 @@ import os
 import tempfile
 import time
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set, TYPE_CHECKING
+from urllib.parse import urlparse, urlunparse
 import uuid
 
 # Third-Party
@@ -275,9 +276,6 @@ class GatewayService:
             >>> GatewayService.normalize_url('https://example.com/api')
             'https://example.com/api'
         """
-        # Standard
-        from urllib.parse import urlparse, urlunparse
-
         parsed = urlparse(url)
         hostname = parsed.hostname
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1134,6 +1134,47 @@ class TestGatewayService:
         with pytest.raises(SQLIntegrityError):
             await gateway_service.update_gateway(test_db, 1, gateway_update)
 
+    def test_normalize_url_preserves_domain(self):
+        """Test that normalize_url preserves domain names but normalizes localhost."""
+        # Test with various domain formats
+        test_cases = [
+            # Regular domains should be preserved as-is
+            ("http://example.com", "http://example.com"),
+            ("https://api.example.com:8080/path", "https://api.example.com:8080/path"),
+            ("https://my-app.cloud-provider.region.example.com/sse",
+             "https://my-app.cloud-provider.region.example.com/sse"),
+            ("https://cdn.service.com/api/v1", "https://cdn.service.com/api/v1"),
+            
+            # localhost should remain localhost
+            ("http://localhost:8000", "http://localhost:8000"),
+            ("https://localhost/api", "https://localhost/api"),
+            
+            # 127.0.0.1 should be normalized to localhost to prevent duplicates
+            ("http://127.0.0.1:8080/path", "http://localhost:8080/path"),
+            ("https://127.0.0.1/sse", "https://localhost/sse"),
+        ]
+
+        for input_url, expected in test_cases:
+            result = GatewayService.normalize_url(input_url)
+            assert result == expected, f"normalize_url({input_url}) should return {expected}, got {result}"
+    
+    def test_normalize_url_prevents_localhost_duplicates(self):
+        """Test that normalization prevents localhost/127.0.0.1 duplicates."""
+        # These URLs should all normalize to the same value
+        equivalent_urls = [
+            "http://127.0.0.1:8080/sse",
+            "http://localhost:8080/sse",
+        ]
+        
+        normalized = [GatewayService.normalize_url(url) for url in equivalent_urls]
+        
+        # All should normalize to localhost version
+        assert all(n == "http://localhost:8080/sse" for n in normalized), \
+            f"All localhost variants should normalize to same URL, got: {normalized}"
+        
+        # They should all be the same (no duplicates possible)
+        assert len(set(normalized)) == 1, "All localhost variants should produce identical normalized URLs"
+
     @pytest.mark.asyncio
     async def test_update_gateway_with_transport_change(self, gateway_service, mock_gateway, test_db):
         """Test updating gateway transport type."""

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1144,11 +1144,11 @@ class TestGatewayService:
             ("https://my-app.cloud-provider.region.example.com/sse",
              "https://my-app.cloud-provider.region.example.com/sse"),
             ("https://cdn.service.com/api/v1", "https://cdn.service.com/api/v1"),
-            
+
             # localhost should remain localhost
             ("http://localhost:8000", "http://localhost:8000"),
             ("https://localhost/api", "https://localhost/api"),
-            
+
             # 127.0.0.1 should be normalized to localhost to prevent duplicates
             ("http://127.0.0.1:8080/path", "http://localhost:8080/path"),
             ("https://127.0.0.1/sse", "https://localhost/sse"),
@@ -1157,7 +1157,7 @@ class TestGatewayService:
         for input_url, expected in test_cases:
             result = GatewayService.normalize_url(input_url)
             assert result == expected, f"normalize_url({input_url}) should return {expected}, got {result}"
-    
+
     def test_normalize_url_prevents_localhost_duplicates(self):
         """Test that normalization prevents localhost/127.0.0.1 duplicates."""
         # These URLs should all normalize to the same value
@@ -1165,13 +1165,13 @@ class TestGatewayService:
             "http://127.0.0.1:8080/sse",
             "http://localhost:8080/sse",
         ]
-        
+
         normalized = [GatewayService.normalize_url(url) for url in equivalent_urls]
-        
+
         # All should normalize to localhost version
         assert all(n == "http://localhost:8080/sse" for n in normalized), \
             f"All localhost variants should normalize to same URL, got: {normalized}"
-        
+
         # They should all be the same (no duplicates possible)
         assert len(set(normalized)) == 1, "All localhost variants should produce identical normalized URLs"
 


### PR DESCRIPTION
# Fix URL Normalization: Preserve Domains While Preventing Localhost Duplicates

## Problem

PR #712 introduced URL normalization that resolves ALL domain names to IP addresses to fix issue #649 (preventing duplicate gateway registrations for localhost/127.0.0.1). However, this breaks services behind CDNs, load balancers, or reverse proxies (issue #744) because:

- CDN endpoints don't accept direct IP connections
- Load balancers require the original domain for routing
- Reverse proxies need the Host header to match the domain

## Solution

This PR implements a balanced approach that fixes both issues:

### Changes

1. **Preserves external domain names** - Services behind CDNs/load balancers work correctly
2. **Only normalizes 127.0.0.1 → localhost** - Prevents local duplicates without breaking external services
3. **Maintains database unique constraint** - The existing URL uniqueness is still enforced

### Implementation

The `normalize_url()` method now:
- Converts `127.0.0.1` to `localhost` (prevents local duplicates)
- Preserves all other domain names as-is (supports CDN/load balancer services)

```python
# Before (broke CDN services):
http://cdn.example.com/sse → http://93.184.216.34/sse ❌

# After (works correctly):
http://cdn.example.com/sse → http://cdn.example.com/sse ✅
http://127.0.0.1:8080/sse → http://localhost:8080/sse ✅
```

## Testing

Added comprehensive tests to verify:
- External domains are preserved (`test_normalize_url_preserves_domain`)
- 127.0.0.1 is normalized to localhost
- Duplicate prevention still works (`test_normalize_url_prevents_localhost_duplicates`)
- All existing tests pass (1660 passing)

## Issues Resolved

- Fixes #744: Gateway fails to connect to services behind CDNs/load balancers
- Maintains fix for #649: Duplicate gateway registration with localhost/127.0.0.1
- Preserves PR #712 functionality for local services

## Backwards Compatibility

This change maintains backwards compatibility:
- Existing gateways with external domains will continue to work
- Existing localhost gateways remain unchanged
- Database schema unchanged (unique constraint on URL still enforced)

## Test Results

```bash
# All tests passing
================ 1660 passed, 11 skipped, 62 warnings in 44.06s ================
```