### PR TITLE
perf(ci): remove redundant steps from full-build-pipeline

### DIFF
--- a/.github/workflows/full-build-pipeline.yml
+++ b/.github/workflows/full-build-pipeline.yml
@@ -85,10 +85,12 @@ jobs:
 
       # -------------------------------------------------------------
       # 5️⃣  Comprehensive Testing & Verification
+      #      REMOVED `test` and `doctest` as they are verified identical
+      #      to other github workflows
       # -------------------------------------------------------------
       - name: 🧪  Comprehensive testing & verification
         run: |
-          make doctest test lint-web flake8 bandit interrogate pylint verify
+          make lint-web flake8 bandit interrogate pylint verify
 
       # -------------------------------------------------------------
       # 6️⃣  Smoke Tests
@@ -99,10 +101,11 @@ jobs:
 
       # -------------------------------------------------------------
       # 7️⃣  Production Docker Build
+      #     REMOVED as identical to another github workflow
       # -------------------------------------------------------------
-      - name: 🐳  Production Docker build
-        run: |
-          make docker-prod
+      # - name: 🐳  Production Docker build
+      #   run: |
+      #     make docker-prod
 
       # -------------------------------------------------------------
       # 8️⃣  Summary
@@ -117,6 +120,6 @@ jobs:
           echo "- Code quality & formatting" >> "$GITHUB_STEP_SUMMARY"
           echo "- Comprehensive testing & verification" >> "$GITHUB_STEP_SUMMARY"
           echo "- End-to-end smoke tests" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Production Docker build" >> "$GITHUB_STEP_SUMMARY"
+          # echo "- Production Docker build" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The complete build pipeline is verified and production-ready." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Remove `test` and `doctest` targets from the comprehensive testing step as they are already verified identical to other GitHub workflows
- Comment out the Production Docker build step which duplicates another workflow
- Update the job summary output to reflect removed steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)