### PR TITLE
fix: MCP tools/list returns all registered items instead of ~50

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4334,7 +4334,7 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
                 tools = await tool_service.list_server_tools(db, server_id, cursor=cursor)
                 result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
             else:
-                tools, next_cursor = await tool_service.list_tools(db, cursor=cursor)
+                tools, next_cursor = await tool_service.list_tools(db, cursor=cursor, limit=0)
                 result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
                 if next_cursor:
                     result["nextCursor"] = next_cursor
@@ -4343,7 +4343,7 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
                 tools = await tool_service.list_server_tools(db, server_id, cursor=cursor)
                 result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
             else:
-                tools, next_cursor = await tool_service.list_tools(db, cursor=cursor)
+                tools, next_cursor = await tool_service.list_tools(db, cursor=cursor, limit=0)
                 result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
                 if next_cursor:
                     result["nextCursor"] = next_cursor
@@ -4358,7 +4358,7 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
                 resources = await resource_service.list_server_resources(db, server_id)
                 result = {"resources": [r.model_dump(by_alias=True, exclude_none=True) for r in resources]}
             else:
-                resources, next_cursor = await resource_service.list_resources(db, cursor=cursor)
+                resources, next_cursor = await resource_service.list_resources(db, cursor=cursor, limit=0)
                 result = {"resources": [r.model_dump(by_alias=True, exclude_none=True) for r in resources]}
                 if next_cursor:
                     result["nextCursor"] = next_cursor
@@ -4415,7 +4415,7 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
                 prompts = await prompt_service.list_server_prompts(db, server_id, cursor=cursor)
                 result = {"prompts": [p.model_dump(by_alias=True, exclude_none=True) for p in prompts]}
             else:
-                prompts, next_cursor = await prompt_service.list_prompts(db, cursor=cursor)
+                prompts, next_cursor = await prompt_service.list_prompts(db, cursor=cursor, limit=0)
                 result = {"prompts": [p.model_dump(by_alias=True, exclude_none=True) for p in prompts]}
                 if next_cursor:
                     result["nextCursor"] = next_cursor

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -548,7 +548,7 @@ async def list_tools() -> List[types.Tool]:
     else:
         try:
             async with get_db() as db:
-                tools, _ = await tool_service.list_tools(db, False, None, None, request_headers)
+                tools, _ = await tool_service.list_tools(db, include_inactive=False, limit=0, _request_headers=request_headers)
                 return [types.Tool(name=tool.name, description=tool.description, inputSchema=tool.input_schema, outputSchema=tool.output_schema, annotations=tool.annotations) for tool in tools]
         except Exception as e:
             logger.exception(f"Error listing tools:{e}")
@@ -586,7 +586,7 @@ async def list_prompts() -> List[types.Prompt]:
     else:
         try:
             async with get_db() as db:
-                prompts, _ = await prompt_service.list_prompts(db, False, None, None)
+                prompts, _ = await prompt_service.list_prompts(db, include_inactive=False, limit=0)
                 return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
         except Exception as e:
             logger.exception(f"Error listing prompts:{e}")
@@ -664,7 +664,7 @@ async def list_resources() -> List[types.Resource]:
     else:
         try:
             async with get_db() as db:
-                resources, _ = await resource_service.list_resources(db, False)
+                resources, _ = await resource_service.list_resources(db, include_inactive=False, limit=0)
                 return [types.Resource(uri=resource.uri, name=resource.name, description=resource.description, mimeType=resource.mime_type) for resource in resources]
         except Exception as e:
             logger.exception(f"Error listing resources:{e}")


### PR DESCRIPTION
MCP list endpoints (tools/list, resources/list, prompts/list) were returning only ~50 items due to pagination default limit being applied. MCP clients expect all items returned without pagination.

Fixed by passing limit=0 to service methods, which returns all items:
- streamablehttp_transport.py: tools/list, prompts/list, resources/list
- main.py handle_rpc(): tools/list, list_tools, resources/list, prompts/list

Also fixed incorrect positional argument passing in streamablehttp transport where request_headers was passed to gateway_id parameter.

Closes #1937

Continues #1664 