### PR TITLE
Decouple JWT Issuer Verification from Audience Verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -278,6 +278,8 @@ JWT_ISSUER=mcpgateway
 # JWT Validation Options
 # Set to false for Dynamic Client Registration (DCR) scenarios where audience varies
 JWT_AUDIENCE_VERIFICATION=true
+# Set to false for custom auth flows where issuer varies or is not present
+JWT_ISSUER_VERIFICATION=true
 
 # Expiry time for generated JWT tokens (in minutes; e.g. 7 days)
 TOKEN_EXPIRY=10080

--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,7 @@ You can get started by copying the provided [.env.example](https://github.com/IB
 | `JWT_PRIVATE_KEY_PATH`      | If an asymmetric algorithm is used, a private key is required                | (empty)             | path to pem |
 | `JWT_AUDIENCE`              | JWT audience claim for token validation                                      | `mcpgateway-api`    | string      |
 | `JWT_AUDIENCE_VERIFICATION` | Disables jwt audience verification (useful for DCR)                          | `true`              | boolean     |
+| `JWT_ISSUER_VERIFICATION`   | Disables jwt issuer verification (useful for custom auth)                    | `true`              | boolean     |
 | `JWT_ISSUER`                | JWT issuer claim for token validation                                        | `mcpgateway`        | string      |
 | `TOKEN_EXPIRY`              | Expiry of generated JWTs in minutes                                          | `10080`             | int > 0     |
 | `REQUIRE_TOKEN_EXPIRATION`  | Require all JWT tokens to have expiration claims                             | `false`             | bool        |
@@ -1618,6 +1619,7 @@ ContextForge implements **OAuth 2.0 Dynamic Client Registration (RFC 7591)** and
 | `OAUTH_DISCOVERY_ENABLED`                  | Enable AS metadata discovery (RFC 8414)                        | `true`                         | bool          |
 | `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD`    | PKCE code challenge method                                     | `S256`                         | `S256`, `plain` |
 | `JWT_AUDIENCE_VERIFICATION`                | JWT audience verification (disable for DCR)                    | `true`                         | bool          |
+| `JWT_ISSUER_VERIFICATION`                  | JWT issuer verification (disable if needed)                    | `true`                         | bool          |
 
 **Documentation:**
 - [DCR Configuration Guide](https://ibm.github.io/mcp-context-forge/manage/dcr/) - Complete DCR setup and troubleshooting

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -387,6 +387,7 @@ Kubernetes: `>=1.21.0-0`
 | mcpContextForge.secret.JWT_AUDIENCE | string | `"mcpgateway-api"` |  |
 | mcpContextForge.secret.JWT_AUDIENCE_VERIFICATION | string | `"true"` |  |
 | mcpContextForge.secret.JWT_ISSUER | string | `"mcpgateway"` |  |
+| mcpContextForge.secret.JWT_ISSUER_VERIFICATION | string | `"true"` |  |
 | mcpContextForge.secret.JWT_PRIVATE_KEY_PATH | string | `""` |  |
 | mcpContextForge.secret.JWT_PUBLIC_KEY_PATH | string | `""` |  |
 | mcpContextForge.secret.JWT_SECRET_KEY | string | `"my-test-key"` |  |

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -628,6 +628,7 @@ mcpContextForge:
 
     # ─ JWT Configuration (Advanced) ─
     JWT_AUDIENCE_VERIFICATION: "true"      # JWT audience verification (disable for DCR)
+    JWT_ISSUER_VERIFICATION: "true"        # JWT issuer verification (disable if needed)
     JWT_PRIVATE_KEY_PATH: ""               # path to JWT private key file (RSA/ECDSA algorithms)
     JWT_PUBLIC_KEY_PATH: ""                # path to JWT public key file (RSA/ECDSA algorithms)
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -104,6 +104,11 @@
       "title": "Jwt Audience Verification",
       "type": "boolean"
     },
+    "jwt_issuer_verification": {
+      "default": true,
+      "title": "Jwt Issuer Verification",
+      "type": "boolean"
+    },
     "auth_required": {
       "default": true,
       "title": "Auth Required",

--- a/docs/docs/architecture/adr/004-combine-jwt-and-basic-auth.md
+++ b/docs/docs/architecture/adr/004-combine-jwt-and-basic-auth.md
@@ -84,6 +84,7 @@ JWT_ALGORITHM=RS256
 JWT_PUBLIC_KEY_PATH=jwt/public.pem
 JWT_PRIVATE_KEY_PATH=jwt/private.pem
 JWT_AUDIENCE_VERIFICATION=true
+JWT_ISSUER_VERIFICATION=true
 ```
 
 ### Benefits of Asymmetric Support

--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -314,6 +314,7 @@ data:
   JWT_AUDIENCE: "mcpgateway-production"
   JWT_ISSUER: "your-organization"
   JWT_AUDIENCE_VERIFICATION: "true"
+  JWT_ISSUER_VERIFICATION: "true"
   REQUIRE_TOKEN_EXPIRATION: "true"
 
   # Security settings

--- a/docs/docs/deployment/proxy-auth.md
+++ b/docs/docs/deployment/proxy-auth.md
@@ -116,6 +116,7 @@ services:
             JWT_PUBLIC_KEY_PATH: /opt/public.pem
             JWT_PRIVATE_KEY_PATH: /opt/private.pem
             JWT_AUDIENCE_VERIFICATION: false
+            JWT_ISSUER_VERIFICATION: false
             JWT_ISSUER: http://localhost:5556
             DATABASE_URL: sqlite:////data/context-forge.db
             HOST: 0.0.0.0

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1004,6 +1004,7 @@ You can get started by copying the provided [.env.example](https://github.com/IB
 | `JWT_PRIVATE_KEY_PATH`      | If an asymmetric algorithm is used, a private key is required                | (empty)             | path to pem |
 | `JWT_AUDIENCE`              | JWT audience claim for token validation                                      | `mcpgateway-api`    | string      |
 | `JWT_AUDIENCE_VERIFICATION` | Disables jwt audience verification (useful for DCR)                          | `true`              | boolean     |
+| `JWT_ISSUER_VERIFICATION`   | Disables jwt issuer verification (useful for custom auth)                    | `true`              | boolean     |
 | `JWT_ISSUER`                | JWT issuer claim for token validation                                        | `mcpgateway`        | string      |
 | `TOKEN_EXPIRY`              | Expiry of generated JWTs in minutes                                          | `10080`             | int > 0     |
 | `REQUIRE_TOKEN_EXPIRATION`  | Require all JWT tokens to have expiration claims                             | `false`             | bool        |

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -349,6 +349,7 @@ JWT_PRIVATE_KEY_PATH=jwt/private.pem   # Required for asymmetric algorithms (RS*
 JWT_AUDIENCE=mcpgateway-api
 JWT_ISSUER=mcpgateway
 JWT_AUDIENCE_VERIFICATION=true         # Set to false for Dynamic Client Registration
+JWT_ISSUER_VERIFICATION=true           # Set to false if issuer validation is not needed
 REQUIRE_TOKEN_EXPIRATION=true
 
 # Basic Auth (Admin UI)
@@ -769,6 +770,7 @@ JWT_SECRET_KEY=your-256-bit-secret-key-here
 JWT_AUDIENCE=mcpgateway-api
 JWT_ISSUER=mcpgateway
 JWT_AUDIENCE_VERIFICATION=true
+JWT_ISSUER_VERIFICATION=true
 ```
 
 ### RSA (Asymmetric) - Enterprise Deployments
@@ -783,6 +785,7 @@ JWT_PRIVATE_KEY_PATH=certs/jwt/private.pem    # Path to RSA private key
 JWT_AUDIENCE=mcpgateway-api
 JWT_ISSUER=mcpgateway
 JWT_AUDIENCE_VERIFICATION=true
+JWT_ISSUER_VERIFICATION=true
 ```
 
 #### Generate RSA Keys
@@ -836,6 +839,7 @@ JWT_ALGORITHM=RS256
 JWT_PUBLIC_KEY_PATH=certs/jwt/public.pem
 JWT_PRIVATE_KEY_PATH=certs/jwt/private.pem
 JWT_AUDIENCE_VERIFICATION=false         # Disable audience validation for DCR
+JWT_ISSUER_VERIFICATION=false           # Disable issuer validation for DCR
 JWT_ISSUER=your-identity-provider
 ```
 

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -45,6 +45,7 @@ JWT_ALGORITHM=RS256                        # Recommended for production (asymmet
 JWT_PUBLIC_KEY_PATH=jwt/public.pem         # Path to public key file
 JWT_PRIVATE_KEY_PATH=jwt/private.pem       # Path to private key file (secure location)
 JWT_AUDIENCE_VERIFICATION=true             # Enable audience validation
+JWT_ISSUER_VERIFICATION=true               # Enable issuer validation
 JWT_ISSUER=your-company-name               # Set to your organization identifier
 
 # Set environment for security defaults
@@ -84,6 +85,7 @@ JWT_PRIVATE_KEY_PATH=/secure/path/jwt/private.pem
 JWT_AUDIENCE=your-api-identifier
 JWT_ISSUER=your-organization
 JWT_AUDIENCE_VERIFICATION=true
+JWT_ISSUER_VERIFICATION=true
 REQUIRE_TOKEN_EXPIRATION=true
 ```
 
@@ -96,6 +98,7 @@ JWT_SECRET_KEY=your-strong-secret-key-here  # Minimum 32 characters
 JWT_AUDIENCE=mcpgateway-api
 JWT_ISSUER=mcpgateway
 JWT_AUDIENCE_VERIFICATION=true
+JWT_ISSUER_VERIFICATION=true
 REQUIRE_TOKEN_EXPIRATION=true
 ```
 

--- a/docs/docs/tutorials/dcr-hyprmcp.md
+++ b/docs/docs/tutorials/dcr-hyprmcp.md
@@ -205,6 +205,7 @@ context-forge:
         JWT_PUBLIC_KEY_PATH: /opt/public.pem
         JWT_PRIVATE_KEY_PATH: /opt/private.pem
         JWT_AUDIENCE_VERIFICATION: false
+        JWT_ISSUER_VERIFICATION: false
         JWT_ISSUER: http://localhost:5556
         DATABASE_URL: sqlite:////data/context-forge.db
         HOST: 0.0.0.0
@@ -367,6 +368,7 @@ services:
             JWT_PUBLIC_KEY_PATH: /opt/public.pem
             JWT_PRIVATE_KEY_PATH: /opt/private.pem
             JWT_AUDIENCE_VERIFICATION: false
+            JWT_ISSUER_VERIFICATION: false
             JWT_ISSUER: http://localhost:5556
             DATABASE_URL: sqlite:////data/context-forge.db
             HOST: 0.0.0.0

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -185,6 +185,7 @@ class Settings(BaseSettings):
     jwt_audience: str = "mcpgateway-api"
     jwt_issuer: str = "mcpgateway"
     jwt_audience_verification: bool = True
+    jwt_issuer_verification: bool = True
     auth_required: bool = True
     token_expiry: int = 10080  # minutes
 

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -16,6 +16,7 @@ Examples:
     ...     jwt_algorithm = 'HS256'
     ...     jwt_audience = 'mcpgateway-api'
     ...     jwt_issuer = 'mcpgateway'
+    ...     jwt_issuer_verification = True
     ...     jwt_audience_verification = True
     ...     basic_auth_user = 'user'
     ...     basic_auth_password = SecretStr('pass')
@@ -97,6 +98,7 @@ async def verify_jwt_token(token: str) -> dict:
 
         options = {
             "verify_aud": settings.jwt_audience_verification,
+            "verify_iss": settings.jwt_issuer_verification,
         }
 
         if settings.require_token_expiration:
@@ -106,9 +108,13 @@ async def verify_jwt_token(token: str) -> dict:
             "key": get_jwt_public_key_or_secret(),
             "algorithms": [settings.jwt_algorithm],
             "options": options,
-            "audience": settings.jwt_audience,
-            "issuer": settings.jwt_issuer,
         }
+
+        if settings.jwt_audience_verification:
+            decode_kwargs["audience"] = settings.jwt_audience
+
+        if settings.jwt_issuer_verification:
+            decode_kwargs["issuer"] = settings.jwt_issuer
 
         payload = jwt.decode(token, **decode_kwargs)
 
@@ -199,6 +205,7 @@ async def verify_credentials(token: str) -> dict:
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = SecretStr('pass')
         ...     auth_required = True
@@ -268,6 +275,7 @@ async def require_auth(request: Request, credentials: Optional[HTTPAuthorization
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = SecretStr('pass')
         ...     auth_required = True
@@ -373,6 +381,7 @@ async def verify_basic_credentials(credentials: HTTPBasicCredentials) -> str:
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = SecretStr('pass')
         ...     auth_required = True
@@ -427,6 +436,7 @@ async def require_basic_auth(credentials: HTTPBasicCredentials = Depends(basic_s
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = SecretStr('pass')
         ...     auth_required = True
@@ -489,6 +499,7 @@ async def require_docs_basic_auth(auth_header: str) -> str:
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = SecretStr('pass')
         ...     auth_required = True
@@ -622,6 +633,7 @@ async def require_docs_auth_override(
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     docs_allow_basic_auth = False
         ...     require_token_expiration = False
         >>> vc.settings = DummySettings()
@@ -703,6 +715,7 @@ async def require_auth_override(
         ...     jwt_audience = 'mcpgateway-api'
         ...     jwt_issuer = 'mcpgateway'
         ...     jwt_audience_verification = True
+        ...     jwt_issuer_verification = True
         ...     basic_auth_user = 'user'
         ...     basic_auth_password = SecretStr('pass')
         ...     auth_required = True


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes #1792

This PR introduces a new configuration setting JWT_ISSUER_VERIFICATION (default: True) to provide granular control over JWT issuer claim validation.

Previously, the verify_jwt_token utility would unconditionally pass the issuer parameter to the underlying PyJWT decode function. Consequently, PyJWT enforced the presence and validity of the iss claim even if a user theoretically intended to disable strict checks (e.g., typically expected when disabling audience verification or for specific auth flows). 

This prevented users from configuring the gateway to accept tokens with varying or missing issuers, which is critical for scenarios like Dynamic Client Registration (DCR) or multi-tenant setups.

---

## 💡 Fix Description

- New Configuration Setting: Added jwt_issuer_verification (boolean, default logic True) to mcpgateway/config.py and exposed it via JWT_ISSUER_VERIFICATION environment variable.
- Conditional Validation Logic: Modified verify_jwt_token in mcpgateway/utils/verify_credentials.py to only include the issuer key in decode_kwargs if settings.jwt_issuer_verification is True.
```python
if settings.jwt_issuer_verification:
      decode_kwargs["issuer"] = settings.jwt_issuer
```
- Documentation: propagated the new setting to README.md, values.yaml, and documentation files (security.md, configuration.md, etc.).

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed