### PR TITLE
header-modal overlap fix

### DIFF
--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -211,3 +211,8 @@
 /* .hidden {
   display: none;
 } */
+
+/* Modal z-index to prevent sticky header overlap */
+.fixed.z-10 {
+    z-index: 9999 !important;
+}


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Closed #1178 
The header does not overlap with the modals such as test, edit, view and all the others.
NOTE: Please test the PR in an incognito window or a different browser, as the changes may not appear due to caching.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed