### PR TITLE
Minor bug fixes to generate_docker_compose

### DIFF
--- a/tests/loadtest/locustfile.py
+++ b/tests/loadtest/locustfile.py
@@ -225,7 +225,7 @@ def on_test_start(environment, **_kwargs):  # pylint: disable=unused-argument
 
 
 @events.test_stop.add_listener
-def on_test_stop(_environment, **_kwargs):  # pylint: disable=unused-argument
+def on_test_stop(environment, **kwargs):  # pylint: disable=unused-argument
     """Clean up after test."""
     logger.info("Test stopped")
     TOOL_IDS.clear()

--- a/tests/performance/utils/generate_docker_compose.py
+++ b/tests/performance/utils/generate_docker_compose.py
@@ -50,8 +50,8 @@ volumes:
 
 GATEWAY_SERVICE_TEMPLATE = """  gateway{instance_suffix}:
     build:
-      context: ../..
-      dockerfile: Dockerfile
+      context: ../../..
+      dockerfile: Containerfile.lite
     container_name: gateway{instance_suffix}
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/mcpgateway
@@ -99,7 +99,7 @@ NGINX_LOAD_BALANCER = """  nginx:
     image: nginx:alpine
     container_name: nginx_lb
     ports:
-      - "4444:80"
+      - "8000:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:


### PR DESCRIPTION
# 🐛 Bug-fix PR

Fixes these issues
1. Fixes a variable name
2. Uses port 8000 for nginx

---

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     pass   |
| Unit tests                            | `make test`          |     pass   |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
