### PR TITLE
Fix: Propagate app_user_email when a global context already exists

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1222,6 +1222,8 @@ class ToolService:
             gateway_id = getattr(tool, "gateway_id", None)
             if gateway_id and isinstance(gateway_id, str):
                 global_context.server_id = gateway_id
+            if gateway_id and isinstance(app_user_email, str):
+                global_context.user = app_user_email
         else:
             # Create new context (fallback when middleware didn't run)
             request_id = uuid.uuid4().hex


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes the issue outlined [here](https://github.com/IBM/mcp-context-forge/issues/1550).

## 🔁 Reproduction Steps

See the issue above.

## 🐞 Root Cause

See the issue above.

## 💡 Fix Description

Added the two lines as mentioned in the issue above.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    done    |
| Unit tests                            | `make test`          |    done    |
| Coverage ≥ 90 %                       | `make coverage`      |    done    |
| Manual regression no longer fails     | steps / screenshots  |    done    |


## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

Screenshots:

<img width="1220" height="766" alt="Screenshot 2025-12-04 at 15 10 34" src="https://github.com/user-attachments/assets/d06ef9c2-1c2a-4686-b7c6-1373ef615b9a" />

<img width="1220" height="876" alt="Screenshot 2025-12-04 at 15 12 25" src="https://github.com/user-attachments/assets/5b001490-56d9-405a-be8d-97ba8d92bc8b" />

