### PR TITLE
feat(helm): add service annotations and CACHE_TYPE none option

### DIFF
--- a/charts/mcp-stack/templates/service-mcp.yaml
+++ b/charts/mcp-stack/templates/service-mcp.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "mcp-stack.fullname" . }}-mcpgateway
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
+  {{- with .Values.mcpContextForge.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.mcpContextForge.service.type }}
   selector:

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -217,6 +217,14 @@
               "minimum": 1,
               "maximum": 65535,
               "default": 80
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Service annotations (e.g., for AWS NLB, GCP load balancer configuration)",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
             }
           },
           "additionalProperties": false
@@ -498,7 +506,7 @@
             "CACHE_TYPE": {
               "type": "string",
               "description": "Cache backend type",
-              "enum": ["redis", "memory", "database"],
+              "enum": ["redis", "memory", "none", "database"],
               "default": "redis"
             },
             "CACHE_PREFIX": {

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -62,6 +62,7 @@ mcpContextForge:
   service:
     type: ClusterIP
     port: 80                    # external port → containerPort below
+    annotations: {}             # Service annotations (e.g., for AWS NLB configuration)
 
   containerPort: 4444           # port the app listens on inside the pod
 


### PR DESCRIPTION
## Summary

This PR extracts the still-valid features from #1798 (now closed), which was superseded by existing implementations for external PostgreSQL and secret injection.

### Changes:
- **Service annotations support**: Adds `mcpContextForge.service.annotations` to allow LoadBalancer configuration (e.g., AWS NLB, GCP load balancer annotations)
- **CACHE_TYPE "none" option**: Adds "none" as a valid cache type in the schema to allow disabling caching entirely

### Why this matters:
- Service annotations are essential for cloud deployments that require specific load balancer configurations
- The "none" cache type allows deployments that don't need caching (e.g., single-node development environments)

### Attribution
Original work by @jinzishuai in #1798 - thank you for identifying these gaps!

### Files changed:
- `charts/mcp-stack/templates/service-mcp.yaml` - Added annotations template block
- `charts/mcp-stack/values.schema.json` - Added annotations schema and "none" to CACHE_TYPE enum
- `charts/mcp-stack/values.yaml` - Added annotations default

Closes #1722 (partial - service annotations portion)