### PR TITLE
[FEATURE][TOOLOPS]: Add LLM settings support for toolops model selection

### DIFF
--- a/tests/unit/mcpgateway/test_final_coverage_push.py
+++ b/tests/unit/mcpgateway/test_final_coverage_push.py
@@ -525,7 +525,7 @@ async def test_toolops_execute_nl_testcases_success(monkeypatch):
         AsyncMock(return_value=["ok"]),
     )
 
-    payload = toolops_router.ToolNLTestInput(tool_id="tool1", tool_nl_test_cases=["hello"])
+    payload = toolops_router.ToolNLTestInput(tool_id="tool1", tool_nl_test_cases=["hello"], model_id="model1")
     result = await _call_toolops(
         toolops_router.execute_tool_nl_testcases,
         monkeypatch,


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Code changes to toolops modules for supporting LLM model configuration using "LLM Settings" tab. Several toolops related modules and test cases are updated to support "Gateway" LLM provider model . Also "Toolops" tab in the UI now supports selecting Gateway LLM Model. Important code change is addition of model_id as the input parameter to toolops functionality and unit test cases related to toolops are updated according to the additional input parameter .

## 🔁 Reproduction Steps
_Link the issue and minimal steps to reproduce the bug._

## 🐞 Root Cause
Changes required to "Toolops" functionality to support LLM model configurations provided using "LLM Settings" Tab.

## 💡 Fix Description
Updated toolops modules to use model_id configured from "LLM Settings" . "model_id" is selected from the "Toolops" tab of UI and test case generation , enrichment modules will use the user selected "model_id". This PR will contains changes to below files
* mcpgateway/routers/toolops_router.py - in this file "model_id" is added as additional input parameter for toolops router
* mcpgateway/static/admin.js , mcpgateway/templates/admin.html - code is updated for "Toolops" tab to include "model_id" selection as a dropdown
* mcpgateway/toolops/utils/llm_util.py - majority of code is changed in this file to support gateway LLM provider and appropriate llm service instance is created using the "model_id" selected by user.
* mcpgateway/toolops/toolops_altk_service.py - in this file "model_id" is added as additional input parameter for toolops functionality and LLM configurations are created using the provider information in the database.
* tests/unit/mcpgateway/test_toolops_altk_service.py , tests/unit/mcpgateway/test_toolops_utils.py - in these files code is changed to handle the "model_id" input parameter and Gateway LLM provider Configurations.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed