### PR TITLE
Fix Postgres 18 startup issue by updating volume mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -393,8 +393,8 @@ services:
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_DB=mcp
     volumes:
-      - pgdata:/var/lib/postgresql/data
-      # - pgdata18:/var/lib/postgresql  # Enable for postgres 18+
+      # - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql  # Enable for postgres 18+
     networks: [mcpnet]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Postgres 18 fails to start when reusing a volume mounted at /var/lib/postgresql/data, which was valid for older Postgres versions. Postgres 18+ enforces a new version-aware data directory layout and intentionally blocks startup to prevent data corruption.

## 🔁 Reproduction Steps
make docker-prod
make compose-up

## 🐞 Root Cause
Postgres 18 fails to start because the old volume was mounted at /var/lib/postgresql/data, which is incompatible with the new version-aware data layout.

## 💡 Fix Description

Updated the Postgres volume mount in docker-compose.yml to use `/var/lib/postgresql` for Postgres 18+, ensuring compatibility with the new version-aware data layout.

File: docker-compose.yml

- For postgres: 18
```yaml
volumes:
  - pgdata:/var/lib/postgresql
```
- For older Postgres versions (<18), the volume remains mounted at `/var/lib/postgresql/data`:
```yaml
volumes:
  - pgdata:/var/lib/postgresql/data