### PR TITLE
Fix: Tool calls failing due to timeout - increase timeout values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -486,6 +486,10 @@ DEFAULT_PASSTHROUGH_HEADERS=["X-Tenant-Id", "X-Trace-Id"]
 # Enable auto-completion for plugins CLI
 PLUGINS_CLI_COMPLETION=false
 
+
+MCPGATEWAY_UI_TOOL_TEST_TIMEOUT=120000
+
+
 # Set markup mode for plugins CLI
 # Valid options:
 #  rich: use rich markup

--- a/Makefile
+++ b/Makefile
@@ -1401,13 +1401,13 @@ nodejsscan:
 
 lint-web: install-web-linters nodejsscan
 	@echo "🔍 Linting HTML files..."
-	@npx htmlhint "mcpgateway/templates/**/*.html" || true
+	@find mcpgateway/templates -name "*.html" -exec npx htmlhint {} + 2>/dev/null || true
 	@echo "🔍 Linting CSS files..."
-	@npx stylelint "mcpgateway/static/**/*.css" || true
+	@find mcpgateway/static -name "*.css" -exec npx stylelint {} + 2>/dev/null || true
 	@echo "🔍 Linting JS files..."
-	@npx eslint "mcpgateway/static/**/*.js" || true
+	@find mcpgateway/static -name "*.js" -exec npx eslint {} + 2>/dev/null || true
 	@echo "🔒 Scanning for known JS/CSS library vulnerabilities with retire.js..."
-	@npx retire --path mcpgateway/static || true
+	@cd mcpgateway/static && npx retire . 2>/dev/null || true
 	@if [ -f package.json ]; then \
 	  echo "🔒 Running npm audit (high severity)..."; \
 	  npm audit --audit-level=high || true; \

