### PR TITLE
Fix SQLite-specific json_extract() breaking PostgreSQL observability queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1302,7 +1302,7 @@ PAGINATION_INCLUDE_LINKS=true
 # OBSERVABILITY_SAMPLE_RATE=1.0
 
 # Paths to exclude from tracing (comma-separated regex patterns)
-# OBSERVABILITY_EXCLUDE_PATHS=/health,/healthz,/ready,/metrics,/static/.*
+# OBSERVABILITY_EXCLUDE_PATHS=["/health", "/healthz", "/ready", "/metrics", "/static/.*"]
 
 # Enable metrics collection
 # OBSERVABILITY_METRICS_ENABLED=true

--- a/mcpgateway/services/event_service.py
+++ b/mcpgateway/services/event_service.py
@@ -212,7 +212,7 @@ class EventService:
                             yield json.loads(message["data"])
                 except asyncio.CancelledError:
                     # Handle client disconnection
-                    logger.error(f"Client disconnected from Redis subscription: {self.channel_name}")
+                    logger.debug(f"Client disconnected from Redis subscription: {self.channel_name}")
                     raise
                 except Exception as e:
                     logger.error(f"Redis subscription error on {self.channel_name}: {e}")
@@ -238,7 +238,7 @@ class EventService:
                     event = await queue.get()
                     yield event
             except asyncio.CancelledError:
-                logger.error(f"Client disconnected from local event subscription: {self.channel_name}")
+                logger.debug(f"Client disconnected from local event subscription: {self.channel_name}")
                 raise
             finally:
                 if queue in self._event_subscribers:

--- a/tests/unit/mcpgateway/services/test_event_service.py
+++ b/tests/unit/mcpgateway/services/test_event_service.py
@@ -502,8 +502,8 @@ class TestEventService:
 
             await asyncio.sleep(0.1)
 
-            mock_logger.error.assert_called()
-            error_message = str(mock_logger.error.call_args)
+            mock_logger.debug.assert_called()
+            error_message = str(mock_logger.debug.call_args)
             assert "Client disconnected" in error_message
             assert len(service._event_subscribers) == 0
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes #1517

This PR fixes a critical database compatibility bug where all observability analytics endpoints failed on PostgreSQL deployments. The code used SQLite-specific func.json_extract() function calls that don't exist in PostgreSQL, causing SQL errors on 11 observability endpoints including tool usage statistics, error rates, performance metrics, and resource analytics.

Impact: All users running MCP Gateway with PostgreSQL backend could not access any observability analytics features.

## 🐞 Root Cause
Location: `mcpgateway/admin.py`
 - 27 occurrences across observability analytics queries

Problem: The code used SQLite-specific func.json_extract() to extract JSON fields from the ObservabilitySpan.attributes column:
```python
func.json_extract(ObservabilitySpan.attributes, '$.\"tool.name\"')
```

Why it failed:

- SQLite uses: json_extract(column, '$.path') function
- PostgreSQL uses: column->>'path' operator or jsonb_extract_path_text()
- The code only supported SQLite syntax

Affected areas:

- Tool analytics: trace filtering, usage, performance, errors, chains (11 occurrences)
- Prompt analytics: usage, performance, errors (8 occurrences)
- Resource analytics: usage, performance, errors (8 occurrences)
- Prompt analytics: usage, performance, errors (8 occurrences)
- Resource analytics: usage, performance, errors (8 occurrences)

## 💡 Fix Description
Created a new `extract_json_field()` helper function that detects the database backend and uses the appropriate syntax.
Converts SQLite JSON path format ($.\"key\") to PostgreSQL format (key)

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed