### PR TITLE
feat: drop stack trace collection from loggers

### DIFF
--- a/mcpgateway/plugins/framework/manager.py
+++ b/mcpgateway/plugins/framework/manager.py
@@ -281,11 +281,11 @@ class PluginExecutor:
         except PluginViolationError:
             raise
         except PluginError as pe:
-            logger.error("Plugin %s failed with error: %s", hook_ref.plugin_ref.name, str(pe), exc_info=True)
+            logger.error("Plugin %s failed with error: %s", hook_ref.plugin_ref.name, str(pe))
             if (self.config and self.config.plugin_settings.fail_on_plugin_error) or hook_ref.plugin_ref.plugin.mode == PluginMode.ENFORCE:
                 raise
         except Exception as e:
-            logger.error("Plugin %s failed with error: %s", hook_ref.plugin_ref.name, str(e), exc_info=True)
+            logger.error("Plugin %s failed with error: %s", hook_ref.plugin_ref.name, str(e))
             if (self.config and self.config.plugin_settings.fail_on_plugin_error) or hook_ref.plugin_ref.plugin.mode == PluginMode.ENFORCE:
                 raise PluginError(error=convert_exception_to_error(e, hook_ref.plugin_ref.name)) from e
             # In permissive or enforce_ignore_error mode, continue with next plugin


### PR DESCRIPTION
## Summary                                                                                                                                                                                                             
                                                                                                                                                                                                                         
Remove `exc_info=True` from error logging in plugin framework hot path to eliminate critical performance bottleneck.                                                                                                   

Closes: #2064 
                                                                                                                                                                                                                         
## Problem                                                                                                                                                                                                             
                                                                                                                                                                                                                         
Performance profiling revealed the plugin framework was spending **~80% of execution time** formatting exception tracebacks that were never displayed or thrown. For a typical plugin hook invocation:                 
  - **0.165ms (80%)** - Exception/traceback formatting                                                                                                                                                                   
  - **0.042ms (20%)** - Actual plugin execution                                                                                                                                                                          
                                                                                                                                                                                                                         
The root cause was `exc_info=True` in `logger.error()` calls within exception handlers in `mcpgateway/plugins/framework/manager.py:284,288`, which forced Python to capture and format full stack traces on every error
   path, even when:                                                                                                                                                                                                      
  - No exception was actually raised                                                                                                                                                                                     
  - Log level suppressed ERROR messages                                                                                                                                                                                  
  - The formatted traceback was never displayed                                                                                                                                                                          
                                                                                                                                                                                                                         
## Changes                                                                                                                                                                                                             
                                                                                                                                                                                                                         
Removed `exc_info=True` parameter from two logger.error() calls in `PluginExecutor._execute_hook()`:                                                                                                                   
  - Line 284: `PluginError` handler                                                                                                                                                                                      
  - Line 288: Generic `Exception` handler                                                                                                                                                                                
                                                                                                                                                                                                                         
Exception details are still captured via `str(pe)` and `str(e)` in the log message.                                                                                                                                    
                                                                                                                                                                                                                         
## Impact                                                                                                                                                                                                              
                                                                                                                                                                                                                         
**Overall Performance Improvement: 84.9% FASTER**                                                                                                                                                                      
                                                                                                                                                                                                                         
  Total execution time reduced from **16.19s to 2.44s** across all plugin tests.                                                                                                                                         
                                                                                                                                                                                                                         
### Detailed Results

