### PR TITLE
fix(helm): add missing metrics configuration to values.schema.json

### DIFF
--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -132,6 +132,45 @@
           "maximum": 65535,
           "default": 4444
         },
+        "metrics": {
+          "type": "object",
+          "description": "Metrics configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable metrics collection",
+              "default": true
+            },
+            "port": {
+              "type": "integer",
+              "description": "Metrics port",
+              "minimum": 1,
+              "maximum": 65535,
+              "default": 8000
+            },
+            "serviceMonitor": {
+              "type": "object",
+              "description": "ServiceMonitor configuration for Prometheus Operator",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable ServiceMonitor creation",
+                  "default": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "customLabels": {
+              "type": "object",
+              "description": "Custom labels for metrics",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
+            }
+          },
+          "additionalProperties": false
+        },
         "probes": {
           "type": "object",
           "description": "Health probe configuration",


### PR DESCRIPTION
## 🐛 Bug Description

Helm template validation fails with schema error after PR #1313 merged:
Error: values don't meet the specifications of the schema(s) in the following chart(s): mcp-stack:
mcpContextForge: Additional property metrics is not allowed

## 🔍 Root Cause

PR #1313 (Prometheus Metrics Instrumentation - Feature #218) added the `metrics` configuration to `values.yaml` but did not update the corresponding JSON schema in `values.schema.json`.

## ✅ Solution

Add the missing `metrics` property definition to `values.schema.json` under `mcpContextForge` properties, including:

- **enabled**: Boolean to toggle metrics collection (default: true)
- **port**: Integer for metrics endpoint port (range: 1-65535, default: 8000)
- **serviceMonitor**: Object for Prometheus Operator ServiceMonitor configuration
  - **enabled**: Boolean to enable ServiceMonitor creation (default: true)
- **customLabels**: Object for custom metric labels (default: {})

## 🧪 Testing

Verified the fix by running Helm template validation:

```bash
helm template mcp-stack -n mcp-stack charts/mcp-stack
✅ Command now completes successfully without schema validation errors.
📚 Related
Fixes schema validation error introduced in PR #1313
Related to Feature #218 (Prometheus Metrics Instrumentation)