### PR TITLE
Temporarily removing limit for tools until pagination is properly implemented

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -596,7 +596,7 @@ class ToolService:
         return result
 
     async def list_tools_for_user(
-        self, db: Session, user_email: str, team_id: Optional[str] = None, visibility: Optional[str] = None, include_inactive: bool = False, skip: int = 0, limit: int = 100
+        self, db: Session, user_email: str, team_id: Optional[str] = None, visibility: Optional[str] = None, include_inactive: bool = False, _skip: int = 0, _limit: int = 100
     ) -> List[ToolRead]:
         """
         List tools user has access to with team filtering.
@@ -657,8 +657,9 @@ class ToolService:
         if visibility:
             query = query.where(DbTool.visibility == visibility)
 
-        # Apply pagination following existing patterns
-        query = query.offset(skip).limit(limit)
+        # Note: Pagination is currently not implemented so this limit is not supporeted as of now
+        # # Apply pagination following existing patterns
+        # query = query.offset(skip).limit(limit)
 
         tools = db.execute(query).scalars().all()
         result = []


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Temporarily removing limit for tools until pagination is properly implemented. 

## 🔁 Reproduction Steps
1. Add 100+ tools in the gateway.
2. Observe that only 100 tools are visible in the UI, other all are not accessible in the UI.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed

