### PR TITLE
Observability: Phoenix - add custom span processor to copy resource attrs to span

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -789,6 +789,11 @@ OTEL_BSP_MAX_QUEUE_SIZE=2048
 OTEL_BSP_MAX_EXPORT_BATCH_SIZE=512
 OTEL_BSP_SCHEDULE_DELAY=5000
 
+# Copy resource attributes to span attributes (for Arize compatibility)
+# Some observability backends like Arize require certain attributes as span attributes
+# rather than resource attributes. Enable this to copy arize.project.name and model_id.
+# OTEL_COPY_RESOURCE_ATTRS_TO_SPANS=false
+
 # Prometheus Metrics Configuration
 # Enable Prometheus-compatible metrics exposition for monitoring and alerting
 # Options: true (default), false

--- a/mcpgateway/observability.py
+++ b/mcpgateway/observability.py
@@ -242,7 +242,10 @@ def init_telemetry() -> Optional[Any]:
                 pass  # pylint: disable=unnecessary-pass
 
         # Add the custom span processor to copy resource attributes to spans
-        if resource is not None:
+        # This is needed for Arize which requires certain attributes as span attributes
+        # Enable via OTEL_COPY_RESOURCE_ATTRS_TO_SPANS=true (disabled by default)
+        copy_resource_attrs = os.getenv("OTEL_COPY_RESOURCE_ATTRS_TO_SPANS", "false").lower() == "true"
+        if resource is not None and copy_resource_attrs:
             logger.info("Adding ResourceAttributeSpanProcessor to copy resource attributes to spans")
             provider.add_span_processor(ResourceAttributeSpanProcessor())
 

--- a/tests/unit/mcpgateway/test_observability.py
+++ b/tests/unit/mcpgateway/test_observability.py
@@ -30,6 +30,7 @@ class TestObservability:
             "OTEL_EXPORTER_OTLP_ENDPOINT",
             "OTEL_SERVICE_NAME",
             "OTEL_RESOURCE_ATTRIBUTES",
+            "OTEL_COPY_RESOURCE_ATTRS_TO_SPANS",
         ]
         for var in env_vars:
             os.environ.pop(var, None)
@@ -82,7 +83,8 @@ class TestObservability:
 
         # Verify provider was created and configured
         mock_provider.assert_called_once()
-        assert provider_instance.add_span_processor.call_count == 2
+        # Only 1 span processor (BatchSpanProcessor) since OTEL_COPY_RESOURCE_ATTRS_TO_SPANS is not set
+        provider_instance.add_span_processor.assert_called_once()
         assert result is not None
 
     @patch("mcpgateway.observability.ConsoleSpanExporter")
@@ -100,6 +102,25 @@ class TestObservability:
 
         # Verify console exporter was created
         mock_exporter.assert_called_once()
+        # Only 1 span processor (SimpleSpanProcessor) since OTEL_COPY_RESOURCE_ATTRS_TO_SPANS is not set
+        provider_instance.add_span_processor.assert_called_once()
+        assert result is not None
+
+    @patch("mcpgateway.observability.ConsoleSpanExporter")
+    @patch("mcpgateway.observability.TracerProvider")
+    @patch("mcpgateway.observability.SimpleSpanProcessor")
+    def test_init_telemetry_with_resource_attr_copy_enabled(self, mock_processor, mock_provider, mock_exporter):
+        """Test that ResourceAttributeSpanProcessor is added when OTEL_COPY_RESOURCE_ATTRS_TO_SPANS=true."""
+        os.environ["OTEL_TRACES_EXPORTER"] = "console"
+        os.environ["OTEL_COPY_RESOURCE_ATTRS_TO_SPANS"] = "true"
+
+        # Mock the provider instance
+        provider_instance = MagicMock()
+        mock_provider.return_value = provider_instance
+
+        result = init_telemetry()
+
+        # Verify 2 span processors: ResourceAttributeSpanProcessor + SimpleSpanProcessor
         assert provider_instance.add_span_processor.call_count == 2
         assert result is not None
 


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

---

## 🚀 Summary (1-2 sentences)
Add custom SpanProcessor to opentelemetry TraceProvider which copies resource attributes into span attributes. This is needed to properly work with Arize (which needs specific span attributes to be present).

---

## 🧪 Checks

- [*] `make lint` passes
- [*] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)
