### PR TITLE
Token scoping issue

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -49,6 +49,8 @@ from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request as starletteRequest
+from starlette.responses import Response as starletteResponse
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 # First-Party
@@ -557,22 +559,36 @@ class DocsAuthMiddleware(BaseHTTPMiddleware):
 
 class MCPPathRewriteMiddleware:
     """
-    Supports requests like '/servers/<server_id>/mcp' by rewriting the path to '/mcp'.
+    Middleware that rewrites paths ending with '/mcp' to '/mcp', after performing authentication.
 
-    - Only rewrites paths ending with '/mcp' but not exactly '/mcp'.
-    - Performs authentication before rewriting.
-    - Passes rewritten requests to `streamable_http_session`.
+    - Rewrites paths like '/servers/<server_id>/mcp' to '/mcp'.
+    - Only paths ending with '/mcp' (but not exactly '/mcp') are rewritten.
+    - Authentication is performed before any path rewriting.
+    - If authentication fails, the request is not processed further.
     - All other requests are passed through without change.
+
+    Attributes:
+        application (Callable): The next ASGI application to process the request.
     """
 
-    def __init__(self, application):
+    def __init__(self, application, dispatch=None):
         """
         Initialize the middleware with the ASGI application.
 
         Args:
-            application (Callable): The next ASGI application in the middleware stack.
+            application (Callable): The next ASGI application to handle the request.
+            dispatch (Callable, optional): An optional dispatch function for additional middleware processing.
+
+        Example:
+            >>> import asyncio
+            >>> from unittest.mock import AsyncMock, patch
+            >>> app_mock = AsyncMock()
+            >>> middleware = MCPPathRewriteMiddleware(app_mock)
+            >>> isinstance(middleware.application, AsyncMock)
+            True
         """
         self.application = application
+        self.dispatch = dispatch  # this can be TokenScopingMiddleware
 
     async def __call__(self, scope, receive, send):
         """
@@ -586,39 +602,78 @@ class MCPPathRewriteMiddleware:
         Examples:
             >>> import asyncio
             >>> from unittest.mock import AsyncMock, patch
-            >>>
-            >>> # Test non-HTTP request passthrough
             >>> app_mock = AsyncMock()
             >>> middleware = MCPPathRewriteMiddleware(app_mock)
-            >>> scope = {"type": "websocket", "path": "/ws"}
+
+            >>> # Test path rewriting for /servers/123/mcp with headers in scope
+            >>> scope = { "type": "http", "path": "/servers/123/mcp", "headers": [(b"host", b"example.com")] }
             >>> receive = AsyncMock()
             >>> send = AsyncMock()
-            >>>
-            >>> asyncio.run(middleware(scope, receive, send))
-            >>> app_mock.assert_called_once_with(scope, receive, send)
-            >>>
-            >>> # Test path rewriting for /servers/123/mcp
-            >>> app_mock.reset_mock()
-            >>> scope = {"type": "http", "path": "/servers/123/mcp"}
             >>> with patch('mcpgateway.main.streamable_http_auth', return_value=True):
             ...     with patch.object(streamable_http_session, 'handle_streamable_http') as mock_handler:
             ...         asyncio.run(middleware(scope, receive, send))
             ...         scope["path"]
             '/mcp'
-            >>>
+
             >>> # Test regular path (no rewrite)
-            >>> scope = {"type": "http", "path": "/tools"}
+            >>> scope = { "type": "http","path": "/tools","headers": [(b"host", b"example.com")] }
             >>> with patch('mcpgateway.main.streamable_http_auth', return_value=True):
             ...     asyncio.run(middleware(scope, receive, send))
             ...     scope["path"]
             '/tools'
         """
-        # Only handle HTTP requests, HTTPS uses scope["type"] == "http" in ASGI
         if scope["type"] != "http":
             await self.application(scope, receive, send)
             return
 
