### PR TITLE
Edit column header for servers catalog table

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -681,7 +681,7 @@
                   <th
                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                   >
-                    ID
+                    UUID
                   </th>
                   <th
                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"


### PR DESCRIPTION
## :pushpin: Summary
This PR changes the column header text from "ID" to "UUID" in the admin interface tables for better clarity and consistency in terminology. The change affects the Servers catalog table.

## :link: Related Issues
Closes #492 

## :bulb: Fix Description
- Modified table column headers from "ID" to "UUID" in admin.html template
- No functional changes, purely cosmetic renaming for better clarity

## ✅ Testing
<img width="1019" height="407" alt="vs" src="https://github.com/user-attachments/assets/16a01af3-0fa9-42fc-8ed1-1931cbc0757c" />
