### PR TITLE
Team Membership Query Optimization

### DIFF
--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -401,10 +401,11 @@ class TeamManagementService:
 
                 asyncio.create_task(auth_cache.invalidate_team_roles(team_id))
                 asyncio.create_task(admin_stats_cache.invalidate_teams())
-                # Also invalidate team cache and teams list cache for each member
+                # Also invalidate team cache, teams list cache, and team membership cache for each member
                 for membership in memberships:
                     asyncio.create_task(auth_cache.invalidate_team(membership.user_email))
                     asyncio.create_task(auth_cache.invalidate_user_teams(membership.user_email))
+                    asyncio.create_task(auth_cache.invalidate_team_membership(membership.user_email))
             except Exception as cache_error:
                 logger.debug(f"Failed to invalidate caches on team delete: {cache_error}")
 
@@ -499,6 +500,7 @@ class TeamManagementService:
                 asyncio.create_task(auth_cache.invalidate_team(user_email))
                 asyncio.create_task(auth_cache.invalidate_user_role(user_email, team_id))
                 asyncio.create_task(auth_cache.invalidate_user_teams(user_email))
+                asyncio.create_task(auth_cache.invalidate_team_membership(user_email))
                 asyncio.create_task(admin_stats_cache.invalidate_teams())
             except Exception as cache_error:
                 logger.debug(f"Failed to invalidate cache on team add: {cache_error}")
@@ -571,6 +573,7 @@ class TeamManagementService:
                 asyncio.create_task(auth_cache.invalidate_team(user_email))
                 asyncio.create_task(auth_cache.invalidate_user_role(user_email, team_id))
                 asyncio.create_task(auth_cache.invalidate_user_teams(user_email))
+                asyncio.create_task(auth_cache.invalidate_team_membership(user_email))
             except Exception as cache_error:
                 logger.debug(f"Failed to invalidate cache on team remove: {cache_error}")
 
@@ -1076,6 +1079,7 @@ class TeamManagementService:
                 asyncio.create_task(auth_cache.invalidate_team(join_request.user_email))
                 asyncio.create_task(auth_cache.invalidate_user_role(join_request.user_email, join_request.team_id))
                 asyncio.create_task(auth_cache.invalidate_user_teams(join_request.user_email))
+                asyncio.create_task(auth_cache.invalidate_team_membership(join_request.user_email))
                 asyncio.create_task(admin_stats_cache.invalidate_teams())
             except Exception as cache_error:
                 logger.debug(f"Failed to invalidate caches on join approval: {cache_error}")


### PR DESCRIPTION
# Performance: Team Membership Query Optimization

## Issues Addressed

- Closes #1887 - Combine double DB sessions in token_scoping middleware
- Closes #1888 - Cache team membership validation in token_scoping middleware

## Problem

Under load testing with 3000 concurrent connections, the `email_team_members` table was a major bottleneck:

1. **Double DB sessions**: Token scoping middleware created 2 separate database sessions per request for resource endpoints (`/tools/{id}`, `/servers/{id}/mcp`, etc.)

2. **Uncached team membership**: Every authenticated request with a team-scoped token queried `email_team_members`, even for the same user/team combination

3. **N+1 query pattern**: Team membership validation looped through teams, executing one query per team

4. **Lazy-loading N+1**: `EmailTeam.get_member_count()` loaded ALL team members into memory just to count them

## Solution

### 1. Single Session for Token Scoping (`mcpgateway/middleware/token_scoping.py`)

Combined `_check_team_membership()` and `_check_resource_team_ownership()` into a single shared database session:

```python
# Before: 2 sessions per request
if not self._check_team_membership(payload):  # Session #1
    raise HTTPException(...)
if not self._check_resource_team_ownership(path, teams):  # Session #2
    raise HTTPException(...)

# After: 1 shared session
db = next(get_db())
try:
    if not self._check_team_membership(payload, db=db):
        raise HTTPException(...)
    if not self._check_resource_team_ownership(path, teams, db=db):
        raise HTTPException(...)
finally:
    db.commit()
    db.close()
```

### 2. Team Membership Caching (`mcpgateway/cache/auth_cache.py`)

Added team membership validation caching with 60s TTL:

- `get_team_membership_valid_sync()` - Synchronous in-memory lookup for middleware
- `set_team_membership_valid_sync()` - Store validation result
- `invalidate_team_membership()` - Clear cache on membership changes

Cache key format: `{user_email}:{sorted_team_ids}`

### 3. Fixed N+1 Query Pattern (`mcpgateway/middleware/token_scoping.py`)

Replaced loop with single IN query:

```python
# Before: N queries (one per team)
for team in teams:
    membership = db.execute(
        select(EmailTeamMember).where(team_id == team_id, ...)
    ).scalar_one_or_none()

# After: 1 query for all teams
memberships = db.execute(
    select(EmailTeamMember.team_id).where(
        EmailTeamMember.team_id.in_(team_ids),
        EmailTeamMember.user_email == user_email,
        EmailTeamMember.is_active == True,
    )
).scalars().all()
```

### 4. Fixed Model Method N+1 (`mcpgateway/db.py`)

Changed `EmailTeam` methods to use direct SQL instead of lazy-loading:

| Method | Before | After |
|--------|--------|-------|
| `get_member_count()` | `len([m for m in self.members if m.is_active])` | `SELECT COUNT(*) FROM email_team_members WHERE ...` |
| `is_member()` | `any(m for m in self.members ...)` | `SELECT id FROM ... LIMIT 1` |
| `get_member_role()` | `for member in self.members: ...` | `SELECT role FROM ... LIMIT 1` |

### 5. Cache Invalidation

Added `invalidate_team_membership()` calls for all membership change paths:

**`mcpgateway/services/team_management_service.py`**:
- `delete_team()` - for all affected members
- `add_member_to_team()` - for the added user
- `remove_member_from_team()` - for the removed user
- `approve_join_request()` - for the approved user

**`mcpgateway/services/team_invitation_service.py`**:
- `accept_invitation()` - when user accepts email invitation

**`mcpgateway/services/email_auth_service.py`**:
- `delete_user()` - when user is permanently deleted

### 6. Fixed `invalidate_user()` to Clear Membership Cache (`mcpgateway/cache/auth_cache.py`)

The `invalidate_user()` method now properly clears membership cache entries by pattern matching keys that start with `{email}:` (membership cache keys are `email:team_id1:team_id2`).

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| DB sessions per resource request | 2 | 1 |
| `email_team_members` queries (cache hit) | N per request | 0 |
| `email_team_members` queries (cache miss) | N per request | 1 |
| Idle in transaction connections | 65-90 | ~14 |
| Query pattern | SELECT all columns | SELECT COUNT / SELECT team_id |
| Index utilization | Mixed | 99.9% index scans |

Load test results (3000 concurrent users):
- **RPS**: ~1000+ sustained
- **Failure rate**: 0%
- **Connection cycling**: Healthy (1-3 second transaction ages)

## Files Changed

- `mcpgateway/middleware/token_scoping.py` - Single session + caching + N+1 fix
- `mcpgateway/cache/auth_cache.py` - Team membership cache methods + fixed `invalidate_user()`
- `mcpgateway/services/team_management_service.py` - Cache invalidation
- `mcpgateway/services/team_invitation_service.py` - Cache invalidation on invitation acceptance
- `mcpgateway/services/email_auth_service.py` - Cache invalidation on user deletion
- `mcpgateway/db.py` - Efficient SQL for model methods

## Testing

```bash
# Unit tests
make test

# Specific tests
uv run pytest tests/unit/mcpgateway/middleware/test_token_scoping.py -v
uv run pytest tests/unit/mcpgateway/services/test_team_management_service.py -v

# Load testing
make load-test-ui  # Then check http://localhost:8089
```
