### PR TITLE
Fix oauth tool write to db

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -653,7 +653,8 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                     try:
                         db_tool = DbTool(
                             original_name=tool.name,
-                            original_name_slug=slugify(tool.name),
+                            custom_name=tool.name,
+                            custom_name_slug=slugify(tool.name),
                             url=gateway.url.rstrip("/"),
                             description=tool.description,
                             integration_type="MCP",  # Gateway-discovered tools are MCP type

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -98,6 +98,7 @@ _TOOL_KEY_MAP = {
     "gatewayId": "gateway_id",
     "gatewaySlug": "gateway_slug",
     "originalNameSlug": "original_name_slug",
+    "customNameSlug": "custom_name_slug",
 }
 
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## Summary
Fixed db write of oauth tools to make it consistent with use of custom_name and custom_name_slug

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |   pass     |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
