### PR TITLE
GUNICORN settings in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1101,10 +1101,10 @@ WELL_KNOWN_CACHE_MAX_AGE=3600
 # GUNICORN_MAX_REQUESTS_JITTER=100
 
 # Preload application before forking workers
-# Options: true, false (default)
-# true: Saves memory (shared code), but slower reload and no per-worker initialization
+# Options: true (default), false
+# true: Saves memory (shared code), runs migrations once before forking
 # false: Each worker loads app independently (more memory, better isolation)
-# GUNICORN_PRELOAD_APP=false
+# GUNICORN_PRELOAD_APP=true
 
 # Developer mode with hot reload
 # Options: true, false (default)

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -91,7 +91,7 @@ Kubernetes: `>=1.21.0-0`
 | mcpContextForge.config.GUNICORN_TIMEOUT | string | `"600"` |  |
 | mcpContextForge.config.GUNICORN_MAX_REQUESTS | string | `"100000"` |  |
 | mcpContextForge.config.GUNICORN_MAX_REQUESTS_JITTER | string | `"100"` |  |
-| mcpContextForge.config.GUNICORN_PRELOAD_APP | string | `"false"` |  |
+| mcpContextForge.config.GUNICORN_PRELOAD_APP | string | `"true"` |  |
 | mcpContextForge.config.GUNICORN_DEV_MODE | string | `"false"` |  |
 | mcpContextForge.config.DISABLE_ACCESS_LOG | string | `"true"` |  |
 | mcpContextForge.config.APP_NAME | string | `"MCP_Gateway"` |  |

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -345,7 +345,7 @@
               "type": "string",
               "enum": ["true", "false"],
               "description": "Preload app code before forking workers",
