### PR TITLE
2058 advanced metrics table update

### DIFF
--- a/mcpgateway/templates/observability_metrics.html
+++ b/mcpgateway/templates/observability_metrics.html
@@ -240,9 +240,9 @@ window.createMetricsController = function() {
         .map(
           (ep, idx) => `
             <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${ep.endpoint}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${ep.count}</td>
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-500">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-300">${ep.endpoint}</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${ep.count}</td>
               <td class="px-4 py-2 text-sm text-orange-600 font-medium">${ep.avg_duration_ms} ms</td>
               <td class="px-4 py-2 text-sm text-red-600">${ep.max_duration_ms} ms</td>
             </tr>
@@ -258,10 +258,10 @@ window.createMetricsController = function() {
         .map(
           (ep, idx) => `
             <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${ep.endpoint}</td>
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-500">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-300">${ep.endpoint}</td>
               <td class="px-4 py-2 text-sm font-medium text-blue-600">${ep.count}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${ep.avg_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${ep.avg_duration_ms} ms</td>
             </tr>
           `
         )
@@ -275,9 +275,9 @@ window.createMetricsController = function() {
         .map(
           (ep, idx) => `
             <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${ep.endpoint}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${ep.total_count}</td>
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-500">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-300">${ep.endpoint}</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${ep.total_count}</td>
               <td class="px-4 py-2 text-sm text-red-600 font-medium">${ep.error_count}</td>
               <td class="px-4 py-2 text-sm text-red-700 font-bold">${ep.error_rate}%</td>
             </tr>
@@ -495,27 +495,27 @@ window.createMetricsController = function() {
           <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 #
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Endpoint
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Count
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Avg
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Max
               </th>
@@ -538,22 +538,22 @@ window.createMetricsController = function() {
           <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 #
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Endpoint
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Requests
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Avg
               </th>
@@ -576,27 +576,27 @@ window.createMetricsController = function() {
           <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 #
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Endpoint
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Total
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Errors
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
               >
                 Rate
               </th>


### PR DESCRIPTION
# 🐛 Bug-fix PR

<img width="1082" height="756" alt="Screenshot 2026-01-13 at 08 45 48" src="https://github.com/user-attachments/assets/e0f5aea5-ebaa-413e-99da-3d595094bca3" />

## 📌 Summary
Increase the contrast on the tables font for better legibility.

Closes #2058

## 🔁 Reproduction Steps
1. Access the gateway UI
2. Click the Observability tab
3. Click the Advanced Metrics on the Observability view

## 🐞 Root Cause
There was no dark-mode font colours defined for the tables

## 💡 Fix Description
Added font colour TW classes with the dark-mode decorator.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] No secrets/credentials committed
