### PR TITLE
Add UI Support for MCP Tool outputSchema Field closes #1258

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@
 # report issues (linters). Modified files will need to be staged again.
 # -----------------------------------------------------------------------------
 
-exclude: '(^|/)(\.pre-commit-config\.yaml|normalize_special_characters\.py|test_input_validation\.py|ai_artifacts_normalizer\.py)$|(^|/)mcp-servers/templates/|.*\.(jinja|j2)$'  # ignore these files, all templates, and jinja files
+exclude: '(^|/)(\.pre-commit-config\.yaml|normalize_special_characters\.py|test_input_validation\.py|ai_artifacts_normalizer\.py)$|(^|/)mcp-servers/templates/|(^|/)tests/load/|.*\.(jinja|j2)$'  # ignore these files, all templates, load tests, and jinja files
 
 repos:
   # -----------------------------------------------------------------------------

--- a/mcp-servers/python/output_schema_test_server/CURL_TESTING.md
+++ b/mcp-servers/python/output_schema_test_server/CURL_TESTING.md
@@ -1,0 +1,326 @@
+# Testing Output Schema with curl
+
+Quick reference for testing the output_schema implementation using curl.
+
+## Setup
+
+First, generate a JWT token and export it:
+
+```bash
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123)
+```
+
+Or use an existing token:
+```bash
+export TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluQGV4YW1wbGUuY29tIiwiaWF0IjoxNzYwNjQzNTU1LCJpc3MiOiJtY3BnYXRld2F5IiwiYXVkIjoibWNwZ2F0ZXdheS1hcGkiLCJzdWIiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.4qSaXA5D3jEEJNh9VTDvPbQP7CflF9wU_x9EAoXVB8I"
+```
+
+## Quick Test Commands
+
+### 1. List All Tools (Check for outputSchema field)
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | jq '.'
+```
+
+### 2. Find a Specific Tool (e.g., add_numbers)
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | jq '.[] | select(.name == "add_numbers")'
+```
+
+### 3. Check outputSchema Field Specifically
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '.[] | select(.name == "add_numbers") | {name, inputSchema, outputSchema}'
+```
+
+**Expected Output**:
+```json
+{
+  "name": "add_numbers",
+  "inputSchema": {
+    "properties": {
+      "a": {
+        "description": "First number",
+        "title": "A",
+        "type": "number"
+      },
+      "b": {
+        "description": "Second number",
+        "title": "B",
+        "type": "number"
+      }
+    },
+    "required": ["a", "b"],
+    "title": "add_numbers",
+    "type": "object"
+  },
+  "outputSchema": {
+    "properties": {
+      "result": {
+        "description": "The calculated result",
+        "title": "Result",
+        "type": "number"
+      },
+      "operation": {
+        "description": "The operation performed",
+        "title": "Operation",
+        "type": "string"
+      },
+      "operands": {
+        "description": "The operands used",
+        "items": {
+          "type": "number"
+        },
+        "title": "Operands",
+        "type": "array"
+      },
+      "success": {
+        "default": true,
+        "description": "Whether the calculation succeeded",
+        "title": "Success",
+        "type": "boolean"
+      }
+    },
+    "required": ["result", "operation", "operands"],
+    "title": "CalculationResult",
+    "type": "object"
+  }
+}
+```
+
+### 4. Check All Tools for outputSchema Presence
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '.[] | select(.name | contains("_numbers") or contains("create_user") or contains("validate_email") or . == "echo") | {name, has_output_schema: (.outputSchema != null)}'
+```
+
+**Expected Output**:
+```json
+{"name": "add_numbers", "has_output_schema": true}
+{"name": "multiply_numbers", "has_output_schema": true}
+{"name": "divide_numbers", "has_output_schema": true}
+{"name": "create_user", "has_output_schema": true}
+{"name": "validate_email", "has_output_schema": true}
+{"name": "echo", "has_output_schema": false}
+```
+
+### 5. Invoke a Tool
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://localhost:4444/tools/invoke \
+  -d '{
+    "name": "add_numbers",
+    "arguments": {"a": 10, "b": 5}
+  }' | jq '.'
+```
+
+**Expected Output**:
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"result\": 15.0, \"operation\": \"addition\", \"operands\": [10.0, 5.0], \"success\": true}"
+    }
+  ]
+}
+```
+
+### 6. Test Complex Tool (create_user)
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://localhost:4444/tools/invoke \
+  -d '{
+    "name": "create_user",
+    "arguments": {
+      "name": "John Doe",
+      "email": "john@example.com",
+      "age": 30,
+      "roles": ["admin", "user"]
+    }
+  }' | jq '.'
+```
+
+**Expected Output**:
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"name\": \"John Doe\", \"email\": \"john@example.com\", \"age\": 30, \"roles\": [\"admin\", \"user\"]}"
+    }
+  ]
+}
+```
+
+### 7. Test Tool Without outputSchema (echo)
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '.[] | select(.name == "echo") | {name, outputSchema}'
+```
+
+**Expected Output**:
+```json
+{
+  "name": "echo",
+  "outputSchema": null
+}
+```
+
+## Export/Import Testing
+
+### 8. Export Tools with outputSchema
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/bulk/export > /tmp/tools-export.json
+
+# Check the export
+jq '.tools[] | select(.name == "add_numbers") | {name, has_output_schema: (.output_schema != null)}' /tmp/tools-export.json
+```
+
+**Expected Output**:
+```json
+{
+  "name": "add_numbers",
+  "has_output_schema": true
+}
+```
+
+### 9. View Exported outputSchema
+
+```bash
+jq '.tools[] | select(.name == "add_numbers") | .output_schema' /tmp/tools-export.json
+```
+
+### 10. Count Tools with outputSchema
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '[.[] | select(.outputSchema != null)] | length'
+```
+
+## Database Validation
+
+### 11. Check Database Schema
+
+```bash
+sqlite3 mcp.db "PRAGMA table_info(tools);" | grep output_schema
+```
+
+**Expected Output**:
+```
+12|output_schema|JSON|1||0
+```
+
+### 12. Query outputSchema from Database
+
+```bash
+sqlite3 mcp.db "SELECT name, output_schema FROM tools WHERE name='add_numbers';"
+```
+
+## Complete Test Script
+
+Save this as `test-output-schema.sh`:
+
+```bash
+#!/bin/bash
+
+# Generate token
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+
+echo "=== Testing outputSchema Implementation ==="
+echo ""
+
+echo "1. Listing all tools with outputSchema status..."
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '.[] | select(.name | contains("_numbers") or contains("create_user") or contains("validate") or . == "echo") | {name, has_outputSchema: (.outputSchema != null)}'
+
+echo ""
+echo "2. Viewing add_numbers outputSchema..."
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '.[] | select(.name == "add_numbers") | .outputSchema | keys'
+
+echo ""
+echo "3. Invoking add_numbers tool..."
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://localhost:4444/tools/invoke \
+  -d '{"name": "add_numbers", "arguments": {"a": 10, "b": 5}}' | jq '.content[0].text | fromjson'
+
+echo ""
+echo "4. Invoking create_user tool..."
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://localhost:4444/tools/invoke \
+  -d '{"name": "create_user", "arguments": {"name": "Test User", "email": "test@example.com", "age": 25, "roles": ["user"]}}' | jq '.content[0].text | fromjson'
+
+echo ""
+echo "5. Checking export includes outputSchema..."
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/bulk/export | \
+  jq '.tools[] | select(.name == "add_numbers") | has("output_schema")'
+
+echo ""
+echo "=== All Tests Complete ==="
+```
+
+Run it:
+```bash
+chmod +x test-output-schema.sh
+./test-output-schema.sh
+```
+
+## Troubleshooting
+
+### Token expired or invalid
+```bash
+# Generate new token
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+```
+
+### Gateway not running
+```bash
+# Check if gateway is running
+curl -s http://localhost:4444/health
+
+# Start gateway
+make dev
+```
+
+### Tools not showing up
+```bash
+# Check gateway registration
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/gateways | jq '.'
+
+# Check if test server is running
+ps aux | grep output_schema_test_server
+```
+
+### outputSchema is null when it shouldn't be
+```bash
+# Check database migration
+sqlite3 mcp.db "SELECT sql FROM sqlite_master WHERE name='tools';" | grep output_schema
+
+# Re-discover tools from gateway
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/gateways/{gateway-id}/refresh
+```

--- a/mcp-servers/python/output_schema_test_server/Makefile
+++ b/mcp-servers/python/output_schema_test_server/Makefile
@@ -1,0 +1,81 @@
+# Makefile for Output Schema Test MCP Server
+
+.PHONY: help install dev-install format lint test dev serve-http serve-sse test-http test-tools mcp-info clean
+
+PYTHON ?= python3
+HTTP_PORT ?= 9100
+HTTP_HOST ?= 0.0.0.0
+
+help: ## Show help
+	@echo "Output Schema Test MCP Server"
+	@echo ""
+	@echo "Quick Start:"
+	@echo "  make install          Install server"
+	@echo "  make dev              Run server (stdio)"
+	@echo "  make serve-http       Run with native FastMCP HTTP"
+	@echo "  make test-tools       Test tool listing with output schemas"
+	@echo ""
+	@awk 'BEGIN {FS=":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## Install in editable mode
+	$(PYTHON) -m pip install -e .
+
+dev-install: ## Install with dev extras
+	$(PYTHON) -m pip install -e ".[dev]"
+
+format: ## Format (black + ruff --fix)
+	black . && ruff check --fix .
+
+lint: ## Lint (ruff, mypy)
+	ruff check . && mypy src/output_schema_test_server
+
+test: ## Run tests
+	pytest -v --cov=output_schema_test_server --cov-report=term-missing
+
+dev: ## Run server (stdio)
+	$(PYTHON) -m output_schema_test_server.server_fastmcp
+
+serve-http: ## Run with native FastMCP HTTP
+	@echo "HTTP endpoint: http://$(HTTP_HOST):$(HTTP_PORT)/mcp/"
+	@echo "Test with: make test-http"
+	$(PYTHON) -m output_schema_test_server.server_fastmcp --transport http --host $(HTTP_HOST) --port $(HTTP_PORT)
+
+serve-sse: ## Run with mcpgateway.translate (SSE bridge)
+	@echo "SSE endpoint: http://$(HTTP_HOST):$(HTTP_PORT)/sse"
+	$(PYTHON) -m mcpgateway.translate --stdio "$(PYTHON) -m output_schema_test_server.server_fastmcp" \
+	  --host $(HTTP_HOST) --port $(HTTP_PORT) --expose-sse
+
+test-http: ## Test native HTTP endpoint - list tools with output schemas
+	@echo "=== Listing tools (should show outputSchema field) ==="
+	curl -s -X POST -H 'Content-Type: application/json' \
+	  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+	  http://$(HTTP_HOST):$(HTTP_PORT)/mcp/ | python3 -m json.tool
+
+test-tools: ## Test tools with output schemas
+	@echo "=== Test 1: List all tools ==="
+	curl -s -X POST -H 'Content-Type: application/json' \
+	  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+	  http://$(HTTP_HOST):$(HTTP_PORT)/mcp/ | python3 -m json.tool | grep -A 50 "add_numbers" || true
+	@echo ""
+	@echo "=== Test 2: Call add_numbers tool ==="
+	curl -s -X POST -H 'Content-Type: application/json' \
+	  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":5,"b":3}}}' \
+	  http://$(HTTP_HOST):$(HTTP_PORT)/mcp/ | python3 -m json.tool
+	@echo ""
+	@echo "=== Test 3: Call create_user tool ==="
+	curl -s -X POST -H 'Content-Type: application/json' \
+	  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"create_user","arguments":{"name":"John Doe","email":"john@example.com","age":30,"roles":["admin","user"]}}}' \
+	  http://$(HTTP_HOST):$(HTTP_PORT)/mcp/ | python3 -m json.tool
+
+mcp-info: ## Show MCP client configs
+	@echo "1. FastMCP Server (stdio - for Claude Desktop):"
+	@echo '{"command": "python", "args": ["-m", "output_schema_test_server.server_fastmcp"]}'
+	@echo ""
+	@echo "2. Native HTTP: make serve-http"
+	@echo "   Then test: make test-http"
+	@echo ""
+	@echo "3. SSE bridge: make serve-sse"
+
+clean: ## Remove caches
+	rm -rf .pytest_cache .ruff_cache .mypy_cache __pycache__ */__pycache__ *.egg-info
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/mcp-servers/python/output_schema_test_server/QUICK_START.md
+++ b/mcp-servers/python/output_schema_test_server/QUICK_START.md
@@ -1,0 +1,168 @@
+# Quick Start - Testing outputSchema with curl
+
+## One-Line Test Commands
+
+Copy and paste these commands to test the outputSchema implementation:
+
+### 1. Generate Token and List Tools
+```bash
+TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1) && curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -m json.tool | grep -A 30 "add_numbers"
+```
+
+### 2. Check for outputSchema Field
+```bash
+TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1) && curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -m json.tool | grep -B 2 -A 20 "outputSchema"
+```
+
+### 3. Invoke add_numbers Tool
+```bash
+TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1) && curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" http://localhost:4444/tools/invoke -d '{"name":"add_numbers","arguments":{"a":10,"b":5}}' | python3 -m json.tool
+```
+
+### 4. Export Tools and Check output_schema
+```bash
+TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1) && curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/bulk/export | python3 -m json.tool | grep -B 2 -A 10 "output_schema"
+```
+
+### 5. Check Database for output_schema Column
+```bash
+sqlite3 mcp.db "PRAGMA table_info(tools);" | grep output_schema
+```
+
+## Interactive Testing
+
+For easier testing, save the token in your shell:
+
+```bash
+# Generate and save token
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+
+# Now you can use $TOKEN in commands:
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -m json.tool
+
+# List specific tool
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -c "import json,sys; [print(json.dumps(t, indent=2)) for t in json.load(sys.stdin) if t.get('name')=='add_numbers']"
+
+# Invoke tool
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" http://localhost:4444/tools/invoke -d '{"name":"add_numbers","arguments":{"a":10,"b":5}}' | python3 -m json.tool
+```
+
+## Verification Steps
+
+### ✅ Step 1: Verify outputSchema in API Response
+```bash
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -c "
+import json, sys
+tools = json.load(sys.stdin)
+for tool in tools:
+    if tool.get('name') == 'add_numbers':
+        has_output = 'outputSchema' in tool and tool['outputSchema'] is not None
+        print(f'✓ add_numbers has outputSchema: {has_output}')
+        if has_output:
+            print(f'  Properties: {list(tool[\"outputSchema\"].get(\"properties\", {}).keys())}')
+"
+```
+
+**Expected**: `✓ add_numbers has outputSchema: True` with properties: `['result', 'operation', 'operands', 'success']`
+
+### ✅ Step 2: Verify Tool Invocation
+```bash
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  http://localhost:4444/tools/invoke \
+  -d '{"name":"add_numbers","arguments":{"a":15,"b":7}}' | python3 -c "
+import json, sys
+result = json.load(sys.stdin)
+if 'content' in result:
+    data = json.loads(result['content'][0]['text'])
+    print(f'✓ Result: {data[\"result\"]}')
+    print(f'✓ Operation: {data[\"operation\"]}')
+    print(f'✓ Operands: {data[\"operands\"]}')
+    print(f'✓ Success: {data[\"success\"]}')
+"
+```
+
+**Expected**: Result: 22.0, Operation: addition, etc.
+
+### ✅ Step 3: Verify Export Includes output_schema
+```bash
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/bulk/export | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for tool in data.get('tools', []):
+    if tool.get('name') == 'add_numbers':
+        has_schema = 'output_schema' in tool and tool['output_schema'] is not None
+        print(f'✓ Export includes output_schema: {has_schema}')
+"
+```
+
+**Expected**: `✓ Export includes output_schema: True`
+
+### ✅ Step 4: Verify Database Column
+```bash
+sqlite3 mcp.db "SELECT name, CASE WHEN output_schema IS NOT NULL THEN 'HAS SCHEMA' ELSE 'NULL' END as schema_status FROM tools WHERE name='add_numbers';"
+```
+
+**Expected**: `add_numbers|HAS SCHEMA`
+
+### ✅ Step 5: Compare Tool With and Without Schema
+```bash
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -c "
+import json, sys
+tools = json.load(sys.stdin)
+for name in ['add_numbers', 'echo']:
+    for tool in tools:
+        if tool.get('name') == name:
+            has_schema = tool.get('outputSchema') is not None
+            print(f'{name:20} outputSchema: {\"✓ Present\" if has_schema else \"✗ Null (expected)\"}')
+            break
+"
+```
+
+**Expected**:
+```
+add_numbers          outputSchema: ✓ Present
+echo                 outputSchema: ✗ Null (expected)
+```
+
+## Troubleshooting
+
+### No tools showing up
+```bash
+# Check gateway registration
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/gateways | python3 -m json.tool
+```
+
+### Authorization errors
+```bash
+# Regenerate token
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+echo "New token: $TOKEN"
+```
+
+### outputSchema is null
+```bash
+# Check if migration ran
+sqlite3 mcp.db "PRAGMA table_info(tools);" | grep output_schema
+
+# Check tool was discovered correctly
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools | python3 -m json.tool | grep -C 5 "add_numbers"
+```
+
+## Summary
+
+The key curl commands you need:
+
+1. **List tools**: `curl -H "Authorization: Bearer $TOKEN" http://localhost:4444/tools`
+2. **Invoke tool**: `curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" http://localhost:4444/tools/invoke -d '{"name":"TOOL_NAME","arguments":{...}}'`
+3. **Export**: `curl -H "Authorization: Bearer $TOKEN" http://localhost:4444/bulk/export`
+4. **Get gateways**: `curl -H "Authorization: Bearer $TOKEN" http://localhost:4444/gateways`
+
+Always set `$TOKEN` first:
+```bash
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+```

