### PR TITLE
fixed duplication of app_root_path for static files

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4237,7 +4237,7 @@ if UI_ENABLED:
     try:
         # Create a sub-application for static files that will respect root_path
         static_app = StaticFiles(directory=str(settings.static_dir))
-        STATIC_PATH = f"{settings.app_root_path}/static" if settings.app_root_path else "/static"
+        STATIC_PATH = "/static"
 
         app.mount(
             STATIC_PATH,


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
When APP_ROOT_PATH is set, the specified path is being added twice to the static file paths, which causes failures in loading UI styles and JavaScript elements. Since the root_path is already handled by the HTML template, there is no need to re add APP_ROOT_PATH to the static mount.

## 🔁 Reproduction Steps
1. Set APP_ROOT_PATH env variable in the .env file to "/dev/my-path"
2. Load the gateway UI
3. Notice that the UI is not loaded properly, the tabs don't work and the css and js files are not loaded properly. 


## 💡 Fix Description
Identified the source of the APP_ROOT_PATH duplication and removed its integration at that point.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed

