### PR TITLE
(fix) Added missing prompts/get

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -1276,7 +1276,6 @@ class SessionRegistry(SessionBackend):
             >>> # Response: {}
         """
         result = {}
-
         if "method" in message and "id" in message:
             method = message["method"]
             params = message.get("params", {})
@@ -1328,6 +1327,9 @@ class SessionRegistry(SessionBackend):
                 else:
                     prompts = await prompt_service.list_prompts(db)
                 result = {"prompts": [p.model_dump(by_alias=True, exclude_none=True) for p in prompts]}
+            elif method == "prompts/get":
+                prompts = await prompt_service.get_prompt(db, name=params.get("name"), arguments=params.get("arguments", {}))
+                result = prompts.model_dump(by_alias=True, exclude_none=True)
             elif method == "ping":
                 result = {}
             elif method == "tools/call":


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Adds a missing implementation to `prompts/get` that caused failure for virtual servers.

## 🔁 Reproduction Steps
1. Create a prompt.
2. Add it to a virtual server
3. Call prompts/get

## 🐞 Root Cause
No implementation. 

## 💡 Fix Description
Added implementation

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
