### PR TITLE
#2044 Add contrast to missing plugin card text

### DIFF
--- a/mcpgateway/templates/plugins_partial.html
+++ b/mcpgateway/templates/plugins_partial.html
@@ -24,7 +24,7 @@
 
     {% if not plugins_enabled %}
     <div
-      class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 rounded mb-4"
+      class="bg-yellow-100 border-l-4 border-yellow-500 dark:text-purple-950 text-yellow-700 p-4 rounded mb-4"
     >
       <p class="font-bold">Plugins are currently disabled</p>
       <p class="text-sm">


### PR DESCRIPTION
# 🐛 Bug-fix PR

closes #2044 

---

## 📌 Summary
Add contrast to missing plugin card text to make it readable

| Before  | After  |
|--------|-------|
| <img width="1450" height="217" alt="Screenshot 2026-01-12 at 10 18 34" src="https://github.com/user-attachments/assets/9ff577e1-a005-4afa-8af6-c40de0950edb" /> | <img width="1460" height="222" alt="Screenshot 2026-01-12 at 10 26 59" src="https://github.com/user-attachments/assets/98c38c16-16d5-48ea-9b25-79776a1453d1" /> |
## 🔁 Reproduction Steps
1 - Log into the the admin ui
2 - Click the Plugins tab

## 🐞 Root Cause
There was no class defined for dark mode on the card (neither on the admin.css overrides)

## 💡 Fix Description
Added a TW class for text colour to the card, using a darker tone of the card background.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] No secrets/credentials committed
