### PR TITLE
Rest tool text response fallback

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1580,7 +1580,7 @@ class ToolService:
                     elif response.status_code not in [200, 201, 202, 206]:
                         try:
                             result = response.json()
-                        except:
+                        except json.JSONDecodeError:
                             result = {"response_text": response.text} if response.text else {}
                         tool_result = ToolResult(
                             content=[TextContent(type="text", text=str(result["error"]) if "error" in result else "Tool error encountered")],
@@ -1590,7 +1590,7 @@ class ToolService:
                     else:
                         try:
                             result = response.json()
-                        except:
+                        except json.JSONDecodeError:
                             result = {"response_text": response.text} if response.text else {}
                         logger.debug(f"REST API tool response: {result}")
                         filtered_response = extract_using_jq(result, tool.jsonpath_filter)


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes #1576

If the Rest API added as a tool in gateway responds with a text data, the tool call fails, since the tool checks for json response only, added a fallback for Rest tool that respond with a text output, if json fails, the code checks for text, if even text is not present then as empty or error as applicable.


## 🐞 Root Cause
Mismatch in Expected Response Format: The tool is set up to handle only JSON responses, so it fails when the API returns a different data format (like plain text).

Lack of Fallback Logic: The system doesn't have logic to handle non-JSON responses like text. It assumes the API will always return JSON, which causes it to break if the actual response type is anything else.

## 💡 Fix Description
Check for JSON Response First: Initially, try parsing the response as JSON. If this succeeds, proceed with normal processing.
Fallback to Text Parsing: If JSON parsing fails, check if the response is plain text. If it is, handle it accordingly.
Error Handling: If neither a valid JSON nor text response is found, set the response to an empty string or trigger an error message, depending on the requirements.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed