### PR TITLE
fix: fixed retry on MCP client plugin connection.

### DIFF
--- a/mcpgateway/plugins/framework/external/mcp/client.py
+++ b/mcpgateway/plugins/framework/external/mcp/client.py
@@ -135,29 +135,54 @@ class ExternalPlugin(Plugin):
             raise PluginError(error=convert_exception_to_error(e, plugin_name=self.name))
 
     async def __connect_to_http_server(self, uri: str) -> None:
-        """Connect to an MCP plugin server via streamable http.
+        """Connect to an MCP plugin server via streamable http with retry logic.
 
         Args:
             uri: the URI of the mcp plugin server.
 
         Raises:
-            PluginError: if there is an external connection error.
+            PluginError: if there is an external connection error after all retries.
         """
+        max_retries = 3
+        base_delay = 1.0
 
-        try:
-            http_transport = await self._exit_stack.enter_async_context(streamablehttp_client(uri))
-            self._http, self._write, _ = http_transport
-            self._session = await self._exit_stack.enter_async_context(ClientSession(self._http, self._write))
+        for attempt in range(max_retries):
+            logger.info(f"Connecting to external plugin server: {uri} (attempt {attempt + 1}/{max_retries})")
 
-            await self._session.initialize()
+            try:
+                # Create a fresh exit stack for each attempt
+                async with AsyncExitStack() as temp_stack:
+                    http_transport = await temp_stack.enter_async_context(streamablehttp_client(uri))
+                    http_client, write_func, _ = http_transport
+                    session = await temp_stack.enter_async_context(ClientSession(http_client, write_func))
 
-            # List available tools
-            response = await self._session.list_tools()
-            tools = response.tools
-            logger.info("\nConnected to plugin MCP (http) server with tools: %s", " ".join([tool.name for tool in tools]))
-        except Exception as e:
-            logger.exception(e)
-            raise PluginError(error=convert_exception_to_error(e, plugin_name=self.name))
+                    await session.initialize()
+
+                    # List available tools
+                    response = await session.list_tools()
+                    tools = response.tools
+                    logger.info("Successfully connected to plugin MCP server with tools: %s", " ".join([tool.name for tool in tools]))
+
+                # Success! Now move to the main exit stack
+                self._http = await self._exit_stack.enter_async_context(streamablehttp_client(uri))
+                self._http, self._write, _ = self._http
+                self._session = await self._exit_stack.enter_async_context(ClientSession(self._http, self._write))
+                await self._session.initialize()
+                return
+
+            except Exception as e:
+                logger.warning(f"Connection attempt {attempt + 1}/{max_retries} failed: {e}")
+
+                if attempt == max_retries - 1:
+                    # Final attempt failed
+                    error_msg = f"External plugin '{self.name}' connection failed after {max_retries} attempts: {uri} is not reachable. Please ensure the MCP server is running."
+                    logger.error(error_msg)
+                    raise PluginError(error=PluginErrorModel(message=error_msg, plugin_name=self.name))
+                await self.shutdown()
+                # Wait before retry
+                delay = base_delay * (2**attempt)
+                logger.info(f"Retrying in {delay}s...")
+                await asyncio.sleep(delay)
 
     async def __invoke_hook(self, payload_result_model: Type[P], hook_type: HookType, payload: BaseModel, context: PluginContext) -> P:
         """Invoke an external plugin hook using the MCP protocol.
@@ -296,4 +321,5 @@ class ExternalPlugin(Plugin):
 
     async def shutdown(self) -> None:
         """Plugin cleanup code."""
-        await self._exit_stack.aclose()
+        if self._exit_stack:
+            await self._exit_stack.aclose()


### PR DESCRIPTION
### 🐞 Bug Summary
Briefly describe the issue or unexpected behavior.

The max retry code was accidentally removed from the external plugin MCP client.  However, it also had a small bug, which caused it to error out on MCPGateway startup when an external plugin.  The issue was that the final session connection was being done in the context of the initial temporary connection.  As a result, the async exit stack which manages the connection was being unravelled in a bad order.


---

### 🧩 Affected Component
Select the area of the project impacted:

- [x] `mcpgateway` - API
- [ ] `mcpgateway` - UI (admin panel)
- [ ] `mcpgateway.wrapper` - stdio wrapper
- [ ] Federation or Transports
- [ ] CLI, Makefiles, or shell scripts
- [ ] Container setup (Docker/Podman/Compose)
- [x] Other (explain below)

---

### 🔁 Steps to Reproduce

1. Configure an external plugin in the MCP Gateway.
2. Start up the server with plugins enabled.
3. The server should immediately crash.
---

### 🤔 Expected Behavior

The server should start as expected.


---

### 📓 Logs / Error Output

```
2025-09-15 10:38:08,344 - mcpgateway.services.gateway_service - INFO - Gateway service shutdown complete
2025-09-15 10:38:08,344 - mcpgateway.services.prompt_service - INFO - Prompt service shutdown complete
2025-09-15 10:38:08,345 - mcpgateway.services.resource_service - INFO - Resource service shutdown complete
2025-09-15 10:38:08,345 - mcpgateway.services.tool_service - INFO - Tool service shutdown complete
2025-09-15 10:38:08,345 - mcpgateway.transports.streamablehttp_transport - INFO - Stopping Streamable HTTP Session Manager...
2025-09-15 10:38:08,346 - mcpgateway - INFO - Shutdown complete
2025-09-15 10:38:08,351 - uvicorn.error - ERROR -   + Exception Group Traceback (most recent call last):
  |   File "/Users/t/.venv/mcpgateway/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  |         "unhandled errors in a TaskGroup", self._exceptions
  |     ) from None
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/t/.venv/mcpgateway/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 776, in __aexit__
    |     raise exc_val
    |   File "/Users/t/.venv/mcpgateway/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 744, in __aexit__
    |     await self._on_completed_fut
    | asyncio.exceptions.CancelledError: Cancelled by cancel scope 1302defd0
    | 
    | During handling of the above exception, another exception occurred:
    | 
    | Traceback (most recent call last):
    |   File "/Users/t/.venv/mcpgateway/lib/python3.13/site-packages/mcp/client/streamable_http.py", line 502, in streamablehttp_client
    |     yield (
    |     ...<3 lines>...
    |     )
    |   File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py", line 751, in __aexit__
    |     cb_suppress = await cb(*exc_details)
```

---

### 🧠 Environment Info
You can retrieve most of this from the `/version` endpoint.

| Key | Value |
|-----|-------|
| Version or commit | `0.6.0` |
| Runtime | `Python 3.13, Gunicorn` |
| Platform / OS | `macOS` |
| Container | `none` |
