### PR TITLE
Refactor jsonpath_modifier() & lifespan() to reduce cyclomatic complexity

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -355,8 +355,7 @@ def transform_data_with_mappings(data: list[Any], mappings: dict[str, str]) -> l
             try:
                 mapping_matches = mapping_expr.find(item)
             except Exception as e:
-                raise HTTPException(status_code=400,
-                                    detail=f"Error executing mapping JSONPath for key '{new_key}': {e}")
+                raise HTTPException(status_code=400, detail=f"Error executing mapping JSONPath for key '{new_key}': {e}")
 
             if not mapping_matches:
                 mapped_item[new_key] = None
@@ -615,14 +614,14 @@ def log_warnings(warnings: list[str]):
 
 def log_critical_issues(critical_issues: list[Any]):
     """
-        Log critical based on configuration settings
-        If REQUIRE_STRONG_SECRETS set, this will output critical errors and exit the mcpgateway server.
+    Log critical based on configuration settings
+    If REQUIRE_STRONG_SECRETS set, this will output critical errors and exit the mcpgateway server.
 
-        Args:
-            critical_issues: List
+    Args:
+        critical_issues: List
 
-        Returns: None
-        """
+    Returns: None
+    """
     # Handle critical issues based on REQUIRE_STRONG_SECRETS setting
     if critical_issues:
         if settings.require_strong_secrets:

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1567,6 +1567,7 @@ def sample_people():
         {"name": "Bob", "id": 2},
     ]
 
+
 def test_jsonpath_modifier_basic_match(sample_people):
     # First-Party
     from mcpgateway.main import jsonpath_modifier
@@ -1616,6 +1617,7 @@ class TestTransformDataWithMappings:
 
         with pytest.raises(HTTPException):
             transform_data_with_mappings(sample_people, {"bad": "$["})
+
 
 # ----------------------------------------------------- #
 # Plugin Exception Handler Tests                       #


### PR DESCRIPTION
# Refactor parts of mcpgateway/main.py to reduce cyclomatic complexity
This is in order to reduce Sonarqube findings on the maintainability of the code base as per https://github.com/IBM/mcp-context-forge/issues/212

(This PR is in draft mode, I'll add more details shortly, I need to add tests for new functions)

## Key Changes
I've refactored jsonpath_modifier() and lifespan() by offloading logical but more complex to read/understand segments of code to separate functions that can easily self contain that logic while making the original functions easier to read and understand.


## Benefits
The key benefits of these changes are to reduce cyclomatic complexity (or increase maintainability in SonarQube terms) of these functions.
Separating the logic like this means that we can more easily make change to the specific functions and not necessarily have to test large logical flows that do many separate things.

## Files Changed
mcpgateway/main.py
tests/unit/mcpgateway/test_main.py
