### PR TITLE
Fix async token creation

### DIFF
--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -636,7 +636,7 @@ mcpFastTimeServer:
   replicaCount: 2
   image:
     repository: ghcr.io/ibm/fast-time-server
-    tag: "0.7.0"
+    tag: "0.5.0"
     pullPolicy: IfNotPresent
   port: 8080
 

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -636,7 +636,7 @@ mcpFastTimeServer:
   replicaCount: 2
   image:
     repository: ghcr.io/ibm/fast-time-server
-    tag: "0.5.0"
+    tag: "0.7.0"
     pullPolicy: IfNotPresent
   port: 8080
 

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -148,7 +148,7 @@ async def login(login_request: LoginRequest, request: Request, db: Session = Dep
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
 
         # Create session JWT token (Tier 1 authentication)
-        access_token, expires_in = create_access_token(user)
+        access_token, expires_in = await create_access_token(user)
 
         logger.info(f"User {email} authenticated successfully")
 


### PR DESCRIPTION
# Description
Updates the `auth.py` router to correctly `await` the asynchronous `create_access_token(user)` function during login.

# Changes
**File:** `mcpgateway/routers/auth.py`

```python
# Before
access_token, expires_in = create_access_token(user)

# After
access_token, expires_in = await create_access_token(user)
```
