### PR TITLE
Fix/1542 oauth validation logs

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1435,7 +1435,17 @@ Disallow: /
     validation_max_description_length: int = 8192  # 8KB
     validation_max_template_length: int = 65536  # 64KB
     validation_max_content_length: int = 1048576  # 1MB
-    validation_max_json_depth: int = 10
+    validation_max_json_depth: int = Field(
+        default=int(os.getenv("VALIDATION_MAX_JSON_DEPTH", "30")),
+        description=(
+            "Maximum allowed JSON nesting depth for tool/resource schemas. "
+            "Increased from 10 to 30 for compatibility with deeply nested schemas "
+            "like Notion MCP (issue #1542). Override with VALIDATION_MAX_JSON_DEPTH "
+            "environment variable. Minimum: 1, Maximum: 100"
+        ),
+        ge=1,
+        le=100,
+    )
     validation_max_url_length: int = 2048
     validation_max_rpc_param_size: int = 262144  # 256KB
 


### PR DESCRIPTION
 researched issue #1542 and found that Notion MCP schemas exceed the default JSON depth limit. Here's what I implemented:

**Solution:**
1. **Increased depth limit**: Default from 10 → 30, configurable via `VALIDATION_MAX_JSON_DEPTH`
2. **Better error handling**: Per-tool validation with logging instead of silent failures
3. **User-friendly OAuth errors**: Clear messages when validation fails during OAuth flows

**Result:** Users will now see helpful error messages instead of "unhandled errors in TaskGroup", and Notion MCP should work out-of-the-box.

Looking forward to your review of these changes!