### PR TITLE
feat(helm): add image pull secrets support and enhance ingress TLS co…

### DIFF
--- a/charts/mcp-stack/templates/_helpers.tpl
+++ b/charts/mcp-stack/templates/_helpers.tpl
@@ -3,7 +3,7 @@
      -------------------------------------------------------------------- */}}
 {{- define "mcp-stack.fullname" -}}
 {{- if .Values.global.fullnameOverride }}
-{{ .Values.global.fullnameOverride }}
+{{- .Values.global.fullnameOverride }}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.global.nameOverride }}
 {{- if contains $name .Release.Name }}

--- a/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
+++ b/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
@@ -23,6 +23,13 @@ spec:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-mcp-fast-time-server
     spec:
+      # Image pull secrets
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: mcp-fast-time-server
           image: "{{ .Values.mcpFastTimeServer.image.repository }}:{{ .Values.mcpFastTimeServer.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -28,6 +28,13 @@ spec:
         app: {{ include "mcp-stack.fullname" . }}-mcpgateway
 
     spec:
+      # Image pull secrets
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: mcp-context-forge
           image: "{{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-pgadmin.yaml
+++ b/charts/mcp-stack/templates/deployment-pgadmin.yaml
@@ -21,6 +21,13 @@ spec:
         app: pgadmin
         release: {{ .Release.Name }}
     spec:
+      # Image pull secrets
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: pgadmin
           image: "{{ .Values.pgadmin.image.repository }}:{{ .Values.pgadmin.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-postgres.yaml
+++ b/charts/mcp-stack/templates/deployment-postgres.yaml
@@ -26,6 +26,13 @@ spec:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-postgres
     spec:
+      # Image pull secrets
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-redis-commander.yaml
+++ b/charts/mcp-stack/templates/deployment-redis-commander.yaml
@@ -21,6 +21,13 @@ spec:
         app: redis-commander
         release: {{ .Release.Name }}
     spec:
+      # Image pull secrets
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: redis-commander
           image: "{{ .Values.redisCommander.image.repository }}:{{ .Values.redisCommander.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-redis.yaml
+++ b/charts/mcp-stack/templates/deployment-redis.yaml
@@ -24,6 +24,13 @@ spec:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-redis
     spec:
+      # Image pull secrets
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"

--- a/charts/mcp-stack/templates/ingress.yaml
+++ b/charts/mcp-stack/templates/ingress.yaml
@@ -17,6 +17,14 @@ metadata:
     {{- end }}
 spec:
   ingressClassName: {{ .Values.mcpContextForge.ingress.className }}
+  {{- if .Values.mcpContextForge.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.mcpContextForge.ingress.host }}
+      {{- if .Values.mcpContextForge.ingress.tls.secretName }}
+      secretName: {{ .Values.mcpContextForge.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
   rules:
     - host: {{ .Values.mcpContextForge.ingress.host }}
       http:

--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -24,6 +24,12 @@ spec:
           image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
           imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
 
+          # Image pull secrets
+          imagePullSecrets:
+            {{- range .Values.global.imagePullSecrets }}
+            - name: {{ . }}
+            {{- end }}
+
           # Migration workflow: wait for DB → run migrations
           command: ["/bin/sh"]
           args:
@@ -71,6 +77,8 @@ spec:
 
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -191,6 +191,23 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "tls": {
+              "type": "object",
+              "description": "TLS configuration for ingress",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable TLS for ingress",
+                  "default": false
+                },
+                "secretName": {
+                  "type": "string",
+                  "description": "Name of the TLS secret (optional, auto-generated if empty)",
+                  "default": ""
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -87,6 +87,10 @@ mcpContextForge:
     pathType: Prefix
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /
+      # cert-manager.io/cluster-issuer: letsencrypt-prod  # Uncomment to enable automatic TLS cert generation
+    tls:
+      enabled: false            # Set to true to enable TLS
+      secretName: ""            # Name of the TLS secret (auto-generated if empty)
 
   ####################################################################
   # CORE ENVIRONMENT - injected one-by-one as name/value pairs.
@@ -561,21 +565,21 @@ pgadmin:
       type: http
       path: /misc/ping      # lightweight endpoint
       port: 80
-      initialDelaySeconds: 15
+      initialDelaySeconds: 60     # pgAdmin needs more time to initialize
       periodSeconds: 10
-      timeoutSeconds: 2
+      timeoutSeconds: 5           # increased timeout
       successThreshold: 1
-      failureThreshold: 3
+      failureThreshold: 5         # more tolerance for failures
 
     liveness:
       type: http
       path: /misc/ping
       port: 80
-      initialDelaySeconds: 10
-      periodSeconds: 15
-      timeoutSeconds: 2
+      initialDelaySeconds: 90     # even longer for liveness
+      periodSeconds: 20           # check less frequently
+      timeoutSeconds: 5           # increased timeout
       successThreshold: 1
-      failureThreshold: 5
+      failureThreshold: 3         # less aggressive killing
 
 ########################################################################
 # REDIS-COMMANDER - Web UI for Redis


### PR DESCRIPTION
# Add Image Pull Secrets Support and Enhance Ingress TLS Configuration

## Summary
Enhances the MCP Stack Helm Chart with support for private container registries and HTTPS/TLS termination for production deployments.

## Changes

### Image Pull Secrets Support
- Added global `imagePullSecrets` configuration for all deployments
- Updated all deployment templates (mcpgateway, postgres, redis, pgadmin, redis-commander, mcp-fast-time-server, migration job)

### Ingress TLS Enhancement
- Added TLS configuration support with `tls.enabled` and `tls.secretName` options
- Included cert-manager annotations for automatic certificate generation
- Updated JSON schema validation for TLS fields

### Configuration Improvements
- Fixed template syntax in `_helpers.tpl` for `fullnameOverride`
- Enhanced pgAdmin probe configuration with longer timeouts for better stability

## Usage

### Private Registry
```yaml
global:
  imagePullSecrets: ["registry-secret"]
 ```

TLS Ingress
```yaml
mcpContextForge:
  ingress:
    tls:
      enabled: true
      secretName: "mcp-stack-tls"
```

## Impact
- Enables deployment in private registry environments
- Adds HTTPS support for production clusters
- Improves deployment reliability
- Maintains backward compatibility (all features opt-in)