### PR TITLE
Update job-migration.yaml

### DIFF
--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app.kubernetes.io/component: migration
   annotations:
-    # Run this Job before install/upgrade
-    "helm.sh/hook": pre-install,pre-upgrade
+    # Run after install (so Postgres exists) and before upgrade (so new app has migrated DB)
+    "helm.sh/hook": post-install,pre-upgrade
     # Delete old Job before new one and clean up succeeded ones
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:


### PR DESCRIPTION
Fixed the Helm template so imagePullSecrets is only defined at the pod level (not inside the container), eliminating the warning about spec.template.spec.containers[0].imagePullSecrets.

# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
It fixes the below warning when trying to deploy using helm:
"Warning: unknown field \"spec.template.spec.containers[0].imagePullSecrets\""

## 🔁 Reproduction Steps
Run the helm install command to deploy on K8S or OCP cluster.

## 🐞 Root Cause
The job-migration.yaml file (charts/mcp-stack/templates/job-migration.yaml) has the imagePullSecrets inside 'containers' section; which is incorrect. This is triggering the warning.

## 💡 Fix Description
Fixed the Helm template so imagePullSecrets is only defined at the pod level (not inside the container), eliminating the warning about spec.template.spec.containers[0].imagePullSecrets.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
