### PR TITLE
For servers/{server_id}/tools - Optional execution count with lazy loading

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1277,7 +1277,7 @@ class ToolRead(BaseModelWithConfigDict):
     enabled: bool
     reachable: bool
     gateway_id: Optional[str]
-    execution_count: int
+    execution_count: Optional[int] = Field(None)
     metrics: Optional[ToolMetrics] = Field(None)
     name: str
     displayName: Optional[str] = Field(None, description="Display name for the tool (shown in UI)")  # noqa: N815


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Related to [#1515](https://github.com/IBM/mcp-context-forge/pull/1515)

For the GET /servers/{server_id}/tools API, database queries were still being executed for each tool in the tool_metrics table, even after making metrics optional. This happened because the execution_count field was being loaded for every tool.

To fix this, selectinload was enabled for the metrics relationship when include_metrics=True, and execution_count was made optional in the response.

When include_metrics=False, both metrics and execution_count will now return as null.

## 🐞 Root Cause
in `_convert_tool_to_read` function `tool_dict["execution_count"] = tool.execution_count` loaded the metrics table for every tool.

## 💡 Fix Description
1. Enabled selectinload for the metrics relationship so that metrics are fetched efficiently in a single query only when include_metrics=True.
2. Made execution_count optional in the response to prevent unnecessary loading of the tool_metrics table.
3. Now, when include_metrics=False, both metrics and execution_count return as null, eliminating extra database queries per tool.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed