### PR TITLE
Support for prompts and resources in streamablehttp client side connection

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -560,11 +560,11 @@ async def read_resource(uri: AnyUrl) -> Union[str, bytes]:
             except Exception as e:
                 logger.exception(f"Error reading resource '{uri}': {e}")
                 return []
-            if not result or not result.content:
+            if not result or not result.text:
                 logger.warning(f"No content returned by resource: {uri}")
                 return []
 
-            return result.content
+            return result.text
     except Exception as e:
         logger.exception(f"Error reading resource '{uri}': {e}")
         return []

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -564,7 +564,7 @@ async def read_resource(uri: AnyUrl) -> Union[str, bytes]:
                 logger.warning(f"No content returned by resource: {uri}")
                 return []
 
-            return [types.TextContent(type=result.content[0].type, text=result.content[0].text)]
+            return result.content
     except Exception as e:
         logger.exception(f"Error reading resource '{uri}': {e}")
         return []

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -45,6 +45,7 @@ from mcp.server.lowlevel import Server
 from mcp.server.streamable_http import EventCallback, EventId, EventMessage, EventStore, StreamId
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import JSONRPCMessage
+from pydantic import AnyUrl
 from sqlalchemy.orm import Session
 from starlette.datastructures import Headers
 from starlette.responses import JSONResponse
@@ -55,6 +56,8 @@ from starlette.types import Receive, Scope, Send
 from mcpgateway.config import settings
 from mcpgateway.db import SessionLocal
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.prompt_service import PromptService
+from mcpgateway.services.resource_service import ResourceService
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.verify_credentials import verify_credentials
 
@@ -62,9 +65,12 @@ from mcpgateway.utils.verify_credentials import verify_credentials
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
-# Initialize ToolService and MCP Server
+# Initialize ToolService, PromptService and MCP Server
 tool_service: ToolService = ToolService()
-mcp_app: Server[Any] = Server("mcp-streamable-http-stateless")
+prompt_service: PromptService = PromptService()
+resource_service: ResourceService = ResourceService()
+
+mcp_app: Server[Any] = Server("mcp-streamable-http")
 
 server_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("server_id", default="default_server_id")
 request_headers_var: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar("request_headers", default={})
@@ -410,6 +416,160 @@ async def list_tools() -> List[types.Tool]:
             return []
 
 
