### PR TITLE
fix: Support APP_ROOT_PATH for static file serving

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3960,7 +3960,6 @@ if UI_ENABLED:
     logger.info("Mounting static files - UI enabled")
     try:
         # Create a sub-application for static files that will respect root_path
-        from fastapi import FastAPI as SubApp
         static_app = StaticFiles(directory=str(settings.static_dir))
         static_path = f"{settings.app_root_path}/static" if settings.app_root_path else "/static"
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3959,12 +3959,17 @@ if UI_ENABLED:
     # Mount static files for UI
     logger.info("Mounting static files - UI enabled")
     try:
+        # Create a sub-application for static files that will respect root_path
+        from fastapi import FastAPI as SubApp
+        static_app = StaticFiles(directory=str(settings.static_dir))
+        static_path = f"{settings.app_root_path}/static" if settings.app_root_path else "/static"
+
         app.mount(
-            "/static",
-            StaticFiles(directory=str(settings.static_dir)),
+            static_path,
+            static_app,
             name="static",
         )
-        logger.info("Static assets served from %s", settings.static_dir)
+        logger.info("Static assets served from %s at %s", settings.static_dir, static_path)
     except RuntimeError as exc:
         logger.warning(
             "Static dir %s not found - Admin UI disabled (%s)",


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
This PR fixes static file serving when APP_ROOT_PATH is configured, ensuring that static assets (CSS, JS) are correctly
  mounted and accessible when the application is deployed behind a reverse proxy with a custom base path.

## 🔁 Reproduction Steps
1. Deploy MCP Gateway behind a reverse proxy with APP_ROOT_PATH=/gateway
2. Access the Admin UI at /gateway/admin
3. Static assets fail to load with 404 errors (e.g., /static/admin.css instead of /gateway/static/admin.css)

## 🐞 Root Cause
When APP_ROOT_PATH was configured for reverse proxy deployments, static files were still mounted at /static instead of {APP_ROOT_PATH}/static, causing the browser to request assets at the wrong path and resulting in 404 errors.

## 💡 Fix Description
Modified the static file mounting logic to:

- Mount static files at {APP_ROOT_PATH}/static when APP_ROOT_PATH is configured
- Maintain backward compatibility by using /static when APP_ROOT_PATH is not set
- Updated logging to clearly show the actual mount path for debugging

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | Tested with reverse proxy setup  |    ✅    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
