### PR TITLE
[Bug Fix] Fixes to findings from standalone app building.

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -466,7 +466,7 @@ def get_user_email(user: Union[str, dict, object] = None) -> str:
     return str(user)
 
 
-def get_user_id(user: Union[str, dict, object] = None) -> str:
+def get_user_id(user: Union[str, dict[str, Any], object] = None) -> str:
     """Return the user ID from a JWT payload, user object, or string.
 
     Args:
@@ -508,16 +508,11 @@ def get_user_id(user: Union[str, dict, object] = None) -> str:
         'unknown'
     """
     if isinstance(user, dict):
-        # Try multiple possible ID fields in order of preference
+        # Try multiple possible ID fields in order of preference.
+        # Email is the primary key in the model, so that's our mostly likely result.
         return user.get("id") or user.get("user_id") or user.get("sub") or user.get("email") or "unknown"
 
-    if hasattr(user, "id"):
-        return str(user.id)
-
-    if user is None:
-        return "unknown"
-
-    return str(user)
+    return "unknown" if user is None else str(getattr(user, "id", user))
 
 
 def serialize_datetime(obj):

--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -235,13 +235,12 @@ class CatalogService:
                 )
 
             # Prepare the gateway creation data
-            # Pass tags as list of strings - GatewayCreate validator will handle conversion
             gateway_data = {
                 "name": request.name if request and request.name else server_data["name"],
                 "url": server_data["url"],
                 "description": server_data["description"],
                 "transport": transport,
-                "tags": server_data.get("tags", []),  # Pass as list of strings
+                "tags": server_data.get("tags", []),
             }
 
             # Set authentication based on server requirements
@@ -282,7 +281,7 @@ class CatalogService:
                     slug=slug_name,
                     url=gateway_data["url"],
                     description=gateway_data["description"],
-                    tags=gateway_data.get("tags", []),  # Keep catalog tags
+                    tags=gateway_data.get("tags", []),
                     transport=gateway_data["transport"],
                     capabilities={},
                     auth_type=None,  # Will be set during OAuth configuration

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -96,6 +96,7 @@ from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_expr
 from mcpgateway.utils.validate_signature import validate_signature
+from mcpgateway.validation.tags import validate_tags_field
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -3227,13 +3228,8 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
         # Convert tags from List[str] to List[Dict[str, str]] for GatewayRead
         # Database stores: ["git", "development"]
         # GatewayRead expects: [{"id": "git", "label": "git"}, {"id": "development", "label": "development"}]
-        if gateway.tags and isinstance(gateway.tags, list) and len(gateway.tags) > 0:
-            # Check if tags are strings (database format) and need conversion
-            if isinstance(gateway.tags[0], str):
-                # First-Party
-                from mcpgateway.validation.tags import validate_tags_field  # pylint: disable=import-outside-toplevel
-
-                gateway.tags = validate_tags_field(gateway.tags)
+        if gateway.tags:
+            gateway.tags = validate_tags_field(gateway.tags)
 
         return gateway
 


### PR DESCRIPTION
Making user ID extraction more flexible across different authentication contexts

Fixes:
```
bug in the authentication middleware. The backend's /admin/plugins endpoints expect a user object but receive a dict.
```

Standardizing admin endpoint authentication to use permission-based context
Fixes:
```
🐞 Bug Summary
The /auth/email/admin/users endpoint uses Depends(get_current_user) instead of Depends(get_current_user_with_permissions), causing the @require_permission decorator to fail with "User authentication required" despite valid authentication.

🧩 Affected Component
 mcpgateway - API
🔁 Steps to Reproduce
Authenticate successfully and obtain a valid Bearer token
Verify authentication works by calling /auth/email/me (returns user with is_admin: true)
Call /auth/email/admin/users with the same Bearer token
Observe "User authentication required" error
🤔 Expected Behavior
The endpoint should work like other permission-protected endpoints (e.g., /teams, /sso/*) that correctly use get_current_user_with_permissions.
````


Ensuring proper tag format conversion between database and API schema representations

Fixes:
```
When registering a catalog server via the `/admin/mcp-registry/{server_id}/register` endpoint, the tags from the catalog are copied to the gateway but in an incompatible format, causing validation errors when listing gateways.
```