### PR TITLE
Skip creds gateway duplication check for one time auth

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,0 @@
-node_modules/**

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.1.1",
     "@stylistic/eslint-plugin": "^5.1.0",
+    "@stylistic/stylelint-config": "^2.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.5",
     "eslint-config-standard": "^17.1.0",
@@ -10,6 +11,11 @@
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-promise": "^6.6.0",
     "prettier": "^3.6.2",
+    "stylelint": "^16.0.0",
+    "stylelint-config-standard": "^36.0.0",
     "stylelint-order": "^7.0.0"
+  },
+  "overrides": {
+    "keyv": "5.1.0"
   }
 }


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

Closes #1448
Duplicate gateway checks used URL and credentials, but with one-time auth the credentials are always None, causing false duplicate errors. When one-time auth is enabled, the logic is updated to skip the duplicate check and enforce only name uniqueness, otherwise the original full duplicate logic was used.

## 🔁 Reproduction Steps

1. Add a Server with One time Authentication enabled.
2. Try to add the second server with same url but may have different tools as different authentication is provided with One time Authentication enabled.
3. The second server will not be registered as we will get a duplicate gateway found error. After the changes, this will be allowed.

## 🐞 Root Cause
The duplicate-gateway validation logic considered a gateway a duplicate when both its URL and stored credentials matched an existing gateway.
However, when one-time authentication is enabled, credentials are not persisted and always evaluate to None.

As a result:
- Every gateway configured with one-time auth appears to have the same credentials value (None)
- Therefore, multiple gateways with the same URL are treated as duplicates—even though they should be independent
- This behavior is valid only for open/no-auth servers, not for one-time auth workflows

This creates a false-positive duplicate error.

## 💡 Fix Description
The fix updates the gateway duplicate detection logic to be conditional based on the authentication mode:

**When one-time auth is enabled**
- Skip the URL+credential duplicate check, because credentials are not stored and cannot reliably distinguish gateways
- Continue enforcing duplicate name checks
- Allow multiple gateways pointing to the same URL (each requiring one-time auth)

**When one-time auth is NOT enabled:**

- Use the original full duplicate check (URL + stored credentials)
- Preserve correct behavior for open/no-auth servers and standard auth flows

This ensures:
- One-time auth workflows function correctly
- Duplicate detection still works where it is meaningful
- Name-based conflicts remain protected

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed