### PR TITLE
feat: add uv installation support #1503

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,21 @@ curl -s -H "Authorization: Bearer $Env:MCPGATEWAY_BEARER_TOKEN" `
      http://127.0.0.1:4444/version | jq
 ```
 
+<details>
+<summary><strong>⚡ Alternative: uv (faster)</strong></summary>
+
+```powershell
+# 1️⃣  Isolated env + install from PyPI using uv
+mkdir mcpgateway ; cd mcpgateway
+uv venv
+.\.venv\Scripts\activate
+uv pip install mcp-contextforge-gateway
+
+# Continue with steps 2️⃣-4️⃣ above...
+```
+
+</details>
+
 </details>
 
 <details>


### PR DESCRIPTION
## What
Adds support for `uv` package manager as an alternative to `pip` for installation.

## Why
- uv is faster and more flexible than pip
- Better dependency resolution
- Modern package handling
- Eases installation in multi-version Python setups

## Changes Made
1. Updated README.md with uv installation instructions
2. [Add here if you update PowerShell scripts]
3. [Add here if you update other documentation]

## Testing
- [x] Verified uv installation works locally
- [x] Tested commands: `uv venv --python 3.11` and `uv pip install`

## Related Issue
Closes #1503