### PR TITLE
Team-Level API Token Scoping with Public-Only Token Support

### DIFF
--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -363,10 +363,10 @@ class TokenScopingMiddleware:
             return False
 
         # Third-Party
-        from sqlalchemy import and_, select # pylint: disable=import-outside-toplevel
+        from sqlalchemy import and_, select  # pylint: disable=import-outside-toplevel
 
         # First-Party
-        from mcpgateway.db import EmailTeamMember, get_db # pylint: disable=import-outside-toplevel
+        from mcpgateway.db import EmailTeamMember, get_db  # pylint: disable=import-outside-toplevel
 
         db = next(get_db())
         try:
@@ -447,20 +447,20 @@ class TokenScopingMiddleware:
 
         # Import database models
         # Third-Party
-        from sqlalchemy import select # pylint: disable=import-outside-toplevel
+        from sqlalchemy import select  # pylint: disable=import-outside-toplevel
 
         # First-Party
-        from mcpgateway.db import get_db, Prompt, Resource, Server, Tool # pylint: disable=import-outside-toplevel
+        from mcpgateway.db import get_db, Prompt, Resource, Server, Tool  # pylint: disable=import-outside-toplevel
 
         db = next(get_db())
         try:
-            # CHECK SERVERS (Virtual Servers)
+            # Check Virtual Servers
             if resource_type == "server":
                 server = db.execute(select(Server).where(Server.id == resource_id)).scalar_one_or_none()
 
                 if not server:
                     logger.warning(f"Server {resource_id} not found in database")
-                    return False
+                    return True
 
                 # Get server visibility (default to 'team' if field doesn't exist)
                 server_visibility = getattr(server, "visibility", "team")
@@ -499,12 +499,11 @@ class TokenScopingMiddleware:
 
             # CHECK TOOLS
             if resource_type == "tool":
-                print("INSIDE TOOL CEHCK")
                 tool = db.execute(select(Tool).where(Tool.id == resource_id)).scalar_one_or_none()
 
                 if not tool:
                     logger.warning(f"Tool {resource_id} not found in database")
-                    return False
+                    return True
 
                 # Get tool visibility (default to 'team' if field doesn't exist)
                 tool_visibility = getattr(tool, "visibility", "team")
@@ -549,7 +548,7 @@ class TokenScopingMiddleware:
 
                 if not resource:
                     logger.warning(f"Resource {resource_id} not found in database")
-                    return False
+                    return True
 
                 # Get resource visibility (default to 'team' if field doesn't exist)
                 resource_visibility = getattr(resource, "visibility", "team")
@@ -594,7 +593,7 @@ class TokenScopingMiddleware:
 
                 if not prompt:
                     logger.warning(f"Prompt {resource_id} not found in database")
-                    return False
+                    return True
 
                 # Get prompt visibility (default to 'team' if field doesn't exist)
                 prompt_visibility = getattr(prompt, "visibility", "team")

--- a/mcpgateway/routers/tokens.py
+++ b/mcpgateway/routers/tokens.py
@@ -59,10 +59,10 @@ async def create_token(
     """
     service = TokenCatalogService(db)
 
-    if not request.team_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="team_id is required. Please select a specific team before creating a token. You cannot create tokens while viewing 'All Teams'."
-        )
+    # if not request.team_id:
+    #     raise HTTPException(
+    #         status_code=status.HTTP_400_BAD_REQUEST, detail="team_id is required. Please select a specific team before creating a token. You cannot create tokens while viewing 'All Teams'."
+    #     )
 
     # Convert request to TokenScope if provided
     scope = None

--- a/mcpgateway/routers/tokens.py
+++ b/mcpgateway/routers/tokens.py
@@ -59,6 +59,11 @@ async def create_token(
     """
     service = TokenCatalogService(db)
 
+    if not request.team_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="team_id is required. Please select a specific team before creating a token. You cannot create tokens while viewing 'All Teams'."
+        )
+
     # Convert request to TokenScope if provided
     scope = None
     if request.scope:
