### PR TITLE
Admin: Enable gateway filtering for search & fix selection persistence

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2208,7 +2208,7 @@
                         data-gateway-null="true"
                         class="mcpserver-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
                       />
-                      <span class="select-none">REST</span>
+                      <span class="select-none">REST/A2A</span>
                     </label>
                     <p
                       id="noGatewayMessage"
@@ -9632,7 +9632,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         data-gateway-null="true"
                         class="mcpserver-checkbox form-checkbox h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
                       />
-                      <span class="select-none">REST</span>
+                      <span class="select-none">REST/A2A</span>
                     </label>
                     <p
                       id="noGatewayEditMessage"


### PR DESCRIPTION
closes issue #1566 
This PR adds **gateway-based filtering support** to Admin search endpoints for **Tools, Resources, and Prompts**, allowing filtering by one or more gateway IDs—including items with **no gateway (`NULL`)**.

It also improves **Admin UI clarity** by updating the gateway label and fixes a **selection persistence issue** on the *Add/Edit Virtual Server* pages.

---

## ✅ Changes Introduced

### 🛠 API Enhancements – Gateway Filtering

* Added a new **optional `gateway_id` query parameter** (comma-separated) to:

  * `admin_search_tools`
  * `admin_search_resources`
  * `admin_search_prompts`
* Supports:

  * ✅ Filtering by **multiple gateway IDs**
  * ✅ Filtering for items with **no gateway** using `"null"`
* Updated:

  * 📄 Endpoint **docstrings**
  * ⚙️ **SQL filtering logic** to correctly handle:

    * Multiple IDs
    * `NULL` gateway values

---

### 🎨 Admin UI Improvements

* Updated the gateway filter label:

  * **"REST" → "REST/A2A"**
* Clarifies that the option includes both **REST and A2A gateways**

---

### 🐞 Bug Fixes

* Fixed **tool/prompt/resource selection persistence** in:

  * ✅ Add Virtual Server
  * ✅ Edit Virtual Server

## 🔍 How to Test – Virtual Server (Selection Persistence)

1. Navigate to **Admin → Virtual Server → Add/Edit** page.
2. Apply a gateway filter using:

   * A single gateway ID
   * Multiple gateway IDs (comma-separated)
   * `"null"` to include items with no assigned gateway
3. Verify that the displayed results match the applied filter conditions.
4. Search for a tool, prompt, or resource and select one or more items.
5. Clear the search keyword from the search box.
6. Change the selected gateway ID and repeat the above steps.
7. Confirm that the selected tools, prompts, and resources **persist correctly**.

