### PR TITLE
feat: add environment isolation warnings and optional env claim validation (#2141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,8 @@ You can get started by copying the provided [.env.example](https://github.com/IB
 | `REQUIRE_TOKEN_EXPIRATION`  | Require all JWT tokens to have expiration claims                             | `false`             | bool        |
 | `REQUIRE_JTI`               | Require JTI (JWT ID) claim in all tokens for revocation support              | `false`             | bool        |
 | `REQUIRE_USER_IN_DB`        | Require all authenticated users to exist in the database                     | `false`             | bool        |
+| `EMBED_ENVIRONMENT_IN_TOKENS` | Embed environment claim in gateway-issued JWTs                             | `false`             | bool        |
+| `VALIDATE_TOKEN_ENVIRONMENT` | Reject tokens with mismatched environment claim                             | `false`             | bool        |
 | `AUTH_ENCRYPTION_SECRET`    | Passphrase used to derive AES key for encrypting tool auth headers           | `my-test-salt`      | string      |
 | `OAUTH_REQUEST_TIMEOUT`     | OAuth request timeout in seconds                                             | `30`                | int > 0     |
 | `OAUTH_MAX_RETRIES`         | Maximum retries for OAuth token requests                                     | `3`                 | int > 0     |

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -423,6 +423,8 @@ Kubernetes: `>=1.21.0-0`
 | mcpContextForge.secret.REQUIRE_TOKEN_EXPIRATION | string | `"false"` |  |
 | mcpContextForge.secret.REQUIRE_JTI | string | `"false"` |  |
 | mcpContextForge.secret.REQUIRE_USER_IN_DB | string | `"false"` |  |
+| mcpContextForge.secret.EMBED_ENVIRONMENT_IN_TOKENS | string | `"false"` | Embed env claim in gateway-issued JWTs |
+| mcpContextForge.secret.VALIDATE_TOKEN_ENVIRONMENT | string | `"false"` | Reject tokens with mismatched env claim |
 | mcpContextForge.secret.SSO_AUTO_ADMIN_DOMAINS | string | `"[]"` |  |
 | mcpContextForge.secret.SSO_AUTO_CREATE_USERS | string | `"true"` |  |
 | mcpContextForge.secret.SSO_ENABLED | string | `"false"` |  |

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -634,6 +634,8 @@ mcpContextForge:
     JWT_ISSUER_VERIFICATION: "true"        # JWT issuer verification (disable if needed)
     JWT_PRIVATE_KEY_PATH: ""               # path to JWT private key file (RSA/ECDSA algorithms)
     JWT_PUBLIC_KEY_PATH: ""                # path to JWT public key file (RSA/ECDSA algorithms)
+    EMBED_ENVIRONMENT_IN_TOKENS: "false"   # embed env claim in gateway-issued JWTs
+    VALIDATE_TOKEN_ENVIRONMENT: "false"    # reject tokens with mismatched env claim
 
     # ─ SSO (Single Sign-On) Configuration ─
     SSO_ENABLED: "false"                   # master switch for Single Sign-On authentication

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -125,6 +125,18 @@
       "title": "Require Token Expiration",
       "type": "boolean"
     },
+    "embed_environment_in_tokens": {
+      "default": false,
+      "description": "Embed environment claim in gateway-issued JWTs for environment isolation",
+      "title": "Embed Environment In Tokens",
+      "type": "boolean"
+    },
+    "validate_token_environment": {
+      "default": false,
+      "description": "Reject tokens with mismatched environment claim (tokens without env claim are allowed)",
+      "title": "Validate Token Environment",
+      "type": "boolean"
+    },
     "sso_enabled": {
       "default": false,
       "description": "Enable Single Sign-On authentication",

--- a/docs/docs/config.schema.json
+++ b/docs/docs/config.schema.json
@@ -120,6 +120,18 @@
       "title": "Require Token Expiration",
       "type": "boolean"
     },
