### PR TITLE
Fix: Remove @require_permission("teams.join") from admin_create_join_request (Issue #1022)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -3580,7 +3580,6 @@ async def admin_leave_team(
 
 
 @admin_router.post("/teams/{team_id}/join-request")
-@require_permission("teams.join")
 async def admin_create_join_request(
     team_id: str,
     request: Request,


### PR DESCRIPTION

This PR addresses [issue #1022](https://github.com/IBM/mcp-context-forge/issues/1022)
During analysis, we found that removing @require_permission("teams.join") enables the request to correctly reach admin_create_join_request. Previously, it was blocked by the permission check, causing different behavior for admins and normal users.

This update removes the @require_permission("teams.join") to ensure consistent access for all users.