### PR TITLE
Modify http config export type from http to streamable-http

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -17645,7 +17645,7 @@ function generateConfig(server, configType) {
             return {
                 servers: {
                     [cleanServerName]: {
-                        type: "http",
+                        type: "streamable-http",
                         url: `${baseUrl}/servers/${server.id}/mcp`,
                         headers: {
                             Authorization: "Bearer your-token-here",


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Changes the "type" for the HTTP config export from "http" to "streamable-http" as that is what agents expect.

## 🔁 Reproduction Steps
https://github.com/IBM/mcp-context-forge/issues/2254

Log in to Context Forge UI
Go to Virtual Servers page
If you don't have a Virtual Server created, you will need to create one
Select the "Export Config" button for one of your Virtual Servers.
Choose the option for "HTTP (REST clients)"
See the configuration JSON contain the setting "type": "http"

## 🐞 Root Cause
The type was set incorrectly in the static/admin.js generateConfig http case. 

## 💡 Fix Description
Changed type from "http" to "streamable-http"

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅   |
| Unit tests                            | `make test`          |    ✅     |
| Coverage ≥ 90 %                       | `make coverage`      |     ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅     |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
