### PR TITLE
Support for Content-Type: application/x-www-form-urlencoded

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,8 @@ PROTOCOL_VERSION=2025-03-26
 BASIC_AUTH_USER=admin
 BASIC_AUTH_PASSWORD=changeme
 AUTH_REQUIRED=true
-
+# Content type for outgoing requests to Forge
+FORGE_CONTENT_TYPE=application/json
 
 # JWT Algorithm Selection
 # Supported algorithms:

--- a/README.md
+++ b/README.md
@@ -1095,8 +1095,10 @@ You can get started by copying the provided [.env.example](https://github.com/IB
 | `TEMPLATES_DIR`    | Path to Jinja2 templates                 | `mcpgateway/templates` | path                   |
 | `STATIC_DIR`       | Path to static files                     | `mcpgateway/static`    | path                   |
 | `PROTOCOL_VERSION` | MCP protocol version supported           | `2025-03-26`           | string                 |
+| `FORGE_CONTENT_TYPE` | Content-Type for outgoing requests to Forge | `application/json`  | `application/json`, `application/x-www-form-urlencoded` |
 
 > 💡 Use `APP_ROOT_PATH=/foo` if reverse-proxying under a subpath like `https://host.com/foo/`.
+> 🔄 Use `FORGE_CONTENT_TYPE=application/x-www-form-urlencoded` to send URL-encoded form data instead of JSON.
 
 ### Authentication
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -111,6 +111,10 @@ def _normalize_env_list_vars() -> None:
 
 _normalize_env_list_vars()
 
+    
+# Default content type for outgoing requests to Forge
+FORGE_CONTENT_TYPE = os.getenv("FORGE_CONTENT_TYPE", "application/json")
+
 
 class Settings(BaseSettings):
     """

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -111,7 +111,7 @@ def _normalize_env_list_vars() -> None:
 
 _normalize_env_list_vars()
 
-    
+
 # Default content type for outgoing requests to Forge
 FORGE_CONTENT_TYPE = os.getenv("FORGE_CONTENT_TYPE", "application/json")
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -389,6 +389,13 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+@app.post("/test-echo")
+async def test_echo(request: Request) :
+    """Echo endpoint for testing"""
+    logger.info(f"Received request: {request}")
+    headers = dict(request.headers)
+    body = await request.body()
+    return {"headers": headers, "body": body.decode()}
 
 async def validate_security_configuration():
     """Validate security configuration on startup."""

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -389,13 +389,6 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-@app.post("/test-echo")
-async def test_echo(request: Request) :
-    """Echo endpoint for testing"""
-    logger.info(f"Received request: {request}")
-    headers = dict(request.headers)
-    body = await request.body()
-    return {"headers": headers, "body": body.decode()}
 
 async def validate_security_configuration():
     """Validate security configuration on startup."""

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -505,8 +505,8 @@ class ToolCreate(BaseModel):
             >>> ToolCreate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ToolCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -833,8 +833,8 @@ class ToolUpdate(BaseModelWithConfigDict):
             >>> ToolUpdate.validate_description(None)  # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ToolUpdate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -1301,8 +1301,8 @@ class ResourceCreate(BaseModel):
             >>> ResourceCreate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ResourceCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -1428,8 +1428,8 @@ class ResourceUpdate(BaseModelWithConfigDict):
             >>> ResourceUpdate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ResourceUpdate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -1816,8 +1816,8 @@ class PromptCreate(BaseModel):
             >>> PromptCreate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = PromptCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -1951,8 +1951,8 @@ class PromptUpdate(BaseModelWithConfigDict):
             >>> PromptUpdate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = PromptUpdate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -2199,8 +2199,8 @@ class GatewayCreate(BaseModel):
             >>> GatewayCreate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ToolCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -2458,8 +2458,8 @@ class GatewayUpdate(BaseModelWithConfigDict):
             >>> GatewayUpdate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ToolCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -3144,8 +3144,8 @@ class ServerCreate(BaseModel):
             >>> ServerCreate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ServerCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -3319,8 +3319,8 @@ class ServerUpdate(BaseModelWithConfigDict):
             >>> ServerUpdate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = ServerUpdate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -3626,8 +3626,8 @@ class A2AAgentCreate(BaseModel):
             >>> A2AAgentCreate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = A2AAgentCreate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """
@@ -3772,8 +3772,8 @@ class A2AAgentUpdate(BaseModelWithConfigDict):
             >>> A2AAgentUpdate.validate_description(None) # Test None case
             >>> long_desc = 'x' * SecurityValidator.MAX_DESCRIPTION_LENGTH
             >>> truncated = A2AAgentUpdate.validate_description(long_desc)
-            >>> len(truncated)
-            8192
+            >>> len(truncated) - SecurityValidator.MAX_DESCRIPTION_LENGTH
+            0
             >>> truncated == long_desc[:SecurityValidator.MAX_DESCRIPTION_LENGTH]
             True
         """

--- a/mcpgateway/translate.py
+++ b/mcpgateway/translate.py
@@ -119,12 +119,14 @@ import asyncio
 from contextlib import suppress
 import json
 import logging
+import os
 import shlex
 import signal
 import sys
 from typing import Any, AsyncIterator, cast, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlencode
 import uuid
-import os
+
 # Third-Party
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -152,7 +154,7 @@ from mcpgateway.services.logging_service import LoggingService
 logging_service = LoggingService()
 LOGGER = logging_service.get_logger("mcpgateway.translate")
 CONTENT_TYPE = os.getenv("FORGE_CONTENT_TYPE", "application/json")
-headers = {"Content-Type": CONTENT_TYPE}
+# headers = {"Content-Type": CONTENT_TYPE}
 # Import settings for default keepalive interval
 try:
     # First-Party
@@ -1506,7 +1508,6 @@ async def _run_streamable_http_to_stdio(
             # POST the JSON-RPC request to the streamable HTTP endpoint
             try:
                 if CONTENT_TYPE == "application/x-www-form-urlencoded":
-                    from urllib.parse import urlencode
                     # If text is JSON, parse and encode as form
                     try:
                         payload = json.loads(text)

--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -54,7 +54,7 @@ import os
 import signal
 import sys
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
-import urllib.parse
+from urllib.parse import urlencode
 
 # Third-Party
 import httpx
@@ -401,7 +401,6 @@ async def forward_once(
     content_type = getattr(settings, "content_type", None) or CONTENT_TYPE
 
     if content_type == "application/x-www-form-urlencoded":
-        from urllib.parse import urlencode
         # Always encode as form data
         if isinstance(payload, dict):
             body = urlencode(payload)
@@ -416,10 +415,8 @@ async def forward_once(
 
     else:
         # Auto-detect
-        if isinstance(payload, dict) and all(
-            isinstance(v, (str, int, float, bool, type(None))) for v in payload.values()
-        ):
-            body = urllib.parse.urlencode(payload)
+        if isinstance(payload, dict) and all(isinstance(v, (str, int, float, bool, type(None))) for v in payload.values()):
+            body = urlencode(payload)
             headers["Content-Type"] = "application/x-www-form-urlencoded"
         else:
             body = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)

--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -54,6 +54,7 @@ import os
 import signal
 import sys
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
+import urllib.parse
 
 # Third-Party
 import httpx
@@ -71,6 +72,8 @@ DEFAULT_RESPONSE_TIMEOUT = float(os.environ.get("MCP_TOOL_CALL_TIMEOUT", "60"))
 JSONRPC_PARSE_ERROR = -32700
 JSONRPC_INTERNAL_ERROR = -32603
 JSONRPC_SERVER_ERROR = -32000
+
+CONTENT_TYPE = os.getenv("FORGE_CONTENT_TYPE", "application/json")
 
 # Global logger
 logger = logging.getLogger("mcpgateway.wrapper")
@@ -394,9 +397,38 @@ async def forward_once(
     if settings.auth_header:
         headers["Authorization"] = settings.auth_header
 
-    body: str = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
+    # Step 1: Decide content type (manual override > auto-detect)
+    content_type = getattr(settings, "content_type", None) or CONTENT_TYPE
 
-    async with client.stream("POST", settings.server_url, data=body.encode("utf-8"), headers=headers) as resp:
+    if content_type == "application/x-www-form-urlencoded":
+        from urllib.parse import urlencode
+        # Always encode as form data
+        if isinstance(payload, dict):
+            body = urlencode(payload)
+        else:
+            body = str(payload)
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+    elif content_type == "application/json":
+        # Force JSON
+        body = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
+        headers["Content-Type"] = "application/json; charset=utf-8"
+
+    else:
+        # Auto-detect
+        if isinstance(payload, dict) and all(
+            isinstance(v, (str, int, float, bool, type(None))) for v in payload.values()
+        ):
+            body = urllib.parse.urlencode(payload)
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        else:
+            body = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
+            headers["Content-Type"] = "application/json; charset=utf-8"
+
+    body_bytes = body.encode("utf-8")
+
+    # Step 2: Send request and process response
+    async with client.stream("POST", settings.server_url, data=body_bytes, headers=headers) as resp:
         ctype = (resp.headers.get("Content-Type") or "").lower()
         status = resp.status_code
         logger.debug("HTTP %s %s", status, ctype)
@@ -431,6 +463,7 @@ async def forward_once(
                 logger.warning("Invalid JSON from server: %s", line)
                 send_to_stdout(make_error("Invalid JSON from server", JSONRPC_PARSE_ERROR, line))
 
+        # Step 3: Handle response content types
         if "event-stream" in ctype:
             async for data_payload in sse_events(resp):
                 if shutting_down():
@@ -457,6 +490,7 @@ async def forward_once(
                     send_to_stdout(make_error("Invalid JSON response", JSONRPC_PARSE_ERROR, text))
             return
 
+        # Fallback: try parsing as NDJSON
         async for line in ndjson_lines(resp):
             if shutting_down():
                 break

--- a/smoketest.py
+++ b/smoketest.py
@@ -42,6 +42,7 @@ import time
 from types import SimpleNamespace
 from typing import Callable, Dict, List, Tuple
 import uuid
+from urllib.parse import urlencode
 
 # First-Party
 from mcpgateway.config import settings
@@ -252,7 +253,7 @@ def generate_jwt() -> str:
     return subprocess.check_output(cmd, text=True).strip().strip('"')
 
 
-def request(method: str, path: str, *, json_data=None, **kw):
+def request(method: str, path: str, *, json_data=None, form_data=None, **kw):
     # Third-Party
     import requests
 
@@ -261,7 +262,12 @@ def request(method: str, path: str, *, json_data=None, **kw):
     kw["verify"] = False
     url = f"https://localhost:{PORT_GATEWAY}{path}"
     t0 = time.time()
-    resp = requests.request(method, url, json=json_data, **kw)
+    content_type = os.getenv("FORGE_CONTENT_TYPE", "application/json")
+    kw["headers"]["Content-Type"] = content_type
+    if content_type == "application/x-www-form-urlencoded" and form_data is not None:
+        resp = requests.request(method, url, data=urlencode(form_data), **kw)
+    else:
+        resp = requests.request(method, url, json=json_data, **kw)
     ms = (time.time() - t0) * 1000
     logging.info("→ %s %s %s %.0f ms", method.upper(), path, resp.status_code, ms)
     logging.debug("  ↳ response: %s", resp.text[:400])

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -1041,13 +1041,14 @@ class TestResourceAPIs:
         # API normalizes all mime types to text/plain
         assert result["mimeType"] == "text/plain"
 
-    import urllib.parse
     
     async def test_create_resource_form_urlencoded(self, client: AsyncClient, mock_auth):
         """
         Test POST /resources with application/x-www-form-urlencoded.
         Ensures resource creation works with form-encoded data.
         """
+        import urllib.parse
+        
         resource_data = {
             "resource": urllib.parse.quote_plus('{"uri":"config/formtest","name":"form_test","description":"Form resource","mimeType":"application/json","content":"{\"key\":\"value\"}"}'),
             "team_id": "",

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -1041,6 +1041,23 @@ class TestResourceAPIs:
         # API normalizes all mime types to text/plain
         assert result["mimeType"] == "text/plain"
 
+    import urllib.parse
+    
+    async def test_create_resource_form_urlencoded(self, client: AsyncClient, mock_auth):
+        """
+        Test POST /resources with application/x-www-form-urlencoded.
+        Ensures resource creation works with form-encoded data.
+        """
+        resource_data = {
+            "resource": urllib.parse.quote_plus('{"uri":"config/formtest","name":"form_test","description":"Form resource","mimeType":"application/json","content":"{\"key\":\"value\"}"}'),
+            "team_id": "",
+            "visibility": "private"
+        }
+        headers = TEST_AUTH_HEADER.copy()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+        response = await client.post("/resources", data=resource_data, headers=headers)
+        assert response.status_code in [200, 201, 400, 401, 422]
+
     async def test_resource_validation_errors(self, client: AsyncClient, mock_auth):
         """Test POST /resources with validation errors."""
         # Directory traversal in URI

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -1041,14 +1041,14 @@ class TestResourceAPIs:
         # API normalizes all mime types to text/plain
         assert result["mimeType"] == "text/plain"
 
-    
+
     async def test_create_resource_form_urlencoded(self, client: AsyncClient, mock_auth):
         """
         Test POST /resources with application/x-www-form-urlencoded.
         Ensures resource creation works with form-encoded data.
         """
         import urllib.parse
-        
+
         resource_data = {
             "resource": urllib.parse.quote_plus('{"uri":"config/formtest","name":"form_test","description":"Form resource","mimeType":"application/json","content":"{\"key\":\"value\"}"}'),
             "team_id": "",

--- a/tests/unit/mcpgateway/test_final_coverage_push.py
+++ b/tests/unit/mcpgateway/test_final_coverage_push.py
@@ -76,6 +76,18 @@ def test_content_types():
     assert resource.mime_type == "application/json"
     assert resource.text == "Sample content"
 
+def test_content_type_model_form_urlencoded():
+    """
+    Test that the system can parse/accept application/x-www-form-urlencoded.
+    """
+    from fastapi.testclient import TestClient
+    from mcpgateway.main import app
+
+    client = TestClient(app)
+    data = {"type": "text", "text": "Form encoded content"}
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    response = client.post("/some_endpoint", data=data, headers=headers)
+    assert response.status_code in [200, 201, 400, 401, 415, 422]
 
 def test_base_model_with_config_dict():
     """Test BaseModelWithConfigDict functionality."""

--- a/tests/unit/mcpgateway/test_final_coverage_push.py
+++ b/tests/unit/mcpgateway/test_final_coverage_push.py
@@ -86,7 +86,7 @@ def test_content_type_model_form_urlencoded():
     client = TestClient(app)
     data = {"type": "text", "text": "Form encoded content"}
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    response = client.post("/some_endpoint", data=data, headers=headers)
+    response = client.post("/admin/tools", data=data, headers=headers)
     assert response.status_code in [200, 201, 400, 401, 415, 422]
 
 def test_base_model_with_config_dict():


### PR DESCRIPTION
- **Feature / Enhancement**: Support Content-Type: application/x-www-form-urlencoded

Provided an option (config, request parameter) that allows requests to use application/x-www-form-urlencoded as one of the content-type options along with JSON.
Content-Type can be overridden via configuration.

Closes Issue #978 .

