### PR TITLE
perf: eager load EmailTeam relationship in Tool model

### DIFF
--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -2726,6 +2726,11 @@ class Tool(Base):
 
     The property `metrics_summary` returns a dictionary with these aggregated values.
 
+    Team association is handled via the `email_team` relationship (eager-loaded via JOIN)
+    which only includes active teams. The `team` property provides convenient access to
+    the team name:
+        - team: Returns the team name if the tool belongs to an active team, otherwise None.
+
     The following fields have been added to support tool invocation configuration:
         - request_type: HTTP method to use when invoking the tool.
         - auth_type: Type of authentication ("basic", "bearer", or None).
@@ -2806,6 +2811,23 @@ class Tool(Base):
     team_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("email_teams.id", ondelete="SET NULL"), nullable=True)
     owner_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="public")
+
+    # Relationship for eager loading team names (only active teams)
+    email_team: Mapped[Optional["EmailTeam"]] = relationship(
+        "EmailTeam",
+        primaryjoin="and_(Tool.team_id == EmailTeam.id, EmailTeam.is_active == True)",
+        foreign_keys=[team_id],
+        lazy="joined",
+    )
+
+    @property
+    def team(self) -> Optional[str]:
+        """Return the team name from the eagerly-loaded email_team relationship.
+
+        Returns:
+            Optional[str]: The team name if the tool belongs to an active team, otherwise None.
+        """
+        return self.email_team.name if self.email_team else None
 
     # @property
     # def gateway_slug(self) -> str:


### PR DESCRIPTION
## Summary

- Add `email_team` relationship with `lazy="joined"` to `Tool` model for eager loading team names via JOIN
- Add `team` property to `Tool` class that returns team name from the relationship
- Remove manual `_get_team_name` helper and batch loading patterns in `tool_service.py`
- Eliminates N+1 query patterns when fetching tools with team information

## Changes

**mcpgateway/db.py:**
- Added `email_team` relationship with `lazy="joined"` to `Tool` class
- Added `team` property that returns `self.email_team.name if self.email_team else None`

**mcpgateway/services/tool_service.py:**
- Removed `_get_team_name` method
- Removed manual `team_map` batch loading in `list_tools`
- Removed manual `outerjoin`/`add_columns` for team names in `list_server_tools` and `list_tools_for_user`
- Removed unused `EmailTeam` import

**tests/unit/mcpgateway/services/test_tool_service.py:**
- Added `tool.team = None` to mock fixture
- Updated tests to use `.scalars().all()` pattern
- Fixed flake8 issues (unused imports/variables, inline comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)