### PR TITLE
2251 - Resolve server deactivation error for servers with email teams

### DIFF
--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1114,7 +1114,7 @@ class ServerService:
                     selectinload(DbServer.resources),
                     selectinload(DbServer.prompts),
                     selectinload(DbServer.a2a_agents),
-                    joinedload(DbServer.email_team),
+                    selectinload(DbServer.email_team),
                 ],
             )
             if not server:
@@ -1432,7 +1432,7 @@ class ServerService:
                     selectinload(DbServer.resources),
                     selectinload(DbServer.prompts),
                     selectinload(DbServer.a2a_agents),
-                    joinedload(DbServer.email_team),
+                    selectinload(DbServer.email_team),
                 ],
             )
             if not server:


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
This PR fixes a critical bug that prevented the deactivation of a virtual server when it was associated with an email notification team. The action would fail due to a database error, making it impossible to disable certain servers through the Admin UI or API. This fix ensures the deactivation process is robust and reliable, regardless of the server's associations

Closes #2251

## 🔁 Reproduction Steps
1. Create a virtual server.
2. Create an email notification team and associate it with the server.
3. Navigate to the Admin UI and attempt to deactivate the server.
4. Observe the operation fails with an internal server error.

## 🐞 Root Cause
The root cause of the issue was a psycopg.errors.FeatureNotSupported error from PostgreSQL, stating: "FOR UPDATE cannot be applied to the nullable side of an outer join".

This occurred because the set_server_state service method used SQLAlchemy's joinedload strategy to fetch the server along with its related email_team. This created a LEFT OUTER JOIN in the SQL query. When the database
transaction attempted to lock the server row for the update using FOR UPDATE, it conflicted with the outer join, as PostgreSQL does not support locking on the nullable side of such joins.

## 💡 Fix Description
The fix replaces the data loading strategy for the email_team relationship within `ServerService`. The `joinedload` has been replaced with `selectinload`.

selectinload resolves the problem by issuing a separate `SELECT` statement to load the related email_team after the server has been retrieved. This decouples the queries, avoiding the problematic `LEFT OUTER JOIN` in the initial
`SELECT ... FOR UPDATE` statement and allowing the row lock to be acquired without error.

In addition to the core fix, this PR introduces comprehensive unit tests for the `set_server_state` method and the corresponding admin API endpoint. These tests cover activation, deactivation, permission handling, and
specifically verify that the fix works correctly when an email team is present, preventing future regressions.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
