### PR TITLE
Synchronize Gateway Activation State Across Tools, Prompts, and Resources

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -5859,11 +5859,11 @@ async function viewServer(serverId) {
 
             const statusSpan = document.createElement("span");
             statusSpan.className = `px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                server.isActive
+                server.enabled
                     ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
                     : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
             }`;
-            statusSpan.textContent = server.isActive ? "Active" : "Inactive";
+            statusSpan.textContent = server.enabled ? "Active" : "Inactive";
             statusP.appendChild(statusSpan);
 
             tagsStatusDiv.appendChild(tagsP);


### PR DESCRIPTION
closes issue https://github.com/IBM/mcp-context-forge/issues/2212
This pull request enhances the gateway activation and deactivation process by ensuring that prompt and resource states are updated in sync with the gateway state, in addition to tools. It also updates the frontend to use the correct property for gateway status display and improves unit tests to cover these new behaviors.

**Gateway state management improvements:**

* When a gateway is activated or deactivated, the system now updates the states of all associated prompts and resources using the new `PromptService` and `ResourceService`, and invalidates their respective caches after batch updates.
* The `GatewayService` class is updated to instantiate and use `PromptService` and `ResourceService` for these state changes. [[1]](diffhunk://#diff-38347137ecdcac92c25748b3518980959a6b8343911b1f028f5d443d9cd49801R96-R97) [[2]](diffhunk://#diff-38347137ecdcac92c25748b3518980959a6b8343911b1f028f5d443d9cd49801R383-R384)

**Frontend status display update:**

* The admin UI now uses the `enabled` property instead of `isActive` to determine and display the gateway's active/inactive status.

**Unit test coverage enhancements:**

* Unit tests for gateway state changes now verify that state changes are applied to tools, prompts, and resources, with appropriate mocks and assertions added for the new services. [[1]](diffhunk://#diff-34b566e8482381769c4aa819039a721f93eaffd7e69a4945cc60cc0ebbd42b56L1101-R1101) [[2]](diffhunk://#diff-34b566e8482381769c4aa819039a721f93eaffd7e69a4945cc60cc0ebbd42b56R1117-R1124) [[3]](diffhunk://#diff-34b566e8482381769c4aa819039a721f93eaffd7e69a4945cc60cc0ebbd42b56R1135-R1136) [[4]](diffhunk://#diff-34b566e8482381769c4aa819039a721f93eaffd7e69a4945cc60cc0ebbd42b56L1137-R1147) [[5]](diffhunk://#diff-34b566e8482381769c4aa819039a721f93eaffd7e69a4945cc60cc0ebbd42b56R1163-R1170) [[6]](diffhunk://#diff-34b566e8482381769c4aa819039a721f93eaffd7e69a4945cc60cc0ebbd42b56R1181-R1182)