### PR TITLE
fix alembic

### DIFF
--- a/mcp-servers/go/fast-time-server/go.mod
+++ b/mcp-servers/go/fast-time-server/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.10
 require github.com/mark3labs/mcp-go v0.32.0 // MCP server/runtime
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/spf13/cast v1.7.1 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+    github.com/google/uuid v1.6.0 // indirect
+    github.com/spf13/cast v1.7.1 // indirect
+    github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 )

--- a/mcpgateway/alembic/versions/h2b3c4d5e6f7_add_oauth_config_to_a2a_agents.py
+++ b/mcpgateway/alembic/versions/h2b3c4d5e6f7_add_oauth_config_to_a2a_agents.py
@@ -40,7 +40,9 @@ def upgrade() -> None:
 
     columns_to_add = []
     if "oauth_config" not in columns:
-        columns_to_add.append(("oauth_config", sa.Column("oauth_config", sa.JSON(), nullable=True, comment="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, and scopes")))
+        columns_to_add.append(
+            ("oauth_config", sa.Column("oauth_config", sa.JSON(), nullable=True, comment="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, and scopes"))
+        )
 
     if "passthrough_headers" not in columns:
         columns_to_add.append(("passthrough_headers", sa.Column("passthrough_headers", sa.JSON(), nullable=True, comment="List of headers allowed to be passed through to the agent")))


### PR DESCRIPTION
fix: Add missing oauth_config and passthrough_headers columns to a2a_agents

PR #1270 added oauth_config and passthrough_headers to the A2AAgent model
but forgot to include the database migration. This caused SQLAlchemy errors
when querying a2a_agents from older databases.

This migration:
- Adds oauth_config column (JSON, nullable)
- Adds passthrough_headers column (JSON, nullable)
- Creates idx_a2a_agents_team_visibility index for query performance
- Creates idx_a2a_agents_owner_visibility index for query performance

The indexes match the pattern used for other resource tables (tools, servers,
gateways, etc.) and are critical for multitenancy/RBAC query performance.

Fixes SQLAlchemy OperationalError: no such column: a2a_agents.oauth_config
