### PR TITLE
Bh/make uv use global venv instead of creating project one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,7 @@ clean:
 ## --- Automated checks --------------------------------------------------------
 smoketest:
 	@echo "🚀 Running smoketest..."
-	@bash -c '\
+	@/bin/bash -c 'source $(VENV_DIR)/bin/activate && \
 		./smoketest.py --verbose || { echo "❌ Smoketest failed!"; exit 1; }; \
 		echo "✅ Smoketest passed!" \
 	'


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
This fixes #1461 - an issue with having the virtual environment(s) split between a global virtual env and a project virtual env.
This change encourages uv to use the global venv instead of accidentally creating a project based one (which it does by default).

## 🔁 Reproduction Steps
Bug: https://github.com/IBM/mcp-context-forge/issues/1461

#### Steps to reproduce:
1. Clone down the repo
2. `make venv`
  ```
  [brian@dogmatix] ➜  mcp-context-forge git:(main) ✗ make venv
  Requirement already satisfied: pip in /Users/brian/.venv/mcpgateway/lib/python3.11/site-packages (24.0)
  [...]
  # Eventually, we want to transition to using uv/uvx exclusively, at which point we will only need
  # a virtual environment if the user has not installed uv into their account.
  uv is /Users/brian/.local/bin/uv
  ✅  Virtual env created.
  💡  Enter it with:
      . /Users/brian/.venv/mcpgateway/bin/activate
  ```
3. Activate virtual environment
  ```
  [brian@dogmatix] ➜ [mcpgateway] mcp-context-forge git:(main) ✗ . /Users/brian/.venv/mcpgateway/bin/activate
  [brian@dogmatix] ➜ [mcpgateway] mcp-context-forge git:(main) ✗ which python
  /Users/brian/.venv/mcpgateway/bin/python
  ```
4. run `make pylint`
  ```
  [brian@dogmatix] ➜ [mcpgateway] mcp-context-forge git:(main) ✗ make pylint
  🐛 pylint mcpgateway (parallel)...
  uv run pylint -j 0 --fail-on E --fail-under 10 mcpgateway
  warning: `VIRTUAL_ENV=/Users/brian/.venv/mcpgateway` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   [...]
  ```
  Note: warning and creation of .venv directory in the project area
5. run `pylint`
  ```
  [brian@dogmatix] ➜ [mcpgateway] mcp-context-forge git:(main) ✗ pylint
  zsh: command not found: pylint
  ```
Note despite having run with make, the tool is not available directly. I'd expect tools to be available in my virtual environment after successful execution of make target.


## 🐞 Root Cause
Inconsistent virtual environment definition means activating the wrong one stops normal function of project make tasks.

## 💡 Fix Description
I've updated the `uv run` tasks to use the active virtual environment instead of uv's default action to ignore the active one in favour of a local ".venv" directory.

I've confirmed the other `uv` based tasks are not affected, it only seems to be the `uv run` commands that cause this issue.

Now steps end up with:
#### Steps to reproduce:
1. Clone down the repo
2. `make venv`
  ```
  [brian@dogmatix] ➜  mcp-context-forge git:(main) ✗ make venv
  Requirement already satisfied: pip in /Users/brian/.venv/mcpgateway/lib/python3.11/site-packages (24.0)
  [...]
  # Eventually, we want to transition to using uv/uvx exclusively, at which point we will only need
  # a virtual environment if the user has not installed uv into their account.
  uv is /Users/brian/.local/bin/uv
  ✅  Virtual env created.
  💡  Enter it with:
      . /Users/brian/.venv/mcpgateway/bin/activate
  ```
3. Activate virtual environment
  ```
  [brian@dogmatix] ➜ [mcpgateway] mcp-context-forge git:(main) ✗ . /Users/brian/.venv/mcpgateway/bin/activate
  [brian@dogmatix] ➜ [mcpgateway] mcp-context-forge git:(main) ✗ which python
  /Users/brian/.venv/mcpgateway/bin/python
  ```
4. run `make pylint`
  ```
  > make pylint
  🐛 pylint mcpgateway (parallel)...
  Uninstalled 10 packages in 119ms
  Installed 242 packages in 559ms

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
  ```
  Note: No warning message
5. run `pylint`
  ```
  > pylint
  No files to lint: exiting.
  ```
Note despite having run with make, the tool is not available directly. I'd expect tools to be available in my virtual environment after successful execution of make target.
6. run `ls .venv`
```
> ls .venv
ls: .venv: No such file or directory
```

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed

