### PR TITLE
fix build and push stage in github workflow

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -123,6 +123,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -144,7 +145,10 @@ jobs:
           context: .
           file: Containerfile.lite
           platforms: ${{ matrix.platform }}
-          push: true
+
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=build-${{ matrix.suffix }}
@@ -152,6 +156,7 @@ jobs:
           provenance: false
 
       - name: Export digest
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
@@ -159,6 +164,7 @@ jobs:
           echo "Digest for ${{ matrix.suffix }}: $digest"
 
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.suffix }}
@@ -173,6 +179,7 @@ jobs:
     name: Create Manifest
     needs: build
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Set image name lowercase
@@ -218,7 +225,7 @@ jobs:
     name: Security Scan
     needs: manifest
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout code
@@ -295,7 +302,7 @@ jobs:
     name: Sign Images
     needs: [manifest, scan]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Set image name lowercase


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Pull request builds from external contributors were failing in the multiplatform Docker workflow, because the GitHub Actions runner attempted to push container images to GHCR.

Fork PRs run with a read-only GITHUB_TOKEN, so any GHCR push resulted in:
`denied: installation not allowed to Write organization package`

This PR fixes the issue by allowing PRs to run builds without pushing, while keeping full push/manifest/scan/sign behavior for merges into main.

## 🔁 Reproduction Steps

1. Create a fork of the repository.
2. Open a pull request modifying any file that triggers the Docker workflow.
3. Wait for the Build amd64/arm64/s390x job.
4. The workflow fails with GHCR permission errors when trying to push an image.

## 🐞 Root Cause
The workflow always executed: `push: true` in docker/build-push-action, regardless of event type.
External PRs cannot push to GHCR, causing:
`failed to push ghcr.io/...: denied: installation not allowed to Write organization package`
Additionally, manifest creation, scanning, and signing jobs also assumed GHCR write access and were not gated behind conditions.

## 💡 Fix Description
This PR introduces PR safe behavior:

**PR builds:**
1. Build multi-arch images
2. Do not push (push: false, load: true)
3. Skip manifest, scan, and signing jobs

**Main branch and manual builds:**
1. Full pipeline runs normally
2. Build + Pus
3. Manifest creation
4. Security scanning
5. Cosign signing

Added conditional logic:
```yaml
push: ${{ github.event_name != 'pull_request' }}
load: ${{ github.event_name == 'pull_request' }}
```

Added if: github.event_name != 'pull_request' to manifest, scan, and sign jobs.
PRs now run securely without requiring GHCR write permissions.
Merges into main maintain the original release workflow.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed