### PR TITLE
fix: use short-lived DB sessions in RBAC permission checks

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11386,7 +11386,7 @@ async def admin_delete_resource(resource_id: str, request: Request, db: Session 
     error_message = None
     try:
         await resource_service.delete_resource(
-            user["db"] if isinstance(user, dict) else db,
+            db,
             resource_id,
             user_email=user_email,
             purge_metrics=purge_metrics,

--- a/mcpgateway/routers/llm_admin_router.py
+++ b/mcpgateway/routers/llm_admin_router.py
@@ -15,9 +15,10 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 import orjson
+from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.db import LLMProviderType
+from mcpgateway.db import get_db, LLMProviderType
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.services.llm_provider_service import (
     LLMModelNotFoundError,
@@ -48,6 +49,7 @@ async def get_providers_partial(
     request: Request,
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(50, ge=1, le=100, description="Items per page"),
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Get HTML partial for LLM providers list.
@@ -56,13 +58,12 @@ async def get_providers_partial(
         request: FastAPI request object.
         page: Page number.
         per_page: Items per page.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
         HTML partial for providers table.
     """
-    db = current_user_ctx["db"]
-
     providers, total = llm_provider_service.list_providers(
         db=db,
         page=page,
@@ -124,6 +125,7 @@ async def get_models_partial(
     provider_id: Optional[str] = Query(None, description="Filter by provider ID"),
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(50, ge=1, le=100, description="Items per page"),
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Get HTML partial for LLM models list.
@@ -133,13 +135,12 @@ async def get_models_partial(
         provider_id: Filter by provider ID.
         page: Page number.
         per_page: Items per page.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
         HTML partial for models table.
     """
-    db = current_user_ctx["db"]
-
     models, total = llm_provider_service.list_models(
         db=db,
         provider_id=provider_id,
@@ -219,6 +220,7 @@ async def get_models_partial(
 async def set_provider_state_html(
     request: Request,
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Set provider enabled state and return updated row.
@@ -226,6 +228,7 @@ async def set_provider_state_html(
     Args:
         request: FastAPI request object.
         provider_id: Provider ID to update.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -235,7 +238,6 @@ async def set_provider_state_html(
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         provider = llm_provider_service.set_provider_state(db, provider_id)
 
         return request.app.state.templates.TemplateResponse(
@@ -264,6 +266,7 @@ async def set_provider_state_html(
 async def check_provider_health(
     request: Request,
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ):
     """Check provider health and return status JSON.
@@ -271,6 +274,7 @@ async def check_provider_health(
     Args:
         request: FastAPI request object.
         provider_id: Provider ID to check.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -280,7 +284,6 @@ async def check_provider_health(
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         health = await llm_provider_service.check_provider_health(db, provider_id)
 
         return {
@@ -298,6 +301,7 @@ async def check_provider_health(
 async def delete_provider_html(
     request: Request,
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Delete provider and return empty response for row removal.
@@ -305,6 +309,7 @@ async def delete_provider_html(
     Args:
         request: FastAPI request object.
         provider_id: Provider ID to delete.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -314,7 +319,6 @@ async def delete_provider_html(
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         llm_provider_service.delete_provider(db, provider_id)
         return HTMLResponse(content="", status_code=200)
     except LLMProviderNotFoundError as e:
@@ -331,6 +335,7 @@ async def delete_provider_html(
 async def set_model_state_html(
     request: Request,
     model_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Set model enabled state and return updated row.
@@ -338,6 +343,7 @@ async def set_model_state_html(
     Args:
         request: FastAPI request object.
         model_id: Model ID to update.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -347,7 +353,6 @@ async def set_model_state_html(
         HTTPException: If model is not found.
     """
     try:
-        db = current_user_ctx["db"]
         model = llm_provider_service.set_model_state(db, model_id)
 
         try:
@@ -383,6 +388,7 @@ async def set_model_state_html(
 async def delete_model_html(
     request: Request,
     model_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Delete model and return empty response for row removal.
@@ -390,6 +396,7 @@ async def delete_model_html(
     Args:
         request: FastAPI request object.
         model_id: Model ID to delete.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -399,7 +406,6 @@ async def delete_model_html(
         HTTPException: If model is not found.
     """
     try:
-        db = current_user_ctx["db"]
         llm_provider_service.delete_model(db, model_id)
         return HTMLResponse(content="", status_code=200)
     except LLMModelNotFoundError as e:
@@ -415,12 +421,14 @@ async def delete_model_html(
 @require_permission("admin.system_config")
 async def get_api_info_partial(
     request: Request,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Get HTML partial for LLM API info and testing.
 
     Args:
         request: FastAPI request object.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -428,8 +436,6 @@ async def get_api_info_partial(
     """
     # First-Party
     from mcpgateway.config import settings
-
-    db = current_user_ctx["db"]
 
     # Get enabled providers and models
     providers, total_providers = llm_provider_service.list_providers(db, enabled_only=True)
@@ -481,6 +487,7 @@ async def get_api_info_partial(
 @require_permission("admin.system_config")
 async def admin_test_api(
     request: Request,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ):
     """Test LLM API without requiring an API key.
@@ -490,6 +497,7 @@ async def admin_test_api(
 
     Args:
         request: FastAPI request object.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -505,7 +513,6 @@ async def admin_test_api(
     from mcpgateway.services.llm_proxy_service import LLMProxyService
     from mcpgateway.utils.orjson_response import ORJSONResponse
 
-    db = current_user_ctx["db"]
     body = orjson.loads(await request.body())
 
     test_type = body.get("test_type", "models")
@@ -649,6 +656,7 @@ async def get_provider_configs(
 async def fetch_provider_models(
     request: Request,
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ):
     """Fetch available models from a provider's API.
@@ -656,6 +664,7 @@ async def fetch_provider_models(
     Args:
         request: FastAPI request object.
         provider_id: Provider ID to fetch models from.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -669,8 +678,6 @@ async def fetch_provider_models(
 
     # First-Party
     from mcpgateway.utils.services_auth import decode_auth
-
-    db = current_user_ctx["db"]
 
     try:
         provider = llm_provider_service.get_provider(db, provider_id)
@@ -783,6 +790,7 @@ async def fetch_provider_models(
 async def sync_provider_models(
     request: Request,
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ):
     """Sync models from provider API to database.
@@ -793,6 +801,7 @@ async def sync_provider_models(
     Args:
         request: FastAPI request object.
         provider_id: Provider ID to sync models for.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -801,10 +810,8 @@ async def sync_provider_models(
     # First-Party
     from mcpgateway.llm_schemas import LLMModelCreate
 
-    db = current_user_ctx["db"]
-
     # First fetch models from the provider
-    fetch_result = await fetch_provider_models(request, provider_id, current_user_ctx)
+    fetch_result = await fetch_provider_models(request, provider_id, db, current_user_ctx)
 
     if not fetch_result.get("success"):
         return fetch_result

--- a/mcpgateway/routers/llm_config_router.py
+++ b/mcpgateway/routers/llm_config_router.py
@@ -65,12 +65,14 @@ llm_provider_service = LLMProviderService()
 @require_permission("admin.system_config")
 async def create_provider(
     provider_data: LLMProviderCreate,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMProviderResponse:
     """Create a new LLM provider.
 
     Args:
         provider_data: Provider configuration data.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -80,7 +82,6 @@ async def create_provider(
         HTTPException: If provider name conflicts or creation fails.
     """
     try:
-        db = current_user_ctx["db"]
         provider = llm_provider_service.create_provider(
             db=db,
             provider_data=provider_data,
@@ -109,6 +110,7 @@ async def list_providers(
     enabled_only: bool = Query(False, description="Only return enabled providers"),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=100, description="Items per page"),
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMProviderListResponse:
     """List all LLM providers.
@@ -117,12 +119,12 @@ async def list_providers(
         enabled_only: Filter to enabled providers only.
         page: Page number.
         page_size: Items per page.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
         Paginated list of providers.
     """
-    db = current_user_ctx["db"]
     providers, total = llm_provider_service.list_providers(
         db=db,
         enabled_only=enabled_only,
@@ -149,12 +151,14 @@ async def list_providers(
 @require_permission("admin.system_config")
 async def get_provider(
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMProviderResponse:
     """Get an LLM provider by ID.
 
     Args:
         provider_id: Provider ID.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -164,7 +168,6 @@ async def get_provider(
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         provider = llm_provider_service.get_provider(db, provider_id)
         model_count = len(provider.models)
         return llm_provider_service.to_provider_response(provider, model_count)
@@ -182,6 +185,7 @@ async def get_provider(
 async def update_provider(
     provider_id: str,
     provider_data: LLMProviderUpdate,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMProviderResponse:
     """Update an LLM provider.
@@ -189,6 +193,7 @@ async def update_provider(
     Args:
         provider_id: Provider ID.
         provider_data: Updated provider data.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -198,7 +203,6 @@ async def update_provider(
         HTTPException: If provider is not found or name conflicts.
     """
     try:
-        db = current_user_ctx["db"]
         provider = llm_provider_service.update_provider(
             db=db,
             provider_id=provider_id,
@@ -222,19 +226,20 @@ async def update_provider(
 @require_permission("admin.system_config")
 async def delete_provider(
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> None:
     """Delete an LLM provider.
 
     Args:
         provider_id: Provider ID.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Raises:
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         llm_provider_service.delete_provider(db, provider_id)
     except LLMProviderNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -250,6 +255,7 @@ async def delete_provider(
 async def set_provider_state(
     provider_id: str,
     activate: Optional[bool] = Query(None, description="Set enabled state. If not provided, inverts current state."),
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMProviderResponse:
     """Set provider enabled state.
@@ -257,6 +263,7 @@ async def set_provider_state(
     Args:
         provider_id: Provider ID.
         activate: If provided, sets enabled to this value. If None, inverts current state.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -266,7 +273,6 @@ async def set_provider_state(
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         provider = llm_provider_service.set_provider_state(db, provider_id, activate)
         model_count = len(provider.models)
         return llm_provider_service.to_provider_response(provider, model_count)
@@ -283,12 +289,14 @@ async def set_provider_state(
 @require_permission("admin.system_config")
 async def check_provider_health(
     provider_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> ProviderHealthCheck:
     """Check health of an LLM provider.
 
     Args:
         provider_id: Provider ID.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -298,7 +306,6 @@ async def check_provider_health(
         HTTPException: If provider is not found.
     """
     try:
-        db = current_user_ctx["db"]
         return await llm_provider_service.check_provider_health(db, provider_id)
     except LLMProviderNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -319,12 +326,14 @@ async def check_provider_health(
 @require_permission("admin.system_config")
 async def create_model(
     model_data: LLMModelCreate,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMModelResponse:
     """Create a new LLM model.
 
     Args:
         model_data: Model configuration data.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -334,7 +343,6 @@ async def create_model(
         HTTPException: If provider is not found or model conflicts.
     """
     try:
-        db = current_user_ctx["db"]
         model = llm_provider_service.create_model(db, model_data)
         provider = llm_provider_service.get_provider(db, model.provider_id)
         return llm_provider_service.to_model_response(model, provider)
@@ -356,6 +364,7 @@ async def list_models(
     enabled_only: bool = Query(False, description="Only return enabled models"),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=100, description="Items per page"),
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMModelListResponse:
     """List all LLM models.
@@ -365,12 +374,12 @@ async def list_models(
         enabled_only: Filter to enabled models only.
         page: Page number.
         page_size: Items per page.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
         Paginated list of models.
     """
-    db = current_user_ctx["db"]
     models, total = llm_provider_service.list_models(
         db=db,
         provider_id=provider_id,
@@ -404,12 +413,14 @@ async def list_models(
 @require_permission("admin.system_config")
 async def get_model(
     model_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMModelResponse:
     """Get an LLM model by ID.
 
     Args:
         model_id: Model ID.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -419,7 +430,6 @@ async def get_model(
         HTTPException: If model is not found.
     """
     try:
-        db = current_user_ctx["db"]
         model = llm_provider_service.get_model(db, model_id)
         try:
             provider = llm_provider_service.get_provider(db, model.provider_id)
@@ -440,6 +450,7 @@ async def get_model(
 async def update_model(
     model_id: str,
     model_data: LLMModelUpdate,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMModelResponse:
     """Update an LLM model.
@@ -447,6 +458,7 @@ async def update_model(
     Args:
         model_id: Model ID.
         model_data: Updated model data.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -456,7 +468,6 @@ async def update_model(
         HTTPException: If model is not found.
     """
     try:
-        db = current_user_ctx["db"]
         model = llm_provider_service.update_model(db, model_id, model_data)
         try:
             provider = llm_provider_service.get_provider(db, model.provider_id)
@@ -476,19 +487,20 @@ async def update_model(
 @require_permission("admin.system_config")
 async def delete_model(
     model_id: str,
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> None:
     """Delete an LLM model.
 
     Args:
         model_id: Model ID.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Raises:
         HTTPException: If model is not found.
     """
     try:
-        db = current_user_ctx["db"]
         llm_provider_service.delete_model(db, model_id)
     except LLMModelNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -504,6 +516,7 @@ async def delete_model(
 async def set_model_state(
     model_id: str,
     activate: Optional[bool] = Query(None, description="Set enabled state. If not provided, inverts current state."),
+    db: Session = Depends(get_db),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
 ) -> LLMModelResponse:
     """Set model enabled state.
@@ -511,6 +524,7 @@ async def set_model_state(
     Args:
         model_id: Model ID.
         activate: If provided, sets enabled to this value. If None, inverts current state.
+        db: Database session.
         current_user_ctx: Authenticated user context.
 
     Returns:
@@ -520,7 +534,6 @@ async def set_model_state(
         HTTPException: If model is not found.
     """
     try:
-        db = current_user_ctx["db"]
         model = llm_provider_service.set_model_state(db, model_id, activate)
         try:
             provider = llm_provider_service.get_provider(db, model.provider_id)

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -112,10 +112,9 @@ async def client(app_with_temp_db):
             return next(test_db_dependency())
         return test_db_dependency
 
-    # Create mock user context with actual test database session
+    # Create mock user context (db no longer needed - permission decorators use fresh_db_session(), Issue #1865)
     test_db_session = get_test_db_session()
     test_user_context = create_mock_user_context(email="admin@example.com", full_name="Test Admin", is_admin=True)
-    test_user_context["db"] = test_db_session
 
     # Mock admin authentication function
     async def mock_require_admin_auth():
@@ -342,7 +341,7 @@ class TestAdminToolAPIs:
         from mcpgateway.services.team_management_service import TeamManagementService
 
         # Get db session from test fixture context
-        # The client fixture sets test_user_context["db"]
+        # Note: user context no longer includes db (Issue #1865)
         db = None
         if hasattr(client, "_default_params") and "db" in client._default_params:
             db = client._default_params["db"]

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -189,9 +189,8 @@ async def temp_db():
         """Mock JWT token function."""
         return generate_test_jwt()
 
-    # Create custom user context with real database session
+    # Create custom user context (db no longer needed - permission decorators use fresh_db_session(), Issue #1865)
     test_user_context = create_mock_user_context(email="testuser@example.com", full_name="Test User", is_admin=True)
-    test_user_context["db"] = TestSessionLocal()  # Use real database session from this fixture
 
     # Create a simple mock function for get_current_user_with_permissions
     async def simple_mock_user_with_permissions():

--- a/tests/e2e/test_oauth_protected_resource.py
+++ b/tests/e2e/test_oauth_protected_resource.py
@@ -142,7 +142,7 @@ async def oauth_test_db():
         return generate_test_jwt()
 
     test_user_context = create_mock_user_context(email="testuser@example.com", full_name="Test User", is_admin=True)
-    test_user_context["db"] = TestSessionLocal()
+    # Note: db no longer in user context - permission decorators use fresh_db_session() (Issue #1865)
 
     async def simple_mock_user_with_permissions():
         return test_user_context

--- a/tests/integration/test_concurrency_row_locking.py
+++ b/tests/integration/test_concurrency_row_locking.py
@@ -107,7 +107,7 @@ async def client(app_with_temp_db):
         test_db_session.commit()
 
     test_user_context = create_mock_user_context(email="admin@example.com", full_name="Test Admin", is_admin=True)
-    test_user_context["db"] = test_db_session
+    # Note: db no longer in user context - permission decorators use fresh_db_session() (Issue #1865)
 
     async def mock_require_admin_auth():
         return "admin@example.com"

--- a/tests/unit/mcpgateway/middleware/test_auth_method_propagation.py
+++ b/tests/unit/mcpgateway/middleware/test_auth_method_propagation.py
@@ -103,9 +103,6 @@ async def test_auth_method_in_user_context():
     mock_request.headers = {"user-agent": "TestAgent"}
     mock_request.cookies = {"jwt_token": "test-token"}
 
-    # Create mock database session
-    mock_db = MagicMock()
-
     # Create mock user
     mock_user = MagicMock()
     mock_user.email = "test@example.com"
@@ -116,23 +113,19 @@ async def test_auth_method_in_user_context():
     with patch("mcpgateway.middleware.rbac.get_current_user", new_callable=AsyncMock) as mock_get_user:
         mock_get_user.return_value = mock_user
 
-        # Mock the database dependency
-        with patch("mcpgateway.middleware.rbac.get_db") as mock_get_db:
-            mock_get_db.return_value = mock_db
+        # Call get_current_user_with_permissions
+        # Note: db parameter removed in Issue #1865 - permission decorators now use fresh_db_session()
+        user_context = await get_current_user_with_permissions(
+            request=mock_request,
+            credentials=None,
+            jwt_token="test-token",
+        )
 
-            # Call get_current_user_with_permissions
-            user_context = await get_current_user_with_permissions(
-                request=mock_request,
-                credentials=None,
-                jwt_token="test-token",
-                db=mock_db,
-            )
-
-            # Verify user_context includes auth_method and request_id
-            assert user_context["auth_method"] == "simple_token"
-            assert user_context["request_id"] == "test-request-id"
-            assert user_context["email"] == "test@example.com"
-            assert user_context["full_name"] == "Test User"
-            assert user_context["is_admin"] is False
-            assert user_context["ip_address"] == "127.0.0.1"
-            assert user_context["user_agent"] == "TestAgent"
+        # Verify user_context includes auth_method and request_id
+        assert user_context["auth_method"] == "simple_token"
+        assert user_context["request_id"] == "test-request-id"
+        assert user_context["email"] == "test@example.com"
+        assert user_context["full_name"] == "Test User"
+        assert user_context["is_admin"] is False
+        assert user_context["ip_address"] == "127.0.0.1"
+        assert user_context["user_agent"] == "TestAgent"

--- a/tests/unit/mcpgateway/test_admin_catalog_htmx.py
+++ b/tests/unit/mcpgateway/test_admin_catalog_htmx.py
@@ -48,8 +48,9 @@ def client():
     # Override auth dependencies
     app.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
+    # auth_method is required to distinguish user context from request body payloads (Issue #2319)
     def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "auth_method": "test", "db": db}
 
     app.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -256,8 +256,9 @@ def test_client(app):
     app.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
     # Override get_current_user_with_permissions for RBAC system
+    # auth_method is required to distinguish user context from request body payloads (Issue #2319)
     def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "auth_method": "test", "db": db}
 
     app.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -372,8 +372,9 @@ def test_client(app):
     app.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
     # Override get_current_user_with_permissions for RBAC system
+    # auth_method is required to distinguish user context from request body payloads (Issue #2319)
     def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "auth_method": "test", "db": db}
 
     app.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/utils/rbac_mocks.py
+++ b/tests/utils/rbac_mocks.py
@@ -32,6 +32,9 @@ def create_mock_user_context(
 ) -> Dict:
     """Create a mock user context for RBAC testing.
 
+    Note: As of Issue #1865, user context no longer includes a 'db' key.
+    Permission decorators now use fresh_db_session() for short-lived permission checks.
+
     Args:
         email: User email address
         full_name: User's full name
@@ -50,7 +53,6 @@ def create_mock_user_context(
         "ip_address": ip_address,
         "user_agent": user_agent,
         "auth_method": auth_method,
-        "db": MagicMock(),  # Mock database session
     }
 
 


### PR DESCRIPTION
## Summary

- Remove `db` parameter from `get_current_user_with_permissions()` to prevent holding DB sessions for entire request lifecycle
- Update permission decorators to use `fresh_db_session()` for short-lived permission checks
- Sessions are now released immediately after permission check, before slow downstream operations

## Problem

Under high load (4000 concurrent users), the RBAC middleware was holding database sessions for entire request lifetimes, causing:
- 433 "idle in transaction" connections (vs normal 40-50)
- Max transaction age of 243 seconds
- QueuePool exhaustion errors
- Gateway availability dropping to 33%

## Changes

| File | Change |
|------|--------|
| `mcpgateway/middleware/rbac.py` | Remove `db` from function signature/return; use `fresh_db_session()` in decorators |
| `mcpgateway/admin.py` | Use endpoint's `db` parameter instead of `user["db"]` |
| Test fixtures | Remove `"db"` from mock user contexts; add `fresh_db_session` mocks |

## Test plan

- [x] Unit tests pass (4863 passed)
- [x] E2E tests pass (187 passed)
- [x] Docker stack healthy
- [ ] Load test with 4000 users shows stable idle-in-transaction count

Closes #2318