-              "default": "false"
+              "default": "true"
             },
             "GUNICORN_DEV_MODE": {
               "type": "string",

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -137,7 +137,7 @@ mcpContextForge:
     GUNICORN_TIMEOUT: "600"             # worker timeout in seconds
     GUNICORN_MAX_REQUESTS: "100000"     # max requests per worker before restart
     GUNICORN_MAX_REQUESTS_JITTER: "100" # random jitter to avoid thundering herd
-    GUNICORN_PRELOAD_APP: "false"       # preload app code before forking workers
+    GUNICORN_PRELOAD_APP: "true"        # preload app code before forking workers
     GUNICORN_DEV_MODE: "false"          # developer mode with hot reload (not for production)
     DISABLE_ACCESS_LOG: "true"          # disable access logging for performance
 

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -188,7 +188,7 @@ GUNICORN_MAX_REQUESTS=100000          # Requests per worker before restart (prev
 GUNICORN_MAX_REQUESTS_JITTER=100      # Random jitter to prevent thundering herd
 
 # Performance Options
-GUNICORN_PRELOAD_APP=false            # Preload app before forking (saves memory, slower reload)
+GUNICORN_PRELOAD_APP=true             # Preload app before forking (saves memory, runs migrations once)
 GUNICORN_DEV_MODE=false               # Enable hot reload (not for production!)
 DISABLE_ACCESS_LOG=true               # Disable access logs for performance (default: true)
 

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -33,7 +33,7 @@ max_requests = 100000  # The maximum number of requests a worker will process be
 max_requests_jitter = 100  # The maximum jitter to add to the max_requests setting.
 
 # Optimization https://docs.gunicorn.org/en/stable/settings.html#preload-app
-preload_app = False  # Load application code before the worker processes are forked.
+preload_app = True  # Load application code before the worker processes are forked.
 reuse_port = True  # Set the SO_REUSEPORT flag on the listening socket
 
 

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -24,7 +24,7 @@
 #    GUNICORN_TIMEOUT             : Worker timeout in seconds (default: 600)
 #    GUNICORN_MAX_REQUESTS        : Max requests per worker before restart (default: 100000)
 #    GUNICORN_MAX_REQUESTS_JITTER : Random jitter for max requests (default: 100)
-#    GUNICORN_PRELOAD_APP         : Preload app before forking workers (default: false)
+#    GUNICORN_PRELOAD_APP         : Preload app before forking workers (default: true)
 #    GUNICORN_DEV_MODE            : Enable developer mode with hot reload (default: false)
 #    SSL                          : Enable TLS/SSL (true/false, default: false)
 #    CERT_FILE                    : Path to SSL certificate (default: certs/cert.pem)
@@ -250,7 +250,7 @@ GUNICORN_MAX_REQUESTS=${GUNICORN_MAX_REQUESTS:-100000}
 GUNICORN_MAX_REQUESTS_JITTER=${GUNICORN_MAX_REQUESTS_JITTER:-100}
 
 # Preload application before forking workers (saves memory but slower reload)
-GUNICORN_PRELOAD_APP=${GUNICORN_PRELOAD_APP:-false}
+GUNICORN_PRELOAD_APP=${GUNICORN_PRELOAD_APP:-true}
 
 # Developer mode with hot reload (disables preload, enables file watching)
 GUNICORN_DEV_MODE=${GUNICORN_DEV_MODE:-false}


### PR DESCRIPTION
## Summary

Add comprehensive Gunicorn configuration support via environment variables with consistent defaults across all deployment methods. Includes fix for database migration race condition.

**Key changes:**
- Gunicorn settings now configurable via `.env` file and environment variables
- Default `GUNICORN_WORKERS=auto` (2×CPU+1, capped at 16) for optimal performance
- Default `GUNICORN_PRELOAD_APP=true` to save memory and run migrations once
- Default `DISABLE_ACCESS_LOG=true` for better throughput
- Added file locking to `bootstrap_db.py` to prevent migration race conditions

## Changes

### Gunicorn Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `GUNICORN_WORKERS` | `auto` | Worker count (`auto` = 2×CPU+1, capped at 16) |
| `GUNICORN_TIMEOUT` | `600` | Worker timeout in seconds |
| `GUNICORN_MAX_REQUESTS` | `100000` | Max requests per worker before restart |
| `GUNICORN_MAX_REQUESTS_JITTER` | `100` | Random jitter to prevent thundering herd |
| `GUNICORN_PRELOAD_APP` | `true` | Preload app before forking (saves memory) |
| `GUNICORN_DEV_MODE` | `false` | Enable hot reload (development only) |
| `DISABLE_ACCESS_LOG` | `true` | Disable access logging for performance |

### SSL/TLS Settings

| Variable | Default | Description |
|----------|---------|-------------|
| `SSL` | `false` | Enable TLS/SSL |
| `CERT_FILE` | `certs/cert.pem` | Path to SSL certificate |
| `KEY_FILE` | `certs/key.pem` | Path to SSL private key |
| `KEY_FILE_PASSWORD` | - | Passphrase for encrypted key |
| `FORCE_START` | `false` | Bypass lock file check |

### Files Changed

- **`.env.example`** - Added Gunicorn configuration section with all settings
- **`run-gunicorn.sh`** - Updated defaults, fixed documentation
- **`gunicorn.config.py`** - Aligned defaults with run-gunicorn.sh
- **`mcpgateway/bootstrap_db.py`** - Added file locking to prevent migration race conditions
- **`charts/mcp-stack/values.yaml`** - Added new settings, aligned defaults
- **`charts/mcp-stack/values.schema.json`** - Added schema entries with updated defaults
- **`charts/mcp-stack/README.md`** - Regenerated with new settings
- **`docs/docs/manage/configuration.md`** - Added Gunicorn Production Server documentation

## Migration Race Condition Fix

When multiple Gunicorn workers start simultaneously (especially with `GUNICORN_PRELOAD_APP=false`), they can race to run database migrations, causing errors like:
- `UNIQUE constraint failed: alembic_version.version_num`
- `duplicate column name: original_name`

**Solution:**
1. Changed default to `GUNICORN_PRELOAD_APP=true` - master process runs migrations once before forking workers
2. Added `FileLock` to `bootstrap_db.py` with 5-minute timeout - serializes migrations within a pod
3. If lock times out, waits for schema to be ready before continuing with bootstrap

**How it works in different scenarios:**

| Scenario | How it's handled |
|----------|-----------------|
| Single pod, preload=true | Master runs migrations once, workers inherit |
| Single pod, preload=false | FileLock serializes migrations across workers |
| Multiple pods (K8s Helm) | Migration Job runs first via Helm hook; pods wait via startup probe |
| Multiple pods (no Helm) | Each pod's FileLock + idempotent `alembic upgrade head` |

## Why These Defaults?

- **`GUNICORN_WORKERS=auto`**: Automatically scales based on available CPU cores
- **`GUNICORN_PRELOAD_APP=true`**: Saves memory, runs migrations once before forking workers
- **`DISABLE_ACCESS_LOG=true`**: Access logs create massive I/O overhead under high concurrency
- **`GUNICORN_MAX_REQUESTS=100000`**: Prevents memory leaks by recycling workers

## Usage Examples

```bash
# Use defaults (auto workers, preload, no access logs)
./run-gunicorn.sh

# Fixed worker count
GUNICORN_WORKERS=8 ./run-gunicorn.sh

# Disable preload for development (each worker loads independently)
GUNICORN_PRELOAD_APP=false ./run-gunicorn.sh

# Enable access logging for debugging
DISABLE_ACCESS_LOG=false ./run-gunicorn.sh

# With TLS
SSL=true ./run-gunicorn.sh
```
