### PR TITLE
Fix serviceAccountName re-creating (wiping) existing DB

### DIFF
--- a/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
+++ b/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
@@ -30,7 +30,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: mcp-fast-time-server
           image: "{{ .Values.mcpFastTimeServer.image.repository }}:{{ .Values.mcpFastTimeServer.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -35,7 +35,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: mcp-context-forge
           image: "{{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-pgadmin.yaml
+++ b/charts/mcp-stack/templates/deployment-pgadmin.yaml
@@ -28,7 +28,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: pgadmin
           image: "{{ .Values.pgadmin.image.repository }}:{{ .Values.pgadmin.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-pgbouncer.yaml
+++ b/charts/mcp-stack/templates/deployment-pgbouncer.yaml
@@ -30,7 +30,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: pgbouncer
           image: "{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-postgres.yaml
+++ b/charts/mcp-stack/templates/deployment-postgres.yaml
@@ -46,7 +46,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       initContainers:
       {{- if and .Values.postgres.upgrade.enabled (eq $targetVersion "18") .Values.postgres.upgrade.backupCompleted }}
         # Init container to upgrade PostgreSQL data from version 17 to 18

--- a/charts/mcp-stack/templates/deployment-redis-commander.yaml
+++ b/charts/mcp-stack/templates/deployment-redis-commander.yaml
@@ -28,7 +28,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: redis-commander
           image: "{{ .Values.redisCommander.image.repository }}:{{ .Values.redisCommander.image.tag }}"

--- a/charts/mcp-stack/templates/deployment-redis.yaml
+++ b/charts/mcp-stack/templates/deployment-redis.yaml
@@ -31,7 +31,9 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"

--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -23,7 +23,9 @@ spec:
         app.kubernetes.io/component: migration
     spec:
       restartPolicy: {{ .Values.migration.restartPolicy }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
 
       containers:
         - name: migration

--- a/charts/mcp-stack/templates/job-postgres-backup.yaml
+++ b/charts/mcp-stack/templates/job-postgres-backup.yaml
@@ -15,7 +15,9 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: postgres-backup
           image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"

--- a/charts/mcp-stack/templates/job-postgres-migration-check.yaml
+++ b/charts/mcp-stack/templates/job-postgres-migration-check.yaml
@@ -15,7 +15,9 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: postgres-migration-check
           image: "{{ .Values.postgres.image.repository }}:18"

--- a/charts/mcp-stack/templates/minio-deployment.yaml
+++ b/charts/mcp-stack/templates/minio-deployment.yaml
@@ -19,7 +19,9 @@ spec:
         app.kubernetes.io/component: minio
         app: {{ include "mcp-stack.fullname" . }}-minio
     spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: minio
           image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fix critical data loss issue in Helm chart caused by unconditional `serviceAccountName` addition to postgres deployment. The change in commit [5b7888d9](https://github.com/IBM/mcp-context-forge/commit/5b7888d9) triggers postgres pod recreation.

## 🔁 Reproduction Steps

1. Deploy mcp-stack chart
2. Populate database with data
3. Upgrade to chart version containing commit 5b7888d9 or later (after Jan 14, 2026)
4. Observe postgres pod recreation due to pod template spec change
5. **Result**: All database data is lost due to new db being triggered

## 🐞 Root Cause

PR #1718 added `serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}` unconditionally to all deployments (`deployment-postgres.yaml` - line 49).

**The problem:**
- Adding a new field to pod template spec triggers a rolling update
- Rolling update recreates the pod
- Pod recreation wipes storage → **complete data loss**

**Why this is a breaking change:**
- The default `serviceAccount.create: false` means the helper returns `"default"`
- Even though the value is `"default"`, adding the field itself changes the pod spec
- Kubernetes treats this as a configuration change requiring pod recreation
- This affects ALL existing deployments, not just those using ServiceAccount features

## 💡 Fix Description

Make `serviceAccountName` conditional - only add it when `serviceAccount.create: true`:

```yaml
# Before (unconditional - BREAKS existing deployments)
serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}

# After (conditional - backward compatible)
{{- if .Values.serviceAccount.create }}
serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
{{- end }}
```

**Benefits:**
1. **Backward compatible**: Existing deployments with `create: false` (default) won't have field added
2. **No pod recreation**: Without field change, Kubernetes doesn't trigger rolling update
3. **Preserves data**: Ephemeral storage not wiped for users without persistence
4. **Opt-in behavior**: Users who need ServiceAccount must explicitly enable it
5. **Still functional**: ServiceAccount support works when explicitly enabled

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Existing deployment upgrades without pod recreation | Tested on live cluster | ✅ |
| Data persists after upgrade           | Verified database contents | ✅ |

**Manual Testing:**
1. Deployed chart with `persistence.enabled: false` and `serviceAccount.create: false`
2. Populated database with test data
3. Upgraded to patched chart version
4. Verified postgres pod was NOT recreated
5. Confirmed database data intact

## ✅ Checklist
- [x] Backward compatible with existing deployments
- [x] Verified no database pod recreation for default configuration

## 🔗 Related Issues

Fixes data loss regression introduced in #1718 