### PR TITLE
Postgresql read replicas 1861

### DIFF
--- a/docker-compose-performance.yml
+++ b/docker-compose-performance.yml
@@ -9,6 +9,7 @@ networks:
 
 volumes:                # Named volumes survive podman-compose down/up
   pgdata:
+  pgreplicadata:        # PostgreSQL read replica data
   # pgdata18:  # Enable for postgres 18+
   mariadbdata:
   mysqldata:
@@ -16,6 +17,9 @@ volumes:                # Named volumes survive podman-compose down/up
   pgadmindata:
   redisinsight_data:
   nginx_cache:
+  grafanadata:
+  prometheusdata:
+  lokidata:
 
 ###############################################################################
 #  CORE SERVICE - MCP Gateway
@@ -40,6 +44,16 @@ services:
     volumes:
       - nginx_cache:/var/cache/nginx    # Persistent cache storage
       - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro  # Mount config as read-only
+    # TCP kernel tuning for 3000 concurrent connections
+    # Note: net.core.* sysctls are host-level and cannot be set per-container
+    # Only net.ipv4.* sysctls that are network-namespace aware work here
+    sysctls:
+      - net.ipv4.tcp_fin_timeout=15          # Faster cleanup of FIN_WAIT2 sockets
+      - net.ipv4.ip_local_port_range=1024 65535  # More ephemeral ports for upstream
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
       interval: 30s
@@ -49,10 +63,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
+          cpus: '4'
           memory: 1G
         reservations:
-          cpus: '1'
+          cpus: '2'
           memory: 512M
 
   # ──────────────────────────────────────────────────────────────────────
@@ -75,14 +89,28 @@ services:
     # Environment - pick ONE database URL line, comment the rest
     # ──────────────────────────────────────────────────────────────────────
     environment:
-      # HTTP Server: granian (default, Rust-based) or gunicorn (Python-based alternative)
-      - HTTP_SERVER=gunicorn
-      # - HTTP_SERVER=gunicorn  # Alternative: use Gunicorn with Uvicorn workers
+      # ═══════════════════════════════════════════════════════════════════════════
+      # HTTP Server Selection: gunicorn vs granian
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Performance comparison (2500 concurrent users, PostgreSQL backend):
+      #   Gunicorn: ~2.7GB RAM, ~740% CPU, no backpressure (queues unbounded)
+      #   Granian:  ~4.0GB RAM, ~680% CPU, native backpressure (rejects excess with 503)
+      #
+      # Choose Gunicorn for: memory-constrained environments (32% less RAM)
+      # Choose Granian for:  load spike protection, bursty traffic (graceful degradation)
+      # Both achieve same RPS when database is the bottleneck.
+      # ═══════════════════════════════════════════════════════════════════════════
+      - HTTP_SERVER=granian    # Rust-based, native backpressure, +47% memory, -8% CPU
+      # - HTTP_SERVER=gunicorn # Python-based, battle-tested, lower memory usage
       - HOST=0.0.0.0
       - PORT=4444
       # Transport: sse, streamablehttp, http, or all (default: all)
       - TRANSPORT_TYPE=streamablehttp
-      - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp
+      # Database connection: Via PgBouncer (default) or direct PostgreSQL
+      # PgBouncer provides connection pooling for better performance under high concurrency
+      - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@pgbouncer:6432/mcp
+      # Direct PostgreSQL connection (bypass PgBouncer - increase DB_POOL_SIZE if using):
+      # - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp
       # - DATABASE_URL=mysql+pymysql://mysql:${MYSQL_PASSWORD:-changeme}@mariadb:3306/mcp
       # - DATABASE_URL=mysql+pymysql://admin:${MARIADB_PASSWORD:-changeme}@mariadb:3306/mcp
       # - DATABASE_URL=mongodb://admin:${MONGO_PASSWORD:-changeme}@mongodb:27017/mcp
@@ -95,6 +123,29 @@ services:
       - REDIS_SOCKET_TIMEOUT=5.0
       - REDIS_SOCKET_CONNECT_TIMEOUT=5.0
       - REDIS_HEALTH_CHECK_INTERVAL=30
+      # Auth Cache Configuration (reduces DB queries per auth request from 3-4 to 0-1)
+      - AUTH_CACHE_ENABLED=true
+      - AUTH_CACHE_USER_TTL=60
+      - AUTH_CACHE_REVOCATION_TTL=30
+      - AUTH_CACHE_TEAM_TTL=60
+      - AUTH_CACHE_ROLE_TTL=60
+      - AUTH_CACHE_BATCH_QUERIES=true
+      # Registry Cache Configuration (reduces DB queries for list endpoints)
+      - REGISTRY_CACHE_ENABLED=true
+      - REGISTRY_CACHE_TOOLS_TTL=20
+      - REGISTRY_CACHE_PROMPTS_TTL=15
+      - REGISTRY_CACHE_RESOURCES_TTL=15
+      - REGISTRY_CACHE_AGENTS_TTL=20
+      - REGISTRY_CACHE_SERVERS_TTL=20
+      - REGISTRY_CACHE_GATEWAYS_TTL=20
+      - REGISTRY_CACHE_CATALOG_TTL=300
+      # Admin Stats Cache Configuration (reduces aggregate queries for dashboard)
+      - ADMIN_STATS_CACHE_ENABLED=true
+      - ADMIN_STATS_CACHE_SYSTEM_TTL=60
+      - ADMIN_STATS_CACHE_OBSERVABILITY_TTL=30
+      - ADMIN_STATS_CACHE_TAGS_TTL=120
+      - ADMIN_STATS_CACHE_PLUGINS_TTL=120
+      - ADMIN_STATS_CACHE_PERFORMANCE_TTL=60
       # MCP Server Health Check
       # Interval in seconds between health checks (default: 300)
       - HEALTH_CHECK_INTERVAL=300
@@ -160,31 +211,69 @@ services:
       - VALIDATION_MIDDLEWARE_ENABLED=true
       - CORRELATION_ID_ENABLED=false
       - OBSERVABILITY_ENABLED=false
-      # Database pool tuning for load testing
-      # Auth uses fresh short-lived sessions, so smaller pools work better
-      # Formula: (replicas × workers) × (pool + overflow) < postgres max_connections
-      # 2 replicas × 16 workers × 30 = 960 connections max
-      - DB_POOL_SIZE=10
-      - DB_MAX_OVERFLOW=20
-      - DB_POOL_TIMEOUT=30
+      # Database pool tuning for 3000 sustained users
+      # With PgBouncer (default): smaller pools since PgBouncer handles connection multiplexing
+      # Direct PostgreSQL: larger pools needed, formula: (replicas × workers) × (pool + overflow) < max_connections
+      #
+      # WITH PgBouncer (default):
+      - DB_POOL_SIZE=15
+      - DB_MAX_OVERFLOW=5              # Low overflow minimizes pool churn under pressure
+      # DIRECT PostgreSQL connection (uncomment if bypassing PgBouncer):
+      # - DB_POOL_SIZE=50
+      # - DB_MAX_OVERFLOW=100
+      - DB_POOL_TIMEOUT=45             # Time to wait for connection before failing
       - DB_POOL_RECYCLE=300
       - DB_POOL_PRE_PING=false
-      # Metrics buffer tuning - larger batches, fewer DB writes
-      - METRICS_BUFFER_MAX_SIZE=5000
-      - METRICS_BUFFER_FLUSH_INTERVAL=120
-      # Tool invocation timeout - prevents hung connections
-      - TOOL_TIMEOUT=30
+      # Tool configuration for high-concurrency load testing
+      - TOOL_TIMEOUT=60               # Seconds before tool invocation times out
+      - MAX_TOOL_RETRIES=3            # Retry attempts for failed tool invocations
+      - TOOL_RATE_LIMIT=3000          # Max tool invocations per minute
+      - TOOL_CONCURRENT_LIMIT=100     # Max concurrent tool invocations
       - FEDERATION_TIMEOUT=30
       # Worker and server tuning for high-concurrency load testing
-      # Optimal: 2 * CPU cores + 1 = 25 for 12 CPUs
-      - GUNICORN_WORKERS=25
-      # Granian high-concurrency tuning (for 1000 concurrent users)
-      # Higher backlog allows more pending connections
-      - GRANIAN_BACKLOG=8192
-      - GRANIAN_BACKPRESSURE=2048
+      - GUNICORN_WORKERS=16
+      # Granian high-concurrency tuning with backpressure (for 3000 concurrent users)
+      # Total capacity = GRANIAN_WORKERS × GRANIAN_BACKPRESSURE = 16 × 64 = 1024 concurrent requests
+      # Requests beyond this limit receive immediate 503 (no queuing, no OOM)
+      - GRANIAN_BACKLOG=4096
+      - GRANIAN_BACKPRESSURE=64
       - GRANIAN_HTTP1_BUFFER_SIZE=524288
+      # Note: GRANIAN_BLOCKING_THREADS must be 1 for ASGI (Granian limitation)
       # Granian workers (auto = CPU count, or set explicit number)
-      - GRANIAN_WORKERS=25
+      - GRANIAN_WORKERS=16
+      # HTTP/2: Granian supports native HTTP/2 multiplexing, but not useful here because:
+      # - nginx sits in front and downgrades to HTTP/1.1 for upstream connections
+      # - nginx open-source doesn't support HTTP/2 to backends (only nginx Plus does)
+      # - Internal Docker network is fast enough that HTTP/2 gains are negligible
+      # To use HTTP/2, either bypass nginx or use Granian with TLS directly.
+      # - GRANIAN_HTTP=2
+
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Execution Metrics Recording
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Controls tool/resource/prompt/server/A2A execution metrics (one DB row per operation).
+      # Disable when using external observability to improve performance.
+      # Set to true if you need per-operation metrics in the database.
+      # Note: Does NOT affect log aggregation (METRICS_AGGREGATION_ENABLED) or Prometheus.
+      - DB_METRICS_RECORDING_ENABLED=true
+
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Metrics Configuration
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Raw metrics are deleted after hourly rollups exist (default: 1 hour retention).
+      # Rollups preserve all analytics (counts, p50/p95/p99) for 365 days.
+      #
+      # If using external observability (ELK, Datadog, Splunk), raw metrics are
+      # redundant - your external platform handles debugging and audit trails.
+      #
+      # Configurable settings (uncomment to override defaults):
+      # - METRICS_DELETE_RAW_AFTER_ROLLUP=true      # Delete raw after rollup (default)
+      # - METRICS_DELETE_RAW_AFTER_ROLLUP_HOURS=1    # Raw retention when rollup exists
+      # - METRICS_CLEANUP_INTERVAL_HOURS=1          # Cleanup frequency (default: hourly)
+      # - METRICS_RETENTION_DAYS=7                  # Fallback retention (rollup disabled)
+      #
+      # For debugging without external observability, increase raw retention:
+      # - METRICS_DELETE_RAW_AFTER_ROLLUP_HOURS=168  # Keep raw data 7 days
 
       # Phoenix Observability Integration (uncomment when using Phoenix)
       # - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006}
@@ -194,11 +283,14 @@ services:
       # - OTEL_METRICS_EXPORTER=${OTEL_METRICS_EXPORTER:-otlp}
       # - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES:-deployment.environment=docker,service.namespace=mcp}
 
-    depends_on:          # Default stack: Postgres + Redis + Alembic migration
-      postgres:
-        condition: service_healthy   # ▶ wait for DB
+    depends_on:          # Default stack: PgBouncer + Redis (PgBouncer depends on Postgres)
+      pgbouncer:
+        condition: service_healthy   # ▶ wait for connection pooler
       redis:
         condition: service_started
+      # Direct PostgreSQL (uncomment if bypassing PgBouncer):
+      # postgres:
+      #   condition: service_healthy
       # migration:
       #   condition: service_completed_successfully
 
@@ -226,13 +318,13 @@ services:
 
     deploy:
       mode: replicated
-      replicas: 2
+      replicas: 5
       resources:
         limits:
-          cpus: '12'
+          cpus: '8'
           memory: 8G
         reservations:
-          cpus: '6'
+          cpus: '4'
           memory: 4G
 
     # ──────────────────────────────────────────────────────────────────────
@@ -261,14 +353,16 @@ services:
 ###############################################################################
 
   postgres:
-    image: postgres:17
+    image: postgres:18
     ports:
       - "5433:5432"      # Expose for baseline load testing (5433 to avoid conflict with local postgres)
-    # Performance tuning for high-load testing (2 replicas × 8 workers × 200 pool = 3200 connections)
+    # Performance tuning for high-load testing (3000 sustained users)
+    # WITH PgBouncer (default): 700 connections provides headroom for 550 pool + system overhead
+    # DIRECT connection mode: increase to 4000 for (3 replicas × 16 workers × 80 pool)
     command:
       - "postgres"
       - "-c"
-      - "max_connections=4000"
+      - "max_connections=700"     # Must exceed PgBouncer MAX_DB_CONNECTIONS (550) + overhead
       - "-c"
       - "shared_buffers=512MB"
       - "-c"
@@ -286,56 +380,105 @@ services:
       - "-c"
       - "effective_io_concurrency=200"
       - "-c"
-      - "max_worker_processes=4"
+      - "max_worker_processes=8"           # Total background workers (must be >= max_parallel_workers)
       - "-c"
-      - "max_parallel_workers_per_gather=2"
+      - "max_parallel_workers_per_gather=4" # Max workers per query's parallel operation
       - "-c"
-      - "max_parallel_workers=4"
-      # === ROLLBACK DEBUGGING ===
+      - "max_parallel_workers=8"            # Total parallel workers available system-wide
+      # Parallel query cost thresholds - lower values make planner consider parallelism for smaller queries
+      # Default parallel_tuple_cost=0.1, parallel_setup_cost=1000 - too conservative for fast SSDs
+      # These lower thresholds encourage parallelism but may not help OLTP workloads (small queries)
       - "-c"
-      - "log_min_error_statement=error"
+      - "parallel_tuple_cost=0.01"          # Cost per tuple transferred to parallel worker (default: 0.1)
       - "-c"
-      - "log_min_messages=warning"
+      - "parallel_setup_cost=100"           # Fixed cost to start parallel worker (default: 1000)
+      # === HIGH-CONCURRENCY TUNING (3000 users) ===
+      # CRITICAL: idle_in_transaction_session_timeout prevents connection starvation
+      # Application code now properly closes transactions via get_db() commit-on-success pattern
+      # This timeout is a safety net for any edge cases
       - "-c"
-      - "log_error_verbosity=verbose"
+      - "idle_in_transaction_session_timeout=60s"  # Kill stuck transactions after 60s
       - "-c"
-      - "log_line_prefix=%t [%p]: user=%u,db=%d,app=%a,client=%h "
+      - "statement_timeout=60s"            # Kill runaway queries after 60s
       - "-c"
-      - "log_lock_waits=on"
+      - "synchronous_commit=off"           # Async WAL writes (2-10x faster commits)
       - "-c"
-      - "deadlock_timeout=1s"
+      - "commit_delay=100"                 # Batch commits within 100μs window
+      # ═══════════════════════════════════════════════════════════════════════════
+      # WAL REPLICATION SETTINGS - Enable streaming replication for read replicas
+      # ═══════════════════════════════════════════════════════════════════════════
       - "-c"
-      - "log_temp_files=0"
+      - "wal_level=replica"                # Enable WAL for replication (minimal/replica/logical)
       - "-c"
-      - "log_checkpoints=on"
+      - "max_wal_senders=4"                # Max concurrent WAL sender processes (replicas + backups)
       - "-c"
-      - "log_connections=on"
+      - "max_replication_slots=4"          # Replication slots prevent WAL cleanup before replica catches up
       - "-c"
-      - "log_disconnections=on"
-      - "-c"
-      - "idle_in_transaction_session_timeout=10s"
-      # === PERFORMANCE OPTIMIZATIONS ===
-      - "-c"
-      - "synchronous_commit=off"
-      - "-c"
-      - "commit_delay=100"
-      # === AGGRESSIVE AUTOVACUUM FOR METRICS ===
-      - "-c"
-      - "autovacuum_vacuum_scale_factor=0.02"
-      - "-c"
-      - "autovacuum_naptime=15"
-      # === QUERY MONITORING ===
-      - "-c"
-      - "shared_preload_libraries=pg_stat_statements"
-      - "-c"
-      - "pg_stat_statements.track=all"
+      - "hot_standby=on"                   # Allow queries on standby servers
+      # ═══════════════════════════════════════════════════════════════════════════
+      # AUTOVACUUM TUNING - High-insert workloads (metrics tables)
+      # ═══════════════════════════════════════════════════════════════════════════
+      # High insert rates cause dead tuple accumulation. These settings help
+      # PostgreSQL keep up with table bloat from metrics writes.
+      # Uncomment if experiencing performance degradation under sustained load:
+      # - "-c"
+      # - "autovacuum_naptime=30s"              # Check more frequently (default: 60s)
+      # - "-c"
+      # - "autovacuum_vacuum_scale_factor=0.05" # Vacuum at 5% dead tuples (default: 0.2)
+      # - "-c"
+      # - "autovacuum_vacuum_cost_limit=1000"   # More vacuum work per cycle (default: 200)
+      # === PG_STAT_STATEMENTS - Query performance tracking ===
+      # Uncomment to enable query statistics (slight overhead, ~2-5%)
+      # After enabling, run in psql:
+      #   CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+      #   SELECT * FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;
+      # - "-c"
+      # - "shared_preload_libraries=pg_stat_statements"
+      # - "-c"
+      # - "pg_stat_statements.track=all"
+      # - "-c"
+      # - "pg_stat_statements.max=10000"
+      # === AUTO_EXPLAIN - Slow query plan logging ===
+      # Uncomment to auto-log execution plans for slow queries
+      # - "-c"
+      # - "shared_preload_libraries=auto_explain"
+      # - "-c"
+      # - "auto_explain.log_min_duration=1000"
+      # - "-c"
+      # - "auto_explain.log_analyze=on"
+      # === ROLLBACK DEBUGGING (disabled for performance) ===
+      # - "-c"
+      # - "log_min_error_statement=error"
+      # - "-c"
+      # - "log_min_messages=warning"
+      # - "-c"
+      # - "log_error_verbosity=verbose"
+      # - "-c"
+      # - "log_line_prefix=%t [%p]: user=%u,db=%d,app=%a,client=%h "
+      # - "-c"
+      # - "log_lock_waits=on"
+      # - "-c"
+      # - "deadlock_timeout=1s"
+      # - "-c"
+      # - "log_temp_files=0"
+      # - "-c"
+      # - "log_checkpoints=on"
+      # - "-c"
+      # - "log_connections=on"
+      # - "-c"
+      # - "log_disconnections=on"
+      # - "-c"
+      # - "idle_in_transaction_session_timeout=60s"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_DB=mcp
     volumes:
-      - pgdata:/var/lib/postgresql/data
-      # - pgdata18:/var/lib/postgresql  # Enable for postgres 18+
+      # - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql  # Enable for postgres 18+
+      # Init script to enable replication connections (required for postgres-replica)
+      # Note: Not using :ro to preserve execute permissions
+      - ./infra/postgres/init-replication.sh:/docker-entrypoint-initdb.d/init-replication.sh
     networks: [mcpnet]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
@@ -346,11 +489,178 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '6'
-          memory: 4G
+          cpus: '4'
+          memory: 8G
         reservations:
-          cpus: '3'
+          cpus: '2'
           memory: 2G
+
+  # ──────────────────────────────────────────────────────────────────────
+  # PostgreSQL Read Replica - Streaming replication for read scaling
+  # ──────────────────────────────────────────────────────────────────────
+  # Provides horizontal scaling for read-heavy workloads. Writes go to primary,
+  # reads can be distributed across primary and replica via PgBouncer.
+  # Use `docker compose --profile replica up -d` to enable.
+  # ──────────────────────────────────────────────────────────────────────
+  postgres-replica:
+    image: postgres:18
+    profiles: ["replica"]    # Only starts with --profile replica
+    restart: unless-stopped
+    networks: [mcpnet]
+    # No port exposed - accessed via PgBouncer only
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-mysecretpassword}
+      - PGUSER=postgres
+      - PGPASSWORD=${POSTGRES_PASSWORD:-mysecretpassword}
+    # Start as replica using pg_basebackup to clone from primary
+    # Note: PostgreSQL 18 uses /var/lib/postgresql/18/docker as PGDATA
+    command:
+      - /bin/bash
+      - -c
+      - |
+        export PGDATA=/var/lib/postgresql/18/docker
+        export PATH=/usr/local/bin:/usr/bin:/bin:$$PATH
+
+        # Wait for primary to be ready and accepting connections
+        echo "Waiting for primary PostgreSQL to be ready..."
+        until pg_isready -h postgres -p 5432 -U postgres; do
+          echo "Primary not ready, waiting..."
+          /usr/bin/sleep 2
+        done
+        echo "Primary is ready!"
+
+        # Check if data directory has valid standby.signal (indicates successful replica setup)
+        if [ ! -f "$$PGDATA/standby.signal" ]; then
+          echo "Initializing replica from primary using pg_basebackup..."
+          rm -rf "$$PGDATA"
+          mkdir -p "$$PGDATA"
+          chown postgres:postgres "$$PGDATA"
+          chmod 700 "$$PGDATA"
+
+          # Clone the primary database (as postgres user)
+          until /usr/local/bin/gosu postgres pg_basebackup \
+            -h postgres \
+            -p 5432 \
+            -U postgres \
+            -D "$$PGDATA" \
+            -Fp \
+            -Xs \
+            -P \
+            -R; do
+            echo "pg_basebackup failed, retrying in 5 seconds..."
+            /usr/bin/sleep 5
+          done
+
+          echo "Base backup complete!"
+        else
+          echo "Replica data directory exists, ensuring permissions..."
+          chown -R postgres:postgres "$$PGDATA"
+          chmod 700 "$$PGDATA"
+        fi
+
+        echo "Starting replica..."
+        # Start PostgreSQL in standby mode (as postgres user)
+        exec /usr/local/bin/gosu postgres postgres \
+          -D "$$PGDATA" \
+          -c max_connections=700 \
+          -c shared_buffers=512MB \
+          -c work_mem=16MB \
+          -c effective_cache_size=1536MB \
+          -c random_page_cost=1.1 \
+          -c effective_io_concurrency=200 \
+          -c hot_standby=on \
+          -c hot_standby_feedback=on \
+          -c max_standby_streaming_delay=30s \
+          -c wal_receiver_timeout=60s
+    volumes:
+      - pgreplicadata:/var/lib/postgresql
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres && psql -U postgres -c 'SELECT pg_is_in_recovery();' | grep -q 't'"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s    # Longer start period for initial sync
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 8G
+        reservations:
+          cpus: '2'
+          memory: 2G
+
+  # ──────────────────────────────────────────────────────────────────────
+  # PgBouncer - Connection Pooler for PostgreSQL
+  # Reduces connection overhead, improves throughput under high concurrency.
+  # Enable by switching gateway DATABASE_URL to use pgbouncer:6432 instead of postgres:5432
+  # ──────────────────────────────────────────────────────────────────────
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "6432:6432"    # PgBouncer port (optional external access)
+    environment:
+      # ═══════════════════════════════════════════════════════════════════════════
+      # PostgreSQL Connection Configuration (Load Balanced)
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Connects to both primary and replica for read distribution.
+      # When replica is not running (default), all traffic goes to primary.
+      # Enable replica with: docker compose --profile replica up -d
+      # Note: Writes hitting replica will fail - for production, implement
+      # application-level read/write splitting (see mcpgateway/db.py).
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres,postgres-replica:5432/mcp
+      # PgBouncer listen port (default would be 5432, using 6432 to distinguish from PostgreSQL)
+      - LISTEN_PORT=6432
+      # Pool mode: transaction (recommended), session, or statement
+      # transaction: connection returned after each transaction (best for web apps)
+      - POOL_MODE=transaction
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Connection Pool Tuning for 3000 Sustained Users
+      # PgBouncer handles connection multiplexing - many app connections share fewer DB connections
+      # ═══════════════════════════════════════════════════════════════════════════
+      # Client-side limits (from gateway workers via SQLAlchemy)
+      - MAX_CLIENT_CONN=5000           # Max app connections; must exceed (replicas × workers × pool)
+      - DEFAULT_POOL_SIZE=450          # Shared DB connections; sized for ~70 concurrent tx × 6x headroom
+      - MIN_POOL_SIZE=50               # Pre-warmed connections for instant response to load spikes
+      - RESERVE_POOL_SIZE=100          # Emergency pool for burst traffic beyond DEFAULT_POOL_SIZE
+      - RESERVE_POOL_TIMEOUT=2         # Seconds before tapping reserve pool
+      # Server-side limits (to PostgreSQL)
+      - MAX_DB_CONNECTIONS=550         # Max connections to PostgreSQL; must be < PG max_connections
+      - MAX_USER_CONNECTIONS=550       # Per-user limit; typically equals MAX_DB_CONNECTIONS
+      # Connection lifecycle
+      - SERVER_LIFETIME=3600           # Recycle server connections after 1 hour (prevents stale state)
+      - SERVER_IDLE_TIMEOUT=300        # Close unused server connections after 5 min
+      # Timeout settings
+      - QUERY_WAIT_TIMEOUT=45          # Max wait for available connection before failing request
+      - CLIENT_IDLE_TIMEOUT=60         # Close idle client connections to free resources quickly
+      - SERVER_CONNECT_TIMEOUT=5       # Timeout for new connections to PostgreSQL
+      # Transaction cleanup - critical for avoiding idle-in-transaction buildup
+      - SERVER_RESET_QUERY=DISCARD ALL # Reset connection state when returned to pool
+      - SERVER_RESET_QUERY_ALWAYS=1    # Always run reset query even after clean transactions
+      - IDLE_TRANSACTION_TIMEOUT=30    # Kill transactions idle > 30s (prevents connection starvation)
+      # Authentication
+      - AUTH_TYPE=scram-sha-256        # Match PostgreSQL auth method
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 256M
+        reservations:
+          cpus: '0.5'
+          memory: 128M
 
   # mariadb:
   #   image: mariadb:10.6
@@ -455,21 +765,238 @@ services:
           memory: 1G
 
 ###############################################################################
+#  MONITORING STACK (enabled with --profile monitoring)
+#  Usage: docker compose --profile monitoring up -d
+#  Access: Grafana http://localhost:3000 (admin/changeme)
+#          Prometheus http://localhost:9090
+###############################################################################
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Prometheus PostgreSQL Exporter - Primary Database metrics
+  # Metrics: connections, query duration, locks, cache hit ratio, replication
+  # ──────────────────────────────────────────────────────────────────────
+  postgres_exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9187:9187"    # http://localhost:9187/metrics
+    environment:
+      - DATA_SOURCE_NAME=postgresql://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp?sslmode=disable
+      - PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Prometheus PostgreSQL Exporter - Replica Database metrics
+  # Only starts when replica profile is enabled (with monitoring-up)
+  # ──────────────────────────────────────────────────────────────────────
+  postgres_exporter_replica:
+    image: quay.io/prometheuscommunity/postgres-exporter:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9188:9187"    # http://localhost:9188/metrics
+    environment:
+      - DATA_SOURCE_NAME=postgresql://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres-replica:5432/mcp?sslmode=disable
+      - PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
+    depends_on:
+      postgres-replica:
+        condition: service_healthy
+    profiles: ["monitoring", "replica"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Prometheus Redis Exporter - Cache metrics
+  # Metrics: memory, clients, commands/sec, keyspace stats
+  # ──────────────────────────────────────────────────────────────────────
+  redis_exporter:
+    image: oliver006/redis_exporter:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9121:9121"    # http://localhost:9121/metrics
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_started
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Prometheus PgBouncer Exporter - Connection pool metrics
+  # Metrics: active/waiting clients, server connections, pool stats
+  # ──────────────────────────────────────────────────────────────────────
+  pgbouncer_exporter:
+    image: prometheuscommunity/pgbouncer-exporter:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9127:9127"    # http://localhost:9127/metrics
+    environment:
+      - PGBOUNCER_EXPORTER_CONNECTION_STRING=postgres://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@pgbouncer:6432/pgbouncer?sslmode=disable
+    depends_on:
+      pgbouncer:
+        condition: service_healthy
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Prometheus Nginx Exporter - Proxy metrics
+  # Metrics: active connections, requests/sec, response codes
+  # Requires stub_status enabled in nginx.conf (location /nginx_status)
+  # ──────────────────────────────────────────────────────────────────────
+  nginx_exporter:
+    image: nginx/nginx-prometheus-exporter:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9113:9113"    # http://localhost:9113/metrics
+    command:
+      - '-nginx.scrape-uri=http://nginx:80/nginx_status'
+    depends_on:
+      nginx:
+        condition: service_healthy
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # cAdvisor - Container metrics (CPU, memory, network, disk I/O)
+  # Metrics: container_cpu_usage_seconds_total, container_memory_usage_bytes
+  # Dashboard: Grafana ID 14282 (Docker and cAdvisor)
+  # ──────────────────────────────────────────────────────────────────────
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "8085:8080"    # http://localhost:8085/metrics
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Prometheus - Metrics collection and storage
+  # Scrapes: gateway, postgres, redis, nginx, cadvisor
+  # Retention: 7 days (configurable via --storage.tsdb.retention.time)
+  # ──────────────────────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9090:9090"    # http://localhost:9090
+    volumes:
+      - ./infra/monitoring/prometheus-performance.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheusdata:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=7d'
+      - '--web.enable-lifecycle'
+    depends_on:
+      - postgres_exporter
+      - redis_exporter
+      - nginx_exporter
+      - cadvisor
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Loki - Log aggregation system (like Prometheus, but for logs)
+  # Query logs with LogQL in Grafana
+  # ──────────────────────────────────────────────────────────────────────
+  loki:
+    image: grafana/loki:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    user: "0"  # Run as root to avoid permission issues
+    ports:
+      - "3100:3100"    # http://localhost:3100/ready
+    volumes:
+      - ./infra/monitoring/loki/loki-config.yaml:/etc/loki/local-config.yaml:ro
+      - lokidata:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Promtail - Log collector for Loki
+  # Collects logs from all containers via Docker socket
+  # ──────────────────────────────────────────────────────────────────────
+  promtail:
+    image: grafana/promtail:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    volumes:
+      - ./infra/monitoring/loki/promtail-config.yaml:/etc/promtail/config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yaml
+    depends_on:
+      - loki
+    profiles: ["monitoring"]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Grafana - Dashboard visualization
+  # Default login: admin / changeme
+  # Recommended dashboards:
+  #   - Docker/cAdvisor: 14282
+  #   - PostgreSQL: 9628
+  #   - Redis: 763
+  #   - Nginx: 12708
+  # ──────────────────────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    user: "0"  # Run as root to avoid permission issues with provisioning
+    ports:
+      - "3000:3000"    # http://localhost:3000
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=changeme
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./infra/monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./infra/monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+    depends_on:
+      - prometheus
+    profiles: ["monitoring"]
+
+###############################################################################
 #  OPTIONAL ADMIN TOOLS - handy web UIs for DB & cache (disabled by default)
 ###############################################################################
-  # pgadmin:              # 🔧 Postgres admin UI
-  #   image: dpage/pgadmin4:latest
-  #   environment:
-  #     - PGADMIN_DEFAULT_EMAIL=admin@example.com
-  #     - PGADMIN_DEFAULT_PASSWORD=changeme
-  #   ports:
-  #     - "5050:80"      # http://localhost:5050
-  #   volumes:
-  #     - pgadmindata:/var/lib/pgadmin
-  #   networks: [mcpnet]
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
+  pgadmin:              # 🔧 Postgres admin UI
+    image: dpage/pgadmin4:9.11.0
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@example.com
+      - PGADMIN_DEFAULT_PASSWORD=changeme
+    ports:
+      - "5050:80"      # http://localhost:5050
+    volumes:
+      - pgadmindata:/var/lib/pgadmin
+    networks: [mcpnet]
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Redis Commander - a web-based Redis GUI
+  # ──────────────────────────────────────────────────────────────────────
+  redis_commander:       # 🔧 Redis key browser
+    image: rediscommander/redis-commander:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    depends_on:
+      redis:
+        condition: service_started
+    ports:
+      - "8081:8081"    # http://localhost:8081
+    environment:
+      - REDIS_HOSTS=local:redis:6379
+      - HTTP_USER=admin
+      - HTTP_PASSWORD=changeme
 
   # # ──────────────────────────────────────────────────────────────────────
   # # Redis Insight - a powerful Redis GUI (recently updated)
@@ -516,64 +1043,6 @@ services:
   #     - RI_APP_HOST=0.0.0.0          # <- listen on all interfaces
   #     - RI_APP_PORT=5540             # <- UI port (container-side)
 
-  #     # ──────────────────────────────────────────────────────────────────
-  #     # (Optional) Enable HTTPS for the UI
-  #     # ──────────────────────────────────────────────────────────────────
-  #     # - RI_SERVER_TLS_KEY=/certs/tls.key
-  #     # - RI_SERVER_TLS_CERT=/certs/tls.crt
-
-  # # ──────────────────────────────────────────────────────────────────────
-  # # Redis Commander - a web-based Redis GUI
-  # # ──────────────────────────────────────────────────────────────────────
-  # redis_commander:       # 🔧 Redis key browser
-  #   image: rediscommander/redis-commander:latest
-  #   restart: unless-stopped
-  #   networks: [mcpnet]
-  #   depends_on:
-  #     redis:
-  #       condition: service_started
-  #   ports:
-  #     - "8081:8081"    # <- change if you want a different host port
-
-  #   # ─────────────────────────────────────────────────────────────────────────
-  #   # Mount your local certs directory (only needed if you want real cert validation)
-  #   # ─────────────────────────────────────────────────────────────────────────
-  #   # volumes:
-  #   #   - ./certs:/certs:ro   # <- put your selfsigned.crt (PEM) in ./certs
-
-  #   environment:
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     # LEGACY HOST LIST (for showing in UI - not used for TLS)
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     - REDIS_HOSTS=local:redis:6379
-
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     # CORE REDIS/TLS
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     - REDIS_HOST=redis                # <- your Redis hostname or IP
-  #     - REDIS_PORT=6379                 # <- your Redis port
-  #     - REDIS_USERNAME=admin          # ← REQUIRED when Redis has users/ACLs
-  #     - REDIS_PASSWORD=${REDIS_PASSWORD}# <- if you need a Redis auth password
-  #     # - REDIS_TLS=true                  # <- turn on TLS
-  #     - CLUSTER_NO_TLS_VALIDATION=true  # <- skip SNI/hostname checks in clusters
-
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     # SELF-SIGNED: trust no-CA by default
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     - NODE_TLS_REJECT_UNAUTHORIZED=0  # <- Node.js will accept your self-signed cert
-
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     # HTTP BASIC-AUTH FOR THE WEB UI
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     - HTTP_USER=admin                # <- change your UI username
-  #     - HTTP_PASSWORD=changeme         # <- change your UI password
-
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     # OPTIONAL: ENABLE REAL CERT VALIDATION (instead of skipping checks)
-  #     # ──────────────────────────────────────────────────────────────────────
-  #     # - REDIS_TLS_CA_CERT_FILE=/certs/selfsigned.crt
-  #     # - REDIS_TLS_SERVER_NAME=redis.example.com
-
 
   # mongo_express:         # 🔧 MongoDB GUI (works if mongodb service is enabled)
   #   image: mongo-express:1
@@ -610,8 +1079,7 @@ services:
   ###############################################################################
   # Fast Time Server - High-performance time/timezone service for MCP
   # Note: This is an amd64-only image. On ARM platforms (Apple Silicon),
-  # emulation may not work properly. Use profiles to disable:
-  # docker compose --profile with-fast-time up -d
+  # emulation may not work properly.
   ###############################################################################
   fast_time_server:
     image: ghcr.io/ibm/fast-time-server:latest
@@ -621,7 +1089,6 @@ services:
       - "8888:8080"    # Map host port 8888 to container port 8080
     # Use dual mode for both SSE (/sse) and Streamable HTTP (/http) endpoints
     command: ["-transport=dual", "-listen=0.0.0.0", "-port=8080", "-log-level=info"]
-    profiles: ["with-fast-time"]  # Optional: enable with --profile with-fast-time
 
   ###############################################################################
   # Auto-registration service - registers fast_time_server with gateway
@@ -638,7 +1105,6 @@ services:
       - JWT_SECRET_KEY=my-test-key
     # This is a one-shot container that exits after registration
     restart: "no"
-    profiles: ["with-fast-time"]  # Optional: enable with --profile with-fast-time
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -384,13 +384,6 @@ services:
       - "max_parallel_workers_per_gather=4" # Max workers per query's parallel operation
       - "-c"
       - "max_parallel_workers=8"            # Total parallel workers available system-wide
-      # Parallel query cost thresholds - lower values make planner consider parallelism for smaller queries
-      # Default parallel_tuple_cost=0.1, parallel_setup_cost=1000 - too conservative for fast SSDs
-      # These lower thresholds encourage parallelism but may not help OLTP workloads (small queries)
-      - "-c"
-      - "parallel_tuple_cost=0.01"          # Cost per tuple transferred to parallel worker (default: 0.1)
-      - "-c"
-      - "parallel_setup_cost=100"           # Fixed cost to start parallel worker (default: 1000)
       # === HIGH-CONCURRENCY TUNING (3000 users) ===
       # CRITICAL: idle_in_transaction_session_timeout prevents connection starvation
       # Application code now properly closes transactions via get_db() commit-on-success pattern

--- a/infra/monitoring/grafana/provisioning/dashboards/postgresql-replication.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/postgresql-replication.json
@@ -1,0 +1,632 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "PostgreSQL Primary + Replica Replication Monitoring",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Replication Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "green", "index": 0, "text": "PRIMARY" } }, "type": "value" },
+            { "options": { "1": { "color": "blue", "index": 1, "text": "REPLICA" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_static{role=\"primary\"}",
+          "legendFormat": "Primary: {{short_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Primary Status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "index": 0, "text": "NOT IN RECOVERY" } }, "type": "value" },
+            { "options": { "1": { "color": "blue", "index": 1, "text": "REPLICA OK" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_static{role=\"replica\"}",
+          "legendFormat": "Replica: {{short_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replica Status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1048576 },
+              { "color": "red", "value": 10485760 }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_stat_replication_pg_wal_lsn_diff{role=\"primary\"}",
+          "legendFormat": "Replication Lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "count(pg_stat_replication_pg_wal_lsn_diff{role=\"primary\"})",
+          "legendFormat": "Connected Replicas",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected Replicas",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "panels": [],
+      "title": "Connection Distribution",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(pg_stat_activity_count{role=\"primary\", state=\"active\"}) by (datname)",
+          "legendFormat": "Primary: {{datname}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(pg_stat_activity_count{role=\"replica\", state=\"active\"}) by (datname)",
+          "legendFormat": "Replica: {{datname}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Active Connections by Server",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count{role=\"primary\", state=~\"idle|idle in transaction\"}",
+          "legendFormat": "Primary: {{state}}",
+          "refId": "A"
+        },
+        {
+          "expr": "pg_stat_activity_count{role=\"replica\", state=~\"idle|idle in transaction\"}",
+          "legendFormat": "Replica: {{state}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Idle Connections by Server",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "panels": [],
+      "title": "Replication Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_stat_replication_pg_wal_lsn_diff{role=\"primary\"}",
+          "legendFormat": "Lag: {{application_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication Lag Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_xact_commit{role=\"primary\"}[5m])",
+          "legendFormat": "Primary Commits",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(pg_stat_database_xact_commit{role=\"replica\"}[5m])",
+          "legendFormat": "Replica Commits",
+          "refId": "B"
+        }
+      ],
+      "title": "Transactions by Server",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 103,
+      "panels": [],
+      "title": "Database Performance Comparison",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_stat_database_blks_hit{role=\"primary\", datname=\"mcp\"} / (pg_stat_database_blks_read{role=\"primary\", datname=\"mcp\"} + pg_stat_database_blks_hit{role=\"primary\", datname=\"mcp\"})",
+          "legendFormat": "Primary Cache Hit",
+          "refId": "A"
+        },
+        {
+          "expr": "pg_stat_database_blks_hit{role=\"replica\", datname=\"mcp\"} / (pg_stat_database_blks_read{role=\"replica\", datname=\"mcp\"} + pg_stat_database_blks_hit{role=\"replica\", datname=\"mcp\"})",
+          "legendFormat": "Replica Cache Hit",
+          "refId": "B"
+        }
+      ],
+      "title": "Cache Hit Rate Comparison",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_tup_fetched{role=\"primary\", datname=\"mcp\"}[5m])",
+          "legendFormat": "Primary SELECTs",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_fetched{role=\"replica\", datname=\"mcp\"}[5m])",
+          "legendFormat": "Replica SELECTs",
+          "refId": "B"
+        }
+      ],
+      "title": "Rows Fetched (SELECT) Comparison",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 104,
+      "panels": [],
+      "title": "WAL & Checkpoint Stats",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint_total{role=\"primary\"}[5m])",
+          "legendFormat": "Primary Checkpoint Buffers",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(pg_stat_bgwriter_buffers_clean_total{role=\"primary\"}[5m])",
+          "legendFormat": "Primary Clean Buffers",
+          "refId": "B"
+        },
+        {
+          "expr": "irate(pg_stat_bgwriter_buffers_backend_total{role=\"primary\"}[5m])",
+          "legendFormat": "Primary Backend Buffers",
+          "refId": "C"
+        }
+      ],
+      "title": "Primary Buffer Writer Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "pg_stat_replication_sent_lsn{role=\"primary\"} - pg_stat_replication_write_lsn{role=\"primary\"}",
+          "legendFormat": "Send Queue",
+          "refId": "A"
+        },
+        {
+          "expr": "pg_stat_replication_write_lsn{role=\"primary\"} - pg_stat_replication_flush_lsn{role=\"primary\"}",
+          "legendFormat": "Write Queue",
+          "refId": "B"
+        },
+        {
+          "expr": "pg_stat_replication_flush_lsn{role=\"primary\"} - pg_stat_replication_replay_lsn{role=\"primary\"}",
+          "legendFormat": "Replay Queue",
+          "refId": "C"
+        }
+      ],
+      "title": "WAL Replication Pipeline",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["postgres", "replication", "database"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "PostgreSQL Replication",
+  "uid": "pg-replication",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/monitoring/prometheus-performance.yml
+++ b/infra/monitoring/prometheus-performance.yml
@@ -1,0 +1,62 @@
+# Prometheus configuration for MCP Gateway stack
+# See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/
+#
+# Usage: docker compose --profile monitoring up -d
+# Access: http://localhost:9090
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Prometheus self-monitoring
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # PostgreSQL metrics via postgres_exporter (primary + replica)
+  - job_name: 'postgresql'
+    static_configs:
+      - targets: ['postgres_exporter:9187']
+        labels:
+          role: 'primary'
+          server: 'postgres'
+      - targets: ['postgres_exporter_replica:9187']
+        labels:
+          role: 'replica'
+          server: 'postgres-replica'
+
+  # Redis metrics via redis_exporter
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis_exporter:9121']
+
+  # Nginx metrics via nginx-prometheus-exporter
+  - job_name: 'nginx'
+    static_configs:
+      - targets: ['nginx_exporter:9113']
+
+  # PgBouncer metrics via pgbouncer-exporter
+  - job_name: 'pgbouncer'
+    static_configs:
+      - targets: ['pgbouncer_exporter:9127']
+
+  # Container metrics via cAdvisor (CPU, memory, network, disk I/O)
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  # MCP Gateway application metrics (FastAPI instrumentation)
+  # Endpoint: /metrics/prometheus (Prometheus format with gzip)
+  # Uses DNS discovery to scrape ALL gateway replicas (not just one)
+  - job_name: 'mcpgateway'
+    dns_sd_configs:
+      - names: ['gateway']
+        type: 'A'
+        port: 4444
+        refresh_interval: 30s
+    metrics_path: '/metrics/prometheus'
+    relabel_configs:
+      # Add instance label from discovered IP for per-replica visibility
+      - source_labels: [__address__]
+        target_label: instance

--- a/infra/postgres/init-replication.sh
+++ b/infra/postgres/init-replication.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Enable replication connections from any host in the Docker network
+# This script runs on PostgreSQL first start via /docker-entrypoint-initdb.d/
+
+set -e
+
+echo "Configuring pg_hba.conf for replication..."
+
+# Add replication entry to pg_hba.conf
+# Allow replication connections from any host using scram-sha-256 authentication
+echo "host replication all 0.0.0.0/0 scram-sha-256" >> "$PGDATA/pg_hba.conf"
+
+echo "Replication access configured successfully."


### PR DESCRIPTION
Implements PostgreSQL streaming replication with a dedicated performance testing profile. This separates the high-capacity configuration from the standard monitoring stack, allowing developers to choose between lightweight monitoring and full performance testing setups.

## New Makefile Targets

```bash
# Standard monitoring (unchanged behavior)
make monitoring-up      # 3 gateway replicas, single PostgreSQL
make monitoring-down
make monitoring-clean

# Performance testing (new)
make performance-up     # 5 gateway replicas, PostgreSQL primary + replica
make performance-down
make performance-clean
make performance-logs
```

## Configuration Comparison

| Setting | `monitoring-up` | `performance-up` |
|---------|-----------------|------------------|
| Compose file | docker-compose.yml | docker-compose-performance.yml |
| Gateway replicas | 3 | 5 |
| PostgreSQL | Single instance | Primary + streaming replica |
| PgBouncer | Connects to primary | Load balances across primary + replica |
| Prometheus | Single exporter | Primary + replica exporters with role labels |

## New Files

### `docker-compose-performance.yml`
Full performance configuration including:
- 5 gateway replicas (vs 3 in standard)
- PostgreSQL WAL replication settings (wal_level=replica, max_wal_senders=4)
- `postgres-replica` service with automatic pg_basebackup initialization
- `postgres_exporter_replica` for monitoring the replica
- PgBouncer configured for round-robin load balancing across both hosts
- Uses `prometheus-performance.yml` for scraping

### `infra/monitoring/prometheus-performance.yml`
Prometheus configuration with:
- Primary PostgreSQL exporter target with `role: primary` label
- Replica PostgreSQL exporter target with `role: replica` label
- Enables per-server metrics in Grafana dashboards

### `infra/postgres/init-replication.sh`
Initialization script that:
- Runs on PostgreSQL first start via `/docker-entrypoint-initdb.d/`
- Adds replication entry to `pg_hba.conf`
- Enables streaming replication connections from Docker network

### `infra/monitoring/grafana/provisioning/dashboards/postgresql-replication.json`
Grafana dashboard with:
- Primary/Replica status indicators
- Replication lag monitoring (bytes and time)
- Connection distribution across servers
- Transaction rates by server
- Cache hit rate comparison
- WAL replication pipeline visualization

## Architecture

```
                                    ┌─────────────────┐
                                    │     Nginx       │
                                    │  (load balancer)│
                                    └────────┬────────┘
                                             │
                    ┌────────────────────────┼────────────────────────┐
                    │                        │                        │
             ┌──────┴──────┐          ┌──────┴──────┐          ┌──────┴──────┐
             │  Gateway 1  │          │  Gateway 2  │   ...    │  Gateway 5  │
             └──────┬──────┘          └──────┬──────┘          └──────┬──────┘
                    │                        │                        │
                    └────────────────────────┼────────────────────────┘
                                             │
                                    ┌────────┴────────┐
                                    │    PgBouncer    │
                                    │ (round-robin)   │
                                    └────────┬────────┘
                                             │
                              ┌──────────────┴──────────────┐
                              │                             │
                    ┌─────────┴─────────┐         ┌─────────┴─────────┐
                    │  PostgreSQL       │         │  PostgreSQL       │
                    │  Primary          │────────▶│  Replica          │
                    │  (read/write)     │ WAL     │  (read-only)      │
                    └───────────────────┘ stream  └───────────────────┘
```

## Usage

### Start Performance Stack
```bash
make performance-up
```

This starts:
- 5 gateway replicas behind Nginx
- PostgreSQL primary with WAL replication enabled
- PostgreSQL replica with streaming replication
- PgBouncer load balancing reads across both databases
- Full Prometheus/Grafana monitoring with replication metrics

### Run Benchmarks
```bash
make load-test-ui
# Access Locust at http://localhost:8089
# Access Grafana at http://localhost:3000 (admin/changeme)
```

### Monitor Replication
```bash
# Check replication status
docker exec mcp-context-forge-postgres-1 psql -U postgres -c \
  "SELECT client_addr, state, sent_lsn, replay_lsn FROM pg_stat_replication;"

# View replication lag
# Grafana → PostgreSQL Replication dashboard
```

### Clean Up
```bash
make performance-down   # Stop containers
make performance-clean  # Stop and remove volumes
```

## Bottleneck Analysis

With this configuration at 3000 concurrent users:

| Component | Typical CPU | Notes |
|-----------|-------------|-------|
| Gateway (x5) | 300-400% each | Distributed load |
| PostgreSQL Primary | 100-180% | Handles writes + some reads |
| PostgreSQL Replica | 40-80% | Handles read overflow |
| PgBouncer | 40-60% | Connection pooling |
| Nginx | 50-80% | Request routing |

The primary PostgreSQL becomes the bottleneck under write-heavy workloads since all writes must go to primary. For read-heavy workloads, the replica provides significant scaling headroom.

## Related Issues

- Closes #1861 - PostgreSQL Read Replicas for Horizontal Scaling
