### PR TITLE
Temporary fix for server tools

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -1211,10 +1211,10 @@ class SessionRegistry(SessionBackend):
             >>> from mcpgateway.cache.session_registry import SessionRegistry
             >>>
             >>> reg = SessionRegistry()
-            >>> body = {'protocol_version': '2025-06-18'}
+            >>> body = {'protocol_version': '2025-03-26'}
             >>> result = asyncio.run(reg.handle_initialize_logic(body))
             >>> result.protocol_version
-            '2025-06-18'
+            '2025-03-26'
             >>> result.server_info.name
             'MCP_Gateway'
             >>>


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Uses `settings.pagination_default_page_size` for limiting the results in server page.

Exploring options for the following fixes
1. Consolidating multiple listing functions - `list_tools`, `list_tools_for_user`, etc.
2. Using `cursor` instead of `limit` and `offset` for pagination in tools page to improve performance
3. Adding pagination UI for tool selection for servers
4. Making `Select All` work with paginated tools

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |  pass      |
| Unit tests                            | `make test`          |  pass      |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
