### PR TITLE
Add OAUTH_DEFAULT_TIMEOUT in settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -201,6 +201,7 @@ AUTH_ENCRYPTION_SECRET=my-test-salt
 # OAuth Configuration
 OAUTH_REQUEST_TIMEOUT=30
 OAUTH_MAX_RETRIES=3
+OAUTH_DEFAULT_TIMEOUT=3600
 
 # OAuth Security Settings
 # When MCP servers require OAuth authorization code flow,

--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,7 @@ You can get started by copying the provided [.env.example](https://github.com/IB
 | `AUTH_ENCRYPTION_SECRET`    | Passphrase used to derive AES key for encrypting tool auth headers           | `my-test-salt`      | string      |
 | `OAUTH_REQUEST_TIMEOUT`     | OAuth request timeout in seconds                                             | `30`                | int > 0     |
 | `OAUTH_MAX_RETRIES`         | Maximum retries for OAuth token requests                                     | `3`                 | int > 0     |
+| `OAUTH_DEFAULT_TIMEOUT`         | Default OAuth token timeout in seconds                                     | `3600`                 | int > 0     |
 
 > 🔐 `BASIC_AUTH_USER`/`PASSWORD` are used for:
 >

--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -351,7 +351,9 @@ sequenceDiagram
 ```env
 # OAuth Configuration
 OAUTH_REQUEST_TIMEOUT=30        # OAuth request timeout in seconds
-OAUTH_MAX_RETRIES=3            # Max retries for token requests
+OAUTH_MAX_RETRIES=3             # Max retries for token requests
+OAUTH_DEFAULT_TIMEOUT=3600      # Default OAuth token timeout in seconds
+
 
 # Encryption
 AUTH_ENCRYPTION_SECRET=your-secret-key  # For encrypting client secrets

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1003,6 +1003,7 @@ You can get started by copying the provided [.env.example](https://github.com/IB
 | `AUTH_ENCRYPTION_SECRET`    | Passphrase used to derive AES key for encrypting tool auth headers           | `my-test-salt`      | string      |
 | `OAUTH_REQUEST_TIMEOUT`     | OAuth request timeout in seconds                                             | `30`                | int > 0     |
 | `OAUTH_MAX_RETRIES`         | Maximum retries for OAuth token requests                                     | `3`                 | int > 0     |
+| `OAUTH_DEFAULT_TIMEOUT`         | Default OAuth token timeout in seconds                                     | `3600`                 | int > 0     |
 
 > 🔐 `BASIC_AUTH_USER`/`PASSWORD` are used for:
 >

--- a/docs/docs/manage/oauth.md
+++ b/docs/docs/manage/oauth.md
@@ -50,6 +50,7 @@ See the flow details and security model in the architecture docs.
 # OAuth HTTP behavior
 OAUTH_REQUEST_TIMEOUT=30      # Seconds
 OAUTH_MAX_RETRIES=3           # Retries for transient failures
+OAUTH_DEFAULT_TIMEOUT=3600    # Default OAuth token timeout in seconds
 
 # Secret encryption for stored OAuth client secrets (and tokens if enabled)
 AUTH_ENCRYPTION_SECRET=<strong-random-key>

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -225,6 +225,7 @@ class Settings(BaseSettings):
     # OAuth Configuration
     oauth_request_timeout: int = Field(default=30, description="OAuth request timeout in seconds")
     oauth_max_retries: int = Field(default=3, description="Maximum retries for OAuth token requests")
+    oauth_default_timeout: int = Field(default=3600, description="Default OAuth token timeout in seconds")
 
     # ===================================
     # Dynamic Client Registration (DCR) - Client Mode

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -592,7 +592,7 @@ class OAuthManager:
                 app_user_email=app_user_email,  # User from state
                 access_token=token_response["access_token"],
                 refresh_token=token_response.get("refresh_token"),
-                expires_in=token_response.get("expires_in", 3600),
+                expires_in=token_response.get("expires_in", self.settings.oauth_default_timeout),
                 scopes=token_response.get("scope", "").split(),
             )
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Adds a user configurable OAUTH_DEFAULT_TIMEOUT in settings and .env.example with a default value of 3600. Provides option to have longer working tokens when the token itself is non expiring.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |   pass     |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
