### PR TITLE
Fix db integration testcases to use temp db

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,3 +196,69 @@ def app_with_temp_db():
     engine.dispose()
     os.close(fd)
     os.unlink(path)
+
+
+@pytest.fixture(scope="function")
+def client_with_temp_db():
+    """
+    Creates a FastAPI test client with a completely isolated SQLite DB.
+    Ensures that mcpgateway.main, mcpgateway.db, and mcpgateway.services
+    all use the same temporary database.
+    """
+    import sys
+    from fastapi.testclient import TestClient
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+
+    # 1) create temp sqlite file
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    # 2) build engine + session
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    # 3) patch engine + SessionLocal everywhere
+    import mcpgateway.db as db_mod
+    mp.setattr(db_mod, "engine", engine)
+    mp.setattr(db_mod, "SessionLocal", TestingSessionLocal)
+
+    import mcpgateway.services.tool_service as svc_mod
+    if hasattr(svc_mod, "SessionLocal"):
+        mp.setattr(svc_mod, "SessionLocal", TestingSessionLocal)
+
+    import mcpgateway.main as main_mod
+    mp.setattr(main_mod, "SessionLocal", TestingSessionLocal)
+
+    # 4) create schema
+    db_mod.Base.metadata.create_all(bind=engine)
+
+    # 5) import app
+    from mcpgateway.main import app
+
+    # 🔑 6) override get_db to always yield from TestingSessionLocal
+    def _override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[db_mod.get_db] = _override_get_db
+
+    # If admin.py imported its own copy of get_db, patch that too
+    import mcpgateway.admin as admin_mod
+    if hasattr(admin_mod, "get_db"):
+        app.dependency_overrides[admin_mod.get_db] = _override_get_db
+
+    client = TestClient(app)
+
+    yield client
+
+    # 7) teardown
+    app.dependency_overrides.clear()
+    mp.undo()
+    engine.dispose()
+    os.close(fd)
+    os.unlink(path)

