### PR TITLE
Fix tag filtering during config export

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -85,6 +85,7 @@ from mcpgateway.utils.create_slug import slugify
 from mcpgateway.utils.display_name import generate_display_name
 from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
+from mcpgateway.utils.sqlalchemy_modifier import json_contains_expr
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -703,12 +704,13 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             logger.error(f"Failed to fetch tools after OAuth for gateway {gateway_id}: {e}")
             raise GatewayConnectionError(f"Failed to fetch tools after OAuth: {str(e)}")
 
-    async def list_gateways(self, db: Session, include_inactive: bool = False) -> List[GatewayRead]:
+    async def list_gateways(self, db: Session, include_inactive: bool = False, tags: Optional[List[str]] = None) -> List[GatewayRead]:
         """List all registered gateways.
 
         Args:
             db: Database session
             include_inactive: Whether to include inactive gateways
+            tags (Optional[List[str]]): Filter resources by tags. If provided, only resources with at least one matching tag will be returned.
 
         Returns:
             List of registered gateways
@@ -744,6 +746,14 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
 
         if not include_inactive:
             query = query.where(DbGateway.enabled)
+
+        if tags:
+            # Filter resources that have any of the specified tags
+            tag_conditions = []
+            for tag in tags:
+                tag_conditions.append(json_contains_expr(db, DbGateway.tags, tag))
+            if tag_conditions:
+                query = query.where(*tag_conditions)
 
         gateways = db.execute(query).scalars().all()
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -748,12 +748,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             query = query.where(DbGateway.enabled)
 
         if tags:
-            # Filter resources that have any of the specified tags
-            tag_conditions = []
-            for tag in tags:
-                tag_conditions.append(json_contains_expr(db, DbGateway.tags, tag))
-            if tag_conditions:
-                query = query.where(*tag_conditions)
+            query = query.where(json_contains_expr(db, DbGateway.tags, tags, match_any=True))
 
         gateways = db.execute(query).scalars().all()
 

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -404,12 +404,7 @@ class PromptService:
 
         # Add tag filtering if tags are provided
         if tags:
-            # Filter prompts that have any of the specified tags
-            tag_conditions = []
-            for tag in tags:
-                tag_conditions.append(json_contains_expr(db, DbPrompt.tags, tag))
-            if tag_conditions:
-                query = query.where(*tag_conditions)
+            query = query.where(json_contains_expr(db, DbPrompt.tags, tags, match_any=True))
 
         # Cursor-based pagination logic can be implemented here in the future.
         logger.debug(cursor)

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -39,6 +39,7 @@ from mcpgateway.plugins.framework import GlobalContext, PluginManager, PluginVio
 from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.metrics_common import build_top_performers
+from mcpgateway.utils.sqlalchemy_modifier import json_contains_expr
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -406,7 +407,7 @@ class PromptService:
             # Filter prompts that have any of the specified tags
             tag_conditions = []
             for tag in tags:
-                tag_conditions.append(func.json_contains(DbPrompt.tags, f'"{tag}"'))
+                tag_conditions.append(json_contains_expr(db, DbPrompt.tags, tag))
             if tag_conditions:
                 query = query.where(*tag_conditions)
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -388,6 +388,10 @@ class ResourceService:
 
             With tags filter:
             >>> db2 = MagicMock()
+            >>> bind = MagicMock()
+            >>> bind.dialect = MagicMock()
+            >>> bind.dialect.name = "sqlite"           # or "postgresql" / "mysql"
+            >>> db2.get_bind.return_value = bind
             >>> db2.execute.return_value.scalars.return_value.all.return_value = [MagicMock()]
             >>> result2 = asyncio.run(service.list_resources(db2, tags=['api']))
             >>> isinstance(result2, list)

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -50,6 +50,7 @@ from mcpgateway.observability import create_span
 from mcpgateway.schemas import ResourceCreate, ResourceMetrics, ResourceRead, ResourceSubscription, ResourceUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.metrics_common import build_top_performers
+from mcpgateway.utils.sqlalchemy_modifier import json_contains_expr
 
 # Plugin support imports (conditional)
 try:
@@ -401,7 +402,7 @@ class ResourceService:
             # Filter resources that have any of the specified tags
             tag_conditions = []
             for tag in tags:
-                tag_conditions.append(func.json_contains(DbResource.tags, f'"{tag}"'))
+                tag_conditions.append(json_contains_expr(db, DbResource.tags, tag))
             if tag_conditions:
                 query = query.where(*tag_conditions)
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -403,12 +403,7 @@ class ResourceService:
 
         # Add tag filtering if tags are provided
         if tags:
-            # Filter resources that have any of the specified tags
-            tag_conditions = []
-            for tag in tags:
-                tag_conditions.append(json_contains_expr(db, DbResource.tags, tag))
-            if tag_conditions:
-                query = query.where(*tag_conditions)
+            query = query.where(json_contains_expr(db, DbResource.tags, tags, match_any=True))
 
         # Cursor-based pagination logic can be implemented here in the future.
         resources = db.execute(query).scalars().all()

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -33,6 +33,7 @@ from mcpgateway.db import Tool as DbTool
 from mcpgateway.schemas import ServerCreate, ServerMetrics, ServerRead, ServerUpdate, TopPerformer
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.metrics_common import build_top_performers
+from mcpgateway.utils.sqlalchemy_modifier import json_contains_expr
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -460,7 +461,7 @@ class ServerService:
             # Filter servers that have any of the specified tags
             tag_conditions = []
             for tag in tags:
-                tag_conditions.append(func.json_contains(DbServer.tags, f'"{tag}"'))
+                tag_conditions.append(json_contains_expr(db, DbServer.tags, tag))
             if tag_conditions:
                 query = query.where(*tag_conditions)
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -458,12 +458,7 @@ class ServerService:
 
         # Add tag filtering if tags are provided
         if tags:
-            # Filter servers that have any of the specified tags
-            tag_conditions = []
-            for tag in tags:
-                tag_conditions.append(json_contains_expr(db, DbServer.tags, tag))
-            if tag_conditions:
-                query = query.where(*tag_conditions)
+            query = query.where(json_contains_expr(db, DbServer.tags, tags, match_any=True))
 
         servers = db.execute(query).scalars().all()
         return [self._convert_server_to_read(s) for s in servers]

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -489,12 +489,7 @@ class ToolService:
 
         # Add tag filtering if tags are provided
         if tags:
-            # Filter tools that have any of the specified tags
-            tag_conditions = []
-            for tag in tags:
-                tag_conditions.append(json_contains_expr(db, DbTool.tags, tag))
-            if tag_conditions:
-                query = query.where(*tag_conditions)
+            query = query.where(json_contains_expr(db, DbTool.tags, tags, match_any=True))
 
         tools = db.execute(query).scalars().all()
         return [self._convert_tool_to_read(t) for t in tools]

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -55,6 +55,7 @@ from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.passthrough_headers import get_passthrough_headers
 from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.services_auth import decode_auth
+from mcpgateway.utils.sqlalchemy_modifier import json_contains_expr
 
 # Local
 from ..config import extract_using_jq
@@ -491,7 +492,7 @@ class ToolService:
             # Filter tools that have any of the specified tags
             tag_conditions = []
             for tag in tags:
-                tag_conditions.append(func.json_contains(DbTool.tags, f'"{tag}"'))
+                tag_conditions.append(json_contains_expr(db, DbTool.tags, tag))
             if tag_conditions:
                 query = query.where(*tag_conditions)
 

--- a/mcpgateway/utils/sqlalchemy_modifier.py
+++ b/mcpgateway/utils/sqlalchemy_modifier.py
@@ -18,6 +18,18 @@ from sqlalchemy import and_, func, or_, text
 
 
 def _ensure_list(values: Union[str, Iterable[str]]) -> List[str]:
+    """
+    Normalize input into a list of strings.
+
+    Args:
+        values: A single string or any iterable of strings. If `None`, an empty
+            list is returned.
+
+    Returns:
+        A list of strings. If `values` is a string it will be wrapped in a
+        single-item list; if it's already an iterable, it will be converted to
+        a list. If `values` is `None`, returns an empty list.
+    """
     if values is None:
         return []
     if isinstance(values, str):

--- a/mcpgateway/utils/sqlalchemy_modifier.py
+++ b/mcpgateway/utils/sqlalchemy_modifier.py
@@ -1,4 +1,4 @@
-"""Location: ./tests/unit/mcpgateway/services/test_resource_service.py
+"""Location: mcpgateway/utils/sqlalchemy_modifier.py
 Copyright 2025
 SPDX-License-Identifier: Apache-2.0
 Authors: Madhav Kandukuri

--- a/mcpgateway/utils/sqlalchemy_modifier.py
+++ b/mcpgateway/utils/sqlalchemy_modifier.py
@@ -1,0 +1,52 @@
+"""Location: ./tests/unit/mcpgateway/services/test_resource_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhav Kandukuri
+
+SQLAlchemy modifiers
+
+- json_contains_expr: handles json_contains logic for different dialects
+"""
+
+# Standard
+import json
+
+# Third-Party
+from sqlalchemy import func, text
+
+
+def json_contains_expr(session, col, value) -> bool:
+    """
+    Return a SQLAlchemy expression that is True when JSON column `col`
+    contains the scalar `value`. `session` is used to detect dialect.
+    Assumes `col` is a JSON/JSONB column (array-of-strings case).
+
+    Args:
+        session: database session
+        col: column that contains JSON
+        value: value to check for in json
+
+    Returns:
+        bool: Whether value in col JSON
+
+    Raises:
+        RuntimeError: If dialect is not supported
+    """
+    dialect = session.get_bind().dialect.name
+
+    if dialect == "mysql":
+        # MySQL: JSON_CONTAINS(target, candidate) -> returns 1 for true
+        # candidate must be a JSON value; json.dumps(value) -> '"value"'
+        return func.json_contains(col, json.dumps(value)) == 1
+
+    if dialect == "postgresql":
+        # Postgres JSONB: .contains() works with Python objects (casts to JSONB)
+        # For an array-of-strings column, check contains([value])
+        return col.contains([value])
+
+    if dialect == "sqlite":
+        # SQLite json1: no json_contains; use json_each to test array membership.
+        # This assumes `col` holds a JSON array of scalars.
+        return text(f"EXISTS (SELECT 1 FROM json_each({col.name}) WHERE value = :_val)").bindparams(_val=value)
+
+    raise RuntimeError(f"Unsupported dialect for json_contains: {dialect}")

--- a/mcpgateway/utils/sqlalchemy_modifier.py
+++ b/mcpgateway/utils/sqlalchemy_modifier.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Location: mcpgateway/utils/sqlalchemy_modifier.py
 Copyright 2025
 SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1976,4 +1976,3 @@ class TestGatewayService:
 
                     mock_model_validate.assert_called_once()
                     assert result == ["masked_result"]
-

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -525,12 +525,22 @@ class TestPromptService:
 
         with patch("mcpgateway.services.prompt_service.select", return_value=mock_query):
             with patch("mcpgateway.services.prompt_service.json_contains_expr") as mock_json_contains:
-                mock_json_contains.return_value = MagicMock()
+                # return a fake condition object that query.where will accept
+                fake_condition = MagicMock()
+                mock_json_contains.return_value = fake_condition
 
                 result = await prompt_service.list_prompts(
                     session, tags=["test", "production"]
                 )
 
-                # Verify tag filtering was applied
-                assert mock_json_contains.call_count == 2
+                # helper should be called once with the tags list (not once per tag)
+                mock_json_contains.assert_called_once()                       # called exactly once
+                called_args = mock_json_contains.call_args[0]                # positional args tuple
+                assert called_args[0] is session                            # session passed through
+                # third positional arg is the tags list (signature: session, col, values, match_any=True)
+                assert called_args[2] == ["test", "production"]
+                # and the fake condition returned must have been passed to where()
+                mock_query.where.assert_called_with(fake_condition)
+                # finally, your service should return the list produced by mock_db.execute(...)
+                assert isinstance(result, list)
                 assert len(result) == 1

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -514,7 +514,7 @@ class TestPromptService:
         # Mock query chain
         mock_query = MagicMock()
         mock_query.where.return_value = mock_query
-        
+
         session = MagicMock()
         session.execute.return_value.scalars.return_value.all.return_value = [mock_prompt]
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1319,14 +1319,24 @@ class TestResourceServiceMetricsExtended:
 
         with patch("mcpgateway.services.resource_service.select", return_value=mock_query):
             with patch("mcpgateway.services.resource_service.json_contains_expr") as mock_json_contains:
-                mock_json_contains.return_value = MagicMock()
+                # return a fake condition object that query.where will accept
+                fake_condition = MagicMock()
+                mock_json_contains.return_value = fake_condition
 
                 result = await resource_service.list_resources(
                     mock_db, tags=["test", "production"]
                 )
 
-                # Verify tag filtering was applied
-                assert mock_json_contains.call_count == 2
+                # helper should be called once with the tags list (not once per tag)
+                mock_json_contains.assert_called_once()                       # called exactly once
+                called_args = mock_json_contains.call_args[0]                # positional args tuple
+                assert called_args[0] is mock_db                            # session passed through
+                # third positional arg is the tags list (signature: session, col, values, match_any=True)
+                assert called_args[2] == ["test", "production"]
+                # and the fake condition returned must have been passed to where()
+                mock_query.where.assert_called_with(fake_condition)
+                # finally, your service should return the list produced by mock_db.execute(...)
+                assert isinstance(result, list)
                 assert len(result) == 1
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1312,16 +1312,21 @@ class TestResourceServiceMetricsExtended:
         mock_query.where.return_value = mock_query
         mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_resource]
 
+        bind = MagicMock()
+        bind.dialect = MagicMock()
+        bind.dialect.name = "sqlite"    # or "postgresql" or "mysql"
+        mock_db.get_bind.return_value = bind
+
         with patch("mcpgateway.services.resource_service.select", return_value=mock_query):
-            with patch("mcpgateway.services.resource_service.func") as mock_func:
-                mock_func.json_contains.return_value = MagicMock()
+            with patch("mcpgateway.services.resource_service.json_contains_expr") as mock_json_contains:
+                mock_json_contains.return_value = MagicMock()
 
                 result = await resource_service.list_resources(
                     mock_db, tags=["test", "production"]
                 )
 
                 # Verify tag filtering was applied
-                assert mock_func.json_contains.call_count == 2
+                assert mock_json_contains.call_count == 2
                 assert len(result) == 1
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -898,7 +898,7 @@ class TestServerService:
         # Mock query chain
         mock_query = MagicMock()
         mock_query.where.return_value = mock_query
-        
+
         session = MagicMock()
         session.execute.return_value.scalars.return_value.all.return_value = [mock_server]
 

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -8,7 +8,7 @@ Tests for server service implementation.
 """
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
 import pytest
