### PR TITLE
fix: Allow OPTIONS requests on /openapi.json for CORS preflight

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -816,6 +816,10 @@ class DocsAuthMiddleware(BaseHTTPMiddleware):
     the request is rejected with a 401 or 403 error.
 
     Note:
+        OPTIONS requests are exempt from authentication to support CORS preflight
+        as per RFC 7231 Section 4.3.7 (OPTIONS must not require authentication).
+
+    Note:
         When DOCS_ALLOW_BASIC_AUTH is enabled, Basic Authentication
         is also accepted using BASIC_AUTH_USER and BASIC_AUTH_PASSWORD credentials.
     """
@@ -855,6 +859,11 @@ class DocsAuthMiddleware(BaseHTTPMiddleware):
             True
         """
         protected_paths = ["/docs", "/redoc", "/openapi.json"]
+
+        # Allow OPTIONS requests to pass through for CORS preflight (RFC 7231)
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
 
         if any(request.url.path.startswith(p) for p in protected_paths):
             try:


### PR DESCRIPTION
## Summary
This PR fixes CORS preflight authentication issues that prevent browser-based OpenAPI integrations (Open WebUI, Swagger UI, etc.) from successfully fetching the OpenAPI specification.

## Problem
The `DocsAuthMiddleware` enforces authentication on all requests to `/openapi.json`, including OPTIONS preflight requests. However, **CORS preflight OPTIONS requests cannot include Authorization headers** per [RFC 7231 Section 4.3.7](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7), causing a 401 response before the browser can send the actual authenticated GET request.

### Symptom
Browser console error when integrating with Open WebUI or other browser-based tools:
```
Access to fetch at 'https://mcp-context-forge.example.com/openapi.json' from origin 'https://openwebui.example.com' 
has been blocked by CORS policy: Response to preflight request doesn't pass access control check: 
Redirect is not allowed for a preflight request.
```

Server returns `401 Unauthorized` with `www-authenticate: Bearer` header on OPTIONS request.

## Solution
Added a check to exempt OPTIONS requests from authentication in `DocsAuthMiddleware` before checking protected paths. This allows:
1. ✅ OPTIONS preflight to succeed (no auth required per CORS spec)
2. ✅ GET requests to still require authentication (security maintained)
3. ✅ Browser to complete CORS flow and fetch spec with proper auth

## Changes
- Added `request.method == "OPTIONS"` check in `DocsAuthMiddleware.dispatch()`
- Updated docstring to document OPTIONS exemption
- Positioned check before authentication to allow CORS headers from `CORSMiddleware` to be added

## Testing
Tested with:
- ✅ curl OPTIONS request returns 200 with CORS headers (no auth required)
- ✅ curl GET request still requires Bearer token (auth maintained)
- ✅ Open WebUI successfully fetches OpenAPI spec via browser
- ✅ Chrome and Firefox CORS preflight now succeeds

### Before
```bash
$ curl -i -X OPTIONS https://mcp-context-forge.example.com/openapi.json \
  -H "Origin: https://openwebui.example.com"
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer
```

### After
```bash
$ curl -i -X OPTIONS https://mcp-context-forge.example.com/openapi.json \
  -H "Origin: https://openwebui.example.com"
HTTP/1.1 200 OK
access-control-allow-origin: https://openwebui.example.com
access-control-allow-credentials: true
```

## Security Considerations
- ✅ No security regression: GET requests still require authentication
- ✅ OPTIONS only returns CORS headers (no sensitive data)
- ✅ Follows IETF RFC 7231 standard for OPTIONS handling
- ✅ Consistent with FastAPI's CORSMiddleware behavior

## Related Issues
This issue affects any browser-based integration attempting to use the OpenAPI spec, including:
- Open WebUI OpenAPI tool integration
- Swagger UI when hosted separately
- Any browser-based API client

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (docstring)
- [x] Tested with curl and browser
- [x] No breaking changes
- [x] Security implications considered