### PR TITLE
fix: Resolve unclosed SQLite connection warnings during tests

### DIFF
--- a/tests/unit/mcpgateway/test_display_name_uuid_features.py
+++ b/tests/unit/mcpgateway/test_display_name_uuid_features.py
@@ -35,6 +35,7 @@ def db_session():
         yield session
     finally:
         session.close()
+        engine.dispose()  # Properly close all connections in the pool
 
 
 @pytest.fixture

--- a/tests/unit/mcpgateway/utils/test_pagination.py
+++ b/tests/unit/mcpgateway/utils/test_pagination.py
@@ -18,7 +18,6 @@ This module tests pagination functionality including:
 import base64
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict
 from unittest.mock import MagicMock
 
 # Third-Party
@@ -655,11 +654,10 @@ class TestPaginationSchemas:
 def db_session():
     """Create a test database session."""
     # Standard
-    from unittest.mock import MagicMock
 
     # Third-Party
     from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session, sessionmaker
+    from sqlalchemy.orm import sessionmaker
 
     # First-Party
     from mcpgateway.db import Base
@@ -675,3 +673,4 @@ def db_session():
     yield session
 
     session.close()
+    engine.dispose()  # Properly close all connections in the pool


### PR DESCRIPTION
## Summary
- Add proper engine disposal in `pytest_sessionfinish` to close all SQLite connections at end of test sessions
- Use context manager pattern in `bootstrap_default_roles()` for proper session cleanup
- Add `engine.dispose()` calls in test fixtures that create their own engines
- Remove unused imports in test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)