### PR TITLE
 Disable live validation until custom validation is setup

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -14805,7 +14805,6 @@ function setupFormValidation() {
                 const validation = validateInputName(this.value, "name");
                 if (!validation.valid) {
                     this.setCustomValidity(validation.error);
-                    this.reportValidity();
                 } else {
                     this.setCustomValidity("");
                     this.value = validation.value;
@@ -14823,7 +14822,6 @@ function setupFormValidation() {
                     const validation = validateUrl(this.value);
                     if (!validation.valid) {
                         this.setCustomValidity(validation.error);
-                        this.reportValidity();
                     } else {
                         this.setCustomValidity("");
                         this.value = validation.value;
@@ -14841,7 +14839,6 @@ function setupFormValidation() {
                 const validation = validateInputName(this.value, "prompt");
                 if (!validation.valid) {
                     this.setCustomValidity(validation.error);
-                    this.reportValidity();
                 } else {
                     this.setCustomValidity("");
                     this.value = validation.value;


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Closes https://github.com/IBM/mcp-context-forge/issues/1916
Disable live validation (valitatind onBlur or onFocusOut) until custom validation is setup. Using browser's native validation
is causing a form lock, where users can't edit interact with other elements until the field value is valid (because the browser keeps focusing on the invalid field).

## 🔁 Reproduction Steps
_Link the issue and minimal steps to reproduce the bug._

## 🐞 Root Cause
Using browser's native validation (`reportValidity()`) on form fields (e.g.: Add New MCP form > Name field) on events such as onBlur and onFocusOut causes the focus to be set back to the field when triggered, and when users try to interact with other elements of the page, the onBlur/onFocusOut events get triggered again, locking the focus on that field.

## 💡 Fix Description
Remove the browser native validation. 

## TODO
Create issue to add custom form validation, to display the invalid fields to the users without focusing them.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |   ✅     |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |


## ✅ Checklist
- [✅] Code formatted (`make black isort pre-commit`)
- [✅] No secrets/credentials committed
