### PR TITLE
Update CLAUDE.md and link to existing documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,29 +276,29 @@ make doctest test htmlcov smoketest lint-web flake8 bandit interrogate pylint ve
 ### Core Features
 - [A2A Agent Integration](docs/docs/using/agents/a2a.md) - Agent-to-Agent setup, authentication, monitoring
 - [Plugin Development](docs/docs/architecture/plugins.md) - Plugin framework, hooks, creating custom plugins
-- [Virtual Servers](docs/docs/manage/virtual-servers.md) - Creating and managing composite MCP servers
+- [Virtual Servers](docs/docs/manage/api-usage.md#virtual-server-management) - Creating and managing composite MCP servers
 - [Export/Import Reference](docs/docs/manage/export-import-reference.md) - Bulk operations and configuration migration
 
 ### Architecture & Design
-- [Architecture Overview](docs/docs/architecture/README.md) - System design, components, data flow
-- [ADR Index](docs/docs/architecture/adr/README.md) - Architecture Decision Records
-- [Security Architecture](docs/docs/architecture/security.md) - Authentication, authorization, security features
+- [Architecture Overview](docs/docs/architecture/index.md) - System design, components, data flow
+- [ADR Index](docs/docs/architecture/adr/index.md) - Architecture Decision Records
+- [Security Architecture](docs/docs/architecture/security-features.md) - Authentication, authorization, security features
 - [Multi-Transport Design](docs/docs/architecture/adr/003-expose-multi-transport-endpoints.md) - HTTP, WebSocket, SSE, STDIO
 
 ### Operations & Management
 - [Logging & Monitoring](docs/docs/manage/logging.md) - Log configuration, rotation, analysis
 - [Performance Tuning](docs/docs/testing/performance.md) - Benchmarks, optimization, profiling
-- [Scaling & High Availability](docs/docs/manage/scaling.md) - Horizontal scaling, load balancing, federation
+- [Scaling & High Availability](docs/docs/manage/scale.md) - Horizontal scaling, load balancing, federation
 - [Well-Known URIs](docs/docs/manage/well-known-uris.md) - Standard endpoints (robots.txt, security.txt)
 
 ### Deployment
-- [Docker/Podman Deployment](docs/docs/deployment/docker.md) - Container setup and configuration
+- [Container Deployment](docs/docs/deployment/container.md) - Docker/Podman setup and configuration
 - [Kubernetes Deployment](docs/docs/deployment/kubernetes.md) - K8s manifests and Helm charts
 - [Cloud Deployments](docs/docs/deployment/) - AWS, Azure, GCP, Fly.io guides
 
 ### Testing & Quality
 - [Testing Guide](docs/docs/testing/basic.md) - Unit, integration, E2E, security testing
-- [Security Testing](docs/docs/testing/security.md) - Vulnerability scanning, penetration testing
+- [Fuzzing & Property Testing](docs/docs/testing/fuzzing.md) - Advanced testing techniques
 - [Documentation Standards](docs/docs/development/documentation.md) - Writing and maintaining docs
 
 ### Integration Guides


### PR DESCRIPTION
## Summary

- Reorganize CLAUDE.md with clearer structure and documentation quick links
- Enable flake8 and black in pre-commit hooks for consistent code quality
- Standardize use of uv environment manager across Makefile and CI
- Configure Neovim linters (flake8, pylint) for editor integration
- Fix pytest warnings configuration in test runs

## Changes

### Documentation Improvements
- Restructure CLAUDE.md with focused essential commands section
- Move detailed performance configuration to dedicated docs
- Add comprehensive documentation quick links section organized by category
- Clarify uv usage for virtual environment management

### Code Quality Tooling
- Enable flake8 pre-commit hook for style enforcement
- Enable black pre-commit hook for consistent formatting
- Remove obsolete fix-encoding-pragma hook
- Configure Neovim ALE linters: mypy, ruff, flake8, pylint

### Build System Updates
- Add `make uv` target to ensure uv is installed (brew or curl fallback)
- Update `make pylint` to use `uv run` with proper error handling
- Adjust `make test` to show warnings (remove --disable-warnings)
- Standardize pylint flags: `--fail-on E --fail-under 10`

### CI/CD Alignment
- Install uv in GitHub Actions lint workflow
- Update pylint job to use `uv run` instead of pip install
- Ensure CI matches local development environment

## Test Plan

- [x] Run `make venv install-dev` - virtual environment setup works
- [x] Run `make flake8` - linting passes
- [x] Run `make pylint` - pylint checks pass with uv
- [x] Run `make black` - formatting applied correctly
- [x] Run `make pre-commit` - all pre-commit hooks execute
- [x] Run `make test` - tests pass with warnings visible
- [x] Verify GitHub Actions lint workflow completes