@@ -47,7 +47,7 @@ def mock_tool():
 @pytest.fixture
 def mock_resource():
     res = MagicMock(spec=DbResource)
-    res.id = 201
+    res.id = "201"
     res.name = "test_resource"
     res._sa_instance_state = MagicMock()  # Mock the SQLAlchemy instance state
     return res
@@ -56,7 +56,7 @@ def mock_resource():
 @pytest.fixture
 def mock_prompt():
     pr = MagicMock(spec=DbPrompt)
-    pr.id = 301
+    pr.id = "301"
     pr.name = "test_prompt"
     pr._sa_instance_state = MagicMock()  # Mock the SQLAlchemy instance state
     return pr
@@ -66,7 +66,7 @@ def mock_prompt():
 def mock_server(mock_tool, mock_resource, mock_prompt):
     """Return a mocked DbServer object with minimal required attributes."""
     server = MagicMock(spec=DbServer)
-    server.id = 1
+    server.id = "1"
     server.name = "test_server"
     server.description = "A test server"
     server.icon = "server-icon"
@@ -887,3 +887,34 @@ class TestServerService:
             # Check that any alphabetic characters are lowercase
             assert normalized.islower() or not any(c.isalpha() for c in normalized)
             assert normalized.isalnum()
+
+
+    @pytest.mark.asyncio
+    async def test_list_servers_with_tags(self, server_service, mock_server):
+        """Test listing servers with tag filtering."""
+        # Third-Party
+        from sqlalchemy import func
+
+        # Mock query chain
+        mock_query = MagicMock()
+        mock_query.where.return_value = mock_query
+        
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = [mock_server]
+
+        bind = MagicMock()
+        bind.dialect = MagicMock()
+        bind.dialect.name = "sqlite"    # or "postgresql" or "mysql"
+        session.get_bind.return_value = bind
+
+        with patch("mcpgateway.services.server_service.select", return_value=mock_query):
+            with patch("mcpgateway.services.server_service.json_contains_expr") as mock_json_contains:
+                mock_json_contains.return_value = MagicMock()
+
+                result = await server_service.list_servers(
+                    session, tags=["test", "production"]
+                )
+
+                # Verify tag filtering was applied
+                assert mock_json_contains.call_count == 2
+                assert len(result) == 1

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -1901,61 +1901,45 @@ class TestToolService:
             mock_build.assert_called_once_with(mock_results)
             test_db.query.assert_called_once()
 
-    async def test_list_tools_with_tags(self, tool_service, mock_tool, test_db):
+    @pytest.mark.asyncio
+    async def test_list_tools_with_tags(self, tool_service, mock_tool):
         """Test listing tools with tag filtering."""
-        # Mock DB to return a list of tools
-        mock_scalars = MagicMock()
-        mock_scalars.all.return_value = [mock_tool]
-        mock_scalar_result = MagicMock()
-        mock_scalar_result.scalars.return_value = mock_scalars
-        mock_execute = Mock(return_value=mock_scalar_result)
-        test_db.execute = mock_execute
+        # Third-Party
+        from sqlalchemy import func
 
-        # Mock conversion
-        tool_read = ToolRead(
-            id="1",
-            original_name="test_tool",
-            custom_name="test_tool",
-            custom_name_slug="test-tool",
-            gateway_slug="test-gateway",
-            name="test-gateway-test-tool",
-            url="http://example.com/tools/test",
-            description="A test tool",
-            integration_type="MCP",
-            request_type="POST",
-            headers={"Content-Type": "application/json"},
-            input_schema={"type": "object", "properties": {"param": {"type": "string"}}},
-            jsonpath_filter="",
-            created_at="2023-01-01T00:00:00",
-            updated_at="2023-01-01T00:00:00",
-            enabled=True,
-            reachable=True,
-            gateway_id=None,
-            execution_count=0,
-            auth=None,
-            annotations={},
-            metrics={
-                "total_executions": 0,
-                "successful_executions": 0,
-                "failed_executions": 0,
-                "failure_rate": 0.0,
-                "min_response_time": None,
-                "max_response_time": None,
-                "avg_response_time": None,
-                "last_execution_time": None,
-            },
-        )
-        tool_service._convert_tool_to_read = Mock(return_value=tool_read)
+        # Mock query chain
+        mock_query = MagicMock()
+        mock_query.where.return_value = mock_query
+        
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = [mock_tool]
 