Performance evaluation using cProfile, following the guideline in `tests/performance`.                                                                                                                                                                                                    
                                                                                                                                                                                                                         
  | Test | Baseline (s) | Current (s) | Change |                                                                                                                                                                         
  |------|--------------|-------------|--------|                                                                                                                                                                         
  | ArgumentNormalizer_prompt_pre_fetch | 0.232463 | 0.056212 | -75.8% |                                                                                                                                                 
  | ArgumentNormalizer_tool_pre_invoke | 0.222858 | 0.048077 | -78.4% |                                                                                                                                                  
  | CachedToolResultPlugin_tool_post_invoke | 0.199008 | 0.031701 | -84.1% |                                                                                                                                             
  | CachedToolResultPlugin_tool_pre_invoke | 0.197429 | 0.031587 | -84.0% |                                                                                                                                              
  | CircuitBreaker_tool_post_invoke | 0.699122 | 0.040346 | -94.2% |                                                                                                                                                     
  | CircuitBreaker_tool_pre_invoke | 0.683927 | 0.038876 | -94.3% |                                                                                                                                                      
  | CitationValidator_resource_post_fetch | 0.202397 | 0.033290 | -83.6% |                                                                                                                                               
  | CitationValidator_tool_post_invoke | 0.204045 | 0.031865 | -84.4% |                                                                                                                                                  
  | CodeFormatter_resource_post_fetch | 0.215267 | 0.041778 | -80.6% |                                                                                                                                                   
  | CodeFormatter_tool_post_invoke | 0.205183 | 0.032670 | -84.1% |                                                                                                                                                      
  | CodeSafetyLinterPlugin_tool_post_invoke | 0.201381 | 0.032067 | -84.1% |                                                                                                                                             
  | DenyListPlugin_prompt_pre_fetch | 0.203179 | 0.034384 | -83.1% |                                                                                                                                                     
  | FileTypeAllowlistPlugin_resource_post_fetch | 0.201911 | 0.032065 | -84.1% |                                                                                                                                         
  | FileTypeAllowlistPlugin_resource_pre_fetch | 0.205651 | 0.034528 | -83.2% |                                                                                                                                          
  | HTMLToMarkdownPlugin_resource_post_fetch | 0.203760 | 0.032999 | -83.8% |                                                                                                                                            
  | HarmfulContentDetector_prompt_pre_fetch | 0.246567 | 0.068672 | -72.1% |                                                                                                                                             
  | HarmfulContentDetector_tool_post_invoke | 0.271827 | 0.090281 | -66.8% |                                                                                                                                             
  | HeaderInjector_resource_pre_fetch | 0.206886 | 0.034413 | -83.4% |                                                                                                                                                   
  | JSONRepairPlugin_tool_post_invoke | 0.199952 | 0.032020 | -84.0% |                                                                                                                                                   
  | LicenseHeaderInjector_resource_post_fetch | 0.214318 | 0.040206 | -81.2% |                                                                                                                                           
  | LicenseHeaderInjector_tool_post_invoke | 0.203814 | 0.031762 | -84.4% |                                                                                                                                              
  | MarkdownCleanerPlugin_prompt_post_fetch | 0.211546 | 0.038252 | -81.9% |                                                                                                                                             
  | MarkdownCleanerPlugin_resource_post_fetch | 0.211933 | 0.038736 | -81.7% |                                                                                                                                           
  | OutputLengthGuardPlugin_tool_post_invoke | 0.201871 | 0.032102 | -84.1% |                                                                                                                                            
  | PIIFilterPlugin_prompt_post_fetch | 0.218788 | 0.047626 | -78.2% |                                                                                                                                                   
  | PIIFilterPlugin_prompt_pre_fetch | 0.286409 | 0.101722 | -64.5% |                                                                                                                                                    
  | PIIFilterPlugin_tool_post_invoke | 0.257708 | 0.079033 | -69.3% |                                                                                                                                                    
  | PIIFilterPlugin_tool_pre_invoke | 0.230615 | 0.057875 | -74.9% |                                                                                                                                                     
  | ReplaceBadWordsPlugin_prompt_post_fetch | 0.204460 | 0.036141 | -82.3% |                                                                                                                                             
  | ReplaceBadWordsPlugin_prompt_pre_fetch | 0.205820 | 0.036515 | -82.3% |                                                                                                                                              
  | ReplaceBadWordsPlugin_tool_post_invoke | 0.202146 | 0.034298 | -83.0% |                                                                                                                                              
  | ReplaceBadWordsPlugin_tool_pre_invoke | 0.205963 | 0.036983 | -82.0% |                                                                                                                                               
  | ResourceFilterExample_resource_post_fetch | 0.669199 | 0.038936 | -94.2% |                                                                                                                                           
  | ResourceFilterExample_resource_pre_fetch | 0.731530 | 0.046166 | -93.7% |                                                                                                                                            
  | ResponseCacheByPrompt_tool_post_invoke | 0.202545 | 0.031488 | -84.5% |                                                                                                                                              
  | ResponseCacheByPrompt_tool_pre_invoke | 0.203682 | 0.032110 | -84.2% |                                                                                                                                               
  | RetryWithBackoffPlugin_resource_post_fetch | 0.205346 | 0.030783 | -85.0% |                                                                                                                                          
  | RetryWithBackoffPlugin_tool_post_invoke | 0.202987 | 0.031478 | -84.5% |                                                                                                                                             
  | RobotsLicenseGuard_resource_post_fetch | 0.207298 | 0.036787 | -82.3% |                                                                                                                                              
  | RobotsLicenseGuard_resource_pre_fetch | 0.200414 | 0.033384 | -83.3% |                                                                                                                                               
  | SPARCStaticValidator_tool_pre_invoke | 0.789975 | 0.038526 | -95.1% |                                                                                                                                                
  | SQLSanitizer_prompt_pre_fetch | 0.218705 | 0.045974 | -79.0% |                                                                                                                                                       
  | SQLSanitizer_tool_pre_invoke | 0.216702 | 0.044055 | -79.7% |                                                                                                                                                        
  | SafeHTMLSanitizer_resource_post_fetch | 0.210452 | 0.038365 | -81.8% |                                                                                                                                               
  | SchemaGuardPlugin_tool_post_invoke | 0.201800 | 0.031904 | -84.2% |                                                                                                                                                  
  | SchemaGuardPlugin_tool_pre_invoke | 0.201547 | 0.031997 | -84.1% |                                                                                                                                                   
  | SecretsDetection_prompt_pre_fetch | 0.224690 | 0.049165 | -78.1% |                                                                                                                                                   
  | SecretsDetection_resource_post_fetch | 0.211360 | 0.039405 | -81.4% |                                                                                                                                                
  | SecretsDetection_tool_post_invoke | 0.238682 | 0.063379 | -73.4% |                                                                                                                                                   
  | Summarizer_resource_post_fetch | 0.204291 | 0.033499 | -83.6% |                                                                                                                                                      
  | Summarizer_tool_post_invoke | 0.201511 | 0.030687 | -84.8% |                                                                                                                                                         
  | TimezoneTranslator_tool_post_invoke | 0.215695 | 0.040307 | -81.3% |                                                                                                                                                 
  | TimezoneTranslator_tool_pre_invoke | 0.199961 | 0.031182 | -84.4% |                                                                                                                                                  
  | URLReputationPlugin_resource_pre_fetch | 0.210241 | 0.036602 | -82.6% |                                                                                                                                              
  | VirusTotalURLCheckerPlugin_prompt_post_fetch | 0.204989 | 0.032940 | -83.9% |                                                                                                                                        
  | VirusTotalURLCheckerPlugin_resource_post_fetch | 0.201330 | 0.033636 | -83.3% |                                                                                                                                      
  | VirusTotalURLCheckerPlugin_resource_pre_fetch | 0.209055 | 0.037660 | -82.0% |                                                                                                                                       
  | VirusTotalURLCheckerPlugin_tool_post_invoke | 0.209288 | 0.033539 | -84.0% |                                                                                                                                         
  | Watchdog_tool_post_invoke | 0.672092 | 0.039136 | -94.2% |                                                                                                                                                           
  | Watchdog_tool_pre_invoke | 0.663058 | 0.038158 | -94.2% |                                                                                                                                                            
  | **TOTAL** | **16.186631** | **2.440332** | **-84.9%** |                                                                                                                                                              
                                                                                                                                                                                                                         
### Key Highlights                                                                                                                                                                                                      
                                                                                                                                                                                                                         
  - **Best improvements** (>94% faster):                                                                                                                                                                                 
    - SPARCStaticValidator_tool_pre_invoke: -95.1%                                                                                                                                                                       
    - CircuitBreaker_tool_pre_invoke: -94.3%                                                                                                                                                                             
    - CircuitBreaker_tool_post_invoke: -94.2%                                                                                                                                                                            
    - Watchdog_tool_pre_invoke: -94.2%                                                                                                                                                                                   
    - Watchdog_tool_post_invoke: -94.2%                                                                                                                                                                                  
    - ResourceFilterExample_resource_post_fetch: -94.2%                                                                                                                                                                  
    - ResourceFilterExample_resource_pre_fetch: -93.7%                                                                                                                                                                   
                                                                                                                                                                                                                         
  - **Typical improvements**: 80-85% reduction in execution time                                                                                                                                                         
  - **Minimum improvement**: 64.5% (PIIFilterPlugin_prompt_pre_fetch) 