### PR TITLE
Fix iframe embedding with consistent CSP and X-Frame-Options headers

### DIFF
--- a/mcpgateway/middleware/security_headers.py
+++ b/mcpgateway/middleware/security_headers.py
@@ -124,12 +124,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             ...     "img-src 'self' data: https:",
             ...     "font-src 'self' data: https://cdnjs.cloudflare.com",
             ...     "connect-src 'self' ws: wss: https:",
-            ...     "frame-ancestors 'none'",
+            ...     "frame-ancestors 'self'",  # Example for SAMEORIGIN
             ... ]
             >>> csp_header = "; ".join(csp_directives) + ";"
             >>> "default-src 'self'" in csp_header
             True
-            >>> "frame-ancestors 'none'" in csp_header
+            >>> "frame-ancestors 'self'" in csp_header
             True
             >>> csp_header.endswith(";")
             True
@@ -268,6 +268,23 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # Content Security Policy
         # This CSP is designed to work with the Admin UI while providing security
+        # Dynamically set frame-ancestors based on X_FRAME_OPTIONS setting
+        x_frame = str(settings.x_frame_options)
+        x_frame_upper = x_frame.upper()
+
+        if x_frame_upper == "DENY":
+            frame_ancestors = "'none'"
+        elif x_frame_upper == "SAMEORIGIN":
+            frame_ancestors = "'self'"
+        elif x_frame_upper.startswith("ALLOW-FROM"):
+            allowed_uri = x_frame.split(" ", 1)[1] if " " in x_frame else "'none'"
+            frame_ancestors = allowed_uri
+        elif not x_frame:  # Empty string means allow all
+            frame_ancestors = "*"
+        else:
+            # Default to none for unknown values
+            frame_ancestors = "'none'"
+
         csp_directives = [
             "default-src 'self'",
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://unpkg.com",
@@ -275,7 +292,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "img-src 'self' data: https:",
             "font-src 'self' data: https://cdnjs.cloudflare.com",
             "connect-src 'self' ws: wss: https:",
-            "frame-ancestors 'none'",
+            f"frame-ancestors {frame_ancestors}",
         ]
         response.headers["Content-Security-Policy"] = "; ".join(csp_directives) + ";"
 


### PR DESCRIPTION
## :bug: Bug-fix PR
## :pushpin: Summary
Fixes iframe embedding blocked by inconsistent security headers in version 0.6.0. Resolves CSP frame-ancestors 'none' overriding X_FRAME_OPTIONS=SAMEORIGIN setting. Implements dynamic CSP frame-ancestors directive based on X-Frame-Options configuration. Adds comprehensive test coverage for all X-Frame-Options scenarios including TestFrameAncestorsCSPConsistency test class. Handles all standard values: DENY, SAMEORIGIN, ALLOW-FROM, and empty string configurations.

## :link: Related Issue
Closes: #922

## 🐞 : Root Cause
CSP frame-ancestors directive was hardcoded to 'none', always blocking iframe embedding. User sets X_FRAME_OPTIONS=SAMEORIGIN but CSP takes precedence in modern browsers. Missing synchronization logic between X-Frame-Options and CSP frame-ancestors directives. Security middleware applied conflicting iframe policies regardless of user configuration.
## :test_tube: Verification
| Check | Command/Status | Result |
|-------|----------------|--------|
| Frame-ancestors CSP tests | `python -m pytest tests/security/test_security_middleware_comprehensive.py::TestFrameAncestorsCSPConsistency -v` | pass |
| All X-Frame-Options mappings | Unit test coverage (DENY→'none', SAMEORIGIN→'self', ALLOW-FROM→URI, empty→'*') | pass |
| Integration test scenario | `python -m pytest tests/security/test_security_middleware_comprehensive.py::TestFrameAncestorsCSPConsistency::test_sameorigin_iframe_integration -v` | pass |
| All security middleware tests | `python -m pytest tests/security/test_security_middleware_comprehensive.py -v` | pass |

## :triangular_ruler: MCP Compliance (if relevant)
:white_check_mark: No breaking change to MCP clients
:white_check_mark: No secrets/credentials committed

## :white_check_mark: Checklist
:white_check_mark: Code formatted (make black isort pre-commit)
:white_check_mark: Comprehensive test coverage added (TestFrameAncestorsCSPConsistency class)
:white_check_mark: Dynamic CSP frame-ancestors generation implemented
:white_check_mark: X-Frame-Options to CSP mapping validated for all scenarios