### PR TITLE
fix: Handle None message in session registry and missing tool_runs tracking

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -863,12 +863,16 @@ class SessionRegistry(SessionBackend):
         elif self._backend == "memory":
             transport = self.get_session_sync(session_id)
             if transport and self._session_message:
-                data = orjson.loads(self._session_message.get("message"))
-                if isinstance(data, dict) and "message" in data:
-                    message = data["message"]
+                message_json = self._session_message.get("message")
+                if message_json:
+                    data = orjson.loads(message_json)
+                    if isinstance(data, dict) and "message" in data:
+                        message = data["message"]
+                    else:
+                        message = data
+                    await self.generate_response(message=message, transport=transport, server_id=server_id, user=user, base_url=base_url)
                 else:
-                    message = data
-                await self.generate_response(message=message, transport=transport, server_id=server_id, user=user, base_url=base_url)
+                    logger.warning(f"Session message stored but message content is None for session {session_id}")
 
         elif self._backend == "redis":
             if not self._redis:


### PR DESCRIPTION
## Bug-fix : Session Registry & Tool Runs Tracking

###  Summary

Fixed two critical bugs in core session and agent services that cause runtime crashes:

1. **Session Registry AttributeError** - Crashes when session message content is None
2. **Tool Execution KeyError** - Crashes during async agent tool execution with race condition

Both bugs have high impact on production reliability.

###  Root Cause

**Bug #1** (session_registry.py:866)
- Code called `orjson.loads(self._session_message.get("message"))` without null check
- If dict key "message" had None value, `orjson.loads(None)` crashes with AttributeError
- Test file documented this as known bug

**Bug #2** (mcp_client_chat_service.py:2740)
- Code checked `if run_id in tool_runs:` but then accessed `tool_runs[run_id]["output"]` unconditionally after the if block
- LangChain event streaming can deliver events out of order (on_tool_end before on_tool_start)
- Causes KeyError when trying to access untracked run_id

### 💡 Fix Description

**Fix #1: Session Registry** (session_registry.py:863-875)
- Extract message content to variable
- Add explicit null check before `orjson.loads()`
- Log warning instead of crashing

**Fix #2: Tool Runs Tracking** (mcp_client_chat_service.py:2723-2745)
- Move all `tool_runs[run_id]` accesses inside the guard clause
- Use safe `.get()` accessor instead of direct bracket access
- Add else clause to handle out-of-order events gracefully

###  Verification

| Check | Command | Status |
|-------|---------|--------|
| Flake8 linting | flake8 mcpgateway/{cache/session_registry.py,services/mcp_client_chat_service.py} | Pass |
| Unit tests | pytest tests/unit/mcpgateway/cache/test_session_registry.py | 55/55 Pass |
| Python syntax | python -m py_compile |  Valid |

### Checklist
- Code formatted (Black, isort)
- Linting passes (flake8)
- Tests pass (55/55)
- No secrets committed
-  Signed commit (DCO)
- Conventional commit format