### PR TITLE
chore: Replace echo /etc/passwd with useradd in Containerfile.lite

### DIFF
--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -214,12 +214,14 @@ LABEL maintainer="Mihai Criveti" \
 # - Python runtime (no devel packages)
 # - ca-certificates for HTTPS
 # - procps-ng for process management (ps command)
+# - shadow-utils for useradd command
 # ----------------------------------------------------------------------------
 # hadolint ignore=DL3041
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 \
         python${PYTHON_VERSION} \
         ca-certificates \
         procps-ng \
+        shadow-utils \
     && microdnf clean all \
     && rm -rf /var/cache/yum
 
@@ -231,7 +233,7 @@ RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3
 # ----------------------------------------------------------------------------
 # Create non-root user
 # ----------------------------------------------------------------------------
-RUN echo 'app:x:1001:0:app:/app:/sbin/nologin' >> /etc/passwd
+RUN useradd --uid 1001 --gid 0 --home-dir /app --shell /sbin/nologin --no-create-home --comment app app
 
 # ----------------------------------------------------------------------------
 # Copy the application from the builder stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         condition: service_healthy
     volumes:
       - nginx_cache:/var/cache/nginx    # Persistent cache storage
-      - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro  # Mount config as read-only
+      # - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro  # Mount config as read-only
     # TCP kernel tuning for 3000 concurrent connections
     # Note: net.core.* sysctls are host-level and cannot be set per-container
     # Only net.ipv4.* sysctls that are network-namespace aware work here


### PR DESCRIPTION
## Summary
- Replace direct `/etc/passwd` manipulation with proper `useradd` command in `Containerfile.lite`
- Add `shadow-utils` package to provide the `useradd` command in ubi-minimal
- Comment out nginx config mount in docker-compose.yml

## Motivation
Enterprise security scanning tools flag direct writes to `/etc/passwd` as suspicious behavior. Using the standard `useradd` command follows system conventions and avoids false positive security alerts.

## Changes
- Added `shadow-utils` package to microdnf install
- Replaced `echo 'app:x:1001:0:app:/app:/sbin/nologin' >> /etc/passwd` with `useradd --uid 1001 --gid 0 --home-dir /app --shell /sbin/nologin --no-create-home app`
- User attributes remain unchanged (UID 1001, GID 0, home /app, nologin shell)

Closes #2134
Closes #2190