@@ -78,7 +83,7 @@ async def create_token(
             scope=scope,
             expires_in_days=request.expires_in_days,
             tags=request.tags,
-            team_id=getattr(request, "team_id", None),
+            team_id=request.team_id,
         )
 
         # Create TokenResponse for the token info

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -11780,29 +11780,20 @@ function initializeTeamScopingMonitor() {
  * Set up create token form handling
  */
 function setupCreateTokenForm() {
-    const form = safeGetElement("create-token-form");
-    if (!form) {
-        return;
-    }
+    const form = safeGetElement('create-token-form');
+    if (!form) return;
 
-    // Check team selection and show/hide warning
+    // Update team scoping warning/info display
     updateTeamScopingWarning();
 
-    form.addEventListener("submit", async (e) => {
+    form.addEventListener('submit', async (e) => {
         e.preventDefault();
-
-        // Check if user is in "All Teams" context
-        const currentTeamId = getCurrentTeamId();
-        if (!currentTeamId || currentTeamId === "") {
-            showErrorMessage(
-                'Please select a specific team from the header before creating a token. You cannot create tokens while viewing "All Teams".',
-            );
-            return; // Prevent form submission
-        }
-
+        
+        // User can create public-only tokens in that context
         await createToken(form);
     });
 }
+
 
 /**
  * Create a new API token
@@ -11814,95 +11805,81 @@ async function createToken(form) {
     const originalText = submitButton.textContent;
 
     try {
-        // Validate team selection
-        const currentTeamId = getCurrentTeamId();
-        if (!currentTeamId) {
-            throw new Error(
-                'Please select a specific team before creating a token. You cannot create tokens while viewing "All Teams".',
-            );
-        }
-
-        submitButton.textContent = "Creating...";
+        submitButton.textContent = 'Creating...';
         submitButton.disabled = true;
 
+        // Get current team ID (null means "All Teams" = public-only token)
+        const currentTeamId = getCurrentTeamId();
+        
         // Build request payload
         const payload = {
-            name: formData.get("name"),
-            description: formData.get("description") || null,
-            expires_in_days: formData.get("expires_in_days")
-                ? parseInt(formData.get("expires_in_days"))
-                : null,
+            name: formData.get('name'),
+            description: formData.get('description') || null,
+            expires_in_days: formData.get('expires_in_days') ? parseInt(formData.get('expires_in_days')) : null,
             tags: [],
-            team_id: currentTeamId,
+            team_id: currentTeamId || null  // null = public-only token
         };
 
         // Add scoping if provided
         const scope = {};
-
-        if (formData.get("server_id")) {
-            scope.server_id = formData.get("server_id");
+        
+        if (formData.get('server_id')) {
+            scope.server_id = formData.get('server_id');
         }
-
-        if (formData.get("ip_restrictions")) {
-            // Parse IP restrictions as array (split by comma if multiple)
-            const ipRestrictions = formData.get("ip_restrictions").trim();
-            scope.ip_restrictions = ipRestrictions
-                ? ipRestrictions.split(",").map((ip) => ip.trim())
-                : [];
+        
+        if (formData.get('ip_restrictions')) {
+            const ipRestrictions = formData.get('ip_restrictions').trim();
+            scope.ip_restrictions = ipRestrictions ? ipRestrictions.split(',').map(ip => ip.trim()) : [];
         } else {
             scope.ip_restrictions = [];
         }
-        if (formData.get("permissions")) {
+        
+        if (formData.get('permissions')) {
             scope.permissions = formData
-                .get("permissions")
-                .split(",")
-                .map((p) => p.trim())
-                .filter((p) => p.length > 0);
+                .get('permissions')
+                .split(',')
+                .map(p => p.trim())
+                .filter(p => p.length > 0);
         } else {
             scope.permissions = [];
         }
-        
-        // Always include time_restrictions and usage_limits as empty objects
+
         scope.time_restrictions = {};
         scope.usage_limits = {};
-
-        // Always add scope object (even if empty) to ensure proper structure
         payload.scope = scope;
 
         const response = await fetchWithTimeout(`${window.ROOT_PATH}/tokens`, {
-            method: "POST",
+            method: 'POST',
             headers: {
-                Authorization: `Bearer ${await getAuthToken()}`,
-                "Content-Type": "application/json",
+                'Authorization': `Bearer ${await getAuthToken()}`,
+                'Content-Type': 'application/json',
             },
             body: JSON.stringify(payload),
         });
 
         if (!response.ok) {
             const error = await response.json();
-            throw new Error(
-                error.detail || `Failed to create token (${response.status})`,
-            );
+            throw new Error(error.detail || `Failed to create token (${response.status})`);
         }
 
         const result = await response.json();
-
-        // Show the new token to the user (this is the only time they'll see it)
         showTokenCreatedModal(result);
-
-        // Reset form and reload tokens list
         form.reset();
         await loadTokensList();
         
-        showNotification("Token created successfully!", "success");
+        // Show appropriate success message
+        const tokenType = currentTeamId ? 'team-scoped' : 'public-only';
+        showNotification(`${tokenType} token created successfully!`, 'success');
+        
     } catch (error) {
-        console.error("Error creating token:", error);
-        showNotification(`Error creating token: ${error.message}`, "error");
+        console.error('Error creating token:', error);
+        showNotification(`Error creating token: ${error.message}`, 'error');
     } finally {
         submitButton.textContent = originalText;
         submitButton.disabled = false;
     }
 }
+
 
 /**
  * Show modal with new token (one-time display)

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -11780,20 +11780,21 @@ function initializeTeamScopingMonitor() {
  * Set up create token form handling
  */
 function setupCreateTokenForm() {
-    const form = safeGetElement('create-token-form');
-    if (!form) return;
+    const form = safeGetElement("create-token-form");
+    if (!form) {
+        return;
+    }
 
     // Update team scoping warning/info display
     updateTeamScopingWarning();
 
-    form.addEventListener('submit', async (e) => {
+    form.addEventListener("submit", async (e) => {
         e.preventDefault();
-        
+
         // User can create public-only tokens in that context
         await createToken(form);
     });
 }
-
 
 /**
  * Create a new API token
@@ -11805,41 +11806,45 @@ async function createToken(form) {
     const originalText = submitButton.textContent;
 
     try {
-        submitButton.textContent = 'Creating...';
+        submitButton.textContent = "Creating...";
         submitButton.disabled = true;
 
         // Get current team ID (null means "All Teams" = public-only token)
         const currentTeamId = getCurrentTeamId();
-        
+
         // Build request payload
         const payload = {
-            name: formData.get('name'),
-            description: formData.get('description') || null,
-            expires_in_days: formData.get('expires_in_days') ? parseInt(formData.get('expires_in_days')) : null,
+            name: formData.get("name"),
+            description: formData.get("description") || null,
+            expires_in_days: formData.get("expires_in_days")
+                ? parseInt(formData.get("expires_in_days"))
+                : null,
             tags: [],
-            team_id: currentTeamId || null  // null = public-only token
+            team_id: currentTeamId || null, // null = public-only token
         };
 
         // Add scoping if provided
         const scope = {};
-        
-        if (formData.get('server_id')) {
-            scope.server_id = formData.get('server_id');
+
+        if (formData.get("server_id")) {
+            scope.server_id = formData.get("server_id");
         }
-        
-        if (formData.get('ip_restrictions')) {
-            const ipRestrictions = formData.get('ip_restrictions').trim();
-            scope.ip_restrictions = ipRestrictions ? ipRestrictions.split(',').map(ip => ip.trim()) : [];
+
+        if (formData.get("ip_restrictions")) {
+            const ipRestrictions = formData.get("ip_restrictions").trim();
+            scope.ip_restrictions = ipRestrictions
+                ? ipRestrictions.split(",").map((ip) => ip.trim())
+                : [];
         } else {
             scope.ip_restrictions = [];
         }
-        
-        if (formData.get('permissions')) {
+
+        if (formData.get("permissions")) {
             scope.permissions = formData
-                .get('permissions')
-                .split(',')
-                .map(p => p.trim())
-                .filter(p => p.length > 0);
+                .get("permissions")
+                .split(",")
+                .map((p) => p.trim())
+                .filter((p) => p.length > 0);
         } else {
             scope.permissions = [];
         }
@@ -11849,37 +11854,37 @@ async function createToken(form) {
         payload.scope = scope;
 
         const response = await fetchWithTimeout(`${window.ROOT_PATH}/tokens`, {
-            method: 'POST',
+            method: "POST",
             headers: {
-                'Authorization': `Bearer ${await getAuthToken()}`,
-                'Content-Type': 'application/json',
+                Authorization: `Bearer ${await getAuthToken()}`,
+                "Content-Type": "application/json",
             },
             body: JSON.stringify(payload),
         });
 
         if (!response.ok) {
             const error = await response.json();
-            throw new Error(error.detail || `Failed to create token (${response.status})`);
+            throw new Error(
+                error.detail || `Failed to create token (${response.status})`,
+            );
         }
 
         const result = await response.json();
         showTokenCreatedModal(result);
         form.reset();
         await loadTokensList();
-        
+
         // Show appropriate success message
-        const tokenType = currentTeamId ? 'team-scoped' : 'public-only';
-        showNotification(`${tokenType} token created successfully!`, 'success');
-        
+        const tokenType = currentTeamId ? "team-scoped" : "public-only";
+        showNotification(`${tokenType} token created successfully!`, "success");
     } catch (error) {
-        console.error('Error creating token:', error);
-        showNotification(`Error creating token: ${error.message}`, 'error');
+        console.error("Error creating token:", error);
+        showNotification(`Error creating token: ${error.message}`, "error");
     } finally {
         submitButton.textContent = originalText;
         submitButton.disabled = false;
     }
 }
-
 
 /**
  * Show modal with new token (one-time display)

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5079,31 +5079,36 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                 <div class="bg-yellow-50 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 rounded-md p-4">
                     <div class="flex">
                         <div class="flex-shrink-0">
-                            <svg class="h-5 w-5 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-                            </svg>
                         </div>
                         <div class="ml-3 flex-1">
-                            <h3 class="text-sm font-bold text-yellow-800 dark:text-yellow-200">
-                                Public Access Token
-                            </h3>
-                            <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
-                                <p class="mb-2">
-                                    You are currently viewing <span class="font-semibold">"All Teams"</span>. Tokens created in this context will have <span class="font-semibold">public-only access</span>.
-                                </p>
-                                <p class="mb-2"><span class="font-semibold">✅ This token CAN access:</span></p>
-                                <ul class="list-disc list-inside ml-2 space-y-1">
-                                    <li>Public servers (virtual servers marked as public)</li>
-                                    <li>Public tools, resources, and prompts</li>
-                                    <li>General API endpoints (health, metrics, etc.)</li>
-                                </ul>
-                                <p class="mt-2 mb-2"><span class="font-semibold">❌ This token CANNOT access:</span></p>
-                                <ul class="list-disc list-inside ml-2 space-y-1">
-                                    <li>Team-scoped or private servers</li>
-                                    <li>Team-scoped or private tools, resources, and prompts</li>
-                                </ul>
-                                <p class="mt-3 text-yellow-800 dark:text-yellow-200 font-medium">
-                                    💡 <span class="font-semibold">Tip:</span> To create a token with full team access, select a specific team from the header above.
+                            <!-- Public Access Token Section -->
+                            <div class="space-y-2">
+                                <div class="flex items-center">
+                                    <h3 class="text-sm font-bold text-yellow-800 dark:text-yellow-200">
+                                        ⚠️ <span class="font-semibold">Public Access Token</span>
+                                    </h3>
+                                </div>
+                                <div class="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
+                                    <p class="mb-1">
+                                        You are currently viewing <span class="font-semibold">"All Teams"</span>. Tokens created in this context will have <span class="font-semibold">public-only access</span>.
+                                    </p>
+                                    <p class="mb-1"><span class="font-semibold">✅ This token CAN access:</span></p>
+                                    <ul class="list-disc list-inside ml-4 space-y-1">
+                                        <li>Public servers (virtual servers marked as public)</li>
+                                        <li>Public tools, resources, and prompts</li>
+                                    </ul>
+                                    <p class="mt-2 mb-1"><span class="font-semibold">❌ This token CANNOT access:</span></p>
+                                    <ul class="list-disc list-inside ml-4 space-y-1">
+                                        <li>Team-scoped or private servers, tools, resources, and prompts</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Tip Section  -->
+                            <div class="mt-4 bg-yellow-50 dark:bg-yellow-900 p-2 rounded-md border border-yellow-200 dark:border-yellow-600 flex items-center">
+                                <span class="text-yellow-600 dark:text-yellow-400 text-lg">💡</span>
+                                <p class="ml-2 text-sm font-semibold text-yellow-700 dark:text-yellow-300">
+                                    To create a token with full Team Access, select a specific team from the header above.
                                 </p>
                             </div>
                         </div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5075,33 +5075,56 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
             </div>
 
             <!-- Team Scoping Info/Warning -->
-            <div id="team-scoping-container">
-                <!-- Warning when "All Teams" is selected -->
-                <div id="team-scoping-warning" class="hidden">
-                    <div class="bg-red-50 dark:bg-red-900 border border-red-300 dark:border-red-700 rounded-md p-3">
-                        <div class="flex items-center">
-                            <svg class="h-5 w-5 text-red-600 dark:text-red-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+            <div id="team-scoping-warning" class="hidden">
+                <div class="bg-yellow-50 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 rounded-md p-4">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
                             </svg>
-                            <p class="text-sm font-medium text-red-800 dark:text-red-200">
-                                Please select a team in the header above for team-level scoping. You are currently viewing "All Teams".
-                            </p>
+                        </div>
+                        <div class="ml-3 flex-1">
+                            <h3 class="text-sm font-bold text-yellow-800 dark:text-yellow-200">
+                                Public Access Token
+                            </h3>
+                            <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+                                <p class="mb-2">
+                                    You are currently viewing <span class="font-semibold">"All Teams"</span>. Tokens created in this context will have <span class="font-semibold">public-only access</span>.
+                                </p>
+                                <p class="mb-2"><span class="font-semibold">✅ This token CAN access:</span></p>
+                                <ul class="list-disc list-inside ml-2 space-y-1">
+                                    <li>Public servers (virtual servers marked as public)</li>
+                                    <li>Public tools, resources, and prompts</li>
+                                    <li>General API endpoints (health, metrics, etc.)</li>
+                                </ul>
+                                <p class="mt-2 mb-2"><span class="font-semibold">❌ This token CANNOT access:</span></p>
+                                <ul class="list-disc list-inside ml-2 space-y-1">
+                                    <li>Team-scoped or private servers</li>
+                                    <li>Team-scoped or private tools, resources, and prompts</li>
+                                </ul>
+                                <p class="mt-3 text-yellow-800 dark:text-yellow-200 font-medium">
+                                    💡 <span class="font-semibold">Tip:</span> To create a token with full team access, select a specific team from the header above.
+                                </p>
+                            </div>
                         </div>
                     </div>
                 </div>
-                
-                <!-- Info when a specific team is selected -->
-                <div id="team-scoping-info" class="hidden">
-                    <div class="bg-blue-50 dark:bg-blue-900 border border-blue-300 dark:border-blue-700 rounded-md p-3">
-                        <div class="flex items-center">
-                            <svg class="h-5 w-5 text-blue-600 dark:text-blue-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
-                            </svg>
-                            <p class="text-sm font-medium text-blue-800 dark:text-blue-200">
-                                <span class="font-semibold">Team-level scoping enabled.</span> This token will be scoped to: <span id="selected-team-name" class="font-bold"></span>
-                            </p>
-                        </div>
+            </div>
+
+            <!-- Info when a specific team is selected -->
+            <div id="team-scoping-info" class="hidden">
+                <div class="bg-blue-50 dark:bg-blue-900 border border-blue-300 dark:border-blue-700 rounded-md p-3">
+                    <div class="flex items-center">
+                        <svg class="h-5 w-5 text-blue-600 dark:text-blue-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+                        </svg>
+                        <p class="text-sm font-medium text-blue-800 dark:text-blue-200">
+                            <span class="font-semibold">Team-level scoping enabled.</span> This token will be scoped to: <span id="selected-team-name" class="font-bold"></span>
+                        </p>
                     </div>
+                    <p class="text-xs text-blue-700 dark:text-blue-300 mt-2 ml-7">
+                        Token can access all resources (public, team, and private) within this team.
+                    </p>
                 </div>
             </div>
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5074,6 +5074,38 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
               ></textarea>
             </div>
 
+            <!-- Team Scoping Info/Warning -->
+            <div id="team-scoping-container">
+                <!-- Warning when "All Teams" is selected -->
+                <div id="team-scoping-warning" class="hidden">
+                    <div class="bg-red-50 dark:bg-red-900 border border-red-300 dark:border-red-700 rounded-md p-3">
+                        <div class="flex items-center">
+                            <svg class="h-5 w-5 text-red-600 dark:text-red-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+                            </svg>
+                            <p class="text-sm font-medium text-red-800 dark:text-red-200">
+                                Please select a team in the header above for team-level scoping. You are currently viewing "All Teams".
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Info when a specific team is selected -->
+                <div id="team-scoping-info" class="hidden">
+                    <div class="bg-blue-50 dark:bg-blue-900 border border-blue-300 dark:border-blue-700 rounded-md p-3">
+                        <div class="flex items-center">
+                            <svg class="h-5 w-5 text-blue-600 dark:text-blue-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+                            </svg>
+                            <p class="text-sm font-medium text-blue-800 dark:text-blue-200">
+                                <span class="font-semibold">Team-level scoping enabled.</span> This token will be scoped to: <span id="selected-team-name" class="font-bold"></span>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
             <!-- Token Scoping -->
             <div class="border-t pt-4">
               <h4

--- a/mcpgateway/utils/token_scoping.py
+++ b/mcpgateway/utils/token_scoping.py
@@ -12,7 +12,6 @@ from typing import Optional
 
 # Third-Party
 from fastapi import HTTPException, Request
-from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.utils.verify_credentials import verify_jwt_token
@@ -145,29 +144,3 @@ def validate_server_access(scopes: Optional[dict], requested_server_id: str) -> 
         return True  # Global scope token
 
     return server_id == requested_server_id
-
-
-def validate_token_team_membership(payload: dict, db: Session) -> None:
-    """
-    Validate that user still belongs to teams in the token.
-
-    Args:
-        payload: Decoded JWT payload
-        db: Database session
-
-    Raises:
-        HTTPException: If team membership is invalid
-    """
-    teams = payload.get("teams", [])
-    user_email = payload.get("sub")
-
-    if not teams or not user_email:
-        return  # No team validation needed
-
-    for team_id in teams:
-        membership = db.execute(
-            select(EmailTeamMember).where(and_(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email, EmailTeamMember.is_active == True))
-        ).scalar_one_or_none()
-
-        if not membership:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"User is no longer a member of team {team_id}. Token is invalid.")

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -100,7 +100,7 @@ class TestTokenScopingMiddleware:
 
         # Mock token extraction to return server-scoped token
         with patch.object(middleware, '_extract_token_scopes') as mock_extract:
-            mock_extract.return_value = {"server_id": "specific-server"}
+            mock_extract.return_value = {"scopes": {"server_id": "specific-server"}}
 
             # Mock call_next (the next middleware or request handler)
             call_next = AsyncMock()
@@ -125,7 +125,7 @@ class TestTokenScopingMiddleware:
 
         # Mock token extraction to return permission-scoped token without admin permissions
         with patch.object(middleware, '_extract_token_scopes') as mock_extract:
-            mock_extract.return_value = {"permissions": [Permissions.TOOLS_READ]}
+            mock_extract.return_value = {"scopes": {"permissions": [Permissions.TOOLS_READ]}}
 
             # Mock call_next (the next middleware or request handler)
             call_next = AsyncMock()

--- a/tests/unit/mcpgateway/services/test_token_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_token_catalog_service.py
@@ -347,7 +347,7 @@ class TestTokenCatalogService:
             mock_api_token,  # Token with same name exists
         ]
 
-        with pytest.raises(ValueError, match="Token name 'Duplicate' already exists"):
+        with pytest.raises(ValueError, match="Token with name 'Duplicate' already exists for user test@example.com in team None. Please choose a different name."):
             await token_service.create_token(user_email="test@example.com", name="Duplicate")
 
     @pytest.mark.asyncio
@@ -389,7 +389,7 @@ class TestTokenCatalogService:
             None,  # User is not team owner
         ]
 
-        with pytest.raises(ValueError, match="Only team owners can create API keys"):
+        with pytest.raises(ValueError, match="User test@example.com is not an active member of team team-123. Only team members can create tokens for the team."):
             await token_service.create_token(user_email="test@example.com", name="Token", team_id="team-123")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #1176 

---

## 🚀 Summary (1-2 sentences)
This PR implements mandatory team-level scoping for API tokens, enforcing proper multi-tenancy isolation to prevent tokens created for one team from accessing another team's resources. It also introduces public-only tokens (created in "All Teams" context) that can only access resources with public visibility, enabling secure integration with public APIs without requiring team-specific access.

Key Changes:

Team-scoped tokens: Full access to team resources + public resources
Public-only tokens: Access only to public resources (servers, tools, resources, prompts)
Runtime enforcement via token scoping middleware with resource ownership validation


### 🔒 Security Considerations

| Resource Visibility | Public-Only Token | Team-Scoped Token (Same Team) | Team-Scoped Token (Different Team) |
|---------------------|-------------------|------------------------------|-----------------------------------|
| **Public**           | ✅ Allow           | ✅ Allow                     | ✅ Allow                          |
| **Team**             | ❌ Deny            | ✅ Allow                     | ❌ Deny                           |
| **Private**          | ❌ Deny            | ✅ Allow                     | ❌ Deny                           |

---

### Case 1: 

When All Teams is selected: public-only access token are created. Detailed scoping of the api token based on the selection is mentioned here 

<img width="947" height="437" alt="image" src="https://github.com/user-attachments/assets/74dcd476-16b3-401c-bc6b-33f013a79349" />

### Case 2:

When a Team is selected, that token will be scoped to that team only and will not work for any other team.

<img width="946" height="437" alt="image" src="https://github.com/user-attachments/assets/d4916537-1b67-44e2-954c-8cb679a08b63" />



---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)
