### PR TITLE
fix(tests): add missing fields required by pydantic validation

### DIFF
--- a/tests/unit/mcpgateway/services/test_authorization_access.py
+++ b/tests/unit/mcpgateway/services/test_authorization_access.py
@@ -85,6 +85,16 @@ def create_mock_tool(visibility="public", owner_email=None, team_id=None, enable
     tool.custom_name_slug = None
     tool.display_name = None
     tool.description = "A test tool"
+    tool.created_by = None
+    tool.created_from_ip = None
+    tool.created_via = None
+    tool.created_user_agent = None
+    tool.modified_by = None
+    tool.modified_from_ip = None
+    tool.modified_via = None
+    tool.modified_user_agent = None
+    tool.import_batch_id = None
+    tool.federation_source = None
     return tool
 
 


### PR DESCRIPTION
**Summary**                                                                                                             

Add missing audit trail fields to `create_mock_tool` test helper to fix Pydantic validation errors.

**Additional details**
 `tests/unit/mcpgateway/services/test_authorization_access.py` tests failing model validation (Mac, Python 3.13.7). 