### PR TITLE
Restore OAuth actions in gateways partial

### DIFF
--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -29,11 +29,25 @@
               Test
             </button>
 
-            <!-- Row 2: View | Edit -->
+            {% if gateway.authType == 'oauth' %}
+            <!-- Row 2: OAuth Authorize | Fetch Tools -->
+            <a href="{{ root_path }}/oauth/authorize/{{ gateway.id }}"
+              class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-indigo-600 hover:text-indigo-900 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900/20 transition-colors"
+              x-tooltip="'🔐 Authorize Users for OAuth'">
+              🔐 Authorize
+            </a>
+            <button onclick="fetchToolsForGateway({{ gateway.id|tojson }}, {{ gateway.name|tojson }})"
+              class="flex items-center justify-center px-1 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors"
+              x-tooltip="'🔧 Fetch Tools from MCP Server'" id="fetch-tools-{{ gateway.id }}">
+              🔧 Fetch Tools
+            </button>
+            {% endif %}
+
+            <!-- Row 3: View | Edit -->
             <button onclick="viewGateway('{{ gateway.id }}')" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-indigo-600 hover:text-indigo-900 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900/20 transition-colors">View</button>
             <button onclick="editGateway('{{ gateway.id }}')" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors">Edit</button>
 
-            <!-- Row 3 & 4: Activate/Deactivate | Delete -->
+            <!-- Row 4: Activate/Deactivate | Delete -->
             <div class="col-span-2 flex flex-col space-y-1">
               <form method="POST" action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'gateways')">
                 <input type="hidden" name="activate" value="{{ 'false' if gateway.enabled else 'true' }}" />


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

Added "Authorize" and "Fetch Tools" buttons for OAuth-enabled gateways, matching the main admin interface.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    pass    |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
