### PR TITLE
Fix A2A tool call

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1533,10 +1533,9 @@ class ToolService:
             input_schema={
                 "type": "object",
                 "properties": {
-                    "parameters": {"type": "object", "description": "Parameters to pass to the A2A agent"},
-                    "interaction_type": {"type": "string", "description": "Type of interaction", "default": "query"},
+                    "query": {"type": "string", "description": "User query", "default": "Hello from MCP Gateway Admin UI test!"},
                 },
-                "required": ["parameters"],
+                "required": ["query"],
             },
             allow_auto=True,
             annotations={
@@ -1626,11 +1625,11 @@ class ToolService:
         # Patch: Build correct JSON-RPC params structure from flat UI input
         params = None
         # If UI sends flat fields, convert to nested message structure
-        if isinstance(parameters, dict) and "parameters" in parameters and "interaction_type" in parameters and isinstance(parameters["interaction_type"], str):
+        if isinstance(parameters, dict) and "query" in parameters and isinstance(parameters["query"], str):
             # Build the nested message object
             message_id = f"admin-test-{int(time.time())}"
-            params = {"message": {"messageId": message_id, "role": "user", "parts": [{"type": "text", "text": parameters["interaction_type"]}]}}
-            method = parameters.get("parameters", "message/send")
+            params = {"message": {"messageId": message_id, "role": "user", "parts": [{"type": "text", "text": parameters["query"]}]}}
+            method = parameters.get("method", "message/send")
         else:
             # Already in correct format or unknown, pass through
             params = parameters.get("params", parameters)


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Updates input_schema for A2A agent based tools to be a simple string query since the earlier schema had a dictionary which would not be clear to users.


1. Replaces input schema for A2A Agent tools from `parameters` and `interaction_type` to a string `query`.
2. Updates `params` dictionary creation code in `_call_a2a_agent` code based on the above change.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |   pass     |
| Manual regression no longer fails     | steps / screenshots  |   Tested with a sample agent     |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
