### PR TITLE
Fix: Get /a2a/ returns 500 due to datatype mistmatch

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2155,7 +2155,7 @@ async def admin_ui(
     if a2a_service and settings.mcpgateway_a2a_enabled:
         a2a_agents_raw = await a2a_service.list_agents_for_user(
             db,
-            user_email=user_email,
+            user_info=user_email,
             include_inactive=include_inactive,
         )
         a2a_agents = [agent.model_dump(by_alias=True) for agent in a2a_agents_raw]
@@ -8647,7 +8647,7 @@ async def admin_list_a2a_agents(
 
     agents = await a2a_service.list_agents_for_user(
         db,
-        user_email=user_email,
+        user_info=user_email,
         include_inactive=include_inactive,
     )
     return [agent.model_dump(by_alias=True) for agent in agents]

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1776,7 +1776,7 @@ async def list_a2a_agents(
     # Use team-aware filtering
     if a2a_service is None:
         raise HTTPException(status_code=503, detail="A2A service not available")
-    return await a2a_service.list_agents_for_user(db, user_email=user_email, team_id=team_id, visibility=visibility, include_inactive=include_inactive, skip=skip, limit=limit)
+    return await a2a_service.list_agents_for_user(db, user_info=user_email, team_id=team_id, visibility=visibility, include_inactive=include_inactive, skip=skip, limit=limit)
 
 
 @a2a_router.get("/{agent_id}", response_model=A2AAgentRead)

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -259,7 +259,7 @@ class A2AAgentService:
 
         Args:
             db: Database session
-            user_info: Object representing identity of the user requesting agents
+            user_info: Object representing identity of the user who is requesting agents
             team_id: Optional team ID to filter by specific team
             visibility: Optional visibility filter (private, team, public)
             include_inactive: Whether to include inactive agents
@@ -270,7 +270,7 @@ class A2AAgentService:
             List[A2AAgentRead]: A2A agents the user has access to
         """
 
-        # Handle case where user_info is a string instead of dict (<0.7.0)
+        # Handle case where user_info is a string (email) instead of dict (<0.7.0)
         if isinstance(user_info, str):
             user_email = str(user_info)
         else:

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -252,14 +252,14 @@ class A2AAgentService:
         return [self._db_to_schema(agent) for agent in agents]
 
     async def list_agents_for_user(
-        self, db: Session, user_email: str, team_id: Optional[str] = None, visibility: Optional[str] = None, include_inactive: bool = False, skip: int = 0, limit: int = 100
+        self, db: Session, user_info: Dict[str, Any], team_id: Optional[str] = None, visibility: Optional[str] = None, include_inactive: bool = False, skip: int = 0, limit: int = 100
     ) -> List[A2AAgentRead]:
         """
         List A2A agents user has access to with team filtering.
 
         Args:
             db: Database session
-            user_email: Email of the user requesting agents
+            user_info: Object representing identity of the user requesting agents
             team_id: Optional team ID to filter by specific team
             visibility: Optional visibility filter (private, team, public)
             include_inactive: Whether to include inactive agents
@@ -269,6 +269,12 @@ class A2AAgentService:
         Returns:
             List[A2AAgentRead]: A2A agents the user has access to
         """
+
+        # Handle case where user_info is a string instead of dict (<0.7.0)
+        if isinstance(user_info, str):
+            user_email = str(user_info)
+        else:
+            user_email = user_info.get("email", "")
 
         # Build query following existing patterns from list_prompts()
         team_service = TeamManagementService(db)


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Fix [Get /a2a/ returns 500 error](https://github.com/IBM/mcp-context-forge/issues/1125)

## 🔁 Reproduction Steps
1. Enable debug mode, and then perform GET /a2a/ from client
```
curl -X 'GET' \
 'https://.../a2a/?include_inactive=false&skip=0&limit=100' \
 -H 'accept: application/json' \
 -H 'Authorization: Bearer ...'
```
2. Receive 500 error


## 🐞 Root Cause
In mcpgateway/services/a2a_service.py
```
list_agents_for_user(
        self, db: Session, user_email: str, team_id: Optional[str] = None, visibility: Optional[str] = None, include_inactive: bool = False, skip: int = 0, limit: int = 100
    ) -> List[A2AAgentRead]:
```
Before 0.7.0, the value passed to variable user_email is a string representing user email.

Starting 0.7.0, the value passed to variable user_email is a dictionary with fields email, full_name, is_admin, ip_address, user_agent.

## 💡 Fix Description
Changed function signature, renamed user_email to user_info.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   ✅    |
| Unit tests                            | `make test`          |   ✅     |
| Coverage ≥ 90 %                       | `make coverage`      |   ✅     |

## ✅ Checklist
- [v ] Code formatted (`make black isort pre-commit`)
- [v ] No secrets/credentials committed
