### PR TITLE
Fixes #831 — Global Tools tab not refreshing on server reactivation

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1114,10 +1114,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                 gateway.enabled = activate
                 gateway.reachable = reachable
                 gateway.updated_at = datetime.now(timezone.utc)
-
                 # Update tracking
                 if activate and reachable:
                     self._active_gateways.add(gateway.url)
+
                     # Try to initialize if activating
                     try:
                         capabilities, tools, resources, prompts = await self._initialize_gateway(gateway.url, gateway.auth_value, gateway.transport, gateway.auth_type, gateway.oauth_config)
@@ -1132,9 +1132,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                                 gateway.tools.append(
                                     DbTool(
                                         original_name=tool.name,
-                                        custom_name=tool.custom_name,
-                                        custom_name_slug=slugify(tool.custom_name),
-                                        display_name=generate_display_name(tool.custom_name),
+                                        display_name=generate_display_name(tool.name),
                                         url=gateway.url,
                                         description=tool.description,
                                         integration_type="MCP",  # Gateway-discovered tools are MCP type
@@ -2006,7 +2004,6 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                     tools = [ToolCreate.model_validate(tool) for tool in tools]
                     if tools:
                         logger.info(f"Fetched {len(tools)} tools from gateway")
-
                     # Fetch resources if supported
                     resources = []
                     logger.debug(f"Checking for resources support: {capabilities.get('resources')}")


### PR DESCRIPTION
This PR addresses the bug where newly added or deleted tools in a gateway server (`http://localhost:8080/sse`) are not reflected in the **Global Tools** tab after deactivating and reactivating the server. Previously, users had to delete and re-add the server for changes to appear.

**Summary of changes:**
- Modifies the refresh logic so that tool additions or removals are correctly shown in the Global Tools tab upon server reactivation.
- Ensures the tool list syncs without requiring a full server re-add.

**Impact:**  
Users can now see the latest tools immediately after server reactivation, improving workflow and usability.

See issue #831 for detailed steps to reproduce and expected behavior.