### PR TITLE
Remove manual name update logic from tool_service.py

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1005,8 +1005,6 @@ class ToolService:
             tool = db.get(DbTool, tool_id)
             if not tool:
                 raise ToolNotFoundError(f"Tool not found: {tool_id}")
-            if tool_update.name is not None:
-                tool.name = tool_update.name
             if tool_update.custom_name is not None:
                 tool.custom_name = tool_update.custom_name
             if tool_update.url is not None:


### PR DESCRIPTION
The `name` field is now a calculated field and should not be manually updated.
This PR removes the redundant code block in `tool_service.py` that previously handled `name` updates:

```python
if tool_update.name is not None:
    tool.name = tool_update.name
```

#### Key Changes

* Removed explicit `name` assignment during tool update.
* Ensures consistency by relying only on calculated logic for the `name` field.
* Prevents unintended overwrites of the computed `name`.
