### PR TITLE
1282 force to user to change password

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -41,6 +41,7 @@ import uuid
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials
 import httpx
 from pydantic import SecretStr, ValidationError
 from pydantic_core import ValidationError as CoreValidationError
@@ -51,6 +52,8 @@ from sqlalchemy.sql.functions import coalesce
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 # First-Party
+# Authentication and password-related imports
+from mcpgateway.auth import get_current_user
 from mcpgateway.common.models import LogLevel
 from mcpgateway.config import settings
 from mcpgateway.db import get_db, GlobalConfig, ObservabilitySavedQuery, ObservabilitySpan, ObservabilityTrace
@@ -59,6 +62,7 @@ from mcpgateway.db import Resource as DbResource
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import utc_now
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
+from mcpgateway.routers.email_auth import create_access_token
 from mcpgateway.schemas import (
     A2AAgentCreate,
     A2AAgentRead,
@@ -99,7 +103,9 @@ from mcpgateway.schemas import (
     ToolUpdate,
 )
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
+from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.catalog_service import catalog_service
+from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, PasswordValidationError
 from mcpgateway.services.encryption_service import get_encryption_service
 from mcpgateway.services.export_service import ExportError, ExportService
 from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayDuplicateConflictError, GatewayNameConflictError, GatewayNotFoundError, GatewayService
@@ -122,6 +128,7 @@ from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.pagination import generate_pagination_links
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
 from mcpgateway.utils.retry_manager import ResilientHttpClient
+from mcpgateway.utils.security_cookies import set_auth_cookie
 from mcpgateway.utils.services_auth import decode_auth
 from mcpgateway.utils.validate_signature import sign_data
 
@@ -222,6 +229,80 @@ grpc_service_mgr: Optional[Any] = GrpcService() if (settings.mcpgateway_grpc_ena
 
 # Rate limiting storage
 rate_limit_storage = defaultdict(list)
+
+
+def get_client_ip(request: Request) -> str:
+    """Extract client IP address from request.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        str: Client IP address
+
+    Examples:
+        >>> from unittest.mock import MagicMock
+        >>>
+        >>> # Test with X-Forwarded-For header
+        >>> mock_request = MagicMock()
+        >>> mock_request.headers = {"X-Forwarded-For": "192.168.1.1, 10.0.0.1"}
+        >>> get_client_ip(mock_request)
+        '192.168.1.1'
+        >>>
+        >>> # Test with X-Real-IP header
+        >>> mock_request.headers = {"X-Real-IP": "10.0.0.5"}
+        >>> get_client_ip(mock_request)
+        '10.0.0.5'
+        >>>
+        >>> # Test with direct client IP
+        >>> mock_request.headers = {}
+        >>> mock_request.client.host = "127.0.0.1"
+        >>> get_client_ip(mock_request)
+        '127.0.0.1'
+        >>>
+        >>> # Test with no client info
+        >>> mock_request.client = None
+        >>> get_client_ip(mock_request)
+        'unknown'
+    """
+    # Check for X-Forwarded-For header (proxy/load balancer)
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+
+    # Check for X-Real-IP header
+    real_ip = request.headers.get("X-Real-IP")
+    if real_ip:
+        return real_ip
+
+    # Fall back to direct client IP
+    return request.client.host if request.client else "unknown"
+
+
+def get_user_agent(request: Request) -> str:
+    """Extract user agent from request.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        str: User agent string
+
+    Examples:
+        >>> from unittest.mock import MagicMock
+        >>>
+        >>> # Test with User-Agent header
+        >>> mock_request = MagicMock()
+        >>> mock_request.headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0)"}
+        >>> get_user_agent(mock_request)
+        'Mozilla/5.0 (Windows NT 10.0)'
+        >>>
+        >>> # Test without User-Agent header
+        >>> mock_request.headers = {}
+        >>> get_user_agent(mock_request)
+        'unknown'
+    """
+    return request.headers.get("User-Agent", "unknown")
 
 
 def rate_limit(requests_per_minute: Optional[int] = None):
@@ -2711,9 +2792,6 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
             return RedirectResponse(url=f"{root_path}/admin/login?error=missing_fields", status_code=303)
 
         # Authenticate using the email auth service
-        # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
-
         auth_service = EmailAuthService(db)
 
         try:
@@ -2727,10 +2805,36 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
                 root_path = request.scope.get("root_path", "")
                 return RedirectResponse(url=f"{root_path}/admin/login?error=invalid_credentials", status_code=303)
 
-            # Create JWT token with proper audience and issuer claims
-            # First-Party
-            from mcpgateway.routers.email_auth import create_access_token  # pylint: disable=import-outside-toplevel
+            # Check if password change is required OR if user is using default password
+            needs_password_change = user.password_change_required
 
+            # Also check if user is using the default password
+            if not needs_password_change:
+                password_service = Argon2PasswordService()
+                is_using_default_password = password_service.verify_password(settings.default_user_password.get_secret_value(), user.password_hash)  # nosec B105
+                if is_using_default_password:
+                    needs_password_change = True
+                    # Set the flag in database for future reference
+                    user.password_change_required = True
+                    db.commit()
+                    LOGGER.info(f"User {email} is using default password - forcing password change")
+
+            if needs_password_change:
+                LOGGER.info(f"User {email} requires password change - redirecting to change password page")
+
+                # Create temporary JWT token for password change process
+                token, _ = await create_access_token(user)
+
+                # Create redirect response to password change page
+                root_path = request.scope.get("root_path", "")
+                response = RedirectResponse(url=f"{root_path}/admin/change-password-required", status_code=303)
+
+                # Set JWT token as secure cookie for the password change process
+                set_auth_cookie(response, token, remember_me=False)
+
+                return response
+
+            # Create JWT token with proper audience and issuer claims
             token, _ = await create_access_token(user)  # expires_seconds not needed here
 
             # Create redirect response
@@ -2738,9 +2842,6 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
             response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
 
             # Set JWT token as secure cookie
-            # First-Party
-            from mcpgateway.utils.security_cookies import set_auth_cookie  # pylint: disable=import-outside-toplevel
-
             set_auth_cookie(response, token, remember_me=False)
 
             LOGGER.info(f"Admin user {email} logged in successfully")
@@ -2803,6 +2904,182 @@ async def admin_logout(request: Request) -> RedirectResponse:
     response.delete_cookie("jwt_token", path=settings.app_root_path or "/", secure=True, httponly=True, samesite="lax")
 
     return response
+
+
+@admin_router.get("/change-password-required", response_class=HTMLResponse)
+async def change_password_required_page(request: Request) -> HTMLResponse:
+    """
+    Render the password change required page.
+
+    This page is shown when a user's password has expired and must be changed
+    to continue accessing the system.
+
+    Args:
+        request (Request): FastAPI request object.
+
+    Returns:
+        HTMLResponse: The password change required page.
+
+    Examples:
+        >>> from unittest.mock import MagicMock
+        >>> from fastapi import Request
+        >>> from fastapi.responses import HTMLResponse
+        >>>
+        >>> # Mock request
+        >>> mock_request = MagicMock(spec=Request)
+        >>> mock_request.scope = {"root_path": "/test"}
+        >>> mock_request.app.state.templates = MagicMock()
+        >>> mock_response = HTMLResponse("<html>Change Password</html>")
+        >>> mock_request.app.state.templates.TemplateResponse.return_value = mock_response
+        >>>
+        >>> import asyncio
+        >>> async def test_change_password_page():
+        ...     # Note: This requires email_auth_enabled=True in settings
+        ...     return True  # Simplified test due to settings dependency
+        >>>
+        >>> asyncio.run(test_change_password_page())
+        True
+    """
+    if not getattr(settings, "email_auth_enabled", False):
+        root_path = request.scope.get("root_path", "")
+        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+
+    # Get root path for template
+    root_path = request.scope.get("root_path", "")
+
+    return request.app.state.templates.TemplateResponse("change-password-required.html", {"request": request, "root_path": root_path})
+
+
+@admin_router.post("/change-password-required")
+async def change_password_required_handler(request: Request, db: Session = Depends(get_db)) -> RedirectResponse:
+    """
+    Handle password change requirement form submission.
+
+    This endpoint processes the forced password change form, validates the credentials,
+    changes the password, clears the password_change_required flag, and redirects to admin panel.
+
+    Args:
+        request (Request): FastAPI request object.
+        db (Session): Database session dependency.
+
+    Returns:
+        RedirectResponse: Redirect to admin panel on success or back to form with error.
+
+    Examples:
+        >>> from unittest.mock import MagicMock, AsyncMock
+        >>> from fastapi import Request
+        >>> from fastapi.responses import RedirectResponse
+        >>>
+        >>> # Mock request with form data
+        >>> mock_request = MagicMock(spec=Request)
+        >>> mock_request.scope = {"root_path": "/test"}
+        >>> mock_form = {
+        ...     "current_password": "oldpass",
+        ...     "new_password": "newpass123",
+        ...     "confirm_password": "newpass123"
+        ... }
+        >>> mock_request.form = AsyncMock(return_value=mock_form)
+        >>> mock_request.cookies = {"jwt_token": "test_token"}
+        >>> mock_request.headers = {"User-Agent": "TestAgent"}
+        >>>
+        >>> mock_db = MagicMock()
+        >>>
+        >>> import asyncio
+        >>> async def test_password_change_handler():
+        ...     # Note: Full test requires email_auth_enabled and valid JWT
+        ...     return True  # Simplified test due to settings/auth dependencies
+        >>>
+        >>> asyncio.run(test_password_change_handler())
+        True
+    """
+    if not getattr(settings, "email_auth_enabled", False):
+        root_path = request.scope.get("root_path", "")
+        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+
+    try:
+        form = await request.form()
+        current_password_val = form.get("current_password")
+        new_password_val = form.get("new_password")
+        confirm_password_val = form.get("confirm_password")
+
+        current_password = current_password_val if isinstance(current_password_val, str) else None
+        new_password = new_password_val if isinstance(new_password_val, str) else None
+        confirm_password = confirm_password_val if isinstance(confirm_password_val, str) else None
+
+        if not all([current_password, new_password, confirm_password]):
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=missing_fields", status_code=303)
+
+        if new_password != confirm_password:
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=mismatch", status_code=303)
+
+        # Get user from JWT token in cookie
+        try:
+            jwt_token = request.cookies.get("jwt_token")
+            if not jwt_token:
+                root_path = request.scope.get("root_path", "")
+                return RedirectResponse(url=f"{root_path}/admin/login?error=session_expired", status_code=303)
+
+            # Authenticate using the token
+            # Create credentials object from cookie
+            credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=jwt_token)
+            current_user = await get_current_user(credentials, db, request)
+
+            if not current_user:
+                root_path = request.scope.get("root_path", "")
+                return RedirectResponse(url=f"{root_path}/admin/login?error=session_expired", status_code=303)
+        except Exception as e:
+            LOGGER.error(f"Authentication error: {e}")
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/login?error=session_expired", status_code=303)
+
+        # Authenticate using the email auth service
+        auth_service = EmailAuthService(db)
+        ip_address = get_client_ip(request)
+        user_agent = get_user_agent(request)
+
+        try:
+            # Change password
+            success = await auth_service.change_password(email=current_user.email, old_password=current_password, new_password=new_password, ip_address=ip_address, user_agent=user_agent)
+
+            if success:
+                # Clear the password_change_required flag
+                current_user.password_change_required = False
+                db.commit()
+
+                # Create new JWT token
+                token, _ = await create_access_token(current_user)
+
+                # Create redirect response to admin panel
+                root_path = request.scope.get("root_path", "")
+                response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+
+                # Update JWT token cookie
+                set_auth_cookie(response, token, remember_me=False)
+
+                LOGGER.info(f"User {current_user.email} successfully changed their expired password")
+                return response
+
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=change_failed", status_code=303)
+
+        except AuthenticationError:
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=invalid_password", status_code=303)
+        except PasswordValidationError as e:
+            LOGGER.warning(f"Password validation failed for {current_user.email}: {e}")
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=weak_password", status_code=303)
+        except Exception as e:
+            LOGGER.error(f"Password change failed for {current_user.email}: {e}", exc_info=True)
+            root_path = request.scope.get("root_path", "")
+            return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=server_error", status_code=303)
+
+    except Exception as e:
+        LOGGER.error(f"Password change handler error: {e}")
+        root_path = request.scope.get("root_path", "")
+        return RedirectResponse(url=f"{root_path}/admin/change-password-required?error=server_error", status_code=303)
 
 
 # ============================================================================ #
@@ -3002,9 +3279,6 @@ async def admin_list_teams(
         return HTMLResponse(content='<div class="text-center py-8"><p class="text-gray-500">Email authentication is disabled. Teams feature requires email auth.</p></div>', status_code=200)
 
     try:
-        # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
-
         auth_service = EmailAuthService(db)
         team_service = TeamManagementService(db)
 
@@ -3203,8 +3477,6 @@ async def admin_view_team_members(
         LOGGER.info(f"User {user_email} viewing members for team {team_id}")
 
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
-
         team_service = TeamManagementService(db)
 
         # Get team details
@@ -3654,8 +3926,6 @@ async def admin_add_team_member(
 
     try:
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
-
         team_service = TeamManagementService(db)
         auth_service = EmailAuthService(db)
 
@@ -4330,7 +4600,6 @@ async def admin_list_users(
         root_path = request.scope.get("root_path", "")
 
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4375,6 +4644,34 @@ async def admin_list_users(
             if not is_current_user and not is_last_admin:
                 delete_button = f'<button class="px-3 py-1 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 border border-red-300 dark:border-red-600 hover:border-red-500 dark:hover:border-red-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500" hx-delete="{root_path}/admin/users/{urllib.parse.quote(user_obj.email, safe="")}" hx-confirm="Are you sure you want to delete this user? This action cannot be undone." hx-target="closest .user-card" hx-swap="outerHTML">Delete</button>'
 
+            # Build force password change button/indicator
+            password_change_button_html = ""  # nosec B105 - HTML content, not password
+            if not is_current_user:
+                if user_obj.password_change_required:
+                    # HTML content for password change required indicator
+                    password_change_required_html = (  # nosec B105 - HTML content, not password
+                        '<span class="px-3 py-1 text-sm font-medium text-orange-600 dark:text-orange-400 '
+                        "bg-orange-50 dark:bg-orange-900/20 border border-orange-300 dark:border-orange-600 "
+                        'rounded-md">Password Change Required</span>'
+                    )
+                    password_change_button_html = password_change_required_html
+                else:
+                    password_change_button_html = (
+                        f'<button class="px-3 py-1 text-sm font-medium text-yellow-600 dark:text-yellow-400 '
+                        f"hover:text-yellow-800 dark:hover:text-yellow-300 border border-yellow-300 dark:border-yellow-600 "
+                        f"hover:border-yellow-500 dark:hover:border-yellow-400 rounded-md focus:outline-none focus:ring-2 "
+                        f'focus:ring-offset-2 focus:ring-yellow-500" hx-post="{root_path}/admin/users/{urllib.parse.quote(user_obj.email, safe="")}/force-password-change" '
+                        f'hx-confirm="Force this user to change their password on next login?" hx-target="closest .user-card" '
+                        f'hx-swap="outerHTML">Force Password Change</button>'
+                    )
+
+            # Password change required badge
+            password_badge = (
+                '<span class="px-2 py-1 text-xs font-semibold bg-orange-100 text-orange-800 rounded-full dark:bg-orange-900 dark:text-orange-200"><i class="fas fa-key mr-1"></i>Password Change Required</span>'
+                if user_obj.password_change_required
+                else ""
+            )
+
             users_html += f"""
             <div class="user-card border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800">
                 <div class="flex justify-between items-start">
@@ -4385,6 +4682,7 @@ async def admin_list_users(
                             <span class="px-2 py-1 text-xs font-semibold {status_class} bg-gray-100 dark:bg-gray-700 rounded-full">{status_text}</span>
                             {'<span class="px-2 py-1 text-xs font-semibold bg-blue-100 text-blue-800 rounded-full dark:bg-blue-900 dark:text-blue-200">You</span>' if is_current_user else ""}
                             {'<span class="px-2 py-1 text-xs font-semibold bg-yellow-100 text-yellow-800 rounded-full dark:bg-yellow-900 dark:text-yellow-200">Last Admin</span>' if is_last_admin else ""}
+                            {password_badge}
                         </div>
                         <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">📧 {user_obj.email}</p>
                         <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">🔐 Provider: {user_obj.auth_provider}</p>
@@ -4396,6 +4694,7 @@ async def admin_list_users(
                             Edit
                         </button>
                         {activate_deactivate_button}
+                        {password_change_button_html}
                         {delete_button}
                     </div>
                 </div>
@@ -4436,7 +4735,6 @@ async def admin_create_user(
         form = await request.form()
 
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4444,6 +4742,11 @@ async def admin_create_user(
         new_user = await auth_service.create_user(
             email=str(form.get("email", "")), password=str(form.get("password", "")), full_name=str(form.get("full_name", "")), is_admin=form.get("is_admin") == "on", auth_provider="local"
         )
+
+        # If the user was created with the default password, force password change
+        if str(form.get("password", "")) == settings.default_user_password.get_secret_value():  # nosec B105
+            new_user.password_change_required = True
+            db.commit()
 
         LOGGER.info(f"Admin {user} created user: {new_user.email}")
 
@@ -4508,7 +4811,6 @@ async def admin_get_user_edit(
         root_path = _request.scope.get("root_path", "") if _request else ""
 
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4597,7 +4899,6 @@ async def admin_update_user(
 
     try:
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4676,7 +4977,6 @@ async def admin_activate_user(
         root_path = _request.scope.get("root_path", "") if _request else ""
 
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4744,7 +5044,6 @@ async def admin_deactivate_user(
         root_path = _request.scope.get("root_path", "") if _request else ""
 
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4818,7 +5117,6 @@ async def admin_delete_user(
 
     try:
         # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel  # pylint: disable=import-outside-toplevel
 
         auth_service = EmailAuthService(db)
 
@@ -4845,6 +5143,136 @@ async def admin_delete_user(
     except Exception as e:
         LOGGER.error(f"Error deleting user {user_email}: {e}")
         return HTMLResponse(content=f'<div class="text-red-500">Error deleting user: {str(e)}</div>', status_code=400)
+
+
+@admin_router.post("/users/{user_email}/force-password-change")
+@require_permission("admin.user_management")
+async def admin_force_password_change(
+    user_email: str,
+    _request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+) -> HTMLResponse:
+    """Force user to change password on next login.
+
+    Args:
+        user_email: Email of user to force password change
+        _request: FastAPI request object
+        db: Database session
+        user: Current authenticated user context
+
+    Returns:
+        HTMLResponse: Updated user card with success message
+
+    Examples:
+        >>> from unittest.mock import MagicMock, AsyncMock
+        >>> from fastapi import Request
+        >>> from fastapi.responses import HTMLResponse
+        >>>
+        >>> # Mock request
+        >>> mock_request = MagicMock(spec=Request)
+        >>> mock_request.scope = {"root_path": "/test"}
+        >>>
+        >>> # Mock database
+        >>> mock_db = MagicMock()
+        >>>
+        >>> # Mock user context
+        >>> mock_user = MagicMock()
+        >>> mock_user.email = "admin@example.com"
+        >>>
+        >>> import asyncio
+        >>> async def test_force_password_change():
+        ...     # Note: Full test requires email_auth_enabled and valid user
+        ...     return True  # Simplified test due to dependencies
+        >>>
+        >>> asyncio.run(test_force_password_change())
+        True
+    """
+    if not settings.email_auth_enabled:
+        return HTMLResponse(content='<div class="text-red-500">Email authentication is disabled</div>', status_code=403)
+
+    try:
+        # Get root path for URL construction
+        root_path = _request.scope.get("root_path", "") if _request else ""
+
+        auth_service = EmailAuthService(db)
+
+        # URL decode the email
+        decoded_email = urllib.parse.unquote(user_email)
+
+        # Get current user email from JWT
+        current_user_email = get_user_email(user)
+
+        # Get the user to update
+        user_obj = await auth_service.get_user_by_email(decoded_email)
+        if not user_obj:
+            return HTMLResponse(content='<div class="text-red-500">User not found</div>', status_code=404)
+
+        # Set password_change_required flag
+        user_obj.password_change_required = True
+        db.commit()
+
+        LOGGER.info(f"Admin {current_user_email} forced password change for user {decoded_email}")
+
+        # Return updated user card with status indicator
+        user_html = f"""
+        <div class="user-card bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 border border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow duration-200">
+            <div class="flex items-start justify-between">
+                <div class="flex items-center space-x-4">
+                    <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-semibold text-lg">
+                        {user_obj.get_display_name()[0].upper()}
+                    </div>
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{html.escape(user_obj.get_display_name())}</h3>
+                        <p class="text-sm text-gray-600 dark:text-gray-400">{html.escape(user_obj.email)}</p>
+                        <div class="flex items-center space-x-2 mt-1">
+                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300' if user_obj.is_active else 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300'}">
+                                {'Active' if user_obj.is_active else 'Inactive'}
+                            </span>
+                            {'<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">Admin</span>' if user_obj.is_admin else ''}
+                            {'<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300"><i class="fas fa-key mr-1"></i>Password Change Required</span>' if user_obj.password_change_required else ''}
+                        </div>
+                    </div>
+                </div>
+                <div class="flex flex-col space-y-2">
+                    <button class="px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 border border-blue-300 dark:border-blue-600 hover:border-blue-500 dark:hover:border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                            hx-get="{root_path}/admin/users/{user_obj.email}/edit" hx-target="#user-edit-modal-content">
+                        Edit
+                    </button>
+                    {(
+                        '<button class="px-3 py-1 text-sm font-medium text-orange-600 dark:text-orange-400 hover:text-orange-800 '
+                        'dark:hover:text-orange-300 border border-orange-300 dark:border-orange-600 hover:border-orange-500 '
+                        'dark:hover:border-orange-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 '
+                        'focus:ring-orange-500" hx-post="' + root_path + '/admin/users/' + user_obj.email.replace("@", "%40") +
+                        '/deactivate" hx-confirm="Deactivate this user?" hx-target="closest .user-card" hx-swap="outerHTML">Deactivate</button>'
+                        if user_obj.is_active else
+                        '<button class="px-3 py-1 text-sm font-medium text-green-600 dark:text-green-400 hover:text-green-800 '
+                        'dark:hover:text-green-300 border border-green-300 dark:border-green-600 hover:border-green-500 '
+                        'dark:hover:border-green-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 '
+                        'focus:ring-green-500" hx-post="' + root_path + '/admin/users/' + user_obj.email.replace("@", "%40") +
+                        '/activate" hx-confirm="Activate this user?" hx-target="closest .user-card" hx-swap="outerHTML">Activate</button>'
+                    )}
+                    {(
+                        '<button class="px-3 py-1 text-sm font-medium text-yellow-600 dark:text-yellow-400 hover:text-yellow-800 '
+                        'dark:hover:text-yellow-300 border border-yellow-300 dark:border-yellow-600 hover:border-yellow-500 '
+                        'dark:hover:border-yellow-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 '
+                        'focus:ring-yellow-500" hx-post="' + root_path + '/admin/users/' + user_obj.email.replace("@", "%40") +
+                        '/force-password-change" hx-confirm="Force this user to change their password on next login?" '
+                        'hx-target="closest .user-card" hx-swap="outerHTML">Force Password Change</button>'
+                        if not user_obj.password_change_required else
+                        '<span class="px-3 py-1 text-sm font-medium text-orange-600 dark:text-orange-400 bg-orange-50 '
+                        'dark:bg-orange-900/20 border border-orange-300 dark:border-orange-600 rounded-md">Password Change Required</span>'
+                    )}
+                    <button class="px-3 py-1 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 border border-red-300 dark:border-red-600 hover:border-red-500 dark:hover:border-red-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500" hx-delete="{root_path}/admin/users/{user_obj.email.replace("@", "%40")}" hx-confirm="Are you sure you want to delete this user? This action cannot be undone." hx-target="closest .user-card" hx-swap="outerHTML">Delete</button>
+                </div>
+            </div>
+        </div>
+        """
+        return HTMLResponse(content=user_html)
+
+    except Exception as e:
+        LOGGER.error(f"Error forcing password change for user {user_email}: {e}")
+        return HTMLResponse(content=f'<div class="text-red-500">Error forcing password change: {str(e)}</div>', status_code=400)
 
 
 @admin_router.get("/tools")

--- a/mcpgateway/alembic/versions/z1a2b3c4d5e6_add_password_change_required.py
+++ b/mcpgateway/alembic/versions/z1a2b3c4d5e6_add_password_change_required.py
@@ -1,0 +1,27 @@
+"""Add password_change_required field to EmailUser
+
+Revision ID: z1a2b3c4d5e6
+Revises: 191a2def08d7
+Create Date: 2025-11-21 14:16:30.000000
+
+"""
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "z1a2b3c4d5e6"
+down_revision = "191a2def08d7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add password_change_required field to email_users table."""
+    op.add_column("email_users", sa.Column("password_change_required", sa.Boolean(), nullable=False, server_default="false"))
+
+
+def downgrade():
+    """Remove password_change_required field from email_users table."""
+    op.drop_column("email_users", "password_change_required")

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -83,11 +83,12 @@ async def bootstrap_admin_user() -> None:
                 is_admin=True,
             )
 
-            # Mark admin user as email verified
+            # Mark admin user as email verified and require password change on first login
             # First-Party
             from mcpgateway.db import utc_now  # pylint: disable=import-outside-toplevel
 
             admin_user.email_verified_at = utc_now()
+            admin_user.password_change_required = True  # Force admin to change default password
             db.commit()
 
             # Personal team is automatically created during user creation if enabled

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -290,6 +290,7 @@ class Settings(BaseSettings):
     email_auth_enabled: bool = Field(default=True, description="Enable email-based authentication")
     platform_admin_email: str = Field(default="admin@example.com", description="Platform administrator email address")
     platform_admin_password: SecretStr = Field(default=SecretStr("changeme"), description="Platform administrator password")
+    default_user_password: SecretStr = Field(default=SecretStr("changeme"), description="Default password for new users")  # nosec B105
     platform_admin_full_name: str = Field(default="Platform Administrator", description="Platform administrator full name")
 
     # Argon2id Password Hashing Configuration

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -482,6 +482,7 @@ class EmailUser(Base):
     password_hash_type: Mapped[str] = mapped_column(String(20), default="argon2id", nullable=False)
     failed_login_attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     locked_until: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    password_change_required: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4865,6 +4865,7 @@ class EmailUserResponse(BaseModel):
     created_at: datetime = Field(..., description="Account creation timestamp")
     last_login: Optional[datetime] = Field(None, description="Last successful login")
     email_verified: bool = Field(False, description="Whether email is verified")
+    password_change_required: bool = Field(False, description="Whether user must change password on next login")
 
     @classmethod
     def from_email_user(cls, user) -> "EmailUserResponse":
@@ -4885,6 +4886,7 @@ class EmailUserResponse(BaseModel):
             created_at=user.created_at,
             last_login=user.last_login,
             email_verified=user.is_email_verified(),
+            password_change_required=user.password_change_required,
         )
 
 

--- a/mcpgateway/templates/change-password-required.html
+++ b/mcpgateway/templates/change-password-required.html
@@ -1,0 +1,582 @@
+<!doctype html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Password Change Required - MCP Gateway</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            animation: {
+              "gradient-x": "gradient-x 15s ease infinite",
+              float: "float 6s ease-in-out infinite",
+              "pulse-soft": "pulse-soft 2s ease-in-out infinite",
+              "slide-up": "slide-up 0.8s ease-out",
+              "fade-in": "fade-in 1s ease-out",
+              "scale-pulse": "scale-pulse 4s ease-in-out infinite",
+            },
+            keyframes: {
+              "gradient-x": {
+                "0%, 100%": {
+                  "background-size": "200% 200%",
+                  "background-position": "left center",
+                },
+                "50%": {
+                  "background-size": "200% 200%",
+                  "background-position": "right center",
+                },
+              },
+              float: {
+                "0%, 100%": { transform: "translateY(0px)" },
+                "50%": { transform: "translateY(-20px)" },
+              },
+              "pulse-soft": {
+                "0%, 100%": { opacity: 1 },
+                "50%": { opacity: 0.8 },
+              },
+              "slide-up": {
+                "0%": { transform: "translateY(30px)", opacity: 0 },
+                "100%": { transform: "translateY(0)", opacity: 1 },
+              },
+              "fade-in": {
+                "0%": { opacity: 0 },
+                "100%": { opacity: 1 },
+              },
+              "scale-pulse": {
+                "0%, 100%": { transform: "scale(1)" },
+                "50%": { transform: "scale(1.05)" },
+              },
+            },
+          },
+        },
+      };
+    </script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+  </head>
+  <body class="h-full bg-gray-50 dark:bg-gray-900 overflow-hidden">
+    <!-- Main Split Layout -->
+    <div class="min-h-screen flex">
+      <!-- Left Side - Password Change Form -->
+      <div
+        class="flex-1 flex flex-col justify-center py-6 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-900 relative overflow-hidden"
+      >
+        <!-- Subtle background decoration -->
+        <div
+          class="absolute inset-0 bg-gradient-to-br from-purple-50/50 to-blue-100/30 dark:from-gray-800/50 dark:to-gray-700/30"
+        ></div>
+        <div
+          class="absolute top-10 left-10 w-32 h-32 bg-gradient-to-br from-purple-200/30 to-blue-200/30 dark:from-purple-800/30 dark:to-blue-800/30 rounded-full animate-float"
+        ></div>
+        <div
+          class="absolute bottom-20 right-10 w-24 h-24 bg-gradient-to-br from-red-200/30 to-pink-200/30 dark:from-red-800/30 dark:to-pink-800/30 rounded-full animate-float"
+          style="animation-delay: 2s"
+        ></div>
+
+        <div class="sm:mx-auto sm:w-full sm:max-w-md relative z-10">
+          <!-- Password Change Required Card -->
+          <div
+            class="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl py-8 px-6 shadow-2xl rounded-2xl border border-gray-200/50 dark:border-gray-700/50 animate-slide-up"
+            style="animation-delay: 0.2s"
+          >
+            <!-- Header with icon -->
+            <div class="text-center mb-6">
+              <div class="mx-auto flex items-center justify-center h-16 w-16 rounded-full bg-gradient-to-r from-purple-400 to-indigo-500 mb-4">
+                <i class="fas fa-key text-white text-xl"></i>
+              </div>
+              <h2 class="text-2xl font-bold text-gray-900 dark:text-white">
+                Password Change Required
+              </h2>
+              <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                Your password has expired and must be changed to continue.
+              </p>
+            </div>
+
+            <!-- Error/Success messages -->
+            <div
+              id="error-message"
+              class="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 rounded-xl text-sm hidden"
+            >
+              <div class="flex items-center">
+                <i class="fas fa-exclamation-circle mr-2"></i>
+                <span id="error-text">An error occurred while changing your password. Please try again.</span>
+              </div>
+            </div>
+
+            <div
+              id="success-message"  
+              class="mb-6 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-400 rounded-xl text-sm hidden"
+            >
+              <div class="flex items-center">
+                <i class="fas fa-check-circle mr-2"></i>
+                <span id="success-text">Password changed successfully! Redirecting...</span>
+              </div>
+            </div>
+
+            <!-- Password Change Form -->
+            <form
+              class="space-y-6"
+              id="password-change-form"
+              action="{{ root_path }}/admin/change-password-required"
+              method="post"
+            >
+              <div>
+                <label
+                  for="current_password"
+                  class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
+                >
+                  <i class="fas fa-lock mr-2 text-gray-400"></i>Current Password
+                </label>
+                <div class="relative">
+                  <input
+                    id="current_password"
+                    name="current_password"
+                    type="password"
+                    autocomplete="current-password"
+                    required
+                    placeholder="Enter your current password"
+                    class="w-full px-3 py-3 border border-gray-300 dark:border-gray-600 rounded-lg placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent dark:bg-gray-700/50 dark:text-white transition-all duration-200 backdrop-blur-sm pr-10"
+                  />
+                  <button
+                    type="button"
+                    onclick="togglePasswordVisibility('current_password')"
+                    class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  >
+                    <i id="current_password_icon" class="fas fa-eye"></i>
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label
+                  for="new_password"
+                  class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
+                >
+                  <i class="fas fa-key mr-2 text-gray-400"></i>New Password
+                </label>
+                <div class="relative">
+                  <input
+                    id="new_password"
+                    name="new_password"
+                    type="password"
+                    autocomplete="new-password"
+                    required
+                    placeholder="Enter your new password"
+                    class="w-full px-3 py-3 border border-gray-300 dark:border-gray-600 rounded-lg placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent dark:bg-gray-700/50 dark:text-white transition-all duration-200 backdrop-blur-sm pr-10"
+                    oninput="validatePassword()"
+                  />
+                  <button
+                    type="button"
+                    onclick="togglePasswordVisibility('new_password')"
+                    class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  >
+                    <i id="new_password_icon" class="fas fa-eye"></i>
+                  </button>
+                </div>
+                <div class="mt-2">
+                  <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">Password strength: <span id="password-strength" class="font-medium">Medium</span></p>
+                </div>
+              </div>
+
+              <div>
+                <label
+                  for="confirm_password"
+                  class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2"
+                >
+                  <i class="fas fa-lock mr-2 text-gray-400"></i>Confirm New Password
+                </label>
+                <div class="relative">
+                  <input
+                    id="confirm_password"
+                    name="confirm_password"
+                    type="password"
+                    autocomplete="new-password"
+                    required
+                    placeholder="Confirm your new password"
+                    class="w-full px-3 py-3 border border-gray-300 dark:border-gray-600 rounded-lg placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent dark:bg-gray-700/50 dark:text-white transition-all duration-200 backdrop-blur-sm pr-10"
+                    oninput="validatePassword()"
+                  />
+                  <button
+                    type="button"
+                    onclick="togglePasswordVisibility('confirm_password')"
+                    class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  >
+                    <i id="confirm_password_icon" class="fas fa-eye"></i>
+                  </button>
+                </div>
+                <div class="mt-1">
+                  <p id="password-match" class="text-xs text-green-600 dark:text-green-400 hidden">
+                    <i class="fas fa-check mr-1"></i>Passwords match
+                  </p>
+                </div>
+              </div>
+
+              <!-- Password Requirements -->
+              <div class="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg border border-blue-200 dark:border-blue-800">
+                <h3 class="text-sm font-semibold text-blue-700 dark:text-blue-300 mb-2">
+                  <i class="fas fa-info-circle mr-2"></i>Password Requirements
+                </h3>
+                <ul class="text-xs text-blue-600 dark:text-blue-400 space-y-1">
+                  <li id="req-length" class="flex items-center">
+                    <i class="fas fa-circle text-green-500 mr-2"></i>
+                    At least 8 characters long
+                  </li>
+                  <li id="req-uppercase" class="flex items-center">
+                    <i class="fas fa-circle text-green-500 mr-2"></i>
+                    Contains uppercase letters (A-Z)
+                  </li>
+                  <li id="req-lowercase" class="flex items-center">
+                    <i class="fas fa-circle text-green-500 mr-2"></i>
+                    Contains lowercase letters (a-z)
+                  </li>
+                  <li id="req-special" class="flex items-center">
+                    <i class="fas fa-circle text-green-500 mr-2"></i>
+                    Contains special characters (!@#$%&*)
+                  </li>
+                </ul>
+              </div>
+
+              <button
+                type="submit"
+                id="submit-btn"
+                class="w-full flex justify-center items-center py-3 px-4 bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition-all duration-200"
+              >
+                <i class="fas fa-key mr-2"></i>
+                Change Password
+              </button>
+            </form>
+
+            <!-- Footer -->
+            <div class="mt-6 text-center">
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                <i class="fas fa-shield-alt mr-1"></i>
+                Your password will be securely encrypted and stored
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right Side - Security Features -->
+      <div
+        class="flex-1 bg-gradient-to-br from-purple-600 via-indigo-600 to-blue-700 dark:from-purple-900 dark:via-indigo-900 dark:to-blue-900 relative overflow-hidden flex items-center justify-center"
+      >
+        <!-- Integrated background pattern -->
+        <div class="absolute inset-0 opacity-10">
+          <div
+            class="absolute inset-0"
+            style="
+              background-image: url('data:image/svg+xml,%3Csvg width=&quot;40&quot; height=&quot;40&quot; viewBox=&quot;0 0 40 40&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot;%3E%3Cg fill=&quot;%23ffffff&quot; fill-opacity=&quot;0.1&quot;%3E%3Cpath d=&quot;M20 20c0-5.5-4.5-10-10-10s-10 4.5-10 10 4.5 10 10 10 10-4.5 10-10zm10 0c0-5.5-4.5-10-10-10s-10 4.5-10 10 4.5 10 10 10 10-4.5 10-10z&quot;/%3E%3C/g%3E%3C/svg%3E');
+            "
+          ></div>
+        </div>
+
+        <!-- Subtle floating accents -->
+        <div
+          class="absolute top-16 right-16 w-2 h-2 bg-white/20 rounded-full animate-pulse-soft"
+        ></div>
+        <div
+          class="absolute bottom-24 left-16 w-1 h-1 bg-white/30 rounded-full animate-pulse-soft"
+          style="animation-delay: 1s"
+        ></div>
+        <div
+          class="absolute top-1/3 right-32 w-1.5 h-1.5 bg-white/25 rounded-full animate-pulse-soft"
+          style="animation-delay: 2s"
+        ></div>
+
+        <!-- Main content container -->
+        <div class="relative z-10 max-w-2xl px-6 py-4">
+          <!-- Compact Hero -->
+          <div class="text-center mb-4">
+            <div class="flex items-center justify-center mb-3">
+              <div
+                class="inline-flex items-center justify-center w-10 h-10 bg-gradient-to-br from-purple-500 to-indigo-600 rounded-xl shadow-lg mr-3 animate-scale-pulse"
+              >
+                <img
+                  src="{{ root_path }}/static/logo.png"
+                  alt="MCP Gateway"
+                  class="w-6 h-6 rounded-lg"
+                  onerror="this.style.display='none'; this.nextElementSibling.style.display='inline';"
+                />
+                <i
+                  class="fas fa-shield-alt text-white text-sm"
+                  style="display: none"
+                ></i>
+              </div>
+              <h2 class="text-2xl font-bold text-white">
+                <a
+                  href="https://github.com/IBM/mcp-context-forge"
+                  target="_blank"
+                  class="hover:opacity-80 transition-opacity"
+                  >Context Forge MCP & AI Gateway</a
+                >
+              </h2>
+            </div>
+            <p class="text-sm text-red-100 opacity-90">
+              MCP, A2A and REST gateway with advanced security & observability
+            </p>
+          </div>
+
+          <!-- Security Features -->
+          <div class="space-y-6">
+            <!-- Password Security -->
+            <div>
+              <h3
+                class="text-xs font-semibold text-red-200 uppercase tracking-wide mb-3 text-center"
+              >
+                SECURITY FEATURES
+              </h3>
+              <div class="grid grid-cols-1 gap-4">
+                <div
+                  class="bg-white/8 backdrop-blur-sm rounded-lg p-4 border border-white/10 hover:bg-white/12 transition-all duration-300 group"
+                >
+                  <div
+                    class="w-8 h-8 bg-gradient-to-br from-green-400 to-emerald-500 rounded-lg flex items-center justify-center mb-3 group-hover:scale-110 transition-transform"
+                  >
+                    <i class="fas fa-lock text-white text-sm"></i>
+                  </div>
+                  <h4 class="text-sm font-semibold text-white mb-2">
+                    Password Security
+                  </h4>
+                  <p class="text-xs text-red-100 leading-relaxed">
+                    Strong password policies with automatic expiration and complexity requirements
+                  </p>
+                </div>
+
+                <div
+                  class="bg-white/8 backdrop-blur-sm rounded-lg p-4 border border-white/10 hover:bg-white/12 transition-all duration-300 group"
+                >
+                  <div
+                    class="w-8 h-8 bg-gradient-to-br from-blue-400 to-indigo-500 rounded-lg flex items-center justify-center mb-3 group-hover:scale-110 transition-transform"
+                  >
+                    <i class="fas fa-shield-alt text-white text-sm"></i>
+                  </div>
+                  <h4 class="text-sm font-semibold text-white mb-2">
+                    Account Protection
+                  </h4>
+                  <p class="text-xs text-red-100 leading-relaxed">
+                    Multi-factor authentication and account lockout protection
+                  </p>
+                </div>
+
+                <div
+                  class="bg-white/8 backdrop-blur-sm rounded-lg p-4 border border-white/10 hover:bg-white/12 transition-all duration-300 group"
+                >
+                  <div
+                    class="w-8 h-8 bg-gradient-to-br from-purple-400 to-pink-500 rounded-lg flex items-center justify-center mb-3 group-hover:scale-110 transition-transform"
+                  >
+                    <i class="fas fa-history text-white text-sm"></i>
+                  </div>
+                  <h4 class="text-sm font-semibold text-white mb-2">
+                    Audit & Monitoring
+                  </h4>
+                  <p class="text-xs text-red-100 leading-relaxed">
+                    Complete audit trail of all authentication events and activities
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Bottom accent -->
+          <div class="mt-6 text-center">
+            <div class="inline-flex items-center space-x-4 text-red-100/80">
+              <div class="flex items-center space-x-1">
+                <i class="fas fa-check-circle text-green-300 text-xs"></i>
+                <span class="text-xs">Secure by Design</span>
+              </div>
+              <div class="flex items-center space-x-1">
+                <i class="fas fa-clock text-yellow-300 text-xs"></i>
+                <span class="text-xs">Enterprise Ready</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // Initialize ROOT_PATH for JavaScript URL composition
+      window.ROOT_PATH = {{ root_path | tojson }};
+
+      // Initialize page
+      document.addEventListener("DOMContentLoaded", function () {
+        setupFormValidation();
+        setupPasswordToggles();
+        handleErrorMessages();
+      });
+
+      // Setup form validation
+      function setupFormValidation() {
+        const form = document.getElementById('password-change-form');
+        form.addEventListener('submit', function(e) {
+          e.preventDefault();
+          
+          const newPassword = document.getElementById('new_password').value;
+          const confirmPassword = document.getElementById('confirm_password').value;
+          
+          if (newPassword !== confirmPassword) {
+            showError('Passwords do not match');
+            return;
+          }
+          
+          if (!isPasswordValid(newPassword)) {
+            showError('Password does not meet requirements');
+            return;
+          }
+          
+          // Show loading state
+          const submitBtn = document.getElementById('submit-btn');
+          submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Changing Password...';
+          submitBtn.disabled = true;
+          
+          // Submit form
+          form.submit();
+        });
+      }
+
+      // Setup password toggle functionality
+      function setupPasswordToggles() {
+        // Add event listeners for password visibility toggles
+      }
+
+      // Toggle password visibility
+      function togglePasswordVisibility(fieldId) {
+        const passwordField = document.getElementById(fieldId);
+        const passwordIcon = document.getElementById(fieldId + '_icon');
+
+        if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          passwordIcon.classList.remove('fa-eye');
+          passwordIcon.classList.add('fa-eye-slash');
+        } else {
+          passwordField.type = 'password';
+          passwordIcon.classList.remove('fa-eye-slash');
+          passwordIcon.classList.add('fa-eye');
+        }
+      }
+
+      // Validate password requirements
+      function validatePassword() {
+        const password = document.getElementById('new_password').value;
+        const strength = getPasswordStrength(password);
+        
+        // Update password strength indicator
+        const strengthElement = document.getElementById('password-strength');
+        strengthElement.textContent = strength.label;
+        strengthElement.className = `font-medium ${strength.color}`;
+        
+        // Update requirement indicators
+        updateRequirement('req-length', password.length >= 8);
+        updateRequirement('req-uppercase', /[A-Z]/.test(password));
+        updateRequirement('req-lowercase', /[a-z]/.test(password));
+        updateRequirement('req-special', /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password));
+      }
+
+      // Get password strength
+      function getPasswordStrength(password) {
+        let score = 0;
+        
+        if (password.length >= 8) score++;
+        if (/[A-Z]/.test(password)) score++;
+        if (/[a-z]/.test(password)) score++;
+        if (/[0-9]/.test(password)) score++;
+        if (/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password)) score++;
+        
+        if (score <= 2) return { label: 'Weak', color: 'text-red-500' };
+        if (score <= 4) return { label: 'Medium', color: 'text-yellow-500' };
+        return { label: 'Strong', color: 'text-green-500' };
+      }
+
+      // Update requirement indicator
+      function updateRequirement(id, met) {
+        const element = document.getElementById(id);
+        const icon = element.querySelector('i');
+        
+        if (met) {
+          icon.className = 'fas fa-check-circle text-green-500 mr-2';
+          element.classList.remove('text-blue-600');
+          element.classList.add('text-green-600');
+        } else {
+          icon.className = 'fas fa-circle text-gray-400 mr-2';
+          element.classList.remove('text-green-600');
+          element.classList.add('text-blue-600');
+        }
+      }
+
+      // Validate password match
+      function validatePasswordMatch() {
+        const newPassword = document.getElementById('new_password').value;
+        const confirmPassword = document.getElementById('confirm_password').value;
+        const matchElement = document.getElementById('password-match');
+        
+        if (confirmPassword && newPassword === confirmPassword) {
+          matchElement.classList.remove('hidden');
+        } else {
+          matchElement.classList.add('hidden');
+        }
+      }
+
+      // Check if password is valid
+      function isPasswordValid(password) {
+        return password.length >= 8 &&
+               /[A-Z]/.test(password) &&
+               /[a-z]/.test(password) &&
+               /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
+      }
+
+      // Handle error messages from URL parameters
+      function handleErrorMessages() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const error = urlParams.get('error');
+
+        if (error) {
+          let errorMessage = 'Password change failed';
+          switch (error) {
+            case 'invalid_password':
+              errorMessage = 'Current password is incorrect';
+              break;
+            case 'weak_password':
+              errorMessage = 'New password does not meet requirements';
+              break;
+            case 'same_password':
+              errorMessage = 'New password must be different from current password';
+              break;
+            case 'mismatch':
+              errorMessage = 'Password confirmation does not match';
+              break;
+            default:
+              errorMessage = error.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+          }
+          showError(errorMessage);
+        }
+      }
+
+      // Show error message
+      function showError(message) {
+        const errorDiv = document.getElementById('error-message');
+        const errorText = document.getElementById('error-text');
+        errorText.textContent = message;
+        errorDiv.classList.remove('hidden');
+
+        // Auto-hide after 8 seconds
+        setTimeout(() => {
+          errorDiv.classList.add('hidden');
+        }, 8000);
+      }
+
+      // Show success message
+      function showSuccess(message) {
+        const successDiv = document.getElementById('success-message');
+        const successText = document.getElementById('success-text');
+        successText.textContent = message;
+        successDiv.classList.remove('hidden');
+      }
+    </script>
+  </body>
+</html>