--- a/README.md
+++ b/README.md
@@ -1101,9 +1101,11 @@ You can get started by copying the provided [.env.example](.env.example) to `.en
 | `MCPGATEWAY_UI_ENABLED`        | Enable the interactive Admin dashboard | `false` | bool    |
 | `MCPGATEWAY_ADMIN_API_ENABLED` | Enable API endpoints for admin ops     | `false` | bool    |
 | `MCPGATEWAY_BULK_IMPORT_ENABLED` | Enable bulk import endpoint for tools | `true`  | bool    |
+| `MCPGATEWAY_UI_TOOL_TEST_TIMEOUT` | Tool test timeout in milliseconds for the admin UI | `60000` | int |
 
 > 🖥️ Set both UI and Admin API to `false` to disable management UI and APIs in production.
 > 📥 The bulk import endpoint allows importing up to 200 tools in a single request via `/admin/tools/import`.
+> ⏱️ Increase `MCPGATEWAY_UI_TOOL_TEST_TIMEOUT` if your tools make multiple API calls or operate in high-latency environments.
 
 ### A2A (Agent-to-Agent) Features
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1861,6 +1861,7 @@ async def admin_ui(
             "email_auth_enabled": getattr(settings, "email_auth_enabled", False),
             "is_admin": bool(user.get("is_admin") if isinstance(user, dict) else False),
             "user_teams": user_teams,
+            "mcpgateway_ui_tool_test_timeout": settings.mcpgateway_ui_tool_test_timeout,
         },
     )
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -255,6 +255,9 @@ class Settings(BaseSettings):
     mcpgateway_bulk_import_max_tools: int = 200
     mcpgateway_bulk_import_rate_limit: int = 10
 
+    # UI Tool Test Configuration
+    mcpgateway_ui_tool_test_timeout: int = Field(default=60000, description="Tool test timeout in milliseconds for the admin UI")
+
     # A2A (Agent-to-Agent) Feature Flags
     mcpgateway_a2a_enabled: bool = True
     mcpgateway_a2a_max_agents: int = 100
@@ -420,7 +423,7 @@ class Settings(BaseSettings):
             return peers
         return list(v)
 
-    federation_timeout: int = 30  # seconds
+    federation_timeout: int = 120  # seconds
     federation_sync_interval: int = 300  # seconds
 
     # Resources

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -252,8 +252,12 @@ function isInactiveChecked(type) {
 }
 
 // Enhanced fetch with timeout and better error handling
-function fetchWithTimeout(url, options = {}, timeout = 30000) {
-    // Increased from 10000
+function fetchWithTimeout(
+    url,
+    options = {},
+    timeout = window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000,
+) {
+    // Use configurable timeout from window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
         console.warn(`Request to ${url} timed out after ${timeout}ms`);
@@ -663,7 +667,7 @@ async function loadMetricsInternal() {
         const result = await fetchWithTimeoutAndRetry(
             `${window.ROOT_PATH}/admin/metrics`,
             {}, // options
-            45000, // Increased timeout specifically for metrics (was 20000)
+            (window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000) * 1.5, // Use 1.5x configurable timeout for metrics
             MAX_METRICS_RETRIES,
         );
 
@@ -713,7 +717,7 @@ async function loadMetricsInternal() {
 async function fetchWithTimeoutAndRetry(
     url,
     options = {},
-    timeout = 20000,
+    timeout = window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000,
     maxRetries = 3,
 ) {
     let lastError;
@@ -4185,7 +4189,7 @@ function showTab(tabName) {
                         fetchWithTimeout(
                             `${window.ROOT_PATH}/version?partial=true`,
                             {},
-                            10000,
+                            window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000,
                         )
                             .then((resp) => {
                                 if (!resp.ok) {
@@ -4968,7 +4972,7 @@ const toolTestState = {
     activeRequests: new Map(), // toolId -> AbortController
     lastRequestTime: new Map(), // toolId -> timestamp
     debounceDelay: 1000, // Increased from 500ms
-    requestTimeout: 30000, // Increased from 10000ms
+    requestTimeout: window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000, // Use configurable timeout
 };
 
 let toolInputSchemaRegistry = null;
@@ -5543,7 +5547,7 @@ async function runToolTest() {
                 body: JSON.stringify(payload),
                 credentials: "include",
             },
-            20000, // Increased from 8000
+            window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000, // Use configurable timeout
         );
 
         const result = await response.json();
@@ -10281,7 +10285,7 @@ async function testA2AAgent(agentId, agentName, endpointUrl) {
                 headers,
                 body: JSON.stringify(testPayload),
             },
-            10000, // 10 second timeout
+            window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT || 60000, // Use configurable timeout
         );
 
         if (!response.ok) {

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -7069,6 +7069,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
       window.GATEWAY_TOOL_NAME_SEPARATOR = {{ gateway_tool_name_separator | tojson }};
       window.MAX_NAME_LENGTH = {{ max_name_length | tojson }};
       window.USER_TEAMS = {{ user_teams | default([]) | tojson }};
+      window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT = {{ mcpgateway_ui_tool_test_timeout | tojson }};
 
       // Tag filtering functionality moved to admin.js
       function clearTagFilter(entityType) {

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -119,7 +119,7 @@ plugin_dirs:
 # Global plugin settings
 plugin_settings:
   parallel_execution_within_band: true
-  plugin_timeout: 30
+  plugin_timeout: 120
   fail_on_plugin_error: false
   enable_plugin_api: true
   plugin_health_check_interval: 60


### PR DESCRIPTION
Replaces #866 originally Signed-off-by: NAYANAR <nayana.r5@ibm.com> as that could not be rebased:

## Summary
- Add configurable `MCPGATEWAY_UI_TOOL_TEST_TIMEOUT` setting (default 60000ms, example set to 120000ms)
- Replace hardcoded 20s timeouts in admin.js with configurable timeout
- Increase federation_timeout and plugin_timeout from 30s to 120s
- Update Makefile lint-web target for better cross-platform compatibility
- Add documentation for new timeout setting

## Changes Made
- Added new environment variable `MCPGATEWAY_UI_TOOL_TEST_TIMEOUT` to config.py
- Updated admin.js to use configurable timeout instead of hardcoded 20000ms
- Increased federation_timeout from 30s to 120s in config.py
- Increased plugin_timeout from 30s to 120s in plugins/config.yaml
- Added new timeout setting to .env.example
- Updated Makefile for cross-platform lint-web compatibility
- Added documentation in README.md for the new timeout configuration

## Test Plan
- [x] Verify timeout configuration is loaded correctly
- [x] Test tool calls with longer execution times
- [x] Confirm admin UI respects new timeout values
- [x] Validate federation and plugin timeouts work as expected

Closes #855