### PR TITLE
test: eliminate remaining test warnings for warning-free test suite

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -505,7 +505,7 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
             if not result or not result.messages:
                 logger.warning(f"No content returned by prompt: {prompt_id}")
                 return []
-            message_dicts = [message.dict() for message in result.messages]
+            message_dicts = [message.model_dump() for message in result.messages]
             return types.GetPromptResult(messages=message_dicts, description=result.description)
     except Exception as e:
         logger.exception(f"Error getting prompt '{prompt_id}': {e}")

--- a/plugins/content_moderation/content_moderation.py
+++ b/plugins/content_moderation/content_moderation.py
@@ -523,7 +523,12 @@ Respond with JSON format:
                     break
 
         return ModerationResult(
-            flagged=flagged, categories=categories, action=action, provider=ModerationProvider.IBM_WATSON, confidence=max_score, details={"method": "pattern_matching"}  # Default fallback
+            flagged=flagged,
+            categories=categories,
+            action=action,
+            provider=ModerationProvider.IBM_WATSON,
+            confidence=max_score,
+            details={"method": "pattern_matching"},  # Default fallback
         )
 
     async def _extract_text_content(self, payload: Any) -> List[str]:
@@ -555,7 +560,7 @@ Respond with JSON format:
 
                 if self._cfg.audit_decisions:
                     logger.info(
-                        f"Content moderation - Prompt: {payload.prompt_id}, Result: {result.flagged}, " f"Action: {result.action}, Provider: {result.provider}, " f"Confidence: {result.confidence:.2f}"
+                        f"Content moderation - Prompt: {payload.prompt_id}, Result: {result.flagged}, Action: {result.action}, Provider: {result.provider}, Confidence: {result.confidence:.2f}"
                     )
 
                 if result.action == ModerationAction.BLOCK:
@@ -572,7 +577,7 @@ Respond with JSON format:
                                 "flagged_text_preview": text[:100] + "..." if len(text) > 100 else text,
                             },
                         ),
-                        metadata={"moderation_result": result.dict(), "provider": result.provider.value},
+                        metadata={"moderation_result": result.model_dump(), "provider": result.provider.value},
                     )
                 elif result.modified_content:
                     # Modify the payload with redacted/transformed content
@@ -598,7 +603,7 @@ Respond with JSON format:
                 result = await self._moderate_content(text)
 
                 if self._cfg.audit_decisions:
-                    logger.info(f"Content moderation - Tool: {payload.name}, Result: {result.flagged}, " f"Action: {result.action}, Provider: {result.provider}")
+                    logger.info(f"Content moderation - Tool: {payload.name}, Result: {result.flagged}, Action: {result.action}, Provider: {result.provider}")
 
                 if result.action == ModerationAction.BLOCK:
                     return ToolPreInvokeResult(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ dev = [
     "pytest-env>=1.1.5",
     "pytest-examples>=0.0.18",
     "pytest-httpx>=0.35.0",
+    "pytest-integration-mark>=0.2.0",
     "pytest-md-report>=0.7.0",
     "pytest-rerunfailures>=16.0.1",
     "pytest-timeout>=2.4.0",

--- a/tests/unit/mcpgateway/federation/test_discovery.py
+++ b/tests/unit/mcpgateway/federation/test_discovery.py
@@ -366,28 +366,6 @@ async def test_start_exception(monkeypatch):
     DummySettings.federation_discovery = False
 
 
-# @pytest.mark.asyncio
-# @patch("mcpgateway.federation.discovery.settings", new=DummySettings)
-# async def test_stop_exceptions(monkeypatch):
-#     service = discovery.DiscoveryService()
-#     # Simulate browser and zeroconf present
-#     class DummyBrowser:
-#         async def async_cancel(self):
-#             raise Exception("fail")
-#     class DummyZeroconf:
-#         async def async_unregister_service(self, *a, **k):
-#             raise Exception("fail")
-#         async def async_close(self):
-#             raise Exception("fail")
-#     service._browser = DummyBrowser()
-#     service._zeroconf = DummyZeroconf()
-#     # Simulate http client close (do not raise, to match implementation)
-#     service._http_client.aclose = AsyncMock(return_value=None)
-#     # Should not raise
-#     await service.stop()
-
-
-@pytest.mark.asyncio
 def test_stop_exceptions(monkeypatch):
     service = discovery.DiscoveryService()
 
@@ -403,9 +381,11 @@ def test_stop_exceptions(monkeypatch):
         async def async_close(self):
             pass  # Do not raise
 
-    service._browser = DummyBrowser()
-    service._zeroconf = DummyZeroconf()
+    monkeypatch.setattr(service, "_browser", DummyBrowser())
+    monkeypatch.setattr(service, "_zeroconf", DummyZeroconf())
+
     # Patch http client close to NOT raise
     service._http_client.aclose = AsyncMock(return_value=None)
+
     # Should not raise
     asyncio.run(service.stop())

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -9,17 +9,14 @@ This module tests all team management endpoints including CRUD operations,
 member management, invitations, and join requests.
 """
 
-# Standard
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
-# Third-Party
-import pytest
 from fastapi import HTTPException, status
+import pytest
 from sqlalchemy.orm import Session
 
-# First-Party
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamJoinRequest, EmailTeamMember
 from mcpgateway.schemas import (
     EmailUserResponse,
@@ -32,7 +29,6 @@ from mcpgateway.schemas import (
 from mcpgateway.services.team_invitation_service import TeamInvitationService
 from mcpgateway.services.team_management_service import TeamManagementService
 
-# Test utilities
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
 
 
@@ -282,8 +278,8 @@ class TestTeamsRouter:
             team.is_personal = False
             team.visibility = "private"
             team.max_members = 100
-            team.created_at = datetime.utcnow()
-            team.updated_at = datetime.utcnow()
+            team.created_at = datetime.now(timezone.utc)
+            team.updated_at = datetime.now(timezone.utc)
             team.is_active = True
             team.get_member_count = MagicMock(return_value=1)
             teams.append(team)
@@ -334,7 +330,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import TeamResponse
 
             async def mock_get_team(team_id, current_user, db):
-                service = TeamManagementService(db)
+                _ = TeamManagementService(db)
                 team = await mock_service.get_team_by_id(team_id)
                 if not team:
                     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")

--- a/tests/unit/mcpgateway/test_display_name_uuid_features.py
+++ b/tests/unit/mcpgateway/test_display_name_uuid_features.py
@@ -205,6 +205,9 @@ class TestServerUUIDFeature:
 
     def test_server_uuid_uniqueness(self, db_session):
         """Test that server UUIDs must be unique."""
+        # Standard
+        import warnings
+
         duplicate_uuid = "duplicate-uuid-1234"
 
         # Create first server with UUID
@@ -217,9 +220,11 @@ class TestServerUUIDFeature:
 
         db_session.add(db_server2)
 
-        # This should raise an integrity error
-        with pytest.raises(Exception):  # SQLAlchemy will raise IntegrityError
-            db_session.commit()
+        # This should raise an integrity error and emit an SAWarning
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=Warning)
+            with pytest.raises(Exception):  # SQLAlchemy will raise IntegrityError
+                db_session.commit()
 
 
 class TestSchemaValidation:

--- a/tests/unit/mcpgateway/test_reverse_proxy.py
+++ b/tests/unit/mcpgateway/test_reverse_proxy.py
@@ -11,7 +11,7 @@ Unit tests for the MCP reverse proxy module.
 import asyncio
 import json
 import signal
-from unittest.mock import AsyncMock, call, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
 import pytest
@@ -79,9 +79,9 @@ class TestStdioProcess:
     async def test_start_no_stdin(self):
         """Test start failure when no stdin."""
         with patch("asyncio.create_subprocess_exec") as mock_create:
-            mock_process = AsyncMock()
+            mock_process = MagicMock()
             mock_process.stdin = None
-            mock_process.stdout = AsyncMock()
+            mock_process.stdout = MagicMock()
             mock_create.return_value = mock_process
 
             with pytest.raises(RuntimeError, match="Failed to create subprocess with stdio"):
@@ -91,8 +91,8 @@ class TestStdioProcess:
     async def test_start_no_stdout(self):
         """Test start failure when no stdout."""
         with patch("asyncio.create_subprocess_exec") as mock_create:
-            mock_process = AsyncMock()
-            mock_process.stdin = AsyncMock()
+            mock_process = MagicMock()
+            mock_process.stdin = MagicMock()
             mock_process.stdout = None
             mock_create.return_value = mock_process
 
@@ -124,8 +124,13 @@ class TestStdioProcess:
     @pytest.mark.asyncio
     async def test_stop_force_kill(self):
         """Test force kill when process doesn't terminate."""
+
+        # Create async function that raises TimeoutError to avoid AsyncMock issues
+        async def mock_wait_for(*args, **kwargs):
+            raise asyncio.TimeoutError()
+
         with patch("asyncio.create_subprocess_exec") as mock_create:
-            with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            with patch("asyncio.wait_for", new=mock_wait_for):
                 mock_process = MagicMock()
                 mock_process.pid = 12345
                 mock_process.stdin = MagicMock()
@@ -133,7 +138,16 @@ class TestStdioProcess:
                 mock_process.stdin.drain = AsyncMock()
                 mock_process.stdout = Mock()  # Use Mock instead of MagicMock to avoid auto-async
                 mock_process.stdout.readline = AsyncMock(return_value=b"")  # EOF immediately
-                mock_process.wait = AsyncMock(return_value=0)
+
+                # Use a function that returns a Future to avoid unawaited coroutine warnings
+                # when wait_for raises TimeoutError before awaiting
+                def mock_wait():
+                    future = asyncio.Future()
+                    future.set_result(0)
+                    return future
+
+                mock_process.wait = mock_wait
+
                 mock_process.terminate = MagicMock()
                 mock_process.kill = MagicMock()
                 mock_process.returncode = None
@@ -184,7 +198,7 @@ class TestStdioProcess:
     @pytest.mark.asyncio
     async def test_send_no_stdin(self):
         """Test sending when stdin is None."""
-        self.stdio.process = AsyncMock()
+        self.stdio.process = MagicMock()
         self.stdio.process.stdin = None
 
         with pytest.raises(RuntimeError, match="Subprocess not running"):
@@ -201,11 +215,13 @@ class TestStdioProcess:
         """Test reading messages from stdout."""
         with patch("asyncio.create_subprocess_exec") as mock_create:
             # Use an iterator to avoid side_effect initialization issues
-            messages = iter([
-                b'{"test": "message1"}\n',
-                b'{"test": "message2"}\n',
-                b"",  # EOF
-            ])
+            messages = iter(
+                [
+                    b'{"test": "message1"}\n',
+                    b'{"test": "message2"}\n',
+                    b"",  # EOF
+                ]
+            )
 
             async def readline_func():
                 return next(messages)
@@ -223,7 +239,12 @@ class TestStdioProcess:
             mock_process.returncode = 0
             mock_create.return_value = mock_process
 
-            handler = AsyncMock()
+            # Use real async function instead of AsyncMock to avoid unawaited coroutines
+            messages_received = []
+
+            async def handler(msg):
+                messages_received.append(msg)
+
             self.stdio.add_message_handler(handler)
 
             await self.stdio.start()
@@ -232,18 +253,21 @@ class TestStdioProcess:
             await self.stdio.stop()
 
             # Verify handler was called with messages
-            assert handler.call_count == 2
-            handler.assert_has_calls([call('{"test": "message1"}'), call('{"test": "message2"}')])
+            assert len(messages_received) == 2
+            assert messages_received[0] == '{"test": "message1"}'
+            assert messages_received[1] == '{"test": "message2"}'
 
     @pytest.mark.asyncio
     async def test_read_stdout_handler_error(self):
         """Test error handling in message handlers."""
         with patch("asyncio.create_subprocess_exec") as mock_create:
             # Use an iterator to avoid side_effect initialization issues
-            messages = iter([
-                b'{"test": "message"}\n',
-                b"",  # EOF
-            ])
+            messages = iter(
+                [
+                    b'{"test": "message"}\n',
+                    b"",  # EOF
+                ]
+            )
 
             async def readline_func():
                 return next(messages)
@@ -364,8 +388,8 @@ class TestReverseProxyClient:
             mock_connection = AsyncMock()
             mock_ws.connect = AsyncMock(return_value=mock_connection)
 
-            with patch.object(self.client.stdio_process, "start", AsyncMock()):
-                with patch.object(self.client, "_register", AsyncMock()):
+            with patch.object(self.client.stdio_process, "start", new_callable=AsyncMock):
+                with patch.object(self.client, "_register", new_callable=AsyncMock):
                     with patch("asyncio.create_task") as mock_create_task:
                         mock_task = MagicMock()  # create_task returns a Task (sync object)
                         mock_create_task.return_value = mock_task
@@ -383,7 +407,7 @@ class TestReverseProxyClient:
         with patch("mcpgateway.reverse_proxy.websockets") as mock_ws:
             mock_ws.connect = AsyncMock(side_effect=Exception("Connection failed"))
 
-            with patch.object(self.client.stdio_process, "start", AsyncMock()):
+            with patch.object(self.client.stdio_process, "start", new_callable=AsyncMock):
                 with pytest.raises(Exception, match="Connection failed"):
                     await self.client.connect()
 
@@ -393,7 +417,7 @@ class TestReverseProxyClient:
     async def test_connect_websocket_no_websockets_module(self):
         """Test WebSocket connection when websockets module not available."""
         with patch("mcpgateway.reverse_proxy.websockets", None):
-            with patch.object(self.client.stdio_process, "start", AsyncMock()):
+            with patch.object(self.client.stdio_process, "start", new_callable=AsyncMock):
                 with pytest.raises(ImportError, match="websockets package required"):
                     await self.client._connect_websocket()
 
@@ -439,8 +463,8 @@ class TestReverseProxyClient:
         """Test registration with gateway."""
         self.client.connection = AsyncMock()
 
-        with patch.object(self.client.stdio_process, "send", AsyncMock()) as mock_send:
-            with patch("asyncio.sleep", AsyncMock()):
+        with patch.object(self.client.stdio_process, "send", new_callable=AsyncMock) as mock_send:
+            with patch("asyncio.sleep", new_callable=AsyncMock):
                 await self.client._register()
 
         # Should send initialize to local server
@@ -494,7 +518,7 @@ class TestReverseProxyClient:
     @pytest.mark.asyncio
     async def test_handle_gateway_message_request(self):
         """Test handling request from gateway."""
-        with patch.object(self.client.stdio_process, "send", AsyncMock()) as mock_send:
+        with patch.object(self.client.stdio_process, "send", new_callable=AsyncMock) as mock_send:
             message = json.dumps({"type": MessageType.REQUEST.value, "payload": {"jsonrpc": "2.0", "id": 1, "method": "test"}})
 
             await self.client._handle_gateway_message(message)
@@ -545,7 +569,7 @@ class TestReverseProxyClient:
         mock_connection.__aiter__.return_value = ['{"type": "heartbeat"}', '{"type": "request", "payload": {"method": "test"}}']
         self.client.connection = mock_connection
 
-        with patch.object(self.client, "_handle_gateway_message", AsyncMock()) as mock_handle:
+        with patch.object(self.client, "_handle_gateway_message", new_callable=AsyncMock) as mock_handle:
             await self.client._receive_websocket()
 
         assert mock_handle.call_count == 2
@@ -629,7 +653,7 @@ class TestReverseProxyClient:
         self.client._keepalive_task = MagicMock()
         self.client._receive_task = MagicMock()
 
-        with patch.object(self.client.stdio_process, "stop", AsyncMock()) as mock_stop:
+        with patch.object(self.client.stdio_process, "stop", new_callable=AsyncMock) as mock_stop:
             await self.client.disconnect()
 
         assert self.client.state == ConnectionState.DISCONNECTED
@@ -651,7 +675,7 @@ class TestReverseProxyClient:
         self.client.state = ConnectionState.CONNECTED
         self.client.connection = AsyncMock()
 
-        with patch.object(self.client.stdio_process, "stop", AsyncMock()):
+        with patch.object(self.client.stdio_process, "stop", new_callable=AsyncMock):
             await self.client.disconnect()
 
         # Should send unregister message
@@ -666,7 +690,7 @@ class TestReverseProxyClient:
         self.client.connection = AsyncMock()
         self.client.connection.send.side_effect = Exception("Send failed")
 
-        with patch.object(self.client.stdio_process, "stop", AsyncMock()):
+        with patch.object(self.client.stdio_process, "stop", new_callable=AsyncMock):
             await self.client.disconnect()
 
         # Should still complete disconnect

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
@@ -3056,6 +3056,7 @@ dev = [
     { name = "pytest-env" },
     { name = "pytest-examples" },
     { name = "pytest-httpx" },
+    { name = "pytest-integration-mark" },
     { name = "pytest-md-report" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
@@ -3122,14 +3123,14 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.11.3" },
     { name = "parse", specifier = ">=1.20.2" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.55.0" },
+    { name = "prometheus-client", specifier = ">=0.16.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "protobuf", marker = "extra == 'grpc'", specifier = ">=6.33.0" },
     { name = "psutil", specifier = ">=7.1.1" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.3" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
-    { name = "prometheus-client", specifier = ">=0.16.0" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pymysql", marker = "extra == 'mysql'", specifier = ">=1.1.2" },
     { name = "pytest-benchmark", marker = "extra == 'fuzz'", specifier = ">=5.1.0" },
@@ -3194,6 +3195,7 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-examples", specifier = ">=0.0.18" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
+    { name = "pytest-integration-mark", specifier = ">=0.2.0" },
     { name = "pytest-md-report", specifier = ">=0.7.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.0.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
@@ -5400,6 +5402,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146, upload-time = "2024-11-28T19:16:54.237Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442, upload-time = "2024-11-28T19:16:52.787Z" },
+]
+
+[[package]]
+name = "pytest-integration-mark"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/1d/e091051123391bc3b7706c2e2d91f35e448b359fd697967ca93cc2fa99e5/pytest_integration_mark-0.2.0.tar.gz", hash = "sha256:2f3580fba9aa7fecc9ede2385ae5c0c1414c688cc4e8511ccb61f65025508a14", size = 6523, upload-time = "2023-05-22T09:54:49.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/29/d7c0776cce4466265fe355faa1b10ffbc14a4b9e7835389aace1ffcbe1f0/pytest_integration_mark-0.2.0-py3-none-any.whl", hash = "sha256:dfff273d47922c2d750923e06ac65bda20ff1c016adba187dee20840f0d5869b", size = 7667, upload-time = "2023-05-22T09:54:47.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR completes the test warning cleanup effort started in #1344 and #1342, achieving a fully warning-free test suite when running `make test`.

### Changes

**Core Code:**
- Added explicit type hints for session registry attributes (`_session_message`, `_cleanup_task`, DB return types)
- Added done_callback to fire-and-forget asyncio futures to prevent ResourceWarning
- Implemented proper logging handler cleanup in `LoggingService.shutdown()`
- Replaced deprecated Pydantic v1 `.dict()` with v2 `.model_dump()`
- Fixed line continuation formatting in content_moderation plugin

**Tests:**
- Fixed AsyncMock usage in session_registry tests with proper SSETransport fixtures
- Improved mock typing with cast() to prevent type warnings
- Removed duplicate test code by consolidating mock fixtures
- Added pytest-integration-mark dependency

### Result

All tests now pass without warnings, improving test output clarity and ensuring proper resource cleanup during test execution.