### PR TITLE
Improve MCP Servers table layout

### DIFF
--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -2,16 +2,16 @@
 <table id="gateways-table" class="min-w-full divide-y divide-gray-200">
   <thead class="bg-gray-50 dark:bg-gray-700">
     <tr>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">S. No.</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Name</th>
-      <th class="px-2 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider w-24">URL</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Tags</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Status</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Last Seen</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Owner</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Team</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Visibility</th>
-      <th class="px-3 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Actions</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">S. No.</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Name</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider w-24">URL</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Tags</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Status</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Last Seen</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Owner</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Team</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Visibility</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Actions</th>
     </tr>
   </thead>
   <tbody id="gateways-table-body" class="bg-white divide-y divide-gray-200 dark:bg-gray-900 dark:divide-gray-700">
@@ -20,7 +20,7 @@
 <tr id="gateway-row-{{ gateway.id }}">
     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ (pagination.page - 1) * pagination.per_page + loop.index }}</td>
     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ gateway.name }}</td>
-    <td class="px-2 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-24 max-w-xs">{{ gateway.url }}</td>
+    <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 w-24 max-w-xs">{{ gateway.url }}</td>
     <td class="px-6 py-4 whitespace-nowrap">
       {% if gateway.tags %}
         {% for tag in gateway.tags %}


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2073

| before | after   |
|--------|-------|
| <img width="1390" height="199" alt="Screenshot 2026-01-13 at 11 14 06" src="https://github.com/user-attachments/assets/fdd236f2-a61c-403a-84d6-fe81e4134031" /> | <img width="1390" height="201" alt="Screenshot 2026-01-13 at 11 14 39" src="https://github.com/user-attachments/assets/c42f112d-ea9c-42c0-a304-715ad4f98cc6" /> |

## 📌 Summary
Improbe MCP Servers table layout by aligning content to header and fixing button spacing on open-menu view.

## 🔁 Reproduction Steps
1. Access the Admin UI
2. Click the MCP Servers tab
3. Scroll the table to the right

## 🐞 Root Cause
The inconsistent horizontal padding between the headers and cells was messing with `table-layout: auto` calculation.

## 💡 Fix Description
Make horizontal padding consistent across all headers and cells.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |   ✅     |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] No secrets/credentials committed