-        # Call method with tags
-        result = await tool_service.list_tools(test_db, tags=["python", "automation"])
+        bind = MagicMock()
+        bind.dialect = MagicMock()
+        bind.dialect.name = "sqlite"    # or "postgresql" or "mysql"
+        session.get_bind.return_value = bind
 
-        # Verify DB query was called and tags were processed
-        test_db.execute.assert_called_once()
+        with patch("mcpgateway.services.tool_service.select", return_value=mock_query):
+            with patch("mcpgateway.services.tool_service.json_contains_expr") as mock_json_contains:
+                # return a fake condition object that query.where will accept
+                fake_condition = MagicMock()
+                mock_json_contains.return_value = fake_condition
 
-        # Verify result
-        assert len(result) == 1
-        assert result[0] == tool_read
+                result = await tool_service.list_tools(
+                    session, tags=["test", "production"]
+                )
+
+                # helper should be called once with the tags list (not once per tag)
+                mock_json_contains.assert_called_once()                       # called exactly once
+                called_args = mock_json_contains.call_args[0]                # positional args tuple
+                assert called_args[0] is session                            # session passed through
+                # third positional arg is the tags list (signature: session, col, values, match_any=True)
+                assert called_args[2] == ["test", "production"]
+                # and the fake condition returned must have been passed to where()
+                mock_query.where.assert_called_with(fake_condition)
+                # finally, your service should return the list produced by mock_db.execute(...)
+                assert isinstance(result, list)
+                assert len(result) == 1
 
     async def test_invoke_tool_rest_oauth_success(self, tool_service, mock_tool, test_db):
         """Test invoking REST tool with successful OAuth authentication."""

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -1910,7 +1910,7 @@ class TestToolService:
         # Mock query chain
         mock_query = MagicMock()
         mock_query.where.return_value = mock_query
