### PR TITLE
Address s390x build issue with podman

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -55,7 +55,6 @@ LABEL maintainer="Mihai Criveti" \
       description="MCP Gateway: An enterprise-ready Model Context Protocol Gateway"
 
 ARG PYTHON_VERSION=3.12
-ARG TARGETPLATFORM
 ARG GRPC_PYTHON_BUILD_SYSTEM_OPENSSL='False'
 
 # Install Python and build dependencies
@@ -73,7 +72,7 @@ WORKDIR /app
 # s390x architecture does not support BoringSSL when building wheel grpcio.
 # Force Python whl to use OpenSSL.
 # ----------------------------------------------------------------------------
-RUN if [ "$TARGETPLATFORM" = "linux/s390x" ]; then \
+RUN if [ `uname -m` = "s390x" ]; then \
         echo "Building for s390x."; \
         echo "export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL='True'" > /etc/profile.d/use-openssl.sh; \
     else \

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -76,7 +76,6 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ARG PYTHON_VERSION
 ARG ROOTFS_PATH
-ARG TARGETPLATFORM=linux/amd64
 ARG GRPC_PYTHON_BUILD_SYSTEM_OPENSSL='False'
 
 # ----------------------------------------------------------------------------
@@ -102,7 +101,7 @@ WORKDIR /app
 # s390x architecture does not support BoringSSL when building wheel grpcio.
 # Force Python whl to use OpenSSL.
 # ----------------------------------------------------------------------------
-RUN if [ "$TARGETPLATFORM" = "linux/s390x" ]; then \
+RUN if [ `uname -m` = "s390x" ]; then \
         echo "Building for s390x."; \
         echo "export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL='True'" > /etc/profile.d/use-openssl.sh; \
     else \

--- a/Makefile
+++ b/Makefile
@@ -2098,7 +2098,7 @@ endif
 # =============================================================================
 
 # Auto-detect container runtime if not specified - DEFAULT TO DOCKER
-CONTAINER_RUNTIME = $(shell command -v docker >/dev/null 2>&1 && echo docker || echo podman)
+CONTAINER_RUNTIME ?= $(shell command -v docker >/dev/null 2>&1 && echo docker || echo podman)
 
 # Alternative: Always default to docker unless explicitly overridden
 # CONTAINER_RUNTIME ?= docker


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
_What problem does this PR fix and **why**?_
Address regression when build environment does not include docker-buildx or uses podman with addition for multi-arch support was added for s390x.

## 🔁 Reproduction Steps
_Link the issue and minimal steps to reproduce the bug._
Resolves issue reported in issue https://github.com/IBM/mcp-context-forge/issues/1462

## 🐞 Root Cause
_What was wrong and where?_
Docker buildx/toolkit arguments were not set in Dockerfile. Specifically "ARG TARGETPLATFORM". Reason is Podman does not support as of release 4.9.x or build environment does not have docker-buildx installed.

## 💡 Fix Description
_How did you solve it?  Key design points._
Removed docker runtime dependency to determine build platform. switched to determine build platform by using "uname -m" test in the Dockerfile.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   PASS     |
| Unit tests                            | `make test`          |    PASS    |
| Coverage ≥ 90 %                       | `make coverage`      |   PASS     |
| Manual regression no longer fails     | steps / screenshots  |   PASS     |

## 📐 MCP Compliance (if relevant)
- [X ] Matches current MCP spec
- [X ] No breaking change to MCP clients

## ✅ Checklist
- [X ] Code formatted (`make black isort pre-commit`)
- [X ] No secrets/credentials committed
