### PR TITLE
fix: multi-arch support for opa server

### DIFF
--- a/plugins/external/opa/Containerfile
+++ b/plugins/external/opa/Containerfile
@@ -11,6 +11,9 @@ ARG SKILLS_SDK_COMMIT_ID
 ARG SKILLS_SDK_VERSION
 ARG BUILD_TIME_SKILLS_INSTALL
 
+ARG OPASERVER_VERSION=1.8.0
+ARG TARGETARCH
+
 ENV APP_HOME=/app
 
 USER 0
@@ -28,7 +31,7 @@ RUN mkdir -p ${APP_HOME} && \
     chown -R 1001:0 ${HOME}/resources/config
 
 # Install opa in container
-RUN curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/v1.7.0/opa_linux_arm64_static
+RUN curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/v${OPASERVER_VERSION}/opa_linux_${TARGETARCH}_static
 RUN chmod +x /usr/local/bin/opa
 RUN opa version
 

--- a/plugins/external/opa/Makefile
+++ b/plugins/external/opa/Makefile
@@ -8,6 +8,7 @@ SHELL := /bin/bash
 PACKAGE_NAME = opapluginfilter
 PROJECT_NAME = opapluginfilter
 TARGET ?= opapluginfilter
+OPASERVER_VERSION ?= 1.8.0
 
 # Virtual-environment variables
 VENVS_DIR ?= $(HOME)/.venv
@@ -117,6 +118,7 @@ container-build:
 	@echo "🔨 Building with $(CONTAINER_RUNTIME) for platform $(PLATFORM)..."
 	$(CONTAINER_RUNTIME) build \
 		--platform=$(PLATFORM) \
+		--build-arg OPASERVER_VERSION=$(OPASERVER_VERSION) \
 		-f $(CONTAINER_FILE) \
 		--tag $(IMAGE_BASE):$(IMAGE_TAG) \
 		.


### PR DESCRIPTION
### Description

This PR fixes an issue where the OPA Server architecture was hard-coded to `arm64`, preventing the OPA plugin from deploying on amd64/x86 environments. 

```dockerfile 
RUN curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/v1.7.0/opa_linux_arm64_static
```

### Solution

Make the target architecture configurable, leveraging the existing multi-platform build infrastructure of external plugins.

**Bonus**: Make the OPA server version a configurable build argument.