### PR TITLE
Event handler for escape

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -536,6 +536,17 @@ function openModal(modalId) {
     }
 }
 
+// Global event handler for Escape key
+document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+        // Find any active modal
+        const activeModal = Array.from(AppState.activeModals)[0];
+        if (activeModal) {
+            closeModal(activeModal);
+        }
+    }
+});
+
 function closeModal(modalId, clearId = null) {
     try {
         const modal = safeGetElement(modalId);


### PR DESCRIPTION
## :pushpin:Summary
This PR adds a global keyboard shortcut to the admin panel UI, allowing users to close the top-most visible modal dialog by pressing the Escape key. This improves accessibility and user experience, especially for dialogs like the Test Tool.

## :link: Related Issues
Closes #491 

## :bulb: Fix Description
Added a global event listener for the Escape key in admin.js. When Escape is pressed, the top-most active modal is closed using the existing modal management logic. No changes to modal structure or styling; purely an accessibility and usability enhancement

## :white_check_mark: Validation
- Opened the Test Tool and other modals in the admin panel
- Pressed Escape to close the modal; verified that the modal closes as expected
- Confirmed no regression in modal behavior for mouse interactions