### PR TITLE
fix: correct 3 blocker severity sonar findings for issue#212

### DIFF
--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -584,7 +584,6 @@ async def update_user(user_email: str, user_request: EmailRegistrationRequest, c
                 new_password=user_request.password,
                 ip_address="admin_update",
                 user_agent="admin_panel",
-                skip_old_password_check=True,
             )
 
         db.commit()

--- a/mcpgateway/routers/rbac.py
+++ b/mcpgateway/routers/rbac.py
@@ -134,7 +134,7 @@ async def list_roles(
     """
     try:
         role_service = RoleService(db)
-        roles = await role_service.list_roles(scope=scope, active_only=active_only)
+        roles = await role_service.list_roles(scope=scope)
 
         return [RoleResponse.from_orm(role) for role in roles]
 

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -436,7 +436,7 @@ class EmailAuthService:
             self.db.add(auth_event)
             self.db.commit()
 
-    async def change_password(self, email: str, old_password: str, new_password: str, ip_address: Optional[str] = None, user_agent: Optional[str] = None) -> bool:
+    async def change_password(self, email: str, old_password: Optional[str], new_password: str, ip_address: Optional[str] = None, user_agent: Optional[str] = None) -> bool:
         """Change a user's password.
 
         Args:


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
_What problem does this PR fix and **why**?_
Addresses part of Issue #212 - This addresses 3 blocker level issues found by Sonar scan.


## 🔁 Reproduction Steps
1. Set up local sonarqube server, and scan:
```
make sonar-deps-podman
make sonar-up-podman
make sonar-info
make pysonar-scanner
```
2. Open web interface for sonarqube
3. Go to "Issues" tab
4. Select "Blocker" severity 
5. From main branch shows 18 issues, following these changes show 15 issues.


## 🐞 Root Cause
1. in mcpgateway/routers/email_auth.py removed unused/unsupported parameter from function call.
2. in mcpgateway/routers/rbac.py removed unused/unsupported parameter from function call.
6. in mcpgateway/services/email_auth_service.py type hint for old_password didn;t allow for None value passed from https://github.com/IBM/mcp-context-forge/blob/main/mcpgateway/routers/email_auth.py#L583
```
...
# Update password if provided
    if user_request.password:
        await auth_service.change_password(
            email=user_email,
            old_password=None,  # Admin can change without old password
            new_password=user_request.password,
...
```

## 💡 Fix Description
Made changes as required to pass Sonarqube scan for target areas.
Confirmed `make test` doesn't show any breakages. 

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed