### PR TITLE
Include missing Container.scratch file in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include pyproject.toml
 include gunicorn.config.py
 include Containerfile
 include Containerfile.lite
+include Containerfile.scratch
 include __init__
 include alembic.ini
 include tox.ini


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Build failure in PR 1520 in the `make verify` stage.

## 🔁 Reproduction Steps
```
make venv install install-dev dist
make verify
```
The failing utility was `check-manifest`

## 🐞 Root Cause
MANIFEST.in does not cover the newly added Containerfile.scratch.
We may need to make some more generic rules for that later, but I don't want to create catchall rules that mean we might add something at a later stage.

## 💡 Fix Description
Include missing file in the MANIFEST.in file.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
