### PR TITLE
Rename Toggle Endpoint to State for Clear and Explicit Status Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -584,7 +584,7 @@ This release focuses on **Advanced OAuth Integration, Plugin Ecosystem, MCP Regi
   - `GET /grpc` - List all gRPC services with team filtering
   - `GET /grpc/{id}` - Get service details
   - `PUT /grpc/{id}` - Update service configuration
-  - `POST /grpc/{id}/toggle` - Enable/disable service
+  - `POST /grpc/{id}/state` - Enable/disable service
   - `POST /grpc/{id}/delete` - Delete service
   - `POST /grpc/{id}/reflect` - Re-trigger service discovery
   - `GET /grpc/{id}/methods` - List discovered methods

--- a/README.md
+++ b/README.md
@@ -2264,9 +2264,9 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=false
+     http://localhost:4444/tools/1/state?activate=false
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=true
+     http://localhost:4444/tools/1/state?activate=true
 
 # Delete tool
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/tools/1
@@ -2326,7 +2326,7 @@ curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle agent status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/a2a/agent-id/toggle?activate=false
+     http://localhost:4444/a2a/agent-id/state?activate=false
 
 # Delete agent
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
@@ -2376,7 +2376,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/gateways/1/toggle?activate=false
+     http://localhost:4444/gateways/1/state?activate=false
 
 # Delete gateway
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/gateways/1
@@ -2462,7 +2462,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/prompts/5/toggle?activate=false
+     http://localhost:4444/prompts/5/state?activate=false
 
 # Delete prompt
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/prompts/greet
@@ -2520,7 +2520,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/servers/UUID_OF_SERVER_1/toggle?activate=false
+     http://localhost:4444/servers/UUID_OF_SERVER_1/state?activate=false
 ```
 
 </details>

--- a/docs/docs/architecture/plugins/gateway-hooks.md
+++ b/docs/docs/architecture/plugins/gateway-hooks.md
@@ -884,7 +884,7 @@ async def server_post_delete(self, payload: ServerPostOperationPayload,
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | **Hook Name** | `server_pre_status_change` | Hook identifier for configuration |
-| **Execution Point** | Before server status toggle | When MCP server is about to be activated or deactivated |
+| **Execution Point** | Before server status change | When MCP server is about to be activated or deactivated |
 | **Purpose** | Access control, dependency validation, impact assessment | Validate status change permissions and assess operational impact |
 
 **Payload Attributes (`ServerPreOperationPayload`)** - Same structure as other pre-hooks:

--- a/docs/docs/design/images/code2flow.svg
+++ b/docs/docs/design/images/code2flow.svg
@@ -1306,7 +1306,7 @@
 <g id="node16" class="node">
 <title>node_7cd26d76</title>
 <path fill="#cccccc" stroke="black" d="M2042,-24530C2042,-24530 1889,-24530 1889,-24530 1883,-24530 1877,-24524 1877,-24518 1877,-24518 1877,-24506 1877,-24506 1877,-24500 1883,-24494 1889,-24494 1889,-24494 2042,-24494 2042,-24494 2048,-24494 2054,-24500 2054,-24506 2054,-24506 2054,-24518 2054,-24518 2054,-24524 2048,-24530 2042,-24530"/>
-<text text-anchor="middle" x="1965.5" y="-24508.3" font-family="Arial" font-size="14.00">419: toggle_agent_status()</text>
+<text text-anchor="middle" x="1965.5" y="-24508.3" font-family="Arial" font-size="14.00">419: set_a2a_agent_state()</text>
 </g>
 <!-- node_7cd26d76&#45;&gt;node_574dcb68 -->
 <g id="edge30" class="edge">
@@ -6813,7 +6813,7 @@
 <g id="node332" class="node">
 <title>node_d8cf5c91</title>
 <path fill="#cccccc" stroke="black" d="M2054,-44559C2054,-44559 1877,-44559 1877,-44559 1871,-44559 1865,-44553 1865,-44547 1865,-44547 1865,-44535 1865,-44535 1865,-44529 1871,-44523 1877,-44523 1877,-44523 2054,-44523 2054,-44523 2060,-44523 2066,-44529 2066,-44535 2066,-44535 2066,-44547 2066,-44547 2066,-44553 2060,-44559 2054,-44559"/>
-<text text-anchor="middle" x="1965.5" y="-44537.3" font-family="Arial" font-size="14.00">1291: toggle_gateway_status()</text>
+<text text-anchor="middle" x="1965.5" y="-44537.3" font-family="Arial" font-size="14.00">1291: set_gateway_state()</text>
 </g>
 <!-- node_59707e37&#45;&gt;node_d8cf5c91 -->
 <g id="edge603" class="edge">
@@ -10222,7 +10222,7 @@
 <g id="node466" class="node">
 <title>node_713e7ad0</title>
 <path fill="#966f33" stroke="black" d="M1076.5,-40613C1076.5,-40613 885.5,-40613 885.5,-40613 879.5,-40613 873.5,-40607 873.5,-40601 873.5,-40601 873.5,-40589 873.5,-40589 873.5,-40583 879.5,-40577 885.5,-40577 885.5,-40577 1076.5,-40577 1076.5,-40577 1082.5,-40577 1088.5,-40583 1088.5,-40589 1088.5,-40589 1088.5,-40601 1088.5,-40601 1088.5,-40607 1082.5,-40613 1076.5,-40613"/>
-<text text-anchor="middle" x="981" y="-40591.3" font-family="Arial" font-size="14.00">1916: toggle_a2a_agent_status()</text>
+<text text-anchor="middle" x="981" y="-40591.3" font-family="Arial" font-size="14.00">1916: set_a2a_agent_state()</text>
 </g>
 <!-- node_713e7ad0&#45;&gt;node_7cd26d76 -->
 <g id="edge961" class="edge">
@@ -10234,7 +10234,7 @@
 <g id="node467" class="node">
 <title>node_8d8912a8</title>
 <path fill="#966f33" stroke="black" d="M1069.5,-43733C1069.5,-43733 892.5,-43733 892.5,-43733 886.5,-43733 880.5,-43727 880.5,-43721 880.5,-43721 880.5,-43709 880.5,-43709 880.5,-43703 886.5,-43697 892.5,-43697 892.5,-43697 1069.5,-43697 1069.5,-43697 1075.5,-43697 1081.5,-43703 1081.5,-43709 1081.5,-43709 1081.5,-43721 1081.5,-43721 1081.5,-43727 1075.5,-43733 1069.5,-43733"/>
-<text text-anchor="middle" x="981" y="-43711.3" font-family="Arial" font-size="14.00">3044: toggle_gateway_status()</text>
+<text text-anchor="middle" x="981" y="-43711.3" font-family="Arial" font-size="14.00">3044: set_gateway_state()</text>
 </g>
 <!-- node_8d8912a8&#45;&gt;node_d8cf5c91 -->
 <g id="edge962" class="edge">
@@ -10246,13 +10246,13 @@
 <g id="node468" class="node">
 <title>node_64a5110c</title>
 <path fill="#966f33" stroke="black" d="M1066,-42200C1066,-42200 896,-42200 896,-42200 890,-42200 884,-42194 884,-42188 884,-42188 884,-42176 884,-42176 884,-42170 890,-42164 896,-42164 896,-42164 1066,-42164 1066,-42164 1072,-42164 1078,-42170 1078,-42176 1078,-42176 1078,-42188 1078,-42188 1078,-42194 1072,-42200 1066,-42200"/>
-<text text-anchor="middle" x="981" y="-42178.3" font-family="Arial" font-size="14.00">2658: toggle_prompt_status()</text>
+<text text-anchor="middle" x="981" y="-42178.3" font-family="Arial" font-size="14.00">2658: set_prompt_state()</text>
 </g>
 <!-- node_bb7af980 -->
 <g id="node582" class="node">
 <title>node_bb7af980</title>
 <path fill="#cccccc" stroke="black" d="M1679,-28310C1679,-28310 1517,-28310 1517,-28310 1511,-28310 1505,-28304 1505,-28298 1505,-28298 1505,-28286 1505,-28286 1505,-28280 1511,-28274 1517,-28274 1517,-28274 1679,-28274 1679,-28274 1685,-28274 1691,-28280 1691,-28286 1691,-28286 1691,-28298 1691,-28298 1691,-28304 1685,-28310 1679,-28310"/>
-<text text-anchor="middle" x="1598" y="-28288.3" font-family="Arial" font-size="14.00">773: toggle_prompt_status()</text>
+<text text-anchor="middle" x="1598" y="-28288.3" font-family="Arial" font-size="14.00">773: set_prompt_state()</text>
 </g>
 <!-- node_64a5110c&#45;&gt;node_bb7af980 -->
 <g id="edge963" class="edge">
@@ -10264,13 +10264,13 @@
 <g id="node469" class="node">
 <title>node_5e76168a</title>
 <path fill="#966f33" stroke="black" d="M1070.5,-41930C1070.5,-41930 891.5,-41930 891.5,-41930 885.5,-41930 879.5,-41924 879.5,-41918 879.5,-41918 879.5,-41906 879.5,-41906 879.5,-41900 885.5,-41894 891.5,-41894 891.5,-41894 1070.5,-41894 1070.5,-41894 1076.5,-41894 1082.5,-41900 1082.5,-41906 1082.5,-41906 1082.5,-41918 1082.5,-41918 1082.5,-41924 1076.5,-41930 1070.5,-41930"/>
-<text text-anchor="middle" x="981" y="-41908.3" font-family="Arial" font-size="14.00">2338: toggle_resource_status()</text>
+<text text-anchor="middle" x="981" y="-41908.3" font-family="Arial" font-size="14.00">2338: set_resource_state()</text>
 </g>
 <!-- node_b0cb6099 -->
 <g id="node649" class="node">
 <title>node_b0cb6099</title>
 <path fill="#cccccc" stroke="black" d="M1684,-27550C1684,-27550 1512,-27550 1512,-27550 1506,-27550 1500,-27544 1500,-27538 1500,-27538 1500,-27526 1500,-27526 1500,-27520 1506,-27514 1512,-27514 1512,-27514 1684,-27514 1684,-27514 1690,-27514 1696,-27520 1696,-27526 1696,-27526 1696,-27538 1696,-27538 1696,-27544 1690,-27550 1684,-27550"/>
-<text text-anchor="middle" x="1598" y="-27528.3" font-family="Arial" font-size="14.00">717: toggle_resource_status()</text>
+<text text-anchor="middle" x="1598" y="-27528.3" font-family="Arial" font-size="14.00">717: set_resource_state()</text>
 </g>
 <!-- node_5e76168a&#45;&gt;node_b0cb6099 -->
 <g id="edge964" class="edge">
@@ -10282,13 +10282,13 @@
 <g id="node470" class="node">
 <title>node_f1ffc7ad</title>
 <path fill="#966f33" stroke="black" d="M1063,-41606C1063,-41606 899,-41606 899,-41606 893,-41606 887,-41600 887,-41594 887,-41594 887,-41582 887,-41582 887,-41576 893,-41570 899,-41570 899,-41570 1063,-41570 1063,-41570 1069,-41570 1075,-41576 1075,-41582 1075,-41582 1075,-41594 1075,-41594 1075,-41600 1069,-41606 1063,-41606"/>
-<text text-anchor="middle" x="981" y="-41584.3" font-family="Arial" font-size="14.00">1484: toggle_server_status()</text>
+<text text-anchor="middle" x="981" y="-41584.3" font-family="Arial" font-size="14.00">1484: set_server_state()</text>
 </g>
 <!-- node_2aaac624 -->
 <g id="node785" class="node">
 <title>node_2aaac624</title>
 <path fill="#cccccc" stroke="black" d="M1676.5,-26319C1676.5,-26319 1519.5,-26319 1519.5,-26319 1513.5,-26319 1507.5,-26313 1507.5,-26307 1507.5,-26307 1507.5,-26295 1507.5,-26295 1507.5,-26289 1513.5,-26283 1519.5,-26283 1519.5,-26283 1676.5,-26283 1676.5,-26283 1682.5,-26283 1688.5,-26289 1688.5,-26295 1688.5,-26295 1688.5,-26307 1688.5,-26307 1688.5,-26313 1682.5,-26319 1676.5,-26319"/>
-<text text-anchor="middle" x="1598" y="-26297.3" font-family="Arial" font-size="14.00">833: toggle_server_status()</text>
+<text text-anchor="middle" x="1598" y="-26297.3" font-family="Arial" font-size="14.00">833: set_server_state()</text>
 </g>
 <!-- node_f1ffc7ad&#45;&gt;node_2aaac624 -->
 <g id="edge965" class="edge">
@@ -10300,13 +10300,13 @@
 <g id="node471" class="node">
 <title>node_c67b693a</title>
 <path fill="#966f33" stroke="black" d="M1055.5,-43172C1055.5,-43172 906.5,-43172 906.5,-43172 900.5,-43172 894.5,-43166 894.5,-43160 894.5,-43160 894.5,-43148 894.5,-43148 894.5,-43142 900.5,-43136 906.5,-43136 906.5,-43136 1055.5,-43136 1055.5,-43136 1061.5,-43136 1067.5,-43142 1067.5,-43148 1067.5,-43148 1067.5,-43160 1067.5,-43160 1067.5,-43166 1061.5,-43172 1055.5,-43172"/>
-<text text-anchor="middle" x="981" y="-43150.3" font-family="Arial" font-size="14.00">2277: toggle_tool_status()</text>
+<text text-anchor="middle" x="981" y="-43150.3" font-family="Arial" font-size="14.00">2277: set_tool_state()</text>
 </g>
 <!-- node_0ddbe8ce -->
 <g id="node989" class="node">
 <title>node_0ddbe8ce</title>
 <path fill="#cccccc" stroke="black" d="M2036,-39444C2036,-39444 1895,-39444 1895,-39444 1889,-39444 1883,-39438 1883,-39432 1883,-39432 1883,-39420 1883,-39420 1883,-39414 1889,-39408 1895,-39408 1895,-39408 2036,-39408 2036,-39408 2042,-39408 2048,-39414 2048,-39420 2048,-39420 2048,-39432 2048,-39432 2048,-39438 2042,-39444 2036,-39444"/>
-<text text-anchor="middle" x="1965.5" y="-39422.3" font-family="Arial" font-size="14.00">707: toggle_tool_status()</text>
+<text text-anchor="middle" x="1965.5" y="-39422.3" font-family="Arial" font-size="14.00">707: set_tool_state()</text>
 </g>
 <!-- node_c67b693a&#45;&gt;node_0ddbe8ce -->
 <g id="edge966" class="edge">

--- a/docs/docs/design/images/code2flow.svg
+++ b/docs/docs/design/images/code2flow.svg
@@ -3093,7 +3093,7 @@
 <g id="node79" class="node">
 <title>node_1b63b77c</title>
 <path fill="#966f33" stroke="black" d="M1385,-36319C1385,-36319 1193,-36319 1193,-36319 1187,-36319 1181,-36313 1181,-36307 1181,-36307 1181,-36295 1181,-36295 1181,-36289 1187,-36283 1193,-36283 1193,-36283 1385,-36283 1385,-36283 1391,-36283 1397,-36289 1397,-36295 1397,-36295 1397,-36307 1397,-36307 1397,-36313 1391,-36319 1385,-36319"/>
-<text text-anchor="middle" x="1289" y="-36297.3" font-family="Arial" font-size="14.00">8588: admin_toggle_a2a_agent()</text>
+<text text-anchor="middle" x="1289" y="-36297.3" font-family="Arial" font-size="14.00">8588: admin_set_a2a_agent_state()</text>
 </g>
 <!-- node_1b63b77c&#45;&gt;node_7cd26d76 -->
 <g id="edge215" class="edge">
@@ -3105,7 +3105,7 @@
 <g id="node80" class="node">
 <title>node_5de30b09</title>
 <path fill="#966f33" stroke="black" d="M1378.5,-37777C1378.5,-37777 1199.5,-37777 1199.5,-37777 1193.5,-37777 1187.5,-37771 1187.5,-37765 1187.5,-37765 1187.5,-37753 1187.5,-37753 1187.5,-37747 1193.5,-37741 1199.5,-37741 1199.5,-37741 1378.5,-37741 1378.5,-37741 1384.5,-37741 1390.5,-37747 1390.5,-37753 1390.5,-37753 1390.5,-37765 1390.5,-37765 1390.5,-37771 1384.5,-37777 1378.5,-37777"/>
-<text text-anchor="middle" x="1289" y="-37755.3" font-family="Arial" font-size="14.00">1596: admin_toggle_gateway()</text>
+<text text-anchor="middle" x="1289" y="-37755.3" font-family="Arial" font-size="14.00">1596: admin_set_gateway_state()</text>
 </g>
 <!-- node_5de30b09&#45;&gt;node_cd86d046 -->
 <g id="edge216" class="edge">
@@ -3117,7 +3117,7 @@
 <g id="node81" class="node">
 <title>node_7a5e44f1</title>
 <path fill="#966f33" stroke="black" d="M1374.5,-38749C1374.5,-38749 1203.5,-38749 1203.5,-38749 1197.5,-38749 1191.5,-38743 1191.5,-38737 1191.5,-38737 1191.5,-38725 1191.5,-38725 1191.5,-38719 1197.5,-38713 1203.5,-38713 1203.5,-38713 1374.5,-38713 1374.5,-38713 1380.5,-38713 1386.5,-38719 1386.5,-38725 1386.5,-38725 1386.5,-38737 1386.5,-38737 1386.5,-38743 1380.5,-38749 1374.5,-38749"/>
-<text text-anchor="middle" x="1289" y="-38727.3" font-family="Arial" font-size="14.00">6872: admin_toggle_prompt()</text>
+<text text-anchor="middle" x="1289" y="-38727.3" font-family="Arial" font-size="14.00">6872: admin_set_prompt_state()</text>
 </g>
 <!-- node_7a5e44f1&#45;&gt;node_cd86d046 -->
 <g id="edge217" class="edge">
@@ -3129,7 +3129,7 @@
 <g id="node82" class="node">
 <title>node_bc807ceb</title>
 <path fill="#966f33" stroke="black" d="M1379.5,-38209C1379.5,-38209 1198.5,-38209 1198.5,-38209 1192.5,-38209 1186.5,-38203 1186.5,-38197 1186.5,-38197 1186.5,-38185 1186.5,-38185 1186.5,-38179 1192.5,-38173 1198.5,-38173 1198.5,-38173 1379.5,-38173 1379.5,-38173 1385.5,-38173 1391.5,-38179 1391.5,-38185 1391.5,-38185 1391.5,-38197 1391.5,-38197 1391.5,-38203 1385.5,-38209 1379.5,-38209"/>
-<text text-anchor="middle" x="1289" y="-38187.3" font-family="Arial" font-size="14.00">6378: admin_toggle_resource()</text>
+<text text-anchor="middle" x="1289" y="-38187.3" font-family="Arial" font-size="14.00">6378: admin_set_resource_state()</text>
 </g>
 <!-- node_bc807ceb&#45;&gt;node_cd86d046 -->
 <g id="edge218" class="edge">
@@ -3141,7 +3141,7 @@
 <g id="node83" class="node">
 <title>node_ddba35fe</title>
 <path fill="#966f33" stroke="black" d="M1372,-38155C1372,-38155 1206,-38155 1206,-38155 1200,-38155 1194,-38149 1194,-38143 1194,-38143 1194,-38131 1194,-38131 1194,-38125 1200,-38119 1206,-38119 1206,-38119 1372,-38119 1372,-38119 1378,-38119 1384,-38125 1384,-38131 1384,-38131 1384,-38143 1384,-38143 1384,-38149 1378,-38155 1372,-38155"/>
-<text text-anchor="middle" x="1289" y="-38133.3" font-family="Arial" font-size="14.00">1080: admin_toggle_server()</text>
+<text text-anchor="middle" x="1289" y="-38133.3" font-family="Arial" font-size="14.00">1080: admin_set_server_state()</text>
 </g>
 <!-- node_ddba35fe&#45;&gt;node_cd86d046 -->
 <g id="edge219" class="edge">
@@ -3153,7 +3153,7 @@
 <g id="node84" class="node">
 <title>node_880f2772</title>
 <path fill="#966f33" stroke="black" d="M1364,-38101C1364,-38101 1214,-38101 1214,-38101 1208,-38101 1202,-38095 1202,-38089 1202,-38089 1202,-38077 1202,-38077 1202,-38071 1208,-38065 1214,-38065 1214,-38065 1364,-38065 1364,-38065 1370,-38065 1376,-38071 1376,-38077 1376,-38077 1376,-38089 1376,-38089 1376,-38095 1370,-38101 1364,-38101"/>
-<text text-anchor="middle" x="1289" y="-38079.3" font-family="Arial" font-size="14.00">5257: admin_toggle_tool()</text>
+<text text-anchor="middle" x="1289" y="-38079.3" font-family="Arial" font-size="14.00">5257: admin_set_tool_state()</text>
 </g>
 <!-- node_880f2772&#45;&gt;node_cd86d046 -->
 <g id="edge220" class="edge">

--- a/docs/docs/development/developer-onboarding.md
+++ b/docs/docs/development/developer-onboarding.md
@@ -173,7 +173,7 @@
         - Resources
         - Prompts
         - Gateways
-    - [ ] Toggle active/inactive switches
+    - [ ] Set active/inactive states
     - [ ] JWT stored in `HttpOnly` cookie, no errors in DevTools Console
 
 ???+ check "Metrics"

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1716,9 +1716,9 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=false
+     http://localhost:4444/tools/1/state?activate=false
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=true
+     http://localhost:4444/tools/1/state?activate=true
 
 # Delete tool
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/tools/1
@@ -1778,7 +1778,7 @@ curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle agent status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/a2a/agent-id/toggle?activate=false
+     http://localhost:4444/a2a/agent-id/state?activate=false
 
 # Delete agent
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
@@ -1828,7 +1828,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/gateways/1/toggle?activate=false
+     http://localhost:4444/gateways/1/state?activate=false
 
 # Delete gateway
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/gateways/1
@@ -1914,7 +1914,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/prompts/5/toggle?activate=false
+     http://localhost:4444/prompts/5/state?activate=false
 
 # Delete prompt
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/prompts/greet
@@ -1972,7 +1972,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/servers/UUID_OF_SERVER_1/toggle?activate=false
+     http://localhost:4444/servers/UUID_OF_SERVER_1/state?activate=false
 ```
 
 </details>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1714,7 +1714,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      -d '{ "description":"Updated desc" }' \
      http://localhost:4444/tools/1
 
-# Toggle active status
+# Set active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      http://localhost:4444/tools/1/state?activate=false
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
@@ -1776,7 +1776,7 @@ curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
          }' \
      http://localhost:4444/a2a/agent-name/invoke
 
-# Toggle agent status
+# Set agent state
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      http://localhost:4444/a2a/agent-id/state?activate=false
 
@@ -1826,7 +1826,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      -d '{"description":"New description"}' \
      http://localhost:4444/gateways/1
 
-# Toggle active status
+# Set active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      http://localhost:4444/gateways/1/state?activate=false
 
@@ -1912,7 +1912,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      -d '{"template":"Hi, {{ user }}!"}' \
      http://localhost:4444/prompts/greet
 
-# Toggle active
+# Set active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      http://localhost:4444/prompts/5/state?activate=false
 
@@ -1970,7 +1970,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      -d '{"description":"Updated"}' \
      http://localhost:4444/servers/UUID_OF_SERVER_1
 
-# Toggle active
+# Set active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
      http://localhost:4444/servers/UUID_OF_SERVER_1/state?activate=false
 ```

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -164,7 +164,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle gateway enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/gateways/$GATEWAY_ID/toggle?activate=false | jq '.'
+  $BASE_URL/gateways/$GATEWAY_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Gateway
@@ -286,7 +286,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle tool enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/tools/$TOOL_ID/toggle?activate=false | jq '.'
+  $BASE_URL/tools/$TOOL_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Tool
@@ -409,7 +409,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle server enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/servers/$SERVER_ID/toggle?activate=false | jq '.'
+  $BASE_URL/servers/$SERVER_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Server
@@ -501,7 +501,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle resource enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/resources/$RESOURCE_ID/toggle?activate=false | jq '.'
+  $BASE_URL/resources/$RESOURCE_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Resource
@@ -583,7 +583,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle prompt enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/prompts/$PROMPT_ID/toggle?activate=false | jq '.'
+  $BASE_URL/prompts/$PROMPT_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Prompt
@@ -1038,7 +1038,7 @@ TOOLS=$(curl -s -H "Authorization: Bearer $TOKEN" $BASE_URL/tools | \
 for TOOL_ID in $TOOLS; do
   echo "Enabling tool: $TOOL_ID"
   curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-    $BASE_URL/tools/$TOOL_ID/toggle > /dev/null
+    $BASE_URL/tools/$TOOL_ID/state > /dev/null
 done
 
 echo "Done!"

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -162,7 +162,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ### Enable/Disable Gateway
 
 ```bash
-# Toggle gateway enabled status
+# Set gateway state (enable/disable)
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/gateways/$GATEWAY_ID/state?activate=false | jq '.'
 ```
@@ -284,7 +284,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ### Enable/Disable Tool
 
 ```bash
-# Toggle tool enabled status
+# Set tool state (enable/disable)
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/tools/$TOOL_ID/state?activate=false | jq '.'
 ```
@@ -407,7 +407,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ### Enable/Disable Server
 
 ```bash
-# Toggle server enabled status
+# Set server state (enable/disable)
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/servers/$SERVER_ID/state?activate=false | jq '.'
 ```
@@ -499,7 +499,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ### Enable/Disable Resource
 
 ```bash
-# Toggle resource enabled status
+# Set resource state (enable/disable)
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/resources/$RESOURCE_ID/state?activate=false | jq '.'
 ```
@@ -581,7 +581,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ### Enable/Disable Prompt
 
 ```bash
-# Toggle prompt enabled status
+# Set prompt state (enable/disable)
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/prompts/$PROMPT_ID/state?activate=false | jq '.'
 ```

--- a/docs/docs/overview/ui.md
+++ b/docs/docs/overview/ui.md
@@ -39,7 +39,7 @@ It provides tabbed access to:
 | Bulk import tools | Use API endpoint `/admin/tools/import` (see [Bulk Import](../manage/bulk-import.md)) |
 | View prompt output | Go to Prompts → click View |
 | **View entity metadata** | Click "View" on any entity → scroll to "Metadata" section |
-| Toggle server activity | Use the "Activate/Deactivate" buttons in Servers tab |
+| Set server activity | Use the "Activate/Deactivate" buttons in Servers tab |
 | Delete a resource | Navigate to Resources → click Delete (after confirming) |
 
 All actions are reflected in the live API via `/tools`, `/prompts`, etc.

--- a/docs/docs/tutorials/openwebui-tutorial.md
+++ b/docs/docs/tutorials/openwebui-tutorial.md
@@ -352,7 +352,7 @@ docker logs -f openwebui
 1. Navigate to **Workspace** → **Models**
 2. Edit each model (granite, llama, mistral)
 3. Scroll to **Tools** section
-4. Toggle on the MCP tools you want available
+4. Enable the MCP tools you want available
 5. Click **Save**
 
 ### 6.4 Add MCP Servers to Gateway

--- a/docs/docs/using/grpc-services.md
+++ b/docs/docs/using/grpc-services.md
@@ -307,7 +307,7 @@ Content-Type: application/json
 ### Toggle Service
 
 ```bash
-POST /grpc/{service_id}/toggle
+POST /grpc/{service_id}/state
 ```
 
 ### Delete Service

--- a/docs/docs/using/grpc-services.md
+++ b/docs/docs/using/grpc-services.md
@@ -236,7 +236,7 @@ Click **View Methods** to see all discovered gRPC methods:
 - Output message type
 - Streaming flags (client/server streaming)
 
-### Toggle Service
+### Service State
 
 Use **Activate/Deactivate** to enable/disable a service:
 - Disabled services are not available for tool invocation
@@ -304,7 +304,7 @@ Content-Type: application/json
 }
 ```
 
-### Toggle Service
+### Service State
 
 ```bash
 POST /grpc/{service_id}/state

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -5083,7 +5083,7 @@ async def admin_tools_partial_html(
 
     # Serialize tools
     data = jsonable_encoder(tools_pydantic)
-
+    
     # Build pagination metadata
     pagination = PaginationMeta(
         page=page,
@@ -5572,13 +5572,20 @@ async def admin_resources_partial_html(
     resources_data = []
     for r in resources_db:
         try:
+            # Ensure the resource has a resolved team name before conversion
+            try:
+                team_name = local_resource_service._get_team_name(db, getattr(r, "team_id", None))
+            except Exception:
+                team_name = None
+            r.team = team_name
             resources_data.append(local_resource_service._convert_resource_to_read(r))  # pylint: disable=protected-access
         except Exception as e:
             LOGGER.warning(f"Failed to convert resource {getattr(r, 'id', '<unknown>')} to schema: {e}")
             continue
 
     data = jsonable_encoder(resources_data)
-
+    LOGGER.info(f"resources_data: {resources_data}")
+    LOGGER.info(f"data: {data}")
     # Build pagination metadata
     pagination = PaginationMeta(
         page=page,

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1377,8 +1377,8 @@ async def admin_set_server_state(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_server_status = server_service.toggle_server_status
-        >>> server_service.toggle_server_status = AsyncMock()
+        >>> original_set_server_state = server_service.set_server_state
+        >>> server_service.set_server_state = AsyncMock()
         >>>
         >>> async def test_admin_set_server_state_activate():
         ...     result = await admin_set_server_state(server_id, mock_request_activate, mock_db, mock_user)
@@ -1415,7 +1415,7 @@ async def admin_set_server_state(
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> server_service.toggle_server_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> server_service.set_server_state = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
         >>> async def test_admin_set_server_state_exception():
         ...     result = await admin_set_server_state(server_id, mock_request_error, mock_db, mock_user)
@@ -1432,7 +1432,7 @@ async def admin_set_server_state(
         True
         >>>
         >>> # Restore original method
-        >>> server_service.toggle_server_status = original_toggle_server_status
+        >>> server_service.set_server_state = original_set_server_state
     """
     form = await request.form()
     error_message = None
@@ -1441,7 +1441,7 @@ async def admin_set_server_state(
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await server_service.toggle_server_status(db, server_id, activate, user_email=user_email)
+        await server_service.set_server_state(db, server_id, activate, user_email=user_email)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} toggling servers {server_id}: {e}")
         error_message = str(e)
@@ -1956,8 +1956,8 @@ async def admin_set_gateway_state(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_gateway_status = gateway_service.toggle_gateway_status
-        >>> gateway_service.toggle_gateway_status = AsyncMock()
+        >>> original_set_gateway_state = gateway_service.set_gateway_state
+        >>> gateway_service.set_gateway_state = AsyncMock()
         >>>
         >>> async def test_admin_set_gateway_state_activate():
         ...     result = await admin_set_gateway_state(gateway_id, mock_request_activate, mock_db, mock_user)
@@ -1982,7 +1982,7 @@ async def admin_set_gateway_state(
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> gateway_service.toggle_gateway_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> gateway_service.set_gateway_state = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
         >>> async def test_admin_set_gateway_state_exception():
         ...     result = await admin_set_gateway_state(gateway_id, mock_request_error, mock_db, mock_user)
@@ -1998,7 +1998,7 @@ async def admin_set_gateway_state(
         >>> asyncio.run(test_admin_set_gateway_state_exception())
         True
         >>> # Restore original method
-        >>> gateway_service.toggle_gateway_status = original_toggle_gateway_status
+        >>> gateway_service.set_gateway_state = original_set_gateway_state
     """
     error_message = None
     user_email = get_user_email(user)
@@ -2008,7 +2008,7 @@ async def admin_set_gateway_state(
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
 
     try:
-        await gateway_service.toggle_gateway_status(db, gateway_id, activate, user_email=user_email)
+        await gateway_service.set_gateway_state(db, gateway_id, activate, user_email=user_email)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} setting gateway {gateway_id} state: {e}")
         error_message = str(e)
@@ -6625,8 +6625,8 @@ async def admin_set_tool_state(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_tool_status = tool_service.toggle_tool_status
-        >>> tool_service.toggle_tool_status = AsyncMock()
+        >>> original_set_tool_state = tool_service.set_tool_state
+        >>> tool_service.set_tool_state = AsyncMock()
         >>>
         >>> async def test_admin_set_tool_state_activate():
         ...     result = await admin_set_tool_state(tool_id, mock_request_activate, mock_db, mock_user)
@@ -6663,7 +6663,7 @@ async def admin_set_tool_state(
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> tool_service.toggle_tool_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> tool_service.set_tool_state = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
         >>> async def test_admin_set_tool_state_exception():
         ...     result = await admin_set_tool_state(tool_id, mock_request_error, mock_db, mock_user)
@@ -6680,7 +6680,7 @@ async def admin_set_tool_state(
         True
         >>>
         >>> # Restore original method
-        >>> tool_service.toggle_tool_status = original_toggle_tool_status
+        >>> tool_service.set_tool_state = original_set_tool_state
     """
     error_message = None
     user_email = get_user_email(user)
@@ -6689,7 +6689,7 @@ async def admin_set_tool_state(
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
+        await tool_service.set_tool_state(db, tool_id, activate, reachable=activate, user_email=user_email)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} setting tool {tool_id} state: {e}")
         error_message = str(e)
@@ -7995,8 +7995,8 @@ async def admin_set_resource_state(
         >>> mock_request.form = AsyncMock(return_value=form_data)
         >>> mock_request.scope = {"root_path": ""}
         >>>
-        >>> original_toggle_resource_status = resource_service.toggle_resource_status
-        >>> resource_service.toggle_resource_status = AsyncMock()
+        >>> original_set_resource_state = resource_service.set_resource_state
+        >>> resource_service.set_resource_state = AsyncMock()
         >>>
         >>> async def test_admin_set_resource_state():
         ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
@@ -8034,7 +8034,7 @@ async def admin_set_resource_state(
         True
         >>>
         >>> # Test exception handling
-        >>> resource_service.toggle_resource_status = AsyncMock(side_effect=Exception("Test error"))
+        >>> resource_service.set_resource_state = AsyncMock(side_effect=Exception("Test error"))
         >>> form_data_error = FormData([
         ...     ("activate", "true"),
         ...     ("is_inactive_checked", "false")
@@ -8047,7 +8047,7 @@ async def admin_set_resource_state(
         >>>
         >>> asyncio.run(test_admin_set_resource_state_exception())
         True
-        >>> resource_service.toggle_resource_status = original_toggle_resource_status
+        >>> resource_service.set_resource_state = original_set_resource_state
     """
     user_email = get_user_email(user)
     LOGGER.debug(f"User {user_email} is setting resource ID {resource_id} state")
@@ -8056,7 +8056,7 @@ async def admin_set_resource_state(
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await resource_service.toggle_resource_status(db, resource_id, activate, user_email=user_email)
+        await resource_service.set_resource_state(db, resource_id, activate, user_email=user_email)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} setting resource state {resource_id}: {e}")
         error_message = str(e)
@@ -8550,8 +8550,8 @@ async def admin_set_prompt_state(
         >>> mock_request.form = AsyncMock(return_value=form_data)
         >>> mock_request.scope = {"root_path": ""}
         >>>
-        >>> original_toggle_prompt_status = prompt_service.toggle_prompt_status
-        >>> prompt_service.toggle_prompt_status = AsyncMock()
+        >>> original_set_prompt_state = prompt_service.set_prompt_state
+        >>> prompt_service.set_prompt_state = AsyncMock()
         >>>
         >>> async def test_admin_set_prompt_state():
         ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
@@ -8589,7 +8589,7 @@ async def admin_set_prompt_state(
         True
         >>>
         >>> # Test exception handling
-        >>> prompt_service.toggle_prompt_status = AsyncMock(side_effect=Exception("Test error"))
+        >>> prompt_service.set_prompt_state = AsyncMock(side_effect=Exception("Test error"))
         >>> form_data_error = FormData([
         ...     ("activate", "true"),
         ...     ("is_inactive_checked", "false")
@@ -8602,7 +8602,7 @@ async def admin_set_prompt_state(
         >>>
         >>> asyncio.run(test_admin_set_prompt_state_exception())
         True
-        >>> prompt_service.toggle_prompt_status = original_toggle_prompt_status
+        >>> prompt_service.set_prompt_state = original_set_prompt_state
     """
     user_email = get_user_email(user)
     LOGGER.debug(f"User {user_email} is setting prompt ID {prompt_id} state")
@@ -8611,7 +8611,7 @@ async def admin_set_prompt_state(
     activate: bool = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked: str = str(form.get("is_inactive_checked", "false"))
     try:
-        await prompt_service.toggle_prompt_status(db, prompt_id, activate, user_email=user_email)
+        await prompt_service.set_prompt_state(db, prompt_id, activate, user_email=user_email)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} setting prompt state {prompt_id}: {e}")
         error_message = str(e)
@@ -10902,7 +10902,7 @@ async def admin_set_a2a_agent_state(
 
         user_email = get_user_email(user)
 
-        await a2a_service.toggle_agent_status(db, agent_id, activate, user_email=user_email)
+        await a2a_service.set_a2a_agent_state(db, agent_id, activate, user_email=user_email)
         root_path = request.scope.get("root_path", "")
         return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
 
@@ -11186,7 +11186,7 @@ async def admin_set_grpc_service_state(
 
     try:
         service = await grpc_service_mgr.get_service(db, service_id)
-        result = await grpc_service_mgr.toggle_service(db, service_id, not service.enabled)
+        result = await grpc_service_mgr.set_grpc_service_state(db, service_id, not service.enabled)
         return JSONResponse(content=jsonable_encoder(result))
     except GrpcServiceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1337,7 +1337,7 @@ async def admin_edit_server(
         return JSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
 
-@admin_router.post("/servers/{server_id}/toggle")
+@admin_router.post("/servers/{server_id}/state")
 async def admin_toggle_server(
     server_id: str,
     request: Request,
@@ -1917,7 +1917,7 @@ async def admin_list_gateway_ids(
     return {"gateway_ids": ids}
 
 
-@admin_router.post("/gateways/{gateway_id}/toggle")
+@admin_router.post("/gateways/{gateway_id}/state")
 async def admin_toggle_gateway(
     gateway_id: str,
     request: Request,
@@ -6585,7 +6585,7 @@ async def admin_delete_tool(tool_id: str, request: Request, db: Session = Depend
     return RedirectResponse(f"{root_path}/admin#tools", status_code=303)
 
 
-@admin_router.post("/tools/{tool_id}/toggle")
+@admin_router.post("/tools/{tool_id}/state")
 async def admin_toggle_tool(
     tool_id: str,
     request: Request,
@@ -7953,7 +7953,7 @@ async def admin_delete_resource(resource_id: str, request: Request, db: Session 
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
 
 
-@admin_router.post("/resources/{resource_id}/toggle")
+@admin_router.post("/resources/{resource_id}/state")
 async def admin_toggle_resource(
     resource_id: int,
     request: Request,
@@ -8508,7 +8508,7 @@ async def admin_delete_prompt(prompt_id: str, request: Request, db: Session = De
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)
 
 
-@admin_router.post("/prompts/{prompt_id}/toggle")
+@admin_router.post("/prompts/{prompt_id}/state")
 async def admin_toggle_prompt(
     prompt_id: int,
     request: Request,
@@ -10869,7 +10869,7 @@ async def admin_edit_a2a_agent(
         return JSONResponse({"message": str(e), "success": False}, status_code=500)
 
 
-@admin_router.post("/a2a/{agent_id}/toggle")
+@admin_router.post("/a2a/{agent_id}/state")
 async def admin_toggle_a2a_agent(
     agent_id: str,
     request: Request,
@@ -11162,7 +11162,7 @@ async def admin_update_grpc_service(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@admin_router.post("/grpc/{service_id}/toggle")
+@admin_router.post("/grpc/{service_id}/state")
 async def admin_toggle_grpc_service(
     service_id: str,
     db: Session = Depends(get_db),

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1345,15 +1345,15 @@ async def admin_set_server_state(
     user=Depends(get_current_user_with_permissions),
 ) -> Response:
     """
-    Toggle a server's active status via the admin UI.
+    Set a server's active state via the admin UI.
 
     This endpoint processes a form request to activate or deactivate a server.
     It expects a form field 'activate' with value "true" to activate the server
     or "false" to deactivate it. The endpoint handles exceptions gracefully and
-    logs any errors that might occur during the status toggle operation.
+    logs any errors that might occur during the state change operation.
 
     Args:
-        server_id (str): The ID of the server whose status to toggle.
+        server_id (str): The ID of the server whose state to set.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.
@@ -1371,7 +1371,7 @@ async def admin_set_server_state(
         >>>
         >>> mock_db = MagicMock()
         >>> mock_user = {"email": "test_user", "db": mock_db}
-        >>> server_id = "server-to-toggle"
+        >>> server_id = "server-to-set"
         >>>
         >>> # Happy path: Activate server
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
@@ -1399,7 +1399,7 @@ async def admin_set_server_state(
         >>> asyncio.run(test_admin_set_server_state_deactivate())
         True
         >>>
-        >>> # Edge case: Toggle with inactive checkbox checked
+        >>> # Edge case: Set state with inactive checkbox checked
         >>> form_data_inactive = FormData([("activate", "true"), ("is_inactive_checked", "true")])
         >>> mock_request_inactive = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_inactive.form = AsyncMock(return_value=form_data_inactive)
@@ -1411,11 +1411,11 @@ async def admin_set_server_state(
         >>> asyncio.run(test_admin_set_server_state_inactive_checked())
         True
         >>>
-        >>> # Error path: Simulate an exception during toggle
+        >>> # Error path: Simulate an exception during state change
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> server_service.set_server_state = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> server_service.set_server_state = AsyncMock(side_effect=Exception("Set failed"))
         >>>
         >>> async def test_admin_set_server_state_exception():
         ...     result = await admin_set_server_state(server_id, mock_request_error, mock_db, mock_user)
@@ -1925,14 +1925,14 @@ async def admin_set_gateway_state(
     user=Depends(get_current_user_with_permissions),
 ) -> RedirectResponse:
     """
-    Toggle the active status of a gateway via the admin UI.
+    Set the active state of a gateway via the admin UI.
 
-    This endpoint allows an admin to toggle the active status of a gateway.
+    This endpoint allows an admin to set the active state of a gateway.
     It expects a form field 'activate' with a value of "true" or "false" to
-    determine the new status of the gateway.
+    determine the new state of the gateway.
 
     Args:
-        gateway_id (str): The ID of the gateway to toggle.
+        gateway_id (str): The ID of the gateway whose state to set.
         request (Request): The FastAPI request object containing form data.
         db (Session): The database session dependency.
         user (str): The authenticated user dependency.
@@ -1950,7 +1950,7 @@ async def admin_set_gateway_state(
         >>>
         >>> mock_db = MagicMock()
         >>> mock_user = {"email": "test_user", "db": mock_db}
-        >>> gateway_id = "gateway-to-toggle"
+        >>> gateway_id = "gateway-to-set"
         >>>
         >>> # Happy path: Activate gateway
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
@@ -1978,11 +1978,11 @@ async def admin_set_gateway_state(
         >>> asyncio.run(test_admin_set_gateway_state_deactivate())
         True
         >>>
-        >>> # Error path: Simulate an exception during toggle
+        >>> # Error path: Simulate an exception during state change
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> gateway_service.set_gateway_state = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> gateway_service.set_gateway_state = AsyncMock(side_effect=Exception("Set failed"))
         >>>
         >>> async def test_admin_set_gateway_state_exception():
         ...     result = await admin_set_gateway_state(gateway_id, mock_request_error, mock_db, mock_user)
@@ -6593,15 +6593,15 @@ async def admin_set_tool_state(
     user=Depends(get_current_user_with_permissions),
 ) -> RedirectResponse:
     """
-    Toggle a tool's active status via the admin UI.
+    Set a tool's active state via the admin UI.
 
     This endpoint processes a form request to activate or deactivate a tool.
     It expects a form field 'activate' with value "true" to activate the tool
     or "false" to deactivate it. The endpoint handles exceptions gracefully and
-    logs any errors that might occur during the status toggle operation.
+    logs any errors that might occur during the state change operation.
 
     Args:
-        tool_id (str): The ID of the tool whose status to toggle.
+        tool_id (str): The ID of the tool whose state to set.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.
@@ -6619,7 +6619,7 @@ async def admin_set_tool_state(
         >>>
         >>> mock_db = MagicMock()
         >>> mock_user = {"email": "test_user", "db": mock_db}
-        >>> tool_id = "tool-to-toggle"
+        >>> tool_id = "tool-to-set"
         >>>
         >>> # Happy path: Activate tool
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
@@ -6647,7 +6647,7 @@ async def admin_set_tool_state(
         >>> asyncio.run(test_admin_set_tool_state_deactivate())
         True
         >>>
-        >>> # Edge case: Toggle with inactive checkbox checked
+        >>> # Edge case: Set state with inactive checkbox checked
         >>> form_data_inactive = FormData([("activate", "true"), ("is_inactive_checked", "true")])
         >>> mock_request_inactive = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_inactive.form = AsyncMock(return_value=form_data_inactive)
@@ -6659,11 +6659,11 @@ async def admin_set_tool_state(
         >>> asyncio.run(test_admin_set_tool_state_inactive_checked())
         True
         >>>
-        >>> # Error path: Simulate an exception during toggle
+        >>> # Error path: Simulate an exception during state change
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> tool_service.set_tool_state = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> tool_service.set_tool_state = AsyncMock(side_effect=Exception("Set failed"))
         >>>
         >>> async def test_admin_set_tool_state_exception():
         ...     result = await admin_set_tool_state(tool_id, mock_request_error, mock_db, mock_user)
@@ -7961,15 +7961,15 @@ async def admin_set_resource_state(
     user=Depends(get_current_user_with_permissions),
 ) -> RedirectResponse:
     """
-    Toggle a resource's active status via the admin UI.
+    Set a resource's active state via the admin UI.
 
     This endpoint processes a form request to activate or deactivate a resource.
     It expects a form field 'activate' with value "true" to activate the resource
     or "false" to deactivate it. The endpoint handles exceptions gracefully and
-    logs any errors that might occur during the status toggle operation.
+    logs any errors that might occur during the state change operation.
 
     Args:
-        resource_id (int): The ID of the resource whose status to toggle.
+        resource_id (int): The ID of the resource whose state to set.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.
@@ -8516,15 +8516,15 @@ async def admin_set_prompt_state(
     user=Depends(get_current_user_with_permissions),
 ) -> RedirectResponse:
     """
-    Toggle a prompt's active status via the admin UI.
+    Set a prompt's active state via the admin UI.
 
     This endpoint processes a form request to activate or deactivate a prompt.
     It expects a form field 'activate' with value "true" to activate the prompt
     or "false" to deactivate it. The endpoint handles exceptions gracefully and
-    logs any errors that might occur during the status toggle operation.
+    logs any errors that might occur during the state change operation.
 
     Args:
-        prompt_id (int): The ID of the prompt whose status to toggle.
+        prompt_id (int): The ID of the prompt whose state to set.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -5083,7 +5083,7 @@ async def admin_tools_partial_html(
 
     # Serialize tools
     data = jsonable_encoder(tools_pydantic)
-    
+
     # Build pagination metadata
     pagination = PaginationMeta(
         page=page,

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1338,7 +1338,7 @@ async def admin_edit_server(
 
 
 @admin_router.post("/servers/{server_id}/state")
-async def admin_toggle_server(
+async def admin_set_server_state(
     server_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -1380,11 +1380,11 @@ async def admin_toggle_server(
         >>> original_toggle_server_status = server_service.toggle_server_status
         >>> server_service.toggle_server_status = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_server_activate():
-        ...     result = await admin_toggle_server(server_id, mock_request_activate, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_activate():
+        ...     result = await admin_set_server_state(server_id, mock_request_activate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin#catalog" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_server_activate())
+        >>> asyncio.run(test_admin_set_server_state_activate())
         True
         >>>
         >>> # Happy path: Deactivate server
@@ -1392,11 +1392,11 @@ async def admin_toggle_server(
         >>> mock_request_deactivate = MagicMock(spec=Request, scope={"root_path": "/api"})
         >>> mock_request_deactivate.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_server_deactivate():
-        ...     result = await admin_toggle_server(server_id, mock_request_deactivate, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_deactivate():
+        ...     result = await admin_set_server_state(server_id, mock_request_deactivate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/api/admin#catalog" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_server_deactivate())
+        >>> asyncio.run(test_admin_set_server_state_deactivate())
         True
         >>>
         >>> # Edge case: Toggle with inactive checkbox checked
@@ -1404,11 +1404,11 @@ async def admin_toggle_server(
         >>> mock_request_inactive = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_inactive.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_server_inactive_checked():
-        ...     result = await admin_toggle_server(server_id, mock_request_inactive, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_inactive_checked():
+        ...     result = await admin_set_server_state(server_id, mock_request_inactive, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin/?include_inactive=true#catalog" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_server_inactive_checked())
+        >>> asyncio.run(test_admin_set_server_state_inactive_checked())
         True
         >>>
         >>> # Error path: Simulate an exception during toggle
@@ -1417,8 +1417,8 @@ async def admin_toggle_server(
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
         >>> server_service.toggle_server_status = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
-        >>> async def test_admin_toggle_server_exception():
-        ...     result = await admin_toggle_server(server_id, mock_request_error, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_exception():
+        ...     result = await admin_set_server_state(server_id, mock_request_error, mock_db, mock_user)
         ...     location_header = result.headers["location"]
         ...     return (
         ...         isinstance(result, RedirectResponse)
@@ -1428,7 +1428,7 @@ async def admin_toggle_server(
         ...         and location_header.endswith("#catalog")  # Ensure the fragment is correct
         ...     )
         >>>
-        >>> asyncio.run(test_admin_toggle_server_exception())
+        >>> asyncio.run(test_admin_set_server_state_exception())
         True
         >>>
         >>> # Restore original method
@@ -1437,7 +1437,7 @@ async def admin_toggle_server(
     form = await request.form()
     error_message = None
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling server ID {server_id} with activate: {form.get('activate')}")
+    LOGGER.debug(f"User {user_email} is setting server ID {server_id} state with activate: {form.get('activate')}")
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
@@ -1918,7 +1918,7 @@ async def admin_list_gateway_ids(
 
 
 @admin_router.post("/gateways/{gateway_id}/state")
-async def admin_toggle_gateway(
+async def admin_set_gateway_state(
     gateway_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -1959,11 +1959,11 @@ async def admin_toggle_gateway(
         >>> original_toggle_gateway_status = gateway_service.toggle_gateway_status
         >>> gateway_service.toggle_gateway_status = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_gateway_activate():
-        ...     result = await admin_toggle_gateway(gateway_id, mock_request_activate, mock_db, mock_user)
+        >>> async def test_admin_set_gateway_state_activate():
+        ...     result = await admin_set_gateway_state(gateway_id, mock_request_activate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin#gateways" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_gateway_activate())
+        >>> asyncio.run(test_admin_set_gateway_state_activate())
         True
         >>>
         >>> # Happy path: Deactivate gateway
@@ -1971,11 +1971,11 @@ async def admin_toggle_gateway(
         >>> mock_request_deactivate = MagicMock(spec=Request, scope={"root_path": "/api"})
         >>> mock_request_deactivate.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_gateway_deactivate():
-        ...     result = await admin_toggle_gateway(gateway_id, mock_request_deactivate, mock_db, mock_user)
+        >>> async def test_admin_set_gateway_state_deactivate():
+        ...     result = await admin_set_gateway_state(gateway_id, mock_request_deactivate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/api/admin#gateways" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_gateway_deactivate())
+        >>> asyncio.run(test_admin_set_gateway_state_deactivate())
         True
         >>>
         >>> # Error path: Simulate an exception during toggle
@@ -1984,8 +1984,8 @@ async def admin_toggle_gateway(
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
         >>> gateway_service.toggle_gateway_status = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
-        >>> async def test_admin_toggle_gateway_exception():
-        ...     result = await admin_toggle_gateway(gateway_id, mock_request_error, mock_db, mock_user)
+        >>> async def test_admin_set_gateway_state_exception():
+        ...     result = await admin_set_gateway_state(gateway_id, mock_request_error, mock_db, mock_user)
         ...     location_header = result.headers["location"]
         ...     return (
         ...         isinstance(result, RedirectResponse)
@@ -1995,14 +1995,14 @@ async def admin_toggle_gateway(
         ...         and location_header.endswith("#gateways")  # Ensure the fragment is correct
         ...     )
         >>>
-        >>> asyncio.run(test_admin_toggle_gateway_exception())
+        >>> asyncio.run(test_admin_set_gateway_state_exception())
         True
         >>> # Restore original method
         >>> gateway_service.toggle_gateway_status = original_toggle_gateway_status
     """
     error_message = None
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling gateway ID {gateway_id}")
+    LOGGER.debug(f"User {user_email} is setting gateway ID {gateway_id} state")
     form = await request.form()
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
@@ -2010,11 +2010,11 @@ async def admin_toggle_gateway(
     try:
         await gateway_service.toggle_gateway_status(db, gateway_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling gateway {gateway_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting gateway {gateway_id} state: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling gateway status: {e}")
-        error_message = "Failed to toggle gateway status. Please try again."
+        LOGGER.error(f"Error setting gateway state: {e}")
+        error_message = "Failed to set gateway state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -6586,7 +6586,7 @@ async def admin_delete_tool(tool_id: str, request: Request, db: Session = Depend
 
 
 @admin_router.post("/tools/{tool_id}/state")
-async def admin_toggle_tool(
+async def admin_set_tool_state(
     tool_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -6628,11 +6628,11 @@ async def admin_toggle_tool(
         >>> original_toggle_tool_status = tool_service.toggle_tool_status
         >>> tool_service.toggle_tool_status = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_tool_activate():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_activate, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_activate():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_activate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin#tools" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_activate())
+        >>> asyncio.run(test_admin_set_tool_state_activate())
         True
         >>>
         >>> # Happy path: Deactivate tool
@@ -6640,11 +6640,11 @@ async def admin_toggle_tool(
         >>> mock_request_deactivate = MagicMock(spec=Request, scope={"root_path": "/api"})
         >>> mock_request_deactivate.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_tool_deactivate():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_deactivate, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_deactivate():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_deactivate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/api/admin#tools" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_deactivate())
+        >>> asyncio.run(test_admin_set_tool_state_deactivate())
         True
         >>>
         >>> # Edge case: Toggle with inactive checkbox checked
@@ -6652,11 +6652,11 @@ async def admin_toggle_tool(
         >>> mock_request_inactive = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_inactive.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_tool_inactive_checked():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_inactive, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_inactive_checked():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_inactive, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin/?include_inactive=true#tools" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_inactive_checked())
+        >>> asyncio.run(test_admin_set_tool_state_inactive_checked())
         True
         >>>
         >>> # Error path: Simulate an exception during toggle
@@ -6665,8 +6665,8 @@ async def admin_toggle_tool(
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
         >>> tool_service.toggle_tool_status = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
-        >>> async def test_admin_toggle_tool_exception():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_error, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_exception():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_error, mock_db, mock_user)
         ...     location_header = result.headers["location"]
         ...     return (
         ...         isinstance(result, RedirectResponse)
@@ -6676,7 +6676,7 @@ async def admin_toggle_tool(
         ...         and location_header.endswith("#tools")  # Ensure fragment is correct
         ...     )
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_exception())
+        >>> asyncio.run(test_admin_set_tool_state_exception())
         True
         >>>
         >>> # Restore original method
@@ -6684,18 +6684,18 @@ async def admin_toggle_tool(
     """
     error_message = None
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling tool ID {tool_id}")
+    LOGGER.debug(f"User {user_email} is setting tool ID {tool_id} state")
     form = await request.form()
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
         await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling tools {tool_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting tool {tool_id} state: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling tool status: {e}")
-        error_message = "Failed to toggle tool status. Please try again."
+        LOGGER.error(f"Error setting tool state: {e}")
+        error_message = "Failed to set tool state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -7954,7 +7954,7 @@ async def admin_delete_resource(resource_id: str, request: Request, db: Session 
 
 
 @admin_router.post("/resources/{resource_id}/state")
-async def admin_toggle_resource(
+async def admin_set_resource_state(
     resource_id: int,
     request: Request,
     db: Session = Depends(get_db),
@@ -7998,11 +7998,11 @@ async def admin_toggle_resource(
         >>> original_toggle_resource_status = resource_service.toggle_resource_status
         >>> resource_service.toggle_resource_status = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_resource():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_resource())
+        >>> asyncio.run(test_admin_set_resource_state())
         True
         >>>
         >>> # Test with activate=false
@@ -8012,11 +8012,11 @@ async def admin_toggle_resource(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_resource_deactivate():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state_deactivate():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_resource_deactivate())
+        >>> asyncio.run(test_admin_set_resource_state_deactivate())
         True
         >>>
         >>> # Test with inactive checkbox checked
@@ -8026,11 +8026,11 @@ async def admin_toggle_resource(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_resource_inactive():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state_inactive():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and "include_inactive=true" in response.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_resource_inactive())
+        >>> asyncio.run(test_admin_set_resource_state_inactive())
         True
         >>>
         >>> # Test exception handling
@@ -8041,16 +8041,16 @@ async def admin_toggle_resource(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_error)
         >>>
-        >>> async def test_admin_toggle_resource_exception():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state_exception():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_resource_exception())
+        >>> asyncio.run(test_admin_set_resource_state_exception())
         True
         >>> resource_service.toggle_resource_status = original_toggle_resource_status
     """
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling resource ID {resource_id}")
+    LOGGER.debug(f"User {user_email} is setting resource ID {resource_id} state")
     form = await request.form()
     error_message = None
     activate = str(form.get("activate", "true")).lower() == "true"
@@ -8058,11 +8058,11 @@ async def admin_toggle_resource(
     try:
         await resource_service.toggle_resource_status(db, resource_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling resource status {resource_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting resource state {resource_id}: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling resource status: {e}")
-        error_message = "Failed to toggle resource status. Please try again."
+        LOGGER.error(f"Error setting resource state: {e}")
+        error_message = "Failed to set resource state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -8509,7 +8509,7 @@ async def admin_delete_prompt(prompt_id: str, request: Request, db: Session = De
 
 
 @admin_router.post("/prompts/{prompt_id}/state")
-async def admin_toggle_prompt(
+async def admin_set_prompt_state(
     prompt_id: int,
     request: Request,
     db: Session = Depends(get_db),
@@ -8553,11 +8553,11 @@ async def admin_toggle_prompt(
         >>> original_toggle_prompt_status = prompt_service.toggle_prompt_status
         >>> prompt_service.toggle_prompt_status = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_prompt():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt())
+        >>> asyncio.run(test_admin_set_prompt_state())
         True
         >>>
         >>> # Test with activate=false
@@ -8567,11 +8567,11 @@ async def admin_toggle_prompt(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_prompt_deactivate():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state_deactivate():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt_deactivate())
+        >>> asyncio.run(test_admin_set_prompt_state_deactivate())
         True
         >>>
         >>> # Test with inactive checkbox checked
@@ -8581,11 +8581,11 @@ async def admin_toggle_prompt(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_prompt_inactive():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state_inactive():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and "include_inactive=true" in response.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt_inactive())
+        >>> asyncio.run(test_admin_set_prompt_state_inactive())
         True
         >>>
         >>> # Test exception handling
@@ -8596,16 +8596,16 @@ async def admin_toggle_prompt(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_error)
         >>>
-        >>> async def test_admin_toggle_prompt_exception():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state_exception():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt_exception())
+        >>> asyncio.run(test_admin_set_prompt_state_exception())
         True
         >>> prompt_service.toggle_prompt_status = original_toggle_prompt_status
     """
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling prompt ID {prompt_id}")
+    LOGGER.debug(f"User {user_email} is setting prompt ID {prompt_id} state")
     error_message = None
     form = await request.form()
     activate: bool = str(form.get("activate", "true")).lower() == "true"
@@ -8613,11 +8613,11 @@ async def admin_toggle_prompt(
     try:
         await prompt_service.toggle_prompt_status(db, prompt_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling prompt {prompt_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting prompt state {prompt_id}: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling prompt status: {e}")
-        error_message = "Failed to toggle prompt status. Please try again."
+        LOGGER.error(f"Error setting prompt state: {e}")
+        error_message = "Failed to set prompt state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -10870,7 +10870,7 @@ async def admin_edit_a2a_agent(
 
 
 @admin_router.post("/a2a/{agent_id}/state")
-async def admin_toggle_a2a_agent(
+async def admin_set_a2a_agent_state(
     agent_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -10907,16 +10907,16 @@ async def admin_toggle_a2a_agent(
         return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
 
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling A2A agent status{agent_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting A2A agent state {agent_id}: {e}")
         error_message = str(e)
     except A2AAgentNotFoundError as e:
-        LOGGER.error(f"A2A agent toggle failed - not found: {e}")
+        LOGGER.error(f"A2A agent set state failed - not found: {e}")
         root_path = request.scope.get("root_path", "")
         error_message = "A2A agent not found."
     except Exception as e:
-        LOGGER.error(f"Error toggling A2A agent: {e}")
+        LOGGER.error(f"Error setting A2A agent state: {e}")
         root_path = request.scope.get("root_path", "")
-        error_message = "Failed to toggle status of A2A agent. Please try again."
+        error_message = "Failed to set status of A2A agent. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -11163,12 +11163,12 @@ async def admin_update_grpc_service(
 
 
 @admin_router.post("/grpc/{service_id}/state")
-async def admin_toggle_grpc_service(
+async def admin_set_grpc_service_state(
     service_id: str,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
-    """Toggle a gRPC service's enabled status.
+    """Set a gRPC service's enabled status (via admin UI).
 
     Args:
         service_id: Service ID

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1815,7 +1815,7 @@ async def update_server(
         raise HTTPException(status_code=409, detail=ErrorFormatter.format_database_error(e))
 
 
-@server_router.post("/{server_id}/toggle", response_model=ServerRead)
+@server_router.post("/{server_id}/state", response_model=ServerRead)
 @require_permission("servers.update")
 async def toggle_server_status(
     server_id: str,
@@ -2290,7 +2290,7 @@ async def update_a2a_agent(
         raise HTTPException(status_code=409, detail=ErrorFormatter.format_database_error(e))
 
 
-@a2a_router.post("/{agent_id}/toggle", response_model=A2AAgentRead)
+@a2a_router.post("/{agent_id}/state", response_model=A2AAgentRead)
 @require_permission("a2a.update")
 async def toggle_a2a_agent_status(
     agent_id: str,
@@ -2689,7 +2689,7 @@ async def delete_tool(tool_id: str, db: Session = Depends(get_db), user=Depends(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
-@tool_router.post("/{tool_id}/toggle")
+@tool_router.post("/{tool_id}/state")
 @require_permission("tools.update")
 async def toggle_tool_status(
     tool_id: str,
@@ -2753,7 +2753,7 @@ async def list_resource_templates(
     return ListResourceTemplatesResult(_meta={}, resource_templates=resource_templates, next_cursor=None)  # No pagination for now
 
 
-@resource_router.post("/{resource_id}/toggle")
+@resource_router.post("/{resource_id}/state")
 @require_permission("resources.update")
 async def toggle_resource_status(
     resource_id: int,
@@ -3101,7 +3101,7 @@ async def subscribe_resource(resource_id: str, user=Depends(get_current_user_wit
 ###############
 # Prompt APIs #
 ###############
-@prompt_router.post("/{prompt_id}/toggle")
+@prompt_router.post("/{prompt_id}/state")
 @require_permission("prompts.update")
 async def toggle_prompt_status(
     prompt_id: int,
@@ -3460,7 +3460,7 @@ async def delete_prompt(prompt_id: str, db: Session = Depends(get_db), user=Depe
 ################
 # Gateway APIs #
 ################
-@gateway_router.post("/{gateway_id}/toggle")
+@gateway_router.post("/{gateway_id}/state")
 @require_permission("gateways.update")
 async def toggle_gateway_status(
     gateway_id: str,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1841,7 +1841,7 @@ async def set_server_state(
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
         logger.debug(f"User {user} is setting server {server_id} to {'active' if activate else 'inactive'}")
-        return await server_service.toggle_server_status(db, server_id, activate, user_email=user_email)
+        return await server_service.set_server_state(db, server_id, activate, user_email=user_email)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except ServerNotFoundError as e:
@@ -2318,7 +2318,7 @@ async def set_a2a_agent_state(
         logger.debug(f"User {user} is setting A2A agent with ID {agent_id} to {'active' if activate else 'inactive'}")
         if a2a_service is None:
             raise HTTPException(status_code=503, detail="A2A service not available")
-        return await a2a_service.toggle_agent_status(db, agent_id, activate, user_email=user_email)
+        return await a2a_service.set_a2a_agent_state(db, agent_id, activate, user_email=user_email)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except A2AAgentNotFoundError as e:
@@ -2715,7 +2715,7 @@ async def set_tool_state(
     try:
         logger.debug(f"User {user} is setting tool with ID {tool_id} to {'active' if activate else 'inactive'}")
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        tool = await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
+        tool = await tool_service.set_tool_state(db, tool_id, activate, reachable=activate, user_email=user_email)
         return {
             "status": "success",
             "message": f"Tool {tool_id} {'activated' if activate else 'deactivated'}",
@@ -2779,7 +2779,7 @@ async def set_resource_state(
     logger.debug(f"User {user} is setting resource with ID {resource_id} to {'active' if activate else 'inactive'}")
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        resource = await resource_service.toggle_resource_status(db, resource_id, activate, user_email=user_email)
+        resource = await resource_service.set_resource_state(db, resource_id, activate, user_email=user_email)
         return {
             "status": "success",
             "message": f"Resource {resource_id} {'activated' if activate else 'deactivated'}",
@@ -3127,7 +3127,7 @@ async def set_prompt_state(
     logger.debug(f"User: {user} requested set state for prompt {prompt_id}, activate={activate}")
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        prompt = await prompt_service.toggle_prompt_status(db, prompt_id, activate, user_email=user_email)
+        prompt = await prompt_service.set_prompt_state(db, prompt_id, activate, user_email=user_email)
         return {
             "status": "success",
             "message": f"Prompt {prompt_id} {'activated' if activate else 'deactivated'}",
@@ -3486,7 +3486,7 @@ async def set_gateway_state(
     logger.debug(f"User '{user}' requested set state for gateway {gateway_id}, activate={activate}")
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        gateway = await gateway_service.toggle_gateway_status(
+        gateway = await gateway_service.set_gateway_state(
             db,
             gateway_id,
             activate,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1817,7 +1817,7 @@ async def update_server(
 
 @server_router.post("/{server_id}/state", response_model=ServerRead)
 @require_permission("servers.update")
-async def toggle_server_status(
+async def set_server_state(
     server_id: str,
     activate: bool = True,
     db: Session = Depends(get_db),
@@ -1840,7 +1840,7 @@ async def toggle_server_status(
     """
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        logger.debug(f"User {user} is toggling server with ID {server_id} to {'active' if activate else 'inactive'}")
+        logger.debug(f"User {user} is setting server {server_id} to {'active' if activate else 'inactive'}")
         return await server_service.toggle_server_status(db, server_id, activate, user_email=user_email)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
@@ -2292,7 +2292,7 @@ async def update_a2a_agent(
 
 @a2a_router.post("/{agent_id}/state", response_model=A2AAgentRead)
 @require_permission("a2a.update")
-async def toggle_a2a_agent_status(
+async def set_a2a_agent_state(
     agent_id: str,
     activate: bool = True,
     db: Session = Depends(get_db),
@@ -2315,7 +2315,7 @@ async def toggle_a2a_agent_status(
     """
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        logger.debug(f"User {user} is toggling A2A agent with ID {agent_id} to {'active' if activate else 'inactive'}")
+        logger.debug(f"User {user} is setting A2A agent with ID {agent_id} to {'active' if activate else 'inactive'}")
         if a2a_service is None:
             raise HTTPException(status_code=503, detail="A2A service not available")
         return await a2a_service.toggle_agent_status(db, agent_id, activate, user_email=user_email)
@@ -2691,7 +2691,7 @@ async def delete_tool(tool_id: str, db: Session = Depends(get_db), user=Depends(
 
 @tool_router.post("/{tool_id}/state")
 @require_permission("tools.update")
-async def toggle_tool_status(
+async def set_tool_state(
     tool_id: str,
     activate: bool = True,
     db: Session = Depends(get_db),
@@ -2713,7 +2713,7 @@ async def toggle_tool_status(
         HTTPException: If an error occurs during status toggling.
     """
     try:
-        logger.debug(f"User {user} is toggling tool with ID {tool_id} to {'active' if activate else 'inactive'}")
+        logger.debug(f"User {user} is setting tool with ID {tool_id} to {'active' if activate else 'inactive'}")
         user_email = user.get("email") if isinstance(user, dict) else str(user)
         tool = await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
         return {
@@ -2755,7 +2755,7 @@ async def list_resource_templates(
 
 @resource_router.post("/{resource_id}/state")
 @require_permission("resources.update")
-async def toggle_resource_status(
+async def set_resource_state(
     resource_id: int,
     activate: bool = True,
     db: Session = Depends(get_db),
@@ -2776,7 +2776,7 @@ async def toggle_resource_status(
     Raises:
         HTTPException: If toggling fails.
     """
-    logger.debug(f"User {user} is toggling resource with ID {resource_id} to {'active' if activate else 'inactive'}")
+    logger.debug(f"User {user} is setting resource with ID {resource_id} to {'active' if activate else 'inactive'}")
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
         resource = await resource_service.toggle_resource_status(db, resource_id, activate, user_email=user_email)
@@ -3103,7 +3103,7 @@ async def subscribe_resource(resource_id: str, user=Depends(get_current_user_wit
 ###############
 @prompt_router.post("/{prompt_id}/state")
 @require_permission("prompts.update")
-async def toggle_prompt_status(
+async def set_prompt_state(
     prompt_id: int,
     activate: bool = True,
     db: Session = Depends(get_db),
@@ -3124,7 +3124,7 @@ async def toggle_prompt_status(
     Raises:
         HTTPException: If the toggle fails (e.g., prompt not found or database error); emitted with *400 Bad Request* status and an error message.
     """
-    logger.debug(f"User: {user} requested toggle for prompt {prompt_id}, activate={activate}")
+    logger.debug(f"User: {user} requested set state for prompt {prompt_id}, activate={activate}")
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
         prompt = await prompt_service.toggle_prompt_status(db, prompt_id, activate, user_email=user_email)
@@ -3462,7 +3462,7 @@ async def delete_prompt(prompt_id: str, db: Session = Depends(get_db), user=Depe
 ################
 @gateway_router.post("/{gateway_id}/state")
 @require_permission("gateways.update")
-async def toggle_gateway_status(
+async def set_gateway_state(
     gateway_id: str,
     activate: bool = True,
     db: Session = Depends(get_db),
@@ -3483,7 +3483,7 @@ async def toggle_gateway_status(
     Raises:
         HTTPException: Returned with **400 Bad Request** if the toggle operation fails (e.g., the gateway does not exist or the database raises an unexpected error).
     """
-    logger.debug(f"User '{user}' requested toggle for gateway {gateway_id}, activate={activate}")
+    logger.debug(f"User '{user}' requested set state for gateway {gateway_id}, activate={activate}")
     try:
         user_email = user.get("email") if isinstance(user, dict) else str(user)
         gateway = await gateway_service.toggle_gateway_status(

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1824,16 +1824,20 @@ async def set_server_state(
     user=Depends(get_current_user_with_permissions),
 ) -> ServerRead:
     """
-    Toggles the status of a server (activate or deactivate).
+    Set the state of a server (activate or deactivate).
+
+    This endpoint updates the server's active/inactive state. Prefer the
+    language "set ... state" over "toggle" to avoid ambiguity; the
+    `activate` boolean explicitly controls the resulting state.
 
     Args:
-        server_id (str): The ID of the server to toggle.
-        activate (bool): Whether to activate or deactivate the server.
+        server_id (str): The ID of the server to modify.
+        activate (bool): Whether to activate (True) or deactivate (False) the server.
         db (Session): The database session used to interact with the data store.
         user (str): The authenticated user making the request.
 
     Returns:
-        ServerRead: The server object after the status change.
+        ServerRead: The server object after the state change.
 
     Raises:
         HTTPException: If the server is not found or there is an error.
@@ -2299,16 +2303,20 @@ async def set_a2a_agent_state(
     user=Depends(get_current_user_with_permissions),
 ) -> A2AAgentRead:
     """
-    Toggles the status of an A2A agent (activate or deactivate).
+    Set the state of an A2A agent (activate or deactivate).
+
+    This endpoint updates the agent's active/inactive state. Use "set ... state"
+    wording rather than "toggle"; the `activate` boolean explicitly controls the
+    resulting state.
 
     Args:
-        agent_id (str): The ID of the agent to toggle.
-        activate (bool): Whether to activate or deactivate the agent.
+        agent_id (str): The ID of the agent to modify.
+        activate (bool): Whether to activate (True) or deactivate (False) the agent.
         db (Session): The database session used to interact with the data store.
         user (str): The authenticated user making the request.
 
     Returns:
-        A2AAgentRead: The agent object after the status change.
+        A2AAgentRead: The agent object after the state change.
 
     Raises:
         HTTPException: If the agent is not found or there is an error.

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2709,7 +2709,7 @@ async def set_tool_state(
     Activates or deactivates a tool.
 
     Args:
-        tool_id (str): The ID of the tool to toggle.
+        tool_id (str): The ID of the tool whose state to set.
         activate (bool): Whether to activate (`True`) or deactivate (`False`) the tool.
         db (Session): The database session dependency.
         user (str): The authenticated user making the request.
@@ -2718,7 +2718,7 @@ async def set_tool_state(
         Dict[str, Any]: The status, message, and updated tool data.
 
     Raises:
-        HTTPException: If an error occurs during status toggling.
+        HTTPException: If an error occurs during the state change.
     """
     try:
         logger.debug(f"User {user} is setting tool with ID {tool_id} to {'active' if activate else 'inactive'}")
@@ -3118,10 +3118,10 @@ async def set_prompt_state(
     user=Depends(get_current_user_with_permissions),
 ) -> Dict[str, Any]:
     """
-    Toggle the activation status of a prompt.
+    Set the activation state of a prompt.
 
     Args:
-        prompt_id: ID of the prompt to toggle.
+        prompt_id: ID of the prompt whose state to set.
         activate: True to activate, False to deactivate.
         db: Database session.
         user: Authenticated user.
@@ -3130,7 +3130,7 @@ async def set_prompt_state(
         Status message and updated prompt details.
 
     Raises:
-        HTTPException: If the toggle fails (e.g., prompt not found or database error); emitted with *400 Bad Request* status and an error message.
+        HTTPException: If the state change fails (e.g., prompt not found or database error); emitted with *400 Bad Request* status and an error message.
     """
     logger.debug(f"User: {user} requested set state for prompt {prompt_id}, activate={activate}")
     try:
@@ -3477,10 +3477,10 @@ async def set_gateway_state(
     user=Depends(get_current_user_with_permissions),
 ) -> Dict[str, Any]:
     """
-    Toggle the activation status of a gateway.
+    Set the activation state of a gateway.
 
     Args:
-        gateway_id (str): String ID of the gateway to toggle.
+        gateway_id (str): String ID of the gateway whose state to set.
         activate (bool): ``True`` to activate, ``False`` to deactivate.
         db (Session): Active SQLAlchemy session.
         user (str): Authenticated username.
@@ -3489,7 +3489,7 @@ async def set_gateway_state(
         Dict[str, Any]: A dict containing the operation status, a message, and the updated gateway object.
 
     Raises:
-        HTTPException: Returned with **400 Bad Request** if the toggle operation fails (e.g., the gateway does not exist or the database raises an unexpected error).
+        HTTPException: Returned with **400 Bad Request** if the state change fails (e.g., the gateway does not exist or the database raises an unexpected error).
     """
     logger.debug(f"User '{user}' requested set state for gateway {gateway_id}, activate={activate}")
     try:

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -119,7 +119,7 @@ class A2AAgentNameConflictError(A2AAgentError):
 class A2AAgentService:
     """Service for managing A2A agents in the gateway.
 
-    Provides methods to create, list, retrieve, update, toggle status, and delete agent records.
+    Provides methods to create, list, retrieve, update, set state, and delete agent records.
     Also supports interactions with A2A-compatible agents.
     """
 

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -675,8 +675,8 @@ class A2AAgentService:
             db.rollback()
             raise A2AAgentError(f"Failed to update A2A agent: {str(e)}")
 
-    async def toggle_agent_status(self, db: Session, agent_id: str, activate: bool, reachable: Optional[bool] = None, user_email: Optional[str] = None) -> A2AAgentRead:
-        """Toggle the activation status of an A2A agent.
+    async def set_a2a_agent_state(self, db: Session, agent_id: str, activate: bool, reachable: Optional[bool] = None, user_email: Optional[str] = None) -> A2AAgentRead:
+        """Set the activation state of an A2A agent.
 
         Args:
             db: Database session.
@@ -717,6 +717,9 @@ class A2AAgentService:
         logger.info(f"A2A agent {status}: {agent.name} (ID: {agent.id})")
 
         return self._db_to_schema(db=db, db_agent=agent)
+
+    # Backwards-compatible alias
+    toggle_agent_status = set_a2a_agent_state
 
     async def delete_agent(self, db: Session, agent_id: str, user_email: Optional[str] = None) -> None:
         """Delete an A2A agent.

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2076,7 +2076,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
         if count >= GW_FAILURE_THRESHOLD:
             logger.error(f"Gateway {gateway.name} failed {GW_FAILURE_THRESHOLD} times. Deactivating...")
             with cast(Any, SessionLocal)() as db:
-                await self.toggle_gateway_status(db, gateway.id, activate=True, reachable=False, only_update_reachable=True)
+                await self.set_gateway_state(db, gateway.id, activate=True, reachable=False, only_update_reachable=True)
                 self._gateway_failure_counts[gateway.id] = 0  # Reset after deactivation
 
     async def check_health_of_gateways(self, db: Session, gateways: List[DbGateway], user_email: Optional[str] = None) -> bool:
@@ -2275,7 +2275,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                             # Reactivate gateway if it was previously inactive and health check passed now
                             if gateway.enabled and not gateway.reachable:
                                 logger.info(f"Reactivating gateway: {gateway.name}, as it is healthy now")
-                                await self.toggle_gateway_status(db, gateway.id, activate=True, reachable=True, only_update_reachable=True)
+                                await self.set_gateway_state(db, gateway.id, activate=True, reachable=True, only_update_reachable=True)
 
                             # Mark successful check
                             gateway.last_seen = datetime.now(timezone.utc)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1671,10 +1671,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
 
                 if only_update_reachable:
                     for tool in tools:
-                        await self.tool_service.toggle_tool_status(db, tool.id, tool.enabled, reachable)
+                        await self.tool_service.set_tool_state(db, tool.id, tool.enabled, reachable)
                 else:
                     for tool in tools:
-                        await self.tool_service.toggle_tool_status(db, tool.id, activate, reachable)
+                        await self.tool_service.set_tool_state(db, tool.id, activate, reachable)
 
                 # Notify subscribers
                 if activate:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1546,9 +1546,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
 
         raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 
-    async def toggle_gateway_status(self, db: Session, gateway_id: str, activate: bool, reachable: bool = True, only_update_reachable: bool = False, user_email: Optional[str] = None) -> GatewayRead:
+    async def set_gateway_state(self, db: Session, gateway_id: str, activate: bool, reachable: bool = True, only_update_reachable: bool = False, user_email: Optional[str] = None) -> GatewayRead:
         """
-        Toggle the activation status of a gateway.
+        Set the activation state of a gateway.
 
         Args:
             db: Database session
@@ -1691,7 +1691,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             raise e
         except Exception as e:
             db.rollback()
-            raise GatewayError(f"Failed to toggle gateway status: {str(e)}")
+            raise GatewayError(f"Failed to set gateway state: {str(e)}")
+
+    # Backwards-compatible alias
+    toggle_gateway_status = set_gateway_state
 
     async def _notify_gateway_updated(self, gateway: DbGateway) -> None:
         """

--- a/mcpgateway/services/grpc_service.py
+++ b/mcpgateway/services/grpc_service.py
@@ -278,13 +278,13 @@ class GrpcService:
 
         return GrpcServiceRead.model_validate(service)
 
-    async def toggle_service(
+    async def set_grpc_service_state(
         self,
         db: Session,
         service_id: str,
         activate: bool,
     ) -> GrpcServiceRead:
-        """Toggle a gRPC service's enabled status.
+        """Set a gRPC service's enabled state.
 
         Args:
             db: Database session
@@ -312,6 +312,9 @@ class GrpcService:
         logger.info(f"gRPC service {service.name} {action}")
 
         return GrpcServiceRead.model_validate(service)
+
+    # Backwards-compatible alias
+    toggle_service = set_grpc_service_state
 
     async def delete_service(
         self,

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -1046,7 +1046,7 @@ class PromptService:
             >>> service._convert_db_prompt = MagicMock(return_value={})
             >>> import asyncio
             >>> try:
-            ...     asyncio.run(service.toggle_prompt_status(db, 1, True))
+            ...     asyncio.run(service.set_prompt_state(db, 1, True))
             ... except Exception:
             ...     pass
         """

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -1014,9 +1014,9 @@ class PromptService:
             db.rollback()
             raise PromptError(f"Failed to update prompt: {str(e)}")
 
-    async def toggle_prompt_status(self, db: Session, prompt_id: int, activate: bool, user_email: Optional[str] = None) -> PromptRead:
+    async def set_prompt_state(self, db: Session, prompt_id: int, activate: bool, user_email: Optional[str] = None) -> PromptRead:
         """
-        Toggle the activation status of a prompt.
+        Set the activation state of a prompt.
 
         Args:
             db: Database session
@@ -1079,7 +1079,10 @@ class PromptService:
             raise e
         except Exception as e:
             db.rollback()
-            raise PromptError(f"Failed to toggle prompt status: {str(e)}")
+            raise PromptError(f"Failed to set prompt state: {str(e)}")
+
+    # Backwards-compatible alias
+    toggle_prompt_status = set_prompt_state
 
     # Get prompt details for admin ui
     async def get_prompt_details(self, db: Session, prompt_id: Union[int, str], include_inactive: bool = False) -> Dict[str, Any]:  # pylint: disable=unused-argument

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -940,9 +940,9 @@ class ResourceService:
                     except Exception as e:
                         logger.warning(f"Failed to end observability span for resource reading: {e}")
 
-    async def toggle_resource_status(self, db: Session, resource_id: int, activate: bool, user_email: Optional[str] = None) -> ResourceRead:
+    async def set_resource_state(self, db: Session, resource_id: int, activate: bool, user_email: Optional[str] = None) -> ResourceRead:
         """
-        Toggle the activation status of a resource.
+        Set the activation state of a resource.
 
         Args:
             db: Database session
@@ -1010,7 +1010,10 @@ class ResourceService:
             raise e
         except Exception as e:
             db.rollback()
-            raise ResourceError(f"Failed to toggle resource status: {str(e)}")
+            raise ResourceError(f"Failed to set resource state: {str(e)}")
+
+    # Backwards-compatible alias
+    toggle_resource_status = set_resource_state
 
     async def subscribe_resource(self, db: Session, subscription: ResourceSubscription) -> None:
         """

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -973,7 +973,7 @@ class ResourceService:
             >>> service._convert_resource_to_read = MagicMock(return_value='resource_read')
             >>> ResourceRead.model_validate = MagicMock(return_value='resource_read')
             >>> import asyncio
-            >>> asyncio.run(service.toggle_resource_status(db, 1, True))
+            >>> asyncio.run(service.set_resource_state(db, 1, True))
             'resource_read'
         """
         try:

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -1363,6 +1363,8 @@ class ResourceService:
 
             raise ResourceNotFoundError(f"Resource not found: {resource_id}")
 
+        # Ensure team name is resolved before conversion (consistent with ToolService.get_tool)
+        resource.team = self._get_team_name(db, getattr(resource, "team_id", None))
         return self._convert_resource_to_read(resource)
 
     async def _notify_resource_activated(self, resource: DbResource) -> None:

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -959,8 +959,8 @@ class ServerService:
             db.rollback()
             raise ServerError(f"Failed to set server state: {str(e)}")
 
-            # Backwards-compatible alias
-            toggle_server_status = set_server_state
+        # Backwards-compatible alias
+        toggle_server_status = set_server_state
 
     async def delete_server(self, db: Session, server_id: str, user_email: Optional[str] = None) -> None:
         """Permanently delete a server.

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -103,7 +103,7 @@ class ServerNameConflictError(ServerError):
 class ServerService:
     """Service for managing MCP Servers in the catalog.
 
-    Provides methods to create, list, retrieve, update, toggle status, and delete server records.
+    Provides methods to create, list, retrieve, update, set state, and delete server records.
     Also supports event notifications for changes in server data.
     """
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -879,8 +879,8 @@ class ServerService:
             db.rollback()
             raise ServerError(f"Failed to update server: {str(e)}")
 
-    async def toggle_server_status(self, db: Session, server_id: str, activate: bool, user_email: Optional[str] = None) -> ServerRead:
-        """Toggle the activation status of a server.
+    async def set_server_state(self, db: Session, server_id: str, activate: bool, user_email: Optional[str] = None) -> ServerRead:
+        """Set the activation state of a server.
 
         Args:
             db: Database session.
@@ -957,7 +957,10 @@ class ServerService:
             raise e
         except Exception as e:
             db.rollback()
-            raise ServerError(f"Failed to toggle server status: {str(e)}")
+            raise ServerError(f"Failed to set server state: {str(e)}")
+
+            # Backwards-compatible alias
+            toggle_server_status = set_server_state
 
     async def delete_server(self, db: Session, server_id: str, user_email: Optional[str] = None) -> None:
         """Permanently delete a server.

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -911,7 +911,7 @@ class ServerService:
             >>> service._convert_server_to_read = MagicMock(return_value='server_read')
             >>> ServerRead.model_validate = MagicMock(return_value='server_read')
             >>> import asyncio
-            >>> asyncio.run(service.toggle_server_status(db, 'server_id', True))
+            >>> asyncio.run(service.set_server_state(db, 'server_id', True))
             'server_read'
         """
         try:
@@ -959,8 +959,8 @@ class ServerService:
             db.rollback()
             raise ServerError(f"Failed to set server state: {str(e)}")
 
-        # Backwards-compatible alias
-        toggle_server_status = set_server_state
+    # Backwards-compatible alias
+    toggle_server_status = set_server_state
 
     async def delete_server(self, db: Session, server_id: str, user_email: Optional[str] = None) -> None:
         """Permanently delete a server.

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1034,7 +1034,7 @@ class ToolService:
             >>> service._convert_tool_to_read = MagicMock(return_value='tool_read')
             >>> ToolRead.model_validate = MagicMock(return_value='tool_read')
             >>> import asyncio
-            >>> asyncio.run(service.toggle_tool_status(db, 'tool_id', True, True))
+            >>> asyncio.run(service.set_tool_state(db, 'tool_id', True, True))
             'tool_read'
         """
         try:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1000,9 +1000,9 @@ class ToolService:
             db.rollback()
             raise ToolError(f"Failed to delete tool: {str(e)}")
 
-    async def toggle_tool_status(self, db: Session, tool_id: str, activate: bool, reachable: bool, user_email: Optional[str] = None) -> ToolRead:
+    async def set_tool_state(self, db: Session, tool_id: str, activate: bool, reachable: bool, user_email: Optional[str] = None) -> ToolRead:
         """
-        Toggle the activation status of a tool.
+        Set the activation state of a tool.
 
         Args:
             db (Session): The SQLAlchemy database session.
@@ -1074,7 +1074,10 @@ class ToolService:
             raise e
         except Exception as e:
             db.rollback()
-            raise ToolError(f"Failed to toggle tool status: {str(e)}")
+            raise ToolError(f"Failed to set tool state: {str(e)}")
+
+    # Backwards-compatible alias
+    toggle_tool_status = set_tool_state
 
     async def invoke_tool(self, db: Session, name: str, arguments: Dict[str, Any], request_headers: Optional[Dict[str, str]] = None, app_user_email: Optional[str] = None) -> ToolResult:
         """
@@ -1620,9 +1623,9 @@ class ToolService:
             db.rollback()
             logger.error(f"Tool name conflict during update: {tnce}")
             raise tnce
-        except Exception as ex:
+        except Exception as e:
             db.rollback()
-            raise ToolError(f"Failed to update tool: {str(ex)}")
+            raise ToolError(f"Failed to update tool: {str(e)}")
 
     async def _notify_tool_updated(self, tool: DbTool) -> None:
         """

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1962,7 +1962,7 @@
                         {% if server.isActive %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/servers/{{ server.id }}/toggle"
+                          action="{{ root_path }}/admin/servers/{{ server.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'servers')"
                         >
@@ -1978,7 +1978,7 @@
                         {% else %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/servers/{{ server.id }}/toggle"
+                          action="{{ root_path }}/admin/servers/{{ server.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'servers')"
                         >
@@ -4173,7 +4173,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         {% if gateway.enabled %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
+                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'gateways')"
                         >
@@ -4189,7 +4189,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         {% else %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
+                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'gateways')"
                         >
@@ -5438,7 +5438,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                           <!-- Row 3: Activate/Deactivate | Delete -->
                           <div class="col-span-2 flex flex-col space-y-1">
                             {% if agent.enabled %}
-                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/toggle" class="contents">
+                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/state" class="contents">
                               <input type="hidden" name="activate" value="false" />
                               <button
                                 type="submit"
@@ -5449,7 +5449,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                               </button>
                             </form>
                             {% else %}
-                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/toggle" class="contents">
+                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/state" class="contents">
                               <input type="hidden" name="activate" value="true" />
                               <button
                                 type="submit"
@@ -6287,7 +6287,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     </div>
                   </div>
                   <div class="flex flex-col space-y-2 ml-4">
-                    <form action="{{ root_path }}/grpc/{{ service.id }}/toggle" method="POST" class="inline">
+                    <form action="{{ root_path }}/grpc/{{ service.id }}/state" method="POST" class="inline">
                       <button
                         type="submit"
                         class="px-3 py-1 text-sm font-medium rounded-md {% if service.enabled %}bg-yellow-100 text-yellow-800 hover:bg-yellow-200{% else %}bg-green-100 text-green-800 hover:bg-green-200{% endif %}"
@@ -9850,11 +9850,11 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
 
         const isActiveFlag = item.isActive || item.enabled || item.is_active;
         const activeButton = isActiveFlag ?
-          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/toggle" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
+          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/state" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
             <input type="hidden" name="activate" value="false" />
             <button type="submit" class="text-yellow-600 hover:text-yellow-900">Deactivate</button>
           </form>` :
-          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/toggle" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
+          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/state" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
             <input type="hidden" name="activate" value="true" />
             <button type="submit" class="text-blue-600 hover:text-blue-900">Activate</button>
           </form>`;

--- a/mcpgateway/templates/prompts_partial.html
+++ b/mcpgateway/templates/prompts_partial.html
@@ -41,7 +41,7 @@
 
         <!-- Row 3 & 4: Activate/Deactivate | Delete -->
         <div class="col-span-2 flex flex-col space-y-1">
-          <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'prompts')">
+          <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'prompts')">
             <input type="hidden" name="activate" value="{{ 'false' if prompt.is_active else 'true' }}" />
             <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md {% if prompt.is_active %}text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20{% else %}text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20{% endif %}">{% if prompt.is_active %}Deactivate{% else %}Activate{% endif %}</button>
           </form>

--- a/mcpgateway/templates/resources_partial.html
+++ b/mcpgateway/templates/resources_partial.html
@@ -34,12 +34,12 @@
         <button onclick="editResource('{{ resource.id }}')" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors">Edit</button>
         <div class="col-span-2 flex flex-col space-y-1">
           {% if resource.isActive %}
-          <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
+          <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
             <input type="hidden" name="activate" value="false" />
             <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20 transition-colors">Deactivate</button>
           </form>
           {% else %}
-          <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
+          <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
             <input type="hidden" name="activate" value="true" />
             <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-blue-600 hover:text-blue-900 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20 transition-colors">Activate</button>
           </form>

--- a/mcpgateway/templates/tools_partial.html
+++ b/mcpgateway/templates/tools_partial.html
@@ -222,7 +222,7 @@
           {% if tool.enabled %}
           <form
             method="POST"
-            action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle"
+            action="{{ root_path }}/admin/tools/{{ tool.id }}/state"
             class="contents"
             onsubmit="return handleToggleSubmit(event, 'tools')"
           >
@@ -238,7 +238,7 @@
           {% else %}
           <form
             method="POST"
-            action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle"
+            action="{{ root_path }}/admin/tools/{{ tool.id }}/state"
             class="contents"
             onsubmit="return handleToggleSubmit(event, 'tools')"
           >

--- a/mcpgateway/templates/tools_with_pagination.html
+++ b/mcpgateway/templates/tools_with_pagination.html
@@ -128,14 +128,14 @@
           <!-- Row 3: Deactivate/Activate | Delete -->
           <div class="col-span-2 flex flex-col space-y-1">
             {% if tool.enabled %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="false" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20 transition-colors" x-tooltip="'💡Temporarily disable this tool'">
                   Deactivate
                 </button>
               </form>
             {% else %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="true" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors" x-tooltip="'💡Re-enable this tool'">
                   Activate
@@ -285,14 +285,14 @@
           <!-- Row 3: Deactivate/Activate | Delete -->
           <div class="col-span-2 flex flex-col space-y-1">
             {% if tool.enabled %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="false" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20 transition-colors" x-tooltip="'💡Temporarily disable this tool'">
                   Deactivate
                 </button>
               </form>
             {% else %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="true" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors" x-tooltip="'💡Re-enable this tool'">
                   Activate

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -249,7 +249,7 @@ class TestAdminServerAPIs:
         response = await client.post(f"/admin/servers/{server_id}/edit", data=edit_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 200
 
-        # Toggle server status
+        # Set server state
         response = await client.post(f"/admin/servers/{server_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 303
 

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -250,7 +250,7 @@ class TestAdminServerAPIs:
         assert response.status_code == 200
 
         # Toggle server status
-        response = await client.post(f"/admin/servers/{server_id}/toggle", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        response = await client.post(f"/admin/servers/{server_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 303
 
         # Delete server
@@ -324,7 +324,7 @@ class TestAdminToolAPIs:
     #     assert response.status_code == 303
 
     #     # Toggle tool status
-    #     response = await client.post(f"/admin/tools/{tool_id}/toggle", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
+    #     response = await client.post(f"/admin/tools/{tool_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
     #     assert response.status_code == 303
 
     #     # Delete tool
@@ -520,7 +520,7 @@ class TestAdminPromptAPIs:
         assert response.status_code == 200
 
         # Toggle prompt status
-        response = await client.post(f"/admin/prompts/{prompt_id}/toggle", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        response = await client.post(f"/admin/prompts/{prompt_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 303
 
         # Delete prompt (use updated name)
@@ -699,7 +699,7 @@ class TestAdminIncludeInactive:
     #         "is_inactive_checked": "true",
     #     }
 
-    #     response = await client.post(f"/admin/servers/{server_id}/toggle", data=form_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
+    #     response = await client.post(f"/admin/servers/{server_id}/state", data=form_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
 
     #     assert response.status_code == 303
     #     assert "include_inactive=true" in response.headers["location"]

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -583,7 +583,7 @@ class TestServerAPIs:
         assert result["description"] == update_data["description"]
         assert result["icon"] == update_data["icon"]
 
-    async def test_toggle_server_status(self, client: AsyncClient, mock_auth):
+    async def test_set_server_state(self, client: AsyncClient, mock_auth):
         """Test POST /servers/{server_id}/state."""
         # Create a server
         server_data = {"server": {"name": "toggle_test_server"}, "team_id": None, "visibility": "private"}

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -584,7 +584,7 @@ class TestServerAPIs:
         assert result["icon"] == update_data["icon"]
 
     async def test_toggle_server_status(self, client: AsyncClient, mock_auth):
-        """Test POST /servers/{server_id}/toggle."""
+        """Test POST /servers/{server_id}/state."""
         # Create a server
         server_data = {"server": {"name": "toggle_test_server"}, "team_id": None, "visibility": "private"}
 
@@ -592,7 +592,7 @@ class TestServerAPIs:
         server_id = create_response.json()["id"]
 
         # Deactivate the server
-        response = await client.post(f"/servers/{server_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/servers/{server_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         result = response.json()
@@ -603,7 +603,7 @@ class TestServerAPIs:
         assert result.get("isActive") is False or result.get("is_active") is False
 
         # Reactivate the server
-        response = await client.post(f"/servers/{server_id}/toggle?activate=true", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/servers/{server_id}/state?activate=true", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         result = response.json()
@@ -819,7 +819,7 @@ class TestToolAPIs:
         assert result["headers"] == update_data["headers"]
 
     async def test_toggle_tool_status(self, client: AsyncClient, mock_auth):
-        """Test POST /tools/{tool_id}/toggle."""
+        """Test POST /tools/{tool_id}/state."""
         # Create a tool
         tool_data = {"tool": {"name": "test_toggle_tool"}, "team_id": None, "visibility": "private"}
 
@@ -827,7 +827,7 @@ class TestToolAPIs:
         tool_id = create_response.json()["id"]
 
         # Deactivate the tool
-        response = await client.post(f"/tools/{tool_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/tools/{tool_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         result = response.json()
@@ -1042,15 +1042,15 @@ class TestResourceAPIs:
         assert result["description"] == update_data["description"]
 
     async def test_toggle_resource_status(self, client: AsyncClient, mock_auth):
-        """Test POST /resources/{resource_id}/toggle."""
+        """Test POST /resources/{resource_id}/state."""
         # Create a resource
-        resource_data = {"resource": {"uri": "test/toggle", "name": "toggle_test", "content": "Test"}, "team_id": None, "visibility": "private"}
+        resource_data = {"resource": {"uri": "test/state", "name": "toggle_test", "content": "Test"}, "team_id": None, "visibility": "private"}
 
         create_response = await client.post("/resources", json=resource_data, headers=TEST_AUTH_HEADER)
         resource_id = create_response.json()["id"]
 
         # Toggle resource status
-        response = await client.post(f"/resources/{resource_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/resources/{resource_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -1256,7 +1256,7 @@ class TestPromptAPIs:
         assert "messages" in result
 
     async def test_toggle_prompt_status(self, client: AsyncClient, mock_auth):
-        """Test POST /prompts/{prompt_id}/toggle."""
+        """Test POST /prompts/{prompt_id}/state."""
         # Create a prompt
         prompt_data = {"prompt": {"name": "toggle_prompt", "template": "Test prompt", "arguments": []}, "team_id": None, "visibility": "private"}
 
@@ -1264,7 +1264,7 @@ class TestPromptAPIs:
         prompt_id = create_response.json()["id"]
 
         # Toggle prompt status
-        response = await client.post(f"/prompts/{prompt_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/prompts/{prompt_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -1408,7 +1408,7 @@ class TestGatewayAPIs:
         """Test POST /gateways - would require mocking external connections."""
 
     async def test_toggle_gateway_status(self, client: AsyncClient, mock_auth):
-        """Test POST /gateways/{gateway_id}/toggle."""
+        """Test POST /gateways/{gateway_id}/state."""
         # Mock a gateway for testing
         # In real tests, you'd need to register a gateway first
         # This is skipped as it requires external connectivity

--- a/tests/integration/test_resource_plugin_integration.py
+++ b/tests/integration/test_resource_plugin_integration.py
@@ -352,7 +352,7 @@ class TestResourcePluginIntegration:
         created = await service.register_resource(test_db, resource)
 
         # Deactivate the resource
-        await service.toggle_resource_status(test_db, created.id, activate=False)
+        await service.set_resource_state(test_db, created.id, activate=False)
 
 
         # Try to read inactive resource

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -243,7 +243,7 @@ class TestA2AAgentService:
         service._db_to_schema = MagicMock(return_value=MagicMock())
 
         # Execute
-        result = await service.toggle_agent_status(mock_db, sample_db_agent.id, False)
+        result = await service.set_a2a_agent_state(mock_db, sample_db_agent.id, False)
 
         # Verify
         assert sample_db_agent.enabled == False

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -234,8 +234,8 @@ class TestA2AAgentService:
         with pytest.raises(A2AAgentNotFoundError):
             await service.update_agent(mock_db, "non-existent-id", update_data)
 
-    async def test_toggle_agent_status_success(self, service, mock_db, sample_db_agent):
-        """Test successful agent status toggle."""
+    async def test_set_a2a_agent_state_success(self, service, mock_db, sample_db_agent):
+        """Test successful agent state update."""
         # Mock database query
         mock_db.execute.return_value.scalar_one_or_none.return_value = sample_db_agent
         mock_db.commit = MagicMock()

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1037,7 +1037,7 @@ class TestGatewayService:
         test_db.commit.assert_called_once()
 
     # ────────────────────────────────────────────────────────────────────
-    # TOGGLE ACTIVE / INACTIVE
+    # SET ACTIVE / INACTIVE
     # ────────────────────────────────────────────────────────────────────
 
     @pytest.mark.asyncio
@@ -1047,7 +1047,7 @@ class TestGatewayService:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        # Return one tool so toggle_tool_status gets called
+        # Return one tool so set_tool_state gets called
         query_proxy = MagicMock()
         filter_proxy = MagicMock()
         filter_proxy.all.return_value = [MagicMock(id=101)]
@@ -1083,7 +1083,7 @@ class TestGatewayService:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        # Return one tool so toggle_tool_status gets called
+        # Return one tool so set_tool_state gets called
         query_proxy = MagicMock()
         filter_proxy = MagicMock()
         filter_proxy.all.return_value = [MagicMock(id=101)]
@@ -1129,7 +1129,7 @@ class TestGatewayService:
         test_db.refresh = Mock()
         test_db.rollback = Mock()
 
-        # Return one tool so toggle_tool_status gets called
+        # Return one tool so set_tool_state gets called
         query_proxy = MagicMock()
         filter_proxy = MagicMock()
         filter_proxy.all.return_value = [MagicMock(id=101)]
@@ -1140,9 +1140,9 @@ class TestGatewayService:
         gateway_service._notify_gateway_deactivated = AsyncMock()
         gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
 
-        # Make tool toggle fail
+        # Make tool set_state fail
         tool_service_stub = MagicMock()
-        tool_service_stub.set_tool_state = AsyncMock(side_effect=Exception("Tool toggle failed"))
+        tool_service_stub.set_tool_state = AsyncMock(side_effect=Exception("Tool set_state failed"))
         gateway_service.tool_service = tool_service_stub
 
         # The toggle_gateway_status method will catch the exception and raise GatewayError
@@ -1150,7 +1150,7 @@ class TestGatewayService:
             await gateway_service.set_gateway_state(test_db, 1, activate=False)
 
         assert "Failed to set gateway state" in str(exc_info.value)
-        assert "Tool toggle failed" in str(exc_info.value)
+        assert "Tool set_state failed" in str(exc_info.value)
         test_db.rollback.assert_called_once()
 
     # ────────────────────────────────────────────────────────────────────

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1041,8 +1041,8 @@ class TestGatewayService:
     # ────────────────────────────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_toggle_gateway_status(self, gateway_service, mock_gateway, test_db):
-        """Deactivating an active gateway triggers tool-status toggle + event."""
+    async def test_set_gateway_state(self, gateway_service, mock_gateway, test_db):
+        """Deactivating an active gateway triggers tool-state updates + event."""
         test_db.get = Mock(return_value=mock_gateway)
         test_db.commit = Mock()
         test_db.refresh = Mock()
@@ -1076,7 +1076,7 @@ class TestGatewayService:
         assert result == mock_gateway_read
 
     @pytest.mark.asyncio
-    async def test_toggle_gateway_status_activate(self, gateway_service, mock_gateway, test_db):
+    async def test_set_gateway_state_activate(self, gateway_service, mock_gateway, test_db):
         """Test activating an inactive gateway."""
         mock_gateway.enabled = False
         test_db.get = Mock(return_value=mock_gateway)
@@ -1112,8 +1112,8 @@ class TestGatewayService:
         assert result == mock_gateway_read
 
     @pytest.mark.asyncio
-    async def test_toggle_gateway_status_not_found(self, gateway_service, test_db):
-        """Test toggling status of non-existent gateway."""
+    async def test_set_gateway_state_not_found(self, gateway_service, test_db):
+        """Test setting status of non-existent gateway."""
         test_db.get = Mock(return_value=None)
 
         with pytest.raises(GatewayError) as exc_info:
@@ -1122,8 +1122,8 @@ class TestGatewayService:
         assert "Gateway not found: 999" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_toggle_gateway_status_with_tools_error(self, gateway_service, mock_gateway, test_db):
-        """Test toggling gateway status when tool toggle fails."""
+    async def test_set_gateway_state_with_tools_error(self, gateway_service, mock_gateway, test_db):
+        """Test setting gateway status when tool state update fails."""
         test_db.get = Mock(return_value=mock_gateway)
         test_db.commit = Mock()
         test_db.refresh = Mock()

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1068,7 +1068,7 @@ class TestGatewayService:
         mock_gateway_read.masked.return_value = mock_gateway_read
 
         with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
-            result = await gateway_service.toggle_gateway_status(test_db, 1, activate=False)
+            result = await gateway_service.set_gateway_state(test_db, 1, activate=False)
 
         assert mock_gateway.enabled is False
         gateway_service._notify_gateway_deactivated.assert_called_once()
@@ -1104,7 +1104,7 @@ class TestGatewayService:
         mock_gateway_read.masked.return_value = mock_gateway_read
 
         with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
-            result = await gateway_service.toggle_gateway_status(test_db, 1, activate=True)
+            result = await gateway_service.set_gateway_state(test_db, 1, activate=True)
 
         assert mock_gateway.enabled is True
         gateway_service._notify_gateway_activated.assert_called_once()
@@ -1117,7 +1117,7 @@ class TestGatewayService:
         test_db.get = Mock(return_value=None)
 
         with pytest.raises(GatewayError) as exc_info:
-            await gateway_service.toggle_gateway_status(test_db, 999, activate=True)
+            await gateway_service.set_gateway_state(test_db, 999, activate=True)
 
         assert "Gateway not found: 999" in str(exc_info.value)
 
@@ -1147,9 +1147,9 @@ class TestGatewayService:
 
         # The toggle_gateway_status method will catch the exception and raise GatewayError
         with pytest.raises(GatewayError) as exc_info:
-            await gateway_service.toggle_gateway_status(test_db, 1, activate=False)
+            await gateway_service.set_gateway_state(test_db, 1, activate=False)
 
-        assert "Failed to toggle gateway status" in str(exc_info.value)
+        assert "Failed to set gateway state" in str(exc_info.value)
         assert "Tool toggle failed" in str(exc_info.value)
         test_db.rollback.assert_called_once()
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1060,7 +1060,7 @@ class TestGatewayService:
         gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
 
         tool_service_stub = MagicMock()
-        tool_service_stub.toggle_tool_status = AsyncMock()
+        tool_service_stub.set_tool_state = AsyncMock()
         gateway_service.tool_service = tool_service_stub
 
         # Patch model_validate to return a mock with .masked()
@@ -1072,7 +1072,7 @@ class TestGatewayService:
 
         assert mock_gateway.enabled is False
         gateway_service._notify_gateway_deactivated.assert_called_once()
-        assert tool_service_stub.toggle_tool_status.called
+        assert tool_service_stub.set_tool_state.called
         assert result == mock_gateway_read
 
     @pytest.mark.asyncio
@@ -1096,7 +1096,7 @@ class TestGatewayService:
         gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
 
         tool_service_stub = MagicMock()
-        tool_service_stub.toggle_tool_status = AsyncMock()
+        tool_service_stub.set_tool_state = AsyncMock()
         gateway_service.tool_service = tool_service_stub
 
         # Patch model_validate to return a mock with .masked()
@@ -1108,7 +1108,7 @@ class TestGatewayService:
 
         assert mock_gateway.enabled is True
         gateway_service._notify_gateway_activated.assert_called_once()
-        assert tool_service_stub.toggle_tool_status.called
+        assert tool_service_stub.set_tool_state.called
         assert result == mock_gateway_read
 
     @pytest.mark.asyncio
@@ -1142,7 +1142,7 @@ class TestGatewayService:
 
         # Make tool toggle fail
         tool_service_stub = MagicMock()
-        tool_service_stub.toggle_tool_status = AsyncMock(side_effect=Exception("Tool toggle failed"))
+        tool_service_stub.set_tool_state = AsyncMock(side_effect=Exception("Tool toggle failed"))
         gateway_service.tool_service = tool_service_stub
 
         # The toggle_gateway_status method will catch the exception and raise GatewayError

--- a/tests/unit/mcpgateway/services/test_grpc_service.py
+++ b/tests/unit/mcpgateway/services/test_grpc_service.py
@@ -247,7 +247,7 @@ class TestGrpcService:
         mock_db.commit = MagicMock()
         mock_db.refresh = MagicMock()
 
-        result = await service.toggle_service(mock_db, sample_db_service.id, activate=False)
+        result = await service.set_grpc_service_state(mock_db, sample_db_service.id, activate=False)
 
         assert result.enabled is False
         mock_db.commit.assert_called()

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -391,7 +391,7 @@ class TestPromptService:
         test_db.commit = Mock(side_effect=Exception("fail"))
         with pytest.raises(PromptError) as exc_info:
             await prompt_service.set_prompt_state(test_db, 1, activate=False)
-        assert "Failed to toggle prompt status" in str(exc_info.value)
+        assert "Failed to set prompt state" in str(exc_info.value)
 
     # ──────────────────────────────────────────────────────────────────
     #   delete_prompt

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -371,7 +371,7 @@ class TestPromptService:
         test_db.refresh = Mock()
         prompt_service._notify_prompt_deactivated = AsyncMock()
 
-        res = await prompt_service.toggle_prompt_status(test_db, 1, activate=False)
+        res = await prompt_service.set_prompt_state(test_db, 1, activate=False)
 
         assert p.is_active is False
         prompt_service._notify_prompt_deactivated.assert_called_once()
@@ -381,7 +381,7 @@ class TestPromptService:
     async def test_toggle_prompt_status_not_found(self, prompt_service, test_db):
         test_db.get = Mock(return_value=None)
         with pytest.raises(PromptError) as exc_info:
-            await prompt_service.toggle_prompt_status(test_db, 999, activate=True)
+            await prompt_service.set_prompt_state(test_db, 999, activate=True)
         assert "Prompt not found" in str(exc_info.value)
 
     @pytest.mark.asyncio
@@ -390,7 +390,7 @@ class TestPromptService:
         test_db.get = Mock(return_value=p)
         test_db.commit = Mock(side_effect=Exception("fail"))
         with pytest.raises(PromptError) as exc_info:
-            await prompt_service.toggle_prompt_status(test_db, 1, activate=False)
+            await prompt_service.set_prompt_state(test_db, 1, activate=False)
         assert "Failed to toggle prompt status" in str(exc_info.value)
 
     # ──────────────────────────────────────────────────────────────────

--- a/tests/unit/mcpgateway/services/test_prompt_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service_extended.py
@@ -184,8 +184,8 @@ class TestPromptServiceExtended:
         service = PromptService()
 
         # Test method exists
-        assert hasattr(service, 'toggle_prompt_status')
-        assert callable(getattr(service, 'toggle_prompt_status'))
+        assert hasattr(service, 'set_prompt_state')
+        assert callable(getattr(service, 'set_prompt_state'))
 
     @pytest.mark.asyncio
     async def test_toggle_prompt_status_no_change_needed(self):
@@ -195,7 +195,7 @@ class TestPromptServiceExtended:
         # Test method is async
         # Standard
         import asyncio
-        assert asyncio.iscoroutinefunction(service.toggle_prompt_status)
+        assert asyncio.iscoroutinefunction(service.set_prompt_state)
 
     @pytest.mark.asyncio
     async def test_delete_prompt_not_found(self):

--- a/tests/unit/mcpgateway/services/test_prompt_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service_extended.py
@@ -179,8 +179,8 @@ class TestPromptServiceExtended:
         assert callable(method)
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status_not_found(self):
-        """Test toggle_prompt_status method exists."""
+    async def test_set_prompt_state_exists(self):
+        """Test set_prompt_state method exists."""
         service = PromptService()
 
         # Test method exists
@@ -188,12 +188,11 @@ class TestPromptServiceExtended:
         assert callable(getattr(service, 'set_prompt_state'))
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status_no_change_needed(self):
-        """Test toggle_prompt_status method is async."""
+    async def test_set_prompt_state_is_async(self):
+        """Test set_prompt_state method is async."""
         service = PromptService()
 
         # Test method is async
-        # Standard
         import asyncio
         assert asyncio.iscoroutinefunction(service.set_prompt_state)
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -524,7 +524,7 @@ class TestResourceManagement:
     """Test resource management operations."""
 
     @pytest.mark.asyncio
-    async def test_toggle_resource_status_activate(self, resource_service, mock_db, mock_inactive_resource):
+    async def test_set_resource_state_activate(self, resource_service, mock_db, mock_inactive_resource):
         """Test activating an inactive resource."""
         mock_db.get.return_value = mock_inactive_resource
 
@@ -558,7 +558,7 @@ class TestResourceManagement:
             mock_db.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_toggle_resource_status_deactivate(self, resource_service, mock_db, mock_resource):
+    async def test_set_resource_state_deactivate(self, resource_service, mock_db, mock_resource):
         """Test deactivating an active resource."""
         mock_db.get.return_value = mock_resource
 
@@ -592,8 +592,8 @@ class TestResourceManagement:
             mock_db.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_toggle_resource_status_not_found(self, resource_service, mock_db):
-        """Test toggling status of non-existent resource."""
+    async def test_set_resource_state_not_found(self, resource_service, mock_db):
+        """Test setting status of non-existent resource."""
         mock_db.get.return_value = None
 
         with pytest.raises(ResourceError) as exc_info:  # ResourceError, not ResourceNotFoundError
@@ -603,8 +603,8 @@ class TestResourceManagement:
         assert "999" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_toggle_resource_status_no_change(self, resource_service, mock_db, mock_resource):
-        """Test toggling status when no change needed."""
+    async def test_set_resource_state_no_change(self, resource_service, mock_db, mock_resource):
+        """Test setting status when no change needed."""
         mock_db.get.return_value = mock_resource
         mock_resource.is_active = True
 
@@ -1407,8 +1407,8 @@ class TestErrorHandling:
             mock_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_toggle_resource_status_error(self, resource_service, mock_db, mock_resource):
-        """Test toggle status with error."""
+    async def test_set_resource_state_error(self, resource_service, mock_db, mock_resource):
+        """Test setting resource status with error."""
         mock_db.get.return_value = mock_resource
         mock_db.commit.side_effect = Exception("Database error")
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -552,7 +552,7 @@ class TestResourceManagement:
                 },
             )
 
-            result = await resource_service.toggle_resource_status(mock_db, 2, activate=True)
+            result = await resource_service.set_resource_state(mock_db, 2, activate=True)
 
             assert mock_inactive_resource.is_active is True
             mock_db.commit.assert_called_once()
@@ -586,7 +586,7 @@ class TestResourceManagement:
                 },
             )
 
-            result = await resource_service.toggle_resource_status(mock_db, 1, activate=False)
+            result = await resource_service.set_resource_state(mock_db, 1, activate=False)
 
             assert mock_resource.is_active is False
             mock_db.commit.assert_called_once()
@@ -597,7 +597,7 @@ class TestResourceManagement:
         mock_db.get.return_value = None
 
         with pytest.raises(ResourceError) as exc_info:  # ResourceError, not ResourceNotFoundError
-            await resource_service.toggle_resource_status(mock_db, 999, activate=True)
+            await resource_service.set_resource_state(mock_db, 999, activate=True)
 
         # The actual error message will vary, just check it mentions the resource
         assert "999" in str(exc_info.value)
@@ -633,7 +633,7 @@ class TestResourceManagement:
             )
 
             # Try to activate already active resource
-            result = await resource_service.toggle_resource_status(mock_db, 1, activate=True)
+            result = await resource_service.set_resource_state(mock_db, 1, activate=True)
 
             # Should not commit or notify
             mock_db.commit.assert_not_called()

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1413,7 +1413,7 @@ class TestErrorHandling:
         mock_db.commit.side_effect = Exception("Database error")
 
         with pytest.raises(ResourceError):
-            await resource_service.toggle_resource_status(mock_db, 1, activate=False)
+            await resource_service.set_resource_state(mock_db, 1, activate=False)
 
         mock_db.rollback.assert_called_once()
 

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -737,7 +737,7 @@ class TestServerService:
             )
         )
 
-        result = await server_service.toggle_server_status(test_db, 1, activate=False)
+        result = await server_service.set_server_state(test_db, 1, activate=False)
 
         test_db.get.assert_called_once_with(DbServer, 1)
         test_db.commit.assert_called_once()

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -704,7 +704,7 @@ class TestServerService:
 
     # -------------------------- toggle --------------------------------- #
     @pytest.mark.asyncio
-    async def test_toggle_server_status(self, server_service, mock_server, test_db):
+    async def test_set_server_state(self, server_service, mock_server, test_db):
         mock_server.team_id = 1
         test_db.get = Mock(return_value=mock_server)
         test_db.commit = Mock()

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -723,8 +723,8 @@ class TestToolService:
         assert "Tool not found: 999" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status(self, tool_service, mock_tool, test_db):
-        """Test toggling tool active status."""
+    async def test_set_tool_state(self, tool_service, mock_tool, test_db):
+        """Test setting tool active status."""
         # Mock DB get to return tool
         test_db.get = Mock(return_value=mock_tool)
         test_db.commit = Mock()
@@ -789,8 +789,8 @@ class TestToolService:
         assert result == tool_read
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status_not_found(self, tool_service, test_db):
-        """Test toggling tool active status."""
+    async def test_set_tool_state_not_found(self, tool_service, test_db):
+        """Test setting tool active status when tool not found."""
         # Mock DB get to return tool
         test_db.get = Mock(return_value=None)
         test_db.commit = Mock()
@@ -805,8 +805,8 @@ class TestToolService:
         test_db.get.assert_called_once_with(DbTool, "1")
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status_activate_tool(self, tool_service, test_db, mock_tool, monkeypatch):
-        """Test toggling tool active status."""
+    async def test_set_tool_state_activate_tool(self, tool_service, test_db, mock_tool, monkeypatch):
+        """Test setting tool active status (activate)."""
         # Mock DB get to return tool
         mock_tool.enabled = False
         test_db.get = Mock(return_value=mock_tool)
@@ -906,8 +906,8 @@ class TestToolService:
         assert q.empty()
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status_no_change(self, tool_service, mock_tool, test_db):
-        """Test toggling tool active status."""
+    async def test_set_tool_state_no_change(self, tool_service, mock_tool, test_db):
+        """Test setting tool active status with no-op when already in desired state."""
         # Mock DB get to return tool
         test_db.get = Mock(return_value=mock_tool)
         test_db.commit = Mock()

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -771,7 +771,7 @@ class TestToolService:
         tool_service._convert_tool_to_read = Mock(return_value=tool_read)
 
         # Deactivate the tool (it's active by default)
-        result = await tool_service.toggle_tool_status(test_db, 1, activate=False, reachable=True)
+        result = await tool_service.set_tool_state(test_db, 1, activate=False, reachable=True)
 
         # Verify DB operations
         test_db.get.assert_called_once_with(DbTool, 1)
@@ -797,7 +797,7 @@ class TestToolService:
         test_db.refresh = Mock()
 
         with pytest.raises(ToolError) as exc:
-            await tool_service.toggle_tool_status(test_db, "1", activate=False, reachable=True)
+            await tool_service.set_tool_state(test_db, "1", activate=False, reachable=True)
 
         assert "Tool not found: 1" in str(exc.value)
 
@@ -815,7 +815,7 @@ class TestToolService:
 
         tool_service._notify_tool_activated = AsyncMock()
 
-        result = await tool_service.toggle_tool_status(test_db, "1", activate=True, reachable=True)
+        result = await tool_service.set_tool_state(test_db, "1", activate=True, reachable=True)
 
         # Verify DB operations
         test_db.get.assert_called_once_with(DbTool, "1")
@@ -954,7 +954,7 @@ class TestToolService:
         tool_service._convert_tool_to_read = Mock(return_value=tool_read)
 
         # Deactivate the tool (it's active by default)
-        result = await tool_service.toggle_tool_status(test_db, 1, activate=True, reachable=True)
+        result = await tool_service.set_tool_state(test_db, 1, activate=True, reachable=True)
 
         # Verify DB operations
         test_db.get.assert_called_once_with(DbTool, 1)

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -328,9 +328,9 @@ class TestAdminServerRoutes:
         assert result.status_code in (200, 409, 422, 500)
 
     @patch.object(ServerService, "set_server_state")
-    async def test_admin_toggle_server_with_exception(self, mock_toggle_status, mock_request, mock_db):
-        """Test toggling server status with exception handling."""
-        mock_toggle_status.side_effect = Exception("Toggle operation failed")
+    async def test_admin_set_server_state_with_exception(self, mock_set_status, mock_request, mock_db):
+        """Test setting server state with exception handling."""
+        mock_set_status.side_effect = Exception("Toggle operation failed")
 
         # Should still return redirect
         result = await admin_set_server_state("server-1", mock_request, mock_db, "test-user")
@@ -530,7 +530,7 @@ class TestAdminToolRoutes:
         assert tool_update.input_schema == {}
 
     @patch.object(ToolService, "set_tool_state")
-    async def test_admin_toggle_tool_various_activate_values(self, mock_toggle_status, mock_request, mock_db):
+    async def test_admin_set_tool_state_various_activate_values(self, mock_set_status, mock_request, mock_db):
         """Test toggling tool with various activate values."""
         tool_id = "tool-1"
 
@@ -539,21 +539,21 @@ class TestAdminToolRoutes:
         mock_request.form = AsyncMock(return_value=form_data)
 
         await admin_set_tool_state(tool_id, mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, tool_id, False, reachable=False, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, tool_id, False, reachable=False, user_email="test-user")
 
         # Test with "FALSE"
         form_data = FakeForm({"activate": "FALSE"})
         mock_request.form = AsyncMock(return_value=form_data)
 
         await admin_set_tool_state(tool_id, mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, tool_id, False, reachable=False, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, tool_id, False, reachable=False, user_email="test-user")
 
         # Test with missing activate field (defaults to true)
         form_data = FakeForm({})
         mock_request.form = AsyncMock(return_value=form_data)
 
         await admin_set_tool_state(tool_id, mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, tool_id, True, reachable=True, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, tool_id, True, reachable=True, user_email="test-user")
 
 
 class TestAdminBulkImportRoutes:
@@ -874,15 +874,15 @@ class TestAdminResourceRoutes:
         assert mock_update_resource.call_args[0][1] == uri
 
     @patch.object(ResourceService, "set_resource_state")
-    async def test_admin_toggle_resource_numeric_id(self, mock_toggle_status, mock_request, mock_db):
+    async def test_admin_set_resource_state_numeric_id(self, mock_set_status, mock_request, mock_db):
         """Test toggling resource with numeric ID."""
         # Test with integer ID
         await admin_set_resource_state(123, mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, 123, True, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, 123, True, user_email="test-user")
 
         # Test with string number
         await admin_set_resource_state("456", mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, "456", True, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, "456", True, user_email="test-user")
 
 
 class TestAdminPromptRoutes:
@@ -1030,15 +1030,15 @@ class TestAdminPromptRoutes:
         assert mock_update_prompt.call_args[0][1] == "old-prompt-name"
 
     @patch.object(PromptService, "set_prompt_state")
-    async def test_admin_toggle_prompt_edge_cases(self, mock_toggle_status, mock_request, mock_db):
+    async def test_admin_set_prompt_state_edge_cases(self, mock_set_status, mock_request, mock_db):
         """Test toggling prompt with edge cases."""
         # Test with string ID that looks like number
         await admin_set_prompt_state("123", mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, "123", True, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, "123", True, user_email="test-user")
 
         # Test with negative number
         await admin_set_prompt_state(-1, mock_request, mock_db, "test-user")
-        mock_toggle_status.assert_called_with(mock_db, -1, True, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, -1, True, user_email="test-user")
 
 
 class TestAdminGatewayRoutes:
@@ -1183,7 +1183,7 @@ class TestAdminGatewayRoutes:
         assert body["success"] is False
 
     @patch.object(GatewayService, "set_gateway_state")
-    async def test_admin_toggle_gateway_concurrent_calls(self, mock_toggle_status, mock_request, mock_db):
+    async def test_admin_set_gateway_state_concurrent_calls(self, mock_set_status, mock_request, mock_db):
         """Test toggling gateway with simulated concurrent calls."""
         # Simulate race condition
         call_count = 0
@@ -1195,7 +1195,7 @@ class TestAdminGatewayRoutes:
                 raise Exception("Gateway is being modified by another process")
             return None
 
-        mock_toggle_status.side_effect = side_effect
+        mock_set_status.side_effect = side_effect
 
         # First call should fail
         result1 = await admin_set_gateway_state("gateway-1", mock_request, mock_db, "test-user")
@@ -1864,7 +1864,7 @@ class TestA2AAgentManagement:
         assert "agent name already exists" in data["message"].lower()
 
     @patch.object(A2AAgentService, "set_a2a_agent_state")
-    async def test_admin_toggle_a2a_agent_success(self, mock_toggle_status, mock_request, mock_db):
+    async def test_admin_set_a2a_agent_state_success(self, mock_set_status, mock_request, mock_db):
         """Test toggling A2A agent status."""
         # First-Party
 
@@ -1877,7 +1877,7 @@ class TestA2AAgentManagement:
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
         assert "#a2a-agents" in result.headers["location"]
-        mock_toggle_status.assert_called_with(mock_db, "agent-1", True, user_email="test-user")
+        mock_set_status.assert_called_with(mock_db, "agent-1", True, user_email="test-user")
 
     @patch.object(A2AAgentService, "delete_agent")
     async def test_admin_delete_a2a_agent_success(self, mock_delete_agent, mock_request, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -327,7 +327,7 @@ class TestAdminServerRoutes:
         assert isinstance(result, JSONResponse)
         assert result.status_code in (200, 409, 422, 500)
 
-    @patch.object(ServerService, "toggle_server_status")
+    @patch.object(ServerService, "set_server_state")
     async def test_admin_toggle_server_with_exception(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling server status with exception handling."""
         mock_toggle_status.side_effect = Exception("Toggle operation failed")
@@ -529,7 +529,7 @@ class TestAdminToolRoutes:
         assert tool_update.headers == {}
         assert tool_update.input_schema == {}
 
-    @patch.object(ToolService, "toggle_tool_status")
+    @patch.object(ToolService, "set_tool_state")
     async def test_admin_toggle_tool_various_activate_values(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling tool with various activate values."""
         tool_id = "tool-1"
@@ -873,7 +873,7 @@ class TestAdminResourceRoutes:
         mock_update_resource.assert_called_once()
         assert mock_update_resource.call_args[0][1] == uri
 
-    @patch.object(ResourceService, "toggle_resource_status")
+    @patch.object(ResourceService, "set_resource_state")
     async def test_admin_toggle_resource_numeric_id(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling resource with numeric ID."""
         # Test with integer ID
@@ -1029,7 +1029,7 @@ class TestAdminPromptRoutes:
         mock_update_prompt.assert_called_once()
         assert mock_update_prompt.call_args[0][1] == "old-prompt-name"
 
-    @patch.object(PromptService, "toggle_prompt_status")
+    @patch.object(PromptService, "set_prompt_state")
     async def test_admin_toggle_prompt_edge_cases(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling prompt with edge cases."""
         # Test with string ID that looks like number
@@ -1182,7 +1182,7 @@ class TestAdminGatewayRoutes:
         assert result.status_code in (400, 422)
         assert body["success"] is False
 
-    @patch.object(GatewayService, "toggle_gateway_status")
+    @patch.object(GatewayService, "set_gateway_state")
     async def test_admin_toggle_gateway_concurrent_calls(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling gateway with simulated concurrent calls."""
         # Simulate race condition
@@ -1863,7 +1863,7 @@ class TestA2AAgentManagement:
         assert data["success"] is False
         assert "agent name already exists" in data["message"].lower()
 
-    @patch.object(A2AAgentService, "toggle_agent_status")
+    @patch.object(A2AAgentService, "set_a2a_agent_state")
     async def test_admin_toggle_a2a_agent_success(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling A2A agent status."""
         # First-Party

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -2591,7 +2591,7 @@ class TestEdgeCasesAndErrorHandling:
         mock_request.form = AsyncMock(return_value=form_data)
 
         # Test with toggle operations which use boolean parsing
-        with patch.object(ServerService, "toggle_server_status", new_callable=AsyncMock) as mock_toggle:
+        with patch.object(ServerService, "set_server_state", new_callable=AsyncMock) as mock_toggle:
             await admin_set_server_state("server-1", mock_request, mock_db, "test-user")
 
             # Check how the value was parsed

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -67,12 +67,12 @@ from mcpgateway.admin import (  # admin_get_metrics,
     admin_stream_logs,
     admin_test_a2a_agent,
     admin_test_gateway,
-    admin_toggle_a2a_agent,
-    admin_toggle_gateway,
-    admin_toggle_prompt,
-    admin_toggle_resource,
-    admin_toggle_server,
-    admin_toggle_tool,
+    admin_set_a2a_agent_state,
+    admin_set_gateway_state,
+    admin_set_prompt_state,
+    admin_set_resource_state,
+    admin_set_server_state,
+    admin_set_tool_state,
     admin_ui,
     get_aggregated_metrics,
     get_global_passthrough_headers,
@@ -333,7 +333,7 @@ class TestAdminServerRoutes:
         mock_toggle_status.side_effect = Exception("Toggle operation failed")
 
         # Should still return redirect
-        result = await admin_toggle_server("server-1", mock_request, mock_db, "test-user")
+        result = await admin_set_server_state("server-1", mock_request, mock_db, "test-user")
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
@@ -538,21 +538,21 @@ class TestAdminToolRoutes:
         form_data = FakeForm({"activate": "false"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        await admin_toggle_tool(tool_id, mock_request, mock_db, "test-user")
+        await admin_set_tool_state(tool_id, mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, tool_id, False, reachable=False, user_email="test-user")
 
         # Test with "FALSE"
         form_data = FakeForm({"activate": "FALSE"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        await admin_toggle_tool(tool_id, mock_request, mock_db, "test-user")
+        await admin_set_tool_state(tool_id, mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, tool_id, False, reachable=False, user_email="test-user")
 
         # Test with missing activate field (defaults to true)
         form_data = FakeForm({})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        await admin_toggle_tool(tool_id, mock_request, mock_db, "test-user")
+        await admin_set_tool_state(tool_id, mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, tool_id, True, reachable=True, user_email="test-user")
 
 
@@ -877,11 +877,11 @@ class TestAdminResourceRoutes:
     async def test_admin_toggle_resource_numeric_id(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling resource with numeric ID."""
         # Test with integer ID
-        await admin_toggle_resource(123, mock_request, mock_db, "test-user")
+        await admin_set_resource_state(123, mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, 123, True, user_email="test-user")
 
         # Test with string number
-        await admin_toggle_resource("456", mock_request, mock_db, "test-user")
+        await admin_set_resource_state("456", mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, "456", True, user_email="test-user")
 
 
@@ -1033,11 +1033,11 @@ class TestAdminPromptRoutes:
     async def test_admin_toggle_prompt_edge_cases(self, mock_toggle_status, mock_request, mock_db):
         """Test toggling prompt with edge cases."""
         # Test with string ID that looks like number
-        await admin_toggle_prompt("123", mock_request, mock_db, "test-user")
+        await admin_set_prompt_state("123", mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, "123", True, user_email="test-user")
 
         # Test with negative number
-        await admin_toggle_prompt(-1, mock_request, mock_db, "test-user")
+        await admin_set_prompt_state(-1, mock_request, mock_db, "test-user")
         mock_toggle_status.assert_called_with(mock_db, -1, True, user_email="test-user")
 
 
@@ -1198,11 +1198,11 @@ class TestAdminGatewayRoutes:
         mock_toggle_status.side_effect = side_effect
 
         # First call should fail
-        result1 = await admin_toggle_gateway("gateway-1", mock_request, mock_db, "test-user")
+        result1 = await admin_set_gateway_state("gateway-1", mock_request, mock_db, "test-user")
         assert isinstance(result1, RedirectResponse)
 
         # Second call should succeed
-        result2 = await admin_toggle_gateway("gateway-1", mock_request, mock_db, "test-user")
+        result2 = await admin_set_gateway_state("gateway-1", mock_request, mock_db, "test-user")
         assert isinstance(result2, RedirectResponse)
 
 
@@ -1872,7 +1872,7 @@ class TestA2AAgentManagement:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.scope = {"root_path": ""}
 
-        result = await admin_toggle_a2a_agent("agent-1", mock_request, mock_db, "test-user")
+        result = await admin_set_a2a_agent_state("agent-1", mock_request, mock_db, "test-user")
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
@@ -2592,7 +2592,7 @@ class TestEdgeCasesAndErrorHandling:
 
         # Test with toggle operations which use boolean parsing
         with patch.object(ServerService, "toggle_server_status", new_callable=AsyncMock) as mock_toggle:
-            await admin_toggle_server("server-1", mock_request, mock_db, "test-user")
+            await admin_set_server_state("server-1", mock_request, mock_db, "test-user")
 
             # Check how the value was parsed
             if form_field == "activate":

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -531,7 +531,7 @@ class TestAdminToolRoutes:
 
     @patch.object(ToolService, "set_tool_state")
     async def test_admin_set_tool_state_various_activate_values(self, mock_set_status, mock_request, mock_db):
-        """Test toggling tool with various activate values."""
+        """Test setting tool state with various activate values."""
         tool_id = "tool-1"
 
         # Test with "false"
@@ -875,7 +875,7 @@ class TestAdminResourceRoutes:
 
     @patch.object(ResourceService, "set_resource_state")
     async def test_admin_set_resource_state_numeric_id(self, mock_set_status, mock_request, mock_db):
-        """Test toggling resource with numeric ID."""
+        """Test setting resource state with numeric ID."""
         # Test with integer ID
         await admin_set_resource_state(123, mock_request, mock_db, "test-user")
         mock_set_status.assert_called_with(mock_db, 123, True, user_email="test-user")
@@ -1031,7 +1031,7 @@ class TestAdminPromptRoutes:
 
     @patch.object(PromptService, "set_prompt_state")
     async def test_admin_set_prompt_state_edge_cases(self, mock_set_status, mock_request, mock_db):
-        """Test toggling prompt with edge cases."""
+        """Test setting prompt state with edge cases."""
         # Test with string ID that looks like number
         await admin_set_prompt_state("123", mock_request, mock_db, "test-user")
         mock_set_status.assert_called_with(mock_db, "123", True, user_email="test-user")
@@ -1184,7 +1184,7 @@ class TestAdminGatewayRoutes:
 
     @patch.object(GatewayService, "set_gateway_state")
     async def test_admin_set_gateway_state_concurrent_calls(self, mock_set_status, mock_request, mock_db):
-        """Test toggling gateway with simulated concurrent calls."""
+        """Test setting gateway state with simulated concurrent calls."""
         # Simulate race condition
         call_count = 0
 
@@ -1865,7 +1865,7 @@ class TestA2AAgentManagement:
 
     @patch.object(A2AAgentService, "set_a2a_agent_state")
     async def test_admin_set_a2a_agent_state_success(self, mock_set_status, mock_request, mock_db):
-        """Test toggling A2A agent status."""
+        """Test setting A2A agent state."""
         # First-Party
 
         form_data = FakeForm({"activate": "true"})

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -507,7 +507,7 @@ class TestServerEndpoints:
         updated_server = MOCK_SERVER_READ.copy()
         updated_server["is_active"] = False
         mock_toggle.return_value = ServerRead(**updated_server)
-        response = test_client.post("/servers/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/servers/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         mock_toggle.assert_called_once()
 
@@ -626,7 +626,7 @@ class TestToolEndpoints:
         mock_tool = MagicMock()
         mock_tool.model_dump.return_value = {"id": 1, "name": "test", "is_active": False}
         mock_toggle.return_value = mock_tool
-        response = test_client.post("/tools/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/tools/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -742,7 +742,7 @@ class TestResourceEndpoints:
         mock_resource = MagicMock()
         mock_resource.model_dump.return_value = {"id": 1, "is_active": False}
         mock_toggle.return_value = mock_resource
-        response = test_client.post("/resources/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/resources/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -822,7 +822,7 @@ class TestPromptEndpoints:
         mock_prompt = MagicMock()
         mock_prompt.model_dump.return_value = {"id": 1, "is_active": False}
         mock_toggle.return_value = mock_prompt
-        response = test_client.post("/prompts/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/prompts/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
         mock_toggle.assert_called_once()
@@ -899,7 +899,7 @@ class TestPromptEndpoints:
         mock_prompt = MagicMock()
         mock_prompt.model_dump.return_value = {"id": 1, "is_active": False}
         mock_toggle.return_value = mock_prompt
-        response = test_client.post("/prompts/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/prompts/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -976,7 +976,7 @@ class TestGatewayEndpoints:
         mock_gateway = MagicMock()
         mock_gateway.model_dump.return_value = {"id": "1", "is_active": False}
         mock_toggle.return_value = mock_gateway
-        response = test_client.post("/gateways/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/gateways/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
         mock_toggle.assert_called_once()
@@ -1036,7 +1036,7 @@ class TestGatewayEndpoints:
         mock_gateway = MagicMock()
         mock_gateway.model_dump.return_value = {"id": "1", "is_active": False}
         mock_toggle.return_value = mock_gateway
-        response = test_client.post("/gateways/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/gateways/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -1389,7 +1389,7 @@ class TestMetricsEndpoints:
 #        """Test toggling A2A agent status."""
 #        mock_toggle.return_value = {"id": "test-id", "enabled": False}
 #
-#        response = test_client.post("/a2a/test-id/toggle?activate=false", headers=auth_headers)
+#        response = test_client.post("/a2a/test-id/state?activate=false", headers=auth_headers)
 #        assert response.status_code == 200
 #        mock_toggle.assert_called_once()
 #

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -501,7 +501,7 @@ class TestServerEndpoints:
         assert response.status_code == 200
         mock_update.assert_called_once()
 
-    @patch("mcpgateway.main.server_service.toggle_server_status")
+    @patch("mcpgateway.main.server_service.set_server_state")
     def test_toggle_server_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling server active/inactive status."""
         updated_server = MOCK_SERVER_READ.copy()
@@ -620,7 +620,7 @@ class TestToolEndpoints:
         assert response.status_code == 200
         mock_update.assert_called_once()
 
-    @patch("mcpgateway.main.tool_service.toggle_tool_status")
+    @patch("mcpgateway.main.tool_service.set_tool_state")
     def test_toggle_tool_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling tool active/inactive status."""
         mock_tool = MagicMock()
@@ -736,7 +736,7 @@ class TestResourceEndpoints:
         assert response.status_code == 200
         mock_list.assert_called_once()
 
-    @patch("mcpgateway.main.resource_service.toggle_resource_status")
+    @patch("mcpgateway.main.resource_service.set_resource_state")
     def test_toggle_resource_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling resource active/inactive status."""
         mock_resource = MagicMock()
@@ -816,7 +816,7 @@ class TestPromptEndpoints:
         assert response.json()["status"] == "success"
         mock_delete.assert_called_once()
 
-    @patch("mcpgateway.main.prompt_service.toggle_prompt_status")
+    @patch("mcpgateway.main.prompt_service.set_prompt_state")
     def test_toggle_prompt_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling prompt active/inactive status."""
         mock_prompt = MagicMock()
@@ -893,7 +893,7 @@ class TestPromptEndpoints:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-    @patch("mcpgateway.main.prompt_service.toggle_prompt_status")
+    @patch("mcpgateway.main.prompt_service.set_prompt_state")
     def test_toggle_prompt_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling prompt active/inactive status."""
         mock_prompt = MagicMock()
@@ -970,7 +970,7 @@ class TestGatewayEndpoints:
         mock_delete.assert_called_once()
         mock_invalidate_cache.assert_called_once()
 
-    @patch("mcpgateway.main.gateway_service.toggle_gateway_status")
+    @patch("mcpgateway.main.gateway_service.set_gateway_state")
     def test_toggle_gateway_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling gateway active/inactive status."""
         mock_gateway = MagicMock()
@@ -1030,7 +1030,7 @@ class TestGatewayEndpoints:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-    @patch("mcpgateway.main.gateway_service.toggle_gateway_status")
+    @patch("mcpgateway.main.gateway_service.set_gateway_state")
     def test_toggle_gateway_status(self, mock_toggle, test_client, auth_headers):
         """Test toggling gateway active/inactive status."""
         mock_gateway = MagicMock()

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -502,14 +502,14 @@ class TestServerEndpoints:
         mock_update.assert_called_once()
 
     @patch("mcpgateway.main.server_service.set_server_state")
-    def test_toggle_server_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling server active/inactive status."""
+    def test_set_server_state(self, mock_set, test_client, auth_headers):
+        """Test setting server active/inactive status."""
         updated_server = MOCK_SERVER_READ.copy()
         updated_server["is_active"] = False
-        mock_toggle.return_value = ServerRead(**updated_server)
+        mock_set.return_value = ServerRead(**updated_server)
         response = test_client.post("/servers/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
-        mock_toggle.assert_called_once()
+        mock_set.assert_called_once()
 
     @patch("mcpgateway.main.server_service.delete_server")
     def test_delete_server_endpoint(self, mock_delete, test_client, auth_headers):
@@ -621,11 +621,11 @@ class TestToolEndpoints:
         mock_update.assert_called_once()
 
     @patch("mcpgateway.main.tool_service.set_tool_state")
-    def test_toggle_tool_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling tool active/inactive status."""
+    def test_set_tool_state(self, mock_set, test_client, auth_headers):
+        """Test setting tool active/inactive status."""
         mock_tool = MagicMock()
         mock_tool.model_dump.return_value = {"id": 1, "name": "test", "is_active": False}
-        mock_toggle.return_value = mock_tool
+        mock_set.return_value = mock_tool
         response = test_client.post("/tools/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -737,11 +737,11 @@ class TestResourceEndpoints:
         mock_list.assert_called_once()
 
     @patch("mcpgateway.main.resource_service.set_resource_state")
-    def test_toggle_resource_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling resource active/inactive status."""
+    def test_set_resource_state(self, mock_set, test_client, auth_headers):
+        """Test setting resource active/inactive status."""
         mock_resource = MagicMock()
         mock_resource.model_dump.return_value = {"id": 1, "is_active": False}
-        mock_toggle.return_value = mock_resource
+        mock_set.return_value = mock_resource
         response = test_client.post("/resources/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -817,15 +817,15 @@ class TestPromptEndpoints:
         mock_delete.assert_called_once()
 
     @patch("mcpgateway.main.prompt_service.set_prompt_state")
-    def test_toggle_prompt_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling prompt active/inactive status."""
+    def test_set_prompt_state(self, mock_set, test_client, auth_headers):
+        """Test setting prompt active/inactive status."""
         mock_prompt = MagicMock()
         mock_prompt.model_dump.return_value = {"id": 1, "is_active": False}
-        mock_toggle.return_value = mock_prompt
+        mock_set.return_value = mock_prompt
         response = test_client.post("/prompts/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
-        mock_toggle.assert_called_once()
+        mock_set.assert_called_once()
 
     """Tests for prompt template management: creation, rendering, arguments, etc."""
 
@@ -894,11 +894,11 @@ class TestPromptEndpoints:
         assert response.json()["status"] == "success"
 
     @patch("mcpgateway.main.prompt_service.set_prompt_state")
-    def test_toggle_prompt_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling prompt active/inactive status."""
+    def test_set_prompt_state_duplicate(self, mock_set, test_client, auth_headers):
+        """Test setting prompt active/inactive status (duplicate entry)."""
         mock_prompt = MagicMock()
         mock_prompt.model_dump.return_value = {"id": 1, "is_active": False}
-        mock_toggle.return_value = mock_prompt
+        mock_set.return_value = mock_prompt
         response = test_client.post("/prompts/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -971,15 +971,15 @@ class TestGatewayEndpoints:
         mock_invalidate_cache.assert_called_once()
 
     @patch("mcpgateway.main.gateway_service.set_gateway_state")
-    def test_toggle_gateway_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling gateway active/inactive status."""
+    def test_set_gateway_state(self, mock_set, test_client, auth_headers):
+        """Test setting gateway active/inactive status."""
         mock_gateway = MagicMock()
         mock_gateway.model_dump.return_value = {"id": "1", "is_active": False}
-        mock_toggle.return_value = mock_gateway
+        mock_set.return_value = mock_gateway
         response = test_client.post("/gateways/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
-        mock_toggle.assert_called_once()
+        mock_set.assert_called_once()
 
     """Tests for gateway federation: registration, discovery, forwarding, etc."""
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -309,13 +309,13 @@ class TestUtilityFunctions:
             mock_toggle.return_value = ServerRead(**mock_server_data)
 
             # Test activate=true
-            response = test_client.post("/servers/1/toggle?activate=true", headers=auth_headers)
+            response = test_client.post("/servers/1/state?activate=true", headers=auth_headers)
             assert response.status_code == 200
 
             # Test activate=false
             mock_server_data["is_active"] = False
             mock_toggle.return_value = ServerRead(**mock_server_data)
-            response = test_client.post("/servers/1/toggle?activate=false", headers=auth_headers)
+            response = test_client.post("/servers/1/state?activate=false", headers=auth_headers)
             assert response.status_code == 200
 
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -277,7 +277,7 @@ class TestUtilityFunctions:
             assert response.status_code in [404, 500, 503]
 
     def test_server_toggle_edge_cases(self, test_client, auth_headers):
-        """Test server toggle endpoint edge cases."""
+        """Test server state endpoint edge cases."""
         with patch("mcpgateway.main.server_service.set_server_state") as mock_toggle:
             # Create a proper ServerRead model response
             # First-Party

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -278,7 +278,7 @@ class TestUtilityFunctions:
 
     def test_server_toggle_edge_cases(self, test_client, auth_headers):
         """Test server toggle endpoint edge cases."""
-        with patch("mcpgateway.main.server_service.toggle_server_status") as mock_toggle:
+        with patch("mcpgateway.main.server_service.set_server_state") as mock_toggle:
             # Create a proper ServerRead model response
             # First-Party
             from mcpgateway.schemas import ServerRead


### PR DESCRIPTION
closes issue #https://github.com/IBM/mcp-context-forge/issues/1497
The existing /toggle endpoint caused confusion because it did not truly “toggle” the resource state. Instead, it always set the state based on the activate parameter (e.g., activate=true), leading users to assume it was flipping the current status.

To remove ambiguity and make the API behavior explicit, this PR updates the endpoint name from /toggle to /state. The new design clearly communicates that the endpoint sets the state rather than toggling it.

**Key Changes**

- Renamed /toggle endpoints to /state across all relevant resources.
- Updated documentation, examples, and UI references to align with the new terminology.
-Improved clarity and consistency across servers, tools, agents, gateways, prompts, resources, and gRPC services.

**API Endpoint Updates:**

* The server admin endpoint `POST /servers/{server_id}/toggle` is renamed to `POST /servers/{server_id}/state`, with corresponding updates to the handler function name and docstrings in `mcpgateway/admin.py`. All references to "toggle" are replaced with "set state" for clarity. [[1]](diffhunk://#diff-7d3a5fe659e5417b4949c80c8fe2a33e6a74f674e18481d113e6b3c8e77fd46aL1340-R1356) [[2]](diffhunk://#diff-7d3a5fe659e5417b4949c80c8fe2a33e6a74f674e18481d113e6b3c8e77fd46aL1374-R1421)

**Documentation and Example Updates:**

* All documentation and example API calls (in `README.md`, `docs/docs/index.md`, `docs/docs/manage/api-usage.md`, etc.) now use `/state?activate=true|false` instead of `/toggle?activate=true|false` for setting active/inactive states of entities. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2267-R2269) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2329-R2329) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2379-R2379) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2465-R2465) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2523-R2523) [[6]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1717-R1721) [[7]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1779-R1781) [[8]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1829-R1831) [[9]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1915-R1917) [[10]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1973-R1975) [[11]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L165-R167) [[12]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L287-R289) [[13]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L410-R412) [[14]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L502-R504) [[15]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L584-R586) [[16]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L1041-R1041)

**Terminology Consistency:**

* Terminology throughout the documentation, changelog, and UI guides is updated to use "Set state" or "Enable/Disable" instead of "Toggle". This applies to server, tool, agent, gateway, prompt, resource, and gRPC service activation/deactivation actions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL587-R587) [[2]](diffhunk://#diff-0d88f289f15f7c48ce3260943a47df09d824c5a7f3301cd432faacd345bde59cL887-R887) [[3]](diffhunk://#diff-40fd72eb94fe86c365c5a64ee98f24dc3d7e557e861af6ace9bafa349e5a93bdL176-R176) [[4]](diffhunk://#diff-b8f4a2326fdf5152a9691ad3032800fa7085be03d564866371e0300fdead2573L42-R42) [[5]](diffhunk://#diff-37e356a4bd2ac172f305347cbe28d638725afaea49cc57afef95da339a8716e9L355-R355) [[6]](diffhunk://#diff-dda3e6a76daeac844cf45087bc2819c89a01f7c004f0cde7b8cf5205a69bbb8fL239-R239) [[7]](diffhunk://#diff-dda3e6a76daeac844cf45087bc2819c89a01f7c004f0cde7b8cf5205a69bbb8fL307-R310)

**gRPC Service Endpoint Update:**

* The gRPC service activation endpoint is changed from `POST /grpc/{id}/toggle` to `POST /grpc/{id}/state` in both the changelog and usage documentation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL587-R587) [[2]](diffhunk://#diff-dda3e6a76daeac844cf45087bc2819c89a01f7c004f0cde7b8cf5205a69bbb8fL307-R310)

**Test and Example Code Updates:**

* Example code and docstring tests in `mcpgateway/admin.py` are updated to use the new endpoint and terminology, ensuring that both happy paths and error cases reflect the "set state" logic.

Also fixed team is coming as N/A in list resources page in admin UI.