### PR TITLE
fix: Set the tool name when changed

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1541,6 +1541,8 @@ class ToolService:
                     ).scalar_one_or_none()
                     if existing_tool:
                         raise ToolNameConflictError(existing_tool.custom_name, enabled=existing_tool.enabled, tool_id=existing_tool.id, visibility=existing_tool.visibility)
+                if tool_update.custom_name is None and tool.name == tool.custom_name:
+                    tool.custom_name = tool_update.name
                 tool.name = tool_update.name
 
             if tool_update.custom_name is not None:


### PR DESCRIPTION
Closes: https://github.com/IBM/mcp-context-forge/issues/1485

Branch: ToolNameUpdate-1485

Signed-off-by: Gabe Goodhart <ghart@us.ibm.com>