### PR TITLE
Optimization: Fix Gateway N+1 Queries via Eager Loading

### DIFF
--- a/tests/unit/mcpgateway/test_multi_auth_headers.py
+++ b/tests/unit/mcpgateway/test_multi_auth_headers.py
@@ -328,7 +328,7 @@ class TestMultiAuthHeaders:
         monkeypatch.setattr(service, "_update_or_create_resources", MagicMock(return_value=[]))
         monkeypatch.setattr(service, "_update_or_create_prompts", MagicMock(return_value=[]))
         monkeypatch.setattr(service, "_notify_gateway_updated", AsyncMock())
-        monkeypatch.setattr(service, "_get_team_name", MagicMock(return_value=None))
+
         monkeypatch.setattr(service, "_prepare_gateway_for_read", lambda value: value)
 
         monkeypatch.setattr(GatewayRead, "model_validate", staticmethod(lambda value: value))


### PR DESCRIPTION
# ✨ Performance Enhancement PR

## 🔗 Epic / Issue
Closes #1994

---

## 🚀 Summary (1-2 sentences)
This PR resolves the N+1 query performance issue in the Gateway service by implementing eager loading for the team relationship. It introduces the email_team relationship and team property to the Gateway model and updates service methods to fetch all necessary data in a single database query, mirroring the optimization recently applied to the Server model.

---

## 🛠️ Fix Description
This PR addresses the N+1 query issue where retrieving a Gateway entity resulted in an additional database query to fetch the associated team name.

**1. Database Model Updates (mcpgateway/db.py)**

- Added an email_team relationship to the Gateway model. This relationship is configured to lazily load by default but can be eagerly loaded using joinedload.
- Added a team property to the Gateway model. This property serves as a proxy to retrieve the team name from the email_team relationship, ensuring consistent access without explicit query calls in the application logic.

**2. Service Layer Optimization (`mcpgateway/services/gateway_service.py`)**

- Eager Loading: Updated `get_gateway`, `update_gateway`, `set_gateway_state`, `create_gateway`, `delete_gateway`, and `_sync_gateway_with_oauth` method to use `db.execute()` with `joinedload(DbGateway.email_team)`. This instructs SQLAlchemy to fetch the Gateway and its associated `EmailTeam` in a single SQL query using a LEFT JOIN.
- Removed Helper: Deleted the `_get_team_name` helper method, which was previously responsible for the secondary query effectively eliminating the N+1 problem.

**3. Test Updates (`tests/unit/mcpgateway/services/test_gateway_service.py`)**

- Refactored unit tests to mock db.execute instead of db.get, reflecting the change in the service layer from simple primary key lookups to complex select statements with options.
- Updated mock_gateway fixtures to include the email_team relationship, ensuring tests accurately simulate the new data structure.

---

### ⚡ Impact Assessment

The following table demonstrates the reduction in database queries for key Gateway operations:

| Operation | Previous Queries | New Queries | Improvement |
|-----------|------------------|-------------|-------------|
| `get_gateway()` | 2+ (One for gateway + one per team lookup) | 1 (Gateway + Team via JOIN) | **50% Reduction** |
| `update_gateway()` | 2+ | 1 | **50% Reduction** |
| `set_gateway_state()` | 2+ | 1 | **50% Reduction** |
| `delete_gateway()` | Lazy loaded (N queries) | 1 (Eager loaded) | **Optimized** |
| `_sync_gateway_with_oauth()` | Lazy loaded (N queries) | 1 (Eager loaded) | **Optimized** |


---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)

This implementation follows the pattern established in PR #1962 and #1975 for the Server model. The _get_team_name helper method, which was responsible for the extra N+1 query, has been removed entirely.

