### PR TITLE
chore: fix makefile clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DIRS_TO_CLEAN := __pycache__ .pytest_cache .tox .ruff_cache .pyre .mypy_cache .p
 	$(VENV_DIR) $(VENV_DIR).sbom $(COVERAGE_DIR) \
 	node_modules .mutmut-cache html
 
-FILES_TO_CLEAN := .coverage coverage.xml mcp.prof mcp.pstats \
+FILES_TO_CLEAN := .coverage .coverage.* coverage.xml mcp.prof mcp.pstats mcp.db-* \
 	$(PROJECT_NAME).sbom.json \
 	snakefood.dot packages.dot classes.dot \
 	$(DOCS_DIR)/pstats.png \
@@ -236,18 +236,14 @@ certs-all: certs certs-jwt       ## Generate both TLS certificates and JWT RSA k
 .PHONY: clean
 clean:
 	@echo "🧹  Cleaning workspace..."
-	@bash -eu -o pipefail -c '\
-		# Remove matching directories \
-		for dir in $(DIRS_TO_CLEAN); do \
-			find . -type d -name "$$dir" -exec rm -rf {} +; \
-		done; \
-		# Remove listed files \
-		rm -f $(FILES_TO_CLEAN); \
-		# Delete Python bytecode \
-		find . -name "*.py[cod]" -delete; \
-		# Delete coverage annotated files \
-		find . -name "*.py,cover" -delete; \
-	'
+	@set +e; \
+	for dir in $(DIRS_TO_CLEAN); do \
+		find . -type d -name "$$dir" -prune -exec rm -rf {} +; \
+	done; \
+	set -e
+	@rm -f $(FILES_TO_CLEAN)
+	@find . -name "*.py[cod]" -delete
+	@find . -name "*.py,cover" -delete
 	@echo "✅  Clean complete."
 
 


### PR DESCRIPTION
### Description

Fix clean target not removing cache directories

###  Problem

The clean target was not actually removing directories like __pycache__, .pytest_cache, and other cache directories specified in DIRS_TO_CLEAN.

**Root Cause**

The original implementation wrapped all cleanup commands in bash -c '...' with backslash line continuations (\) inside the single-quoted string. Make was including these backslash-newline sequences as literal characters in the bash script, preventing proper execution of the for loop and cleanup commands (problem verified on Mac).

### Solution

Restructured the clean target to use Make's native recipe execution instead of wrapping commands in bash -c:
- Removed the bash -c '...' wrapper
- Each command now runs as a separate Make recipe line with proper @ prefixes
- Backslash continuations are now at the Make level (not inside a quoted string)
- Added set +e/set -e to allow directory removal to fail gracefully if directories don't exist

### Changes

  - Makefile: Rewrote clean target recipe from bash -c wrapper to native Make recipe lines
  - Included missing files to be removed in the Makefile

### Testing

Verified that make clean now successfully removes:
- All directories in DIRS_TO_CLEAN
- Python bytecode files (*.py[cod], *.py,cover)
- All files listed in FILES_TO_CLEAN