### PR TITLE
Align SSO service teams claim format with /tokens and /auth/login

### DIFF
--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -889,11 +889,11 @@ class SSOService:
 
         # Add user teams to token
         teams = user.get_teams()
-        token_data["teams"] = [{"id": team.id, "name": team.name, "slug": team.slug, "is_personal": team.is_personal, "role": user.get_team_role(team.id)} for team in teams]
+        token_data["teams"] = [team.id for team in teams]
 
         # Add namespaces for RBAC
         namespaces = [f"user:{user.email}"]
-        namespaces.extend([f"team:{team['slug']}" for team in token_data["teams"]])
+        namespaces.extend([f"team:{team.slug}" for team in teams])
         namespaces.append("public")
         token_data["namespaces"] = namespaces
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2233 

---

## 📌 Summary
It is a simple change to treat teams in the token claim format as list of team_ids instead of dicts.

Token reading code at the following places is backward compatible to handle dict format for teams.
- ` mcpgateway/auth.py:183-185`
- `mcpgateway/main.py:286-310`
- `mcpgateway/middleware/token_scoping.py:124-126`

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    pass    |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
