### PR TITLE
Security: Update pyasn1 to 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,9 @@ dev = [
     "vulture>=2.14",
     "websockets>=15.0.1",
     "yamllint>=1.37.1",
+    # Required by other packages but here for security version control (CVEs)
+    # Can be removed once the associated packages update their dependencies
+    "pyasn1>=0.6.2", # a2a-sdk; https://github.com/IBM/mcp-context-forge/security/dependabot/73
 ]
 
 # ----------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -3505,6 +3505,7 @@ dev = [
     { name = "pip-licenses" },
     { name = "pre-commit" },
     { name = "prospector", extra = ["with-everything"] },
+    { name = "pyasn1" },
     { name = "pydocstyle" },
     { name = "pylint" },
     { name = "pylint-pydantic" },
@@ -3655,6 +3656,7 @@ dev = [
     { name = "pip-licenses", specifier = ">=5.0.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "prospector", extras = ["with-everything"], specifier = ">=1.17.3" },
+    { name = "pyasn1", specifier = ">=0.6.2" },
     { name = "pydocstyle", specifier = ">=6.3.0" },
     { name = "pylint", specifier = ">=3.3.9" },
     { name = "pylint-pydantic", specifier = ">=0.3.5" },
@@ -5063,11 +5065,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Updates `pyasn1` from 0.6.1 to 0.6.2 to address Dependabot security alert #73
- Adds explicit `pyasn1>=0.6.2` pin to dev dependencies to ensure the patched version is used

## Test plan
- [ ] Verify CI passes
- [ ] Confirm Dependabot alert #73 is resolved after merge