### PR TITLE
feat: add optional persistence support for PostgreSQL and Redis

### DIFF
--- a/charts/mcp-stack/templates/configmap-redis.yaml
+++ b/charts/mcp-stack/templates/configmap-redis.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.redis.enabled .Values.redis.persistence.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-redis-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-redis
+data:
+  redis.conf: |
+    # Redis persistence configuration
+    # Enable AOF (Append Only File) persistence
+    appendonly yes
+    appendfilename "appendonly.aof"
+    
+    # AOF rewrite configuration
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+    
+    # RDB configuration (backup snapshots)
+    save 900 1     # Save after 900 sec if at least 1 key changed
+    save 300 10    # Save after 300 sec if at least 10 keys changed
+    save 60 10000  # Save after 60 sec if at least 10000 keys changed
+    
+    # Set the directory for persistence files
+    dir /data
+    
+    # Other recommended settings for data safety
+    stop-writes-on-bgsave-error yes
+    rdbcompression yes
+    rdbchecksum yes
+{{- end }}

--- a/charts/mcp-stack/templates/deployment-postgres.yaml
+++ b/charts/mcp-stack/templates/deployment-postgres.yaml
@@ -73,6 +73,10 @@ spec:
 
       volumes:
         - name: postgredb
+          {{- if .Values.postgres.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: postgres-pv-claim   # keep aligned with templates/postgres-pvc.yaml
+            claimName: {{ include "mcp-stack.fullname" . }}-postgres-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
 {{- end }}

--- a/charts/mcp-stack/templates/deployment-redis.yaml
+++ b/charts/mcp-stack/templates/deployment-redis.yaml
@@ -35,6 +35,11 @@ spec:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          
+          {{- if .Values.redis.persistence.enabled }}
+          # Use custom redis.conf with persistence settings
+          command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+          {{- end }}
 
           # Expose Redis TCP port inside the pod
           ports:
@@ -53,8 +58,27 @@ spec:
 {{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
           {{- end }}
 
+          # ─── Volume mounts for persistence ───
+          volumeMounts:
+            {{- if .Values.redis.persistence.enabled }}
+            - name: redis-data
+              mountPath: /data
+            - name: redis-config
+              mountPath: /usr/local/etc/redis
+            {{- end }}
+
           # ─── Resource limits & requests ───
           {{- with .Values.redis.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
+
+      volumes:
+        {{- if .Values.redis.persistence.enabled }}
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-stack.fullname" . }}-redis-pvc
+        - name: redis-config
+          configMap:
+            name: {{ include "mcp-stack.fullname" . }}-redis-config
+        {{- end }}
 {{- end }}

--- a/charts/mcp-stack/templates/postgres-pv.yaml
+++ b/charts/mcp-stack/templates/postgres-pv.yaml
@@ -2,15 +2,20 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: postgres-pv-volume
+  name: {{ include "mcp-stack.fullname" . }}-{{ .Release.Namespace }}-postgres-pv
   labels:
-    type: local
-    app: postgres
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-postgres
+    component: storage
 spec:
   storageClassName: {{ .Values.postgres.persistence.storageClassName }}
   capacity:
     storage: {{ .Values.postgres.persistence.size }}
   accessModes: {{- toYaml .Values.postgres.persistence.accessModes | nindent 4 }}
+  persistentVolumeReclaimPolicy: {{ .Values.postgres.persistence.reclaimPolicy | default "Retain" }}
+  claimRef:
+    name: {{ include "mcp-stack.fullname" . }}-postgres-pvc
+    namespace: {{ .Release.Namespace }}
   hostPath:
-    path: "/mnt/data"
+    path: "/mnt/data/postgres"
 {{- end }}

--- a/charts/mcp-stack/templates/postgres-pvc.yaml
+++ b/charts/mcp-stack/templates/postgres-pvc.yaml
@@ -2,12 +2,21 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: postgres-pv-claim
+  name: {{ include "mcp-stack.fullname" . }}-postgres-pvc
   labels:
-    app: postgres
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-postgres
+    component: storage
+  {{- if .Values.postgres.persistence.annotations }}
+  annotations:
+    {{- toYaml .Values.postgres.persistence.annotations | nindent 4 }}
+  {{- end }}
 spec:
   storageClassName: {{ .Values.postgres.persistence.storageClassName }}
   accessModes: {{- toYaml .Values.postgres.persistence.accessModes | nindent 4 }}
+  selector:
+    matchLabels:
+      app: {{ include "mcp-stack.fullname" . }}-postgres
   resources:
     requests:
       storage: {{ .Values.postgres.persistence.size }}

--- a/charts/mcp-stack/templates/redis-pv.yaml
+++ b/charts/mcp-stack/templates/redis-pv.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.redis.enabled .Values.redis.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-{{ .Release.Namespace }}-redis-pv
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-redis
+    component: storage
+spec:
+  storageClassName: {{ .Values.redis.persistence.storageClassName }}
+  capacity:
+    storage: {{ .Values.redis.persistence.size }}
+  accessModes: {{- toYaml .Values.redis.persistence.accessModes | nindent 4 }}
+  persistentVolumeReclaimPolicy: {{ .Values.redis.persistence.reclaimPolicy | default "Retain" }}
+  claimRef:
+    name: {{ include "mcp-stack.fullname" . }}-redis-pvc
+    namespace: {{ .Release.Namespace }}
+  hostPath:
+    path: "/mnt/data/redis"
+{{- end }}

--- a/charts/mcp-stack/templates/redis-pvc.yaml
+++ b/charts/mcp-stack/templates/redis-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.redis.enabled .Values.redis.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-redis-pvc
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-redis
+    component: storage
+  {{- if .Values.redis.persistence.annotations }}
+  annotations:
+    {{- toYaml .Values.redis.persistence.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  storageClassName: {{ .Values.redis.persistence.storageClassName }}
+  accessModes: {{- toYaml .Values.redis.persistence.accessModes | nindent 4 }}
+  selector:
+    matchLabels:
+      app: {{ include "mcp-stack.fullname" . }}-redis
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+{{- end }}

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -557,9 +557,13 @@ postgres:
   # PersistentVolumeClaim for data durability
   persistence:
     enabled: true
-    storageClassName: manual     # pick a StorageClass (e.g. gp2, standard)
-    accessModes: [ReadWriteMany]
+    storageClassName: ""         # Use empty string for default StorageClass
+    accessModes: [ReadWriteOnce]
     size: 5Gi
+    reclaimPolicy: Retain        # Retain prevents data loss when PVC is deleted (manual cleanup required after uninstall)
+    annotations: {}              # Optional annotations for backup tools
+      # backup.velero.io/backup-volumes: "postgres-data"
+      # backup.policy/schedule: "daily"
 
   # Leave blank to autogenerate <release>-mcp-stack-postgres-secret.
   existingSecret: ""
@@ -641,6 +645,17 @@ redis:
       timeoutSeconds: 2
       successThreshold: 1
       failureThreshold: 5
+
+  # ─── Persistence configuration ───
+  persistence:
+    enabled: false               # Set to true to enable Redis persistence
+    storageClassName: ""         # Use empty string for default StorageClass
+    accessModes: [ReadWriteOnce]
+    size: 1Gi
+    reclaimPolicy: Retain        # Retain prevents data loss when PVC is deleted (manual cleanup required after uninstall)
+    annotations: {}              # Optional annotations for backup tools
+      # backup.velero.io/backup-volumes: "redis-data"
+      # backup.policy/schedule: "daily"
 
 ########################################################################
 # PGADMIN - Web UI for Postgres


### PR DESCRIPTION
feat: add optional persistence support for PostgreSQL and Redis in mcp-stack Helm chart

- Add conditional PV/PVC templates for PostgreSQL and Redis with proper Helm templating
- Enhance PostgreSQL deployment with conditional persistence (PVC or emptyDir fallback) 
- Add Redis persistence configuration with AOF and RDB settings via ConfigMap
- Standardize resource naming using Helm template helpers for consistency
- Add backup annotations support for both PostgreSQL and Redis persistence
- Set default reclaim policy to 'Retain' to prevent accidental data loss
- Enable Redis custom configuration mounting when persistence is enabled

Templates added:
- charts/mcp-stack/templates/redis-pv.yaml
- charts/mcp-stack/templates/redis-pvc.yaml  
- charts/mcp-stack/templates/configmap-redis.yaml

Templates enhanced:
- Improve PostgreSQL PV/PVC naming and labeling consistency
- Add conditional volume mounting logic for both PostgreSQL and Redis
- Add persistence configuration sections in values.yaml

Note: Persistence is disabled by default for Redis (caching use case) and can be enabled via values.yaml

Discussed here: https://github.com/IBM/mcp-context-forge/issues/1308
