### PR TITLE
Fixed tag structured in CommonAttributes

### DIFF
--- a/mcpgateway/common/models.py
+++ b/mcpgateway/common/models.py
@@ -587,7 +587,7 @@ class CommonAttributes(BaseModel):
     enabled: Optional[bool] = None
     reachable: Optional[bool] = None
     auth_type: Optional[str] = None
-    tags: Optional[list[Dict[str,str]]] = None
+    tags: Optional[list[Dict[str, str]]] = None
     # Comprehensive metadata for audit tracking
     created_by: Optional[str] = None
     created_from_ip: Optional[str] = None


### PR DESCRIPTION
Following up on PR [https://github.com/IBM/mcp-context-forge/pull/1516](https://github.com/IBM/mcp-context-forge/pull/1516) and issue [https://github.com/IBM/mcp-context-forge/issues/1442](https://github.com/IBM/mcp-context-forge/issues/1442):
https://github.com/IBM/mcp-context-forge/issues/1553

When `PLUGINS_ENABLED=True`, the `tool_invoke` validation fails due to a tag-related validation error.
To fix this, update the tag structure in the `CommonAttributes` class in `model.py`.