### PR TITLE
Fix Admin UI to Display Tag Values Instead of Objects

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -3386,7 +3386,7 @@ async function viewAgent(agentId) {
                         "inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mr-1";
                     const raw =
                         typeof tag === "object" && tag !== null
-                            ? tag.id || tag.label
+                            ? tag.id || tag.label || JSON.stringify(tag)
                             : tag;
                     tagSpan.textContent = raw;
                     tagsP.appendChild(tagSpan);
@@ -4300,7 +4300,7 @@ async function viewResource(resourceId) {
                         "inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mr-1 mb-1 dark:bg-blue-900 dark:text-blue-200";
                     const raw =
                         typeof tag === "object" && tag !== null
-                            ? tag.id || tag.label
+                            ? tag.id || tag.label || JSON.stringify(tag)
                             : tag;
                     tagSpan.textContent = raw;
                     tagsP.appendChild(tagSpan);
@@ -5223,9 +5223,8 @@ async function viewGateway(gatewayId) {
                         "inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mr-1";
                     const raw =
                         typeof tag === "object" && tag !== null
-                            ? tag.id || tag.label
+                            ? tag.id || tag.label || JSON.stringify(tag)
                             : tag;
-
                     tagSpan.textContent = raw;
                     tagsP.appendChild(tagSpan);
                 });
@@ -14156,7 +14155,7 @@ async function viewTool(toolId) {
                         .map((tag) => {
                             const raw =
                                 typeof tag === "object" && tag !== null
-                                    ? tag.id || tag.label
+                                    ? tag.id || tag.label || JSON.stringify(tag)
                                     : tag;
                             return `<span class="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mr-1 mb-1 dark:bg-blue-900 dark:text-blue-200">${escapeHtml(raw)}</span>`;
                         })
@@ -20734,7 +20733,15 @@ function showTokenDetailsModal(token) {
             <div class="mb-6">
                 <h4 class="text-md font-semibold text-gray-900 dark:text-white mb-3 border-b border-gray-200 dark:border-gray-600 pb-2">Tags</h4>
                 <div class="flex flex-wrap gap-2">
-                    ${token.tags.map((tag) => `<span class="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs rounded">${escapeHtml(tag)}</span>`).join("")}
+                    ${token.tags
+                        .map((tag) => {
+                            const raw =
+                                typeof tag === "object" && tag !== null
+                                    ? tag.id || tag.label || JSON.stringify(tag)
+                                    : tag;
+                            return `<span class="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs rounded">${escapeHtml(raw)}</span>`;
+                        })
+                        .join("")}
                 </div>
             </div>
             `


### PR DESCRIPTION
closes issue #2267
This pull request updates how tags are displayed in the admin interface to better handle cases where tags may be objects rather than simple strings. The changes ensure that, when a tag is an object, either its `id` or `label` is shown, improving robustness and consistency across different admin views.

**Improvements to tag display logic:**

* Updated tag rendering in `viewAgent`, `viewResource`, and `viewGateway` functions to check if a tag is an object and display its `id` or `label` if available, otherwise showing the tag as-is. [[1]](diffhunk://#diff-c14eef5270c1a251b36b2ef8aab846f5cf354a8fa43b10f0c367ca6f176d58ecL3387-R3391) [[2]](diffhunk://#diff-c14eef5270c1a251b36b2ef8aab846f5cf354a8fa43b10f0c367ca6f176d58ecL4297-R4305) [[3]](diffhunk://#diff-c14eef5270c1a251b36b2ef8aab846f5cf354a8fa43b10f0c367ca6f176d58ecL5216-R5229)
* Modified the tag rendering in `viewTool` to use the same logic when generating HTML, ensuring object tags are handled correctly in the tool view as well.