### PR TITLE
Fix encode in SecretStr

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -220,7 +220,7 @@ class Settings(BaseSettings):
     proxy_user_header: str = Field(default="X-Authenticated-User", description="Header containing authenticated username from proxy")
 
     #  Encryption key phrase for auth storage
-    auth_encryption_secret: SecretStr = Field(default="my-test-salt", env="AUTH_ENCRYPTION_SECRET")
+    auth_encryption_secret: SecretStr = Field(default=SecretStr("my-test-salt"), env="AUTH_ENCRYPTION_SECRET")
 
     # OAuth Configuration
     oauth_request_timeout: int = Field(default=30, description="OAuth request timeout in seconds")

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -431,7 +431,7 @@ class OAuthManager:
             received_signature = state_with_sig[-32:]
 
             # Verify HMAC signature
-            secret_key = self.settings.auth_encryption_secret.encode() if self.settings.auth_encryption_secret else b"default-secret-key"
+            secret_key = self.settings.auth_encryption_secret.get_secret_value().encode() if self.settings.auth_encryption_secret else b"default-secret-key"
             expected_signature = hmac.new(secret_key, state_bytes, hashlib.sha256).digest()
 
             if not hmac.compare_digest(received_signature, expected_signature):
@@ -507,7 +507,7 @@ class OAuthManager:
         state_bytes = state_json.encode()
 
         # Create HMAC signature
-        secret_key = self.settings.auth_encryption_secret.encode() if self.settings.auth_encryption_secret else b"default-secret-key"
+        secret_key = self.settings.auth_encryption_secret.get_secret_value().encode() if self.settings.auth_encryption_secret else b"default-secret-key"
         signature = hmac.new(secret_key, state_bytes, hashlib.sha256).digest()
 
         # Combine state and signature, then base64 encode

--- a/mcpgateway/utils/oauth_encryption.py
+++ b/mcpgateway/utils/oauth_encryption.py
@@ -14,12 +14,12 @@ using the AUTH_ENCRYPTION_SECRET from configuration.
 import base64
 import logging
 from typing import Optional
-from pydantic import SecretStr
 
 # Third-Party
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from pydantic import SecretStr
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ def get_oauth_encryption(encryption_secret: SecretStr) -> OAuthEncryption:
         OAuthEncryption instance
 
     Examples:
-        >>> enc = get_oauth_encryption('k')
+        >>> enc = get_oauth_encryption(SecretStr('k'))
         >>> isinstance(enc, OAuthEncryption)
         True
     """

--- a/mcpgateway/utils/oauth_encryption.py
+++ b/mcpgateway/utils/oauth_encryption.py
@@ -29,7 +29,7 @@ class OAuthEncryption:
 
     Examples:
         Basic roundtrip:
-        >>> enc = OAuthEncryption('very-secret-key')
+        >>> enc = OAuthEncryption(SecretStr('very-secret-key'))
         >>> cipher = enc.encrypt_secret('hello')
         >>> isinstance(cipher, str) and enc.is_encrypted(cipher)
         True
@@ -124,7 +124,7 @@ class OAuthEncryption:
             return False
 
 
-def get_oauth_encryption(encryption_secret: str) -> OAuthEncryption:
+def get_oauth_encryption(encryption_secret: SecretStr) -> OAuthEncryption:
     """Get an OAuth encryption instance.
 
     Args:

--- a/mcpgateway/utils/oauth_encryption.py
+++ b/mcpgateway/utils/oauth_encryption.py
@@ -47,7 +47,7 @@ class OAuthEncryption:
         Args:
             encryption_secret: Secret key for encryption/decryption
         """
-        self.encryption_secret = encryption_secret.get_secret_value()encode()
+        self.encryption_secret = encryption_secret.get_secret_value().encode()
         self._fernet = None
 
     def _get_fernet(self) -> Fernet:

--- a/mcpgateway/utils/oauth_encryption.py
+++ b/mcpgateway/utils/oauth_encryption.py
@@ -14,6 +14,7 @@ using the AUTH_ENCRYPTION_SECRET from configuration.
 import base64
 import logging
 from typing import Optional
+from pydantic import SecretStr
 
 # Third-Party
 from cryptography.fernet import Fernet
@@ -40,13 +41,13 @@ class OAuthEncryption:
         False
     """
 
-    def __init__(self, encryption_secret: str):
+    def __init__(self, encryption_secret: SecretStr):
         """Initialize the encryption handler.
 
         Args:
             encryption_secret: Secret key for encryption/decryption
         """
-        self.encryption_secret = encryption_secret.encode()
+        self.encryption_secret = encryption_secret.get_secret_value()encode()
         self._fernet = None
 
     def _get_fernet(self) -> Fernet:


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
1. Fixes encode for `auth_encryption_secret` after it is changed to SecretStr and updates relevant test cases.
2. Fixes specifically addition of OAuth MCP servers

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |   pass     |
| Manual regression no longer fails     | steps / screenshots  |   Tested with GitHub repo     |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