+@mcp_app.list_prompts()
+async def list_prompts() -> List[types.Prompt]:
+    """
+    Lists all prompts available to the MCP Server.
+
+    Returns:
+        A list of Prompt objects containing metadata such as name, description, and arguments.
+        Logs and returns an empty list on failure.
+
+    Examples:
+        >>> import inspect
+        >>> sig = inspect.signature(list_prompts)
+        >>> list(sig.parameters.keys())
+        []
+        >>> sig.return_annotation
+        typing.List[mcp.types.Prompt]
+    """
+
+    server_id = server_id_var.get()
+
+    if server_id:
+        try:
+            async with get_db() as db:
+                prompts = await prompt_service.list_server_prompts(db, server_id)
+                return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
+        except Exception as e:
+            logger.exception(f"Error listing Prompts:{e}")
+            return []
+    else:
+        try:
+            async with get_db() as db:
+                prompts = await prompt_service.list_prompts(db, False, None, None)
+                return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
+        except Exception as e:
+            logger.exception(f"Error listing prompts:{e}")
+            return []
+
+
+@mcp_app.get_prompt()
+async def get_prompt(name: str, arguments: dict[str, str] | None = None) -> types.GetPromptResult:
+    """
+    Retrieves a prompt by name, optionally substituting arguments.
+
+    Args:
+        name (str): The name of the prompt to retrieve.
+        arguments (Optional[dict[str, str]]): Optional dictionary of arguments to substitute into the prompt.
+
+    Returns:
+        GetPromptResult: Object containing the prompt messages and description.
+        Returns an empty list on failure or if no prompt content is found.
+
+    Logs exceptions if any errors occur during retrieval.
+
+    Examples:
+        >>> import inspect
+        >>> sig = inspect.signature(get_prompt)
+        >>> list(sig.parameters.keys())
+        ['name', 'arguments']
+        >>> sig.return_annotation.__name__
+        'GetPromptResult'
+    """
+    try:
+        async with get_db() as db:
+            try:
+                result = await prompt_service.get_prompt(db=db, name=name, arguments=arguments)
+            except Exception as e:
+                logger.exception(f"Error getting prompt '{name}': {e}")
+                return []
+            if not result or not result.messages:
+                logger.warning(f"No content returned by prompt: {name}")
+                return []
+            message_dicts = [message.dict() for message in result.messages]
+            return types.GetPromptResult(messages=message_dicts, description=result.description)
+    except Exception as e:
+        logger.exception(f"Error getting prompt '{name}': {e}")
+        return []
+
+
+@mcp_app.list_resources()
+async def list_resources() -> List[types.Resource]:
+    """
+    Lists all resources available to the MCP Server.
+
+    Returns:
+        A list of Resource objects containing metadata such as uri, name, description, and mimeType.
+        Logs and returns an empty list on failure.
+
+    Examples:
+        >>> import inspect
+        >>> sig = inspect.signature(list_resources)
+        >>> list(sig.parameters.keys())
+        []
+        >>> sig.return_annotation
+        typing.List[mcp.types.Resource]
+    """
+    server_id = server_id_var.get()
+
+    if server_id:
+        try:
+            async with get_db() as db:
+                resources = await resource_service.list_server_resources(db, server_id)
+                return [types.Resource(uri=resource.uri, name=resource.name, description=resource.description, mimeType=resource.mime_type) for resource in resources]
+        except Exception as e:
+            logger.exception(f"Error listing Resources:{e}")
+            return []
+    else:
+        try:
+            async with get_db() as db:
+                resources = await resource_service.list_resources(db, False)
+                return [types.Resource(uri=resource.uri, name=resource.name, description=resource.description, mimeType=resource.mime_type) for resource in resources]
+        except Exception as e:
+            logger.exception(f"Error listing resources:{e}")
+            return []
+
+
+@mcp_app.read_resource()
+async def read_resource(uri: AnyUrl) -> Union[str, bytes]:
+    """
+    Reads the content of a resource specified by its URI.
+
+    Args:
+        uri (AnyUrl): The URI of the resource to read.
+
+    Returns:
+        Union[str, bytes]: The content of the resource, typically as text.
+        Returns an empty list on failure or if no content is found.
+
+    Logs exceptions if any errors occur during reading.
+
+    Examples:
+        >>> import inspect
+        >>> sig = inspect.signature(read_resource)
+        >>> list(sig.parameters.keys())
+        ['uri']
+        >>> sig.return_annotation
+        typing.Union[str, bytes]
+    """
+    try:
+        async with get_db() as db:
+            try:
+                result = await resource_service.read_resource(db=db, uri=str(uri))
+            except Exception as e:
+                logger.exception(f"Error reading resource '{uri}': {e}")
+                return []
+            if not result or not result.content:
+                logger.warning(f"No content returned by resource: {uri}")
+                return []
+
+            return [types.TextContent(type=result.content[0].type, text=result.content[0].text)]
+    except Exception as e:
+        logger.exception(f"Error reading resource '{uri}': {e}")
+        return []
+
+
 class SessionManagerWrapper:
     """
     Wrapper class for managing the lifecycle of a StreamableHTTPSessionManager instance.
@@ -526,6 +686,8 @@ class SessionManagerWrapper:
         if match:
             server_id = match.group("server_id")
             server_id_var.set(server_id)
+        else:
+            server_id_var.set(None)
 
         try:
             await self.session_manager.handle_request(scope, receive, send)

--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -165,9 +165,9 @@ def convert_url(url: str) -> str:
 
     Examples:
         >>> convert_url("http://localhost:4444/servers/uuid")
-        'http://localhost:4444/servers/uuid/mcp'
+        'http://localhost:4444/servers/uuid/mcp/'
         >>> convert_url("http://localhost:4444/servers/uuid/sse")
-        'http://localhost:4444/servers/uuid/mcp'
+        'http://localhost:4444/servers/uuid/mcp/'
         >>> convert_url("http://localhost:4444/servers/uuid/mcp")
         'http://localhost:4444/servers/uuid/mcp/'
     """
