### PR TITLE
Rename Toggle Endpoint to State for Clear and Explicit Status Updates(issue1497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,7 +755,7 @@ This release focuses on **Advanced OAuth Integration, Plugin Ecosystem, MCP Regi
   - `GET /grpc` - List all gRPC services with team filtering
   - `GET /grpc/{id}` - Get service details
   - `PUT /grpc/{id}` - Update service configuration
-  - `POST /grpc/{id}/toggle` - Enable/disable service
+  - `POST /grpc/{id}/state` - Enable/disable service
   - `POST /grpc/{id}/delete` - Delete service
   - `POST /grpc/{id}/reflect` - Re-trigger service discovery
   - `GET /grpc/{id}/methods` - List discovered methods

--- a/README.md
+++ b/README.md
@@ -2553,9 +2553,9 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=false
+     http://localhost:4444/tools/1/state?activate=false
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=true
+     http://localhost:4444/tools/1/state?activate=true
 
 # Delete tool
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/tools/1
@@ -2615,7 +2615,7 @@ curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle agent status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/a2a/agent-id/toggle?activate=false
+     http://localhost:4444/a2a/agent-id/state?activate=false
 
 # Delete agent
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
@@ -2665,7 +2665,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/gateways/1/toggle?activate=false
+     http://localhost:4444/gateways/1/state?activate=false
 
 # Delete gateway
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/gateways/1
@@ -2751,7 +2751,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/prompts/5/toggle?activate=false
+     http://localhost:4444/prompts/5/state?activate=false
 
 # Delete prompt
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/prompts/greet
@@ -2809,7 +2809,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/servers/UUID_OF_SERVER_1/toggle?activate=false
+     http://localhost:4444/servers/UUID_OF_SERVER_1/state?activate=false
 ```
 
 </details>

--- a/docs/docs/architecture/adr/011-tool-federation.md
+++ b/docs/docs/architecture/adr/011-tool-federation.md
@@ -37,7 +37,7 @@ We implemented this by making the following changes:
    - When storing and updating tools, use `original_name` in `DbTool` objects to store the original name coming from `_initiate_gateway`.
    - Remove check for only storing tools without matching original names
    - Check if `gateway.url` exists instead of `gateway.name` exists before thowing `GatewayNameConflictError`.
-   - Check for existing tools on `original_name` and `gateway_id` instead of just `name` (as earlier) in **update_gateway** and **toggle_gateway_status** code.
+   - Check for existing tools on `original_name` and `gateway_id` instead of just `name` (as earlier) in **update_gateway** and **set_gateway_state** code.
    - Set `name` and `gateway_slug` just before passing to `ToolRead` seprately since these don't come from the database as these are properties and not columns.
    - To obtain tool from database for invocation, handle the case that `name` from the API is not stored as a column in the database, but is a property by making an appropriate comparison as `DbTool.gateway_slug + settings.gateway_tool_name_separator + DbTool.original_name == name`
 

--- a/docs/docs/architecture/adr/033-tool-lookup-cache.md
+++ b/docs/docs/architecture/adr/033-tool-lookup-cache.md
@@ -39,8 +39,8 @@ Introduce a two-tier tool lookup cache keyed by tool name, with:
    - Negative cache entries short-circuit missing/inactive/offline tool calls
 
 3. **Cache invalidation**
-   - Tool create/update/delete/toggle invalidates tool lookup cache
-   - Gateway update/toggle/delete invalidates all tools for that gateway
+   - Tool create/update/delete/state invalidates tool lookup cache
+   - Gateway update/state/delete invalidates all tools for that gateway
 
 4. **Configuration**
 

--- a/docs/docs/design/images/code2flow.svg
+++ b/docs/docs/design/images/code2flow.svg
@@ -1306,7 +1306,7 @@
 <g id="node16" class="node">
 <title>node_7cd26d76</title>
 <path fill="#cccccc" stroke="black" d="M2042,-24530C2042,-24530 1889,-24530 1889,-24530 1883,-24530 1877,-24524 1877,-24518 1877,-24518 1877,-24506 1877,-24506 1877,-24500 1883,-24494 1889,-24494 1889,-24494 2042,-24494 2042,-24494 2048,-24494 2054,-24500 2054,-24506 2054,-24506 2054,-24518 2054,-24518 2054,-24524 2048,-24530 2042,-24530"/>
-<text text-anchor="middle" x="1965.5" y="-24508.3" font-family="Arial" font-size="14.00">419: toggle_agent_status()</text>
+<text text-anchor="middle" x="1965.5" y="-24508.3" font-family="Arial" font-size="14.00">419: set_agent_state()</text>
 </g>
 <!-- node_7cd26d76&#45;&gt;node_574dcb68 -->
 <g id="edge30" class="edge">
@@ -3093,7 +3093,7 @@
 <g id="node79" class="node">
 <title>node_1b63b77c</title>
 <path fill="#966f33" stroke="black" d="M1385,-36319C1385,-36319 1193,-36319 1193,-36319 1187,-36319 1181,-36313 1181,-36307 1181,-36307 1181,-36295 1181,-36295 1181,-36289 1187,-36283 1193,-36283 1193,-36283 1385,-36283 1385,-36283 1391,-36283 1397,-36289 1397,-36295 1397,-36295 1397,-36307 1397,-36307 1397,-36313 1391,-36319 1385,-36319"/>
-<text text-anchor="middle" x="1289" y="-36297.3" font-family="Arial" font-size="14.00">8588: admin_toggle_a2a_agent()</text>
+<text text-anchor="middle" x="1289" y="-36297.3" font-family="Arial" font-size="14.00">8588: admin_set_a2a_agent_state()</text>
 </g>
 <!-- node_1b63b77c&#45;&gt;node_7cd26d76 -->
 <g id="edge215" class="edge">
@@ -3105,7 +3105,7 @@
 <g id="node80" class="node">
 <title>node_5de30b09</title>
 <path fill="#966f33" stroke="black" d="M1378.5,-37777C1378.5,-37777 1199.5,-37777 1199.5,-37777 1193.5,-37777 1187.5,-37771 1187.5,-37765 1187.5,-37765 1187.5,-37753 1187.5,-37753 1187.5,-37747 1193.5,-37741 1199.5,-37741 1199.5,-37741 1378.5,-37741 1378.5,-37741 1384.5,-37741 1390.5,-37747 1390.5,-37753 1390.5,-37753 1390.5,-37765 1390.5,-37765 1390.5,-37771 1384.5,-37777 1378.5,-37777"/>
-<text text-anchor="middle" x="1289" y="-37755.3" font-family="Arial" font-size="14.00">1596: admin_toggle_gateway()</text>
+<text text-anchor="middle" x="1289" y="-37755.3" font-family="Arial" font-size="14.00">1596: admin_set_gateway_state()</text>
 </g>
 <!-- node_5de30b09&#45;&gt;node_cd86d046 -->
 <g id="edge216" class="edge">
@@ -3117,7 +3117,7 @@
 <g id="node81" class="node">
 <title>node_7a5e44f1</title>
 <path fill="#966f33" stroke="black" d="M1374.5,-38749C1374.5,-38749 1203.5,-38749 1203.5,-38749 1197.5,-38749 1191.5,-38743 1191.5,-38737 1191.5,-38737 1191.5,-38725 1191.5,-38725 1191.5,-38719 1197.5,-38713 1203.5,-38713 1203.5,-38713 1374.5,-38713 1374.5,-38713 1380.5,-38713 1386.5,-38719 1386.5,-38725 1386.5,-38725 1386.5,-38737 1386.5,-38737 1386.5,-38743 1380.5,-38749 1374.5,-38749"/>
-<text text-anchor="middle" x="1289" y="-38727.3" font-family="Arial" font-size="14.00">6872: admin_toggle_prompt()</text>
+<text text-anchor="middle" x="1289" y="-38727.3" font-family="Arial" font-size="14.00">6872: admin_set_prompt_state()</text>
 </g>
 <!-- node_7a5e44f1&#45;&gt;node_cd86d046 -->
 <g id="edge217" class="edge">
@@ -3129,7 +3129,7 @@
 <g id="node82" class="node">
 <title>node_bc807ceb</title>
 <path fill="#966f33" stroke="black" d="M1379.5,-38209C1379.5,-38209 1198.5,-38209 1198.5,-38209 1192.5,-38209 1186.5,-38203 1186.5,-38197 1186.5,-38197 1186.5,-38185 1186.5,-38185 1186.5,-38179 1192.5,-38173 1198.5,-38173 1198.5,-38173 1379.5,-38173 1379.5,-38173 1385.5,-38173 1391.5,-38179 1391.5,-38185 1391.5,-38185 1391.5,-38197 1391.5,-38197 1391.5,-38203 1385.5,-38209 1379.5,-38209"/>
-<text text-anchor="middle" x="1289" y="-38187.3" font-family="Arial" font-size="14.00">6378: admin_toggle_resource()</text>
+<text text-anchor="middle" x="1289" y="-38187.3" font-family="Arial" font-size="14.00">6378: admin_set_resource_state()</text>
 </g>
 <!-- node_bc807ceb&#45;&gt;node_cd86d046 -->
 <g id="edge218" class="edge">
@@ -3141,7 +3141,7 @@
 <g id="node83" class="node">
 <title>node_ddba35fe</title>
 <path fill="#966f33" stroke="black" d="M1372,-38155C1372,-38155 1206,-38155 1206,-38155 1200,-38155 1194,-38149 1194,-38143 1194,-38143 1194,-38131 1194,-38131 1194,-38125 1200,-38119 1206,-38119 1206,-38119 1372,-38119 1372,-38119 1378,-38119 1384,-38125 1384,-38131 1384,-38131 1384,-38143 1384,-38143 1384,-38149 1378,-38155 1372,-38155"/>
-<text text-anchor="middle" x="1289" y="-38133.3" font-family="Arial" font-size="14.00">1080: admin_toggle_server()</text>
+<text text-anchor="middle" x="1289" y="-38133.3" font-family="Arial" font-size="14.00">1080: admin_set_server_state()</text>
 </g>
 <!-- node_ddba35fe&#45;&gt;node_cd86d046 -->
 <g id="edge219" class="edge">
@@ -3153,7 +3153,7 @@
 <g id="node84" class="node">
 <title>node_880f2772</title>
 <path fill="#966f33" stroke="black" d="M1364,-38101C1364,-38101 1214,-38101 1214,-38101 1208,-38101 1202,-38095 1202,-38089 1202,-38089 1202,-38077 1202,-38077 1202,-38071 1208,-38065 1214,-38065 1214,-38065 1364,-38065 1364,-38065 1370,-38065 1376,-38071 1376,-38077 1376,-38077 1376,-38089 1376,-38089 1376,-38095 1370,-38101 1364,-38101"/>
-<text text-anchor="middle" x="1289" y="-38079.3" font-family="Arial" font-size="14.00">5257: admin_toggle_tool()</text>
+<text text-anchor="middle" x="1289" y="-38079.3" font-family="Arial" font-size="14.00">5257: admin_set_tool_state()</text>
 </g>
 <!-- node_880f2772&#45;&gt;node_cd86d046 -->
 <g id="edge220" class="edge">
@@ -6813,7 +6813,7 @@
 <g id="node332" class="node">
 <title>node_d8cf5c91</title>
 <path fill="#cccccc" stroke="black" d="M2054,-44559C2054,-44559 1877,-44559 1877,-44559 1871,-44559 1865,-44553 1865,-44547 1865,-44547 1865,-44535 1865,-44535 1865,-44529 1871,-44523 1877,-44523 1877,-44523 2054,-44523 2054,-44523 2060,-44523 2066,-44529 2066,-44535 2066,-44535 2066,-44547 2066,-44547 2066,-44553 2060,-44559 2054,-44559"/>
-<text text-anchor="middle" x="1965.5" y="-44537.3" font-family="Arial" font-size="14.00">1291: toggle_gateway_status()</text>
+<text text-anchor="middle" x="1965.5" y="-44537.3" font-family="Arial" font-size="14.00">1291: set_gateway_state()</text>
 </g>
 <!-- node_59707e37&#45;&gt;node_d8cf5c91 -->
 <g id="edge603" class="edge">
@@ -10234,7 +10234,7 @@
 <g id="node467" class="node">
 <title>node_8d8912a8</title>
 <path fill="#966f33" stroke="black" d="M1069.5,-43733C1069.5,-43733 892.5,-43733 892.5,-43733 886.5,-43733 880.5,-43727 880.5,-43721 880.5,-43721 880.5,-43709 880.5,-43709 880.5,-43703 886.5,-43697 892.5,-43697 892.5,-43697 1069.5,-43697 1069.5,-43697 1075.5,-43697 1081.5,-43703 1081.5,-43709 1081.5,-43709 1081.5,-43721 1081.5,-43721 1081.5,-43727 1075.5,-43733 1069.5,-43733"/>
-<text text-anchor="middle" x="981" y="-43711.3" font-family="Arial" font-size="14.00">3044: toggle_gateway_status()</text>
+<text text-anchor="middle" x="981" y="-43711.3" font-family="Arial" font-size="14.00">3044: set_gateway_state()</text>
 </g>
 <!-- node_8d8912a8&#45;&gt;node_d8cf5c91 -->
 <g id="edge962" class="edge">
@@ -10246,13 +10246,13 @@
 <g id="node468" class="node">
 <title>node_64a5110c</title>
 <path fill="#966f33" stroke="black" d="M1066,-42200C1066,-42200 896,-42200 896,-42200 890,-42200 884,-42194 884,-42188 884,-42188 884,-42176 884,-42176 884,-42170 890,-42164 896,-42164 896,-42164 1066,-42164 1066,-42164 1072,-42164 1078,-42170 1078,-42176 1078,-42176 1078,-42188 1078,-42188 1078,-42194 1072,-42200 1066,-42200"/>
-<text text-anchor="middle" x="981" y="-42178.3" font-family="Arial" font-size="14.00">2658: toggle_prompt_status()</text>
+<text text-anchor="middle" x="981" y="-42178.3" font-family="Arial" font-size="14.00">2658: set_prompt_state()</text>
 </g>
 <!-- node_bb7af980 -->
 <g id="node582" class="node">
 <title>node_bb7af980</title>
 <path fill="#cccccc" stroke="black" d="M1679,-28310C1679,-28310 1517,-28310 1517,-28310 1511,-28310 1505,-28304 1505,-28298 1505,-28298 1505,-28286 1505,-28286 1505,-28280 1511,-28274 1517,-28274 1517,-28274 1679,-28274 1679,-28274 1685,-28274 1691,-28280 1691,-28286 1691,-28286 1691,-28298 1691,-28298 1691,-28304 1685,-28310 1679,-28310"/>
-<text text-anchor="middle" x="1598" y="-28288.3" font-family="Arial" font-size="14.00">773: toggle_prompt_status()</text>
+<text text-anchor="middle" x="1598" y="-28288.3" font-family="Arial" font-size="14.00">773: set_prompt_state()</text>
 </g>
 <!-- node_64a5110c&#45;&gt;node_bb7af980 -->
 <g id="edge963" class="edge">
@@ -10264,13 +10264,13 @@
 <g id="node469" class="node">
 <title>node_5e76168a</title>
 <path fill="#966f33" stroke="black" d="M1070.5,-41930C1070.5,-41930 891.5,-41930 891.5,-41930 885.5,-41930 879.5,-41924 879.5,-41918 879.5,-41918 879.5,-41906 879.5,-41906 879.5,-41900 885.5,-41894 891.5,-41894 891.5,-41894 1070.5,-41894 1070.5,-41894 1076.5,-41894 1082.5,-41900 1082.5,-41906 1082.5,-41906 1082.5,-41918 1082.5,-41918 1082.5,-41924 1076.5,-41930 1070.5,-41930"/>
-<text text-anchor="middle" x="981" y="-41908.3" font-family="Arial" font-size="14.00">2338: toggle_resource_status()</text>
+<text text-anchor="middle" x="981" y="-41908.3" font-family="Arial" font-size="14.00">2338: set_resource_state()</text>
 </g>
 <!-- node_b0cb6099 -->
 <g id="node649" class="node">
 <title>node_b0cb6099</title>
 <path fill="#cccccc" stroke="black" d="M1684,-27550C1684,-27550 1512,-27550 1512,-27550 1506,-27550 1500,-27544 1500,-27538 1500,-27538 1500,-27526 1500,-27526 1500,-27520 1506,-27514 1512,-27514 1512,-27514 1684,-27514 1684,-27514 1690,-27514 1696,-27520 1696,-27526 1696,-27526 1696,-27538 1696,-27538 1696,-27544 1690,-27550 1684,-27550"/>
-<text text-anchor="middle" x="1598" y="-27528.3" font-family="Arial" font-size="14.00">717: toggle_resource_status()</text>
+<text text-anchor="middle" x="1598" y="-27528.3" font-family="Arial" font-size="14.00">717: set_resource_state()</text>
 </g>
 <!-- node_5e76168a&#45;&gt;node_b0cb6099 -->
 <g id="edge964" class="edge">
@@ -10282,13 +10282,13 @@
 <g id="node470" class="node">
 <title>node_f1ffc7ad</title>
 <path fill="#966f33" stroke="black" d="M1063,-41606C1063,-41606 899,-41606 899,-41606 893,-41606 887,-41600 887,-41594 887,-41594 887,-41582 887,-41582 887,-41576 893,-41570 899,-41570 899,-41570 1063,-41570 1063,-41570 1069,-41570 1075,-41576 1075,-41582 1075,-41582 1075,-41594 1075,-41594 1075,-41600 1069,-41606 1063,-41606"/>
-<text text-anchor="middle" x="981" y="-41584.3" font-family="Arial" font-size="14.00">1484: toggle_server_status()</text>
+<text text-anchor="middle" x="981" y="-41584.3" font-family="Arial" font-size="14.00">1484: set_server_state()</text>
 </g>
 <!-- node_2aaac624 -->
 <g id="node785" class="node">
 <title>node_2aaac624</title>
 <path fill="#cccccc" stroke="black" d="M1676.5,-26319C1676.5,-26319 1519.5,-26319 1519.5,-26319 1513.5,-26319 1507.5,-26313 1507.5,-26307 1507.5,-26307 1507.5,-26295 1507.5,-26295 1507.5,-26289 1513.5,-26283 1519.5,-26283 1519.5,-26283 1676.5,-26283 1676.5,-26283 1682.5,-26283 1688.5,-26289 1688.5,-26295 1688.5,-26295 1688.5,-26307 1688.5,-26307 1688.5,-26313 1682.5,-26319 1676.5,-26319"/>
-<text text-anchor="middle" x="1598" y="-26297.3" font-family="Arial" font-size="14.00">833: toggle_server_status()</text>
+<text text-anchor="middle" x="1598" y="-26297.3" font-family="Arial" font-size="14.00">833: set_server_state()</text>
 </g>
 <!-- node_f1ffc7ad&#45;&gt;node_2aaac624 -->
 <g id="edge965" class="edge">
@@ -10300,13 +10300,13 @@
 <g id="node471" class="node">
 <title>node_c67b693a</title>
 <path fill="#966f33" stroke="black" d="M1055.5,-43172C1055.5,-43172 906.5,-43172 906.5,-43172 900.5,-43172 894.5,-43166 894.5,-43160 894.5,-43160 894.5,-43148 894.5,-43148 894.5,-43142 900.5,-43136 906.5,-43136 906.5,-43136 1055.5,-43136 1055.5,-43136 1061.5,-43136 1067.5,-43142 1067.5,-43148 1067.5,-43148 1067.5,-43160 1067.5,-43160 1067.5,-43166 1061.5,-43172 1055.5,-43172"/>
-<text text-anchor="middle" x="981" y="-43150.3" font-family="Arial" font-size="14.00">2277: toggle_tool_status()</text>
+<text text-anchor="middle" x="981" y="-43150.3" font-family="Arial" font-size="14.00">2277: set_tool_state()</text>
 </g>
 <!-- node_0ddbe8ce -->
 <g id="node989" class="node">
 <title>node_0ddbe8ce</title>
 <path fill="#cccccc" stroke="black" d="M2036,-39444C2036,-39444 1895,-39444 1895,-39444 1889,-39444 1883,-39438 1883,-39432 1883,-39432 1883,-39420 1883,-39420 1883,-39414 1889,-39408 1895,-39408 1895,-39408 2036,-39408 2036,-39408 2042,-39408 2048,-39414 2048,-39420 2048,-39420 2048,-39432 2048,-39432 2048,-39438 2042,-39444 2036,-39444"/>
-<text text-anchor="middle" x="1965.5" y="-39422.3" font-family="Arial" font-size="14.00">707: toggle_tool_status()</text>
+<text text-anchor="middle" x="1965.5" y="-39422.3" font-family="Arial" font-size="14.00">707: set_tool_state()</text>
 </g>
 <!-- node_c67b693a&#45;&gt;node_0ddbe8ce -->
 <g id="edge966" class="edge">

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1719,9 +1719,9 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=false
+     http://localhost:4444/tools/1/state?activate=false
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/tools/1/toggle?activate=true
+     http://localhost:4444/tools/1/state?activate=true
 
 # Delete tool
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/tools/1
@@ -1781,7 +1781,7 @@ curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle agent status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/a2a/agent-id/toggle?activate=false
+     http://localhost:4444/a2a/agent-id/state?activate=false
 
 # Delete agent
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
@@ -1831,7 +1831,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active status
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/gateways/1/toggle?activate=false
+     http://localhost:4444/gateways/1/state?activate=false
 
 # Delete gateway
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/gateways/1
@@ -1917,7 +1917,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/prompts/5/toggle?activate=false
+     http://localhost:4444/prompts/5/state?activate=false
 
 # Delete prompt
 curl -X DELETE -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" http://localhost:4444/prompts/greet
@@ -1975,7 +1975,7 @@ curl -X PUT -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 
 # Toggle active
 curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
-     http://localhost:4444/servers/UUID_OF_SERVER_1/toggle?activate=false
+     http://localhost:4444/servers/UUID_OF_SERVER_1/state?activate=false
 ```
 
 </details>

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -312,7 +312,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle gateway enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/gateways/$GATEWAY_ID/toggle?activate=false | jq '.'
+  $BASE_URL/gateways/$GATEWAY_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Gateway
@@ -503,7 +503,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle tool enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/tools/$TOOL_ID/toggle?activate=false | jq '.'
+  $BASE_URL/tools/$TOOL_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Tool
@@ -654,7 +654,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle server enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/servers/$SERVER_ID/toggle?activate=false | jq '.'
+  $BASE_URL/servers/$SERVER_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Server
@@ -773,7 +773,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle resource enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/resources/$RESOURCE_ID/toggle?activate=false | jq '.'
+  $BASE_URL/resources/$RESOURCE_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Resource
@@ -882,7 +882,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Toggle prompt enabled status
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  $BASE_URL/prompts/$PROMPT_ID/toggle?activate=false | jq '.'
+  $BASE_URL/prompts/$PROMPT_ID/state?activate=false | jq '.'
 ```
 
 ### Delete Prompt
@@ -1364,7 +1364,7 @@ TOOLS=$(curl -s -H "Authorization: Bearer $TOKEN" $BASE_URL/tools | \
 for TOOL_ID in $TOOLS; do
   echo "Enabling tool: $TOOL_ID"
   curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-    $BASE_URL/tools/$TOOL_ID/toggle > /dev/null
+    $BASE_URL/tools/$TOOL_ID/state > /dev/null
 done
 
 echo "Done!"

--- a/docs/docs/using/grpc-services.md
+++ b/docs/docs/using/grpc-services.md
@@ -307,7 +307,7 @@ Content-Type: application/json
 ### Toggle Service
 
 ```bash
-POST /grpc/{service_id}/toggle
+POST /grpc/{service_id}/state
 ```
 
 ### Delete Service

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2283,23 +2283,23 @@ async def admin_edit_server(
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
 
-@admin_router.post("/servers/{server_id}/toggle")
-async def admin_toggle_server(
+@admin_router.post("/servers/{server_id}/state")
+async def admin_set_server_state(
     server_id: str,
     request: Request,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ) -> Response:
     """
-    Toggle a server's active status via the admin UI.
+    Set a server's active status via the admin UI.
 
     This endpoint processes a form request to activate or deactivate a server.
     It expects a form field 'activate' with value "true" to activate the server
     or "false" to deactivate it. The endpoint handles exceptions gracefully and
-    logs any errors that might occur during the status toggle operation.
+    logs any errors that might occur during the status change operation.
 
     Args:
-        server_id (str): The ID of the server whose status to toggle.
+        server_id (str): The ID of the server whose status to set.
         request (Request): FastAPI request containing form data with the 'activate' field.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.
@@ -2323,14 +2323,14 @@ async def admin_toggle_server(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_server_status = server_service.toggle_server_status
-        >>> server_service.toggle_server_status = AsyncMock()
+        >>> original_set_server_state= server_service.set_server_state
+        >>> server_service.set_server_state = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_server_activate():
-        ...     result = await admin_toggle_server(server_id, mock_request_activate, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_activate():
+        ...     result = await admin_set_server_state(server_id, mock_request_activate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin#catalog" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_server_activate())
+        >>> asyncio.run(test_admin_set_server_state_activate())
         True
         >>>
         >>> # Happy path: Deactivate server
@@ -2338,33 +2338,33 @@ async def admin_toggle_server(
         >>> mock_request_deactivate = MagicMock(spec=Request, scope={"root_path": "/api"})
         >>> mock_request_deactivate.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_server_deactivate():
-        ...     result = await admin_toggle_server(server_id, mock_request_deactivate, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_deactivate():
+        ...     result = await admin_set_server_state(server_id, mock_request_deactivate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/api/admin#catalog" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_server_deactivate())
+        >>> asyncio.run(test_admin_set_server_state_deactivate())
         True
         >>>
-        >>> # Edge case: Toggle with inactive checkbox checked
+        >>> # Edge case: Set state with inactive checkbox checked
         >>> form_data_inactive = FormData([("activate", "true"), ("is_inactive_checked", "true")])
         >>> mock_request_inactive = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_inactive.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_server_inactive_checked():
-        ...     result = await admin_toggle_server(server_id, mock_request_inactive, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_inactive_checked():
+        ...     result = await admin_set_server_state(server_id, mock_request_inactive, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin/?include_inactive=true#catalog" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_server_inactive_checked())
+        >>> asyncio.run(test_admin_set_server_state_inactive_checked())
         True
         >>>
-        >>> # Error path: Simulate an exception during toggle
+        >>> # Error path: Simulate an exception during state change
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> server_service.toggle_server_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> server_service.set_server_state = AsyncMock(side_effect=Exception("State change failed"))
         >>>
-        >>> async def test_admin_toggle_server_exception():
-        ...     result = await admin_toggle_server(server_id, mock_request_error, mock_db, mock_user)
+        >>> async def test_admin_set_server_state_exception():
+        ...     result = await admin_set_server_state(server_id, mock_request_error, mock_db, mock_user)
         ...     location_header = result.headers["location"]
         ...     return (
         ...         isinstance(result, RedirectResponse)
@@ -2374,26 +2374,26 @@ async def admin_toggle_server(
         ...         and location_header.endswith("#catalog")  # Ensure the fragment is correct
         ...     )
         >>>
-        >>> asyncio.run(test_admin_toggle_server_exception())
+        >>> asyncio.run(test_admin_set_server_state_exception())
         True
         >>>
         >>> # Restore original method
-        >>> server_service.toggle_server_status = original_toggle_server_status
+        >>> server_service.set_server_state = original_set_server_state
     """
     form = await request.form()
     error_message = None
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling server ID {server_id} with activate: {form.get('activate')}")
+    LOGGER.debug(f"User {user_email} is setting server ID {server_id} state with activate: {form.get('activate')}")
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await server_service.toggle_server_status(db, server_id, activate, user_email=user_email)
+        await server_service.set_server_state(db, server_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling servers {server_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting server {server_id} state: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling server status: {e}")
-        error_message = "Error toggling server status. Please try again."
+        LOGGER.error(f"Error setting server status: {e}")
+        error_message = "Error setting server status. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -2787,22 +2787,22 @@ async def admin_list_gateways(
     }
 
 
-@admin_router.post("/gateways/{gateway_id}/toggle")
-async def admin_toggle_gateway(
+@admin_router.post("/gateways/{gateway_id}/state")
+async def admin_set_gateway_state(
     gateway_id: str,
     request: Request,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ) -> RedirectResponse:
     """
-    Toggle the active status of a gateway via the admin UI.
+    Set the active status of a gateway via the admin UI.
 
-    This endpoint allows an admin to toggle the active status of a gateway.
+    This endpoint allows an admin to set the active status of a gateway.
     It expects a form field 'activate' with a value of "true" or "false" to
     determine the new status of the gateway.
 
     Args:
-        gateway_id (str): The ID of the gateway to toggle.
+        gateway_id (str): The ID of the gateway to set state for.
         request (Request): The FastAPI request object containing form data.
         db (Session): The database session dependency.
         user (str): The authenticated user dependency.
@@ -2826,14 +2826,14 @@ async def admin_toggle_gateway(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_gateway_status = gateway_service.toggle_gateway_status
-        >>> gateway_service.toggle_gateway_status = AsyncMock()
+        >>> original_set_gateway_state = gateway_service.set_gateway_state
+        >>> gateway_service.set_gateway_state = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_gateway_activate():
-        ...     result = await admin_toggle_gateway(gateway_id, mock_request_activate, mock_db, mock_user)
+        >>> async def test_admin_set_gateway_state_activate():
+        ...     result = await admin_set_gateway_state(gateway_id, mock_request_activate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin#gateways" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_gateway_activate())
+        >>> asyncio.run(test_admin_set_gateway_state_activate())
         True
         >>>
         >>> # Happy path: Deactivate gateway
@@ -2841,21 +2841,21 @@ async def admin_toggle_gateway(
         >>> mock_request_deactivate = MagicMock(spec=Request, scope={"root_path": "/api"})
         >>> mock_request_deactivate.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_gateway_deactivate():
-        ...     result = await admin_toggle_gateway(gateway_id, mock_request_deactivate, mock_db, mock_user)
+        >>> async def test_admin_set_gateway_state_deactivate():
+        ...     result = await admin_set_gateway_state(gateway_id, mock_request_deactivate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/api/admin#gateways" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_gateway_deactivate())
+        >>> asyncio.run(test_admin_set_gateway_state_deactivate())
         True
         >>>
         >>> # Error path: Simulate an exception during toggle
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> gateway_service.toggle_gateway_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> gateway_service.set_gateway_state = AsyncMock(side_effect=Exception("State change failed"))
         >>>
-        >>> async def test_admin_toggle_gateway_exception():
-        ...     result = await admin_toggle_gateway(gateway_id, mock_request_error, mock_db, mock_user)
+        >>> async def test_admin_set_gateway_state_exception():
+        ...     result = await admin_set_gateway_state(gateway_id, mock_request_error, mock_db, mock_user)
         ...     location_header = result.headers["location"]
         ...     return (
         ...         isinstance(result, RedirectResponse)
@@ -2865,26 +2865,26 @@ async def admin_toggle_gateway(
         ...         and location_header.endswith("#gateways")  # Ensure the fragment is correct
         ...     )
         >>>
-        >>> asyncio.run(test_admin_toggle_gateway_exception())
+        >>> asyncio.run(test_admin_set_gateway_state_exception())
         True
         >>> # Restore original method
-        >>> gateway_service.toggle_gateway_status = original_toggle_gateway_status
+        >>> gateway_service.set_gateway_state = original_set_gateway_state
     """
     error_message = None
     user_email = get_user_email(user)
-    LOGGER.debug(f"User {user_email} is toggling gateway ID {gateway_id}")
+    LOGGER.debug(f"User {user_email} is setting gateway state for ID {gateway_id}")
     form = await request.form()
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
 
     try:
-        await gateway_service.toggle_gateway_status(db, gateway_id, activate, user_email=user_email)
+        await gateway_service.set_gateway_state(db, gateway_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling gateway {gateway_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting gateway state {gateway_id}: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling gateway status: {e}")
-        error_message = "Failed to toggle gateway status. Please try again."
+        LOGGER.error(f"Error setting gateway state: {e}")
+        error_message = "Failed to set gateway state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -9797,8 +9797,8 @@ async def admin_delete_tool(tool_id: str, request: Request, db: Session = Depend
     return RedirectResponse(f"{root_path}/admin#tools", status_code=303)
 
 
-@admin_router.post("/tools/{tool_id}/toggle")
-async def admin_toggle_tool(
+@admin_router.post("/tools/{tool_id}/state")
+async def admin_set_tool_state(
     tool_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -9837,14 +9837,14 @@ async def admin_toggle_tool(
         >>> form_data_activate = FormData([("activate", "true"), ("is_inactive_checked", "false")])
         >>> mock_request_activate = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_activate.form = AsyncMock(return_value=form_data_activate)
-        >>> original_toggle_tool_status = tool_service.toggle_tool_status
-        >>> tool_service.toggle_tool_status = AsyncMock()
+        >>> original_set_tool_state = tool_service.set_tool_state
+        >>> tool_service.set_tool_state = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_tool_activate():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_activate, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_activate():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_activate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin#tools" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_activate())
+        >>> asyncio.run(test_admin_set_tool_state_activate())
         True
         >>>
         >>> # Happy path: Deactivate tool
@@ -9852,11 +9852,11 @@ async def admin_toggle_tool(
         >>> mock_request_deactivate = MagicMock(spec=Request, scope={"root_path": "/api"})
         >>> mock_request_deactivate.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_tool_deactivate():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_deactivate, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_deactivate():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_deactivate, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/api/admin#tools" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_deactivate())
+        >>> asyncio.run(test_admin_set_tool_state_deactivate())
         True
         >>>
         >>> # Edge case: Toggle with inactive checkbox checked
@@ -9864,21 +9864,21 @@ async def admin_toggle_tool(
         >>> mock_request_inactive = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_inactive.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_tool_inactive_checked():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_inactive, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_inactive_checked():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_inactive, mock_db, mock_user)
         ...     return isinstance(result, RedirectResponse) and result.status_code == 303 and "/admin/?include_inactive=true#tools" in result.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_inactive_checked())
+        >>> asyncio.run(test_admin_set_tool_state_inactive_checked())
         True
         >>>
         >>> # Error path: Simulate an exception during toggle
         >>> form_data_error = FormData([("activate", "true")])
         >>> mock_request_error = MagicMock(spec=Request, scope={"root_path": ""})
         >>> mock_request_error.form = AsyncMock(return_value=form_data_error)
-        >>> tool_service.toggle_tool_status = AsyncMock(side_effect=Exception("Toggle failed"))
+        >>> tool_service.set_tool_state = AsyncMock(side_effect=Exception("State change failed"))
         >>>
-        >>> async def test_admin_toggle_tool_exception():
-        ...     result = await admin_toggle_tool(tool_id, mock_request_error, mock_db, mock_user)
+        >>> async def test_admin_set_tool_state_exception():
+        ...     result = await admin_set_tool_state(tool_id, mock_request_error, mock_db, mock_user)
         ...     location_header = result.headers["location"]
         ...     return (
         ...         isinstance(result, RedirectResponse)
@@ -9888,11 +9888,11 @@ async def admin_toggle_tool(
         ...         and location_header.endswith("#tools")  # Ensure fragment is correct
         ...     )
         >>>
-        >>> asyncio.run(test_admin_toggle_tool_exception())
+        >>> asyncio.run(test_admin_set_tool_state_exception())
         True
         >>>
         >>> # Restore original method
-        >>> tool_service.toggle_tool_status = original_toggle_tool_status
+        >>> tool_service.set_tool_state = original_set_tool_state
     """
     error_message = None
     user_email = get_user_email(user)
@@ -9901,13 +9901,13 @@ async def admin_toggle_tool(
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await tool_service.toggle_tool_status(db, tool_id, activate, reachable=activate, user_email=user_email)
+        await tool_service.set_tool_state(db, tool_id, activate, reachable=activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling tools {tool_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting tool state {tool_id}: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling tool status: {e}")
-        error_message = "Failed to toggle tool status. Please try again."
+        LOGGER.error(f"Error setting tool state: {e}")
+        error_message = "Failed to set tool state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -11279,8 +11279,8 @@ async def admin_delete_resource(resource_id: str, request: Request, db: Session 
     return RedirectResponse(f"{root_path}/admin#resources", status_code=303)
 
 
-@admin_router.post("/resources/{resource_id}/toggle")
-async def admin_toggle_resource(
+@admin_router.post("/resources/{resource_id}/state")
+async def admin_set_resource_state(
     resource_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -11321,14 +11321,14 @@ async def admin_toggle_resource(
         >>> mock_request.form = AsyncMock(return_value=form_data)
         >>> mock_request.scope = {"root_path": ""}
         >>>
-        >>> original_toggle_resource_status = resource_service.toggle_resource_status
-        >>> resource_service.toggle_resource_status = AsyncMock()
+        >>> original_set_resource_state= resource_service.set_resource_state
+        >>> resource_service.set_resource_state = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_resource():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_resource())
+        >>> asyncio.run(test_admin_set_resource_state())
         True
         >>>
         >>> # Test with activate=false
@@ -11338,11 +11338,11 @@ async def admin_toggle_resource(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_resource_deactivate():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state_deactivate():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_resource_deactivate())
+        >>> asyncio.run(test_admin_set_resource_state_deactivate())
         True
         >>>
         >>> # Test with inactive checkbox checked
@@ -11352,28 +11352,28 @@ async def admin_toggle_resource(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_resource_inactive():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state_inactive():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and "include_inactive=true" in response.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_resource_inactive())
+        >>> asyncio.run(test_admin_set_resource_state_inactive())
         True
         >>>
         >>> # Test exception handling
-        >>> resource_service.toggle_resource_status = AsyncMock(side_effect=Exception("Test error"))
+        >>> resource_service.set_resource_state = AsyncMock(side_effect=Exception("Test error"))
         >>> form_data_error = FormData([
         ...     ("activate", "true"),
         ...     ("is_inactive_checked", "false")
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_error)
         >>>
-        >>> async def test_admin_toggle_resource_exception():
-        ...     response = await admin_toggle_resource(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_resource_state_exception():
+        ...     response = await admin_set_resource_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_resource_exception())
+        >>> asyncio.run(test_admin_set_resource_state_exception())
         True
-        >>> resource_service.toggle_resource_status = original_toggle_resource_status
+        >>> resource_service.set_resource_state = original_set_resource_state
     """
     user_email = get_user_email(user)
     LOGGER.debug(f"User {user_email} is toggling resource ID {resource_id}")
@@ -11382,13 +11382,13 @@ async def admin_toggle_resource(
     activate = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked = str(form.get("is_inactive_checked", "false"))
     try:
-        await resource_service.toggle_resource_status(db, resource_id, activate, user_email=user_email)
+        await resource_service.set_resource_state(db, resource_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling resource status {resource_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting resource state {resource_id}: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling resource status: {e}")
-        error_message = "Failed to toggle resource status. Please try again."
+        LOGGER.error(f"Error setting resource state: {e}")
+        error_message = "Failed to set resource state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -11840,8 +11840,8 @@ async def admin_delete_prompt(prompt_id: str, request: Request, db: Session = De
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)
 
 
-@admin_router.post("/prompts/{prompt_id}/toggle")
-async def admin_toggle_prompt(
+@admin_router.post("/prompts/{prompt_id}/state")
+async def admin_set_prompt_state(
     prompt_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -11882,14 +11882,14 @@ async def admin_toggle_prompt(
         >>> mock_request.form = AsyncMock(return_value=form_data)
         >>> mock_request.scope = {"root_path": ""}
         >>>
-        >>> original_toggle_prompt_status = prompt_service.toggle_prompt_status
-        >>> prompt_service.toggle_prompt_status = AsyncMock()
+        >>> original_set_prompt_state = prompt_service.set_prompt_state
+        >>> prompt_service.set_prompt_state = AsyncMock()
         >>>
-        >>> async def test_admin_toggle_prompt():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt())
+        >>> asyncio.run(test_admin_set_prompt_state())
         True
         >>>
         >>> # Test with activate=false
@@ -11899,11 +11899,11 @@ async def admin_toggle_prompt(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_deactivate)
         >>>
-        >>> async def test_admin_toggle_prompt_deactivate():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state_deactivate():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt_deactivate())
+        >>> asyncio.run(test_admin_set_prompt_state_deactivate())
         True
         >>>
         >>> # Test with inactive checkbox checked
@@ -11913,28 +11913,28 @@ async def admin_toggle_prompt(
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_inactive)
         >>>
-        >>> async def test_admin_toggle_prompt_inactive():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state_inactive():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and "include_inactive=true" in response.headers["location"]
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt_inactive())
+        >>> asyncio.run(test_admin_set_prompt_state_inactive())
         True
         >>>
         >>> # Test exception handling
-        >>> prompt_service.toggle_prompt_status = AsyncMock(side_effect=Exception("Test error"))
+        >>> prompt_service.set_prompt_state = AsyncMock(side_effect=Exception("Test error"))
         >>> form_data_error = FormData([
         ...     ("activate", "true"),
         ...     ("is_inactive_checked", "false")
         ... ])
         >>> mock_request.form = AsyncMock(return_value=form_data_error)
         >>>
-        >>> async def test_admin_toggle_prompt_exception():
-        ...     response = await admin_toggle_prompt(1, mock_request, mock_db, mock_user)
+        >>> async def test_admin_set_prompt_state_exception():
+        ...     response = await admin_set_prompt_state(1, mock_request, mock_db, mock_user)
         ...     return isinstance(response, RedirectResponse) and response.status_code == 303
         >>>
-        >>> asyncio.run(test_admin_toggle_prompt_exception())
+        >>> asyncio.run(test_admin_set_prompt_state_exception())
         True
-        >>> prompt_service.toggle_prompt_status = original_toggle_prompt_status
+        >>> prompt_service.set_prompt_state = original_set_prompt_state
     """
     user_email = get_user_email(user)
     LOGGER.debug(f"User {user_email} is toggling prompt ID {prompt_id}")
@@ -11943,13 +11943,13 @@ async def admin_toggle_prompt(
     activate: bool = str(form.get("activate", "true")).lower() == "true"
     is_inactive_checked: str = str(form.get("is_inactive_checked", "false"))
     try:
-        await prompt_service.toggle_prompt_status(db, prompt_id, activate, user_email=user_email)
+        await prompt_service.set_prompt_state(db, prompt_id, activate, user_email=user_email)
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling prompt {prompt_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting prompt state {prompt_id}: {e}")
         error_message = str(e)
     except Exception as e:
-        LOGGER.error(f"Error toggling prompt status: {e}")
-        error_message = "Failed to toggle prompt status. Please try again."
+        LOGGER.error(f"Error setting prompt state: {e}")
+        error_message = "Failed to set prompt state. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -14543,8 +14543,8 @@ async def admin_edit_a2a_agent(
         return ORJSONResponse({"message": str(e), "success": False}, status_code=500)
 
 
-@admin_router.post("/a2a/{agent_id}/toggle")
-async def admin_toggle_a2a_agent(
+@admin_router.post("/a2a/{agent_id}/state")
+async def admin_set_a2a_agent_state(
     agent_id: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -14576,21 +14576,21 @@ async def admin_toggle_a2a_agent(
 
         user_email = get_user_email(user)
 
-        await a2a_service.toggle_agent_status(db, agent_id, activate, user_email=user_email)
+        await a2a_service.set_agent_state(db, agent_id, activate, user_email=user_email)
         root_path = request.scope.get("root_path", "")
         return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
 
     except PermissionError as e:
-        LOGGER.warning(f"Permission denied for user {user_email} toggling A2A agent status{agent_id}: {e}")
+        LOGGER.warning(f"Permission denied for user {user_email} setting A2A agent state {agent_id}: {e}")
         error_message = str(e)
     except A2AAgentNotFoundError as e:
-        LOGGER.error(f"A2A agent toggle failed - not found: {e}")
+        LOGGER.error(f"A2A agent state change failed - not found: {e}")
         root_path = request.scope.get("root_path", "")
         error_message = "A2A agent not found."
     except Exception as e:
-        LOGGER.error(f"Error toggling A2A agent: {e}")
+        LOGGER.error(f"Error setting A2A agent state: {e}")
         root_path = request.scope.get("root_path", "")
-        error_message = "Failed to toggle status of A2A agent. Please try again."
+        error_message = "Failed to set state of A2A agent. Please try again."
 
     root_path = request.scope.get("root_path", "")
 
@@ -14855,16 +14855,18 @@ async def admin_update_grpc_service(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@admin_router.post("/grpc/{service_id}/toggle")
-async def admin_toggle_grpc_service(
+@admin_router.post("/grpc/{service_id}/state")
+async def admin_set_grpc_service_state(
     service_id: str,
+    activate: Optional[bool] = Query(None, description="Set enabled state. If not provided, inverts current state."),
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
-    """Toggle a gRPC service's enabled status.
+    """Set a gRPC service's enabled state.
 
     Args:
         service_id: Service ID
+        activate: If provided, sets enabled to this value. If None, inverts current state (legacy behavior).
         db: Database session
         user: Authenticated user
 
@@ -14872,14 +14874,17 @@ async def admin_toggle_grpc_service(
         Updated gRPC service
 
     Raises:
-        HTTPException: If gRPC support is disabled or toggle fails
+        HTTPException: If gRPC support is disabled or state change fails
     """
     if not GRPC_AVAILABLE or not settings.mcpgateway_grpc_enabled:
         raise HTTPException(status_code=404, detail="gRPC support is not available or disabled")
 
     try:
-        service = await grpc_service_mgr.get_service(db, service_id)
-        result = await grpc_service_mgr.toggle_service(db, service_id, not service.enabled)
+        if activate is None:
+            # Legacy toggle behavior - invert current state
+            service = await grpc_service_mgr.get_service(db, service_id)
+            activate = not service.enabled
+        result = await grpc_service_mgr.set_service_state(db, service_id, activate)
         return ORJSONResponse(content=jsonable_encoder(result))
     except GrpcServiceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/mcpgateway/routers/llm_admin_router.py
+++ b/mcpgateway/routers/llm_admin_router.py
@@ -214,18 +214,18 @@ async def get_models_partial(
 # ---------------------------------------------------------------------------
 
 
-@llm_admin_router.post("/providers/{provider_id}/toggle", response_class=HTMLResponse)
+@llm_admin_router.post("/providers/{provider_id}/state", response_class=HTMLResponse)
 @require_permission("admin.system_config")
-async def toggle_provider_html(
+async def set_provider_state_html(
     request: Request,
     provider_id: str,
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
-    """Toggle provider enabled status and return updated row.
+    """Set provider enabled state and return updated row.
 
     Args:
         request: FastAPI request object.
-        provider_id: Provider ID to toggle.
+        provider_id: Provider ID to update.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -236,7 +236,7 @@ async def toggle_provider_html(
     """
     try:
         db = current_user_ctx["db"]
-        provider = llm_provider_service.toggle_provider(db, provider_id)
+        provider = llm_provider_service.set_provider_state(db, provider_id)
 
         return request.app.state.templates.TemplateResponse(
             "llm_provider_row.html",
@@ -326,18 +326,18 @@ async def delete_provider_html(
 # ---------------------------------------------------------------------------
 
 
-@llm_admin_router.post("/models/{model_id}/toggle", response_class=HTMLResponse)
+@llm_admin_router.post("/models/{model_id}/state", response_class=HTMLResponse)
 @require_permission("admin.system_config")
-async def toggle_model_html(
+async def set_model_state_html(
     request: Request,
     model_id: str,
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
-    """Toggle model enabled status and return updated row.
+    """Set model enabled state and return updated row.
 
     Args:
         request: FastAPI request object.
-        model_id: Model ID to toggle.
+        model_id: Model ID to update.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -348,7 +348,7 @@ async def toggle_model_html(
     """
     try:
         db = current_user_ctx["db"]
-        model = llm_provider_service.toggle_model(db, model_id)
+        model = llm_provider_service.set_model_state(db, model_id)
 
         try:
             provider = llm_provider_service.get_provider(db, model.provider_id)

--- a/mcpgateway/routers/llm_config_router.py
+++ b/mcpgateway/routers/llm_config_router.py
@@ -241,20 +241,22 @@ async def delete_provider(
 
 
 @llm_config_router.post(
-    "/providers/{provider_id}/toggle",
+    "/providers/{provider_id}/state",
     response_model=LLMProviderResponse,
-    summary="Toggle LLM Provider",
-    description="Toggle the enabled status of an LLM provider.",
+    summary="Set LLM Provider State",
+    description="Set the enabled status of an LLM provider.",
 )
 @require_permission("admin.system_config")
-async def toggle_provider(
+async def set_provider_state(
     provider_id: str,
+    activate: Optional[bool] = Query(None, description="Set enabled state. If not provided, inverts current state."),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMProviderResponse:
-    """Toggle provider enabled status.
+    """Set provider enabled state.
 
     Args:
         provider_id: Provider ID.
+        activate: If provided, sets enabled to this value. If None, inverts current state.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -265,7 +267,7 @@ async def toggle_provider(
     """
     try:
         db = current_user_ctx["db"]
-        provider = llm_provider_service.toggle_provider(db, provider_id)
+        provider = llm_provider_service.set_provider_state(db, provider_id, activate)
         model_count = len(provider.models)
         return llm_provider_service.to_provider_response(provider, model_count)
     except LLMProviderNotFoundError as e:
@@ -493,20 +495,22 @@ async def delete_model(
 
 
 @llm_config_router.post(
-    "/models/{model_id}/toggle",
+    "/models/{model_id}/state",
     response_model=LLMModelResponse,
-    summary="Toggle LLM Model",
-    description="Toggle the enabled status of an LLM model.",
+    summary="Set LLM Model State",
+    description="Set the enabled status of an LLM model.",
 )
 @require_permission("admin.system_config")
-async def toggle_model(
+async def set_model_state(
     model_id: str,
+    activate: Optional[bool] = Query(None, description="Set enabled state. If not provided, inverts current state."),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMModelResponse:
-    """Toggle model enabled status.
+    """Set model enabled state.
 
     Args:
         model_id: Model ID.
+        activate: If provided, sets enabled to this value. If None, inverts current state.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -517,7 +521,7 @@ async def toggle_model(
     """
     try:
         db = current_user_ctx["db"]
-        model = llm_provider_service.toggle_model(db, model_id)
+        model = llm_provider_service.set_model_state(db, model_id, activate)
         try:
             provider = llm_provider_service.get_provider(db, model.provider_id)
         except LLMProviderNotFoundError:

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -146,7 +146,7 @@ class A2AAgentNameConflictError(A2AAgentError):
 class A2AAgentService:
     """Service for managing A2A agents in the gateway.
 
-    Provides methods to create, list, retrieve, update, toggle status, and delete agent records.
+    Provides methods to create, list, retrieve, update, set state, and delete agent records.
     Also supports interactions with A2A-compatible agents.
     """
 
@@ -1039,8 +1039,8 @@ class A2AAgentService:
             db.rollback()
             raise A2AAgentError(f"Failed to update A2A agent: {str(e)}")
 
-    async def toggle_agent_status(self, db: Session, agent_id: str, activate: bool, reachable: Optional[bool] = None, user_email: Optional[str] = None) -> A2AAgentRead:
-        """Toggle the activation status of an A2A agent.
+    async def set_agent_state(self, db: Session, agent_id: str, activate: bool, reachable: Optional[bool] = None, user_email: Optional[str] = None) -> A2AAgentRead:
+        """Set the activation status of an A2A agent.
 
         Args:
             db: Database session.

--- a/mcpgateway/services/grpc_service.py
+++ b/mcpgateway/services/grpc_service.py
@@ -280,13 +280,13 @@ class GrpcService:
 
         return GrpcServiceRead.model_validate(service)
 
-    async def toggle_service(
+    async def set_service_state(
         self,
         db: Session,
         service_id: str,
         activate: bool,
     ) -> GrpcServiceRead:
-        """Toggle a gRPC service's enabled status.
+        """Set a gRPC service's enabled status.
 
         Args:
             db: Database session

--- a/mcpgateway/services/llm_provider_service.py
+++ b/mcpgateway/services/llm_provider_service.py
@@ -337,21 +337,26 @@ class LLMProviderService:
         logger.info(f"Deleted LLM provider: {provider_name} (ID: {provider_id})")
         return True
 
-    def toggle_provider(self, db: Session, provider_id: str) -> LLMProvider:
-        """Toggle provider enabled status.
+    def set_provider_state(self, db: Session, provider_id: str, activate: Optional[bool] = None) -> LLMProvider:
+        """Set provider enabled state.
 
         Args:
             db: Database session.
-            provider_id: Provider ID to toggle.
+            provider_id: Provider ID to update.
+            activate: If provided, sets enabled to this value. If None, inverts current state (legacy behavior).
 
         Returns:
             Updated LLMProvider instance.
         """
         provider = self.get_provider(db, provider_id)
-        provider.enabled = not provider.enabled
+        if activate is None:
+            # Legacy toggle behavior for backward compatibility
+            provider.enabled = not provider.enabled
+        else:
+            provider.enabled = activate
         db.commit()
         db.refresh(provider)
-        logger.info(f"Toggled LLM provider: {provider.name} enabled={provider.enabled}")
+        logger.info(f"Set LLM provider state: {provider.name} enabled={provider.enabled}")
         return provider
 
     # ---------------------------------------------------------------------------
@@ -547,21 +552,26 @@ class LLMProviderService:
         logger.info(f"Deleted LLM model: {model_name} (ID: {model_id})")
         return True
 
-    def toggle_model(self, db: Session, model_id: str) -> LLMModel:
-        """Toggle model enabled status.
+    def set_model_state(self, db: Session, model_id: str, activate: Optional[bool] = None) -> LLMModel:
+        """Set model enabled state.
 
         Args:
             db: Database session.
-            model_id: Model ID to toggle.
+            model_id: Model ID to update.
+            activate: If provided, sets enabled to this value. If None, inverts current state (legacy behavior).
 
         Returns:
             Updated LLMModel instance.
         """
         model = self.get_model(db, model_id)
-        model.enabled = not model.enabled
+        if activate is None:
+            # Legacy toggle behavior for backward compatibility
+            model.enabled = not model.enabled
+        else:
+            model.enabled = activate
         db.commit()
         db.refresh(model)
-        logger.info(f"Toggled LLM model: {model.model_id} enabled={model.enabled}")
+        logger.info(f"Set LLM model state: {model.model_id} enabled={model.enabled}")
         return model
 
     # ---------------------------------------------------------------------------

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -28352,7 +28352,7 @@ function generateStatusBadgeHtml(enabled, reachable, typeLabel) {
  */
 function updateEntityActionButtons(cell, type, id, isEnabled) {
     // We look for the form that toggles activation inside the cell
-    const form = cell.querySelector('form[action*="/toggle"]');
+    const form = cell.querySelector('form[action*="/state"]');
     if (!form) {
         return;
     }
@@ -29836,7 +29836,7 @@ async function deleteLLMProvider(providerId, providerName) {
 async function toggleLLMProvider(providerId) {
     try {
         const response = await fetch(
-            `${window.ROOT_PATH}/llm/providers/${providerId}/toggle`,
+            `${window.ROOT_PATH}/llm/providers/${providerId}/state`,
             {
                 method: "POST",
                 headers: {
@@ -30219,7 +30219,7 @@ async function deleteLLMModel(modelId, modelName) {
 async function toggleLLMModel(modelId) {
     try {
         const response = await fetch(
-            `${window.ROOT_PATH}/llm/models/${modelId}/toggle`,
+            `${window.ROOT_PATH}/llm/models/${modelId}/state`,
             {
                 method: "POST",
                 headers: {

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2435,7 +2435,7 @@
                         {% if server.enabled %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/servers/{{ server.id }}/toggle"
+                          action="{{ root_path }}/admin/servers/{{ server.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'servers')"
                         >
@@ -2451,7 +2451,7 @@
                         {% else %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/servers/{{ server.id }}/toggle"
+                          action="{{ root_path }}/admin/servers/{{ server.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'servers')"
                         >
@@ -4902,7 +4902,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         {% if gateway.enabled %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
+                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'gateways')"
                         >
@@ -4918,7 +4918,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         {% else %}
                         <form
                           method="POST"
-                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle"
+                          action="{{ root_path }}/admin/gateways/{{ gateway.id }}/state"
                           class="contents"
                           onsubmit="return handleToggleSubmit(event, 'gateways')"
                         >
@@ -6331,7 +6331,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                           <!-- Row 3: Activate/Deactivate | Delete -->
                           <div class="col-span-2 flex flex-col space-y-1">
                             {% if agent.enabled %}
-                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/toggle" class="contents">
+                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/state" class="contents">
                               <input type="hidden" name="activate" value="false" />
                               <button
                                 type="submit"
@@ -6342,7 +6342,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                               </button>
                             </form>
                             {% else %}
-                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/toggle" class="contents">
+                            <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/state" class="contents">
                               <input type="hidden" name="activate" value="true" />
                               <button
                                 type="submit"
@@ -7231,7 +7231,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     </div>
                   </div>
                   <div class="flex flex-col space-y-2 ml-4">
-                    <form action="{{ root_path }}/grpc/{{ service.id }}/toggle" method="POST" class="inline">
+                    <form action="{{ root_path }}/admin/grpc/{{ service.id }}/state?activate={{ 'false' if service.enabled else 'true' }}" method="POST" class="inline">
                       <button
                         type="submit"
                         class="px-3 py-1 text-sm font-medium rounded-md {% if service.enabled %}bg-yellow-100 text-yellow-800 hover:bg-yellow-200{% else %}bg-green-100 text-green-800 hover:bg-green-200{% endif %}"
@@ -7239,7 +7239,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         {% if service.enabled %}Deactivate{% else %}Activate{% endif %}
                       </button>
                     </form>
-                    <form action="{{ root_path }}/grpc/{{ service.id }}/reflect" method="POST" class="inline">
+                    <form action="{{ root_path }}/admin/grpc/{{ service.id }}/reflect" method="POST" class="inline">
                       <button
                         type="submit"
                         class="px-3 py-1 text-sm font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200"
@@ -7253,7 +7253,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     >
                       View Methods
                     </button>
-                    <form action="{{ root_path }}/grpc/{{ service.id }}/delete" method="POST" class="inline" onsubmit="return confirm('Are you sure you want to delete this gRPC service?')">
+                    <form action="{{ root_path }}/admin/grpc/{{ service.id }}/delete" method="POST" class="inline" onsubmit="return confirm('Are you sure you want to delete this gRPC service?')">
                       <button
                         type="submit"
                         class="px-3 py-1 text-sm font-medium bg-red-100 text-red-800 rounded-md hover:bg-red-200"
@@ -11331,11 +11331,11 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 
         const isActiveFlag = item.isActive || item.enabled || item.is_active;
         const activeButton = isActiveFlag ?
-          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/toggle" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
+          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/state" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
             <input type="hidden" name="activate" value="false" />
             <button type="submit" class="text-yellow-600 hover:text-yellow-900">Deactivate</button>
           </form>` :
-          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/toggle" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
+          `<form method="POST" action="${window.ROOT_PATH}/admin/${backendPath}/${item.id}/state" class="inline mr-2" onsubmit="return handleToggleSubmit(event, '${sectionType}')">
             <input type="hidden" name="activate" value="true" />
             <button type="submit" class="text-blue-600 hover:text-blue-900">Activate</button>
           </form>`;

--- a/mcpgateway/templates/agents_partial.html
+++ b/mcpgateway/templates/agents_partial.html
@@ -37,7 +37,7 @@
 
             <!-- Row 3 & 4: Activate/Deactivate | Delete -->
             <div class="col-span-2 flex flex-col space-y-1">
-              <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'a2a')">
+              <form method="POST" action="{{ root_path }}/admin/a2a/{{ agent.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'a2a')">
                 <input type="hidden" name="activate" value="{{ 'false' if agent.enabled else 'true' }}" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md {% if agent.enabled %}text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20{% else %}text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20{% endif %}">{% if agent.enabled %}Deactivate{% else %}Activate{% endif %}</button>
               </form>

--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -49,7 +49,7 @@
 
             <!-- Row 4: Activate/Deactivate | Delete -->
             <div class="col-span-2 flex flex-col space-y-1">
-              <form method="POST" action="{{ root_path }}/admin/gateways/{{ gateway.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'gateways')">
+              <form method="POST" action="{{ root_path }}/admin/gateways/{{ gateway.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'gateways')">
                 <input type="hidden" name="activate" value="{{ 'false' if gateway.enabled else 'true' }}" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md {% if gateway.enabled %}text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20{% else %}text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20{% endif %}">{% if gateway.enabled %}Deactivate{% else %}Activate{% endif %}</button>
               </form>

--- a/mcpgateway/templates/llm_models_partial.html
+++ b/mcpgateway/templates/llm_models_partial.html
@@ -128,7 +128,7 @@
             <td class="px-6 py-4 whitespace-nowrap">
               <div class="flex items-center space-x-2">
                 <button onclick="toggleLLMModel('{{ model.id }}')" class="focus:outline-none"
-                  hx-post="{{ root_path }}/admin/llm/models/{{ model.id }}/toggle" hx-target="#model-row-{{ model.id }}"
+                  hx-post="{{ root_path }}/admin/llm/models/{{ model.id }}/state" hx-target="#model-row-{{ model.id }}"
                   hx-swap="outerHTML">
                   {% if model.enabled %}
                   <span

--- a/mcpgateway/templates/llm_providers_partial.html
+++ b/mcpgateway/templates/llm_providers_partial.html
@@ -97,7 +97,7 @@
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
               <button onclick="toggleLLMProvider('{{ provider.id }}')" class="focus:outline-none"
-                hx-post="{{ root_path }}/admin/llm/providers/{{ provider.id }}/toggle"
+                hx-post="{{ root_path }}/admin/llm/providers/{{ provider.id }}/state"
                 hx-target="#provider-row-{{ provider.id }}" hx-swap="outerHTML">
                 {% if provider.enabled %}
                 <span

--- a/mcpgateway/templates/prompts_partial.html
+++ b/mcpgateway/templates/prompts_partial.html
@@ -36,7 +36,7 @@
 
             <!-- Row 3 & 4: Activate/Deactivate | Delete -->
             <div class="col-span-2 flex flex-col space-y-1">
-              <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'prompts')">
+              <form method="POST" action="{{ root_path }}/admin/prompts/{{ prompt.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'prompts')">
                 <input type="hidden" name="activate" value="{{ 'false' if prompt.enabled else 'true' }}" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md {% if prompt.enabled %}text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20{% else %}text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20{% endif %}">{% if prompt.enabled %}Deactivate{% else %}Activate{% endif %}</button>
               </form>

