### PR TITLE
fix: resource URI template listing and field rename

### DIFF
--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -349,7 +349,7 @@ mcpContextForge:
     VALIDATION_DANGEROUS_JS_PATTERN: '(?i)(?:^|\s|[\"''`<>=])(javascript:|vbscript:|data:\s*[^,]*[;\s]*(javascript|vbscript)|\bon[a-z]+\s*=|<\s*script\b)' # pattern to detect JavaScript injection
     VALIDATION_NAME_PATTERN: '^[a-zA-Z0-9_.\-\s]+$' # pattern for validating names (allows spaces)
     VALIDATION_IDENTIFIER_PATTERN: '^[a-zA-Z0-9_\-\.]+$' # pattern for validating IDs (no spaces)
-    VALIDATION_SAFE_URI_PATTERN: '^[a-zA-Z0-9_\-.:/?=&%]+$' # pattern for safe URI characters
+    VALIDATION_SAFE_URI_PATTERN: '^[a-zA-Z0-9_\-.:/?=&%{}]+$' # pattern for safe URI characters
     VALIDATION_UNSAFE_URI_PATTERN: '[<>"''\\]' # pattern to detect unsafe URI characters
     VALIDATION_TOOL_NAME_PATTERN: '^[a-zA-Z][a-zA-Z0-9._-]*$' # MCP tool naming pattern
     VALIDATION_TOOL_METHOD_PATTERN: '^[a-zA-Z][a-zA-Z0-9_\./-]*$' # MCP tool method naming pattern

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1609,7 +1609,7 @@
       "type": "string"
     },
     "validation_safe_uri_pattern": {
-      "default": "^[a-zA-Z0-9_\\-.:/?=&%]+$",
+      "default": "^[a-zA-Z0-9_\\-.:/?=&%{}]+$",
       "title": "Validation Safe Uri Pattern",
       "type": "string"
     },

--- a/docs/docs/config.schema.json
+++ b/docs/docs/config.schema.json
@@ -1609,7 +1609,7 @@
       "type": "string"
     },
     "validation_safe_uri_pattern": {
-      "default": "^[a-zA-Z0-9_\\-.:/?=&%]+$",
+      "default": "^[a-zA-Z0-9_\\-.:/?=&%{}]+$",
       "title": "Validation Safe Uri Pattern",
       "type": "string"
     },

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -7566,7 +7566,7 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
         ...     ("name", "Test Resource"),
         ...     ("description", "A test resource"),
         ...     ("mimeType", "text/plain"),
-        ...     ("template", ""),
+        ...     ("uri_template", ""),
         ...     ("content", "Sample content"),
         ... ])
         >>> mock_request = MagicMock(spec=Request)
@@ -7599,15 +7599,22 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
 
     try:
         # Handle template field: convert empty string to None for optional field
-        template_value = form.get("template")
+        template = None
+        template_value = form.get("uri_template")
         template = template_value if template_value else None
+        template_value = form.get("uri_template")
+        uri_value = form.get("uri")
+
+        # Ensure uri_value is a string
+        if isinstance(uri_value, str) and "{" in uri_value and "}" in uri_value:
+            template = uri_value
 
         resource = ResourceCreate(
             uri=str(form["uri"]),
             name=str(form["name"]),
             description=str(form.get("description", "")),
             mime_type=str(form.get("mimeType", "")),
-            template=template,
+            uri_template=template,
             content=str(form["content"]),
             tags=tags,
             visibility=visibility,

--- a/mcpgateway/alembic/versions/191a2def08d7_resource_rename_template_to_uri_template.py
+++ b/mcpgateway/alembic/versions/191a2def08d7_resource_rename_template_to_uri_template.py
@@ -1,0 +1,45 @@
+"""resource_rename_template_to_uri_template
+
+Revision ID: 191a2def08d7
+Revises: f3a3a3d901b8
+Create Date: 2025-11-17 21:20:05.223248
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "191a2def08d7"
+down_revision: Union[str, Sequence[str], None] = "f3a3a3d901b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    columns = [c["name"] for c in inspector.get_columns("resources")]
+
+    # Only rename if old column exists
+    if "template" in columns and "uri_template" not in columns:
+        with op.batch_alter_table("resources") as batch_op:
+            batch_op.alter_column("template", new_column_name="uri_template")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    columns = [c["name"] for c in inspector.get_columns("resources")]
+
+    # Only rename back if current column exists
+    if "uri_template" in columns and "template" not in columns:
+        with op.batch_alter_table("resources") as batch_op:
+            batch_op.alter_column("uri_template", new_column_name="template")

--- a/mcpgateway/common/config.py
+++ b/mcpgateway/common/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     # Character validation patterns
     validation_name_pattern: str = r"^[a-zA-Z0-9_.\-\s]+$"  # Allow spaces for names
     validation_identifier_pattern: str = r"^[a-zA-Z0-9_\-\.]+$"  # No spaces for IDs
-    validation_safe_uri_pattern: str = r"^[a-zA-Z0-9_\-.:/?=&%]+$"
+    validation_safe_uri_pattern: str = r"^[a-zA-Z0-9_\-.:/?=&%{}]+$"
     validation_unsafe_uri_pattern: str = r'[<>"\'\\]'
     validation_tool_name_pattern: str = r"^[a-zA-Z][a-zA-Z0-9._-]*$"  # MCP tool naming
     validation_tool_method_pattern: str = r"^[a-zA-Z][a-zA-Z0-9_\./-]*$"

--- a/mcpgateway/common/models.py
+++ b/mcpgateway/common/models.py
@@ -715,11 +715,14 @@ class ResourceTemplate(BaseModelWithConfigDict):
                                         Serialized as '_meta' in JSON.
     """
 
-    uri_template: str
+    # ✅ DB field name: uri_template
+    # ✅ API (JSON) alias:
+    id: Optional[int] = None
+    uri_template: str = Field(..., alias="uriTemplate")
     name: str
     description: Optional[str] = None
     mime_type: Optional[str] = None
-    annotations: Optional[Annotations] = None
+    annotations: Optional[Dict[str, Any]] = None
     meta: Optional[Dict[str, Any]] = Field(None, alias="_meta")
 
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1303,7 +1303,7 @@ Disallow: /
     # Character validation patterns
     validation_name_pattern: str = r"^[a-zA-Z0-9_.\-\s]+$"  # Allow spaces for names
     validation_identifier_pattern: str = r"^[a-zA-Z0-9_\-\.]+$"  # No spaces for IDs
-    validation_safe_uri_pattern: str = r"^[a-zA-Z0-9_\-.:/?=&%]+$"
+    validation_safe_uri_pattern: str = r"^[a-zA-Z0-9_\-.:/?=&%{}]+$"
     validation_unsafe_uri_pattern: str = r'[<>"\'\\]'
     validation_tool_name_pattern: str = r"^[a-zA-Z][a-zA-Z0-9._-]*$"  # MCP tool naming
     validation_tool_method_pattern: str = r"^[a-zA-Z][a-zA-Z0-9_\./-]*$"

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -2161,7 +2161,7 @@ class Resource(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     mime_type: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     size: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    template: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # URI template for parameterized resources
+    uri_template: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # URI template for parameterized resources
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     is_active: Mapped[bool] = mapped_column(default=True)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2865,7 +2865,7 @@ async def read_resource(resource_id: str, request: Request, db: Session = Depend
 
     try:
         # Call service with context for plugin support
-        content = await resource_service.read_resource(db, resource_id, request_id=request_id, user=user, server_id=server_id)
+        content = await resource_service.read_resource(db, resource_id=resource_id, request_id=request_id, user=user, server_id=server_id)
     except (ResourceNotFoundError, ResourceError) as exc:
         # Translate to FastAPI HTTP error
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1501,7 +1501,7 @@ class ResourceCreate(BaseModel):
     name: str = Field(..., description="Human-readable resource name")
     description: Optional[str] = Field(None, description="Resource description")
     mime_type: Optional[str] = Field(None, alias="mimeType", description="Resource MIME type")
-    template: Optional[str] = Field(None, description="URI template for parameterized resources")
+    uri_template: Optional[str] = Field(None, description="URI template for parameterized resources")
     content: Union[str, bytes] = Field(..., description="Resource content (text or binary)")
     tags: Optional[List[str]] = Field(default_factory=list, description="Tags for categorizing the resource")
 
@@ -1642,7 +1642,7 @@ class ResourceUpdate(BaseModelWithConfigDict):
     name: Optional[str] = Field(None, description="Human-readable resource name")
     description: Optional[str] = Field(None, description="Resource description")
     mime_type: Optional[str] = Field(None, description="Resource MIME type")
-    template: Optional[str] = Field(None, description="URI template for parameterized resources")
+    uri_template: Optional[str] = Field(None, description="URI template for parameterized resources")
     content: Optional[Union[str, bytes]] = Field(None, description="Resource content (text or binary)")
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the resource")
 
@@ -1776,6 +1776,7 @@ class ResourceRead(BaseModelWithConfigDict):
     name: str
     description: Optional[str]
     mime_type: Optional[str]
+    uri_template: Optional[str] = Field(None, description="URI template for parameterized resources")
     size: Optional[int]
     created_at: datetime
     updated_at: datetime

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3524,16 +3524,24 @@ function toggleA2AAuthFields(authType) {
 /**
  * SECURE: View Resource function with safe display
  */
-async function viewResource(resourceUri) {
+async function viewResource(resourceId) {
     try {
-        console.log(`Viewing resource: ${resourceUri}`);
+        console.log(`Viewing resource: ${resourceId}`);
 
         const response = await fetchWithTimeout(
-            `${window.ROOT_PATH}/admin/resources/${encodeURIComponent(resourceUri)}`,
+            `${window.ROOT_PATH}/admin/resources/${encodeURIComponent(resourceId)}`,
         );
 
         if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            let errorDetail = "";
+            try {
+                const errorJson = await response.json();
+                errorDetail = errorJson.detail || "";
+            } catch (_) {}
+
+            throw new Error(
+                `HTTP ${response.status}: ${errorDetail || response.statusText}`,
+            );
         }
 
         const data = await response.json();
@@ -10549,6 +10557,13 @@ async function handleResourceFormSubmit(e) {
         // Validate inputs
         const name = formData.get("name");
         const uri = formData.get("uri");
+        let template = null;
+        // Check if URI contains '{' and '}'
+        if (uri && uri.includes("{") && uri.includes("}")) {
+            template = uri;
+        }
+
+        formData.append("uri_template", template);
         const nameValidation = validateInputName(name, "resource");
         const uriValidation = validateInputName(uri, "resource URI");
 
@@ -11353,6 +11368,12 @@ async function handleEditResFormSubmit(e) {
         // Validate inputs
         const name = formData.get("name");
         const uri = formData.get("uri");
+        let template = null;
+        // Check if URI contains '{' and '}'
+        if (uri && uri.includes("{") && uri.includes("}")) {
+            template = uri;
+        }
+        formData.append("uri_template", template);
         const nameValidation = validateInputName(name, "resource");
         const uriValidation = validateInputName(uri, "resource URI");
 

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -1005,10 +1005,11 @@ class TestResourceAPIs:
     async def test_read_resource(self, client: AsyncClient, mock_auth):
         """Test GET /resources/{uri:path}."""
         # Create a resource first
-        resource_data = {"resource": {"uri": "test/document", "name": "test_doc", "content": "Test content", "mimeType": "text/plain"}, "team_id": None, "visibility": "private"}
+        resource_data = {"resource": {"uri": "resource://test", "name": "test_doc", "content": "Test content", "mimeType": "text/plain"}, "team_id": None, "visibility": "private"}
 
         response = await client.post("/resources", json=resource_data, headers=TEST_AUTH_HEADER)
         resource = response.json()
+        print ("\n----------HBD------------> Resource \n",resource,"\n----------HBD------------> Resource\n")
         assert resource["name"] == "test_doc"
         resource_id = resource["id"]
 
@@ -1848,7 +1849,7 @@ class TestIntegrationScenarios:
 
     async def test_create_and_use_resource(self, client: AsyncClient, mock_auth):
         """Integration: create a resource and read it back."""
-        resource_data = {"resource": {"uri": "integration/resource", "name": "integration_resource", "content": "test"}, "team_id": None, "visibility": "private"}
+        resource_data = {"resource": {"uri": "resource://test", "name": "integration_resource", "content": "test"}, "team_id": None, "visibility": "private"}
         create_resp = await client.post("/resources", json=resource_data, headers=TEST_AUTH_HEADER)
         assert create_resp.status_code == 200
         resource_id = create_resp.json()["id"]

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -822,17 +822,16 @@ class TestAdminResourceRoutes:
         # Use a valid MIME type
         form_data = FakeForm(
             {
-                "uri": "/template/resource",
-                "name": "Template-Resource",  # Valid resource name
-                "mimeType": "text/plain",  # Valid MIME type
-                "template": "Hello {{name}}!",
-                "content": "Default content",
+                        "uri": "greetme://morning/{name}", 
+                        "name": "test_doc", 
+                        "content": "Test content", 
+                        "mimeType": "text/plain"
             }
         )
+        
         mock_request.form = AsyncMock(return_value=form_data)
 
         result = await admin_add_resource(mock_request, mock_db, "test-user")
-
         # Assert
         mock_register_resource.assert_called_once()
         assert result.status_code == 200
@@ -840,7 +839,7 @@ class TestAdminResourceRoutes:
         # Verify template was passed
         call_args = mock_register_resource.call_args[0]
         resource_create = call_args[1]
-        assert resource_create.template == "Hello {{name}}!"
+        assert resource_create.uri_template == "greetme://morning/{name}"
 
     @patch.object(ResourceService, "register_resource")
     async def test_admin_add_resource_database_errors(self, mock_register_resource, mock_request, mock_db):

--- a/tests/unit/mcpgateway/validation/test_validators.py
+++ b/tests/unit/mcpgateway/validation/test_validators.py
@@ -25,7 +25,7 @@ class DummySettings:
     validation_allowed_url_schemes = ["http://", "https://", "ws://", "wss://"]
     validation_name_pattern = r"^[a-zA-Z0-9_\-]+$"
     validation_identifier_pattern = r"^[a-zA-Z0-9_\-\.]+$"
-    validation_safe_uri_pattern = r"^[a-zA-Z0-9_\-.:/?=&%]+$"
+    validation_safe_uri_pattern = r"^[a-zA-Z0-9_\-.:/?=&%{}]+$"
     validation_unsafe_uri_pattern = r"[<>\"'\\]"
     validation_tool_name_pattern = r"^[a-zA-Z][a-zA-Z0-9_]*$"
     validation_max_name_length = 10  # Increased for realistic URIs

--- a/tests/unit/mcpgateway/validation/test_validators_advanced.py
+++ b/tests/unit/mcpgateway/validation/test_validators_advanced.py
@@ -56,7 +56,7 @@ class DummySettings:
     # Character validation patterns
     validation_name_pattern = r"^[a-zA-Z0-9_.\-\s]+$"  # Names can have spaces
     validation_identifier_pattern = r"^[a-zA-Z0-9_\-\.]+$"  # IDs cannot have spaces
-    validation_safe_uri_pattern = r"^[a-zA-Z0-9_\-.:/?=&%]+$"
+    validation_safe_uri_pattern = r"^[a-zA-Z0-9_\-.:/?=&%{}]+$"
     validation_unsafe_uri_pattern = r'[<>"\'\\]'
     validation_tool_name_pattern = r"^[a-zA-Z][a-zA-Z0-9._-]*$"  # Must start with letter
 


### PR DESCRIPTION
- Rename resource table field 'template' to 'uri_template' for clarity
- Add Alembic migration script for column rename
- Update resource_service.py read_resource to use either resource_id or resource_uri
- Fix resource template URI handling in gateway_service.py
- Include Resource of type URI template from MCP server when registering
- Update VALIDATION_SAFE_URI_PATTERN to allow {} characters for templates
- Fix related test cases for resource URI templates

Closes #1455

# 📝 Pull Request Template Selection

Thank you for contributing! To help us review your pull request effectively, please select the appropriate template (go to the `Preview` tab and select the appropriate sub-template):

- **Bug Fix**: [Use the Bug Fix Template](?template=bug_fix.md)
- **Feature / Enhancement**: [Use the Feature Template](?template=feature.md)
- **Documentation Update**: [Use the Docs Template](?template=docs.md)
- **Plugin**: [Use the Plugin Template](?template=plugin.md)

Alternatively, after opening your pull request, you can choose the appropriate template from the **"Choose a template"** dropdown menu located at the top-right of the description box.

If none of the above templates fit your changes, feel free to provide a clear and concise description of your pull request below.
