### PR TITLE
Use UUIDs for resources and prompts

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -627,8 +627,8 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
             description=form.get("description"),
             icon=form.get("icon"),
             associated_tools=",".join(form.getlist("associatedTools")),
-            associated_resources=form.get("associatedResources"),
-            associated_prompts=form.get("associatedPrompts"),
+            associated_resources=",".join(form.getlist("associatedResources")),
+            associated_prompts=",".join(form.getlist("associatedPrompts")),
             tags=tags,
         )
     except KeyError as e:
@@ -785,8 +785,8 @@ async def admin_edit_server(
             description=form.get("description"),
             icon=form.get("icon"),
             associated_tools=",".join(form.getlist("associatedTools")),
-            associated_resources=form.get("associatedResources"),
-            associated_prompts=form.get("associatedPrompts"),
+            associated_resources=",".join(form.getlist("associatedResources")),
+            associated_prompts=",".join(form.getlist("associatedPrompts")),
             tags=tags,
         )
         await server_service.update_server(db, server_id, server)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -3442,7 +3442,7 @@ async def admin_delete_resource(uri: str, request: Request, db: Session = Depend
 
 @admin_router.post("/resources/{resource_id}/toggle")
 async def admin_toggle_resource(
-    resource_id: int,
+    resource_id: str,
     request: Request,
     db: Session = Depends(get_db),
     user: str = Depends(require_auth),
@@ -3456,7 +3456,7 @@ async def admin_toggle_resource(
     logs any errors that might occur during the status toggle operation.
 
     Args:
-        resource_id (int): The ID of the resource whose status to toggle.
+        resource_id (str): The ID of the resource whose status to toggle.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.
@@ -3927,7 +3927,7 @@ async def admin_delete_prompt(name: str, request: Request, db: Session = Depends
 
 @admin_router.post("/prompts/{prompt_id}/toggle")
 async def admin_toggle_prompt(
-    prompt_id: int,
+    prompt_id: str,
     request: Request,
     db: Session = Depends(get_db),
     user: str = Depends(require_auth),
@@ -3941,7 +3941,7 @@ async def admin_toggle_prompt(
     logs any errors that might occur during the status toggle operation.
 
     Args:
-        prompt_id (int): The ID of the prompt whose status to toggle.
+        prompt_id (str): The ID of the prompt whose status to toggle.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -173,7 +173,7 @@ server_resource_association = Table(
     "server_resource_association",
     Base.metadata,
     Column("server_id", String, ForeignKey("servers.id"), primary_key=True),
-    Column("resource_id", Integer, ForeignKey("resources.id"), primary_key=True),
+    Column("resource_id", String, ForeignKey("resources.id"), primary_key=True),
 )
 
 # Association table for servers and prompts
@@ -181,7 +181,7 @@ server_prompt_association = Table(
     "server_prompt_association",
     Base.metadata,
     Column("server_id", String, ForeignKey("servers.id"), primary_key=True),
-    Column("prompt_id", Integer, ForeignKey("prompts.id"), primary_key=True),
+    Column("prompt_id", String, ForeignKey("prompts.id"), primary_key=True),
 )
 
 # Association table for servers and A2A agents
@@ -241,7 +241,7 @@ class ResourceMetric(Base):
 
     Attributes:
         id (int): Primary key.
-        resource_id (int): Foreign key linking to the resource.
+        resource_id (str): Foreign key linking to the resource.
         timestamp (datetime): The time when the invocation occurred.
         response_time (float): The response time in seconds.
         is_success (bool): True if the invocation succeeded, False otherwise.
@@ -251,7 +251,7 @@ class ResourceMetric(Base):
     __tablename__ = "resource_metrics"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    resource_id: Mapped[int] = mapped_column(Integer, ForeignKey("resources.id"), nullable=False)
+    resource_id: Mapped[str] = mapped_column(Integer, ForeignKey("resources.id"), nullable=False)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
@@ -293,7 +293,7 @@ class PromptMetric(Base):
 
     Attributes:
         id (int): Primary key.
-        prompt_id (int): Foreign key linking to the prompt.
+        prompt_id (str): Foreign key linking to the prompt.
         timestamp (datetime): The time when the invocation occurred.
         response_time (float): The response time in seconds.
         is_success (bool): True if the invocation succeeded, False otherwise.
@@ -303,7 +303,7 @@ class PromptMetric(Base):
     __tablename__ = "prompt_metrics"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    prompt_id: Mapped[int] = mapped_column(Integer, ForeignKey("prompts.id"), nullable=False)
+    prompt_id: Mapped[str] = mapped_column(Integer, ForeignKey("prompts.id"), nullable=False)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
@@ -645,7 +645,7 @@ class Resource(Base):
 
     __tablename__ = "resources"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: uuid.uuid4().hex)
     uri: Mapped[str] = mapped_column(unique=True)
     name: Mapped[str]
     description: Mapped[Optional[str]]
@@ -846,7 +846,7 @@ class ResourceSubscription(Base):
     __tablename__ = "resource_subscriptions"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    resource_id: Mapped[int] = mapped_column(ForeignKey("resources.id"))
+    resource_id: Mapped[str] = mapped_column(ForeignKey("resources.id"))
     subscriber_id: Mapped[str]  # Client identifier
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     last_notification: Mapped[Optional[datetime]] = mapped_column(DateTime)
@@ -874,7 +874,7 @@ class Prompt(Base):
 
     __tablename__ = "prompts"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: uuid.uuid4().hex)
     name: Mapped[str] = mapped_column(unique=True)
     description: Mapped[Optional[str]]
     template: Mapped[str] = mapped_column(Text)

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -1901,6 +1901,7 @@ def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unu
     else:
         target.name = target.custom_name_slug
 
+
 @event.listens_for(Resource, "before_insert")
 @event.listens_for(Resource, "before_update")
 def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -1838,7 +1838,7 @@ def set_a2a_agent_slug(_mapper, _conn, target):
 
 @event.listens_for(Tool, "before_insert")
 @event.listens_for(Tool, "before_update")
-def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument
+def set_tool_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument
     """
     Event listener to set custom_name, custom_name_slug, and name for Tool before insert/update.
 
@@ -1871,7 +1871,7 @@ def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unu
 
 @event.listens_for(Prompt, "before_insert")
 @event.listens_for(Prompt, "before_update")
-def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument
+def set_prompt_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument
     """
     Event listener to set custom_name, custom_name_slug, and name for Prompt before insert/update.
 
@@ -1904,7 +1904,7 @@ def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unu
 
 @event.listens_for(Resource, "before_insert")
 @event.listens_for(Resource, "before_update")
-def set_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument
+def set_resource_custom_name_and_slug(mapper, connection, target):  # pylint: disable=unused-argument
     """
     Event listener to set custom_name, custom_name_slug, and name for Resource before insert/update.
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -713,7 +713,7 @@ class Resource(Base):
     display_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
     gateway_id: Mapped[Optional[str]] = mapped_column(ForeignKey("gateways.id"))
-    gateway: Mapped["Gateway"] = relationship("Gateway", back_populates="resources")
+    gateway: Mapped["Gateway"] = relationship("Gateway", primaryjoin="Resource.gateway_id == Gateway.id", foreign_keys=[gateway_id], back_populates="resources")
     # federated_with = relationship("Gateway", secondary=resource_gateway_table, back_populates="federated_resources")
 
     # Many-to-many relationship with Servers
@@ -1003,7 +1003,7 @@ class Prompt(Base):
     display_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
     gateway_id: Mapped[Optional[str]] = mapped_column(ForeignKey("gateways.id"))
-    gateway: Mapped["Gateway"] = relationship("Gateway", back_populates="prompts")
+    gateway: Mapped["Gateway"] = relationship("Gateway", primaryjoin="Prompt.gateway_id == Gateway.id", foreign_keys=[gateway_id], back_populates="prompts")
     # federated_with = relationship("Gateway", secondary=prompt_gateway_table, back_populates="federated_prompts")
 
     # Many-to-many relationship with Servers

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1742,7 +1742,7 @@ async def list_resource_templates(
 
 @resource_router.post("/{resource_id}/toggle")
 async def toggle_resource_status(
-    resource_id: int,
+    resource_id: str,
     activate: bool = True,
     db: Session = Depends(get_db),
     user: str = Depends(require_auth),
@@ -1751,7 +1751,7 @@ async def toggle_resource_status(
     Activate or deactivate a resource by its ID.
 
     Args:
-        resource_id (int): The ID of the resource.
+        resource_id (str): The ID of the resource.
         activate (bool): True to activate, False to deactivate.
         db (Session): Database session.
         user (str): Authenticated user.
@@ -1983,7 +1983,7 @@ async def subscribe_resource(uri: str, user: str = Depends(require_auth)) -> Str
 ###############
 @prompt_router.post("/{prompt_id}/toggle")
 async def toggle_prompt_status(
-    prompt_id: int,
+    prompt_id: str,
     activate: bool = True,
     db: Session = Depends(get_db),
     user: str = Depends(require_auth),

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1374,7 +1374,7 @@ class ResourceRead(BaseModelWithConfigDict):
     - Metrics: Aggregated metrics for the resource invocations.
     """
 
-    id: int
+    id: str
     uri: str
     name: str
     description: Optional[str]
@@ -1847,7 +1847,7 @@ class PromptRead(BaseModelWithConfigDict):
     - Metrics: Aggregated metrics for the prompt invocations.
     """
 
-    id: int
+    id: str
     name: str
     description: Optional[str]
     template: str
@@ -3107,8 +3107,8 @@ class ServerRead(BaseModelWithConfigDict):
     updated_at: datetime
     is_active: bool
     associated_tools: List[str] = []
-    associated_resources: List[int] = []
-    associated_prompts: List[int] = []
+    associated_resources: List[str] = []
+    associated_prompts: List[str] = []
     associated_a2a_agents: List[str] = []
     metrics: ServerMetrics
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the server")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -373,7 +373,7 @@ class ToolCreate(BaseModel):
             str: Value if validated as safe
 
         Raises:
-            ValueError: When displayName contains unsafe content or exceeds length limits
+            ValueError: When name contains unsafe content or exceeds length limits
 
         Examples:
             >>> from mcpgateway.schemas import ToolCreate
@@ -398,7 +398,7 @@ class ToolCreate(BaseModel):
             str: Value if validated as safe
 
         Raises:
-            ValueError: When displayName contains unsafe content or exceeds length limits
+            ValueError: When url contains unsafe content or exceeds length limits
 
         Examples:
             >>> from mcpgateway.schemas import ToolCreate
@@ -1291,7 +1291,7 @@ class ResourceUpdate(BaseModelWithConfigDict):
     """
 
     name: Optional[str] = Field(None, description="Human-readable resource name")
-    displayName: Optional[str] = Field(None, description="Display name for the tool (shown in UI)")  # noqa: N815
+    displayName: Optional[str] = Field(None, description="Display name for the resource (shown in UI)")  # noqa: N815
     custom_name: Optional[str] = Field(None, description="Custom name for the resource")
     description: Optional[str] = Field(None, description="Resource description")
     mime_type: Optional[str] = Field(None, description="Resource MIME type")
@@ -1757,7 +1757,7 @@ class PromptCreate(BaseModel):
         if len(v) > SecurityValidator.MAX_DESCRIPTION_LENGTH:
             raise ValueError(f"Description exceeds maximum length of {SecurityValidator.MAX_DESCRIPTION_LENGTH}")
         return SecurityValidator.sanitize_display_text(v, "Description")
-    
+
     @field_validator("displayName")
     @classmethod
     def validate_display_name(cls, v: Optional[str]) -> Optional[str]:
@@ -3009,7 +3009,7 @@ class ServerCreate(BaseModel):
             str: Value if validated as safe
 
         Raises:
-            ValueError: When displayName contains unsafe content or exceeds length limits
+            ValueError: When id contains unsafe content or exceeds length limits
 
         Examples:
             >>> from mcpgateway.schemas import ServerCreate

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1141,6 +1141,7 @@ class ResourceCreate(BaseModel):
 
     uri: str = Field(..., description="Unique URI for the resource")
     name: str = Field(..., description="Human-readable resource name")
+    displayName: Optional[str] = Field(None, description="Display name for the resource (shown in UI)")  # noqa: N815
     description: Optional[str] = Field(None, description="Resource description")
     mime_type: Optional[str] = Field(None, description="Resource MIME type")
     template: Optional[str] = Field(None, description="URI template for parameterized resources")
@@ -1703,6 +1704,7 @@ class PromptCreate(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     name: str = Field(..., description="Unique name for the prompt")
+    displayName: Optional[str] = Field(None, description="Display name for the prompt (shown in UI)")  # noqa: N815
     description: Optional[str] = Field(None, description="Prompt description")
     template: str = Field(..., description="Prompt template text")
     arguments: List[PromptArgument] = Field(default_factory=list, description="List of arguments for the template")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1206,6 +1206,35 @@ class ResourceCreate(BaseModel):
             raise ValueError(f"Description exceeds maximum length of {SecurityValidator.MAX_DESCRIPTION_LENGTH}")
         return SecurityValidator.sanitize_display_text(v, "Description")
 
+    @field_validator("displayName")
+    @classmethod
+    def validate_display_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure display names display safely
+
+        Args:
+            v (str): Value to validate
+
+        Returns:
+            str: Value if validated as safe
+
+        Raises:
+            ValueError: When displayName contains unsafe content or exceeds length limits
+
+        Examples:
+            >>> from mcpgateway.schemas import ResourceCreate
+            >>> ResourceCreate.validate_display_name('My Custom Resource')
+            'My Custom Resource'
+            >>> ResourceCreate.validate_display_name('<script>alert("xss")</script>')
+            Traceback (most recent call last):
+                ...
+            ValueError: ...
+        """
+        if v is None:
+            return v
+        if len(v) > SecurityValidator.MAX_NAME_LENGTH:
+            raise ValueError(f"Display name exceeds maximum length of {SecurityValidator.MAX_NAME_LENGTH}")
+        return SecurityValidator.sanitize_display_text(v, "Display name")
+
     @field_validator("mime_type")
     @classmethod
     def validate_mime_type(cls, v: Optional[str]) -> Optional[str]:
@@ -1363,6 +1392,35 @@ class ResourceUpdate(BaseModelWithConfigDict):
             raise ValueError("Content contains HTML tags that may cause display issues")
 
         return v
+
+    @field_validator("displayName")
+    @classmethod
+    def validate_display_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure display names display safely
+
+        Args:
+            v (str): Value to validate
+
+        Returns:
+            str: Value if validated as safe
+
+        Raises:
+            ValueError: When displayName contains unsafe content or exceeds length limits
+
+        Examples:
+            >>> from mcpgateway.schemas import ResourceUpdate
+            >>> ResourceUpdate.validate_display_name('My Custom Resource')
+            'My Custom Resource'
+            >>> ResourceUpdate.validate_display_name('<script>alert("xss")</script>')
+            Traceback (most recent call last):
+                ...
+            ValueError: ...
+        """
+        if v is None:
+            return v
+        if len(v) > SecurityValidator.MAX_NAME_LENGTH:
+            raise ValueError(f"Display name exceeds maximum length of {SecurityValidator.MAX_NAME_LENGTH}")
+        return SecurityValidator.sanitize_display_text(v, "Display name")
 
 
 class ResourceRead(BaseModelWithConfigDict):
@@ -1695,6 +1753,35 @@ class PromptCreate(BaseModel):
         if len(v) > SecurityValidator.MAX_DESCRIPTION_LENGTH:
             raise ValueError(f"Description exceeds maximum length of {SecurityValidator.MAX_DESCRIPTION_LENGTH}")
         return SecurityValidator.sanitize_display_text(v, "Description")
+    
+    @field_validator("displayName")
+    @classmethod
+    def validate_display_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure display names display safely
+
+        Args:
+            v (str): Value to validate
+
+        Returns:
+            str: Value if validated as safe
+
+        Raises:
+            ValueError: When displayName contains unsafe content or exceeds length limits
+
+        Examples:
+            >>> from mcpgateway.schemas import PromptCreate
+            >>> PromptCreate.validate_display_name('My Custom Prompt')
+            'My Custom Prompt'
+            >>> PromptCreate.validate_display_name('<script>alert("xss")</script>')
+            Traceback (most recent call last):
+                ...
+            ValueError: ...
+        """
+        if v is None:
+            return v
+        if len(v) > SecurityValidator.MAX_NAME_LENGTH:
+            raise ValueError(f"Display name exceeds maximum length of {SecurityValidator.MAX_NAME_LENGTH}")
+        return SecurityValidator.sanitize_display_text(v, "Display name")
 
     @field_validator("template")
     @classmethod
@@ -1841,6 +1928,35 @@ class PromptUpdate(BaseModelWithConfigDict):
         """
         SecurityValidator.validate_json_depth(v)
         return v
+
+    @field_validator("displayName")
+    @classmethod
+    def validate_display_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure display names display safely
+
+        Args:
+            v (str): Value to validate
+
+        Returns:
+            str: Value if validated as safe
+
+        Raises:
+            ValueError: When displayName contains unsafe content or exceeds length limits
+
+        Examples:
+            >>> from mcpgateway.schemas import PromptUpdate
+            >>> PromptUpdate.validate_display_name('My Custom Prompt')
+            'My Custom Prompt'
+            >>> PromptUpdate.validate_display_name('<script>alert("xss")</script>')
+            Traceback (most recent call last):
+                ...
+            ValueError: ...
+        """
+        if v is None:
+            return v
+        if len(v) > SecurityValidator.MAX_NAME_LENGTH:
+            raise ValueError(f"Display name exceeds maximum length of {SecurityValidator.MAX_NAME_LENGTH}")
+        return SecurityValidator.sanitize_display_text(v, "Display name")
 
 
 class PromptRead(BaseModelWithConfigDict):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1445,6 +1445,8 @@ class ResourceRead(BaseModelWithConfigDict):
     updated_at: datetime
     is_active: bool
     metrics: ResourceMetrics
+    displayName: Optional[str] = Field(None, description="Display name for the resource (shown in UI)")  # noqa: N815
+    gateway_slug: str
     custom_name: str
     custom_name_slug: str
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the resource")
@@ -1979,6 +1981,8 @@ class PromptRead(BaseModelWithConfigDict):
     created_at: datetime
     updated_at: datetime
     is_active: bool
+    displayName: Optional[str] = Field(None, description="Display name for the prompt (shown in UI)")  # noqa: N815
+    gateway_slug: str
     custom_name: str
     custom_name_slug: str
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the prompt")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1384,6 +1384,8 @@ class ResourceRead(BaseModelWithConfigDict):
     updated_at: datetime
     is_active: bool
     metrics: ResourceMetrics
+    custom_name: str
+    custom_name_slug: str
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the resource")
 
     # Comprehensive metadata for audit tracking
@@ -1855,6 +1857,8 @@ class PromptRead(BaseModelWithConfigDict):
     created_at: datetime
     updated_at: datetime
     is_active: bool
+    custom_name: str
+    custom_name_slug: str
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the prompt")
     metrics: PromptMetrics
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1261,6 +1261,8 @@ class ResourceUpdate(BaseModelWithConfigDict):
     """
 
     name: Optional[str] = Field(None, description="Human-readable resource name")
+    displayName: Optional[str] = Field(None, description="Display name for the tool (shown in UI)")  # noqa: N815
+    custom_name: Optional[str] = Field(None, description="Custom name for the resource")
     description: Optional[str] = Field(None, description="Resource description")
     mime_type: Optional[str] = Field(None, description="Resource MIME type")
     template: Optional[str] = Field(None, description="URI template for parameterized resources")
@@ -1757,6 +1759,8 @@ class PromptUpdate(BaseModelWithConfigDict):
     """
 
     name: Optional[str] = Field(None, description="Unique name for the prompt")
+    displayName: Optional[str] = Field(None, description="Display name for the prompt (shown in UI)")  # noqa: N815
+    custom_name: Optional[str] = Field(None, description="Custom name for the prompt")
     description: Optional[str] = Field(None, description="Prompt description")
     template: Optional[str] = Field(None, description="Prompt template text")
     arguments: Optional[List[PromptArgument]] = Field(None, description="List of arguments for the template")

--- a/mcpgateway/services/export_service.py
+++ b/mcpgateway/services/export_service.py
@@ -326,6 +326,7 @@ class ExportService:
         for prompt in prompts:
             prompt_data = {
                 "name": prompt.name,
+                "displayName": prompt.displayName,
                 "template": prompt.template,
                 "description": prompt.description,
                 "input_schema": {"type": "object", "properties": {}, "required": []},
@@ -366,6 +367,7 @@ class ExportService:
         for resource in resources:
             resource_data = {
                 "name": resource.name,
+                "displayName": resource.displayName,
                 "uri": resource.uri,
                 "description": resource.description,
                 "mime_type": resource.mime_type,

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -496,7 +496,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             db_resources = [
                 DbResource(
                     uri=resource.uri,
-                    name=resource.name,
+                    original_name=resource.name,
+                    custom_name=resource.name,
+                    custom_name_slug=slugify(resource.name),
                     description=resource.description,
                     mime_type=resource.mime_type,
                     template=resource.template,
@@ -514,7 +516,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             # Create prompt DB models
             db_prompts = [
                 DbPrompt(
-                    name=prompt.name,
+                    original_name=prompt.name,
+                    custom_name=prompt.name,
+                    custom_name_slug=slugify(prompt.name),
                     description=prompt.description,
                     template=prompt.template if hasattr(prompt, "template") else "",
                     argument_schema={},  # Use argument_schema instead of arguments
@@ -863,7 +867,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                                 gateway.resources.append(
                                     DbResource(
                                         uri=resource.uri,
-                                        name=resource.name,
+                                        original_name=resource.name,
+                                        custom_name=resource.custom_name,
+                                        custom_name_slug=slugify(resource.custom_name),
+                                        display_name=generate_display_name(resource.custom_name),
                                         description=resource.description,
                                         mime_type=resource.mime_type,
                                         template=resource.template,
@@ -876,7 +883,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                             if not existing_prompt:
                                 gateway.prompts.append(
                                     DbPrompt(
-                                        name=prompt.name,
+                                        original_name=prompt.name,
+                                        custom_name=prompt.custom_name,
+                                        custom_name_slug=slugify(prompt.custom_name),
+                                        display_name=generate_display_name(prompt.custom_name),
                                         description=prompt.description,
                                         template=prompt.template if hasattr(prompt, "template") else "",
                                         argument_schema={},  # Use argument_schema instead of arguments

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -896,7 +896,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                         gateway.capabilities = capabilities
                         gateway.tools = [tool for tool in gateway.tools if tool.original_name in new_tool_names]  # keep only still-valid rows
                         gateway.resources = [resource for resource in gateway.resources if resource.uri in new_resource_uris]  # keep only still-valid rows
-                        gateway.prompts = [prompt for prompt in gateway.prompts if prompt.name in new_prompt_names]  # keep only still-valid rows
+                        gateway.prompts = [prompt for prompt in gateway.prompts if prompt.original_name in new_prompt_names]  # keep only still-valid rows
                         gateway.last_seen = datetime.now(timezone.utc)
 
                         # Update tracking with new URL
@@ -1062,7 +1062,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                                 gateway.resources.append(
                                     DbResource(
                                         uri=resource.uri,
-                                        name=resource.name,
+                                        original_name=resource.name,
+                                        custom_name=resource.custom_name,
+                                        custom_name_slug=slugify(resource.custom_name),
+                                        display_name=generate_display_name(resource.custom_name),
                                         description=resource.description,
                                         mime_type=resource.mime_type,
                                         template=resource.template,
@@ -1075,7 +1078,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                             if not existing_prompt:
                                 gateway.prompts.append(
                                     DbPrompt(
-                                        name=prompt.name,
+                                        original_name=prompt.name,
+                                        custom_name=prompt.custom_name,
+                                        custom_name_slug=slugify(prompt.custom_name),
+                                        display_name=generate_display_name(prompt.custom_name),
                                         description=prompt.description,
                                         template=prompt.template if hasattr(prompt, "template") else "",
                                         argument_schema={},  # Use argument_schema instead of arguments
@@ -1085,7 +1091,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                         gateway.capabilities = capabilities
                         gateway.tools = [tool for tool in gateway.tools if tool.original_name in new_tool_names]  # keep only still-valid rows
                         gateway.resources = [resource for resource in gateway.resources if resource.uri in new_resource_uris]  # keep only still-valid rows
-                        gateway.prompts = [prompt for prompt in gateway.prompts if prompt.name in new_prompt_names]  # keep only still-valid rows
+                        gateway.prompts = [prompt for prompt in gateway.prompts if prompt.original_name in new_prompt_names]  # keep only still-valid rows
                         gateway.last_seen = datetime.now(timezone.utc)
                     except Exception as e:
                         logger.warning(f"Failed to initialize reactivated gateway: {e}")

--- a/mcpgateway/services/import_service.py
+++ b/mcpgateway/services/import_service.py
@@ -1073,7 +1073,14 @@ class ImportService:
             for prop_name, prop_data in properties.items():
                 arguments.append({"name": prop_name, "description": prop_data.get("description", ""), "required": prop_name in required_fields})
 
-        return PromptCreate(name=prompt_data["name"], template=prompt_data["template"], description=prompt_data.get("description"), arguments=arguments, tags=prompt_data.get("tags", []))
+        return PromptCreate(
+            name=prompt_data["name"],
+            displayName=prompt_data.get("displayName"),
+            template=prompt_data["template"],
+            description=prompt_data.get("description"),
+            arguments=arguments,
+            tags=prompt_data.get("tags", []),
+        )
 
     def _convert_to_prompt_update(self, prompt_data: Dict[str, Any]) -> PromptUpdate:
         """Convert import data to PromptUpdate schema.
@@ -1094,7 +1101,12 @@ class ImportService:
                 arguments.append({"name": prop_name, "description": prop_data.get("description", ""), "required": prop_name in required_fields})
 
         return PromptUpdate(
-            name=prompt_data.get("name"), template=prompt_data.get("template"), description=prompt_data.get("description"), arguments=arguments if arguments else None, tags=prompt_data.get("tags")
+            name=prompt_data.get("name"),
+            displayName=prompt_data.get("displayName"),
+            template=prompt_data.get("template"),
+            description=prompt_data.get("description"),
+            arguments=arguments if arguments else None,
+            tags=prompt_data.get("tags"),
         )
 
     def _convert_to_resource_create(self, resource_data: Dict[str, Any]) -> ResourceCreate:
@@ -1108,6 +1120,7 @@ class ImportService:
         """
         return ResourceCreate(
             uri=resource_data["uri"],
+            displayName=resource_data.get("displayName"),
             name=resource_data["name"],
             description=resource_data.get("description"),
             mime_type=resource_data.get("mime_type"),
@@ -1125,7 +1138,12 @@ class ImportService:
             ResourceUpdate schema object
         """
         return ResourceUpdate(
-            name=resource_data.get("name"), description=resource_data.get("description"), mime_type=resource_data.get("mime_type"), content=resource_data.get("content"), tags=resource_data.get("tags")
+            name=resource_data.get("name"),
+            displayName=resource_data.get("displayName"),
+            description=resource_data.get("description"),
+            mime_type=resource_data.get("mime_type"),
+            content=resource_data.get("content"),
+            tags=resource_data.get("tags"),
         )
 
     def get_import_status(self, import_id: str) -> Optional[ImportStatus]:

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -38,6 +38,7 @@ from mcpgateway.plugins.framework import GlobalContext, PluginManager, PluginVio
 from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.metrics_common import build_top_performers
+from mcpgateway.utils.create_slug import slugify
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -310,6 +311,8 @@ class PromptService:
             # Create DB model
             db_prompt = DbPrompt(
                 name=prompt.name,
+                custom_name=prompt.name,
+                custom_name_slug=slugify(prompt.name),
                 description=prompt.description,
                 template=prompt.template,
                 argument_schema=argument_schema,

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -644,8 +644,10 @@ class PromptService:
 
                 raise PromptNotFoundError(f"Prompt not found: {name}")
 
-            if prompt_update.name is not None:
-                prompt.name = prompt_update.name
+            if prompt_update.custom_name is not None:
+                prompt.custom_name = prompt_update.custom_name
+            if prompt_update.displayName is not None:
+                prompt.display_name = prompt_update.displayName
             if prompt_update.description is not None:
                 prompt.description = prompt_update.description
             if prompt_update.template is not None:

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -310,7 +310,7 @@ class PromptService:
 
             # Create DB model
             db_prompt = DbPrompt(
-                name=prompt.name,
+                original_name=prompt.name,
                 custom_name=prompt.name,
                 custom_name_slug=slugify(prompt.name),
                 description=prompt.description,

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -219,7 +219,7 @@ class PromptService:
         avg_rt = (sum(m.response_time for m in db_prompt.metrics) / total) if total > 0 else None
         last_time = max((m.timestamp for m in db_prompt.metrics), default=None) if total > 0 else None
 
-        return {
+        prompt_dict = {
             "id": db_prompt.id,
             "name": db_prompt.name,
             "description": db_prompt.description,
@@ -240,6 +240,16 @@ class PromptService:
             },
             "tags": db_prompt.tags or [],
         }
+
+        display_name = getattr(db_prompt, "display_name", None)
+        custom_name = getattr(db_prompt, "custom_name", db_prompt.original_name)
+        prompt_dict["displayName"] = display_name or custom_name
+        prompt_dict["custom_name"] = custom_name
+        prompt_dict["gateway_slug"] = getattr(db_prompt, "gateway_slug", "") or ""
+        prompt_dict["custom_name_slug"] = getattr(db_prompt, "custom_name_slug", "") or ""
+        prompt_dict["tags"] = getattr(db_prompt, "tags", []) or []
+
+        return prompt_dict
 
     async def register_prompt(
         self,

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -37,8 +37,8 @@ from mcpgateway.observability import create_span
 from mcpgateway.plugins.framework import GlobalContext, PluginManager, PluginViolationError, PromptPosthookPayload, PromptPrehookPayload
 from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.create_slug import slugify
+from mcpgateway.utils.metrics_common import build_top_performers
 
 # Initialize logging service first
 logging_service = LoggingService()

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -675,7 +675,7 @@ class PromptService:
             db.rollback()
             raise PromptError(f"Failed to update prompt: {str(e)}")
 
-    async def toggle_prompt_status(self, db: Session, prompt_id: int, activate: bool) -> PromptRead:
+    async def toggle_prompt_status(self, db: Session, prompt_id: str, activate: bool) -> PromptRead:
         """
         Toggle the activation status of a prompt.
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -49,8 +49,8 @@ from mcpgateway.models import ResourceContent, ResourceTemplate, TextContent
 from mcpgateway.observability import create_span
 from mcpgateway.schemas import ResourceCreate, ResourceMetrics, ResourceRead, ResourceSubscription, ResourceUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.create_slug import slugify
+from mcpgateway.utils.metrics_common import build_top_performers
 
 # Plugin support imports (conditional)
 try:

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -749,8 +749,10 @@ class ResourceService:
                 raise ResourceNotFoundError(f"Resource not found: {uri}")
 
             # Update fields if provided
-            if resource_update.name is not None:
-                resource.name = resource_update.name
+            if resource_update.custom_name is not None:
+                resource.custom_name = resource_update.custom_name
+            if resource_update.displayName is not None:
+                resource.display_name = resource_update.displayName
             if resource_update.description is not None:
                 resource.description = resource_update.description
             if resource_update.mime_type is not None:

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -545,7 +545,7 @@ class ResourceService:
             # Return content
             return content
 
-    async def toggle_resource_status(self, db: Session, resource_id: int, activate: bool) -> ResourceRead:
+    async def toggle_resource_status(self, db: Session, resource_id: str, activate: bool) -> ResourceRead:
         """
         Toggle the activation status of a resource.
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -280,7 +280,7 @@ class ResourceService:
             # Create DB model
             db_resource = DbResource(
                 uri=resource.uri,
-                name=resource.name,
+                original_name=resource.name,
                 custom_name=resource.name,
                 custom_name_slug=slugify(resource.name),
                 description=resource.description,

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -218,6 +218,17 @@ class ResourceService:
             "last_execution_time": last_time,
         }
         resource_dict["tags"] = resource.tags or []
+
+        resource_dict["name"] = resource.name
+        # Handle displayName with fallback and None checks
+        display_name = getattr(resource, "display_name", None)
+        custom_name = getattr(resource, "custom_name", resource.original_name)
+        resource_dict["displayName"] = display_name or custom_name
+        resource_dict["custom_name"] = custom_name
+        resource_dict["gateway_slug"] = getattr(resource, "gateway_slug", "") or ""
+        resource_dict["custom_name_slug"] = getattr(resource, "custom_name_slug", "") or ""
+        resource_dict["tags"] = getattr(resource, "tags", []) or []
+
         return ResourceRead.model_validate(resource_dict)
 
     async def register_resource(

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -50,6 +50,7 @@ from mcpgateway.observability import create_span
 from mcpgateway.schemas import ResourceCreate, ResourceMetrics, ResourceRead, ResourceSubscription, ResourceUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.metrics_common import build_top_performers
+from mcpgateway.utils.create_slug import slugify
 
 # Plugin support imports (conditional)
 try:
@@ -280,6 +281,8 @@ class ResourceService:
             db_resource = DbResource(
                 uri=resource.uri,
                 name=resource.name,
+                custom_name=resource.name,
+                custom_name_slug=slugify(resource.name),
                 description=resource.description,
                 mime_type=mime_type,
                 template=resource.template,

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -338,7 +338,7 @@ class ServerService:
                 for resource_id in server_in.associated_resources:
                     if resource_id.strip() == "":
                         continue
-                    resource_obj = db.get(DbResource, int(resource_id))
+                    resource_obj = db.get(DbResource, resource_id)
                     if not resource_obj:
                         raise ServerError(f"Resource with id {resource_id} does not exist.")
                     db_server.resources.append(resource_obj)
@@ -348,7 +348,7 @@ class ServerService:
                 for prompt_id in server_in.associated_prompts:
                     if prompt_id.strip() == "":
                         continue
-                    prompt_obj = db.get(DbPrompt, int(prompt_id))
+                    prompt_obj = db.get(DbPrompt, prompt_id)
                     if not prompt_obj:
                         raise ServerError(f"Prompt with id {prompt_id} does not exist.")
                     db_server.prompts.append(prompt_obj)
@@ -559,7 +559,7 @@ class ServerService:
             if server_update.associated_resources is not None:
                 server.resources = []
                 for resource_id in server_update.associated_resources:
-                    resource_obj = db.get(DbResource, int(resource_id))
+                    resource_obj = db.get(DbResource, resource_id)
                     if resource_obj:
                         server.resources.append(resource_obj)
 
@@ -567,7 +567,7 @@ class ServerService:
             if server_update.associated_prompts is not None:
                 server.prompts = []
                 for prompt_id in server_update.associated_prompts:
-                    prompt_obj = db.get(DbPrompt, int(prompt_id))
+                    prompt_obj = db.get(DbPrompt, prompt_id)
                     if prompt_obj:
                         server.prompts.append(prompt_obj)
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -207,8 +207,8 @@ class ServerService:
         }
         # Also update associated IDs (if not already done)
         server_dict["associated_tools"] = [tool.name for tool in server.tools] if server.tools else []
-        server_dict["associated_resources"] = [res.id for res in server.resources] if server.resources else []
-        server_dict["associated_prompts"] = [prompt.id for prompt in server.prompts] if server.prompts else []
+        server_dict["associated_resources"] = [res.name for res in server.resources] if server.resources else []
+        server_dict["associated_prompts"] = [prompt.name for prompt in server.prompts] if server.prompts else []
         server_dict["associated_a2a_agents"] = [agent.id for agent in server.a2a_agents] if server.a2a_agents else []
         server_dict["tags"] = server.tags or []
         return ServerRead.model_validate(server_dict)
@@ -475,8 +475,8 @@ class ServerService:
             "updated_at": server.updated_at,
             "is_active": server.is_active,
             "associated_tools": [tool.name for tool in server.tools],
-            "associated_resources": [res.id for res in server.resources],
-            "associated_prompts": [prompt.id for prompt in server.prompts],
+            "associated_resources": [res.name for res in server.resources],
+            "associated_prompts": [prompt.name for prompt in server.prompts],
         }
         logger.debug(f"Server Data: {server_data}")
         return self._convert_server_to_read(server)

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4233,6 +4233,99 @@ function initToolSelect(
     checkboxes.forEach((cb) => cb.addEventListener("change", update));
 }
 
+function initResourceSelect(
+    selectId,
+    max = 6,
+    selectBtnId = null,
+    clearBtnId = null,
+) {
+    const container = document.getElementById(selectId);
+    const clearBtn = clearBtnId ? document.getElementById(clearBtnId) : null;
+    const selectBtn = selectBtnId ? document.getElementById(selectBtnId) : null;
+
+    if (!container) {
+        console.warn(
+            `Resource select elements not found: ${selectId}`,
+        );
+        return;
+    }
+
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+
+    function update() {
+        try {
+            const checked = Array.from(checkboxes).filter((cb) => cb.checked);
+            const count = checked.length;
+
+        } catch (error) {
+            console.error("Error updating resource select:", error);
+        }
+    }
+
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            checkboxes.forEach((cb) => (cb.checked = false));
+            update();
+        });
+    }
+
+    if (selectBtn) {
+        selectBtn.addEventListener("click", () => {
+            checkboxes.forEach((cb) => (cb.checked = true));
+            update();
+        });
+    }
+
+    update(); // Initial render
+    checkboxes.forEach((cb) => cb.addEventListener("change", update));
+}
+
+function initPromptSelect(
+    selectId,
+    max = 6,
+    selectBtnId = null,
+    clearBtnId = null,
+) {
+    const container = document.getElementById(selectId);
+    const clearBtn = clearBtnId ? document.getElementById(clearBtnId) : null;
+    const selectBtn = selectBtnId ? document.getElementById(selectBtnId) : null;
+
+    if (!container) {
+        console.warn(
+            `Prompt select elements not found: ${selectId}`,
+        );
+        return;
+    }
+
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+
+    function update() {
+        try {
+            const checked = Array.from(checkboxes).filter((cb) => cb.checked);
+            const count = checked.length;
+
+        } catch (error) {
+            console.error("Error updating prompt select:", error);
+        }
+    }
+
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            checkboxes.forEach((cb) => (cb.checked = false));
+            update();
+        });
+    }
+
+    if (selectBtn) {
+        selectBtn.addEventListener("click", () => {
+            checkboxes.forEach((cb) => (cb.checked = true));
+            update();
+        });
+    }
+
+    update(); // Initial render
+    checkboxes.forEach((cb) => cb.addEventListener("change", update));
+}
 // ===================================================================
 // INACTIVE ITEMS HANDLING
 // ===================================================================

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -6694,8 +6694,10 @@ document.addEventListener("DOMContentLoaded", () => {
         // 1. Initialize CodeMirror editors first
         initializeCodeMirrorEditors();
 
-        // 2. Initialize tool selects
+        // 2. Initialize tool, resource, prompt selects
         initializeToolSelects();
+        initializeResourceSelects();
+        initializePromptSelects();
 
         // 3. Set up all event listeners
         initializeEventListeners();
@@ -6853,6 +6855,40 @@ function initializeToolSelects() {
         6,
         "selectAllEditToolsBtn",
         "clearAllEditToolsBtn",
+    );
+}
+
+function initializeResourceSelects() {
+    console.log("Initializing resource selects...");
+
+    initResourceSelect(
+        "associatedResources",
+        6,
+        "selectAllResourcesBtn",
+        "clearAllResourcesBtn",
+    );
+    initResourceSelect(
+        "edit-server-resources",
+        6,
+        "selectAllEditResourcesBtn",
+        "clearAllEditResourcesBtn",
+    );
+}
+
+function initializePromptSelects() {
+    console.log("Initializing prompt selects...");
+
+    initPromptSelect(
+        "associatedPrompts",
+        6,
+        "selectAllPromptsBtn",
+        "clearAllPromptsBtn",
+    );
+    initPromptSelect(
+        "edit-server-prompts",
+        6,
+        "selectAllEditPromptsBtn",
+        "clearAllEditPromptsBtn",
     );
 }
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1066,7 +1066,7 @@
           <form
             method="POST"
             id="add-server-form"
-            onreset="document.getElementById('associatedTools').selectedIndex = -1;"
+            onreset="document.getElementById('associatedTools').selectedIndex = -1;document.getElementById('associatedResources').selectedIndex = -1;document.getElementById('associatedPrompts').selectedIndex = -1;"
           >
             <div class="grid grid-cols-1 gap-6">
               <div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -4682,30 +4682,15 @@
                       />
                     </div>
                     <div>
-                      <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                      <label class="block text-sm font-medium text-gray-700"
                         >Name</label
                       >
                       <input
                         type="text"
-                        name="customName"
+                        name="name"
                         required
-                        id="edit-resource-custom-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                      />
-                    </div>
-
-                    <div>
-                      <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                        >Display Name</label
-                      >
-                      <input
-                        type="text"
-                        name="displayName"
-                        id="edit-resource-display-name"
-                        placeholder="Custom display name for your UI"
-                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        id="edit-resource-name"
+                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
@@ -4844,30 +4829,15 @@
                 <form id="edit-prompt-form" method="POST">
                   <div class="grid grid-cols-1 gap-6">
                     <div>
-                      <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                      <label class="block text-sm font-medium text-gray-700"
                         >Name</label
                       >
                       <input
                         type="text"
-                        name="customName"
+                        name="name"
                         required
-                        id="edit-prompt-custom-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                      />
-                    </div>
-
-                    <div>
-                      <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                        >Display Name</label
-                      >
-                      <input
-                        type="text"
-                        name="displayName"
-                        id="edit-prompt-display-name"
-                        placeholder="Custom display name for your UI"
-                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        id="edit-prompt-name"
+                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -959,16 +959,16 @@
                   <td
                     class="px-6 py-4 max-w-xs break-words text-sm text-gray-500 dark:text-gray-300"
                   >
-                    {% if server.associatedResources %} {{
-                    server.associatedResources | join(', ') }} {% else %}
+                    {% if server.associatedResources %} {{ server.associatedResources |
+                    map('string') | join(', ') }} {% else %}
                     <span class="text-gray-500 dark:text-gray-300">N/A</span>
                     {% endif %}
                   </td>
                   <td
                     class="px-6 py-4 max-w-xs break-words text-sm text-gray-500 dark:text-gray-300"
                   >
-                    {% if server.associatedPrompts %} {{
-                    server.associatedPrompts | join(', ') }} {% else %}
+                    {% if server.associatedPrompts %} {{ server.associatedPrompts |
+                    map('string') | join(', ') }} {% else %}
                     <span class="text-gray-500 dark:text-gray-300">N/A</span>
                     {% endif %}
                   </td>
@@ -1154,7 +1154,7 @@
                     class="text-gray-700 dark:text-gray-300"
                     style="display: none"
                   >
-                    No tool found containing "<span id="searchQuery"></span>"
+                    No tool found containing "<span id="toolSearchQuery"></span>"
                   </p>
                 </div>
                 <div class="flex justify-end mt-3 gap-2">
@@ -1227,7 +1227,7 @@
                     class="text-gray-700 dark:text-gray-300"
                     style="display: none"
                   >
-                    No resource found containing "<span id="searchQuery"></span>"
+                    No resource found containing "<span id="resourceSearchQuery"></span>"
                   </p>
                 </div>
                 <div class="flex justify-end mt-3 gap-2">
@@ -1287,7 +1287,7 @@
                     class="text-gray-700 dark:text-gray-300"
                     style="display: none"
                   >
-                    No prompt found containing "<span id="searchQuery"></span>"
+                    No prompt found containing "<span id="promptSearchQuery"></span>"
                   </p>
                 </div>
                 <div class="flex justify-end mt-3 gap-2">
@@ -6003,12 +6003,23 @@
 
       // Add search functionality for filtering tools
       document.addEventListener('DOMContentLoaded', function() {
-        const searchBox = document.getElementById('searchTools');
+        const toolSearchBox = document.getElementById('searchTools');
+        const resourceSearchBox = document.getElementById('searchResources');
+        const promptSearchBox = document.getElementById('searchPrompts');
+        
         const toolItems = document.querySelectorAll('#associatedTools .tool-item');
-        const noToolsMessage = document.getElementById('noToolsMessage');
-        const searchQuerySpan = document.getElementById('searchQuery');
+        const resourceItems = document.querySelectorAll('#associatedResources .resource-item');
+        const promptItems = document.querySelectorAll('#associatedPrompts .prompt-item');
 
-        searchBox.addEventListener('input', function() {
+        const noToolsMessage = document.getElementById('noToolsMessage');
+        const noResourcesMessage = document.getElementById('noResourcesMessage');
+        const noPromptsMessage = document.getElementById('noPromptsMessage');
+
+        const toolSearchQuerySpan = document.getElementById('toolSearchQuery');
+        const resourceSearchQuerySpan = document.getElementById('resourceSearchQuery');
+        const promptSearchQuerySpan = document.getElementById('promptSearchQuery');
+
+        toolSearchBox.addEventListener('input', function() {
           const filter = this.value.toLowerCase();
           let hasVisibleItems = false;
 
@@ -6025,8 +6036,52 @@
           if (hasVisibleItems) {
             noToolsMessage.style.display = 'none';
           } else {
-            searchQuerySpan.textContent = filter;
+            toolSearchQuerySpan.textContent = filter;
             noToolsMessage.style.display = 'block';
+          }
+        });
+
+        resourceSearchBox.addEventListener('input', function() {
+          const filter = this.value.toLowerCase();
+          let hasVisibleItems = false;
+
+          resourceItems.forEach(function(resourceItem) {
+            const resourceName = resourceItem.querySelector('span').textContent.toLowerCase();
+            if (resourceName.includes(filter)) {
+              resourceItem.style.display = '';
+              hasVisibleItems = true;
+            } else {
+              resourceItem.style.display = 'none';
+            }
+          });
+
+          if (hasVisibleItems) {
+            noResourcesMessage.style.display = 'none';
+          } else {
+            resourceSearchQuerySpan.textContent = filter;
+            noResourcesMessage.style.display = 'block';
+          }
+        });
+
+        promptSearchBox.addEventListener('input', function() {
+          const filter = this.value.toLowerCase();
+          let hasVisibleItems = false;
+
+          promptItems.forEach(function(promptItem) {
+            const promptName = promptItem.querySelector('span').textContent.toLowerCase();
+            if (promptName.includes(filter)) {
+              promptItem.style.display = '';
+              hasVisibleItems = true;
+            } else {
+              promptItem.style.display = 'none';
+            }
+          });
+
+          if (hasVisibleItems) {
+            noPromptsMessage.style.display = 'none';
+          } else {
+            promptSearchQuerySpan.textContent = filter;
+            noPromptsMessage.style.display = 'block';
           }
         });
       });

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -4682,15 +4682,30 @@
                       />
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Name</label
                       >
                       <input
                         type="text"
-                        name="name"
+                        name="customName"
                         required
-                        id="edit-resource-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        id="edit-resource-custom-name"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                    </div>
+
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Display Name</label
+                      >
+                      <input
+                        type="text"
+                        name="displayName"
+                        id="edit-resource-display-name"
+                        placeholder="Custom display name for your UI"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>
@@ -4829,15 +4844,30 @@
                 <form id="edit-prompt-form" method="POST">
                   <div class="grid grid-cols-1 gap-6">
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Name</label
                       >
                       <input
                         type="text"
-                        name="name"
+                        name="customName"
                         required
-                        id="edit-prompt-name"
-                        class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        id="edit-prompt-custom-name"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                    </div>
+
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Display Name</label
+                      >
+                      <input
+                        type="text"
+                        name="displayName"
+                        id="edit-prompt-display-name"
+                        placeholder="Custom display name for your UI"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>
                     <div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2361,7 +2361,12 @@
                   <th
                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                   >
-                    ID
+                    S. No.
+                  </th>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
+                  >
+                    Gateway Name
                   </th>
                   <th
                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
@@ -2682,7 +2687,12 @@
                   <th
                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                   >
-                    ID
+                    S. No.
+                  </th>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
+                  >
+                    Gateway Name
                   </th>
                   <th
                     class="px-6 py-3 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider"

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1190,29 +1190,125 @@
                   aria-live="polite"
                 ></div>
               </div>
-              <div>
+              <div
+                class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-300 dark:border-gray-700"
+              >
                 <label
-                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
-                  >Associated Resources (comma-separated IDs)</label
+                  class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
+                  for="associatedResources"
                 >
+                  Associated Resources
+                </label>
                 <input
                   type="text"
-                  name="associatedResources"
-                  class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                  placeholder="e.g., resource1, resource2"
+                  id="searchResources"
+                  placeholder="Search for resources..."
+                  class="mb-4 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm p-2 dark:bg-gray-900 dark:text-gray-300"
                 />
+                <div
+                  id="associatedResources"
+                  class="max-h-60 overflow-y-auto rounded-md border border-gray-300 dark:border-gray-700 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
+                >
+                  {% for resource in resources %}
+                  <label
+                    class="flex items-center space-x-3 text-gray-700 dark:text-gray-300 mb-2 cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 rounded-md p-1 resource-item"
+                  >
+                    <input
+                      type="checkbox"
+                      name="associatedResources"
+                      value="{{ resource.id }}"
+                      class="resource-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
+                    />
+                    <span class="select-none">{{ resource.displayName or resource.customName or resource.name }}</span>
+                  </label>
+                  {% endfor %}
+                  <p
+                    id="noResourcesMessage"
+                    class="text-gray-700 dark:text-gray-300"
+                    style="display: none"
+                  >
+                    No resource found containing "<span id="searchQuery"></span>"
+                  </p>
+                </div>
+                <div class="flex justify-end mt-3 gap-2">
+                  <button
+                    type="button"
+                    id="selectAllResourcesBtn"
+                    class="px-3 py-1 text-sm font-semibold text-green-600 border border-green-600 rounded-md hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1"
+                    aria-label="Select all resources"
+                  >
+                    Select All
+                  </button>
+
+                  <button
+                    type="button"
+                    id="clearAllResourcesBtn"
+                    class="px-3 py-1 text-sm font-semibold text-red-600 border border-red-600 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1"
+                    aria-label="Clear all selected resources"
+                  >
+                    Clear All
+                  </button>
+                </div>
               </div>
-              <div>
+              <div
+                class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-300 dark:border-gray-700"
+              >
                 <label
-                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
-                  >Associated Prompts (comma-separated IDs)</label
+                  class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
+                  for="associatedPrompts"
                 >
+                  Associated Prompts
+                </label>
                 <input
                   type="text"
-                  name="associatedPrompts"
-                  class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                  placeholder="e.g., prompt1, prompt2"
+                  id="searchPrompts"
+                  placeholder="Search for prompts..."
+                  class="mb-4 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm p-2 dark:bg-gray-900 dark:text-gray-300"
                 />
+                <div
+                  id="associatedPrompts"
+                  class="max-h-60 overflow-y-auto rounded-md border border-gray-300 dark:border-gray-700 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
+                >
+                  {% for prompt in prompts %}
+                  <label
+                    class="flex items-center space-x-3 text-gray-700 dark:text-gray-300 mb-2 cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 rounded-md p-1 prompt-item"
+                  >
+                    <input
+                      type="checkbox"
+                      name="associatedPrompts"
+                      value="{{ prompt.id }}"
+                      class="prompt-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
+                    />
+                    <span class="select-none">{{ prompt.displayName or prompt.customName or prompt.name }}</span>
+                  </label>
+                  {% endfor %}
+                  <p
+                    id="noPromptsMessage"
+                    class="text-gray-700 dark:text-gray-300"
+                    style="display: none"
+                  >
+                    No prompt found containing "<span id="searchQuery"></span>"
+                  </p>
+                </div>
+                <div class="flex justify-end mt-3 gap-2">
+                  <button
+                    type="button"
+                    id="selectAllPromptsBtn"
+                    class="px-3 py-1 text-sm font-semibold text-green-600 border border-green-600 rounded-md hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1"
+                    aria-label="Select all prompts"
+                  >
+                    Select All
+                  </button>
+
+                  <button
+                    type="button"
+                    id="clearAllPromptsBtn"
+                    class="px-3 py-1 text-sm font-semibold text-red-600 border border-red-600 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1"
+                    aria-label="Clear all selected prompts"
+                  >
+                    Clear All
+                  </button>
+                </div>
               </div>
             </div>
             <!-- 🔻 Error Display Span -->
@@ -2312,7 +2408,12 @@
                   <td
                     class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100"
                   >
-                    {{ resource.id }}
+                    {{ loop.index }}
+                  </td>
+                  <td
+                    class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-36"
+                  >
+                    {{ resource.gatewaySlug }}
                   </td>
                   <td
                     class="px-6 py-4 whitespace-normal break-words text-sm font-medium text-gray-900 dark:text-gray-100"
@@ -2623,7 +2724,12 @@
                   <td
                     class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100"
                   >
-                    {{ prompt.id }}
+                    {{ loop.index }}
+                  </td>
+                  <td
+                    class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-36"
+                  >
+                    {{ prompt.gatewaySlug }}
                   </td>
                   <td
                     class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100"
@@ -5518,31 +5624,125 @@
                       ></div>
                     </div>
 
-                    <div>
+                    <div
+                      class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-600"
+                    >
                       <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                        >Associated Resources (comma-separated IDs)</label
+                        for="edit-server-resources"
+                        class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
                       >
-                      <input
-                        type="text"
-                        name="associatedResources"
+                        Associated Resources
+                      </label>
+                      <div
                         id="edit-server-resources"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                        placeholder="e.g., 3,4"
-                      />
-                    </div>
-                    <div>
-                      <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                        >Associated Prompts (comma-separated IDs)</label
+                        class="max-h-60 overflow-y-auto rounded-md border border-gray-600 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
                       >
-                      <input
-                        type="text"
-                        name="associatedPrompts"
+                        {% for resource in resources %}
+                        <label
+                          class="flex items-center space-x-3 text-gray-700 dark:text-gray-300 mb-2 cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 rounded-md p-1"
+                        >
+                          <input
+                            type="checkbox"
+                            name="associatedResources"
+                            value="{{ resource.id }}"
+                            class="resource-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
+                          />
+                          <span class="select-none">{{ resource.displayName or resource.customName or resource.name }}</span>
+                        </label>
+                        {% endfor %}
+                      </div>
+                      <div class="flex justify-end gap-3 mt-3">
+                        <button
+                          type="button"
+                          id="selectAllEditResourcesBtn"
+                          class="px-3 py-1 text-sm font-semibold text-green-600 border border-green-600 rounded-md hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1"
+                          aria-label="Select all resources"
+                        >
+                          Select All
+                        </button>
+
+                        <button
+                          type="button"
+                          id="clearAllEditResourcesBtn"
+                          class="px-3 py-1 text-sm font-semibold text-red-600 border border-red-600 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1"
+                          aria-label="Clear all selected resources"
+                        >
+                          Clear All
+                        </button>
+                      </div>
+
+                      <!-- Selected pills -->
+                      <div
+                        id="selectedEditResourcesPills"
+                        class="mt-4 flex flex-wrap gap-2"
+                      ></div>
+
+                      <!-- Warning message -->
+                      <div
+                        id="selectedEditResourcesWarning"
+                        class="mt-2 min-h-[1.25rem] text-sm font-semibold text-yellow-600"
+                        aria-live="polite"
+                      ></div>
+                    </div>
+                    <div
+                      class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-600"
+                    >
+                      <label
+                        for="edit-server-prompts"
+                        class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
+                      >
+                        Associated Prompts
+                      </label>
+                      <div
                         id="edit-server-prompts"
-                        class="mt-1 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                        placeholder="e.g., 5,6"
-                      />
+                        class="max-h-60 overflow-y-auto rounded-md border border-gray-600 shadow-sm p-3 bg-gray-50 dark:bg-gray-900"
+                      >
+                        {% for prompt in prompts %}
+                        <label
+                          class="flex items-center space-x-3 text-gray-700 dark:text-gray-300 mb-2 cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 rounded-md p-1"
+                        >
+                          <input
+                            type="checkbox"
+                            name="associatedPrompts"
+                            value="{{ prompt.id }}"
+                            class="prompt-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
+                          />
+                          <span class="select-none">{{ prompt.displayName or prompt.customName or prompt.name }}</span>
+                        </label>
+                        {% endfor %}
+                      </div>
+                      <div class="flex justify-end gap-3 mt-3">
+                        <button
+                          type="button"
+                          id="selectAllEditPromptsBtn"
+                          class="px-3 py-1 text-sm font-semibold text-green-600 border border-green-600 rounded-md hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1"
+                          aria-label="Select all prompts"
+                        >
+                          Select All
+                        </button>
+
+                        <button
+                          type="button"
+                          id="clearAllEditPromptsBtn"
+                          class="px-3 py-1 text-sm font-semibold text-red-600 border border-red-600 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1"
+                          aria-label="Clear all selected prompts"
+                        >
+                          Clear All
+                        </button>
+                      </div>
+
+                      <!-- Selected pills -->
+                      <div
+                        id="selectedEditPromptsPills"
+                        class="mt-4 flex flex-wrap gap-2"
+                      ></div>
+
+                      <!-- Warning message -->
+                      <div
+                        id="selectedEditPromptsWarning"
+                        class="mt-2 min-h-[1.25rem] text-sm font-semibold text-yellow-600"
+                        aria-live="polite"
+                      ></div>
                     </div>
                   </div>
                   <div

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -146,7 +146,7 @@ MOCK_SERVER = ServerRead(
 )
 
 MOCK_RESOURCE = ResourceRead(
-    id=1,
+    id="1",
     uri="file:///tmp/hello.txt",
     name="Hello",
     description="demo text",

--- a/tests/unit/mcpgateway/services/test_export_service.py
+++ b/tests/unit/mcpgateway/services/test_export_service.py
@@ -911,14 +911,14 @@ async def test_export_selective_all_entity_types(export_service, mock_db):
     )
 
     sample_prompt = PromptRead(
-        id=1, name="test_prompt", template="Test template",
+        id="1", name="test_prompt", template="Test template",
         description="Test prompt", arguments=[], is_active=True,
         created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
         metrics=create_default_prompt_metrics(), tags=[]
     )
 
     sample_resource = ResourceRead(
-        id=1, name="test_resource", uri="file:///test.txt",
+        id="1", name="test_resource", uri="file:///test.txt",
         description="Test resource", mime_type="text/plain", size=None, is_active=True,
         created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
         metrics=create_default_resource_metrics(), tags=[]
@@ -1056,7 +1056,7 @@ async def test_export_selected_prompts(export_service, mock_db):
     from mcpgateway.schemas import PromptRead
 
     sample_prompt = PromptRead(
-        id=1, name="test_prompt", template="Test template",
+        id="1", name="test_prompt", template="Test template",
         description="Test prompt", arguments=[], is_active=True,
         created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
         metrics=create_default_prompt_metrics(), tags=[]
@@ -1088,7 +1088,7 @@ async def test_export_selected_resources(export_service, mock_db):
     from mcpgateway.schemas import ResourceRead
 
     sample_resource = ResourceRead(
-        id=1, name="test_resource", uri="file:///test.txt",
+        id="1", name="test_resource", uri="file:///test.txt",
         description="Test resource", mime_type="text/plain", size=None, is_active=True,
         created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
         metrics=create_default_resource_metrics(), tags=[]

--- a/tests/unit/mcpgateway/services/test_prompt_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service_extended.py
@@ -54,10 +54,10 @@ class TestPromptServiceExtended:
         assert "test_prompt" in str(error)
 
         # Test inactive prompt conflict
-        error_inactive = PromptNameConflictError("inactive_prompt", False, 123)
+        error_inactive = PromptNameConflictError("inactive_prompt", False, "123")
         assert error_inactive.name == "inactive_prompt"
         assert error_inactive.is_active is False
-        assert error_inactive.prompt_id == 123
+        assert error_inactive.prompt_id == "123"
         assert "inactive_prompt" in str(error_inactive)
         assert "currently inactive, ID: 123" in str(error_inactive)
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -62,7 +62,7 @@ def mock_resource():
     resource = MagicMock()
 
     # core attributes
-    resource.id = 1
+    resource.id = "1"
     resource.uri = "http://example.com/resource"
     resource.name = "Test Resource"
     resource.description = "A test resource"
@@ -94,7 +94,7 @@ def mock_inactive_resource():
     resource = MagicMock()
 
     # core attributes
-    resource.id = 2
+    resource.id = "2"
     resource.uri = "http://example.com/inactive"
     resource.name = "Inactive Resource"
     resource.description = "An inactive resource"
@@ -177,7 +177,7 @@ class TestResourceRegistration:
             patch.object(resource_service, "_convert_resource_to_read") as mock_convert,
         ):
             mock_convert.return_value = ResourceRead(
-                id=1,
+                id="1",
                 uri=sample_resource_create.uri,
                 name=sample_resource_create.name,
                 description=sample_resource_create.description or "",
@@ -290,7 +290,7 @@ class TestResourceRegistration:
             patch.object(resource_service, "_convert_resource_to_read") as mock_convert,
         ):
             mock_convert.return_value = ResourceRead(
-                id=1,
+                id="1",
                 uri=binary_resource.uri,
                 name=binary_resource.name,
                 description=binary_resource.description or "",
@@ -442,7 +442,7 @@ class TestResourceManagement:
 
         with patch.object(resource_service, "_notify_resource_activated", new_callable=AsyncMock), patch.object(resource_service, "_convert_resource_to_read") as mock_convert:
             mock_convert.return_value = ResourceRead(
-                id=2,
+                id="2",
                 uri=mock_inactive_resource.uri,
                 name=mock_inactive_resource.name,
                 description=mock_inactive_resource.description or "",
@@ -464,7 +464,7 @@ class TestResourceManagement:
                 },
             )
 
-            result = await resource_service.toggle_resource_status(mock_db, 2, activate=True)
+            result = await resource_service.toggle_resource_status(mock_db, "2", activate=True)
 
             assert mock_inactive_resource.is_active is True
             mock_db.commit.assert_called_once()
@@ -476,7 +476,7 @@ class TestResourceManagement:
 
         with patch.object(resource_service, "_notify_resource_deactivated", new_callable=AsyncMock), patch.object(resource_service, "_convert_resource_to_read") as mock_convert:
             mock_convert.return_value = ResourceRead(
-                id=1,
+                id="1",
                 uri=mock_resource.uri,
                 name=mock_resource.name,
                 description=mock_resource.description,
@@ -498,7 +498,7 @@ class TestResourceManagement:
                 },
             )
 
-            result = await resource_service.toggle_resource_status(mock_db, 1, activate=False)
+            result = await resource_service.toggle_resource_status(mock_db, "1", activate=False)
 
             assert mock_resource.is_active is False
             mock_db.commit.assert_called_once()
@@ -522,7 +522,7 @@ class TestResourceManagement:
 
         with patch.object(resource_service, "_convert_resource_to_read") as mock_convert:
             mock_convert.return_value = ResourceRead(
-                id=1,
+                id="1",
                 uri=mock_resource.uri,
                 name=mock_resource.name,
                 description=mock_resource.description,
@@ -545,7 +545,7 @@ class TestResourceManagement:
             )
 
             # Try to activate already active resource
-            result = await resource_service.toggle_resource_status(mock_db, 1, activate=True)
+            result = await resource_service.toggle_resource_status(mock_db, "1", activate=True)
 
             # Should not commit or notify
             mock_db.commit.assert_not_called()
@@ -561,7 +561,7 @@ class TestResourceManagement:
 
         with patch.object(resource_service, "_notify_resource_updated", new_callable=AsyncMock), patch.object(resource_service, "_convert_resource_to_read") as mock_convert:
             mock_convert.return_value = ResourceRead(
-                id=1,
+                id="1",
                 uri=mock_resource.uri,
                 name="Updated Name",
                 description="Updated description",
@@ -630,7 +630,7 @@ class TestResourceManagement:
 
         with patch.object(resource_service, "_notify_resource_updated", new_callable=AsyncMock), patch.object(resource_service, "_convert_resource_to_read") as mock_convert:
             mock_convert.return_value = ResourceRead(
-                id=1,
+                id="1",
                 uri=mock_resource.uri,
                 name=mock_resource.name,
                 description=mock_resource.description,
@@ -1384,7 +1384,7 @@ class TestResourceServiceMetricsExtended:
         """Test getting top performing resources."""
         # Mock query results
         mock_result1 = MagicMock()
-        mock_result1.id = 1
+        mock_result1.id = "1"
         mock_result1.name = "resource1"
         mock_result1.execution_count = 10
         mock_result1.avg_response_time = 1.5
@@ -1392,7 +1392,7 @@ class TestResourceServiceMetricsExtended:
         mock_result1.last_execution = "2025-01-10T12:00:00"
 
         mock_result2 = MagicMock()
-        mock_result2.id = 2
+        mock_result2.id = "2"
         mock_result2.name = "resource2"
         mock_result2.execution_count = 7
         mock_result2.avg_response_time = 2.3

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -47,7 +47,7 @@ def mock_tool():
 @pytest.fixture
 def mock_resource():
     res = MagicMock(spec=DbResource)
-    res.id = 201
+    res.id = "201"
     res.name = "test_resource"
     res._sa_instance_state = MagicMock()  # Mock the SQLAlchemy instance state
     return res
@@ -56,7 +56,7 @@ def mock_resource():
 @pytest.fixture
 def mock_prompt():
     pr = MagicMock(spec=DbPrompt)
-    pr.id = 301
+    pr.id = "301"
     pr.name = "test_prompt"
     pr._sa_instance_state = MagicMock()  # Mock the SQLAlchemy instance state
     return pr
@@ -157,8 +157,8 @@ class TestServerService:
         test_db.get = Mock(
             side_effect=lambda cls, _id: {
                 (DbTool, "101"): mock_tool,
-                (DbResource, 201): mock_resource,
-                (DbPrompt, 301): mock_prompt,
+                (DbResource, "201"): mock_resource,
+                (DbPrompt, "301"): mock_prompt,
             }.get((cls, _id))
         )
 
@@ -174,8 +174,8 @@ class TestServerService:
                 updated_at="2023-01-01T00:00:00",
                 is_active=True,
                 associated_tools=["101"],
-                associated_resources=[201],
-                associated_prompts=[301],
+                associated_resources=["201"],
+                associated_prompts=["301"],
                 metrics={
                     "total_executions": 0,
                     "successful_executions": 0,
@@ -209,8 +209,8 @@ class TestServerService:
 
         assert result.name == "test_server"
         assert "101" in result.associated_tools
-        assert 201 in result.associated_resources
-        assert 301 in result.associated_prompts
+        assert "201" in result.associated_resources
+        assert "301" in result.associated_prompts
 
     @pytest.mark.asyncio
     async def test_register_server_name_conflict(self, server_service, mock_server, test_db):
@@ -279,8 +279,8 @@ class TestServerService:
             updated_at="2023-01-01T00:00:00",
             is_active=True,
             associated_tools=["101"],
-            associated_resources=[201],
-            associated_prompts=[301],
+            associated_resources=["201"],
+            associated_prompts=["301"],
             metrics={
                 "total_executions": 0,
                 "successful_executions": 0,
@@ -313,8 +313,8 @@ class TestServerService:
             updated_at="2023-01-01T00:00:00",
             is_active=True,
             associated_tools=["101"],
-            associated_resources=[201],
-            associated_prompts=[301],
+            associated_resources=["201"],
+            associated_prompts=["301"],
             metrics={
                 "total_executions": 0,
                 "successful_executions": 0,
@@ -410,8 +410,8 @@ class TestServerService:
                 updated_at="2023-01-01T00:00:00",
                 is_active=True,
                 associated_tools=["102"],
-                associated_resources=[202],
-                associated_prompts=[302],
+                associated_resources=["202"],
+                associated_prompts=["302"],
                 metrics={
                     "total_executions": 0,
                     "successful_executions": 0,
@@ -490,8 +490,8 @@ class TestServerService:
                 updated_at="2023-01-01T00:00:00",
                 is_active=False,
                 associated_tools=["101"],
-                associated_resources=[201],
-                associated_prompts=[301],
+                associated_resources=["201"],
+                associated_prompts=["301"],
                 metrics={
                     "total_executions": 0,
                     "successful_executions": 0,

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -910,7 +910,7 @@ class TestAdminPromptRoutes:
     async def test_admin_get_prompt_with_detailed_metrics(self, mock_get_prompt_details, mock_db):
         """Test getting prompt with detailed metrics."""
         mock_get_prompt_details.return_value = {
-            "id": 1,
+            "id": "1",
             "name": "test-prompt",
             "template": "Test {{var}}",
             "description": "Test prompt",

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -56,8 +56,8 @@ MOCK_SERVER_READ = {
     "updated_at": "2023-01-01T00:00:00+00:00",
     "is_active": True,
     "associated_tools": ["101"],
-    "associated_resources": [201],
-    "associated_prompts": [301],
+    "associated_resources": ["201"],
+    "associated_prompts": ["301"],
     "metrics": MOCK_METRICS,
 }
 
@@ -116,7 +116,7 @@ MOCK_TOOL_READ_SNAKE = camel_to_snake_tool(MOCK_TOOL_READ)
 
 
 MOCK_RESOURCE_READ = {
-    "id": 1,
+    "id": "1",
     "uri": "test/resource",
     "name": "Test Resource",
     "description": "A test resource",
@@ -129,7 +129,7 @@ MOCK_RESOURCE_READ = {
 }
 
 MOCK_PROMPT_READ = {
-    "id": 1,
+    "id": "1",
     "name": "test_prompt",
     "description": "A test prompt",
     "template": "Hello {name}",

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -757,8 +757,8 @@ class TestServerSchemas:
             updated_at=now,
             is_active=True,
             associated_tools=["1", "2", "3"],
-            associated_resources=[4, 5],
-            associated_prompts=[6],
+            associated_resources=["4", "5"],
+            associated_prompts=["6"],
             metrics=ServerMetrics(
                 total_executions=100,
                 successful_executions=95,
@@ -779,8 +779,8 @@ class TestServerSchemas:
         assert server.updated_at == now
         assert server.is_active is True
         assert server.associated_tools == ["1", "2", "3"]
-        assert server.associated_resources == [4, 5]
-        assert server.associated_prompts == [6]
+        assert server.associated_resources == ["4", "5"]
+        assert server.associated_prompts == ["6"]
         assert server.metrics.total_executions == 100
         assert server.metrics.successful_executions == 95
 
@@ -794,8 +794,8 @@ class TestServerSchemas:
             updated_at=now,
             is_active=True,
             associated_tools=[Mock(id="10"), Mock(id="11")],
-            associated_resources=[Mock(id=12)],
-            associated_prompts=[Mock(id=13)],
+            associated_resources=[Mock(id="12")],
+            associated_prompts=[Mock(id="13")],
             metrics=ServerMetrics(
                 total_executions=10,
                 successful_executions=10,
@@ -805,8 +805,8 @@ class TestServerSchemas:
         )
 
         assert server_with_objects.associated_tools == ["10", "11"]
-        assert server_with_objects.associated_resources == [12]
-        assert server_with_objects.associated_prompts == [13]
+        assert server_with_objects.associated_resources == ["12"]
+        assert server_with_objects.associated_prompts == ["13"]
 
 
 class TestToggleAndListSchemas:


### PR DESCRIPTION
- Made prompt and resource IDs UUIDs Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Fix test cases Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Add custom names Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Testing updates Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Some more changes to schemas and services Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Fix bugs Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- UI fix Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Some more db changes Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Add gateway name to resources and prompts Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Add search Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Fix display of resources and prompts Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Updating edit screens Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Minor changes Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Clean up code Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>
- Minor changes Signed-off-by: Madhav Kandukuri <madhav165@gmail.com>

# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
_Link to the epic or parent issue:_
Closes #

---

## 🚀 Summary (1-2 sentences)
_What does this PR add or change?_

---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)
_Design sketch, screenshots, or extra context._

If the change introduces or alters an architectural decision, add or update an ADR in **`docs/docs/adr/`** and link it here._

```mermaid
%% Example diagram - delete if not needed
flowchart TD
    A[Client] -->|POST /completions| B(MCPGateway)
    B --> C[Completion Service]
```
