### PR TITLE
Fix db integration testcases

### DIFF
--- a/mcp-servers/python/mcp_eval_server/mcp_eval_server/hybrid_server.py
+++ b/mcp-servers/python/mcp_eval_server/mcp_eval_server/hybrid_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """Hybrid server that runs both MCP (stdio) and REST API simultaneously.
 
 This module creates a server that can handle both:

--- a/mcp-servers/python/mcp_eval_server/mcp_eval_server/rest_server.py
+++ b/mcp-servers/python/mcp_eval_server/mcp_eval_server/rest_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """FastAPI REST server for MCP Evaluation Tools.
 
 This module provides a REST API interface to all the evaluation tools

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -207,7 +207,7 @@
                   >
                   <select
                     id="log-level-filter"
-                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600"
+                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 text-gray-800 dark:text-gray-200"
                   >
                     <option value="">All Levels</option>
                     <option value="debug">Debug</option>
@@ -225,7 +225,7 @@
                   >
                   <select
                     id="log-entity-filter"
-                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600"
+                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 text-gray-800 dark:text-gray-200"
                   >
                     <option value="">All Types</option>
                     <option value="tool">Tool</option>
@@ -287,7 +287,7 @@
               <!-- Log Stats -->
               <div
                 id="log-stats"
-                class="mb-4 p-3 bg-gray-100 dark:bg-gray-700 rounded"
+                class="mb-4 p-3 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200"
               >
                 <span class="text-sm text-gray-600 dark:text-gray-300"
                   >Loading stats...</span
@@ -949,26 +949,35 @@
                     {{ server.description }}
                   </td>
                   <td
-                    class="px-6 py-4 max-w-xs break-words text-sm text-gray-500 dark:text-gray-300"
+                    class="px-6 py-4 max-w-xs whitespace-nowrap break-words text-sm text-gray-500 dark:text-gray-300"
                   >
-                    {% if server.associatedTools %} {{ server.associatedTools |
-                    map('string') | join(', ') }} {% else %}
+                    {% if server.associatedTools %}
+                      {% for tool in server.associatedTools %}
+                        {{ tool }}<br>
+                      {% endfor %}
+                    {% else %}
                     <span class="text-gray-500 dark:text-gray-300">N/A</span>
                     {% endif %}
                   </td>
                   <td
-                    class="px-6 py-4 max-w-xs break-words text-sm text-gray-500 dark:text-gray-300"
+                    class="px-6 py-4 max-w-xs whitespace-nowrap break-words text-sm text-gray-500 dark:text-gray-300"
                   >
-                    {% if server.associatedResources %} {{
-                    server.associatedResources | join(', ') }} {% else %}
+                    {% if server.associatedResources %}
+                      {% for resource in server.associatedResources %}
+                        {{ resource }}<br>
+                      {% endfor %}
+                    {% else %}
                     <span class="text-gray-500 dark:text-gray-300">N/A</span>
                     {% endif %}
                   </td>
                   <td
-                    class="px-6 py-4 max-w-xs break-words text-sm text-gray-500 dark:text-gray-300"
+                    class="px-6 py-4 max-w-xs whitespace-nowrap break-words text-sm text-gray-500 dark:text-gray-300"
                   >
-                    {% if server.associatedPrompts %} {{
-                    server.associatedPrompts | join(', ') }} {% else %}
+                    {% if server.associatedPrompts %}
+                      {% for prompt in server.associatedPrompts %}
+                        {{ prompt }}<br>
+                      {% endfor %}
+                    {% else %}
                     <span class="text-gray-500 dark:text-gray-300">N/A</span>
                     {% endif %}
                   </td>
@@ -1393,7 +1402,7 @@
                     {{ loop.index }}
                   </td>
                   <td
-                    class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-36"
+                    class="px-2 py-4 whitespace-nowrap break-words text-sm text-gray-500 dark:text-gray-300 w-36"
                   >
                     {{ tool.gatewaySlug }}
                   </td>
@@ -1418,13 +1427,13 @@
                     {{ tool.requestType }}
                   </td>
                   <td
-                    class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300"
+                    class="px-6 py-4 max-w-lg whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300"
                   >
                     {% set clean_desc = (tool.description or "") | replace('\n',
                     ' ') | replace('\r', ' ') %} {% set refactor_desc =
                     clean_desc | striptags | trim | escape %} {% if
-                    refactor_desc | length is greaterthan 120 %} {{
-                    refactor_desc[:120] }}... {% else %} {{ refactor_desc }} {%
+                    refactor_desc | length is greaterthan 512 %} {{
+                    refactor_desc[:512] }}... {% else %} {{ refactor_desc }} {%
                     endif %}
                   </td>
                   <td class="px-2 py-4 whitespace-nowrap">
@@ -1967,7 +1976,7 @@
               </div>
               <div id="auth-basic-fields" style="display: none">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700"
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >Username</label
                   >
                   <input
@@ -1977,7 +1986,7 @@
                   />
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700"
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >Password</label
                   >
                   <input
@@ -1989,7 +1998,7 @@
               </div>
               <div id="auth-bearer-fields" style="display: none">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700"
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >Token</label
                   >
                   <input
@@ -2003,7 +2012,7 @@
                 <div class="space-y-3">
                   <div class="flex items-center justify-between">
                     <label
-                      class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                      class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >
                       Custom Headers
                     </label>
@@ -2297,12 +2306,12 @@
                     {{ resource.name }}
                   </td>
                   <td
-                    class="px-6 py-4 whitespace-normal break-words text-sm font-medium text-gray-900 dark:text-gray-100"
+                    class="px-6 py-4 max-w-lg whitespace-normal break-words text-sm font-medium text-gray-600 dark:text-gray-400"
                   >
                     {{ resource.description or "N/A" }}
                   </td>
                   <td
-                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-500"
+                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400"
                   >
                     {{ resource.mimeType or "N/A" }}
                   </td>
@@ -2603,7 +2612,7 @@
                     {{ prompt.name }}
                   </td>
                   <td
-                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300"
+                    class="px-6 py-4 max-w-lg whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300"
                   >
                     {{ prompt.description }}
                   </td>
@@ -3179,7 +3188,7 @@
               </div>
               <div id="auth-basic-fields-gw" style="display: none">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700"
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >Username</label
                   >
                   <input
@@ -3189,7 +3198,7 @@
                   />
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700"
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >Password</label
                   >
                   <input
@@ -3201,7 +3210,7 @@
               </div>
               <div id="auth-bearer-fields-gw" style="display: none">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700"
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                     >Token</label
                   >
                   <input
@@ -3886,15 +3895,15 @@
                   <td
                     class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100"
                   >
-                    {{ root.id }}
+                    {{ loop.index }}
                   </td>
                   <td
-                    class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100s"
+                    class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
                     {{ root.uri }}
                   </td>
                   <td
-                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-500"
+                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100"
                   >
                     {{ root.name }}
                   </td>
@@ -4428,7 +4437,7 @@
                     <button
                       type="button"
                       onclick="closeModal('tool-edit-modal')"
-                      class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
+                      class="px-4 py-2 border border-gray-500 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
                     >
                       Cancel
                     </button>
@@ -4510,7 +4519,7 @@
                 <form id="edit-resource-form" method="POST">
                   <div class="grid grid-cols-1 gap-6">
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >URI</label
                       >
                       <!-- URI is read-only -->
@@ -4520,11 +4529,11 @@
                         required
                         id="edit-resource-uri"
                         readonly
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Name</label
                       >
                       <input
@@ -4532,39 +4541,39 @@
                         name="name"
                         required
                         id="edit-resource-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Description</label
                       >
                       <textarea
                         name="description"
                         id="edit-resource-description"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >MIME Type</label
                       >
                       <input
                         type="text"
                         name="mimeType"
                         id="edit-resource-mime-type"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Content</label
                       >
                       <!-- Remove required attribute to avoid browser validation issues -->
                       <textarea
                         name="content"
                         id="edit-resource-content"
-                        class="mt-1 block w-full h-48 rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                        class="mt-1 block w-full h-48 rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                       ></textarea>
                     </div>
                     <!-- Tags Section -->
@@ -4592,7 +4601,7 @@
                     <button
                       type="button"
                       onclick="closeModal('resource-edit-modal')"
-                      class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
+                      class="px-4 py-2 border border-gray-500 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
                     >
                       Cancel
                     </button>
