### PR TITLE
fix(login): fix login on macos due to datetime utc timestamp

### DIFF
--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -18,7 +18,7 @@ Examples:
 """
 
 # Standard
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Optional
 
 # Third-Party
@@ -115,7 +115,7 @@ def create_access_token(user: EmailUser, token_scopes: Optional[dict] = None, jt
     Returns:
         Tuple of (token_string, expires_in_seconds)
     """
-    now = datetime.utcnow()
+    now = datetime.now(tz=UTC)
     expires_delta = timedelta(minutes=settings.token_expiry)
     expire = now + expires_delta
 


### PR DESCRIPTION
Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary

Platform admin users cannot login to MCPGateway when the gateway is hosted on a MacOS machine.  This is because the `datetime` utc timestamp code actually returns the local time rather than the UTC time, causing jwt token validation to break.

## 🔁 Reproduction Steps

1. Use an intel/ARM based MAC.   
2. Start up the server `make serve`.
3. Go to the login page: http://localhost:4444/admin
4. Try to login:  admin@example.com password: changeme
5. The login page does not log the user in.

## 🐞 Root Cause

Basically, context forge uses the following to add a timestamp to the JWT token for encoding:

```python
now = datetime.utcnow().timestamp()
```

PyJWT uses the following timestamp when decoding the token:

```python
now = datetime.now(tz=timezone.utc).timestamp()
```

Note that on MacOS the python interpreter correctly assigns a UTC timestamp for the `utcnow()` call, but incorrectly assigns a local timestamp for `datetime.now(tz=timezone.utc).timestamp()`. So when comparing the timestamps, it causes the jwt token to be rejected.   Interesting `utcnow()` is deprecated by python.   To fix this, I changed `utcnow()` to be `datetime.now(tz=timezone.utc)` which is the preferred way.  Even though this is broken on MacOS, using the same APIs for encoding/decoding allows it to work.   And it works for the other OSes.
  


## 💡 Fix Description

Changed:
```python
now = datetime.utcnow()
```

to 

```python
now = datetime.now(tz=timezone.utc)
```

in `create_access_token()`


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed