### PR TITLE
Fix gateway addition from UI

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -7692,6 +7692,10 @@ async function handleGatewayFormSubmit(e) {
         // if (authType === "oauth") {
         //     ... backend handles this now ...
         // }
+        const authType = formData.get("auth_type");
+        if (authType !== "oauth") {
+            formData.set("oauth_grant_type", "");
+        }
 
         formData.append("visibility", formData.get("visibility"));
 
@@ -8282,6 +8286,10 @@ async function handleEditGatewayFormSubmit(e) {
         // if (authType === "oauth") {
         //     ... backend handles this now ...
         // }
+        const authType = formData.get("auth_type");
+        if (authType !== "oauth") {
+            formData.set("oauth_grant_type", "");
+        }
 
         const isInactiveCheckedBool = isInactiveChecked("gateways");
         formData.append("is_inactive_checked", isInactiveCheckedBool);


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Gateway addition from UI is broken after admin API started treating any gateway with `oauth_config` as an `oauth` gateway. This was because UI was sending `oauth_grant_type` as `authorization_code` for all gateways irrespective of gateway `auth_type`. This led to all gateways being treated as `oauth` gateways.

## 💡 Fix Description
Makes `oauth_grant_type` as '' when `auth_type` in gateway submit and edit forms is ''.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |   pass     |
| Manual regression no longer fails     | steps / screenshots  |   Tested with sse server with no auth     |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
