### PR TITLE
Migrate OAuth/DCR services to shared singleton http client to leverage full potential of session connection pooling

### DIFF
--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -254,7 +254,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data)
+                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # GitHub returns form-encoded responses, not JSON
@@ -353,7 +353,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data)
+                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # Handle both JSON and form-encoded responses
@@ -464,7 +464,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data)
+                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # GitHub returns form-encoded responses, not JSON
@@ -1044,7 +1044,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data)
+                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # GitHub returns form-encoded responses, not JSON
@@ -1123,7 +1123,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data)
+                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 if response.status_code == 200:
                     token_response = response.json()
 


### PR DESCRIPTION
# PR Summary: - Migrate OAuth/DCR Services to Singleton HTTP Client

## Problem
Issue #1987 identified that `dcr_service.py` and `oauth_manager.py` were creating new HTTP client instances for every request, causing:
- Unnecessary TCP + TLS handshake overhead (10-50ms per request)
- No connection reuse across requests
- Potential socket leaks from unclosed clients
- Services instantiated per-request instead of using singleton pattern

## Solution
Migrated both services to use the existing `http_client_service.py` singleton pattern with `get_http_client()`, enabling true cross-request connection pooling.

## Changes

### Modified Files

**1. `mcpgateway/services/dcr_service.py`**
- Added import: `from mcpgateway.services.http_client_service import get_http_client`
- Removed `self._client` instance variable
- Simplified `_get_client()` method to return singleton client
- Removed `close()` method (no longer needed)

**2. `mcpgateway/services/oauth_manager.py`**
- Added import: `from mcpgateway.services.http_client_service import get_http_client`
- Removed `self._client` instance variable from `__init__()`
- Simplified `_get_client()` method to return singleton client
- Removed `close()` method (no longer needed)

### Key Code Changes

**Before:**
```python
def __init__(self, ...):
    self._client: httpx.AsyncClient | None = None

async def _get_client(self) -> httpx.AsyncClient:
    if self._client is None or self._client.is_closed:
        self._client = httpx.AsyncClient(...)
    return self._client

async def close(self):
    if self._client is not None:
        await self._client.aclose()
```

**After:**
```python
async def _get_client(self) -> httpx.AsyncClient:
    """Get the shared singleton HTTP client."""
    return await get_http_client()
```

## Benefits

✅ **Performance**: Eliminates 10-50ms TCP/TLS handshake overhead per request  
✅ **Connection Reuse**: True cross-request connection pooling (200 max connections, 100 keepalive)  
✅ **Resource Management**: No socket leaks, proper lifecycle management via FastAPI lifespan  
✅ **Consistency**: Aligns with existing `http_client_service.py` singleton pattern  
✅ **HTTP/2 Support**: Leverages shared client's HTTP/2 capabilities  

## Testing

All existing tests pass without modification:
- ✅ `tests/unit/mcpgateway/services/test_dcr_service.py` (5 tests)
- ✅ `tests/unit/mcpgateway/test_oauth_manager.py` (42+ tests)
- ✅ `tests/unit/mcpgateway/services/test_oauth_manager_pkce.py` (2 tests)

Tests continue to work because they mock `_get_client()` method, which still exists but now returns the singleton.

## Technical Details

The shared HTTP client (`http_client_service.py`) provides:
- Connection pooling with configurable limits
- HTTP/2 support with fallback to HTTP/1.1
- Automatic connection lifecycle management
- Thread-safe singleton pattern
- Proper cleanup via FastAPI lifespan events

## Closes

Closes #1929
Closes #1987 