@@ -176,8 +176,8 @@ def convert_url(url: str) -> str:
             return url + "/"
         return url
     if url.endswith("/sse"):
-        return url.replace("/sse", "/mcp")
-    return url + "/mcp"
+        return url.replace("/sse", "/mcp/")
+    return url + "/mcp/"
 
 
 def send_to_stdout(obj: Union[dict, str]) -> None:
@@ -632,7 +632,7 @@ def parse_args() -> Settings:
         >>> sys.argv = ["prog", "--url", "http://localhost:4444/servers/u"]
         >>> try:
         ...     s = parse_args()
-        ...     s.server_url.endswith("/mcp")
+        ...     s.server_url.endswith("/mcp/")
         ... finally:
         ...     sys.argv = _argv
         True

--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -169,9 +169,11 @@ def convert_url(url: str) -> str:
         >>> convert_url("http://localhost:4444/servers/uuid/sse")
         'http://localhost:4444/servers/uuid/mcp'
         >>> convert_url("http://localhost:4444/servers/uuid/mcp")
-        'http://localhost:4444/servers/uuid/mcp'
+        'http://localhost:4444/servers/uuid/mcp/'
     """
     if url.endswith("/mcp") or url.endswith("/mcp/"):
+        if url.endswith("/mcp"):
+            return url + "/"
         return url
     if url.endswith("/sse"):
         return url.replace("/sse", "/mcp")

--- a/tests/unit/mcpgateway/test_wrapper.py
+++ b/tests/unit/mcpgateway/test_wrapper.py
@@ -30,10 +30,10 @@ def setup_function():
 # Utilities
 # -------------------
 def test_convert_url_variants():
-    assert wrapper.convert_url("http://x/servers/uuid") == "http://x/servers/uuid/mcp"
-    assert wrapper.convert_url("http://x/servers/uuid/") == "http://x/servers/uuid//mcp"
-    assert wrapper.convert_url("http://x/servers/uuid/mcp") == "http://x/servers/uuid/mcp"
-    assert wrapper.convert_url("http://x/servers/uuid/sse") == "http://x/servers/uuid/mcp"
+    assert wrapper.convert_url("http://x/servers/uuid") == "http://x/servers/uuid/mcp/"
+    assert wrapper.convert_url("http://x/servers/uuid/") == "http://x/servers/uuid//mcp/"
+    assert wrapper.convert_url("http://x/servers/uuid/mcp") == "http://x/servers/uuid/mcp/"
+    assert wrapper.convert_url("http://x/servers/uuid/sse") == "http://x/servers/uuid/mcp/"
 
 
 def test_make_error_defaults_and_data():
@@ -145,7 +145,7 @@ def test_parse_args_with_env(monkeypatch):
     sys.argv = ["prog"]
     try:
         s = wrapper.parse_args()
-        assert s.server_url.endswith("/mcp")
+        assert s.server_url.endswith("/mcp/")
         assert s.auth_header == "Bearer 123"
     finally:
         sys.argv = sys_argv


### PR DESCRIPTION

# ✨ Feature / Enhancement PR

---

## 🚀 Summary (1-2 sentences)
1. Enhanced Resource and Prompt Access:
Added support for list_resources, read_resource, list_prompts, and get_prompts when any MCP client is connected to virtual servers or the gateway via streamable_http.

2. Direct Gateway Connection Support:
MCP clients can now connect directly to the entire gateway using the URL http://localhost:4444/mcp, without requiring a virtual server. (Existing virtual server implementations and connection methods remain supported.)
---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

