### PR TITLE
fix: switched rust base image to manifest list to support multi-arch build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,7 +5,7 @@
 ###############################################################################
 ARG ENABLE_RUST=false
 
-FROM quay.io/pypa/manylinux2014_x86_64:2025.10.19-2 AS rust-builder-base
+FROM quay.io/pypa/manylinux2014:2025.10.19-2 AS rust-builder-base
 ARG ENABLE_RUST
 
 # Set shell with pipefail for safety

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -29,7 +29,7 @@ ARG ENABLE_RUST=false
 # To build WITH Rust: docker build --build-arg ENABLE_RUST=true -f Containerfile.lite .
 # To build WITHOUT Rust (default): docker build -f Containerfile.lite .
 ###############################################################################
-FROM quay.io/pypa/manylinux2014_x86_64:2025.10.19-2 AS rust-builder-base
+FROM quay.io/pypa/manylinux2014:2025.10.19-2 AS rust-builder-base
 ARG ENABLE_RUST
 
 # Set shell with pipefail for safety


### PR DESCRIPTION
**Description**
This PR fixes an issue where the base image for rust in Containerfile is only for amd64, preventing the build for other architectures.

**Fix**
Change to use the manifest list to leverage multi-arch build.