### PR TITLE
Scope-based uniqueness for Virtual Servers (Private/Team/Public visibility rules)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -872,6 +872,8 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
         return JSONResponse(content={"message": str(ex), "success": False}, status_code=422)
     except ServerError as ex:
         return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+    except ServerNameConflictError as ex:
+        return JSONResponse(content={"message": str(ex), "success": False}, status_code=409)    
     except ValueError as ex:
         return JSONResponse(content={"message": str(ex), "success": False}, status_code=400)
     except ValidationError as ex:

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -2151,7 +2151,7 @@ class Server(Base):
     __tablename__ = "servers"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: uuid.uuid4().hex)
-    name: Mapped[str] = mapped_column(String(255), unique=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     icon: Mapped[Optional[str]] = mapped_column(String(767), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
@@ -2298,6 +2298,8 @@ class Server(Base):
     team_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("email_teams.id"), nullable=True)
     owner_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="private")
+
+    __table_args__ = (UniqueConstraint("team_id", "owner_email", "name", name="uq_team_owner_name_server"),)
 
 
 class Gateway(Base):

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -451,25 +451,95 @@ class TestServerService:
 
     @pytest.mark.asyncio
     async def test_update_server_name_conflict(self, server_service, mock_server, test_db):
-        server1 = mock_server
-        server2 = MagicMock(spec=DbServer)
-        server2.id = 2
-        server2.name = "existing_server"
-        server2.is_active = True
+        import types
+        from mcpgateway.services.server_service import ServerNameConflictError, ServerError
 
-        test_db.get = Mock(return_value=server1)
+        # --- PRIVATE: allow same name across users/teams (should NOT raise ServerNameConflictError) --- #
+        server_private = mock_server
+        server_private.id = "1"
+        server_private.name = "other_server"
+        server_private.visibility = "private"
+        server_private.team_id = "teamA"
+
+        # Simulate no conflict found (should not raise)
+        test_db.get = Mock(return_value=server_private)
         mock_scalar = Mock()
-        mock_scalar.scalar_one_or_none.return_value = server2
+        mock_scalar.scalar_one_or_none.return_value = None
         test_db.execute = Mock(return_value=mock_scalar)
         test_db.rollback = Mock()
+        test_db.refresh = Mock()
 
-        with pytest.raises(ServerError) as exc:
+        # Should not raise ServerNameConflictError for private, but should raise IntegrityError for duplicate name
+        from sqlalchemy.exc import IntegrityError
+        test_db.commit = Mock(side_effect=IntegrityError("Duplicate name", None, None))
+        with pytest.raises(IntegrityError):
             await server_service.update_server(
                 test_db,
-                1,
-                ServerUpdate(name="existing_server"),
+                "1",
+                ServerUpdate(name="existing_server", visibility="private"),
             )
-        assert "Server already exists with name" in str(exc.value)
+
+        # --- TEAM: restrict within team only (should raise ServerNameConflictError) --- #
+        server_team = mock_server
+        server_team.id = "2"
+        server_team.name = "other_server"
+        server_team.visibility = "team"
+        server_team.team_id = "teamA"
+
+        conflict_team_server = types.SimpleNamespace(
+            id="3",
+            name="existing_server",
+            is_active=True,
+            visibility="team",
+            team_id="teamA"
+        )
+
+        test_db.get = Mock(return_value=server_team)
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = conflict_team_server
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.rollback = Mock()
+        test_db.refresh = Mock()
+
+        with pytest.raises(ServerNameConflictError) as exc:
+            await server_service.update_server(
+                test_db,
+                "2",
+                ServerUpdate(name="existing_server", visibility="team", team_id="teamA"),
+            )
+        assert "Team Server already exists with name" in str(exc.value)
+        test_db.rollback.assert_called()
+
+        # --- PUBLIC: restrict globally (should raise ServerNameConflictError) --- #
+        server_public = mock_server
+        server_public.id = "4"
+        server_public.name = "other_server"
+        server_public.visibility = "public"
+        server_public.team_id = None
+
+        conflict_public_server = types.SimpleNamespace(
+            id="5",
+            name="existing_server",
+            is_active=True,
+            visibility="public",
+            team_id=None
+        )
+
+        test_db.get = Mock(return_value=server_public)
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = conflict_public_server
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.rollback = Mock()
+        test_db.refresh = Mock()
+
+        with pytest.raises(ServerNameConflictError) as exc:
+            await server_service.update_server(
+                test_db,
+                "4",
+                ServerUpdate(name="existing_server", visibility="public"),
+            )
+        assert "Public Server already exists with name" in str(exc.value)
+        test_db.rollback.assert_called()
 
     # -------------------------- toggle --------------------------------- #
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR updates the uniqueness logic for **Virtual Servers** to enforce constraints based on **visibility scope** (`private`, `team`, `public`) instead of globally on the `name` field.  

## Background / Issue
Previously, the `name` field had a **global unique constraint**.  

- If a user created a Virtual Server with `visibility = private`, other users could not create a server with the same name, even in a different team.  
- This prevented valid scenarios where names should only be unique within their visibility scope.  

## Fix Implemented
- **Database change**: Added a unique constraint on `(name,  owner_email,team_id)` to enforce **private-level uniqueness**.  
- **Application logic**: Implemented checks to enforce additional rules:  
  - **Private** → uniqueness enforced by DB constraint `(name, team_id, owner_email)`  
  - **Team** → validation ensures no duplicates within the same team  
  - **Public** → validation ensures no duplicates globally across all teams  
- Removed the old global uniqueness constraint on `name`.  

## Expected Behavior After Fix
| Visibility | Uniqueness Scope               | Example Conflict                                   |
|------------|-------------------------------|---------------------------------------------------|
| Private    | `(name, team_id, owner_email)` | Only if same user & same team                     |
| Team       | `(name, team_id)`              | Blocked if another user in the same team uses the same name |
| Public     | `(name)` globally              | Blocked if any user/team already created a public resource |

## Testing / Verification
- [x] User A (Team 1, private) can create `vir_name`  
- [x] User B (Team 2, private) can also create `vir_name` ✅ allowed  
- [x] Two users in the same team cannot create duplicate names ❌ blocked  
- [x] Public resource name is restricted globally ❌ blocked  
- [x] Migration tested with existing data  

## Next Steps
Apply the same visibility-based uniqueness logic to:  
- Gateway Servers  
- Tools  
- Resources  
- Prompts  
```

