### PR TITLE
docs: Add SPARC Syntactic Tool Calls Validator plugin docs

### DIFF
--- a/docs/docs/using/plugins/plugins.md
+++ b/docs/docs/using/plugins/plugins.md
@@ -82,6 +82,7 @@ Plugins for filtering, validating, and controlling content.
 | [Output Length Guard](https://github.com/IBM/mcp-context-forge/tree/main/plugins/output_length_guard) | Native | Guards tool outputs by length with block or truncate strategies |
 | [Schema Guard](https://github.com/IBM/mcp-context-forge/tree/main/plugins/schema_guard) | Native | Validates tool arguments and results against JSONSchema subset with optional blocking |
 | [Citation Validator](https://github.com/IBM/mcp-context-forge/tree/main/plugins/citation_validator) | Native | Validates citations/links by checking reachability and optional content keywords |
+| [SPARC Syntactic Tool Calls Validator](https://github.com/IBM/mcp-context-forge/tree/main/plugins/sparc_static_validator) | Native | Performs pre-execution syntactic validation of tool calls against their JSON Schemas - checking required parameters, types, enums, and schema constraints - and can automatically suggest or apply safe corrections (e.g., type coercions) before the tool is executed. |
 
 
 ## Compliance & Governance


### PR DESCRIPTION
# 📚 Documentation PR

> Run `make markdownlint spellcheck` and fix any issues.
> Preview locally with `cd docs && make serve`.
> Do **not** commit secrets or internal URLs.

---

## 🔗 Related Issue / Epic
_Link to the doc bug or epic this PR addresses:_
related to this PR feat: sparc plugin #1781

---

## 📝 Summary (1-2 sentences)
Add the new plugin (SPARC) to the plugin docs.

---

## ✏️ Type of Change
- [ ] Typo / formatting
- [ ] Outdated or incorrect info
- [ ] Missing explanation / example
- [ ] Unclear instructions
- [ ] New page or major rewrite
- [x] Other (describe)

---