@@ -4671,7 +4680,7 @@
                 <form id="edit-prompt-form" method="POST">
                   <div class="grid grid-cols-1 gap-6">
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Name</label
                       >
                       <input
@@ -4679,37 +4688,37 @@
                         name="name"
                         required
                         id="edit-prompt-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Description</label
                       >
                       <textarea
                         name="description"
                         id="edit-prompt-description"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Template</label
                       >
                       <textarea
                         name="template"
                         id="edit-prompt-template"
-                        class="mt-1 block w-full h-48 rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                        class="mt-1 block w-full h-48 rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                       ></textarea>
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Arguments (JSON)</label
                       >
                       <textarea
                         name="arguments"
                         id="edit-prompt-arguments"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
                     </div>
                     <!-- Tags Section -->
@@ -4737,7 +4746,7 @@
                     <button
                       type="button"
                       onclick="closeModal('prompt-edit-modal')"
-                      class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
+                      class="px-4 py-2 border border-gray-500 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
                     >
                       Cancel
                     </button>
@@ -4944,7 +4953,7 @@
                 <form id="edit-gateway-form" method="POST">
                   <div class="grid grid-cols-1 gap-6">
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Name</label
                       >
                       <input
@@ -4952,11 +4961,11 @@
                         name="name"
                         required
                         id="edit-gateway-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >URL</label
                       >
                       <input
@@ -4964,21 +4973,21 @@
                         name="url"
                         required
                         id="edit-gateway-url"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Description</label
                       >
                       <textarea
                         name="description"
                         id="edit-gateway-description"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Tags</label
                       >
                       <input
@@ -4986,34 +4995,34 @@
                         name="tags"
                         id="edit-gateway-tags"
                         placeholder="e.g., production,external,api-gateway (comma-separated)"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
-                      <p class="mt-1 text-sm text-gray-500">
+                      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                         Separate multiple tags with commas. Tags will be
                         automatically normalized.
                       </p>
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Transport Type</label
                       >
                       <select
                         name="transport"
                         id="edit-gateway-transport"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       >
                         <option value="SSE" selected>SSE</option>
                         <option value="STREAMABLEHTTP">Streamable HTTP</option>
                       </select>
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Authentication Type</label
                       >
                       <select
                         name="auth_type"
                         id="auth-type-gw-edit"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       >
                         <option value="">None</option>
                         <option value="basic">Basic</option>
@@ -5024,35 +5033,35 @@
                     </div>
                     <div id="auth-basic-fields-gw-edit" style="display: none">
                       <div>
-                        <label class="block text-sm font-medium text-gray-700"
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                           >Username</label
                         >
                         <input
                           type="text"
                           name="auth_username"
-                          class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         />
                       </div>
                       <div>
-                        <label class="block text-sm font-medium text-gray-700"
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                           >Password</label
                         >
                         <input
                           type="password"
                           name="auth_password"
-                          class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         />
                       </div>
                     </div>
                     <div id="auth-bearer-fields-gw-edit" style="display: none">
                       <div>
-                        <label class="block text-sm font-medium text-gray-700"
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                           >Token</label
                         >
                         <input
                           type="password"
                           name="auth_token"
-                          class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         />
                       </div>
                     </div>
@@ -5255,7 +5264,7 @@
                         name="passthrough_headers"
                         id="edit-gateway-passthrough-headers"
                         placeholder="Authorization, X-Tenant-Id, X-Trace-Id"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                   </div>
@@ -5265,7 +5274,7 @@
                     <button
                       type="button"
                       onclick="closeModal('gateway-edit-modal')"
-                      class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
+                      class="px-4 py-2 border border-gray-500 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
                     >
                       Cancel
                     </button>
@@ -5354,7 +5363,7 @@
                         name="name"
                         required
                         id="edit-server-name"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
@@ -5365,7 +5374,7 @@
                       <textarea
                         name="description"
                         id="edit-server-description"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
                     </div>
                     <div>
@@ -5377,7 +5386,7 @@
                         type="url"
                         name="icon"
                         id="edit-server-icon"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
 
@@ -5401,7 +5410,7 @@
                     </div>
 
                     <div
-                      class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-600"
+                      class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-400 dark:border-gray-600"
                     >
                       <label
                         for="edit-server-tools"
@@ -5411,7 +5420,7 @@
                       </label>
                       <div
                         id="edit-server-tools"
-                        class="max-h-60 overflow-y-auto rounded-md border border-gray-600 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
+                        class="max-h-60 overflow-y-auto rounded-md border bborder-gray-300 dark:border-gray-600 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
                       >
                         {% for tool in tools %}
                         <label
@@ -5470,7 +5479,7 @@
                         type="text"
                         name="associatedResources"
                         id="edit-server-resources"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         placeholder="e.g., 3,4"
                       />
                     </div>
@@ -5483,7 +5492,7 @@
                         type="text"
                         name="associatedPrompts"
                         id="edit-server-prompts"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         placeholder="e.g., 5,6"
                       />
                     </div>
@@ -5494,7 +5503,7 @@
                     <button
                       type="button"
                       onclick="closeModal('server-edit-modal')"
-                      class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
+                      class="px-4 py-2 border border-gray-500 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:text-gray-300"
                     >
                       Cancel
                     </button>

--- a/tests/integration/test_metadata_integration.py
+++ b/tests/integration/test_metadata_integration.py
@@ -11,238 +11,185 @@ and UI integration.
 """
 
 # Standard
-import asyncio
-from datetime import datetime
-import json
 import uuid
-from typing import Dict
+from types import SimpleNamespace
 
 # Third-Party
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
 # First-Party
-from mcpgateway.db import Base, get_db, Tool as DbTool
-from mcpgateway.main import app
+from mcpgateway.db import get_db, SessionLocal
 from mcpgateway.schemas import ToolCreate
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.verify_credentials import require_auth
+from mcpgateway.utils.metadata_capture import MetadataCapture
 
 
+# --------------------------------------------------------------------------------------
+# Test client bound to the isolated, patched DB from conftest.py (client_with_temp_db)
+# --------------------------------------------------------------------------------------
 @pytest.fixture
-def test_app():
-    """Create test app with in-memory database."""
-    # Create in-memory SQLite database for testing
-    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
-    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-    Base.metadata.create_all(bind=engine)
-
-    def override_get_db():
+def client(client_with_temp_db: TestClient):
+    """
+    Provide a TestClient tied to the in-memory/temp DB.
+    Ensures API code paths use the same patched SessionLocal as services.
+    """
+    def _override_get_db():
+        db = SessionLocal()
         try:
-            db = TestingSessionLocal()
             yield db
         finally:
             db.close()
 
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[require_auth] = lambda: "test_user"
+    client_with_temp_db.app.dependency_overrides[get_db] = _override_get_db
+    client_with_temp_db.app.dependency_overrides[require_auth] = lambda: "test_user"
 
-    yield app
+    from mcpgateway.admin import get_db as admin_get_db
+    client_with_temp_db.app.dependency_overrides[admin_get_db] = _override_get_db
 
-    # Cleanup
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def client(test_app):
-    """Create test client."""
-    return TestClient(test_app)
+    return client_with_temp_db
 
 
 class TestMetadataIntegration:
     """Integration tests for metadata tracking across the application."""
 
-    def test_tool_creation_api_metadata(self, client):
-        """Test that tool creation via API captures metadata correctly."""
+    def test_tool_creation_api_metadata(self, client: TestClient):
+        """Tool creation via API captures metadata correctly."""
         unique_name = f"api_test_tool_{uuid.uuid4().hex[:8]}"
         tool_data = {
             "name": unique_name,
             "url": "http://example.com/api",
             "description": "Tool created via API",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         tool = response.json()
-
-        # Verify metadata was captured
         assert tool["createdBy"] == "test_user"
-        assert tool["createdVia"] == "api"  # Should detect API call
+        assert tool["createdVia"] == "api"
         assert tool["version"] == 1
-        assert tool["createdFromIp"] is not None  # Should capture some IP
-
-        # Verify metadata is properly serialized
+        assert tool.get("createdFromIp") is not None
         assert "createdAt" in tool
-        # modifiedAt is only set after modifications, not during creation
 
-    def test_tool_creation_admin_ui_metadata(self, client):
-        """Test that tool creation via admin UI works with metadata."""
-        tool_data = {
-            "name": f"admin_ui_test_tool_{uuid.uuid4().hex[:8]}",
-            "url": "http://example.com/admin",
-            "description": "Tool created via admin UI",
-            "integrationType": "REST",
-            "requestType": "GET"
-        }
-
-        # Simulate admin UI request
-        response = client.post("/admin/tools", data=tool_data)
-
-        # Admin endpoint might return different status codes, just verify it doesn't crash
-        assert response.status_code in [200, 400, 422, 500]  # Allow various responses
-
-        # The important thing is that the metadata capture code doesn't break the endpoint
-
-    def test_tool_update_metadata(self, client):
-        """Test that tool updates capture modification metadata."""
-        # First create a tool
+    def test_tool_update_metadata(self, client: TestClient):
+        """Updates capture modification metadata and version increments."""
         tool_data = {
             "name": f"update_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/test",
             "description": "Tool for update testing",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         create_response = client.post("/tools", json=tool_data)
-        assert create_response.status_code == 200
+        assert create_response.status_code == 200, create_response.text
         tool_id = create_response.json()["id"]
 
-        # Now update the tool
-        update_data = {
-            "description": "Updated description"
-        }
-
+        update_data = {"description": "Updated description"}
         update_response = client.put(f"/tools/{tool_id}", json=update_data)
-        assert update_response.status_code == 200
+        assert update_response.status_code == 200, update_response.text
 
         updated_tool = update_response.json()
-
-        # Verify modification metadata
         assert updated_tool["modifiedBy"] == "test_user"
         assert updated_tool["modifiedVia"] == "api"
-        assert updated_tool["version"] == 2  # Should increment
+        assert updated_tool["version"] == 2
         assert updated_tool["description"] == "Updated description"
 
-    def test_metadata_backwards_compatibility(self, client):
-        """Test that metadata works with legacy entities."""
-        # Create a tool and then manually remove metadata to simulate legacy entity
+    def test_metadata_backwards_compatibility(self, client: TestClient):
+        """Creating a tool still produces expected metadata assumptions."""
         tool_data = {
             "name": f"legacy_simulation_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/legacy",
             "description": "Simulated legacy tool",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         tool = response.json()
 
-        # Even "legacy" simulation should have metadata since we're testing new code
-        # But verify that optional fields handle None gracefully
-        assert tool["createdBy"] is not None  # Should have metadata
-        assert "version" in tool
-        assert tool["version"] >= 1
+        assert tool["createdBy"] is not None
+        assert "version" in tool and tool["version"] >= 1
 
-    def test_auth_disabled_metadata(self, client, test_app):
-        """Test metadata capture when authentication is disabled."""
-        # Override auth to return anonymous
-        test_app.dependency_overrides[require_auth] = lambda: "anonymous"
+    def test_auth_disabled_metadata(self, client: TestClient):
+        """When auth is overridden to 'anonymous', metadata should reflect it."""
+        client.app.dependency_overrides[require_auth] = lambda: "anonymous"
 
         tool_data = {
             "name": f"anonymous_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/anon",
             "description": "Tool created anonymously",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
-
+        assert response.status_code == 200, response.text
         tool = response.json()
 
-        # Verify anonymous metadata
         assert tool["createdBy"] == "anonymous"
         assert tool["version"] == 1
         assert tool["createdVia"] == "api"
 
-    def test_metadata_fields_in_tool_read_schema(self, client):
-        """Test that all metadata fields are present in API responses."""
+    def test_metadata_fields_in_tool_read_schema(self, client: TestClient):
+        """All expected metadata fields are present in API responses (create path)."""
         tool_data = {
             "name": f"schema_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/schema",
             "description": "Tool for schema testing",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
-
+        assert response.status_code == 200, response.text
         tool = response.json()
 
-        # Verify all metadata fields are present
         expected_fields = [
-            "createdBy", "createdFromIp", "createdVia", "createdUserAgent",
-            "modifiedBy", "modifiedFromIp", "modifiedVia", "modifiedUserAgent",
-            "importBatchId", "federationSource", "version"
+            "createdBy",
+            "createdFromIp",
+            "createdVia",
+            "createdUserAgent",
+            "modifiedBy",
+            "modifiedFromIp",
+            "modifiedVia",
+            "modifiedUserAgent",
+            "importBatchId",
+            "federationSource",
+            "version",
         ]
-
         for field in expected_fields:
             assert field in tool, f"Missing metadata field: {field}"
 
-    def test_tool_list_includes_metadata(self, client):
-        """Test that tool list endpoint includes metadata fields."""
-        # Create a tool first
+    def test_tool_list_includes_metadata(self, client: TestClient):
+        """List endpoint should include metadata for items."""
         tool_data = {
             "name": f"list_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/list",
             "description": "Tool for list testing",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
-
         client.post("/tools", json=tool_data)
 
-        # List tools
         response = client.get("/tools")
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         tools = response.json()
-        assert len(tools) > 0
-
-        # Verify metadata is included in list response
-        tool = tools[0]
-        assert "createdBy" in tool
-        assert "version" in tool
+        assert isinstance(tools, list) and len(tools) > 0
+        sample = tools[0]
+        assert "createdBy" in sample
+        assert "version" in sample
 
     @pytest.mark.asyncio
-    async def test_service_layer_metadata_handling(self):
-        """Test metadata handling at the service layer."""
-        from mcpgateway.db import SessionLocal
-        from mcpgateway.utils.metadata_capture import MetadataCapture
-        from types import SimpleNamespace
-
-        # Create mock request
+    async def test_service_layer_metadata_handling(self, test_db):
+        """Test metadata handling directly via the service layer using the test DB fixture."""
+        # Simulate a FastAPI request object for metadata extraction
         mock_request = SimpleNamespace()
         mock_request.client = SimpleNamespace()
         mock_request.client.host = "test-ip"
@@ -250,38 +197,28 @@ class TestMetadataIntegration:
         mock_request.url = SimpleNamespace()
         mock_request.url.path = "/admin/tools"
 
-        # Extract metadata
         metadata = MetadataCapture.extract_creation_metadata(mock_request, "service_test_user")
 
-        # Create tool data
         tool_data = ToolCreate(
             name=f"service_layer_test_{uuid.uuid4().hex[:8]}",
             url="http://example.com/service",
             description="Service layer test tool",
             integration_type="REST",
-            request_type="GET"
+            request_type="GET",
         )
 
-        # Test service creation with metadata
         service = ToolService()
-        db = SessionLocal()
+        tool_read = await service.register_tool(
+            test_db,
+            tool_data,
+            created_by=metadata["created_by"],
+            created_from_ip=metadata["created_from_ip"],
+            created_via=metadata["created_via"],
+            created_user_agent=metadata["created_user_agent"],
+        )
 
-        try:
-            tool_read = await service.register_tool(
-                db,
-                tool_data,
-                created_by=metadata["created_by"],
-                created_from_ip=metadata["created_from_ip"],
-                created_via=metadata["created_via"],
-                created_user_agent=metadata["created_user_agent"],
-            )
-
-            # Verify metadata was stored
-            assert tool_read.created_by == "service_test_user"
-            assert tool_read.created_from_ip == "test-ip"
-            assert tool_read.created_via == "ui"
-            assert tool_read.created_user_agent == "test-agent"
-            assert tool_read.version == 1
-
-        finally:
-            db.close()
+        assert tool_read.created_by == "service_test_user"
+        assert tool_read.created_from_ip == "test-ip"
+        assert tool_read.created_via == "ui"   # path "/admin" should map to ui
+        assert tool_read.created_user_agent == "test-agent"
+        assert tool_read.version == 1


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

Closes #810 
Previously, test cases were unintentionally using the production (or main) database configured in the .env file. As a result, test data including tools created during tests were being written to the main DB, causing data pollution and potentially impacting the integrity of production data.

## 💡 Fix Description

1. All test cases now use an in-memory (mock) database, isolated from the production environment.
2. Test data is ephemeral and discarded after each test run, maintaining a clean state.
3. The .env configuration for the production database is no longer referenced during test execution.
4. Tools and other entities created during testing are now invisible in the UI or any environment tied to the main DB.

## Testing 🛠️

1. Run make test.
2. Confirm that no tools are created in your main database (as configured in .env).
3. Run make serve and open the UI.
4. Ensure that no new tools appear in the UI as a result of running the test cases.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