-        # Call auth check first
+        # If a dispatch (request middleware) is provided, adapt it
+        if self.dispatch is not None:
+            request = starletteRequest(scope, receive=receive)
+
+            # async def call_next(req: starletteRequest) -> starletteResponse:
+            async def call_next(_req: starletteRequest) -> starletteResponse:
+                return await self._call_streamable_http(scope, receive, send)
+
+            response = await self.dispatch(request, call_next)
+
+            if response is None:
+                # Either the dispatch handled the response itself,
+                # or it blocked the request. Just return.
+                return
+
+            await response(scope, receive, send)
+            return
+
+        # Otherwise, just continue as normal
+        await self._call_streamable_http(scope, receive, send)
+
+    async def _call_streamable_http(self, scope, receive, send):
+        """
+        Handles the streamable HTTP request after authentication and path rewriting.
+
+        - If authentication is successful and the path is rewritten, this method processes the request
+          using the `streamable_http_session` handler.
+
+        Args:
+            scope (dict): The ASGI connection scope containing request metadata.
+            receive (Callable): The function to receive events from the client.
+            send (Callable): The function to send events to the client.
+
+        Example:
+            >>> import asyncio
+            >>> from unittest.mock import AsyncMock, patch
+            >>> app_mock = AsyncMock()
+            >>> middleware = MCPPathRewriteMiddleware(app_mock)
+            >>> scope = {"type": "http", "path": "/servers/123/mcp"}
+            >>> receive = AsyncMock()
+            >>> send = AsyncMock()
+            >>> with patch('mcpgateway.main.streamable_http_auth', return_value=True):
+            ...     with patch.object(streamable_http_session, 'handle_streamable_http') as mock_handler:
+            ...         asyncio.run(middleware._call_streamable_http(scope, receive, send))
+            >>> mock_handler.assert_called_once_with(scope, receive, send)
+            >>> # The streamable HTTP session handler was called after path rewriting.
+        """
+        # Auth check first
         auth_ok = await streamable_http_auth(scope, receive, send)
         if not auth_ok:
             return
@@ -657,12 +712,14 @@ app.add_middleware(SecurityHeadersMiddleware)
 # Add token scoping middleware (only when email auth is enabled)
 if settings.email_auth_enabled:
     app.add_middleware(BaseHTTPMiddleware, dispatch=token_scoping_middleware)
+    # Add streamable HTTP middleware for /mcp routes with token scoping
+    app.add_middleware(MCPPathRewriteMiddleware, dispatch=token_scoping_middleware)
+else:
+    # Add streamable HTTP middleware for /mcp routes
+    app.add_middleware(MCPPathRewriteMiddleware)
 
 # Add custom DocsAuthMiddleware
 app.add_middleware(DocsAuthMiddleware)
-
-# Add streamable HTTP middleware for /mcp routes
-app.add_middleware(MCPPathRewriteMiddleware)
 
 # Trust all proxies (or lock down with a list of host patterns)
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -631,6 +631,15 @@ class MCPPathRewriteMiddleware:
             request = starletteRequest(scope, receive=receive)
 
             async def call_next(_req: starletteRequest) -> starletteResponse:
+                """
+                Handles the next request in the middleware chain by calling a streamable HTTP response.
+
+                Args:
+                    _req (starletteRequest): The incoming request to be processed.
+
+                Returns:
+                    starletteResponse: A response generated from the streamable HTTP call.
+                """
                 return await self._call_streamable_http(scope, receive, send)
 
             response = await self.dispatch(request, call_next)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -630,7 +630,6 @@ class MCPPathRewriteMiddleware:
         if self.dispatch is not None:
             request = starletteRequest(scope, receive=receive)
 
-            # async def call_next(req: starletteRequest) -> starletteResponse:
             async def call_next(_req: starletteRequest) -> starletteResponse:
                 return await self._call_streamable_http(scope, receive, send)
 

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -18,14 +18,20 @@ from typing import Optional
 
 # Third-Party
 from fastapi import HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer
 
 # First-Party
 from mcpgateway.db import Permissions
+from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.verify_credentials import verify_jwt_token
 
 # Security scheme
 bearer_scheme = HTTPBearer(auto_error=False)
+
+# Initialize logging service first
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
 
 
 class TokenScopingMiddleware:
@@ -343,47 +349,68 @@ class TokenScopingMiddleware:
         Raises:
             HTTPException: If token scoping restrictions are violated
         """
-        # Skip scoping for certain paths (truly public endpoints only)
-        skip_paths = ["/health", "/metrics", "/openapi.json", "/docs", "/redoc", "/auth/email/login", "/auth/email/register", "/.well-known/"]
+        try:
+            # Skip scoping for certain paths (truly public endpoints only)
+            skip_paths = [
+                "/health",
+                "/metrics",
+                "/openapi.json",
+                "/docs",
+                "/redoc",
+                "/auth/email/login",
+                "/auth/email/register",
+                "/.well-known/",
+            ]
 
-        # Check exact root path separately
-        if request.url.path == "/":
+            # Check exact root path separately
+            if request.url.path == "/":
+                return await call_next(request)
+
+            if any(request.url.path.startswith(path) for path in skip_paths):
+                return await call_next(request)
+
+            # Extract token scopes
+            scopes = await self._extract_token_scopes(request)
+
+            # If no scopes, continue (regular auth will handle this)
+            if not scopes:
+                return await call_next(request)
+
+            # Check server ID restriction
+            server_id = scopes.get("server_id")
+            if not self._check_server_restriction(request.url.path, server_id):
+                logger.warning(f"Token not authorized for this server. Required: {server_id}")
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Token not authorized for this server. Required: {server_id}")
+
+            # Check IP restrictions
+            ip_restrictions = scopes.get("ip_restrictions", [])
+            if ip_restrictions:
+                client_ip = self._get_client_ip(request)
+                if not self._check_ip_restrictions(client_ip, ip_restrictions):
+                    logger.warning(f"Request from IP {client_ip} not allowed by token restrictions")
+                    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Request from IP {client_ip} not allowed by token restrictions")
+
+            # Check time restrictions
+            time_restrictions = scopes.get("time_restrictions", {})
+            if not self._check_time_restrictions(time_restrictions):
+                logger.warning("Request not allowed at this time by token restrictions")
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Request not allowed at this time by token restrictions")
+
+            # Check permission restrictions
+            permissions = scopes.get("permissions", [])
+            if not self._check_permission_restrictions(request.url.path, request.method, permissions):
+                logger.warning("Insufficient permissions for this operation")
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions for this operation")
+
+            # All scoping checks passed, continue
             return await call_next(request)
 
-        if any(request.url.path.startswith(path) for path in skip_paths):
-            return await call_next(request)
-
-        # Extract token scopes
-        scopes = await self._extract_token_scopes(request)
-
-        # If no scopes, continue (regular auth will handle this)
-        if not scopes:
-            return await call_next(request)
-
-        # Check server ID restriction
-        server_id = scopes.get("server_id")
-        if not self._check_server_restriction(request.url.path, server_id):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Token not authorized for this server. Required: {server_id}")
-
-        # Check IP restrictions
-        ip_restrictions = scopes.get("ip_restrictions", [])
-        if ip_restrictions:
-            client_ip = self._get_client_ip(request)
-            if not self._check_ip_restrictions(client_ip, ip_restrictions):
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Request from IP {client_ip} not allowed by token restrictions")
-
-        # Check time restrictions
-        time_restrictions = scopes.get("time_restrictions", {})
-        if not self._check_time_restrictions(time_restrictions):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Request not allowed at this time by token restrictions")
-
-        # Check permission restrictions
-        permissions = scopes.get("permissions", [])
-        if not self._check_permission_restrictions(request.url.path, request.method, permissions):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions for this operation")
-
-        # All scoping checks passed, continue to next handler
-        return await call_next(request)
+        except HTTPException as exc:
+            # Return clean JSON response instead of traceback
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+            )
 
 
 # Create middleware instance

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -7,6 +7,7 @@ This module tests the token scoping middleware, particularly the security fixes 
 """
 
 # Standard
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -83,6 +84,8 @@ class TestTokenScopingMiddleware:
         result = middleware._check_permission_restrictions("/admin", "GET", ["admin.read"])
         assert result == False, "Should reject non-canonical 'admin.read' permission"
 
+
+
     @pytest.mark.asyncio
     async def test_server_scoped_token_blocked_from_admin(self, middleware, mock_request):
         """Test that server-scoped tokens are blocked from admin endpoints (security fix)."""
@@ -94,16 +97,19 @@ class TestTokenScopingMiddleware:
         with patch.object(middleware, '_extract_token_scopes') as mock_extract:
             mock_extract.return_value = {"server_id": "specific-server"}
 
-            # Create mock call_next
+            # Mock call_next (the next middleware or request handler)
             call_next = AsyncMock()
 
-            # Should raise HTTPException due to server restriction
-            with pytest.raises(HTTPException) as exc_info:
-                await middleware(mock_request, call_next)
+            # Perform the request, which should return a JSONResponse instead of raising HTTPException
+            response = await middleware(mock_request, call_next)
 
-            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-            assert "not authorized for this server" in exc_info.value.detail
-            call_next.assert_not_called()
+            # Ensure response is a JSONResponse and parse its content
+            content = json.loads(response.body)  # Parse response content to dictionary
+
+            # Check that the response is a JSONResponse with status 403 and the correct detail
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+            assert "not authorized for this server" in content.get("detail")
+            call_next.assert_not_called()  # Ensure the next handler is not called
 
     @pytest.mark.asyncio
     async def test_permission_restricted_token_blocked_from_admin(self, middleware, mock_request):
@@ -116,15 +122,21 @@ class TestTokenScopingMiddleware:
         with patch.object(middleware, '_extract_token_scopes') as mock_extract:
             mock_extract.return_value = {"permissions": [Permissions.TOOLS_READ]}
 
+            # Mock call_next (the next middleware or request handler)
             call_next = AsyncMock()
 
-            # Should raise HTTPException due to insufficient permissions
-            with pytest.raises(HTTPException) as exc_info:
-                await middleware(mock_request, call_next)
+            # Perform the request, which should return a JSONResponse instead of raising HTTPException
+            response = await middleware(mock_request, call_next)
 
-            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-            assert "Insufficient permissions" in exc_info.value.detail
-            call_next.assert_not_called()
+            # Ensure response is a JSONResponse and parse its content
+            content = json.loads(response.body)  # Parse response content to dictionary
+
+            # Check that the response is a JSONResponse with status 403 and the correct detail
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+            assert "Insufficient permissions for this operation" in content.get("detail")
+            call_next.assert_not_called()  # Ensure the next handler is not called
+
+
 
     @pytest.mark.asyncio
     async def test_admin_token_allowed_to_admin_endpoints(self, middleware, mock_request):


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Closes #941

In the original implementation, the token_scoping_middleware was not being applied within the streamable_http process. Instead, the middleware chain used in streamable_http included MCPPathRewriteMiddleware, which handled request processing in a different way.

The fix introduced now ensures that the token_scoping_middleware is properly dispatched during the request flow. This middleware is responsible for verifying the token's validity and checking it against the required permissions. Only after this validation is completed, the token is forwarded for further processing within the handle_streamable_http function.

Improved raising token_scoping_middleware error, rather than raising exception, capture the exception and send with details, so the mcp client gets a correct response for the failure instead of just 500 with internal server error.

## 🔁 Reproduction Steps
1. Create two virtual servers, server-1 and server-2
2. Create an api-token scoped for a specific server with the id of server-1
3. Use the token to connect to server-1.
4. Notice that the same token can be used to connect to server-2 even if that server was not scoped with that api token.

## 🐞 Root Cause
streamable http middleware did not call the token_scoping_middleware, as a result the api token wasn't scoped as per the additional configurations.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
