### PR TITLE
Fix JWT token follows default variable payload expiry instead of UI

### DIFF
--- a/mcpgateway/utils/create_jwt_token.py
+++ b/mcpgateway/utils/create_jwt_token.py
@@ -125,7 +125,8 @@ def _create_jwt_token(
     if "username" in payload and "sub" not in payload:
         payload["sub"] = payload["username"]
 
-    if payload["exp"] and payload["exp"] > 0:
+    payload_exp = payload.get("exp", 0)
+    if payload_exp > 0:
         pass  # The token already has a valid expiration time
     elif expires_in_minutes > 0:
         expire = now + _dt.timedelta(minutes=expires_in_minutes)


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes #1261 
This PR resolves the issue where the expiry time for API tokens generated via the UI is not being respected correctly. The _create_jwt_token function was using a default environment variable (TOKEN_EXPIRY) for the token expiration, even when a custom expiry was specified via the UI. This PR ensures that when an expiry time is provided in the UI payload, that value is used. If no expiry is provided in the payload, the function will fall back to using the value from the function's argument (expires_in_minutes), and if that is also absent, it will use the default value set in the environment.

## 🔁 Reproduction Steps
1. Set the TOKEN_EXPIRY to 1 minute in the env : TOKEN_EXPIRY=1
2. Create the token via user interface panel with expiry as 30 days.
3. Try using the token after 1 minute. Observe that the token does not work after a minute as its expired, even though the expiry set was 30 days in the UI.

## 🐞 Root Cause

The root cause is that the _create_jwt_token function takes expires_in_minutes as a function argument, but it was overriding this with the exp value already present in the payload (when sent via the UI). The function was not properly handling the situation where the payload contained its own exp value, and instead was always using the default expiry time set in the environment variable (DEFAULT_EXP_MINUTES).

## 💡 Fix Description
```python
def _create_jwt_token(
    data: Dict[str, Any],
    expires_in_minutes: int = DEFAULT_EXP_MINUTES,
    secret: str = "",  # nosec B107 - Legacy parameter, not used for authentication
    algorithm: str = DEFAULT_ALGO,
) -> str:
```
The solution is to modify the _create_jwt_token function to respect the expiry time in the following order of precedence:
- If the exp key exists in the payload (provided via UI), use that expiry value.
- If the exp key is not provided in the payload but the expires_in_minutes parameter is passed to the function, use that value.
- If neither is provided, use the default expiry time defined in the environment variable (DEFAULT_EXP_MINUTES).

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed