### PR TITLE
UI Improvement: Make “All Team” Dropdown Scrollable

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -516,7 +516,7 @@
                   x-transition:leave="transition ease-in duration-75"
                   x-transition:leave-start="transform opacity-100 scale-100"
                   x-transition:leave-end="transform opacity-0 scale-95"
-                  class="origin-top-right absolute right-0 mt-2 w-64 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 dark:divide-gray-700 z-50"
+                  class="origin-top-right absolute right-0 mt-2 w-64 max-h-60 overflow-y-auto rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 dark:divide-gray-700 z-50"
                   role="menu"
                   aria-orientation="vertical"
                   aria-labelledby="team-selector-button"


### PR DESCRIPTION
This pull request introduces a small UI improvement to the dropdown in the 'All team" in Admin UI. The change ensures that if the menu content exceeds a certain height, it becomes scrollable rather than overflowing the page.

* Added `max-h-60` and `overflow-y-auto` classes to the dropdown menu to limit its maximum height and enable vertical scrolling when needed.