--- a/mcpgateway/utils/jwt_config_helper.py
+++ b/mcpgateway/utils/jwt_config_helper.py
@@ -16,7 +16,16 @@ from mcpgateway.config import settings
 
 
 class JWTConfigurationError(Exception):
-    """Raised when JWT configuration is invalid or incomplete."""
+    """Raised when JWT configuration is invalid or incomplete.
+
+    Examples:
+        >>> # Create a configuration error
+        >>> error = JWTConfigurationError("Missing secret key")
+        >>> str(error)
+        'Missing secret key'
+        >>> isinstance(error, Exception)
+        True
+    """
 
 
 def validate_jwt_algo_and_keys() -> None:
@@ -79,6 +88,12 @@ def get_jwt_private_key_or_secret() -> str:
 
     Returns:
         str: The signing key as string
+
+    Examples:
+        >>> # Function returns a string key
+        >>> result = get_jwt_private_key_or_secret()
+        >>> isinstance(result, str)
+        True
     """
     algorithm = settings.jwt_algorithm.upper()
 
@@ -100,6 +115,12 @@ def get_jwt_public_key_or_secret() -> str:
 
     Returns:
         str: The verification key as string
+
+    Examples:
+        >>> # Function returns a string key
+        >>> result = get_jwt_public_key_or_secret()
+        >>> isinstance(result, str)
+        True
     """
     algorithm = settings.jwt_algorithm.upper()
 

--- a/mcpgateway/utils/validate_signature.py
+++ b/mcpgateway/utils/validate_signature.py
@@ -42,6 +42,26 @@ def sign_data(data: bytes, private_key_pem: str) -> str:
 
     Raises:
         TypeError: If the provided key is not an Ed25519 private key.
+
+    Examples:
+        >>> from cryptography.hazmat.primitives.asymmetric import ed25519
+        >>> from cryptography.hazmat.primitives import serialization
+        >>>
+        >>> # Generate a test key pair
+        >>> private_key = ed25519.Ed25519PrivateKey.generate()
+        >>> private_pem = private_key.private_bytes(
+        ...     encoding=serialization.Encoding.PEM,
+        ...     format=serialization.PrivateFormat.PKCS8,
+        ...     encryption_algorithm=serialization.NoEncryption()
+        ... ).decode()
+        >>>
+        >>> # Sign some data
+        >>> data = b"test message"
+        >>> signature = sign_data(data, private_pem)
+        >>> isinstance(signature, str)
+        True
+        >>> len(signature) == 128  # 64 bytes = 128 hex chars
+        True
     """
     try:
         private_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
@@ -68,6 +88,33 @@ def validate_signature(data: bytes, signature: bytes | str, public_key_pem: str)
 
     Returns:
         bool: True if signature is valid, False otherwise.
+
+    Examples:
+        >>> from cryptography.hazmat.primitives.asymmetric import ed25519
+        >>> from cryptography.hazmat.primitives import serialization
+        >>>
+        >>> # Generate a test key pair
+        >>> private_key = ed25519.Ed25519PrivateKey.generate()
+        >>> public_key = private_key.public_key()
+        >>> public_pem = public_key.public_bytes(
+        ...     encoding=serialization.Encoding.PEM,
+        ...     format=serialization.PublicFormat.SubjectPublicKeyInfo
+        ... ).decode()
+        >>>
+        >>> # Sign and verify
+        >>> data = b"test message"
+        >>> signature = private_key.sign(data)
+        >>> validate_signature(data, signature, public_pem)
+        True
+        >>>
+        >>> # Test with hex signature
+        >>> hex_sig = signature.hex()
+        >>> validate_signature(data, hex_sig, public_pem)
+        True
+        >>>
+        >>> # Test invalid signature
+        >>> validate_signature(b"wrong data", signature, public_pem)
+        False
     """
     if isinstance(data, str):
         data = data.encode()
@@ -110,6 +157,31 @@ def resign_data(
 
     Returns:
         bytes | None: New signature if re-signed, None if verification fails.
+
+    Examples:
+        >>> from cryptography.hazmat.primitives.asymmetric import ed25519
+        >>> from cryptography.hazmat.primitives import serialization
+        >>>
+        >>> # Generate old and new key pairs
+        >>> old_private = ed25519.Ed25519PrivateKey.generate()
+        >>> old_public = old_private.public_key()
+        >>> new_private = ed25519.Ed25519PrivateKey.generate()
+        >>>
+        >>> old_public_pem = old_public.public_bytes(
+        ...     encoding=serialization.Encoding.PEM,
+        ...     format=serialization.PublicFormat.SubjectPublicKeyInfo
+        ... ).decode()
+        >>> new_private_pem = new_private.private_bytes(
+        ...     encoding=serialization.Encoding.PEM,
+        ...     format=serialization.PrivateFormat.PKCS8,
+        ...     encryption_algorithm=serialization.NoEncryption()
+        ... ).decode()
+        >>>
+        >>> # Test first-time signing (no old signature)
+        >>> data = b"test message"
+        >>> new_sig = resign_data(data, old_public_pem, "", new_private_pem)
+        >>> isinstance(new_sig, str)
+        True
     """
     # Handle first-time signing (no old signature)
     if not old_signature:


### PR DESCRIPTION
- Enforcing a password reset for the user
- pylint fix

# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 💡 Fix Description
_How did you solve it?  Key design points._

Blocking screen — must change password to proceed
## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | pass   |
| Unit tests                            | `make test`          | pass   |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