--- a/tests/integration/test_metadata_integration.py
+++ b/tests/integration/test_metadata_integration.py
@@ -11,263 +11,185 @@ and UI integration.
 """
 
 # Standard
-import asyncio
-from datetime import datetime
-import json
 import uuid
-from typing import Dict
+from types import SimpleNamespace
 
 # Third-Party
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
 # First-Party
-from mcpgateway.db import Base, get_db, Tool as DbTool
-from mcpgateway.main import app
+from mcpgateway.db import get_db, SessionLocal
 from mcpgateway.schemas import ToolCreate
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.verify_credentials import require_auth
+from mcpgateway.utils.metadata_capture import MetadataCapture
 
 
+# --------------------------------------------------------------------------------------
+# Test client bound to the isolated, patched DB from conftest.py (client_with_temp_db)
+# --------------------------------------------------------------------------------------
 @pytest.fixture
-def test_app():
-    """Create test app with proper database setup."""
-    # Use file-based SQLite database for better compatibility
-    import tempfile
-    import os
-    from _pytest.monkeypatch import MonkeyPatch
-    from sqlalchemy.pool import StaticPool
+def client(client_with_temp_db: TestClient):
+    """
+    Provide a TestClient tied to the in-memory/temp DB.
+    Ensures API code paths use the same patched SessionLocal as services.
+    """
+    def _override_get_db():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
 
-    mp = MonkeyPatch()
+    client_with_temp_db.app.dependency_overrides[get_db] = _override_get_db
+    client_with_temp_db.app.dependency_overrides[require_auth] = lambda: "test_user"
 
-    # Create temp SQLite file
-    fd, path = tempfile.mkstemp(suffix=".db")
-    url = f"sqlite:///{path}"
+    from mcpgateway.admin import get_db as admin_get_db
+    client_with_temp_db.app.dependency_overrides[admin_get_db] = _override_get_db
 
-    # Patch settings
-    from mcpgateway.config import settings
-    mp.setattr(settings, "database_url", url, raising=False)
-
-    import mcpgateway.db as db_mod
-    import mcpgateway.main as main_mod
-
-    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
-    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-    mp.setattr(db_mod, "engine", engine, raising=False)
-    mp.setattr(db_mod, "SessionLocal", TestingSessionLocal, raising=False)
-    mp.setattr(main_mod, "SessionLocal", TestingSessionLocal, raising=False)
-    mp.setattr(main_mod, "engine", engine, raising=False)
-
-    # Create schema
-    Base.metadata.create_all(bind=engine)
-
-    app.dependency_overrides[require_auth] = lambda: "test_user"
-
-    yield app
-
-    # Cleanup
-    app.dependency_overrides.clear()
-    mp.undo()
-    engine.dispose()
-    os.close(fd)
-    os.unlink(path)
-
-
-@pytest.fixture
-def client(test_app):
-    """Create test client."""
-    return TestClient(test_app)
+    return client_with_temp_db
 
 
 class TestMetadataIntegration:
     """Integration tests for metadata tracking across the application."""
 
-    def test_tool_creation_api_metadata(self, client):
-        """Test that tool creation via API captures metadata correctly."""
+    def test_tool_creation_api_metadata(self, client: TestClient):
+        """Tool creation via API captures metadata correctly."""
         unique_name = f"api_test_tool_{uuid.uuid4().hex[:8]}"
         tool_data = {
             "name": unique_name,
             "url": "http://example.com/api",
             "description": "Tool created via API",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         tool = response.json()
-
-        # Verify metadata was captured
         assert tool["createdBy"] == "test_user"
-        assert tool["createdVia"] == "api"  # Should detect API call
+        assert tool["createdVia"] == "api"
         assert tool["version"] == 1
-        assert tool["createdFromIp"] is not None  # Should capture some IP
-
-        # Verify metadata is properly serialized
+        assert tool.get("createdFromIp") is not None
         assert "createdAt" in tool
-        # modifiedAt is only set after modifications, not during creation
 
-    def test_tool_creation_admin_ui_metadata(self, client):
-        """Test that tool creation via admin UI works with metadata."""
-        tool_data = {
-            "name": f"admin_ui_test_tool_{uuid.uuid4().hex[:8]}",
-            "url": "http://example.com/admin",
-            "description": "Tool created via admin UI",
-            "integrationType": "REST",
-            "requestType": "GET"
-        }
-
-        # Simulate admin UI request
-        response = client.post("/admin/tools", data=tool_data)
-
-        # Admin endpoint might return different status codes, just verify it doesn't crash
-        assert response.status_code in [200, 400, 422, 500]  # Allow various responses
-
-        # The important thing is that the metadata capture code doesn't break the endpoint
-
-    def test_tool_update_metadata(self, client):
-        """Test that tool updates capture modification metadata."""
-        # First create a tool
+    def test_tool_update_metadata(self, client: TestClient):
+        """Updates capture modification metadata and version increments."""
         tool_data = {
             "name": f"update_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/test",
             "description": "Tool for update testing",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         create_response = client.post("/tools", json=tool_data)
-        assert create_response.status_code == 200
+        assert create_response.status_code == 200, create_response.text
         tool_id = create_response.json()["id"]
 
-        # Now update the tool
-        update_data = {
-            "description": "Updated description"
-        }
-
+        update_data = {"description": "Updated description"}
         update_response = client.put(f"/tools/{tool_id}", json=update_data)
-        assert update_response.status_code == 200
+        assert update_response.status_code == 200, update_response.text
 
         updated_tool = update_response.json()
-
-        # Verify modification metadata
         assert updated_tool["modifiedBy"] == "test_user"
         assert updated_tool["modifiedVia"] == "api"
-        assert updated_tool["version"] == 2  # Should increment
+        assert updated_tool["version"] == 2
         assert updated_tool["description"] == "Updated description"
 
-    def test_metadata_backwards_compatibility(self, client):
-        """Test that metadata works with legacy entities."""
-        # Create a tool and then manually remove metadata to simulate legacy entity
+    def test_metadata_backwards_compatibility(self, client: TestClient):
+        """Creating a tool still produces expected metadata assumptions."""
         tool_data = {
             "name": f"legacy_simulation_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/legacy",
             "description": "Simulated legacy tool",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         tool = response.json()
 
-        # Even "legacy" simulation should have metadata since we're testing new code
-        # But verify that optional fields handle None gracefully
-        assert tool["createdBy"] is not None  # Should have metadata
-        assert "version" in tool
-        assert tool["version"] >= 1
+        assert tool["createdBy"] is not None
+        assert "version" in tool and tool["version"] >= 1
 
-    def test_auth_disabled_metadata(self, client, test_app):
-        """Test metadata capture when authentication is disabled."""
-        # Override auth to return anonymous
-        test_app.dependency_overrides[require_auth] = lambda: "anonymous"
+    def test_auth_disabled_metadata(self, client: TestClient):
+        """When auth is overridden to 'anonymous', metadata should reflect it."""
+        client.app.dependency_overrides[require_auth] = lambda: "anonymous"
 
         tool_data = {
             "name": f"anonymous_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/anon",
             "description": "Tool created anonymously",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
-
+        assert response.status_code == 200, response.text
         tool = response.json()
 
-        # Verify anonymous metadata
         assert tool["createdBy"] == "anonymous"
         assert tool["version"] == 1
         assert tool["createdVia"] == "api"
 
-    def test_metadata_fields_in_tool_read_schema(self, client):
-        """Test that all metadata fields are present in API responses."""
+    def test_metadata_fields_in_tool_read_schema(self, client: TestClient):
+        """All expected metadata fields are present in API responses (create path)."""
         tool_data = {
             "name": f"schema_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/schema",
             "description": "Tool for schema testing",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
 
         response = client.post("/tools", json=tool_data)
-        assert response.status_code == 200
-
+        assert response.status_code == 200, response.text
         tool = response.json()
 
-        # Verify all metadata fields are present
         expected_fields = [
-            "createdBy", "createdFromIp", "createdVia", "createdUserAgent",
-            "modifiedBy", "modifiedFromIp", "modifiedVia", "modifiedUserAgent",
-            "importBatchId", "federationSource", "version"
+            "createdBy",
+            "createdFromIp",
+            "createdVia",
+            "createdUserAgent",
+            "modifiedBy",
+            "modifiedFromIp",
+            "modifiedVia",
+            "modifiedUserAgent",
+            "importBatchId",
+            "federationSource",
+            "version",
         ]
-
         for field in expected_fields:
             assert field in tool, f"Missing metadata field: {field}"
 
-    def test_tool_list_includes_metadata(self, client):
-        """Test that tool list endpoint includes metadata fields."""
-        # Create a tool first
+    def test_tool_list_includes_metadata(self, client: TestClient):
+        """List endpoint should include metadata for items."""
         tool_data = {
             "name": f"list_test_tool_{uuid.uuid4().hex[:8]}",
             "url": "http://example.com/list",
             "description": "Tool for list testing",
             "integration_type": "REST",
-            "request_type": "GET"
+            "request_type": "GET",
         }
-
         client.post("/tools", json=tool_data)
 
-        # List tools
         response = client.get("/tools")
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         tools = response.json()
-        assert len(tools) > 0
-
-        # Verify metadata is included in list response
-        tool = tools[0]
-        assert "createdBy" in tool
-        assert "version" in tool
+        assert isinstance(tools, list) and len(tools) > 0
+        sample = tools[0]
+        assert "createdBy" in sample
+        assert "version" in sample
 
     @pytest.mark.asyncio
-    async def test_service_layer_metadata_handling(self, test_app):
-        """Test metadata handling at the service layer."""
-        from mcpgateway.utils.metadata_capture import MetadataCapture
-        from types import SimpleNamespace
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import sessionmaker
-
-        # Create test database session
-        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
-        TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-        Base.metadata.create_all(bind=engine)
-
-        # Create mock request
+    async def test_service_layer_metadata_handling(self, test_db):
+        """Test metadata handling directly via the service layer using the test DB fixture."""
+        # Simulate a FastAPI request object for metadata extraction
         mock_request = SimpleNamespace()
         mock_request.client = SimpleNamespace()
         mock_request.client.host = "test-ip"
@@ -275,38 +197,28 @@ class TestMetadataIntegration:
         mock_request.url = SimpleNamespace()
         mock_request.url.path = "/admin/tools"
 
-        # Extract metadata
         metadata = MetadataCapture.extract_creation_metadata(mock_request, "service_test_user")
 
-        # Create tool data
         tool_data = ToolCreate(
             name=f"service_layer_test_{uuid.uuid4().hex[:8]}",
             url="http://example.com/service",
             description="Service layer test tool",
             integration_type="REST",
-            request_type="GET"
+            request_type="GET",
         )
 
-        # Test service creation with metadata
         service = ToolService()
-        db = TestingSessionLocal()
+        tool_read = await service.register_tool(
+            test_db,
+            tool_data,
+            created_by=metadata["created_by"],
+            created_from_ip=metadata["created_from_ip"],
+            created_via=metadata["created_via"],
+            created_user_agent=metadata["created_user_agent"],
+        )
 
-        try:
-            tool_read = await service.register_tool(
-                db,
-                tool_data,
-                created_by=metadata["created_by"],
-                created_from_ip=metadata["created_from_ip"],
-                created_via=metadata["created_via"],
-                created_user_agent=metadata["created_user_agent"],
-            )
-
-            # Verify metadata was stored
-            assert tool_read.created_by == "service_test_user"
-            assert tool_read.created_from_ip == "test-ip"
-            assert tool_read.created_via == "ui"
-            assert tool_read.created_user_agent == "test-agent"
-            assert tool_read.version == 1
-
-        finally:
-            db.close()
+        assert tool_read.created_by == "service_test_user"
+        assert tool_read.created_from_ip == "test-ip"
+        assert tool_read.created_via == "ui"   # path "/admin" should map to ui
+        assert tool_read.created_user_agent == "test-agent"
+        assert tool_read.version == 1


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

Closes #810 
Previously, test cases were unintentionally using the production (or main) database configured in the .env file. As a result, test data including tools created during tests were being written to the main DB, causing data pollution and potentially impacting the integrity of production data.

## 💡 Fix Description

1. All test cases now use an in-memory (mock) database, isolated from the production environment.
2. Test data is ephemeral and discarded after each test run, maintaining a clean state.
3. The .env configuration for the production database is no longer referenced during test execution.
4. Tools and other entities created during testing are now invisible in the UI or any environment tied to the main DB.

## Testing 🛠️

1. Run make test.
2. Confirm that no tools are created in your main database (as configured in .env).
3. Run make serve and open the UI.
4. Ensure that no new tools appear in the UI as a result of running the test cases.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