+    "embed_environment_in_tokens": {
+      "default": false,
+      "description": "Embed environment claim in gateway-issued JWTs for environment isolation",
+      "title": "Embed Environment In Tokens",
+      "type": "boolean"
+    },
+    "validate_token_environment": {
+      "default": false,
+      "description": "Reject tokens with mismatched environment claim (tokens without env claim are allowed)",
+      "title": "Validate Token Environment",
+      "type": "boolean"
+    },
     "sso_enabled": {
       "default": false,
       "description": "Enable Single Sign-On authentication",

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -351,6 +351,8 @@ JWT_ISSUER=mcpgateway
 JWT_AUDIENCE_VERIFICATION=true         # Set to false for Dynamic Client Registration
 JWT_ISSUER_VERIFICATION=true           # Set to false if issuer validation is not needed
 REQUIRE_TOKEN_EXPIRATION=true
+EMBED_ENVIRONMENT_IN_TOKENS=false      # Embed env claim in tokens for environment isolation
+VALIDATE_TOKEN_ENVIRONMENT=false       # Reject tokens with mismatched env claim
 
 # Basic Auth (Admin UI)
 BASIC_AUTH_USER=admin

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -670,8 +670,7 @@ async def get_current_user(
                             db_user = await asyncio.to_thread(_get_user_by_email_sync, email)
                             if db_user is None:
                                 logger.warning(
-                                    f"Authentication rejected for {email}: cached user not found in database. "
-                                    "REQUIRE_USER_IN_DB is enabled.",
+                                    f"Authentication rejected for {email}: cached user not found in database. " "REQUIRE_USER_IN_DB is enabled.",
                                     extra={"security_event": "user_not_in_db_rejected", "user_id": email},
                                 )
                                 raise HTTPException(
@@ -749,8 +748,7 @@ async def get_current_user(
                     # Check if strict user-in-DB mode is enabled
                     if settings.require_user_in_db:
                         logger.warning(
-                            f"Authentication rejected for {email}: user not found in database. "
-                            "REQUIRE_USER_IN_DB is enabled.",
+                            f"Authentication rejected for {email}: user not found in database. " "REQUIRE_USER_IN_DB is enabled.",
                             extra={"security_event": "user_not_in_db_rejected", "user_id": email},
                         )
                         raise HTTPException(
@@ -762,8 +760,7 @@ async def get_current_user(
                     # Platform admin bootstrap (only when REQUIRE_USER_IN_DB=false)
                     if email == getattr(settings, "platform_admin_email", "admin@example.com"):
                         logger.info(
-                            f"Platform admin bootstrap authentication for {email}. "
-                            "User authenticated via platform admin configuration.",
+                            f"Platform admin bootstrap authentication for {email}. " "User authenticated via platform admin configuration.",
                             extra={"security_event": "platform_admin_bootstrap", "user_id": email},
                         )
                         _batched_user = EmailUser(
@@ -879,8 +876,7 @@ async def get_current_user(
         # Check if strict user-in-DB mode is enabled
         if settings.require_user_in_db:
             logger.warning(
-                f"Authentication rejected for {email}: user not found in database. "
-                "REQUIRE_USER_IN_DB is enabled.",
+                f"Authentication rejected for {email}: user not found in database. " "REQUIRE_USER_IN_DB is enabled.",
                 extra={"security_event": "user_not_in_db_rejected", "user_id": email},
             )
             raise HTTPException(
@@ -894,8 +890,7 @@ async def get_current_user(
         # create a virtual admin user object
         if email == getattr(settings, "platform_admin_email", "admin@example.com"):
             logger.info(
-                f"Platform admin bootstrap authentication for {email}. "
-                "User authenticated via platform admin configuration.",
+                f"Platform admin bootstrap authentication for {email}. " "User authenticated via platform admin configuration.",
                 extra={"security_event": "platform_admin_bootstrap", "user_id": email},
             )
             # Create a virtual admin user for authentication purposes

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -198,6 +198,8 @@ class Settings(BaseSettings):
         default=False,
         description="Require all authenticated users to exist in the database. When true, disables the platform admin bootstrap mechanism. WARNING: Enabling this on a fresh deployment will lock you out.",
     )
+    embed_environment_in_tokens: bool = Field(default=False, description="Embed environment claim in gateway-issued JWTs for environment isolation")
+    validate_token_environment: bool = Field(default=False, description="Reject tokens with mismatched environment claim (tokens without env claim are allowed)")
 
     # SSO Configuration
     sso_enabled: bool = Field(default=False, description="Enable Single Sign-On authentication")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -969,9 +969,14 @@ def validate_security_configuration():
     if not getattr(settings, "require_user_in_db", False):
         is_ephemeral = ":memory:" in settings.database_url or settings.database_url == "sqlite:///./mcp.db"
         if is_ephemeral:
-            logger.warning(
-                "Using potentially ephemeral storage with platform admin bootstrap enabled. Consider using persistent storage or setting REQUIRE_USER_IN_DB=true for production."
-            )
+            logger.warning("Using potentially ephemeral storage with platform admin bootstrap enabled. Consider using persistent storage or setting REQUIRE_USER_IN_DB=true for production.")
+
+    # Warn about default JWT issuer/audience in non-development environments
+    if settings.environment != "development":
+        if settings.jwt_issuer == "mcpgateway":
+            logger.warning("Using default JWT_ISSUER in %s environment. Set a unique JWT_ISSUER per environment to prevent cross-environment token acceptance.", settings.environment)
+        if settings.jwt_audience == "mcpgateway-api":
+            logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", settings.environment)
 
     log_security_recommendations(security_status)
 

--- a/mcpgateway/utils/create_jwt_token.py
+++ b/mcpgateway/utils/create_jwt_token.py
@@ -46,8 +46,8 @@ import argparse
 import asyncio
 import datetime as _dt
 import sys
-import uuid
 from typing import Any, Dict, List, Sequence
+import uuid
 
 # Third-Party
 import jwt  # PyJWT
@@ -124,6 +124,10 @@ def _create_jwt_token(
     payload["iss"] = settings.jwt_issuer  # Issuer
     payload["aud"] = settings.jwt_audience  # Audience
     payload["jti"] = payload.get("jti") or str(uuid.uuid4())  # JWT ID for revocation support
+
+    # Optionally embed environment claim for cross-environment isolation
+    if settings.embed_environment_in_tokens:
+        payload["env"] = settings.environment
 
     # Handle legacy username format - convert to sub for consistency
     if "username" in payload and "sub" not in payload:


### PR DESCRIPTION
Closes #2141 

- Add EMBED_ENVIRONMENT_IN_TOKENS config to include env claim in gateway JWTs
- Add VALIDATE_TOKEN_ENVIRONMENT config to reject tokens with mismatched env claim
- Add startup warnings for default JWT_ISSUER/JWT_AUDIENCE in non-dev environments
- Update documentation, schema files, and Helm chart values