### PR TITLE
Fix/passthrough header save

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -560,6 +560,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                 auth_type=auth_type,
                 auth_value=auth_value,
                 oauth_config=oauth_config,
+                passthrough_headers=gateway.passthrough_headers,
                 tools=tools,
                 resources=db_resources,
                 prompts=db_prompts,
@@ -897,12 +898,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                             parsed = [h.strip() for h in gateway_update.passthrough_headers.split(",") if h.strip()]
                             gateway.passthrough_headers = parsed
                         else:
-                            raise GatewayError(
-                                "Invalid passthrough_headers format: must be list[str] or comma-separated string")
+                            raise GatewayError("Invalid passthrough_headers format: must be list[str] or comma-separated string")
 
-                    logger.info(
-                        "Updated passthrough_headers for gateway {gateway.id}: {gateway.passthrough_headers}"
-                    )
+                    logger.info("Updated passthrough_headers for gateway {gateway.id}: {gateway.passthrough_headers}")
 
                 if getattr(gateway, "auth_type", None) is not None:
                     gateway.auth_type = gateway_update.auth_type

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -6903,13 +6903,10 @@ async function handleGatewayFormSubmit(e) {
             formData.append("oauth_config", JSON.stringify(oauthConfig));
         }
 
-        const response = await fetchWithTimeout(
-            `${window.ROOT_PATH}/admin/gateways`,
-            {
-                method: "POST",
-                body: formData,
-            },
-        );
+        const response = await fetch(`${window.ROOT_PATH}/admin/gateways`, {
+            method: "POST",
+            body: formData,
+        });
         const result = await response.json();
 
         if (!result || !result.success) {
@@ -6967,13 +6964,10 @@ async function handleResourceFormSubmit(e) {
         const isInactiveCheckedBool = isInactiveChecked("resources");
         formData.append("is_inactive_checked", isInactiveCheckedBool);
 
-        const response = await fetchWithTimeout(
-            `${window.ROOT_PATH}/admin/resources`,
-            {
-                method: "POST",
-                body: formData,
-            },
-        );
+        const response = await fetch(`${window.ROOT_PATH}/admin/resources`, {
+            method: "POST",
+            body: formData,
+        });
         const result = await response.json();
         if (!result || !result.success) {
             throw new Error(result?.message || "Failed to add Resource");
@@ -7025,13 +7019,10 @@ async function handlePromptFormSubmit(e) {
         const isInactiveCheckedBool = isInactiveChecked("prompts");
         formData.append("is_inactive_checked", isInactiveCheckedBool);
 
-        const response = await fetchWithTimeout(
-            `${window.ROOT_PATH}/admin/prompts`,
-            {
-                method: "POST",
-                body: formData,
-            },
-        );
+        const response = await fetch(`${window.ROOT_PATH}/admin/prompts`, {
+            method: "POST",
+            body: formData,
+        });
         const result = await response.json();
         if (!result || !result.success) {
             throw new Error(result?.message || "Failed to add prompt");
@@ -7131,14 +7122,10 @@ async function handleServerFormSubmit(e) {
         const isInactiveCheckedBool = isInactiveChecked("servers");
         formData.append("is_inactive_checked", isInactiveCheckedBool);
 
-        const response = await fetchWithTimeout(
-            `${window.ROOT_PATH}/admin/servers`,
-            {
-                method: "POST",
-                body: formData,
-                redirect: "manual",
-            },
-        );
+        const response = await fetch(`${window.ROOT_PATH}/admin/servers`, {
+            method: "POST",
+            body: formData,
+        });
         const result = await response.json();
         if (!result || !result.success) {
             throw new Error(result?.message || "Failed to add server.");
@@ -7214,13 +7201,10 @@ async function handleToolFormSubmit(event) {
         const isInactiveCheckedBool = isInactiveChecked("tools");
         formData.append("is_inactive_checked", isInactiveCheckedBool);
 
-        const response = await fetchWithTimeout(
-            `${window.ROOT_PATH}/admin/tools`,
-            {
-                method: "POST",
-                body: formData,
-            },
-        );
+        const response = await fetch(`${window.ROOT_PATH}/admin/tools`, {
+            method: "POST",
+            body: formData,
+        });
         const result = await response.json();
         if (!result || !result.success) {
             throw new Error(result?.message || "Failed to add tool");

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2383,7 +2383,7 @@
             </div>
           </div>
 
-          <form id="add-tool-form">
+          <form method="POST" id="add-tool-form">
             <div class="grid grid-cols-1 gap-6">
               <div>
                 <label
@@ -3018,7 +3018,7 @@
           <h3 class="text-lg font-bold mb-4 dark:text-gray-200">
             Add New Resource
           </h3>
-          <form id="add-resource-form">
+          <form method="POST" id="add-resource-form">
             <div class="grid grid-cols-1 gap-6">
               <div>
                 <label
@@ -3820,7 +3820,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
           <h3 class="text-lg font-bold mb-4 dark:text-gray-200">
             Add New MCP Server or Gateway
           </h3>
-          <form id="add-gateway-form">
+          <form method="POST" id="add-gateway-form">
             <div class="grid grid-cols-1 gap-6">
               <div>
                 <label


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Edit Gateway API does not persist the passthrough_headers field from GatewayUpdate.
Although the field exists in the GatewayUpdate model, it is ignored during update and never stored in the DB.

## 🔁 Reproduction Steps
Create a Gateway Server.
Reopen the "Edit" modal.
Fill in the Passthrough Headers input and hit save
Observe that Passthrough headers are not saved
issue: https://github.com/IBM/mcp-context-forge/issues/867

## 🐞 Root Cause
This was confirmed in the update_gateway method: while it updates name, url, tags, auth, etc., it never checks gateway_update.passthrough_headers.


## 💡 Fix Description
Update passthrough headers as well

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [X] Matches current MCP spec
- [X] No breaking change to MCP clients

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
