### PR TITLE
fix: Add non-root user to scratch go containers

### DIFF
--- a/mcp-servers/go/benchmark-server/Dockerfile
+++ b/mcp-servers/go/benchmark-server/Dockerfile
@@ -1,5 +1,5 @@
 # This build supports multi-platform builds through standard Docker Buildx
-# techniques, including the $TARGETPLATFORM environment veriable.
+# techniques, including the $TARGETPLATFORM environment variable.
 FROM golang:1.23 AS builder
 WORKDIR /src
 COPY go.mod .

--- a/mcp-servers/go/fast-time-server/Dockerfile
+++ b/mcp-servers/go/fast-time-server/Dockerfile
@@ -10,7 +10,7 @@
 #        # now visit http://localhost:8080/sse   or   http://localhost:8080/http
 #
 # This build supports multi-platform builds through standard Docker Buildx
-# techniques, including the $TARGETPLATFORM environment veriable.
+# techniques, including the $TARGETPLATFORM environment variable.
 # =============================================================================
 
 # =============================================================================

--- a/mcp-servers/templates/go/Dockerfile.jinja
+++ b/mcp-servers/templates/go/Dockerfile.jinja
@@ -1,7 +1,7 @@
 # Multi-stage container for {{ project_name }}
 
 # This build supports multi-platform builds through standard Docker Buildx
-# techniques, including the $TARGETPLATFORM environment veriable.
+# techniques, including the $TARGETPLATFORM environment variable.
 
 FROM golang:{{ go_version }} AS builder
 WORKDIR /src


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Go Docker images built from scratch run as root

## 🔁 Reproduction Steps
Issue #1227

## 🐞 Root Cause
Images did not set USER

## 💡 Fix Description
Set USER to 1001

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Unrelated errors and failures |
| Unit tests                            | `make test`          | 2 Unrelated failures       |
| Coverage ≥ 90 %                       | `make coverage`      |   71% - Unrelated to changes   |
| Manual regression no longer fails     | steps / screenshots  | Tested go modules per Makefiles |

## 📐 MCP Compliance (if relevant)
- [-] Matches current MCP spec
- [-] No breaking change to MCP clients

## ✅ Checklist
- [-] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
