### PR TITLE
perf: reduce SQLite busy_timeout default to 5s and make configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,12 @@ DB_MAX_BACKOFF_SECONDS=30
 # Set to 0 to disable, 1 to prepare immediately. Higher values reduce memory usage.
 DB_PREPARE_THRESHOLD=5
 
+# SQLite Configuration
+# SQLite busy timeout (milliseconds) - maximum time SQLite will block while waiting
+# to acquire a database lock before returning SQLITE_BUSY. Limits lock-wait latency
+# and prevents prolonged thread blocking under write contention (default: 5000ms)
+DB_SQLITE_BUSY_TIMEOUT=5000
+
 # Database Performance Optimization
 # Use database-native percentile functions for observability performance metrics
 # When true: PostgreSQL uses native percentile_cont (5-10x faster for large datasets)

--- a/README.md
+++ b/README.md
@@ -2155,6 +2155,7 @@ Automatic management of metrics data to prevent unbounded table growth and maint
 | `DB_POOL_RECYCLE`.      | Recycle connections (secs)      | `3600`  | int > 0 |
 | `DB_MAX_RETRIES` .      | Max retry attempts at startup (exponential backoff) | `30`    | int > 0 |
 | `DB_RETRY_INTERVAL_MS`  | Base retry interval (ms), doubles each attempt up to 30s | `2000`  | int > 0 |
+| `DB_SQLITE_BUSY_TIMEOUT`| SQLite lock wait timeout (ms)   | `5000`  | 1000-60000 |
 
 ### Cache Backend
 

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -65,6 +65,7 @@ Kubernetes: `>=1.21.0-0`
 | mcpContextForge.config.DB_POOL_SIZE | string | `"15"` |  |
 | mcpContextForge.config.DB_POOL_TIMEOUT | string | `"30"` |  |
 | mcpContextForge.config.DB_RETRY_INTERVAL_MS | string | `"2000"` |  |
+| mcpContextForge.config.DB_SQLITE_BUSY_TIMEOUT | string | `"5000"` |  |
 | mcpContextForge.config.DEBUG | string | `"false"` |  |
 | mcpContextForge.config.DEFAULT_PASSTHROUGH_HEADERS | string | `"[\"X-Tenant-Id\", \"X-Trace-Id\"]"` |  |
 | mcpContextForge.config.DEFAULT_ROOTS | string | `"[]"` |  |
@@ -735,3 +736,4 @@ Kubernetes: `>=1.21.0-0`
 | serviceAccount.automountServiceAccountToken | bool | `true` | Mount the ServiceAccount token in pods. Only applies when create=true (existing ServiceAccounts control their own token mounting) |
 | serviceAccount.create | bool | `false` | Create a ServiceAccount for all pods in this release |
 | serviceAccount.name | string | `""` | ServiceAccount name. If empty and create=true, uses release fullname. If create=false, uses this name or "default" |
+

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -503,6 +503,11 @@
               "description": "Database pool recycle time",
               "default": "3600"
             },
+            "DB_SQLITE_BUSY_TIMEOUT": {
+              "type": "string",
+              "description": "SQLite lock wait timeout in milliseconds",
+              "default": "5000"
+            },
             "CACHE_TYPE": {
               "type": "string",
               "description": "Cache backend type",

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -196,6 +196,7 @@ mcpContextForge:
     DB_MAX_OVERFLOW: "30"            # extra connections allowed beyond pool size
     DB_POOL_TIMEOUT: "30"            # seconds to wait for a connection
     DB_POOL_RECYCLE: "3600"          # recycle connections after N seconds
+    DB_SQLITE_BUSY_TIMEOUT: "5000"   # SQLite lock wait timeout in ms (1000-60000)
 
     # ─ Cache behaviour ─
     CACHE_TYPE: redis                # Backend cache driver (redis, memory, database)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1396,6 +1396,9 @@ class Settings(BaseSettings):
         description="Pre-ping connections: auto, true, or false",
     )
 
+    # SQLite busy timeout: Maximum time (ms) SQLite will wait to acquire a database lock before returning SQLITE_BUSY.
+    db_sqlite_busy_timeout: int = Field(default=5000, ge=1000, le=60000, description="SQLite busy timeout in milliseconds (default: 5000ms)")
+
     # Cache
     cache_type: Literal["redis", "memory", "none", "database"] = "database"  # memory or redis or database
     redis_url: Optional[str] = "redis://localhost:6379/0"

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -288,8 +288,8 @@ if backend == "sqlite":
         cursor = dbapi_conn.cursor()
         # Enable WAL mode for better concurrency
         cursor.execute("PRAGMA journal_mode=WAL")
-        # Set busy timeout to 30 seconds (30000 ms) to handle lock contention from observability
-        cursor.execute("PRAGMA busy_timeout=30000")
+        # Configure SQLite lock wait upper bound (ms) to prevent prolonged blocking under contention
+        cursor.execute(f"PRAGMA busy_timeout={settings.db_sqlite_busy_timeout}")
         # Synchronous=NORMAL is safe with WAL mode and improves performance
         cursor.execute("PRAGMA synchronous=NORMAL")
         # Increase cache size for better performance (negative value = KB)


### PR DESCRIPTION
Address - issue #1612 
- reduces the default SQLite busy_timeout from 30 seconds to 5 seconds and makes it configurable via an environment variable.

## Acceptance Criteria

- [x] Default timeout reduced to 5000ms (5 seconds)
- [x] Timeout configurable via `DB_SQLITE_BUSY_TIMEOUT` environment variable
- [x] `.env.example` documents the setting
- [x] Setting follows `db_*` naming convention
- [x] No regression in existing tests
- [x] Passes `make verify`
