### PR TITLE
chore: add type annotations to slugify function

### DIFF
--- a/mcpgateway/utils/create_slug.py
+++ b/mcpgateway/utils/create_slug.py
@@ -29,7 +29,7 @@ SPECIAL_CHAR_MAP = {
 }
 
 
-def slugify(text):
+def slugify(text: str) -> str:
     """Make an ASCII slug of text.
 
     Args:


### PR DESCRIPTION
## Summary

- Added explicit type annotations to the `slugify` function in `mcpgateway/utils/create_slug.py`
- Parameter `text` now annotated as `str`
- Return type now annotated as `str`

## Rationale

The `slugify` function is used throughout the codebase for generating URL-safe slugs from text. Adding type annotations improves:
- Type checker accuracy (mypy, pyright)
- IDE autocomplete and inline documentation
- Code maintainability and self-documentation

## Changes

- `mcpgateway/utils/create_slug.py:32` - Updated function signature from `def slugify(text):` to `def slugify(text: str) -> str:`

## Test Plan

- [ ] Verify existing unit tests pass: `pytest tests/unit/mcpgateway/utils/test_create_slug.py -v`
- [ ] Run type checker: `mypy mcpgateway/utils/create_slug.py`
- [ ] Verify no regressions in dependent code: `make flake8 pylint`
- [ ] Confirm doctest still passes: `make doctest`