### PR TITLE
Fix header propagation so we don's send X-Vault-Headers to mcp server

### DIFF
--- a/plugins/vault/README.md
+++ b/plugins/vault/README.md
@@ -94,5 +94,53 @@ async def vault_pre_fetch(self, payload: VaultPreFetchPayload) -> VaultPreFetchP
 
 
 ## Testing
-TBD
-### Run Individual Tests
+### Create an MCP gateway  that is OAUTH2 authenticated:
+
+```bash
+curl -s \
+  -X POST \
+  -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "github_com",
+        "url": "https://api.githubcopilot.com/mcp/",
+        "description": "A new MCP server added with OAuth2 authentication",
+        "auth_type": "oauth",
+        "auth_value": {
+          "client_id": "'$CLIENT_ID'",
+          "client_secret": "'$CLIENT_SECRET'",
+          "token_url": "https://github.com/login/oauth/access_token",
+          "redirect_url": "http://localhost:4444/oauth/callback"
+        },
+        "tags": ["system:github.com"],
+        "passthrough_headers": ["X-Vault-Tokens"]
+      }' \
+  http://localhost:4444/gateways
+```
+The bearer token can be created by running:
+
+```bash
+ export MCPGATEWAY_BEARER_TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token \              --username admin@example.com --exp 10080 --secret my-test-key)
+```
+
+### Invoke a tool sending the tokens in a dictionary
+```bash
+curl --request POST \
+  --url http://localhost:4444/rpc \
+  --header "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
+  --header "Content-Type: application/json" \
+  --header "x-vault-tokens: {\"github.com\": \"123\"}" \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "github-com-get-me",
+      "arguments": {
+        "timezone": "Asia/Kolkata"
+      }
+    }
+  }'
+```
+
+

--- a/plugins/vault/vault_plugin.py
+++ b/plugins/vault/vault_plugin.py
@@ -118,6 +118,7 @@ class Vault(Plugin):
                 logger.info(f"Set Bearer token for system tag: {system_key}")
                 bearer_token: str = str(vault_tokens[system_key])
                 headers["Authorization"] = f"Bearer {bearer_token}"
+                del headers[self._sconfig.vault_header_name]
                 modified = True
                 del vault_tokens
 

--- a/plugins/vault/vault_plugin.py
+++ b/plugins/vault/vault_plugin.py
@@ -120,7 +120,7 @@ class Vault(Plugin):
                 headers["Authorization"] = f"Bearer {bearer_token}"
                 del headers[self._sconfig.vault_header_name]
                 modified = True
-                del vault_tokens
+
 
             payload.headers = HttpHeaderPayload(root=headers)
 


### PR DESCRIPTION
## 📌 Summary
Fix header propagation so we don's send X-Vault-Headers to mcp server. X-Vault-Headers was forwarded to final MCP server and as such is a security risk


## 🔁 Reproduction Steps

Header is visible in MCP server logs when a tool is invoked.

## 🐞 Root Cause

 X-Vault-Headers  was not removed correctly

## 💡 Fix Description
Header is removed programmaticaly in Vault plugin