-        
+
         session = MagicMock()
         session.execute.return_value.scalars.return_value.all.return_value = [mock_tool]
 

--- a/tests/unit/mcpgateway/utils/test_sqlalchemy_modifier.py
+++ b/tests/unit/mcpgateway/utils/test_sqlalchemy_modifier.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/utils/test_sqlalchemy_modifier.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhav Kandukuri
+
+Comprehensive test suite for sqlalchemy_modiier.
+This suite provides complete test coverage for:
+- _ensure_list
+- json_contains_expr
+"""
+
+import uuid
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import Table, Column, MetaData, JSON
+from sqlalchemy.sql.elements import ClauseElement
+
+# adjust import path to where your helper actually lives
+from mcpgateway.utils.sqlalchemy_modifier import _ensure_list, json_contains_expr
+
+
+def test__ensure_list_none_returns_empty():
+    assert _ensure_list(None) == []
+
+
+def test__ensure_list_string_returns_list():
+    assert _ensure_list("foo") == ["foo"]
+
+
+def test__ensure_list_iterable_returns_list():
+    assert _ensure_list(["a", "b"]) == ["a", "b"]
+    assert _ensure_list(("x", "y")) == ["x", "y"]
+
+
+def make_session_with_dialect(name: str):
+    """Helper to produce a session-like MagicMock with a bind whose dialect.name is set."""
+    session = MagicMock()
+    bind = MagicMock()
+    bind.dialect = MagicMock()
+    bind.dialect.name = name
+    session.get_bind.return_value = bind
+    return session
+
+
+def make_column(table_name="tools", col_name="tags"):
+    """Create a real SQLAlchemy Column element attached to a simple table. Useful for .contains()."""
+    md = MetaData()
+    tbl = Table(table_name, md, Column(col_name, JSON))
+    return tbl.c[col_name]
+
+
+def test_json_contains_expr_raises_on_empty_values():
+    session = make_session_with_dialect("sqlite")
+    col = make_column()
+    with pytest.raises(ValueError):
+        json_contains_expr(session, col, [])
+
+
+def test_json_contains_expr_mysql_any_and_all():
+    session = make_session_with_dialect("mysql")
+    col = make_column()
+
+    # any-of: expects json_overlaps or fallback
+    expr_any = json_contains_expr(session, col, ["a", "b"], match_any=True)
+    assert isinstance(expr_any, ClauseElement)
+    # string representation should contain the function name
+    assert "json_overlaps" in str(expr_any).lower() or "json_contains" in str(expr_any).lower()
+
+    # all-of: json_contains([...]) == 1 expected
+    expr_all = json_contains_expr(session, col, ["a", "b"], match_any=False)
+    assert isinstance(expr_all, ClauseElement)
+    assert "json_contains" in str(expr_all).lower()
+
+
+def test_json_contains_expr_postgresql_any_and_all():
+    session = make_session_with_dialect("postgresql")
+    col = make_column(table_name="servers")
+
+    # any-of: returns an OR of col.contains([...]) expressions (ClauseElement)
+    expr_any = json_contains_expr(session, col, ["x", "y"], match_any=True)
+    assert isinstance(expr_any, ClauseElement)
+
+    # all-of: returns col.contains(list) (ClauseElement)
+    expr_all = json_contains_expr(session, col, ["x", "y"], match_any=False)
+    assert isinstance(expr_all, ClauseElement)
+
+
+def test_json_contains_expr_sqlite_any_of_binds_params_correctly():
+    session = make_session_with_dialect("sqlite")
+    col = make_column(table_name="tools", col_name="tags")
+
+    values = ["test1", "test2"]
+    expr = json_contains_expr(session, col, values, match_any=True)
+
+    # Should be a ClauseElement (text() based)
+    assert isinstance(expr, ClauseElement)
+    sql_text = str(expr).lower()
+    assert "json_each" in sql_text  # uses json_each in SQLite branch
+    # compiled params should include our two values
+    compiled_params = expr.compile().params
+    assert set(compiled_params.values()) == set(values)
+
+
+def test_json_contains_expr_sqlite_all_of_and_combination():
+    session = make_session_with_dialect("sqlite")
+    col = make_column(table_name="tools", col_name="tags")
+
+    values = ["one"]
+    expr_single = json_contains_expr(session, col, values, match_any=False)
+    assert isinstance(expr_single, ClauseElement)
+    assert "json_each" in str(expr_single).lower()
+    # params contain the single value
+    assert list(expr_single.compile().params.values())[0] == "one"
+
+    # multi-value AND (all-of)
+    values_multi = ["a", "b"]
+    expr_multi = json_contains_expr(session, col, values_multi, match_any=False)
+    assert isinstance(expr_multi, ClauseElement)
+    # ensure compiled params contain both
+    assert set(expr_multi.compile().params.values()) == set(values_multi)
+
+
+def test_json_contains_expr_unsupported_dialect_raises():
+    session = make_session_with_dialect("oracle")
+    col = make_column()
+    with pytest.raises(RuntimeError):
+        json_contains_expr(session, col, ["x"])


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

Closes #857 

Filtering by tags during config export was broken since json_filtering is not supported in all dialects. Fixed by adding a helper function to handle this.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |   pass     |
| Manual regression no longer fails     | steps / screenshots  |   Tested by exporting config filtered with tags     |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