--- a/mcp-servers/python/output_schema_test_server/README.md
+++ b/mcp-servers/python/output_schema_test_server/README.md
@@ -1,0 +1,219 @@
+# Output Schema Test MCP Server
+
+A test MCP server for validating outputSchema field support in the MCP Gateway.
+
+## Purpose
+
+This server demonstrates and tests the `outputSchema` field implementation (PR #1263) by providing tools with:
+- **Structured output schemas** using Pydantic models
+- **Complex nested structures** (lists, dicts, nested models)
+- **Output validation** and error handling
+- **Mixed output types** (typed models, dicts, simple strings)
+
+## Features
+
+### Tools with Output Schemas
+
+1. **add_numbers** - Simple calculation with CalculationResult output
+2. **multiply_numbers** - Multiplication with structured output
+3. **divide_numbers** - Division with error handling in output
+4. **create_user** - Complex nested structure (UserInfo model)
+5. **validate_email** - Validation with ValidationResult output
+6. **calculate_stats** - Dict-based output schema
+7. **echo** - Simple string output (no schema for comparison)
+8. **get_server_info** - Server capabilities information
+
+### Output Schema Types
+
+The server demonstrates three types of output schemas:
+
+1. **Pydantic Models** (CalculationResult, UserInfo, ValidationResult)
+   - Fully typed with field validation
+   - Automatic JSON Schema generation
+   - FastMCP converts these to outputSchema
+
+2. **Dict Returns** (calculate_stats, get_server_info)
+   - Flexible structure
+   - No strict typing
+
+3. **Simple Returns** (echo)
+   - No output schema
+   - For baseline comparison
+
+## Installation
+
+```bash
+# From the server directory
+make install
+
+# Or with pip directly
+pip install -e .
+```
+
+## Usage
+
+### Run with stdio (for local testing)
+
+```bash
+make dev
+```
+
+### Run with HTTP
+
+```bash
+make serve-http
+# Server runs on http://0.0.0.0:9100/mcp/
+```
+
+### Test the output schemas
+
+```bash
+# Start HTTP server first
+make serve-http
+
+# In another terminal, run tests
+make test-tools
+```
+
+This will:
+1. List all tools (showing outputSchema fields)
+2. Call add_numbers and show structured output
+3. Call create_user and show complex nested output
+
+## Testing Output Schema Support
+
+### 1. Register with MCP Gateway
+
+```bash
+# Add as a gateway peer
+curl -X POST http://localhost:4444/gateways \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "output-schema-test",
+    "url": "http://localhost:9100/mcp/",
+    "description": "Test server for output schemas",
+    "auth_type": "none"
+  }'
+```
+
+### 2. List tools from gateway
+
+```bash
+# Should show outputSchema field for each tool
+curl http://localhost:4444/tools | jq '.[] | select(.name | contains("add_numbers"))'
+```
+
+Expected output should include:
+```json
+{
+  "name": "add_numbers",
+  "description": "Add two numbers and return a structured result with output schema",
+  "inputSchema": {...},
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {"type": "number", "description": "The calculated result"},
+      "operation": {"type": "string", "description": "The operation performed"},
+      "operands": {"type": "array", "items": {"type": "number"}},
+      "success": {"type": "boolean", "description": "Whether the calculation succeeded"}
+    },
+    "required": ["result", "operation", "operands", "success"]
+  }
+}
+```
+
+### 3. Invoke a tool
+
+```bash
+# Call add_numbers
+curl -X POST http://localhost:4444/tools/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "add_numbers",
+    "arguments": {"a": 10, "b": 5}
+  }'
+```
+
+Expected output:
+```json
+{
+  "result": 15.0,
+  "operation": "addition",
+  "operands": [10.0, 5.0],
+  "success": true
+}
+```
+
+### 4. Test import/export
+
+```bash
+# Export tools (should include outputSchema)
+curl http://localhost:4444/bulk/export > tools.json
+
+# Check that output_schema is present
+jq '.tools[] | select(.name == "add_numbers") | .output_schema' tools.json
+
+# Re-import (should preserve outputSchema)
+curl -X POST http://localhost:4444/bulk/import \
+  -H "Content-Type: application/json" \
+  -d @tools.json
+```
+
+## Validation Checklist
+
+Use this server to verify:
+
+- [ ] outputSchema field appears in tools/list response
+- [ ] outputSchema is stored in database
+- [ ] outputSchema is included in tool export
+- [ ] outputSchema is restored on import
+- [ ] outputSchema is displayed in admin UI
+- [ ] FastMCP Pydantic models generate correct schemas
+- [ ] Dict returns work with and without schemas
+- [ ] Tools without output schemas still work (echo)
+- [ ] Complex nested schemas work (create_user)
+- [ ] Validation schemas work (validate_email)
+
+## MCP Client Configuration
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "output-schema-test": {
+      "command": "python",
+      "args": ["-m", "output_schema_test_server.server_fastmcp"]
+    }
+  }
+}
+```
+
+### Via MCP Gateway
+
+Register as a gateway peer (see Testing section above).
+
+## Development
+
+```bash
+# Install with dev dependencies
+make dev-install
+
+# Format code
+make format
+
+# Run linters
+make lint
+
+# Run tests
+make test
+
+# Clean caches
+make clean
+```
+
+## License
+
+Apache-2.0

--- a/mcp-servers/python/output_schema_test_server/TESTING.md
+++ b/mcp-servers/python/output_schema_test_server/TESTING.md
@@ -1,0 +1,290 @@
+# Testing Output Schema Support
+
+This document provides step-by-step instructions for testing the `outputSchema` field implementation using the output-schema-test-server.
+
+## Setup
+
+1. **Install the server**:
+   ```bash
+   cd mcp-servers/python/output_schema_test_server
+   make install
+   ```
+
+2. **Start the MCP Gateway** (in separate terminal):
+   ```bash
+   cd /home/cmihai/github/mcp-context-forge
+   make dev
+   ```
+
+## Test Method 1: Using mcpgateway.translate (Recommended)
+
+This method is easiest for testing as it wraps the stdio server in an SSE endpoint.
+
+### 1. Start the test server with translate
+
+```bash
+cd mcp-servers/python/output_schema_test_server
+python3 -m mcpgateway.translate \
+  --stdio "python3 -m output_schema_test_server.server_fastmcp" \
+  --host 0.0.0.0 \
+  --port 9100 \
+  --expose-sse
+```
+
+### 2. Register with MCP Gateway
+
+```bash
+curl -X POST http://localhost:4444/gateways \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "output-schema-test",
+    "slug": "output-schema-test",
+    "url": "http://localhost:9100/sse",
+    "description": "Test server for output schemas",
+    "transport": "SSE",
+    "auth_type": "none"
+  }'
+```
+
+### 3. List tools from gateway
+
+```bash
+# Should show outputSchema field
+curl -s http://localhost:4444/tools | jq '.[] | select(.name | contains("add_numbers")) | {name, inputSchema, outputSchema}'
+```
+
+**Expected output**:
+```json
+{
+  "name": "add_numbers",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "a": {
+        "type": "number",
+        "description": "First number"
+      },
+      "b": {
+        "type": "number",
+        "description": "Second number"
+      }
+    },
+    "required": ["a", "b"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "number",
+        "description": "The calculated result"
+      },
+      "operation": {
+        "type": "string",
+        "description": "The operation performed"
+      },
+      "operands": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "description": "The operands used"
+      },
+      "success": {
+        "type": "boolean",
+        "description": "Whether the calculation succeeded"
+      }
+    },
+    "required": ["result", "operation", "operands", "success"]
+  }
+}
+```
+
+### 4. Invoke a tool
+
+```bash
+curl -X POST http://localhost:4444/tools/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "add_numbers",
+    "arguments": {"a": 10, "b": 5}
+  }' | jq
+```
+
+**Expected output**:
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"result\": 15.0, \"operation\": \"addition\", \"operands\": [10.0, 5.0], \"success\": true}"
+    }
+  ]
+}
+```
+
+### 5. Test Export/Import
+
+```bash
+# Export tools (should include outputSchema)
+curl -s http://localhost:4444/bulk/export > /tmp/tools-export.json
+
+# Check that output_schema is present
+jq '.tools[] | select(.name == "add_numbers") | has("output_schema")' /tmp/tools-export.json
+
+# Should output: true
+
+# View the output_schema
+jq '.tools[] | select(.name == "add_numbers") | .output_schema' /tmp/tools-export.json
+```
+
+## Test Method 2: Direct stdio Testing (Advanced)
+
+### Using mcp client (Python)
+
+```python
+import asyncio
+import json
+from mcp.client.session import ClientSession
+from mcp.client.stdio import stdio_client
+
+async def test_output_schemas():
+    """Test outputSchema support via stdio transport."""
+
+    # Start the server
+    server_params = {
+        "command": "python3",
+        "args": ["-m", "output_schema_test_server.server_fastmcp"]
+    }
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            # Initialize
+            await session.initialize()
+
+            # List tools
+            tools = await session.list_tools()
+
+            # Check for outputSchema
+            for tool in tools:
+                print(f"\nTool: {tool.name}")
+                if hasattr(tool, 'outputSchema') and tool.outputSchema:
+                    print(f"  Has outputSchema: ✓")
+                    print(f"  Schema: {json.dumps(tool.outputSchema, indent=2)}")
+                else:
+                    print(f"  Has outputSchema: ✗")
+
+            # Call a tool
+            result = await session.call_tool("add_numbers", {"a": 5, "b": 3})
+            print(f"\nTool call result: {result}")
+
+if __name__ == "__main__":
+    asyncio.run(test_output_schemas())
+```
+
+## Validation Checklist
+
+Use this checklist to verify outputSchema support:
+
+- [ ] **Database**: output_schema column exists in tools table
+- [ ] **API - List Tools**: outputSchema field appears in GET /tools response
+- [ ] **API - Get Tool**: outputSchema field appears in GET /tools/{id} response
+- [ ] **Gateway Discovery**: outputSchema preserved when discovering tools from peer gateway
+- [ ] **Export**: output_schema included in bulk export JSON
+- [ ] **Import**: output_schema restored from bulk import JSON
+- [ ] **Admin UI**: outputSchema displayed in tool details page
+- [ ] **FastMCP Integration**: Pydantic models generate correct outputSchema
+- [ ] **Mixed Types**: Tools with and without outputSchema both work
+- [ ] **Null Handling**: Tools without outputSchema have `null` (not empty object)
+
+## Expected Output Schemas
+
+### add_numbers, multiply_numbers
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {"type": "number"},
+    "operation": {"type": "string"},
+    "operands": {"type": "array", "items": {"type": "number"}},
+    "success": {"type": "boolean"}
+  },
+  "required": ["result", "operation", "operands", "success"]
+}
+```
+
+### create_user
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "email": {"type": "string"},
+    "age": {"type": "integer", "minimum": 0, "maximum": 150},
+    "roles": {"type": "array", "items": {"type": "string"}}
+  },
+  "required": ["name", "email", "age", "roles"]
+}
+```
+
+### validate_email
+```json
+{
+  "type": "object",
+  "properties": {
+    "valid": {"type": "boolean"},
+    "errors": {"type": "array", "items": {"type": "string"}},
+    "cleaned_value": {"type": "string"}
+  },
+  "required": ["valid", "errors", "cleaned_value"]
+}
+```
+
+### echo
+```json
+null
+```
+(No outputSchema - simple string return)
+
+## Troubleshooting
+
+### Server won't start
+```bash
+# Check if port is in use
+lsof -i :9100
+
+# Try a different port
+python3 -m mcpgateway.translate \
+  --stdio "python3 -m output_schema_test_server.server_fastmcp" \
+  --port 9101
+```
+
+### Gateway not discovering tools
+```bash
+# Check gateway registration
+curl http://localhost:4444/gateways | jq
+
+# Check gateway connectivity
+curl http://localhost:9100/sse
+
+# Check gateway logs
+tail -f logs/mcpgateway.log
+```
+
+### outputSchema missing in response
+```bash
+# Verify database migration ran
+sqlite3 mcp.db "PRAGMA table_info(tools);" | grep output_schema
+
+# Check tool in database
+sqlite3 mcp.db "SELECT name, output_schema FROM tools WHERE name='add_numbers';"
+```
+
+## Clean Up
+
+```bash
+# Stop the test server
+pkill -f "output_schema_test_server"
+
+# Remove gateway registration
+curl -X DELETE http://localhost:4444/gateways/{gateway-id}
+```

