### PR TITLE
fix: Support Kubernetes versions with vendor suffixes in Helm chart

### DIFF
--- a/charts/mcp-stack/Chart.yaml
+++ b/charts/mcp-stack/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # * appVersion   - upstream application version; shown in UIs but not
 #                  used for upgrade logic.
 # --------------------------------------------------------------------
-version: 0.6.1
+version: 0.6.2
 appVersion: "0.7.0"
 
 # Icon shown by registries / dashboards (must be an http(s) URL).
@@ -46,4 +46,4 @@ maintainers:
     url: https://github.com/IBM
 
 # Require Kubernetes ≥1.21 for networking v1 and recent securityContext fields
-kubeVersion: ">=1.21.0"
+kubeVersion: ">=1.21.0-0"

--- a/charts/mcp-stack/Chart.yaml
+++ b/charts/mcp-stack/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # * appVersion   - upstream application version; shown in UIs but not
 #                  used for upgrade logic.
 # --------------------------------------------------------------------
-version: 0.6.2
+version: 0.7.0
 appVersion: "0.7.0"
 
 # Icon shown by registries / dashboards (must be an http(s) URL).


### PR DESCRIPTION
## Summary
Fixes Helm chart installation failures on Kubernetes distributions with vendor-specific version suffixes.

## Problem
The current `kubeVersion: ">=1.21.0"` constraint in `Chart.yaml` fails to handle vendor-specific version suffixes like:
- AWS EKS: `1.31.10-eks-931bdca`
- Google GKE: `1.30.0-gke.1234`
- Other managed Kubernetes services with similar suffixes

## Solution
Changed `kubeVersion` constraint from `>=1.21.0` to `>=1.21.0-0` to properly support semantic versioning with pre-release/build metadata suffixes.

## Testing
- [x] Chart passes `helm lint` validation
- [x] Templates render correctly with default values
- [x] Chart version bumped from 0.6.1 to 0.6.2 (patch fix)

## Closes
Fixes #931