### PR TITLE
Fix UI margins

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -125,7 +125,7 @@
                 href="https://github.com/IBM/mcp-context-forge"
                 target="_blank"
                 class="text-indigo-600 dark:text-indigo-500 hover:underline"
-                >Github</a
+                >⭐ GitHub</a
               >
               <span class="mx-2 text-gray-400">|</span>
               <button


### PR DESCRIPTION
# 🐛 Fix UI margin issue

## 📌 Summary
Unable to switch between page tabs by selecting tab names. Noticed this issue in `0.8.0` and latest, doesn't seem to occur in `0.7.0`.

## 🔁 Reproduction Steps

1. Run `0.8.0`: `podman run -p 4444:4444 --env-file .env ghcr.io/ibm/mcp-context-forge:0.8.0`
2. Try to switch tabs by selecting name. 

<img width="1606" height="239" alt="image" src="https://github.com/user-attachments/assets/5a8dc783-54f8-466c-a019-41810c9d0a8b" />


## 🐞 Root Cause
Header margins seems to override with the navigation links.

## 💡 Fix Description
Increased top margin for navigation link.

<img width="1656" height="299" alt="image" src="https://github.com/user-attachments/assets/adb3534c-a0ba-4bc5-99d3-8eb2deb321bf" />


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed