### PR TITLE
fix: improve tool status updates and fix test flake8 errors #1641

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -363,7 +363,7 @@ repos:
         description: Verifies test files in tests/ directories start with `test_`.
         language: python
         files: (^|/)tests/.+\.py$
-        exclude: ^tests/(.*/)?(pages|helpers|fuzzers|scripts|fixtures|migration|utils|manual|async|load)/.*\.py$
+        exclude: ^tests/(.*/)?(pages|helpers|fuzzers|scripts|fixtures|migration|utils|manual|async|load|loadtest)/.*\.py$
         args: [--pytest-test-first] # `test_.*\.py`
 
   - repo: https://github.com/pycqa/flake8

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -7399,8 +7399,8 @@ async def admin_toggle_tool(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_tool_status = tool_service.toggle_tool_status
-        >>> tool_service.toggle_tool_status = AsyncMock()
+        >>> original_set_tool_status = tool_service.set_tool_status
+        >>> tool_service.set_tool_status = AsyncMock()
         >>>
         >>> async def test_admin_toggle_tool_activate():
         ...     result = await admin_toggle_tool(tool_id, mock_request_activate, mock_db, mock_user)
@@ -7437,7 +7437,7 @@ async def admin_toggle_tool(
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> tool_service.toggle_tool_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> tool_service.set_tool_status = AsyncMock(side_effect=Exception("Toggle failed"))
         >>>
         >>> async def test_admin_toggle_tool_exception():
         ...     result = await admin_toggle_tool(tool_id, mock_request_error, mock_db, mock_user)
@@ -7454,7 +7454,7 @@ async def admin_toggle_tool(
         True
         >>>
         >>> # Restore original method
-        >>> tool_service.toggle_tool_status = original_toggle_tool_status
+        >>> tool_service.set_tool_status = original_set_tool_status
     """
     error_message = None
     user_email = get_user_email(user)
@@ -7463,7 +7463,7 @@ async def admin_toggle_tool(
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
+        await tool_service.set_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} toggling tools {tool_id}: {e}")
         error_message = str(e)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3026,7 +3026,7 @@ async def toggle_tool_status(
     try:
         logger.debug(f"User {user} is toggling tool with ID {tool_id} to {'active' if activate else 'inactive'}")
         user_email = user.get("email") if isinstance(user, dict) else str(user)
-        tool = await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
+        tool = await tool_service.set_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
         return {
             "status": "success",
             "message": f"Tool {tool_id} {'activated' if activate else 'deactivated'}",

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2253,13 +2253,13 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
 
                 tools = db.query(DbTool).filter(DbTool.gateway_id == gateway_id).all()
 
-                # Toggle tools with skip_cache_invalidation=True to avoid N invalidations
+                # Set tool status with skip_cache_invalidation=True to avoid N invalidations
                 if only_update_reachable:
                     for tool in tools:
-                        await self.tool_service.toggle_tool_status(db, tool.id, tool.enabled, reachable, skip_cache_invalidation=True)
+                        await self.tool_service.set_tool_status(db, tool.id, tool.enabled, reachable, skip_cache_invalidation=True)
                 else:
                     for tool in tools:
-                        await self.tool_service.toggle_tool_status(db, tool.id, activate, reachable, skip_cache_invalidation=True)
+                        await self.tool_service.set_tool_status(db, tool.id, activate, reachable, skip_cache_invalidation=True)
 
                 # Invalidate tools cache once after all tool status changes
                 if tools:

--- a/tests/loadtest/locustfile.py
+++ b/tests/loadtest/locustfile.py
@@ -1229,8 +1229,8 @@ class WriteAPIUser(BaseUser):
 
     @task(2)
     @tag("api", "write", "toggle")
-    def toggle_tool_status(self):
-        """Toggle a tool's enabled status."""
+    def set_tool_status(self):
+        """Set a tool's enabled status."""
         if TOOL_IDS:
             tool_id = random.choice(TOOL_IDS)
             with self.client.post(

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -15,12 +15,10 @@ enough behaviour to satisfy the code paths under test.
 from __future__ import annotations
 
 # Standard
-import asyncio
 from typing import TypeVar
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
-import httpx
 import pytest
 from url_normalize import url_normalize
 
@@ -70,8 +68,7 @@ def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | N
 @pytest.fixture(autouse=True)
 def mock_logging_services():
     """Mock audit_trail and structured_logger to prevent database writes during tests."""
-    with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, \
-         patch("mcpgateway.services.gateway_service.structured_logger") as mock_logger:
+    with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger") as mock_logger:
         mock_audit.log_action = MagicMock(return_value=None)
         mock_logger.log = MagicMock(return_value=None)
         yield {"audit_trail": mock_audit, "structured_logger": mock_logger}
@@ -1080,7 +1077,7 @@ class TestGatewayService:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        # Return one tool so toggle_tool_status gets called
+        # Return one tool so set_tool_status gets called
         query_proxy = MagicMock()
         filter_proxy = MagicMock()
         filter_proxy.all.return_value = [MagicMock(id=101)]
@@ -1093,7 +1090,7 @@ class TestGatewayService:
         gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
 
         tool_service_stub = MagicMock()
-        tool_service_stub.toggle_tool_status = AsyncMock()
+        tool_service_stub.set_tool_status = AsyncMock()
         gateway_service.tool_service = tool_service_stub
 
         # Patch model_validate to return a mock with .masked()
@@ -1105,7 +1102,7 @@ class TestGatewayService:
 
         assert mock_gateway.enabled is False
         gateway_service._notify_gateway_deactivated.assert_called_once()
-        assert tool_service_stub.toggle_tool_status.called
+        assert tool_service_stub.set_tool_status.called
         assert result == mock_gateway_read
 
     @pytest.mark.asyncio
@@ -1116,7 +1113,7 @@ class TestGatewayService:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        # Return one tool so toggle_tool_status gets called
+        # Return one tool so set_tool_status gets called
         query_proxy = MagicMock()
         filter_proxy = MagicMock()
         filter_proxy.all.return_value = [MagicMock(id=101)]
@@ -1129,7 +1126,7 @@ class TestGatewayService:
         gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
 
         tool_service_stub = MagicMock()
-        tool_service_stub.toggle_tool_status = AsyncMock()
+        tool_service_stub.set_tool_status = AsyncMock()
         gateway_service.tool_service = tool_service_stub
 
         # Patch model_validate to return a mock with .masked()
@@ -1141,7 +1138,7 @@ class TestGatewayService:
 
         assert mock_gateway.enabled is True
         gateway_service._notify_gateway_activated.assert_called_once()
-        assert tool_service_stub.toggle_tool_status.called
+        assert tool_service_stub.set_tool_status.called
         assert result == mock_gateway_read
 
     @pytest.mark.asyncio
@@ -1162,7 +1159,7 @@ class TestGatewayService:
         test_db.refresh = Mock()
         test_db.rollback = Mock()
 
-        # Return one tool so toggle_tool_status gets called
+        # Return one tool so set_tool_status gets called
         query_proxy = MagicMock()
         filter_proxy = MagicMock()
         filter_proxy.all.return_value = [MagicMock(id=101)]
@@ -1173,9 +1170,9 @@ class TestGatewayService:
         gateway_service._notify_gateway_deactivated = AsyncMock()
         gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
 
-        # Make tool toggle fail
+        # Make tool status update fail
         tool_service_stub = MagicMock()
-        tool_service_stub.toggle_tool_status = AsyncMock(side_effect=Exception("Tool toggle failed"))
+        tool_service_stub.set_tool_status = AsyncMock(side_effect=Exception("Tool toggle failed"))
         gateway_service.tool_service = tool_service_stub
 
         # The toggle_gateway_status method will catch the exception and raise GatewayError


### PR DESCRIPTION
## Summary

- Rename `toggle_tool_status` to `set_tool_status` for clarity and consistency
- Add row-level locking with `with_for_update` to prevent race conditions during concurrent status updates
- Wrap status updates in explicit transaction with `db.begin()` for better atomicity
- Fix multiple flake8 errors in test files (E402, E262, F841, F401, F541, F811, E266)

This is the first PR addressing Issue #1641 - more PRs will follow.

Addresses #1641 (more to come)