### PR TITLE
fix: tool schema team_id not effective(#1395)

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -672,10 +672,10 @@ class ToolService:
                 import_batch_id=import_batch_id,
                 federation_source=federation_source,
                 version=1,
-                # Team scoping fields
-                team_id=team_id,
-                owner_email=owner_email or created_by,
-                visibility=visibility,
+                # Team scoping fields - use schema values if provided, otherwise fallback to parameters
+                team_id=getattr(tool, "team_id", None) or team_id,
+                owner_email=getattr(tool, "owner_email", None) or owner_email or created_by,
+                visibility=getattr(tool, "visibility", None) or visibility,
                 # passthrough REST tools fields
                 base_url=tool.base_url if tool.integration_type == "REST" else None,
                 path_template=tool.path_template if tool.integration_type == "REST" else None,


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
_What problem does this PR fix and **why**?_

```
fix: tool schema team_id not effective(#1395)
```

## 🔁 Reproduction Steps
_Link the issue and minimal steps to reproduce the bug._

```
https://github.com/IBM/mcp-context-forge/issues/1395
```

## 🐞 Root Cause
_What was wrong and where?_

```
The tool schema team_id was not read when the tool was saved, but instead used parameters from the parameters. It should be read from the schema first, and then from the parameters like other resources
```

## 💡 Fix Description
_How did you solve it?  Key design points._

```
Prioritize reading team_id and other parameters from the tool schema
```

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
