### PR TITLE
fix for redis missing module

### DIFF
--- a/mcpgateway/services/event_service.py
+++ b/mcpgateway/services/event_service.py
@@ -67,8 +67,12 @@ from mcpgateway.utils.redis_client import get_redis_client
 
 try:
     REDIS_AVAILABLE = importlib.util.find_spec("redis.asyncio") is not None
-except (ModuleNotFoundError, AttributeError):
-    # AttributeError can occur if 'redis' exists but isn't a package
+except (ModuleNotFoundError, AttributeError) as e:
+    # ModuleNotFoundError: redis package not installed
+    # AttributeError: 'redis' exists but isn't a proper package (e.g., shadowed by a file)
+    import logging
+
+    logging.getLogger(__name__).warning(f"Redis module check failed ({type(e).__name__}: {e}), Redis support disabled")
     REDIS_AVAILABLE = False
 
 # Initialize logging

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -83,7 +83,15 @@ try:
 except ImportError:
     psutil = None  # type: ignore
 
-REDIS_AVAILABLE = importlib.util.find_spec("redis.asyncio") is not None
+try:
+    REDIS_AVAILABLE = importlib.util.find_spec("redis.asyncio") is not None
+except (ModuleNotFoundError, AttributeError) as e:
+    # ModuleNotFoundError: redis package not installed
+    # AttributeError: 'redis' exists but isn't a proper package (e.g., shadowed by a file)
+    import logging
+
+    logging.getLogger(__name__).warning(f"Redis module check failed ({type(e).__name__}: {e}), Redis support disabled")
+    REDIS_AVAILABLE = False
 
 # Globals
 


### PR DESCRIPTION
While running the OPA external plugin within the MCP Gateway, the system consistently threw a `ModuleNotFoundError `for the module` redis`. The issue originated in the event_service.py file where the line


`REDIS_AVAILABLE = importlib.util.find_spec("redis.asyncio") is not None`
failed during import when the redis library was missing or improperly structured. This caused the plugin loader to crash, resulting in the failure to initialize the OPAPluginFilter plugin.

The problem was resolved by wrapping the `find_spec` call in a try/except block to safely handle both ModuleNotFoundError and AttributeError, ensuring the plugin proceeds without Redis support instead of failing entirely.


Here is the trace of error:
```
Traceback (most recent call last):
 File "/opt/app-root/lib64/python3.12/site-packages/mcpgateway/plugins/framework/loader/plugin.py", line 61, in __get_plugin_type
  module = import_module(mod_name)
       ^^^^^^^^^^^^^^^^^^^^^^^
 File "/opt/app-root/lib64/python3.12/site-packages/mcpgateway/plugins/framework/utils.py", line 41, in import_module
  return importlib.import_module(mod_name)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/lib64/python3.12/importlib/__init__.py", line 90, in import_module
  return _bootstrap._gcd_import(name[level:], package, level)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
 File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
 File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
 File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
 File "<frozen importlib._bootstrap_external>", line 999, in exec_module
 File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
 File "/opt/app-root/lib64/python3.12/site-packages/opapluginfilter/plugin.py", line 44, in <module>
  from mcpgateway.services.logging_service import LoggingService
 File "/opt/app-root/lib64/python3.12/site-packages/mcpgateway/services/__init__.py", line 15, in <module>
  from mcpgateway.services.gateway_service import GatewayError, GatewayService
 File "/opt/app-root/lib64/python3.12/site-packages/mcpgateway/services/gateway_service.py", line 91, in <module>
  from mcpgateway.services.event_service import EventService
 File "/opt/app-root/lib64/python3.12/site-packages/mcpgateway/services/event_service.py", line 68, in <module>
  REDIS_AVAILABLE = importlib.util.find_spec("redis.asyncio") is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "<frozen importlib.util>", line 91, in find_spec
ModuleNotFoundError: No module named 'redis'
2026-01-08T15:25:51 - mcpgateway.plugins.framework.manager - ERROR - Failed to load plugin OPAPluginFilter: {No module named 'redis'}
Traceback (most recent call last):
 File "/opt/app-root/lib64/python3.12/site-packages/mcpg
```
