### PR TITLE
fix: propagate app_user_email when global context already exists

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1466,6 +1466,9 @@ class ToolService:
             gateway_id = getattr(tool, "gateway_id", None)
             if gateway_id and isinstance(gateway_id, str):
                 global_context.server_id = gateway_id
+            # Propagate user email to global context for plugin access
+            if app_user_email and isinstance(app_user_email, str):
+                global_context.user = app_user_email
         else:
             # Create new context (fallback when middleware didn't run)
             # Use correlation ID from context if available, otherwise generate new one


### PR DESCRIPTION
## Summary

- Fixes bug where plugins receive `user: null` in `GlobalContext` when the context is reused from middleware
- Ensures `app_user_email` is propagated to `global_context.user` when available

## Root Cause

In `invoke_tool`, when a `plugin_global_context` is passed from middleware, the code updated `server_id` but not `user`. This caused security plugins to be unable to track which user made each request.

## Fix

Added propagation of `app_user_email` to `global_context.user` in the existing context reuse path, consistent with how the fallback path already sets the user.

## Attribution

This PR supersedes #1551 by @IliaMManolov from Edison-Watch, which identified the issue correctly but had a minor bug in the condition (checking `gateway_id` instead of `app_user_email`).

Closes #1550
Supersedes #1551

Co-authored-by: Ilia Manolov <iliamanolov@outlook.com>