### PR TITLE
fix for _sleep_with_jitter for stream

### DIFF
--- a/mcpgateway/utils/retry_manager.py
+++ b/mcpgateway/utils/retry_manager.py
@@ -595,8 +595,10 @@ class ResilientHttpClient:
                     raise
                 logging.warning("Error opening stream (will retry): %s", exc)
 
-            backoff = min(self.base_backoff * (2**attempt), self.max_delay)
-            await self._sleep_with_jitter(backoff)
+            backoff = self.base_backoff * (2**attempt)
+            jitter_range = backoff * self.jitter_max
+            await self._sleep_with_jitter(backoff, jitter_range)
+
             attempt += 1
             logging.debug("Retrying stream open (attempt %d) after backoff %.2f", attempt + 1, backoff)
 

--- a/tests/unit/mcpgateway/utils/test_retry_manager.py
+++ b/tests/unit/mcpgateway/utils/test_retry_manager.py
@@ -620,7 +620,7 @@ async def test_stream_max_retries_no_exception(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_stream_sleep_with_jitter_single_argument(monkeypatch):
-    """Test that _sleep_with_jitter is called with single argument in stream method."""
+    """Test that _sleep_with_jitter is called with arguments in stream method."""
     client = ResilientHttpClient(max_retries=2, base_backoff=0.1, max_delay=1, jitter_max=0.1)
 
     class AsyncContextManager:
@@ -653,12 +653,13 @@ async def test_stream_sleep_with_jitter_single_argument(monkeypatch):
         async with client.stream("GET", "http://always-503.com") as resp:
             pass
 
-    # Should have called _sleep_with_jitter with single argument (backoff)
+    # Should have called _sleep_with_jitter with arguments (backoff + jitter range)
     assert len(sleep_calls) == 2  # Two retry attempts
     for call_args in sleep_calls:
-        assert len(call_args) == 1  # Single argument (backoff)
+        assert len(call_args) == 2  # arguments (backoff + jitter range)
         # Verify the argument is a number (the backoff value)
         assert isinstance(call_args[0], (int, float))
+        assert isinstance(call_args[1], (int, float))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Closes #822 
_sleep_with_jitter needs two parameters (backoff/delay and jitter_range) but only backoff was passed. Calculated both and passed correct parameters.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed

