### PR TITLE
fix: mistakes for where conditions of ORM

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -232,7 +232,7 @@ class A2AAgentService:
                 tag_conditions.append(func.json_extract(DbA2AAgent.tags, "$").contains(tag))
 
             if tag_conditions:
-                query = query.where(func.or_(*tag_conditions))
+                query = query.where(*tag_conditions)
 
         query = query.order_by(desc(DbA2AAgent.created_at))
 

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -408,7 +408,7 @@ class PromptService:
             for tag in tags:
                 tag_conditions.append(func.json_contains(DbPrompt.tags, f'"{tag}"'))
             if tag_conditions:
-                query = query.where(func.or_(*tag_conditions))
+                query = query.where(*tag_conditions)
 
         # Cursor-based pagination logic can be implemented here in the future.
         logger.debug(cursor)

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -403,7 +403,7 @@ class ResourceService:
             for tag in tags:
                 tag_conditions.append(func.json_contains(DbResource.tags, f'"{tag}"'))
             if tag_conditions:
-                query = query.where(func.or_(*tag_conditions))
+                query = query.where(*tag_conditions)
 
         # Cursor-based pagination logic can be implemented here in the future.
         resources = db.execute(query).scalars().all()

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -464,7 +464,7 @@ class ServerService:
             for tag in tags:
                 tag_conditions.append(func.json_contains(DbServer.tags, f'"{tag}"'))
             if tag_conditions:
-                query = query.where(func.or_(*tag_conditions))
+                query = query.where(*tag_conditions)
 
         servers = db.execute(query).scalars().all()
         return [self._convert_server_to_read(s) for s in servers]

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -493,7 +493,7 @@ class ToolService:
             for tag in tags:
                 tag_conditions.append(func.json_contains(DbTool.tags, f'"{tag}"'))
             if tag_conditions:
-                query = query.where(func.or_(*tag_conditions))
+                query = query.where(*tag_conditions)
 
         tools = db.execute(query).scalars().all()
         return [self._convert_tool_to_read(t) for t in tools]

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1315,7 +1315,6 @@ class TestResourceServiceMetricsExtended:
         with patch("mcpgateway.services.resource_service.select", return_value=mock_query):
             with patch("mcpgateway.services.resource_service.func") as mock_func:
                 mock_func.json_contains.return_value = MagicMock()
-                mock_func.or_.return_value = MagicMock()
 
                 result = await resource_service.list_resources(
                     mock_db, tags=["test", "production"]
@@ -1323,7 +1322,6 @@ class TestResourceServiceMetricsExtended:
 
                 # Verify tag filtering was applied
                 assert mock_func.json_contains.call_count == 2
-                mock_func.or_.assert_called_once()
                 assert len(result) == 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
All the api about tag filtering is not worked now.
The `func.or_` wrapped call is redundant.