### PR TITLE
decode auth before connection

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1598,6 +1598,8 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             tools = []
             resources = []
             prompts = []
+            if auth_type in ("basic", "bearer", "headers"):
+                authentication = decode_auth(authentication)
             if transport.lower() == "sse":
                 capabilities, tools, resources, prompts = await self.connect_to_sse_server(url, authentication)
             elif transport.lower() == "streamablehttp":


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Decode auth before trying to connect to sse and streamable http servers as the auth stored in db is encrypted.

## 🐞 Root Cause
As the auth for connection of mcp servers is authenticated and was not decrypted before connection, connection through sse and streamable http to the mcp servers failed.

## 💡 Fix Description
For auth_type as bearer, basic and custom headers, decrypt the auth before connection.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed