### PR TITLE
fix: root redirect uses app_root_path with trailing slash

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5261,25 +5261,21 @@ if UI_ENABLED:
 
     # Redirect root path to admin UI
     @app.get("/")
-    async def root_redirect(request: Request):
+    async def root_redirect():
         """
-        Redirects the root path ("/") to "/admin".
+        Redirects the root path ("/") to "/admin/".
 
         Logs a debug message before redirecting.
 
-        Args:
-            request (Request): The incoming HTTP request (used only to build the
-                target URL via :pymeth:`starlette.requests.Request.url_for`).
-
         Returns:
-            RedirectResponse: Redirects to /admin.
+            RedirectResponse: Redirects to /admin/.
 
         Raises:
             HTTPException: If there is an error during redirection.
         """
-        logger.debug("Redirecting root path to /admin")
-        root_path = request.scope.get("root_path", "")
-        return RedirectResponse(f"{root_path}/admin", status_code=303)
+        logger.debug("Redirecting root path to /admin/")
+        root_path = settings.app_root_path
+        return RedirectResponse(f"{root_path}/admin/", status_code=303)
         # return RedirectResponse(request.url_for("admin_home"))
 
 else:

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -328,9 +328,9 @@ class TestHealthAndInfrastructure:
 
         # Check if UI is enabled
         if settings.mcpgateway_ui_enabled:
-            # When UI is enabled, should redirect to admin
+            # When UI is enabled, should redirect to admin with trailing slash
             assert response.status_code == 303
-            assert response.headers["location"] == "/admin"
+            assert response.headers["location"] == f"{settings.app_root_path}/admin/"
         else:
             # When UI is disabled, should return API info
             assert response.status_code == 200

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.main import app
 
 
@@ -186,9 +187,9 @@ class TestUtilityFunctions:
             client = TestClient(app)
             response = client.get("/", follow_redirects=False)
 
-            # Should redirect to /admin when UI is enabled
+            # Should redirect to /admin/ when UI is enabled
             if response.status_code == 303:
-                assert response.headers.get("location") == "/admin"
+                assert response.headers.get("location") == f"{settings.app_root_path}/admin/"
             else:
                 # Fallback behavior
                 assert response.status_code == 200


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Root path redirect (`/` → `/admin/`) was ignoring APP_ROOT_PATH setting and causing unnecessary 307 redirect.

## 🔁 Reproduction Steps
1. Set `APP_ROOT_PATH=/api`
2. Request `GET /api`
3. Observe redirect to `/admin/` instead of `/api/admin/`
4. Also observe 303 → 307 double redirect due to missing trailing slash

## 🐞 Root Cause
`root_redirect` function used `request.scope.get("root_path", "")` which returns empty string, while other parts of the codebase use `settings.app_root_path`. Also missing trailing slash caused extra 307 redirect.

## 💡 Fix Description
- Changed from `request.scope.get("root_path")` to `settings.app_root_path` for consistency (missing from #1332 )
- Added trailing slash (`/admin/`) to avoid 307 redirect

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
