### PR TITLE
feat: add JWT token lifecycle management with JTI support Closes #2127

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -292,6 +292,10 @@ JWT_ISSUER_VERIFICATION=true
 TOKEN_EXPIRY=10080
 REQUIRE_TOKEN_EXPIRATION=false
 
+# Require JTI (JWT ID) claim in all tokens for revocation support
+# When true, tokens without JTI will be rejected
+REQUIRE_JTI=false
+
 #####################################
 # Security Validation & Sanitization
 #####################################

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -732,6 +732,11 @@ async def get_current_user(
                 # Handle platform admin case
                 if _batched_user is None:
                     if email == getattr(settings, "platform_admin_email", "admin@example.com"):
+                        logger.info(
+                            f"Platform admin bootstrap authentication for {email}. "
+                            "User authenticated via platform admin configuration.",
+                            extra={"security_event": "platform_admin_bootstrap", "user_id": email},
+                        )
                         _batched_user = EmailUser(
                             email=email,
                             password_hash="",  # nosec B106
@@ -845,6 +850,11 @@ async def get_current_user(
         # Special case for platform admin - if user doesn't exist but token is valid
         # and email matches platform admin, create a virtual admin user object
         if email == getattr(settings, "platform_admin_email", "admin@example.com"):
+            logger.info(
+                f"Platform admin bootstrap authentication for {email}. "
+                "User authenticated via platform admin configuration.",
+                extra={"security_event": "platform_admin_bootstrap", "user_id": email},
+            )
             # Create a virtual admin user for authentication purposes
             user = EmailUser(
                 email=email,

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -190,6 +190,7 @@ class Settings(BaseSettings):
     token_expiry: int = 10080  # minutes
 
     require_token_expiration: bool = Field(default=False, description="Require all JWT tokens to have expiration claims")  # Default to flexible mode for backward compatibility
+    require_jti: bool = Field(default=False, description="Require JTI (JWT ID) claim in all tokens for revocation support")  # Default to flexible mode for backward compatibility
 
     # SSO Configuration
     sso_enabled: bool = Field(default=False, description="Enable Single Sign-On authentication")

--- a/mcpgateway/utils/create_jwt_token.py
+++ b/mcpgateway/utils/create_jwt_token.py
@@ -46,6 +46,7 @@ import argparse
 import asyncio
 import datetime as _dt
 import sys
+import uuid
 from typing import Any, Dict, List, Sequence
 
 # Third-Party
@@ -122,6 +123,7 @@ def _create_jwt_token(
     payload["iat"] = int(now.timestamp())  # Issued at
     payload["iss"] = settings.jwt_issuer  # Issuer
     payload["aud"] = settings.jwt_audience  # Audience
+    payload["jti"] = payload.get("jti") or str(uuid.uuid4())  # JWT ID for revocation support
 
     # Handle legacy username format - convert to sub for consistency
     if "username" in payload and "sub" not in payload:


### PR DESCRIPTION
## Summary

- Add automatic JTI (JWT ID) generation to all tokens created via `_create_jwt_token()`, enabling token revocation support
- Add `REQUIRE_JTI` configuration option to enforce JTI claims in tokens (default: false for backward compatibility)
- Log warnings when tokens without JTI are accepted, providing visibility during migration
- Add platform admin bootstrap authentication logging for audit trails (both batched and fallback auth paths)

Closes #2127

## Test plan

- [x] Unit tests for JTI generation (`test_create_token_includes_jti`, `test_create_token_preserves_provided_jti`)
- [x] Unit tests for REQUIRE_JTI validation (`test_verify_jwt_token_require_jti_enabled_rejects_missing_jti`, `test_verify_jwt_token_require_jti_enabled_accepts_with_jti`, `test_verify_jwt_token_require_jti_disabled_accepts_missing_jti`)
- [x] Verify existing JWT tests pass (42 tests)
- [x] Verify auth tests pass (24 tests)
- [x] Full unit test suite passes (2823 tests)