--- a/mcpgateway/templates/resources_partial.html
+++ b/mcpgateway/templates/resources_partial.html
@@ -22,12 +22,12 @@
             <button onclick="editResource('{{ resource.id }}')" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors">Edit</button>
             <div class="col-span-2 flex flex-col space-y-1">
               {% if resource.enabled %}
-              <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
+              <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
                 <input type="hidden" name="activate" value="false" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20 transition-colors">Deactivate</button>
               </form>
               {% else %}
-              <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
+              <form method="POST" action="{{ root_path }}/admin/resources/{{ resource.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'resources')">
                 <input type="hidden" name="activate" value="true" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-blue-600 hover:text-blue-900 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20 transition-colors">Activate</button>
               </form>

--- a/mcpgateway/templates/servers_partial.html
+++ b/mcpgateway/templates/servers_partial.html
@@ -29,7 +29,7 @@
 
         <!-- Row 3 & 4: Activate/Deactivate | Delete -->
         <div class="col-span-2 flex flex-col space-y-1">
-          <form method="POST" action="{{ root_path }}/admin/servers/{{ server.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'servers')">
+          <form method="POST" action="{{ root_path }}/admin/servers/{{ server.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'servers')">
             <input type="hidden" name="activate" value="{{ 'false' if server.enabled else 'true' }}" />
             <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md {% if server.enabled %}text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20{% else %}text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20{% endif %}">{% if server.enabled %}Deactivate{% else %}Activate{% endif %}</button>
           </form>

--- a/mcpgateway/templates/tools_partial.html
+++ b/mcpgateway/templates/tools_partial.html
@@ -53,7 +53,7 @@
               {% if tool.enabled %}
               <form
                 method="POST"
-                action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle"
+                action="{{ root_path }}/admin/tools/{{ tool.id }}/state"
                 class="contents"
                 onsubmit="return handleToggleSubmit(event, 'tools')"
               >
@@ -69,7 +69,7 @@
               {% else %}
               <form
                 method="POST"
-                action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle"
+                action="{{ root_path }}/admin/tools/{{ tool.id }}/state"
                 class="contents"
                 onsubmit="return handleToggleSubmit(event, 'tools')"
               >

--- a/mcpgateway/templates/tools_with_pagination.html
+++ b/mcpgateway/templates/tools_with_pagination.html
@@ -128,14 +128,14 @@
           <!-- Row 3: Deactivate/Activate | Delete -->
           <div class="col-span-2 flex flex-col space-y-1">
             {% if tool.enabled %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="false" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20 transition-colors" x-tooltip="'💡Temporarily disable this tool'">
                   Deactivate
                 </button>
               </form>
             {% else %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="true" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors" x-tooltip="'💡Re-enable this tool'">
                   Activate
@@ -285,14 +285,14 @@
           <!-- Row 3: Deactivate/Activate | Delete -->
           <div class="col-span-2 flex flex-col space-y-1">
             {% if tool.enabled %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="false" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-yellow-600 hover:text-yellow-900 hover:bg-yellow-50 dark:text-yellow-400 dark:hover:bg-yellow-900/20 transition-colors" x-tooltip="'💡Temporarily disable this tool'">
                   Deactivate
                 </button>
               </form>
             {% else %}
-              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/toggle" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
+              <form method="POST" action="{{ root_path }}/admin/tools/{{ tool.id }}/state" class="contents" onsubmit="return handleToggleSubmit(event, 'tools')">
                 <input type="hidden" name="activate" value="true" />
                 <button type="submit" class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors" x-tooltip="'💡Re-enable this tool'">
                   Activate

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -251,8 +251,8 @@ class TestAdminServerAPIs:
         response = await client.post(f"/admin/servers/{server_id}/edit", data=edit_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 200
 
-        # Toggle server status
-        response = await client.post(f"/admin/servers/{server_id}/toggle", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        # Set server state
+        response = await client.post(f"/admin/servers/{server_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 303
 
         # Delete server
@@ -325,8 +325,8 @@ class TestAdminToolAPIs:
     #     response = await client.post(f"/admin/tools/{tool_id}/edit", data=edit_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
     #     assert response.status_code == 303
 
-    #     # Toggle tool status
-    #     response = await client.post(f"/admin/tools/{tool_id}/toggle", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
+    #     # Set tool state
+    #     response = await client.post(f"/admin/tools/{tool_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
     #     assert response.status_code == 303
 
     #     # Delete tool
@@ -528,8 +528,8 @@ class TestAdminPromptAPIs:
         response = await client.post(f"/admin/prompts/{prompt_id}/edit", data=edit_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 200
 
-        # Toggle prompt status
-        response = await client.post(f"/admin/prompts/{prompt_id}/toggle", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        # Set prompt state
+        response = await client.post(f"/admin/prompts/{prompt_id}/state", data={"activate": "false"}, headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 303
 
         # Delete prompt (use updated name)
@@ -711,7 +711,7 @@ class TestAdminIncludeInactive:
     #         "is_inactive_checked": "true",
     #     }
 
-    #     response = await client.post(f"/admin/servers/{server_id}/toggle", data=form_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
+    #     response = await client.post(f"/admin/servers/{server_id}/state", data=form_data, headers=TEST_AUTH_HEADER, follow_redirects=False)
 
     #     assert response.status_code == 303
     #     assert "include_inactive=true" in response.headers["location"]

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -594,27 +594,27 @@ class TestServerAPIs:
         assert result["description"] == update_data["description"]
         assert result["icon"] == update_data["icon"]
 
-    async def test_toggle_server_status(self, client: AsyncClient, mock_auth):
-        """Test POST /servers/{server_id}/toggle."""
+    async def test_set_server_state(self, client: AsyncClient, mock_auth):
+        """Test POST /servers/{server_id}/state."""
         # Create a server
-        server_data = {"server": {"name": "toggle_test_server"}, "team_id": None, "visibility": "private"}
+        server_data = {"server": {"name": "state_test_server"}, "team_id": None, "visibility": "private"}
 
         create_response = await client.post("/servers", json=server_data, headers=TEST_AUTH_HEADER)
         server_id = create_response.json()["id"]
 
         # Deactivate the server
-        response = await client.post(f"/servers/{server_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/servers/{server_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         result = response.json()
-        # The toggle endpoint returns the full server object
+        # The state endpoint returns the full server object
         assert "id" in result
         assert "name" in result
         # Check if server was deactivated
         assert result.get("enabled") is False or result.get("enabled") is False
 
         # Reactivate the server
-        response = await client.post(f"/servers/{server_id}/toggle?activate=true", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/servers/{server_id}/state?activate=true", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         result = response.json()
@@ -830,16 +830,16 @@ class TestToolAPIs:
         assert result["description"] == update_data["description"]
         assert result["headers"] == update_data["headers"]
 
-    async def test_toggle_tool_status(self, client: AsyncClient, mock_auth):
-        """Test POST /tools/{tool_id}/toggle."""
+    async def test_set_tool_state(self, client: AsyncClient, mock_auth):
+        """Test POST /tools/{tool_id}/state."""
         # Create a tool
-        tool_data = {"tool": {"name": "test_toggle_tool"}, "team_id": None, "visibility": "private"}
+        tool_data = {"tool": {"name": "test_state_tool"}, "team_id": None, "visibility": "private"}
 
         create_response = await client.post("/tools", json=tool_data, headers=TEST_AUTH_HEADER)
         tool_id = create_response.json()["id"]
 
         # Deactivate the tool
-        response = await client.post(f"/tools/{tool_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/tools/{tool_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         result = response.json()
@@ -1055,16 +1055,16 @@ class TestResourceAPIs:
         result = response.json()
         assert result["description"] == update_data["description"]
 
-    async def test_toggle_resource_status(self, client: AsyncClient, mock_auth):
-        """Test POST /resources/{resource_id}/toggle."""
+    async def test_set_resource_state(self, client: AsyncClient, mock_auth):
+        """Test POST /resources/{resource_id}/state."""
         # Create a resource
-        resource_data = {"resource": {"uri": "test/toggle", "name": "toggle_test", "content": "Test"}, "team_id": None, "visibility": "private"}
+        resource_data = {"resource": {"uri": "test/state", "name": "state_test", "content": "Test"}, "team_id": None, "visibility": "private"}
 
         create_response = await client.post("/resources", json=resource_data, headers=TEST_AUTH_HEADER)
         resource_id = create_response.json()["id"]
 
-        # Toggle resource status
-        response = await client.post(f"/resources/{resource_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        # Set resource state
+        response = await client.post(f"/resources/{resource_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -1271,16 +1271,16 @@ class TestPromptAPIs:
         result = response.json()
         assert "messages" in result
 
-    async def test_toggle_prompt_status(self, client: AsyncClient, mock_auth):
-        """Test POST /prompts/{prompt_id}/toggle."""
+    async def test_set_prompt_state(self, client: AsyncClient, mock_auth):
+        """Test POST /prompts/{prompt_id}/state."""
         # Create a prompt
-        prompt_data = {"prompt": {"name": "toggle_prompt", "template": "Test prompt", "arguments": []}, "team_id": None, "visibility": "private"}
+        prompt_data = {"prompt": {"name": "state_prompt", "template": "Test prompt", "arguments": []}, "team_id": None, "visibility": "private"}
 
         create_response = await client.post("/prompts", json=prompt_data, headers=TEST_AUTH_HEADER)
         prompt_id = create_response.json()["id"]
 
-        # Toggle prompt status
-        response = await client.post(f"/prompts/{prompt_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        # Set prompt state
+        response = await client.post(f"/prompts/{prompt_id}/state?activate=false", headers=TEST_AUTH_HEADER)
 
         assert response.status_code == 200
         assert response.json()["status"] == "success"
@@ -1424,8 +1424,8 @@ class TestGatewayAPIs:
     async def test_register_gateway(self, client: AsyncClient, mock_auth):
         """Test POST /gateways - would require mocking external connections."""
 
-    async def test_toggle_gateway_status(self, client: AsyncClient, mock_auth):
-        """Test POST /gateways/{gateway_id}/toggle."""
+    async def test_set_gateway_state(self, client: AsyncClient, mock_auth):
+        """Test POST /gateways/{gateway_id}/state."""
         # Mock a gateway for testing
         # In real tests, you'd need to register a gateway first
         # This is skipped as it requires external connectivity

--- a/tests/e2e/test_oauth_protected_resource.py
+++ b/tests/e2e/test_oauth_protected_resource.py
@@ -197,7 +197,7 @@ class TestOAuthProtectedResourceMetadata:
 
     async def _disable_server(self, client: AsyncClient, server_id: str):
         """Helper to disable a server using the toggle endpoint."""
-        response = await client.post(f"/servers/{server_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/servers/{server_id}/state?activate=false", headers=TEST_AUTH_HEADER)
         assert response.status_code == 200, f"Failed to disable server: {response.text}"
 
     async def test_server_without_oauth_returns_404(self, client: AsyncClient):
@@ -412,7 +412,7 @@ class TestVirtualServerWellKnownFiles:
 
     async def _disable_server(self, client: AsyncClient, server_id: str):
         """Helper to disable a server using the toggle endpoint."""
-        response = await client.post(f"/servers/{server_id}/toggle?activate=false", headers=TEST_AUTH_HEADER)
+        response = await client.post(f"/servers/{server_id}/state?activate=false", headers=TEST_AUTH_HEADER)
         assert response.status_code == 200, f"Failed to disable server: {response.text}"
 
     async def test_robots_txt_on_public_server(self, client: AsyncClient):

--- a/tests/integration/test_concurrency_row_locking.py
+++ b/tests/integration/test_concurrency_row_locking.py
@@ -249,7 +249,7 @@ async def test_concurrent_tool_toggle(client: AsyncClient):
     tool_id = tool["id"]
 
     async def toggle():
-        return await client.post(f"/admin/tools/{tool_id}/toggle", data={}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/admin/tools/{tool_id}/state", data={}, headers=TEST_AUTH_HEADER)
 
     # Run 20 concurrent toggles
     results = await asyncio.gather(*[toggle() for _ in range(20)], return_exceptions=True)
@@ -392,7 +392,7 @@ async def test_concurrent_mixed_operations(client: AsyncClient):
         return await client.post(f"/admin/tools/{tool_id}/edit", data=update_data, headers=TEST_AUTH_HEADER)
 
     async def toggle_tool():
-        return await client.post(f"/admin/tools/{tool_id}/toggle", data={}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/admin/tools/{tool_id}/state", data={}, headers=TEST_AUTH_HEADER)
 
     async def read_tool():
         return await client.get("/admin/tools", headers=TEST_AUTH_HEADER)
@@ -601,7 +601,7 @@ async def test_concurrent_gateway_toggle(client: AsyncClient):
     gateway_id = gateway["id"]
 
     async def toggle():
-        return await client.post(f"/admin/gateways/{gateway_id}/toggle", data={}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/admin/gateways/{gateway_id}/state", data={}, headers=TEST_AUTH_HEADER)
 
     # Run 20 concurrent toggles
     results = await asyncio.gather(*[toggle() for _ in range(20)], return_exceptions=True)
@@ -943,7 +943,7 @@ async def test_concurrent_prompt_toggle(client: AsyncClient):
     prompt_id = prompt["id"]
 
     async def toggle():
-        return await client.post(f"/admin/prompts/{prompt_id}/toggle", data={}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/admin/prompts/{prompt_id}/state", data={}, headers=TEST_AUTH_HEADER)
 
     # Run 20 concurrent toggles
     results = await asyncio.gather(*[toggle() for _ in range(20)], return_exceptions=True)
@@ -1088,7 +1088,7 @@ async def test_concurrent_resource_toggle(client: AsyncClient):
     resource_id = resource["id"]
 
     async def toggle():
-        return await client.post(f"/resources/{resource_id}/toggle", json={}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/resources/{resource_id}/state", json={}, headers=TEST_AUTH_HEADER)
 
     # Run 20 concurrent toggles
     results = await asyncio.gather(*[toggle() for _ in range(20)], return_exceptions=True)
@@ -1253,7 +1253,7 @@ async def test_concurrent_a2a_toggle(client: AsyncClient):
     agent_id = agent["id"]
 
     async def toggle():
-        return await client.post(f"/a2a/{agent_id}/toggle", json={"activate": True}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/a2a/{agent_id}/state", json={"activate": True}, headers=TEST_AUTH_HEADER)
 
     # Run 20 concurrent toggles
     results = await asyncio.gather(*[toggle() for _ in range(20)], return_exceptions=True)
@@ -1436,7 +1436,7 @@ async def test_concurrent_server_toggle(client: AsyncClient):
     server_id = server["id"]
 
     async def toggle():
-        return await client.post(f"/servers/{server_id}/toggle", json={}, headers=TEST_AUTH_HEADER)
+        return await client.post(f"/servers/{server_id}/state", json={}, headers=TEST_AUTH_HEADER)
 
     # Run 20 concurrent toggles
     results = await asyncio.gather(*[toggle() for _ in range(20)], return_exceptions=True)

--- a/tests/integration/test_resource_plugin_integration.py
+++ b/tests/integration/test_resource_plugin_integration.py
@@ -359,7 +359,7 @@ class TestResourcePluginIntegration:
         created = await service.register_resource(test_db, resource)
 
         # Deactivate the resource
-        await service.toggle_resource_status(test_db, created.id, activate=False)
+        await service.set_resource_state(test_db, created.id, activate=False)
 
 
         # Try to read inactive resource

--- a/tests/loadtest/locustfile.py
+++ b/tests/loadtest/locustfile.py
@@ -1246,75 +1246,75 @@ class WriteAPIUser(BaseUser):
                 response.success()  # Conflict or validation error is acceptable for load test
 
     @task(2)
-    @tag("api", "write", "toggle")
-    def toggle_server_status(self):
-        """Toggle a server's enabled status."""
+    @tag("api", "write", "state")
+    def set_server_state(self):
+        """Set a server's enabled state."""
         if SERVER_IDS:
             server_id = random.choice(SERVER_IDS)
             with self.client.post(
-                f"/servers/{server_id}/toggle",
+                f"/servers/{server_id}/state",
                 headers=self.auth_headers,
-                name="/servers/[id]/toggle",
+                name="/servers/[id]/state",
                 catch_response=True,
             ) as response:
                 # 403/404 are acceptable - entity may not exist or may be read-only
                 self._validate_json_response(response, allowed_codes=[200, 403, 404])
 
     @task(2)
-    @tag("api", "write", "toggle")
-    def toggle_tool_status(self):
-        """Toggle a tool's enabled status."""
+    @tag("api", "write", "state")
+    def set_tool_state(self):
+        """Set a tool's enabled state."""
         if TOOL_IDS:
             tool_id = random.choice(TOOL_IDS)
             with self.client.post(
-                f"/tools/{tool_id}/toggle",
+                f"/tools/{tool_id}/state",
                 headers=self.auth_headers,
-                name="/tools/[id]/toggle",
+                name="/tools/[id]/state",
                 catch_response=True,
             ) as response:
                 # 403/404 are acceptable - entity may not exist or may be read-only
                 self._validate_json_response(response, allowed_codes=[200, 403, 404])
 
     @task(2)
-    @tag("api", "write", "toggle")
-    def toggle_resource_status(self):
-        """Toggle a resource's enabled status."""
+    @tag("api", "write", "state")
+    def set_resource_state(self):
+        """Set a resource's enabled state."""
         if RESOURCE_IDS:
             resource_id = random.choice(RESOURCE_IDS)
             with self.client.post(
-                f"/resources/{resource_id}/toggle",
+                f"/resources/{resource_id}/state",
                 headers=self.auth_headers,
-                name="/resources/[id]/toggle",
+                name="/resources/[id]/state",
                 catch_response=True,
             ) as response:
                 # 403/404 are acceptable - entity may not exist or may be read-only
                 self._validate_json_response(response, allowed_codes=[200, 403, 404])
 
     @task(2)
-    @tag("api", "write", "toggle")
-    def toggle_prompt_status(self):
-        """Toggle a prompt's enabled status."""
+    @tag("api", "write", "state")
+    def set_prompt_state(self):
+        """Set a prompt's enabled state."""
         if PROMPT_IDS:
             prompt_id = random.choice(PROMPT_IDS)
             with self.client.post(
-                f"/prompts/{prompt_id}/toggle",
+                f"/prompts/{prompt_id}/state",
                 headers=self.auth_headers,
-                name="/prompts/[id]/toggle",
+                name="/prompts/[id]/state",
                 catch_response=True,
             ) as response:
                 # 403/404 are acceptable - entity may not exist or may be read-only
                 self._validate_json_response(response, allowed_codes=[200, 403, 404])
 
     @task(2)
-    @tag("api", "write", "toggle")
-    def toggle_gateway_status(self):
-        """Toggle a gateway's enabled status."""
+    @tag("api", "write", "state")
+    def set_gateway_state(self):
+        """Set a gateway's enabled state."""
         if GATEWAY_IDS:
             gateway_id = random.choice(GATEWAY_IDS)
             with self.client.post(
-                f"/gateways/{gateway_id}/toggle",
+                f"/gateways/{gateway_id}/state",
                 headers=self.auth_headers,
-                name="/gateways/[id]/toggle",
+                name="/gateways/[id]/state",
                 catch_response=True,
             ) as response:
                 # 403/404/502 are acceptable - gateway may not exist or may be unreachable

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -263,8 +263,8 @@ class TestA2AAgentService:
             with pytest.raises(A2AAgentNotFoundError):
                 await service.update_agent(mock_db, "non-existent-id", update_data)
 
-    async def test_toggle_agent_status_success(self, service, mock_db, sample_db_agent):
-        """Test successful agent status toggle."""
+    async def test_set_agent_state_success(self, service, mock_db, sample_db_agent):
+        """Test successful agent state change."""
         # Mock database query
         mock_db.execute.return_value.scalar_one_or_none.return_value = sample_db_agent
         mock_db.commit = MagicMock()
@@ -272,7 +272,7 @@ class TestA2AAgentService:
         service.convert_agent_to_read = MagicMock(return_value=MagicMock())
 
         # Execute
-        await service.toggle_agent_status(mock_db, sample_db_agent.id, False)
+        await service.set_agent_state(mock_db, sample_db_agent.id, False)
 
         # Verify
         assert sample_db_agent.enabled is False

--- a/tests/unit/mcpgateway/services/test_grpc_service.py
+++ b/tests/unit/mcpgateway/services/test_grpc_service.py
@@ -241,13 +241,13 @@ class TestGrpcService:
         with pytest.raises(GrpcServiceNameConflictError):
             await service.update_service(mock_db, sample_db_service.id, update_data)
 
-    async def test_toggle_service(self, service, mock_db, sample_db_service):
-        """Test toggling service enabled status."""
+    async def test_set_service_state(self, service, mock_db, sample_db_service):
+        """Test setting service enabled state."""
         mock_db.execute.return_value.scalar_one_or_none.return_value = sample_db_service
         mock_db.commit = MagicMock()
         mock_db.refresh = MagicMock()
 
-        result = await service.toggle_service(mock_db, sample_db_service.id, activate=False)
+        result = await service.set_service_state(mock_db, sample_db_service.id, activate=False)
 
         assert result.enabled is False
         mock_db.commit.assert_called()

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -422,11 +422,11 @@ class TestPromptService:
         assert "Failed to update prompt" in str(exc_info.value)
 
     # ──────────────────────────────────────────────────────────────────
-    #   toggle status
+    #   set state
     # ──────────────────────────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status(self, prompt_service, test_db):
+    async def test_set_prompt_state(self, prompt_service, test_db):
         # Ensure the mock prompt has a real id and primitive attributes
         p = MagicMock(spec=DbPrompt)
         p.id = 1
@@ -439,27 +439,27 @@ class TestPromptService:
         test_db.refresh = Mock()
         prompt_service._notify_prompt_deactivated = AsyncMock()
 
-        res = await prompt_service.toggle_prompt_status(test_db, 1, activate=False)
+        res = await prompt_service.set_prompt_state(test_db, 1, activate=False)
 
         assert p.enabled is False
         prompt_service._notify_prompt_deactivated.assert_called_once()
         assert res["enabled"] is False
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status_not_found(self, prompt_service, test_db):
+    async def test_set_prompt_state_not_found(self, prompt_service, test_db):
         test_db.get = Mock(return_value=None)
         with pytest.raises(PromptError) as exc_info:
-            await prompt_service.toggle_prompt_status(test_db, 999, activate=True)
+            await prompt_service.set_prompt_state(test_db, 999, activate=True)
         assert "Prompt not found" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status_exception(self, prompt_service, test_db):
+    async def test_set_prompt_state_exception(self, prompt_service, test_db):
         p = _build_db_prompt(is_active=True)
         test_db.get = Mock(return_value=p)
         test_db.commit = Mock(side_effect=Exception("fail"))
         with pytest.raises(PromptError) as exc_info:
-            await prompt_service.toggle_prompt_status(test_db, 1, activate=False)
-        assert "Failed to toggle prompt status" in str(exc_info.value)
+            await prompt_service.set_prompt_state(test_db, 1, activate=False)
+        assert "Failed to set prompt state" in str(exc_info.value)
 
     # ──────────────────────────────────────────────────────────────────
     #   delete_prompt

--- a/tests/unit/mcpgateway/services/test_prompt_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service_extended.py
@@ -183,23 +183,23 @@ class TestPromptServiceExtended:
         assert callable(method)
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status_not_found(self):
-        """Test toggle_prompt_status method exists."""
+    async def test_set_prompt_state_method_exists(self):
+        """Test set_prompt_state method exists."""
         service = PromptService()
 
         # Test method exists
-        assert hasattr(service, 'toggle_prompt_status')
-        assert callable(getattr(service, 'toggle_prompt_status'))
+        assert hasattr(service, 'set_prompt_state')
+        assert callable(getattr(service, 'set_prompt_state'))
 
     @pytest.mark.asyncio
-    async def test_toggle_prompt_status_no_change_needed(self):
-        """Test toggle_prompt_status method is async."""
+    async def test_set_prompt_state_no_change_needed(self):
+        """Test set_prompt_state method is async."""
         service = PromptService()
 
         # Test method is async
         # Standard
         import asyncio
-        assert asyncio.iscoroutinefunction(service.toggle_prompt_status)
+        assert asyncio.iscoroutinefunction(service.set_prompt_state)
 
     @pytest.mark.asyncio
     async def test_delete_prompt_not_found(self):

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -816,9 +816,9 @@ class TestServerService:
             assert "Public Server already exists with name" in str(exc.value)
             test_db.rollback.assert_called()
 
-    # -------------------------- toggle --------------------------------- #
+    # -------------------------- set state --------------------------------- #
     @pytest.mark.asyncio
-    async def test_toggle_server_status(self, server_service, mock_server, test_db):
+    async def test_set_server_state(self, server_service, mock_server, test_db):
         mock_server.team_id = 1
         test_db.get = Mock(return_value=mock_server)
         # Ensure get_for_update returns the mocked server when loader options are used
@@ -853,7 +853,7 @@ class TestServerService:
             )
         )
 
-        result = await server_service.toggle_server_status(test_db, 1, activate=False)
+        result = await server_service.set_server_state(test_db, 1, activate=False)
 
         # get_for_update may use `db.get(..., options=...)` or execute a select;
         # accept either approach.

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -1051,8 +1051,8 @@ class TestToolService:
         assert "Tool not found: 999" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status(self, tool_service, mock_tool, test_db):
-        """Test toggling tool active status."""
+    async def test_set_tool_state(self, tool_service, mock_tool, test_db):
+        """Test setting tool active state."""
         # Mock DB get to return tool
         test_db.get = Mock(return_value=mock_tool)
         test_db.commit = Mock()
@@ -1099,7 +1099,7 @@ class TestToolService:
         tool_service.convert_tool_to_read = Mock(return_value=tool_read)
 
         # Deactivate the tool (it's active by default)
-        result = await tool_service.toggle_tool_status(test_db, 1, activate=False, reachable=True)
+        result = await tool_service.set_tool_state(test_db, 1, activate=False, reachable=True)
 
         # Verify DB operations
         test_db.get.assert_called_once_with(DbTool, 1)
@@ -1117,15 +1117,15 @@ class TestToolService:
         assert result == tool_read
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status_not_found(self, tool_service, test_db):
-        """Test toggling tool active status."""
+    async def test_set_tool_state_not_found(self, tool_service, test_db):
+        """Test setting tool state when not found."""
         # Mock DB get to return tool
         test_db.get = Mock(return_value=None)
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
         with pytest.raises(ToolError) as exc:
-            await tool_service.toggle_tool_status(test_db, "1", activate=False, reachable=True)
+            await tool_service.set_tool_state(test_db, "1", activate=False, reachable=True)
 
         assert "Tool not found: 1" in str(exc.value)
 
@@ -1133,8 +1133,8 @@ class TestToolService:
         test_db.get.assert_called_once_with(DbTool, "1")
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status_activate_tool(self, tool_service, test_db, mock_tool, monkeypatch):
-        """Test toggling tool active status."""
+    async def test_set_tool_state_activate_tool(self, tool_service, test_db, mock_tool, monkeypatch):
+        """Test activating tool state."""
         # Mock DB get to return tool
         mock_tool.enabled = False
         test_db.get = Mock(return_value=mock_tool)
@@ -1143,7 +1143,7 @@ class TestToolService:
 
         tool_service._notify_tool_activated = AsyncMock()
 
-        result = await tool_service.toggle_tool_status(test_db, "1", activate=True, reachable=True)
+        result = await tool_service.set_tool_state(test_db, "1", activate=True, reachable=True)
 
         # Verify DB operations
         test_db.get.assert_called_once_with(DbTool, "1")
@@ -1207,8 +1207,8 @@ class TestToolService:
         assert q.empty()
 
     @pytest.mark.asyncio
-    async def test_toggle_tool_status_no_change(self, tool_service, mock_tool, test_db):
-        """Test toggling tool active status."""
+    async def test_set_tool_state_no_change(self, tool_service, mock_tool, test_db):
+        """Test setting tool state with no change."""
         # Mock DB get to return tool
         test_db.get = Mock(return_value=mock_tool)
         test_db.commit = Mock()
@@ -1255,7 +1255,7 @@ class TestToolService:
         tool_service.convert_tool_to_read = Mock(return_value=tool_read)
 
         # Deactivate the tool (it's active by default)
-        result = await tool_service.toggle_tool_status(test_db, 1, activate=True, reachable=True)
+        result = await tool_service.set_tool_state(test_db, 1, activate=True, reachable=True)
 
         # Verify DB operations
         test_db.get.assert_called_once_with(DbTool, 1)

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -517,13 +517,13 @@ class TestServerEndpoints:
         assert response.status_code == 200
         mock_update.assert_called_once()
 
-    @patch("mcpgateway.main.server_service.toggle_server_status")
-    def test_toggle_server_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling server active/inactive status."""
+    @patch("mcpgateway.main.server_service.set_server_state")
+    def test_set_server_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting server active/inactive state."""
         updated_server = MOCK_SERVER_READ.copy()
         updated_server["enabled"] = False
         mock_toggle.return_value = ServerRead(**updated_server)
-        response = test_client.post("/servers/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/servers/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         mock_toggle.assert_called_once()
 
@@ -651,13 +651,13 @@ class TestToolEndpoints:
         assert response.status_code == 200
         mock_update.assert_called_once()
 
-    @patch("mcpgateway.main.tool_service.toggle_tool_status")
-    def test_toggle_tool_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling tool active/inactive status."""
+    @patch("mcpgateway.main.tool_service.set_tool_state")
+    def test_set_tool_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting tool active/inactive state."""
         mock_tool = MagicMock()
         mock_tool.model_dump.return_value = {"id": 1, "name": "test", "is_active": False}
         mock_toggle.return_value = mock_tool
-        response = test_client.post("/tools/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/tools/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -769,13 +769,13 @@ class TestResourceEndpoints:
         assert response.status_code == 200
         mock_list.assert_called_once()
 
-    @patch("mcpgateway.main.resource_service.toggle_resource_status")
-    def test_toggle_resource_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling resource active/inactive status."""
+    @patch("mcpgateway.main.resource_service.set_resource_state")
+    def test_set_resource_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting resource active/inactive state."""
         mock_resource = MagicMock()
         mock_resource.model_dump.return_value = {"id": "1", "enabled": False}
         mock_toggle.return_value = mock_resource
-        response = test_client.post("/resources/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/resources/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -849,13 +849,13 @@ class TestPromptEndpoints:
         assert response.json()["status"] == "success"
         mock_delete.assert_called_once()
 
-    @patch("mcpgateway.main.prompt_service.toggle_prompt_status")
-    def test_toggle_prompt_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling prompt active/inactive status."""
+    @patch("mcpgateway.main.prompt_service.set_prompt_state")
+    def test_set_prompt_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting prompt active/inactive state."""
         mock_prompt = MagicMock()
         mock_prompt.model_dump.return_value = {"id": 1, "enabled": False}
         mock_toggle.return_value = mock_prompt
-        response = test_client.post("/prompts/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/prompts/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
         mock_toggle.assert_called_once()
@@ -929,13 +929,13 @@ class TestPromptEndpoints:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-    @patch("mcpgateway.main.prompt_service.toggle_prompt_status")
-    def test_toggle_prompt_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling prompt active/inactive status."""
+    @patch("mcpgateway.main.prompt_service.set_prompt_state")
+    def test_set_prompt_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting prompt active/inactive state."""
         mock_prompt = MagicMock()
         mock_prompt.model_dump.return_value = {"id": 1, "enabled": False}
         mock_toggle.return_value = mock_prompt
-        response = test_client.post("/prompts/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/prompts/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -1009,13 +1009,13 @@ class TestGatewayEndpoints:
         mock_delete.assert_called_once()
         mock_invalidate_cache.assert_called_once()
 
-    @patch("mcpgateway.main.gateway_service.toggle_gateway_status")
-    def test_toggle_gateway_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling gateway active/inactive status."""
+    @patch("mcpgateway.main.gateway_service.set_gateway_state")
+    def test_set_gateway_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting gateway active/inactive state."""
         mock_gateway = MagicMock()
         mock_gateway.model_dump.return_value = {"id": "1", "is_active": False}
         mock_toggle.return_value = mock_gateway
-        response = test_client.post("/gateways/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/gateways/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
         mock_toggle.assert_called_once()
@@ -1072,13 +1072,13 @@ class TestGatewayEndpoints:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-    @patch("mcpgateway.main.gateway_service.toggle_gateway_status")
-    def test_toggle_gateway_status(self, mock_toggle, test_client, auth_headers):
-        """Test toggling gateway active/inactive status."""
+    @patch("mcpgateway.main.gateway_service.set_gateway_state")
+    def test_set_gateway_state(self, mock_toggle, test_client, auth_headers):
+        """Test setting gateway active/inactive state."""
         mock_gateway = MagicMock()
         mock_gateway.model_dump.return_value = {"id": "1", "is_active": False}
         mock_toggle.return_value = mock_gateway
-        response = test_client.post("/gateways/1/toggle?activate=false", headers=auth_headers)
+        response = test_client.post("/gateways/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -290,7 +290,7 @@ class TestUtilityFunctions:
 
     def test_server_toggle_edge_cases(self, test_client, auth_headers):
         """Test server toggle endpoint edge cases."""
-        with patch("mcpgateway.main.server_service.toggle_server_status") as mock_toggle:
+        with patch("mcpgateway.main.server_service.set_server_state") as mock_toggle:
             # Create a proper ServerRead model response
             # First-Party
             from mcpgateway.schemas import ServerRead
@@ -321,13 +321,13 @@ class TestUtilityFunctions:
             mock_toggle.return_value = ServerRead(**mock_server_data)
 
             # Test activate=true
-            response = test_client.post("/servers/1/toggle?activate=true", headers=auth_headers)
+            response = test_client.post("/servers/1/state?activate=true", headers=auth_headers)
             assert response.status_code == 200
 
             # Test activate=false
             mock_server_data["enabled"] = False
             mock_toggle.return_value = ServerRead(**mock_server_data)
-            response = test_client.post("/servers/1/toggle?activate=false", headers=auth_headers)
+            response = test_client.post("/servers/1/state?activate=false", headers=auth_headers)
             assert response.status_code == 200
 
 


### PR DESCRIPTION
closes issue #1497
This pull request standardizes API endpoints and related documentation by replacing the verb "toggle" with "state" for activating or deactivating resources across the codebase, documentation, and admin UI. This change improves clarity and consistency for users and developers interacting with the system.

**API and Endpoint Changes**
* All REST endpoints for toggling resource states (servers, gateways, tools, agents, prompts, resources, gRPC services) have been renamed from `/toggle` to `/state`, clarifying that the endpoint sets the state rather than simply toggling it. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL758-R758) [[2]](diffhunk://#diff-7d3a5fe659e5417b4949c80c8fe2a33e6a74f674e18481d113e6b3c8e77fd46aL2285-R2301) [[3]](diffhunk://#diff-7d3a5fe659e5417b4949c80c8fe2a33e6a74f674e18481d113e6b3c8e77fd46aL2789-R2804)

**Documentation Updates**
* All relevant documentation files (`README.md`, `docs/docs/index.md`, `docs/docs/manage/api-usage.md`, `docs/docs/using/grpc-services.md`) have been updated to use the new `/state` endpoint in example API calls, ensuring instructions match the codebase. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2556-R2558) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2618-R2618) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2668-R2668) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2754-R2754) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2812-R2812) [[6]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1722-R1724) [[7]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1784-R1784) [[8]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1834-R1834) [[9]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1920-R1920) [[10]](diffhunk://#diff-7dd3ba15306fb8ca0c3fa4a2e10b4d3b708c3a338bc2c4a028b4e1d0e565dc88L1978-R1978) [[11]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L315-R315) [[12]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L506-R506) [[13]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L657-R657) [[14]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L776-R776) [[15]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L885-R885) [[16]](diffhunk://#diff-f5676153b777338a4d39ccce0a4def60b2cd17a42e0b45caccb185ade2bd1a67L1367-R1367) [[17]](diffhunk://#diff-dda3e6a76daeac844cf45087bc2819c89a01f7c004f0cde7b8cf5205a69bbb8fL310-R310)

**Architecture and ADR Updates**
* Architecture Decision Records have been updated to reflect the new terminology, replacing "toggle" with "state" for cache invalidation logic and gateway/tool operations.

**Code and Test Refactoring**
* Admin UI route handlers and associated docstrings, logging, and test code have been refactored to use the new "state" terminology and method names (e.g., `set_server_state` instead of `toggle_server_status`), improving code clarity and alignment with endpoint changes. [[1]](diffhunk://#diff-7d3a5fe659e5417b4949c80c8fe2a33e6a74f674e18481d113e6b3c8e77fd46aL2325-R2366) [[2]](diffhunk://#diff-7d3a5fe659e5417b4949c80c8fe2a33e6a74f674e18481d113e6b3c8e77fd46aL2376-R2395)

These changes collectively enhance the clarity and maintainability of both the API and its documentation, making it easier for users and developers to understand and interact with resource state management.