### PR TITLE
use database as cache_type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ DATABASE_URL=sqlite:///./mcp.db
 # DATABASE_URL=mysql+pymysql://mysql:changeme@localhost:3306/mcp
 
 # Cache Configuration
-CACHE_TYPE=memory
+CACHE_TYPE=database
 # CACHE_TYPE=redis
 # REDIS_URL=redis://localhost:6379/0
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Updates cache_type in .env.example from memory to database. This fixes connection issues from clients to gateway.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    pass    |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