--- a/mcp-servers/python/output_schema_test_server/pyproject.toml
+++ b/mcp-servers/python/output_schema_test_server/pyproject.toml
@@ -1,0 +1,54 @@
+[project]
+name = "output-schema-test-server"
+version = "0.1.0"
+description = "MCP server for testing outputSchema field support"
+authors = [
+  { name = "MCP Context Forge", email = "noreply@example.com" }
+]
+license = { text = "Apache-2.0" }
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "fastmcp>=2.11.3",
+  "pydantic>=2.5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0.0",
+  "pytest-asyncio>=0.21.0",
+  "pytest-cov>=4.0.0",
+  "black>=23.0.0",
+  "mypy>=1.5.0",
+  "ruff>=0.0.290",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/output_schema_test_server"]
+
+[project.scripts]
+output-schema-test-server = "output_schema_test_server.server_fastmcp:main"
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = ["E", "W", "F", "B", "I", "N", "UP"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "--cov=output_schema_test_server --cov-report=term-missing"

--- a/mcp-servers/python/output_schema_test_server/src/output_schema_test_server/__init__.py
+++ b/mcp-servers/python/output_schema_test_server/src/output_schema_test_server/__init__.py
@@ -1,0 +1,3 @@
+"""Output Schema Test Server - MCP server for testing output_schema field support."""
+
+__version__ = "0.1.0"

--- a/mcp-servers/python/output_schema_test_server/src/output_schema_test_server/server_fastmcp.py
+++ b/mcp-servers/python/output_schema_test_server/src/output_schema_test_server/server_fastmcp.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./mcp-servers/python/output_schema_test_server/src/output_schema_test_server/server_fastmcp.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Output Schema Test Server
+
+MCP server for testing the outputSchema field support in tools.
+Implements tools with explicit output schemas to verify the complete workflow.
+"""
+
+import argparse
+import logging
+import sys
+from typing import Dict, Any
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+# Configure logging to stderr to avoid MCP protocol interference
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stderr)],
+)
+logger = logging.getLogger(__name__)
+
+# Create FastMCP server instance
+mcp = FastMCP(
+    name="output-schema-test-server",
+    version="0.1.0"
+)
+
+
+# Pydantic models for structured outputs
+class CalculationResult(BaseModel):
+    """Result of a mathematical calculation."""
+    result: float = Field(..., description="The calculated result")
+    operation: str = Field(..., description="The operation performed")
+    operands: list[float] = Field(..., description="The operands used")
+    success: bool = Field(True, description="Whether the calculation succeeded")
+
+
+class UserInfo(BaseModel):
+    """User information structure."""
+    name: str = Field(..., description="User's full name")
+    email: str = Field(..., description="User's email address")
+    age: int = Field(..., ge=0, le=150, description="User's age")
+    roles: list[str] = Field(default_factory=list, description="User's roles")
+
+
+class ValidationResult(BaseModel):
+    """Result of input validation."""
+    valid: bool = Field(..., description="Whether the input is valid")
+    errors: list[str] = Field(default_factory=list, description="Validation errors if any")
+    cleaned_value: str = Field(..., description="Cleaned/normalized value")
+
+
+# Tools with output schemas
+@mcp.tool(
+    description="Add two numbers and return a structured result with output schema"
+)
+async def add_numbers(
+    a: float = Field(..., description="First number"),
+    b: float = Field(..., description="Second number")
+) -> CalculationResult:
+    """Add two numbers and return a structured result.
+
+    This tool demonstrates outputSchema support by returning a typed Pydantic model.
+    The MCP framework should automatically generate the output schema.
+    """
+    logger.info(f"Adding {a} + {b}")
+    return CalculationResult(
+        result=a + b,
+        operation="addition",
+        operands=[a, b],
+        success=True
+    )
+
+
+@mcp.tool(
+    description="Multiply two numbers with structured output"
+)
+async def multiply_numbers(
+    a: float = Field(..., description="First number"),
+    b: float = Field(..., description="Second number")
+) -> CalculationResult:
+    """Multiply two numbers and return a structured result."""
+    logger.info(f"Multiplying {a} * {b}")
+    return CalculationResult(
+        result=a * b,
+        operation="multiplication",
+        operands=[a, b],
+        success=True
+    )
+
+
+@mcp.tool(
+    description="Divide two numbers with error handling in output"
+)
+async def divide_numbers(
+    a: float = Field(..., description="Numerator"),
+    b: float = Field(..., description="Denominator")
+) -> CalculationResult:
+    """Divide two numbers with error handling."""
+    logger.info(f"Dividing {a} / {b}")
+
+    if b == 0:
+        # Return structured error
+        return CalculationResult(
+            result=0.0,
+            operation="division",
+            operands=[a, b],
+            success=False
+        )
+
+    return CalculationResult(
+        result=a / b,
+        operation="division",
+        operands=[a, b],
+        success=True
+    )
+
+
+@mcp.tool(
+    description="Create a user profile with structured validation"
+)
+async def create_user(
+    name: str = Field(..., min_length=1, max_length=100, description="User's full name"),
+    email: str = Field(..., pattern=r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", description="Valid email address"),
+    age: int = Field(..., ge=0, le=150, description="User's age"),
+    roles: list[str] = Field(default_factory=list, description="User's roles")
+) -> UserInfo:
+    """Create a user profile with validation.
+
+    This tool demonstrates complex output schemas with nested fields and validation.
+    """
+    logger.info(f"Creating user: {name}")
+    return UserInfo(
+        name=name,
+        email=email,
+        age=age,
+        roles=roles if roles else ["user"]
+    )
+
+
+@mcp.tool(
+    description="Validate email address format"
+)
+async def validate_email(
+    email: str = Field(..., description="Email address to validate")
+) -> ValidationResult:
+    """Validate an email address and return structured validation result."""
+    import re
+
+    email_pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    errors = []
+
+    if not email:
+        errors.append("Email cannot be empty")
+    elif not re.match(email_pattern, email):
+        errors.append("Invalid email format")
+
+    if "@" not in email:
+        errors.append("Email must contain @ symbol")
+
+    cleaned = email.strip().lower()
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        errors=errors,
+        cleaned_value=cleaned
+    )
+
+
+@mcp.tool(
+    description="Perform calculation with multiple operations (testing complex output)"
+)
+async def calculate_stats(
+    numbers: list[float] = Field(..., min_length=1, description="List of numbers to analyze")
+) -> Dict[str, Any]:
+    """Calculate statistics from a list of numbers.
+
+    Returns a dictionary with statistical measures.
+    This tests dict-based output schemas.
+    """
+    if not numbers:
+        return {
+            "error": "Empty list provided",
+            "success": False
+        }
+
+    result = {
+        "count": len(numbers),
+        "sum": sum(numbers),
+        "mean": sum(numbers) / len(numbers),
+        "min": min(numbers),
+        "max": max(numbers),
+        "range": max(numbers) - min(numbers),
+        "success": True
+    }
+
+    # Calculate median
+    sorted_numbers = sorted(numbers)
+    n = len(sorted_numbers)
+    if n % 2 == 0:
+        result["median"] = (sorted_numbers[n//2 - 1] + sorted_numbers[n//2]) / 2
+    else:
+        result["median"] = sorted_numbers[n//2]
+
+    return result
+
+
+@mcp.tool(
+    description="Simple echo tool without output schema (for comparison)"
+)
+async def echo(
+    message: str = Field(..., description="Message to echo back")
+) -> str:
+    """Echo a message back - simple string return without schema."""
+    logger.info(f"Echoing: {message}")
+    return f"Echo: {message}"
+
+
+@mcp.tool(
+    description="Get server information and capabilities"
+)
+async def get_server_info() -> Dict[str, Any]:
+    """Get information about this MCP server and its output schema capabilities."""
+    return {
+        "server_name": "output-schema-test-server",
+        "version": "0.1.0",
+        "supports_output_schema": True,
+        "tools_with_schemas": [
+            "add_numbers",
+            "multiply_numbers",
+            "divide_numbers",
+            "create_user",
+            "validate_email",
+            "calculate_stats"
+        ],
+        "tools_without_schemas": ["echo"],
+        "description": "Test server demonstrating MCP outputSchema field support",
+        "schema_types": {
+            "pydantic_models": ["CalculationResult", "UserInfo", "ValidationResult"],
+            "dict_returns": ["calculate_stats", "get_server_info"],
+            "simple_returns": ["echo"]
+        }
+    }
+
+
+def main() -> None:
+    """Main server entry point with transport selection."""
+    parser = argparse.ArgumentParser(
+        description="Output Schema Test MCP Server - Tests outputSchema field support"
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="Transport mode (stdio or http)"
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="HTTP host (only for http transport)"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=9100,
+        help="HTTP port (only for http transport)"
+    )
+
+    args = parser.parse_args()
+
+    if args.transport == "http":
+        logger.info(
+            f"Starting Output Schema Test Server on HTTP at {args.host}:{args.port}"
+        )
+        logger.info(f"HTTP endpoint: http://{args.host}:{args.port}/mcp/")
+        mcp.run(transport="http", host=args.host, port=args.port)
+    else:
+        logger.info("Starting Output Schema Test Server on stdio")
+        mcp.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/mcp-servers/python/output_schema_test_server/test-quick.sh
+++ b/mcp-servers/python/output_schema_test_server/test-quick.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Quick test script for outputSchema implementation
+
+# Generate token
+echo "Generating JWT token..."
+export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 0 --secret changeme123 2>/dev/null | head -1)
+
+echo "Token: ${TOKEN:0:50}..."
+echo ""
+
+echo "=== Test 1: List tools with outputSchema ==="
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | python3 -c "
+import json, sys
+tools = json.load(sys.stdin)
+for tool in tools:
+    if 'add_numbers' in tool.get('name', '') or 'create_user' in tool.get('name', '') or tool.get('name') == 'echo':
+        print(f\"{tool['name']}: has_outputSchema={tool.get('outputSchema') is not None}\")
+"
+
+echo ""
+echo "=== Test 2: View add_numbers with full details ==="
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | python3 -c "
+import json, sys
+tools = json.load(sys.stdin)
+for tool in tools:
+    if tool.get('name') == 'add_numbers':
+        print('Name:', tool['name'])
+        print('Has inputSchema:', 'inputSchema' in tool)
+        print('Has outputSchema:', 'outputSchema' in tool)
+        if tool.get('outputSchema'):
+            print('outputSchema keys:', list(tool['outputSchema'].keys()))
+            if 'properties' in tool['outputSchema']:
+                print('Output properties:', list(tool['outputSchema']['properties'].keys()))
+        break
+"
+
+echo ""
+echo "=== Test 3: Invoke add_numbers ==="
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://localhost:4444/tools/invoke \
+  -d '{"name": "add_numbers", "arguments": {"a": 10, "b": 5}}' | python3 -c "
+import json, sys
+result = json.load(sys.stdin)
+if 'content' in result:
+    text = json.loads(result['content'][0]['text'])
+    print('Result:', json.dumps(text, indent=2))
+else:
+    print('Error:', result)
+"
+
+echo ""
+echo "=== Test 4: Check echo tool (should have null outputSchema) ==="
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | python3 -c "
+import json, sys
+tools = json.load(sys.stdin)
+for tool in tools:
+    if tool.get('name') == 'echo':
+        print('Name:', tool['name'])
+        print('outputSchema:', tool.get('outputSchema'))
+        break
+"
+
+echo ""
+echo "=== All Tests Complete ==="

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4942,6 +4942,7 @@ async def admin_add_tool(
       - integrationType (mapped to integration_type; defaults to "MCP")
       - headers (JSON string)
       - input_schema (JSON string)
+      - output_schema (JSON string, optional)
       - jsonpath_filter (optional)
       - auth_type (optional)
       - auth_username (optional)
@@ -5077,6 +5078,7 @@ async def admin_add_tool(
     # Safely parse potential JSON strings from form
     headers_raw = form.get("headers")
     input_schema_raw = form.get("input_schema")
+    output_schema_raw = form.get("output_schema")
     annotations_raw = form.get("annotations")
     tool_data: dict[str, Any] = {
         "name": form.get("name"),
@@ -5087,6 +5089,7 @@ async def admin_add_tool(
         "integration_type": integration_type,
         "headers": json.loads(headers_raw if isinstance(headers_raw, str) and headers_raw else "{}"),
         "input_schema": json.loads(input_schema_raw if isinstance(input_schema_raw, str) and input_schema_raw else "{}"),
+        "output_schema": json.loads(output_schema_raw if isinstance(output_schema_raw, str) and output_schema_raw else "{}"),
         "annotations": json.loads(annotations_raw if isinstance(annotations_raw, str) and annotations_raw else "{}"),
         "jsonpath_filter": form.get("jsonpath_filter", ""),
         "auth_type": form.get("auth_type", ""),
@@ -5159,6 +5162,7 @@ async def admin_edit_tool(
       - integrationType (to be mapped to integration_type)
       - headers (as a JSON string)
       - input_schema (as a JSON string)
+      - output_schema (as a JSON string, optional)
       - jsonpathFilter (optional)
       - auth_type (optional, string: "basic", "bearer", or empty)
       - auth_username (optional, for basic auth)
@@ -5334,6 +5338,7 @@ async def admin_edit_tool(
 
     headers_raw2 = form.get("headers")
     input_schema_raw2 = form.get("input_schema")
+    output_schema_raw2 = form.get("output_schema")
     annotations_raw2 = form.get("annotations")
 
     tool_data: dict[str, Any] = {
@@ -5344,6 +5349,7 @@ async def admin_edit_tool(
         "description": form.get("description"),
         "headers": json.loads(headers_raw2 if isinstance(headers_raw2, str) and headers_raw2 else "{}"),
         "input_schema": json.loads(input_schema_raw2 if isinstance(input_schema_raw2, str) and input_schema_raw2 else "{}"),
+        "output_schema": json.loads(output_schema_raw2 if isinstance(output_schema_raw2, str) and output_schema_raw2 else "{}"),
         "annotations": json.loads(annotations_raw2 if isinstance(annotations_raw2, str) and annotations_raw2 else "{}"),
         "jsonpath_filter": form.get("jsonpathFilter", ""),
         "auth_type": form.get("auth_type", ""),

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -2183,6 +2183,10 @@ async function editTool(toolId) {
             JSON.stringify(tool.inputSchema || {}),
             "Schema",
         );
+        const outputSchemaValidation = validateJson(
+            JSON.stringify(tool.outputSchema || {}),
+            "Output Schema",
+        );
         const annotationsValidation = validateJson(
             JSON.stringify(tool.annotations || {}),
             "Annotations",
@@ -2190,6 +2194,7 @@ async function editTool(toolId) {
 
         const headersField = safeGetElement("edit-tool-headers");
         const schemaField = safeGetElement("edit-tool-schema");
+        const outputSchemaField = safeGetElement("edit-tool-output-schema");
         const annotationsField = safeGetElement("edit-tool-annotations");
 
         if (headersField && headersValidation.valid) {
@@ -2201,6 +2206,13 @@ async function editTool(toolId) {
         }
         if (schemaField && schemaValidation.valid) {
             schemaField.value = JSON.stringify(schemaValidation.value, null, 2);
+        }
+        if (outputSchemaField && outputSchemaValidation.valid) {
+            outputSchemaField.value = JSON.stringify(
+                outputSchemaValidation.value,
+                null,
+                2,
+            );
         }
         if (annotationsField && annotationsValidation.valid) {
             annotationsField.value = JSON.stringify(
@@ -2222,6 +2234,12 @@ async function editTool(toolId) {
                 JSON.stringify(schemaValidation.value, null, 2),
             );
             window.editToolSchemaEditor.refresh();
+        }
+        if (window.editToolOutputSchemaEditor && outputSchemaValidation.valid) {
+            window.editToolOutputSchemaEditor.setValue(
+                JSON.stringify(outputSchemaValidation.value, null, 2),
+            );
+            window.editToolOutputSchemaEditor.refresh();
         }
 
         // Prefill integration type from DB and set request types accordingly
@@ -7328,6 +7346,10 @@ async function viewTool(toolId) {
               <strong class="text-gray-700 dark:text-gray-300">Input Schema:</strong>
               <pre class="mt-1 bg-gray-100 p-3 rounded text-xs dark:bg-gray-800 dark:text-gray-200 tool-schema overflow-x-auto"></pre>
             </div>
+            <div>
+              <strong class="text-gray-700 dark:text-gray-300">Output Schema:</strong>
+              <pre class="mt-1 bg-gray-100 p-3 rounded text-xs dark:bg-gray-800 dark:text-gray-200 tool-output-schema overflow-x-auto"></pre>
+            </div>
           </div>
 
           <!-- Metrics Section -->
@@ -7465,6 +7487,10 @@ async function viewTool(toolId) {
             setTextSafely(
                 ".tool-schema",
                 JSON.stringify(tool.inputSchema || {}, null, 2),
+            );
+            setTextSafely(
+                ".tool-output-schema",
+                JSON.stringify(tool.outputSchema || {}, null, 2),
             );
 
             // Set auth fields safely

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3091,6 +3091,21 @@
               <div>
                 <label
                   class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                  >Output Schema (JSON)</label
+                >
+                <textarea
+                  name="output_schema"
+                  id="output-schema-editor"
+                  class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                  placeholder="{&quot;type&quot;: &quot;object&quot;, &quot;properties&quot;: {}}"
+                ></textarea>
+                <p class="mt-1 text-xs text-gray-500 dark:text-indigo-300">
+                  Optional JSON Schema for validating structured tool output. Leave empty if not needed.
+                </p>
+              </div>
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
                   >Json Path Filter</label
                 >
                 <input
@@ -6528,6 +6543,21 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         id="edit-tool-schema"
                         class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
+                    </div>
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Output Schema (JSON)</label
+                      >
+                      <textarea
+                        name="output_schema"
+                        id="edit-tool-output-schema"
+                        class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        placeholder="{&quot;type&quot;: &quot;object&quot;, &quot;properties&quot;: {}}"
+                      ></textarea>
+                      <p class="mt-1 text-xs text-gray-500 dark:text-indigo-300">
+                        Optional JSON Schema for validating structured tool output. Per MCP spec, servers should return structured results that conform to this schema.
+                      </p>
                     </div>
                     <div>
                       <label


### PR DESCRIPTION
Implements UI support for the MCP Tool `outputSchema` field to complete issue #1258. The backend support was already added in PR #1263 (database, models, schemas, service layer). This PR adds the missing UI components.

Also adds test tools in `mcp-servers/python/output_schema_test_server`

## Changes

### Modified Files

1. **mcpgateway/templates/admin.html**
   - Added `output_schema` field to tool creation form (lines 3091-3105)
   - Added `output_schema` field to tool edit form (lines 6547-6561)
   - Both fields include JSON textarea with CodeMirror support
   - Added help text explaining the optional nature and MCP spec compliance

2. **mcpgateway/admin.py**
   - Updated `admin_add_tool()` to parse `output_schema` from form data (lines 5080-5091)
   - Updated `admin_edit_tool()` to parse `output_schema` from form data (lines 5339-5351)
   - Both handlers convert JSON string to dict for storage

3. **mcpgateway/static/admin.js**
   - Updated `editTool()` function to populate `output_schema` field (lines 2186-2239)
   - Added JSON validation and CodeMirror editor support for output_schema
   - Updated `viewTool()` function to display output_schema in tool details modal (lines 7349-7352, 7491-7494)
   - Output schema displayed as formatted JSON alongside input schema

## Features

### Tool Creation Form
- New "Output Schema (JSON)" textarea field
- Placeholder shows example JSON schema structure
- Optional field with clear help text
- Validates JSON format on save

### Tool Edit Form
- Output schema field populated from database
- JSON validation before display
- CodeMirror editor support for syntax highlighting
- Preserves formatting with 2-space indentation

### Tool View/Details
- Output Schema section added to technical details
- Displayed in consistent format with Input Schema
- Shows formatted JSON with syntax highlighting
- Falls back to empty object if not present

## Testing

All quality checks passed:
- ✅ HTML linting (prettier, htmlhint)
- ✅ JavaScript linting (prettier, eslint)
- ✅ Pre-commit hooks
- ✅ Unit tests (3446 passed, 45 skipped)

## MCP Specification Compliance

This implementation follows the MCP specification for tool output schemas:
- Field name uses `output_schema` in database with alias `outputSchema` for API responses
- Accepts JSON Schema format for structured output validation
- Optional field - tools without output schemas continue to work normally
- Compatible with FastMCP auto-generated schemas from Pydantic return types

## Integration

Works seamlessly with existing MCP server discovery:
- FastMCP servers with Pydantic return types automatically generate `outputSchema`
- Discovery process captures and stores `outputSchema` in database
- UI displays discovered schemas without additional configuration
- Users can manually add/edit schemas for tools without auto-generation

## Database

No migration required - `output_schema` column already exists from PR #1263.

## Closes

Closes #1258

<img width="1225" height="1471" alt="image" src="https://github.com/user-attachments/assets/5837bcbb-b012-43a8-8546-ff1025f8fc5c" />
