### PR TITLE
fix: postgres 18 default data volume change and fasttime server on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2756,8 +2756,13 @@ endif
 # Alternative: Always default to docker compose unless explicitly overridden
 # COMPOSE_CMD ?= docker compose
 
+# Profile detection (for platform-specific services)
+ifeq ($(PLATFORM),linux/amd64)
+    PROFILE = --profile with-fast-time 
+endif
+
 define COMPOSE
-$(COMPOSE_CMD) -f $(COMPOSE_FILE)
+$(COMPOSE_CMD) -f $(COMPOSE_FILE) $(PROFILE) 
 endef
 
 .PHONY: compose-up compose-restart compose-build compose-pull \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_DB=mcp
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql  # Postgres 18+ uses /var/lib/postgresql (not /data subdirectory)
     networks: [mcpnet]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
@@ -378,6 +378,9 @@ services:
 
   ###############################################################################
   # Fast Time Server - High-performance time/timezone service for MCP
+  # Note: This is an amd64-only image. On ARM platforms (Apple Silicon),
+  # emulation may not work properly. Use profiles to disable:
+  # docker compose --profile with-fast-time up -d
   ###############################################################################
   fast_time_server:
     image: ghcr.io/ibm/fast-time-server:latest
@@ -386,6 +389,7 @@ services:
     ports:
       - "8888:8080"    # Map host port 8888 to container port 8080
     command: ["-transport=sse", "-listen=0.0.0.0", "-port=8080", "-log-level=info"]
+    profiles: ["with-fast-time"]  # Optional: enable with --profile with-fast-time
 
   ###############################################################################
   # Auto-registration service - registers fast_time_server with gateway
@@ -402,6 +406,7 @@ services:
       - JWT_SECRET_KEY=my-test-key
     # This is a one-shot container that exits after registration
     restart: "no"
+    profiles: ["with-fast-time"]  # Optional: enable with --profile with-fast-time
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |


### PR DESCRIPTION
### Summary

Resolves container startup failures caused by PostgreSQL 18's new data directory structure and cross-platform compatibility issues with amd64-only images on ARM hosts.

### Changes

#### docker-compose.yml
  - **PostgreSQL 18 volume compatibility**: Changed postgres volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` to align with PostgreSQL 18's new directory structure that uses `pg_ctlcluster`-compatible paths
  - **Optional fast_time_server**: Made `fast_time_server` and `register_fast_time` services optional using Docker Compose profiles to prevent emulation failures on ARM platforms (Apple Silicon)
    - Added `profiles: ["with-fast-time"]`
    - Added documentation comment explaining ARM compatibility issues

#### Makefile
  - **Platform-aware profiles**: Added automatic profile detection based on platform architecture
    - Enables `with-fast-time` profile automatically on `linux/amd64` platforms
    - Skips fast_time_server on ARM platforms by default

### Impact

**Before**:
  - `make compose-up` failed with PostgreSQL 18 data directory errors
  - Platform mismatch warnings for fast_time_server on ARM

  **After**:
  - Clean startup on both x86_64 and ARM platforms
  - PostgreSQL 18 starts successfully with proper volume structure  
  - Optional fast_time_server on x86_64: `docker compose --profile with-fast-time up -d`
  - No build or runtime errors
