### PR TITLE
2324 - Observability dark mode

### DIFF
--- a/mcpgateway/templates/observability_metrics.html
+++ b/mcpgateway/templates/observability_metrics.html
@@ -193,6 +193,7 @@ window.createMetricsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'line',
         data: {
@@ -239,9 +240,13 @@ window.createMetricsController = function() {
             title: {
               display: true,
               text: 'Latency Percentiles Over Time',
+              color: defaults.titleColor,
             },
             legend: {
               position: 'bottom',
+              labels: {
+                color: defaults.color,
+              },
             },
             tooltip: {
               callbacks: {
@@ -257,6 +262,21 @@ window.createMetricsController = function() {
               title: {
                 display: true,
                 text: 'Latency (ms)',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            x: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -306,6 +326,7 @@ window.createMetricsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'line',
         data: {
@@ -340,12 +361,24 @@ window.createMetricsController = function() {
             title: {
               display: true,
               text: 'Request Rate & Error Rate',
+              color: defaults.titleColor,
             },
             legend: {
               position: 'bottom',
+              labels: {
+                color: defaults.color,
+              },
             },
           },
           scales: {
+            x: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
             y: {
               type: 'linear',
               display: true,
@@ -353,6 +386,13 @@ window.createMetricsController = function() {
               title: {
                 display: true,
                 text: 'Requests',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
             y1: {
@@ -362,6 +402,10 @@ window.createMetricsController = function() {
               title: {
                 display: true,
                 text: 'Error Rate (%)',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
               },
               grid: {
                 drawOnChartArea: false,
@@ -386,12 +430,12 @@ window.createMetricsController = function() {
       tbody.innerHTML = data.endpoints
         .map(
           (ep, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-500">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-300">${ep.endpoint}</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${ep.endpoint}</td>
               <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${ep.count}</td>
-              <td class="px-4 py-2 text-sm text-orange-600 font-medium">${ep.avg_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-red-600">${ep.max_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-orange-600 dark:text-orange-400 font-medium">${ep.avg_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-red-600 dark:text-red-400">${ep.max_duration_ms} ms</td>
             </tr>
           `
         )
@@ -404,10 +448,10 @@ window.createMetricsController = function() {
       tbody.innerHTML = data.endpoints
         .map(
           (ep, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-500">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-300">${ep.endpoint}</td>
-              <td class="px-4 py-2 text-sm font-medium text-blue-600">${ep.count}</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${ep.endpoint}</td>
+              <td class="px-4 py-2 text-sm font-medium text-blue-600 dark:text-blue-400">${ep.count}</td>
               <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${ep.avg_duration_ms} ms</td>
             </tr>
           `
@@ -421,12 +465,12 @@ window.createMetricsController = function() {
       tbody.innerHTML = data.endpoints
         .map(
           (ep, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-500">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-300">${ep.endpoint}</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${ep.endpoint}</td>
               <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${ep.total_count}</td>
-              <td class="px-4 py-2 text-sm text-red-600 font-medium">${ep.error_count}</td>
-              <td class="px-4 py-2 text-sm text-red-700 font-bold">${ep.error_rate}%</td>
+              <td class="px-4 py-2 text-sm text-red-600 dark:text-red-400 font-medium">${ep.error_count}</td>
+              <td class="px-4 py-2 text-sm text-red-700 dark:text-red-300 font-bold">${ep.error_rate}%</td>
             </tr>
           `
         )
@@ -479,6 +523,7 @@ window.createMetricsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
             type: 'scatter',
         data: {
@@ -504,6 +549,7 @@ window.createMetricsController = function() {
             title: {
               display: true,
               text: 'Latency Distribution Heatmap',
+              color: defaults.titleColor,
             },
             legend: {
               display: false,
@@ -527,6 +573,7 @@ window.createMetricsController = function() {
               position: 'bottom',
               ticks: {
                 stepSize: 1,
+                color: defaults.tickColor,
                 callback: function (value) {
                   return data.time_labels[value] || '';
                 },
@@ -534,12 +581,17 @@ window.createMetricsController = function() {
               title: {
                 display: true,
                 text: 'Time',
+                color: defaults.titleColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
             y: {
               type: 'linear',
               ticks: {
                 stepSize: 1,
+                color: defaults.tickColor,
                 callback: function (value) {
                   return data.latency_labels[value] || '';
                 },
@@ -547,6 +599,10 @@ window.createMetricsController = function() {
               title: {
                 display: true,
                 text: 'Latency',
+                color: defaults.titleColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -595,7 +651,7 @@ window.createMetricsController = function() {
 
 <div class="metrics-dashboard" x-data="createMetricsController()" x-init="init()" @destroy.window="cleanup()">
   <!-- Controls -->
-  <div class="mb-6 p-4 bg-white dark:bg-gray-800 rounded-lg shadow">
+  <div class="mb-6 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
       <div>
         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
@@ -604,7 +660,7 @@ window.createMetricsController = function() {
         <select
           x-model="timeRange"
           @change="applyFilters()"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
         >
           <option value="1">Last Hour</option>
           <option value="6">Last 6 Hours</option>
@@ -621,7 +677,7 @@ window.createMetricsController = function() {
         <select
           x-model="interval"
           @change="applyFilters()"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
         >
           <option value="5">5 Minutes</option>
           <option value="15">15 Minutes</option>
@@ -638,7 +694,7 @@ window.createMetricsController = function() {
         <select
           x-model="limit"
           @change="applyFilters()"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
         >
           <option value="5">Top 5</option>
           <option value="10" selected>Top 10</option>
@@ -651,7 +707,7 @@ window.createMetricsController = function() {
         <button
           @click="applyFilters()"
           :disabled="loading"
-          class="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+          class="w-full px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50 transition-colors"
         >
           <span x-show="!loading">Refresh</span>
           <span x-show="loading">Loading...</span>
@@ -659,29 +715,29 @@ window.createMetricsController = function() {
       </div>
     </div>
 
-    <div x-show="error" class="mt-4 p-3 bg-red-100 text-red-700 rounded-lg" x-text="error"></div>
+    <div x-show="error" class="mt-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 rounded-lg" x-text="error"></div>
   </div>
 
   <!-- Charts Grid -->
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
     <!-- Percentile Chart -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-      <div style="height: 300px">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-4">
+      <div class="h-[300px]">
         <canvas id="percentileChart"></canvas>
       </div>
     </div>
 
     <!-- Time Series Chart -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-      <div style="height: 300px">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-4">
+      <div class="h-[300px]">
         <canvas id="timeSeriesChart"></canvas>
       </div>
     </div>
   </div>
 
   <!-- Heatmap -->
-  <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 mb-6">
-    <div style="height: 400px">
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-4 mb-6">
+    <div class="h-[400px]">
       <canvas id="heatmapChart"></canvas>
     </div>
   </div>
@@ -689,42 +745,42 @@ window.createMetricsController = function() {
   <!-- Top N Tables -->
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
     <!-- Top Slow Endpoints -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow">
-      <div class="px-4 py-3 border-b border-gray-200">
-        <h3 class="text-lg font-medium text-gray-900 dark:text-white">📉 Slowest Endpoints</h3>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30">
+      <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">📉 Slowest Endpoints</h3>
       </div>
       <div class="overflow-x-auto">
-        <table id="topSlowTable" class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50 dark:bg-gray-700">
+        <table id="topSlowTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-700/50">
             <tr>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 #
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Endpoint
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Count
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Avg
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Max
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200">
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             <!-- Populated by Alpine.js -->
           </tbody>
         </table>
@@ -732,37 +788,37 @@ window.createMetricsController = function() {
     </div>
 
     <!-- Top Volume Endpoints -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow">
-      <div class="px-4 py-3 border-b border-gray-200">
-        <h3 class="text-lg font-medium text-gray-900 dark:text-white">📊 Highest Volume</h3>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30">
+      <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">📊 Highest Volume</h3>
       </div>
       <div class="overflow-x-auto">
-        <table id="topVolumeTable" class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50 dark:bg-gray-700">
+        <table id="topVolumeTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-700/50">
             <tr>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 #
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Endpoint
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Requests
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Avg
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200">
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             <!-- Populated by Alpine.js -->
           </tbody>
         </table>
@@ -770,42 +826,42 @@ window.createMetricsController = function() {
     </div>
 
     <!-- Top Error Endpoints -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow">
-      <div class="px-4 py-3 border-b border-gray-200">
-        <h3 class="text-lg font-medium text-gray-900 dark:text-white">❌ Most Errors</h3>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30">
+      <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">❌ Most Errors</h3>
       </div>
       <div class="overflow-x-auto">
-        <table id="topErrorsTable" class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50 dark:bg-gray-700">
+        <table id="topErrorsTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-700/50">
             <tr>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 #
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Endpoint
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Total
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Errors
               </th>
               <th
-                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+                class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
               >
                 Rate
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200">
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             <!-- Populated by Alpine.js -->
           </tbody>
         </table>

--- a/mcpgateway/templates/observability_partial.html
+++ b/mcpgateway/templates/observability_partial.html
@@ -1,5 +1,19 @@
 <!-- htmlhint doctype-first:false -->
 <!-- Observability Dashboard Partial -->
+<script>
+// Dark mode aware Chart.js defaults - shared across all observability charts
+if (!window.getChartDefaults) {
+  window.getChartDefaults = function() {
+    const isDark = document.documentElement.classList.contains('dark');
+    return {
+      color: isDark ? '#e5e7eb' : '#374151',
+      gridColor: isDark ? '#374151' : '#e5e7eb',
+      titleColor: isDark ? '#f3f4f6' : '#1f2937',
+      tickColor: isDark ? '#d1d5db' : '#6b7280',
+    };
+  };
+}
+</script>
 <div class="observability-container" x-data="{
     viewMode: 'traces',
     selectedTrace: null,
@@ -457,382 +471,16 @@
     $watch('selectedQueryId', () => { if(selectedQueryId) applySavedQuery(); });
 ">
     <style>
-        .observability-container {
-            /* No extra padding - parent already has p-4 lg:p-6 */
-        }
-        .view-toggle-btn {
-            padding: 0.5rem 1rem;
-            border-radius: 0.375rem;
-            border: 1px solid #d1d5db;
-            background: white;
-            cursor: pointer;
-            font-size: 0.875rem;
-            transition: all 0.2s;
-        }
-        .view-toggle-btn:hover {
-            background: #f3f4f6;
-        }
-        .view-toggle-btn.active {
-            background: #3b82f6;
-            color: white;
-            border-color: #3b82f6;
-        }
-        .obs-header {
-            margin-bottom: 2rem;
-            padding-bottom: 1rem;
-            border-bottom: 2px solid #e5e7eb;
-        }
-        .obs-header-top {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1rem;
-        }
-        .obs-tabs-row {
-            display: flex;
-            gap: 0.5rem;
-            flex-wrap: wrap;
-        }
-        .obs-title {
-            font-size: 1.875rem;
-            font-weight: 700;
-            color: #1f2937;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        .obs-filters {
-            display: flex;
-            gap: 1rem;
-            align-items: center;
-        }
-        .obs-filter-btn {
-            padding: 0.5rem 1rem;
-            border-radius: 0.375rem;
-            border: 1px solid #d1d5db;
-            background: white;
-            cursor: pointer;
-            transition: all 0.2s;
-        }
-        .obs-filter-btn:hover {
-            background: #f3f4f6;
-        }
-        .obs-filter-btn.active {
-            background: #3b82f6;
-            color: white;
-            border-color: #3b82f6;
-        }
-        .stats-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            gap: 1rem;
-            margin-bottom: 2rem;
-        }
-        .stat-card {
-            background: white;
-            border-radius: 0.5rem;
-            padding: 1.5rem;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            border-left: 4px solid #3b82f6;
-        }
-        .stat-card.success {
-            border-left-color: #10b981;
-        }
-        .stat-card.error {
-            border-left-color: #ef4444;
-        }
-        .stat-card.warning {
-            border-left-color: #f59e0b;
-        }
-        .stat-label {
-            font-size: 0.875rem;
-            color: #6b7280;
-            margin-bottom: 0.5rem;
-        }
-        .stat-value {
-            font-size: 2rem;
-            font-weight: 700;
-            color: #1f2937;
-        }
-        .stat-unit {
-            font-size: 1rem;
-            color: #6b7280;
-            margin-left: 0.25rem;
-        }
-        .traces-table {
-            width: 100%;
-            background: white;
-            border-radius: 0.5rem;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            overflow: hidden;
-        }
-        .traces-table table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        .traces-table th {
-            background: #f9fafb;
-            padding: 0.75rem 1rem;
-            text-align: left;
-            font-size: 0.875rem;
-            font-weight: 600;
-            color: #6b7280;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        .traces-table td {
-            padding: 0.75rem 1rem;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        .traces-table tr:hover {
-            background: #f9fafb;
-            cursor: pointer;
-        }
-        .status-badge {
-            display: inline-block;
-            padding: 0.25rem 0.75rem;
-            border-radius: 9999px;
-            font-size: 0.75rem;
-            font-weight: 600;
-        }
-        .status-ok {
-            background: #d1fae5;
-            color: #065f46;
-        }
-        .status-error {
-            background: #fee2e2;
-            color: #991b1b;
-        }
-        .duration-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 0.25rem;
-            font-size: 0.875rem;
-            font-family: monospace;
-        }
-        .duration-fast {
-            background: #d1fae5;
-            color: #065f46;
-        }
-        .duration-medium {
-            background: #fef3c7;
-            color: #92400e;
-        }
-        .duration-slow {
-            background: #fee2e2;
-            color: #991b1b;
-        }
-        .trace-detail-modal {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: rgba(0,0,0,0.5);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            z-index: 1000;
-        }
-        .trace-detail-content {
-            background: white;
-            border-radius: 0.5rem;
-            max-width: 90%;
-            max-height: 90%;
-            overflow: auto;
-            box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1);
-        }
-        .trace-detail-header {
-            padding: 1.5rem;
-            border-bottom: 1px solid #e5e7eb;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        .trace-detail-body {
-            padding: 1.5rem;
-        }
-        .waterfall {
-            margin-top: 1rem;
-        }
-        .span-row {
-            display: flex;
-            align-items: center;
-            padding: 0.5rem;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        .span-name {
-            width: 200px;
-            font-size: 0.875rem;
-            color: #374151;
-        }
+        /* Minimal styles for components that need precise positioning */
         .span-timeline {
             flex: 1;
             height: 24px;
             position: relative;
-            background: #f3f4f6;
-            border-radius: 0.25rem;
-        }
-        .span-bar {
-            position: absolute;
-            height: 100%;
-            background: #3b82f6;
-            border-radius: 0.25rem;
-            display: flex;
-            align-items: center;
-            padding: 0 0.5rem;
-            font-size: 0.75rem;
-            color: white;
-        }
-        .span-bar.error {
-            background: #ef4444;
-        }
-        .span-duration {
-            width: 80px;
-            text-align: right;
-            font-size: 0.875rem;
-            color: #6b7280;
-            font-family: monospace;
-        }
-        .refresh-btn {
-            padding: 0.5rem 1rem;
-            background: #3b82f6;
-            color: white;
-            border: none;
-            border-radius: 0.375rem;
-            cursor: pointer;
-            font-weight: 500;
-            transition: background 0.2s;
-        }
-        .refresh-btn:hover {
-            background: #2563eb;
-        }
-        .empty-state {
-            text-align: center;
-            padding: 3rem;
-            color: #6b7280;
-        }
-        .empty-state-icon {
-            font-size: 3rem;
-            margin-bottom: 1rem;
-        }
-
-        /* Gantt Chart Styles */
-        .gantt-container {
-            background: white;
-            border: 1px solid #e5e7eb;
-            border-radius: 0.5rem;
-            padding: 1rem;
-            min-height: 400px;
-        }
-        .gantt-toolbar {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1rem;
-            padding-bottom: 0.5rem;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        .gantt-info {
-            font-size: 0.875rem;
-            color: #374151;
-        }
-        .gantt-controls {
-            display: flex;
-            gap: 0.5rem;
-        }
-        .gantt-btn {
-            padding: 0.375rem 0.75rem;
-            background: #f3f4f6;
-            border: 1px solid #d1d5db;
-            border-radius: 0.375rem;
-            font-size: 0.875rem;
-            cursor: pointer;
-            transition: all 0.2s;
-        }
-        .gantt-btn:hover {
-            background: #e5e7eb;
-        }
-        .gantt-timescale {
-            position: relative;
-            height: 40px;
-            border-bottom: 2px solid #d1d5db;
-            margin-bottom: 0.5rem;
-        }
-        .time-marker {
-            position: absolute;
-            top: 0;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
-        .time-tick {
-            width: 1px;
-            height: 10px;
-            background: #9ca3af;
-        }
-        .time-label {
-            font-size: 0.75rem;
-            color: #6b7280;
-            margin-top: 0.25rem;
-        }
-        .gantt-spans {
-            max-height: 600px;
-            overflow-y: auto;
-        }
-        .span-row {
-            display: flex;
-            align-items: center;
-            padding: 0.25rem 0;
-            border-bottom: 1px solid #f3f4f6;
-            transition: background 0.1s;
-        }
-        .span-row:hover {
-            background: #f9fafb;
-        }
-        .critical-path-row {
-            background: #fef3c7 !important;
-        }
-        .span-name {
-            width: 250px;
-            font-size: 0.875rem;
-            color: #374151;
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-        }
-        .span-toggle {
-            background: none;
-            border: none;
-            cursor: pointer;
-            font-size: 0.75rem;
-            padding: 0.125rem;
-            color: #6b7280;
-            width: 16px;
-            height: 16px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        .span-spacer {
-            width: 16px;
-            display: inline-block;
-        }
-        .span-label {
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .span-timeline {
-            flex: 1;
-            height: 24px;
-            position: relative;
-            background: #f9fafb;
-            border-radius: 0.25rem;
             margin: 0 0.5rem;
         }
         .span-bar {
             position: absolute;
             height: 100%;
-            background: #3b82f6;
             border-radius: 0.25rem;
             cursor: pointer;
             transition: opacity 0.2s;
@@ -847,72 +495,27 @@
         .critical-path-bar {
             box-shadow: 0 0 0 2px #f59e0b;
         }
-        .span-bar-label {
-            font-size: 0.7rem;
-            color: white;
-            font-weight: 500;
-            text-shadow: 0 1px 2px rgba(0,0,0,0.3);
-        }
-        .span-duration {
-            width: 100px;
-            text-align: right;
-            font-size: 0.75rem;
-            color: #6b7280;
-            font-family: monospace;
-        }
-        .gantt-legend {
+        .time-marker {
+            position: absolute;
+            top: 0;
             display: flex;
-            gap: 1rem;
-            margin-top: 1rem;
-            padding-top: 1rem;
-            border-top: 1px solid #e5e7eb;
-            font-size: 0.875rem;
-        }
-        .legend-item {
-            display: flex;
+            flex-direction: column;
             align-items: center;
-            gap: 0.5rem;
-        }
-        .legend-color {
-            width: 16px;
-            height: 16px;
-            border-radius: 0.25rem;
-        }
-        .legend-color.critical-path {
-            background: #fbbf24;
-            border: 2px solid #f59e0b;
-        }
-        .view-toggle-btn {
-            padding: 0.5rem 1rem;
-            background: #f3f4f6;
-            border: 1px solid #d1d5db;
-            border-radius: 0.375rem;
-            font-size: 0.875rem;
-            cursor: pointer;
-            transition: all 0.2s;
-        }
-        .view-toggle-btn:hover {
-            background: #e5e7eb;
-        }
-        .view-toggle-btn.active {
-            background: #3b82f6;
-            color: white;
-            border-color: #3b82f6;
         }
     </style>
 
     <!-- Header -->
-    <div class="obs-header">
+    <div class="mb-8 pb-4 border-b-2 border-gray-200 dark:border-gray-700">
         <!-- Title and Filters Row -->
-        <div class="obs-header-top">
-            <h1 class="obs-title">
+        <div class="flex justify-between items-center mb-4 flex-wrap gap-4">
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
                 <span>🔍</span>
                 Observability Dashboard
             </h1>
-            <div class="obs-filters" x-show="viewMode === 'traces'" style="margin: 0;">
+            <div class="flex gap-4 items-center" x-show="viewMode === 'traces'">
             <select
                 x-model="selectedQueryId"
-                class="obs-filter-btn"
+                class="px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600"
                 style="min-width: 200px;"
             >
                 <option value="">📋 Saved Queries</option>
@@ -921,7 +524,7 @@
                 </template>
             </select>
             <button
-                class="obs-filter-btn"
+                class="px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600"
                 @click="showSaveQueryModal = true"
                 title="Save current filters as a query"
             >
@@ -929,7 +532,7 @@
             </button>
             <select
                 x-model="timeRange"
-                class="obs-filter-btn"
+                class="px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600"
             >
                 <option value="1h">Last Hour</option>
                 <option value="6h">Last 6 Hours</option>
@@ -938,21 +541,21 @@
             </select>
             <select
                 x-model="statusFilter"
-                class="obs-filter-btn"
+                class="px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600"
             >
                 <option value="all" selected>All Status</option>
                 <option value="ok">Success Only</option>
                 <option value="error">Errors Only</option>
             </select>
             <button
-                class="obs-filter-btn"
+                class="px-4 py-2 text-sm border rounded-md cursor-pointer transition-all dark:border-gray-600 dark:hover:bg-gray-600"
+                :class="showAdvancedFilters ? 'bg-blue-500 text-white border-blue-500 dark:bg-blue-600 dark:border-blue-500' : 'bg-white border-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-100'"
                 @click="showAdvancedFilters = !showAdvancedFilters"
-                :class="{'active': showAdvancedFilters}"
             >
                 ⚙️ Advanced Filters
             </button>
             <button
-                class="refresh-btn"
+                class="px-4 py-2 text-sm bg-blue-500 text-white rounded-md cursor-pointer font-medium transition-colors hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-500"
                 @click="refreshStats(); refreshTraces();"
             >
                 🔄 Refresh
@@ -961,39 +564,39 @@
         </div>
 
         <!-- View Mode Tabs Row -->
-        <div class="obs-tabs-row">
+        <div class="flex gap-2 flex-wrap">
             <button
                 @click="viewMode = 'traces'"
-                :class="{'active': viewMode === 'traces'}"
-                class="view-toggle-btn"
+                :class="viewMode === 'traces' ? 'bg-blue-500 text-white border-blue-500 dark:bg-blue-600 dark:border-blue-500' : 'bg-white border-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600'"
+                class="px-4 py-2 text-sm border rounded-md cursor-pointer transition-all"
             >
                 📋 Traces
             </button>
             <button
                 @click="viewMode = 'metrics'; loadMetricsView()"
-                :class="{'active': viewMode === 'metrics'}"
-                class="view-toggle-btn"
+                :class="viewMode === 'metrics' ? 'bg-blue-500 text-white border-blue-500 dark:bg-blue-600 dark:border-blue-500' : 'bg-white border-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600'"
+                class="px-4 py-2 text-sm border rounded-md cursor-pointer transition-all"
             >
                 📊 Advanced Metrics
             </button>
             <button
                 @click="viewMode = 'tools'; loadToolsView()"
-                :class="{'active': viewMode === 'tools'}"
-                class="view-toggle-btn"
+                :class="viewMode === 'tools' ? 'bg-blue-500 text-white border-blue-500 dark:bg-blue-600 dark:border-blue-500' : 'bg-white border-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600'"
+                class="px-4 py-2 text-sm border rounded-md cursor-pointer transition-all"
             >
                 🔧 MCP Tools
             </button>
             <button
                 @click="viewMode = 'prompts'; loadPromptsView()"
-                :class="{'active': viewMode === 'prompts'}"
-                class="view-toggle-btn"
+                :class="viewMode === 'prompts' ? 'bg-blue-500 text-white border-blue-500 dark:bg-blue-600 dark:border-blue-500' : 'bg-white border-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600'"
+                class="px-4 py-2 text-sm border rounded-md cursor-pointer transition-all"
             >
                 💬 Prompts
             </button>
             <button
                 @click="viewMode = 'resources'; loadResourcesView()"
-                :class="{'active': viewMode === 'resources'}"
-                class="view-toggle-btn"
+                :class="viewMode === 'resources' ? 'bg-blue-500 text-white border-blue-500 dark:bg-blue-600 dark:border-blue-500' : 'bg-white border-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600'"
+                class="px-4 py-2 text-sm border rounded-md cursor-pointer transition-all"
             >
                 📦 Resources
             </button>
@@ -1005,48 +608,45 @@
     <!-- Advanced Filters Panel -->
     <div x-show="showAdvancedFilters"
          x-transition
-         style="background: white; border-radius: 0.5rem; padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
-        <h3 style="margin: 0 0 1rem 0; font-size: 1.125rem; font-weight: 600; color: #374151;">
+         class="bg-white dark:bg-gray-800 rounded-lg p-6 mb-6 shadow-sm dark:shadow-gray-900/30">
+        <h3 class="m-0 mb-4 text-lg font-semibold text-gray-700 dark:text-gray-200">
             🔧 Advanced Filters
         </h3>
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1rem;">
             <!-- Duration Range -->
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Min Duration (ms)
                 </label>
                 <input
                     type="number"
                     x-model="minDuration"
                     placeholder="e.g., 100"
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400"
                     @change="refreshTraces()"
                 />
             </div>
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Max Duration (ms)
                 </label>
                 <input
                     type="number"
                     x-model="maxDuration"
                     placeholder="e.g., 5000"
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400"
                     @change="refreshTraces()"
                 />
             </div>
 
             <!-- HTTP Method -->
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     HTTP Method
                 </label>
                 <select
                     x-model="httpMethod"
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
                     @change="refreshTraces()"
                 >
                     <option value="">All Methods</option>
@@ -1060,71 +660,66 @@
 
             <!-- User Email -->
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     User Email
                 </label>
                 <input
                     type="text"
                     x-model="userEmail"
                     placeholder="admin@example.com"
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400"
                     @input.debounce.500ms="refreshTraces()"
                 />
             </div>
 
             <!-- Name Search -->
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Trace Name
                 </label>
                 <input
                     type="text"
                     x-model="nameSearch"
                     placeholder="e.g., GET /api/tools"
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400"
                     @input.debounce.500ms="refreshTraces()"
                 />
             </div>
 
             <!-- Attribute Search -->
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Attribute Search
                 </label>
                 <input
                     type="text"
                     x-model="attributeSearch"
                     placeholder="Search in attributes..."
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400"
                     @input.debounce.500ms="refreshTraces()"
                 />
             </div>
 
             <!-- Tool Name Filter -->
             <div>
-                <label style="display: block; font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.25rem;">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     🔧 MCP Tool Name
                 </label>
                 <input
                     type="text"
                     x-model="toolName"
                     placeholder="Filter by tool name..."
-                    class="obs-filter-btn"
-                    style="width: 100%;"
+                    class="w-full px-4 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400"
                     @input.debounce.500ms="refreshTraces()"
                 />
             </div>
         </div>
 
         <!-- Clear Filters Button -->
-        <div style="margin-top: 1rem; text-align: right;">
+        <div class="mt-4 text-right">
             <button
-                class="obs-filter-btn"
+                class="px-6 py-2 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600"
                 @click="minDuration=''; maxDuration=''; httpMethod=''; userEmail=''; nameSearch=''; attributeSearch=''; refreshTraces();"
-                style="padding: 0.5rem 1.5rem;"
             >
                 🗑️ Clear All Filters
             </button>
@@ -1133,30 +728,30 @@
 
     <!-- Statistics Cards -->
     <div id="stats-container">
-        <div class="stats-grid">
-            <div class="stat-card">
-                <div class="stat-label">Loading statistics...</div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+            <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm dark:shadow-gray-900/30 border-l-4 border-blue-500">
+                <div class="text-sm text-gray-600 dark:text-gray-400 mb-2">Loading statistics...</div>
             </div>
         </div>
     </div>
 
     <!-- Traces Table -->
-    <div class="traces-table">
-        <table>
+    <div class="w-full bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 overflow-hidden">
+        <table class="w-full border-collapse">
             <thead>
                 <tr>
-                    <th>Timestamp</th>
-                    <th>Method</th>
-                    <th>Endpoint</th>
-                    <th>Status</th>
-                    <th>Duration</th>
-                    <th>User</th>
-                    <th>Actions</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">Timestamp</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">Method</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">Endpoint</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">Status</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">Duration</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">User</th>
+                    <th class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">Actions</th>
                 </tr>
             </thead>
             <tbody id="traces-list">
                 <tr>
-                    <td colspan="7" style="text-align: center; padding: 2rem;">
+                    <td colspan="7" class="text-center py-8 text-gray-500 dark:text-gray-400">
                         Loading traces...
                     </td>
                 </tr>
@@ -1167,9 +762,9 @@
     <!-- Trace Detail Modal (shown when trace is selected) -->
     <div x-show="selectedTrace"
          x-cloak
-         class="trace-detail-modal"
+         class="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-[1000]"
          @click.self="selectedTrace = null">
-        <div class="trace-detail-content" id="trace-detail-content">
+        <div class="bg-white dark:bg-gray-800 rounded-lg max-w-[90%] max-h-[90%] overflow-auto shadow-2xl" id="trace-detail-content">
             <!-- Loaded via HTMX -->
         </div>
     </div>
@@ -1177,81 +772,80 @@
     <!-- Save Query Modal -->
     <div x-show="showSaveQueryModal"
          x-cloak
-         class="trace-detail-modal"
+         class="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-[1000]"
          @click.self="showSaveQueryModal = false">
-        <div class="trace-detail-content" style="max-width: 600px; padding: 2rem;">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; border-bottom: 1px solid #e5e7eb; padding-bottom: 1rem;">
-                <h2 style="font-size: 1.5rem; font-weight: 700; color: #1f2937; margin: 0;">💾 Save Query</h2>
-                <button @click="showSaveQueryModal = false" style="background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #6b7280;">×</button>
+        <div class="bg-white dark:bg-gray-800 rounded-lg max-w-2xl w-full mx-4 p-8 shadow-2xl">
+            <div class="flex justify-between items-center mb-6 pb-4 border-b border-gray-200 dark:border-gray-700">
+                <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 m-0">💾 Save Query</h2>
+                <button @click="showSaveQueryModal = false" class="bg-transparent border-0 text-2xl cursor-pointer text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">×</button>
             </div>
 
-            <div style="display: flex; flex-direction: column; gap: 1.5rem;">
+            <div class="flex flex-col gap-6">
                 <!-- Query Name -->
                 <div>
-                    <label style="display: block; font-size: 0.875rem; font-weight: 600; color: #374151; margin-bottom: 0.5rem;">
-                        Query Name <span style="color: #ef4444;">*</span>
+                    <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                        Query Name <span class="text-red-500">*</span>
                     </label>
                     <input
                         x-model="saveQueryName"
                         type="text"
                         placeholder="e.g., Slow Requests Last Hour"
-                        style="width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem;"
+                        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
                     />
                 </div>
 
                 <!-- Query Description -->
                 <div>
-                    <label style="display: block; font-size: 0.875rem; font-weight: 600; color: #374151; margin-bottom: 0.5rem;">
+                    <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                         Description (optional)
                     </label>
                     <textarea
                         x-model="saveQueryDescription"
                         placeholder="What does this query help you find?"
                         rows="3"
-                        style="width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; resize: vertical;"
+                        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 resize-y focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
                     ></textarea>
                 </div>
 
                 <!-- Share with Team -->
-                <div style="display: flex; align-items: center; gap: 0.5rem;">
+                <div class="flex items-center gap-2">
                     <input
                         x-model="saveQueryIsShared"
                         type="checkbox"
                         id="save-query-shared"
-                        style="width: 1.125rem; height: 1.125rem;"
+                        class="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-500 dark:bg-gray-700"
                     />
-                    <label for="save-query-shared" style="font-size: 0.875rem; font-weight: 500; color: #374151; cursor: pointer;">
+                    <label for="save-query-shared" class="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
                         Share with team (visible to all users)
                     </label>
                 </div>
 
                 <!-- Current Filters Preview -->
-                <div style="background: #f9fafb; border-radius: 0.5rem; padding: 1rem;">
-                    <p style="font-size: 0.75rem; font-weight: 600; color: #6b7280; margin: 0 0 0.5rem 0; text-transform: uppercase;">Current Filters</p>
-                    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.5rem; font-size: 0.875rem; color: #374151;">
+                <div class="bg-gray-50 dark:bg-gray-900/50 rounded-lg p-4">
+                    <p class="text-xs font-semibold text-gray-600 dark:text-gray-400 mb-2 uppercase">Current Filters</p>
+                    <div class="grid grid-cols-2 gap-2 text-sm text-gray-700 dark:text-gray-300">
                         <div x-show="timeRange"><strong>Time:</strong> <span x-text="timeRange"></span></div>
                         <div x-show="statusFilter"><strong>Status:</strong> <span x-text="statusFilter"></span></div>
                         <div x-show="minDuration"><strong>Min Duration:</strong> <span x-text="minDuration + 'ms'"></span></div>
                         <div x-show="maxDuration"><strong>Max Duration:</strong> <span x-text="maxDuration + 'ms'"></span></div>
                         <div x-show="httpMethod"><strong>HTTP Method:</strong> <span x-text="httpMethod"></span></div>
                         <div x-show="userEmail"><strong>User:</strong> <span x-text="userEmail"></span></div>
-                        <div x-show="nameSearch" style="grid-column: span 2;"><strong>Name:</strong> <span x-text="nameSearch"></span></div>
-                        <div x-show="attributeSearch" style="grid-column: span 2;"><strong>Attributes:</strong> <span x-text="attributeSearch"></span></div>
+                        <div x-show="nameSearch" class="col-span-2"><strong>Name:</strong> <span x-text="nameSearch"></span></div>
+                        <div x-show="attributeSearch" class="col-span-2"><strong>Attributes:</strong> <span x-text="attributeSearch"></span></div>
                     </div>
                 </div>
 
                 <!-- Action Buttons -->
-                <div style="display: flex; justify-content: flex-end; gap: 1rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;">
+                <div class="flex justify-end gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
                     <button
                         @click="showSaveQueryModal = false"
-                        style="padding: 0.5rem 1.5rem; border: 1px solid #d1d5db; background: white; color: #374151; border-radius: 0.375rem; cursor: pointer; font-weight: 500;"
+                        class="px-6 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md cursor-pointer font-medium hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
                     >
                         Cancel
                     </button>
                     <button
                         @click="saveCurrentQuery()"
-                        class="refresh-btn"
-                        style="padding: 0.5rem 1.5rem;"
+                        class="px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md cursor-pointer font-medium hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors"
                     >
                         Save Query
                     </button>
@@ -1263,28 +857,28 @@
 
     <!-- Metrics View -->
     <div x-show="viewMode === 'metrics'" id="metrics-container">
-        <div style="padding: 2rem; text-align: center; color: #6b7280;">
+        <div class="p-8 text-center text-gray-600 dark:text-gray-400">
             Loading metrics dashboard...
         </div>
     </div>
 
     <!-- Tools View -->
     <div x-show="viewMode === 'tools'" id="tools-container">
-        <div style="padding: 2rem; text-align: center; color: #6b7280;">
+        <div class="p-8 text-center text-gray-600 dark:text-gray-400">
             Loading tool metrics dashboard...
         </div>
     </div>
 
     <!-- Prompts View -->
     <div x-show="viewMode === 'prompts'" id="prompts-container">
-        <div style="padding: 2rem; text-align: center; color: #6b7280;">
+        <div class="p-8 text-center text-gray-600 dark:text-gray-400">
             Loading prompt metrics dashboard...
         </div>
     </div>
 
     <!-- Resources View -->
     <div x-show="viewMode === 'resources'" id="resources-container">
-        <div style="padding: 2rem; text-align: center; color: #6b7280;">
+        <div class="p-8 text-center text-gray-600 dark:text-gray-400">
             Loading resource metrics dashboard...
         </div>
     </div>

--- a/mcpgateway/templates/observability_prompts.html
+++ b/mcpgateway/templates/observability_prompts.html
@@ -177,6 +177,7 @@ window.createPromptsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'bar',
         data: {
@@ -199,6 +200,7 @@ window.createPromptsController = function() {
             title: {
               display: true,
               text: `Prompt Rendering Frequency (Last ${this.timeRange}h)`,
+              color: defaults.titleColor,
             },
             legend: {
               display: false,
@@ -221,6 +223,21 @@ window.createPromptsController = function() {
               title: {
                 display: true,
                 text: 'Number of Renders',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            y: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -241,17 +258,17 @@ window.createPromptsController = function() {
       tbody.innerHTML = data.prompts
         .map(
           (prompt, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${prompt.prompt_id}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${prompt.count}</td>
-              <td class="px-4 py-2 text-sm text-orange-600 font-medium">${prompt.avg_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-green-600">${prompt.min_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-blue-600">${prompt.p50} ms</td>
-              <td class="px-4 py-2 text-sm text-indigo-600">${prompt.p90} ms</td>
-              <td class="px-4 py-2 text-sm text-purple-600">${prompt.p95} ms</td>
-              <td class="px-4 py-2 text-sm text-pink-600">${prompt.p99} ms</td>
-              <td class="px-4 py-2 text-sm text-red-600">${prompt.max_duration_ms} ms</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${prompt.prompt_id}</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${prompt.count}</td>
+              <td class="px-4 py-2 text-sm text-orange-600 dark:text-orange-400 font-medium">${prompt.avg_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-green-600 dark:text-green-400">${prompt.min_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-blue-600 dark:text-blue-400">${prompt.p50} ms</td>
+              <td class="px-4 py-2 text-sm text-indigo-600 dark:text-indigo-400">${prompt.p90} ms</td>
+              <td class="px-4 py-2 text-sm text-purple-600 dark:text-purple-400">${prompt.p95} ms</td>
+              <td class="px-4 py-2 text-sm text-pink-600 dark:text-pink-400">${prompt.p99} ms</td>
+              <td class="px-4 py-2 text-sm text-red-600 dark:text-red-400">${prompt.max_duration_ms} ms</td>
             </tr>
           `
         )
@@ -297,6 +314,7 @@ window.createPromptsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'bar',
         data: {
@@ -326,10 +344,14 @@ window.createPromptsController = function() {
             title: {
               display: true,
               text: `Top 10 Slowest Prompts (Last ${this.timeRange}h)`,
+              color: defaults.titleColor,
             },
             legend: {
               display: true,
               position: 'top',
+              labels: {
+                color: defaults.color,
+              },
             },
             tooltip: {
               callbacks: {
@@ -351,6 +373,21 @@ window.createPromptsController = function() {
               title: {
                 display: true,
                 text: 'Latency (ms)',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            y: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -394,7 +431,14 @@ window.createPromptsController = function() {
         const ctx = canvas.getContext('2d');
         if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
         const parent = canvas.parentElement;
-        if (parent) parent.innerHTML = '<p style="text-align: center; color: #10b981; padding: 2rem;">✓ No errors found - all prompts rendering successfully!</p>';
+        if (parent) {
+          // Use safe DOM manipulation instead of innerHTML with static content
+          parent.textContent = '';
+          const p = document.createElement('p');
+          p.className = 'text-center text-emerald-500 p-8';
+          p.textContent = '✓ No errors found - all prompts rendering successfully!';
+          parent.appendChild(p);
+        }
         return;
       }
 
@@ -413,6 +457,7 @@ window.createPromptsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'bar',
         data: {
@@ -435,6 +480,7 @@ window.createPromptsController = function() {
             title: {
               display: true,
               text: `Top 10 Error-Prone Prompts (Last ${this.timeRange}h)`,
+              color: defaults.titleColor,
             },
             legend: {
               display: false,
@@ -460,6 +506,21 @@ window.createPromptsController = function() {
               title: {
                 display: true,
                 text: 'Error Rate (%)',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            y: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -502,11 +563,11 @@ window.createPromptsController = function() {
 
 <div class="prompts-dashboard" x-data="createPromptsController()" x-init="init()">
   <!-- Header with filters -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-4">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-4">
     <div class="flex flex-wrap gap-4 items-end">
       <div class="flex-1 min-w-[200px]">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Time Range</label>
-        <select x-model="timeRange" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Time Range</label>
+        <select x-model="timeRange" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">
           <option value="1">Last 1 Hour</option>
           <option value="6">Last 6 Hours</option>
           <option value="24">Last 24 Hours</option>
@@ -515,8 +576,8 @@ window.createPromptsController = function() {
         </select>
       </div>
       <div class="flex-1 min-w-[200px]">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Results Limit</label>
-        <select x-model="limit" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Results Limit</label>
+        <select x-model="limit" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">
           <option value="10">Top 10</option>
           <option value="20">Top 20</option>
           <option value="50">Top 50</option>
@@ -524,68 +585,68 @@ window.createPromptsController = function() {
         </select>
       </div>
       <div class="flex-shrink-0">
-        <button @click="applyFilters()" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <button @click="applyFilters()" class="px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 transition-colors">
           Apply Filters
         </button>
       </div>
     </div>
-    <div x-show="loading" class="mt-3 text-sm text-gray-600">
+    <div x-show="loading" class="mt-3 text-sm text-gray-600 dark:text-gray-400">
       Loading prompt metrics...
     </div>
-    <div x-show="error" class="mt-3 text-sm text-red-600" x-text="error"></div>
+    <div x-show="error" class="mt-3 text-sm text-red-600 dark:text-red-400" x-text="error"></div>
   </div>
 
   <!-- Summary Cards -->
   <div class="mb-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
     <!-- Overall Health Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4" :class="{
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4" :class="{
       'border-green-500': summaryCards.overallHealth === 'good',
       'border-yellow-500': summaryCards.overallHealth === 'warning',
       'border-red-500': summaryCards.overallHealth === 'critical'
     }">
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm font-medium text-gray-600">Overall Health</p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Overall Health</p>
           <p class="mt-2 text-3xl font-bold" :class="{
-            'text-green-600': summaryCards.overallHealth === 'good',
-            'text-yellow-600': summaryCards.overallHealth === 'warning',
-            'text-red-600': summaryCards.overallHealth === 'critical'
+            'text-green-600 dark:text-green-400': summaryCards.overallHealth === 'good',
+            'text-yellow-600 dark:text-yellow-400': summaryCards.overallHealth === 'warning',
+            'text-red-600 dark:text-red-400': summaryCards.overallHealth === 'critical'
           }" x-text="summaryCards.overallHealth === 'good' ? '🟢 Healthy' : summaryCards.overallHealth === 'warning' ? '🟡 Warning' : '🔴 Critical'"></p>
         </div>
       </div>
     </div>
 
     <!-- Most Used Prompt Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-purple-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-purple-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Most Rendered</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.mostUsed?.name || 'N/A'"></p>
-          <p class="text-sm text-purple-600 font-medium" x-text="summaryCards.mostUsed ? `${summaryCards.mostUsed.value} ${summaryCards.mostUsed.metric}` : ''"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Most Rendered</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.mostUsed?.name || 'N/A'"></p>
+          <p class="text-sm text-purple-600 dark:text-purple-400 font-medium" x-text="summaryCards.mostUsed ? `${summaryCards.mostUsed.value} ${summaryCards.mostUsed.metric}` : ''"></p>
         </div>
         <div class="text-3xl">💬</div>
       </div>
     </div>
 
     <!-- Slowest Prompt Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-orange-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-orange-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Slowest Prompt</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.slowest?.name || 'N/A'"></p>
-          <p class="text-sm text-orange-600 font-medium" x-text="summaryCards.slowest ? `${summaryCards.slowest.value} ${summaryCards.slowest.metric}` : ''"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Slowest Prompt</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.slowest?.name || 'N/A'"></p>
+          <p class="text-sm text-orange-600 dark:text-orange-400 font-medium" x-text="summaryCards.slowest ? `${summaryCards.slowest.value} ${summaryCards.slowest.metric}` : ''"></p>
         </div>
         <div class="text-3xl">🐌</div>
       </div>
     </div>
 
     <!-- Most Error-Prone Prompt Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-red-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-red-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Most Error-Prone</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.mostErrorProne?.name || 'None'"></p>
-          <p class="text-sm text-red-600 font-medium" x-text="summaryCards.mostErrorProne ? `${summaryCards.mostErrorProne.value}${summaryCards.mostErrorProne.metric}` : '0% errors'"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Most Error-Prone</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.mostErrorProne?.name || 'None'"></p>
+          <p class="text-sm text-red-600 dark:text-red-400 font-medium" x-text="summaryCards.mostErrorProne ? `${summaryCards.mostErrorProne.value}${summaryCards.mostErrorProne.metric}` : '0% errors'"></p>
         </div>
         <div class="text-3xl">⚠️</div>
       </div>
@@ -593,46 +654,46 @@ window.createPromptsController = function() {
   </div>
 
   <!-- Prompt Usage Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="promptUsageChart"></canvas>
     </div>
   </div>
 
   <!-- Top 10 Slowest Prompts Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="promptSlownessChart"></canvas>
     </div>
   </div>
 
   <!-- Top 10 Error-Prone Prompts Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="promptErrorProneChart"></canvas>
     </div>
   </div>
 
   <!-- Prompt Performance Table -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Prompt Performance Metrics</h3>
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Prompt Performance Metrics</h3>
     <div class="overflow-x-auto">
-      <table id="promptPerformanceTable" class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table id="promptPerformanceTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700/50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Prompt ID</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Count</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Min</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p50</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p90</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p95</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p99</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Max</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Prompt ID</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Count</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Avg</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Min</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p50</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p90</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p95</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p99</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Max</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200"></tbody>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"></tbody>
       </table>
     </div>
   </div>

--- a/mcpgateway/templates/observability_resources.html
+++ b/mcpgateway/templates/observability_resources.html
@@ -156,6 +156,12 @@ window.createResourcesController = function() {
       const canvas = document.getElementById('resourceUsageChart');
       if (!canvas) return;
 
+      // Check if canvas is visible before rendering
+      if (canvas.offsetParent === null) {
+        console.warn('resourceUsageChart canvas is hidden, deferring render');
+        return;
+      }
+
       // Destroy existing chart via global registry
       window.chartRegistry.destroy('resources-usage');
 
@@ -166,58 +172,94 @@ window.createResourcesController = function() {
         return;
       }
 
-      const chart = new Chart(canvas, {
-        type: 'bar',
-        data: {
-          labels: data.resources.map(r => r.resource_uri),
-          datasets: [
-            {
-              label: 'Fetch Count',
-              data: data.resources.map(r => r.count),
-              backgroundColor: 'rgba(34, 197, 94, 0.6)',
-              borderColor: '#22c55e',
-              borderWidth: 1,
+      requestAnimationFrame(() => {
+        try {
+          // Double-check visibility after animation frame
+          if (canvas.offsetParent === null) {
+            console.warn('resourceUsageChart canvas became hidden, aborting render');
+            return;
+          }
+
+          // Verify canvas is still in DOM and get valid context
+          const ctx = canvas.getContext('2d');
+          if (!ctx) {
+            console.error('Failed to get 2d context for resourceUsageChart');
+            return;
+          }
+
+          const defaults = getChartDefaults();
+          const chart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels: data.resources.map(r => r.resource_uri),
+              datasets: [
+                {
+                  label: 'Fetch Count',
+                  data: data.resources.map(r => r.count),
+                  backgroundColor: 'rgba(34, 197, 94, 0.6)',
+                  borderColor: '#22c55e',
+                  borderWidth: 1,
+                },
+              ],
             },
-          ],
-        },
-        options: {
-          indexAxis: 'y',
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            title: {
-              display: true,
-              text: `Resource Fetch Frequency (Last ${this.timeRange}h)`,
-            },
-            legend: {
-              display: false,
-            },
-            tooltip: {
-              callbacks: {
-                label: function (context) {
-                  const resource = data.resources[context.dataIndex];
-                  return [
-                    `Fetches: ${resource.count}`,
-                    `Percentage: ${resource.percentage}%`
-                  ];
+            options: {
+              indexAxis: 'y',
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                title: {
+                  display: true,
+                  text: `Resource Fetch Frequency (Last ${this.timeRange}h)`,
+                  color: defaults.titleColor,
+                },
+                legend: {
+                  display: false,
+                },
+                tooltip: {
+                  callbacks: {
+                    label: function (context) {
+                      const resource = data.resources[context.dataIndex];
+                      return [
+                        `Fetches: ${resource.count}`,
+                        `Percentage: ${resource.percentage}%`
+                      ];
+                    },
+                  },
+                },
+              },
+              scales: {
+                x: {
+                  beginAtZero: true,
+                  title: {
+                    display: true,
+                    text: 'Number of Fetches',
+                    color: defaults.titleColor,
+                  },
+                  ticks: {
+                    color: defaults.tickColor,
+                  },
+                  grid: {
+                    color: defaults.gridColor,
+                  },
+                },
+                y: {
+                  ticks: {
+                    color: defaults.tickColor,
+                  },
+                  grid: {
+                    color: defaults.gridColor,
+                  },
                 },
               },
             },
-          },
-          scales: {
-            x: {
-              beginAtZero: true,
-              title: {
-                display: true,
-                text: 'Number of Fetches',
-              },
-            },
-          },
-        },
+          });
+          // Register with global registry
+          window.chartRegistry.register('resources-usage', chart);
+          this.charts.resourceUsage = chart;
+        } catch (e) {
+          console.error('Failed to create resource usage chart:', e);
+        }
       });
-      // Register with global registry
-      window.chartRegistry.register('resources-usage', chart);
-      this.charts.resourceUsage = chart;
     },
     renderResourcePerformanceTable(data) {
       const tbody = document.querySelector('#resourcePerformanceTable tbody');
@@ -226,17 +268,17 @@ window.createResourcesController = function() {
       tbody.innerHTML = data.resources
         .map(
           (resource, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${resource.resource_uri}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${resource.count}</td>
-              <td class="px-4 py-2 text-sm text-orange-600 font-medium">${resource.avg_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-green-600">${resource.min_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-blue-600">${resource.p50} ms</td>
-              <td class="px-4 py-2 text-sm text-indigo-600">${resource.p90} ms</td>
-              <td class="px-4 py-2 text-sm text-purple-600">${resource.p95} ms</td>
-              <td class="px-4 py-2 text-sm text-pink-600">${resource.p99} ms</td>
-              <td class="px-4 py-2 text-sm text-red-600">${resource.max_duration_ms} ms</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${resource.resource_uri}</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${resource.count}</td>
+              <td class="px-4 py-2 text-sm text-orange-600 dark:text-orange-400 font-medium">${resource.avg_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-green-600 dark:text-green-400">${resource.min_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-blue-600 dark:text-blue-400">${resource.p50} ms</td>
+              <td class="px-4 py-2 text-sm text-indigo-600 dark:text-indigo-400">${resource.p90} ms</td>
+              <td class="px-4 py-2 text-sm text-purple-600 dark:text-purple-400">${resource.p95} ms</td>
+              <td class="px-4 py-2 text-sm text-pink-600 dark:text-pink-400">${resource.p99} ms</td>
+              <td class="px-4 py-2 text-sm text-red-600 dark:text-red-400">${resource.max_duration_ms} ms</td>
             </tr>
           `
         )
@@ -245,6 +287,12 @@ window.createResourcesController = function() {
     renderResourceSlownessChart(data) {
       const canvas = document.getElementById('resourceSlownessChart');
       if (!canvas) return;
+
+      // Check if canvas is visible before rendering
+      if (canvas.offsetParent === null) {
+        console.warn('resourceSlownessChart canvas is hidden, deferring render');
+        return;
+      }
 
       // Destroy existing chart via global registry
       window.chartRegistry.destroy('resources-slowness');
@@ -261,72 +309,117 @@ window.createResourcesController = function() {
         .sort((a, b) => b.p95 - a.p95)
         .slice(0, 10);
 
-      const chart = new Chart(canvas, {
-        type: 'bar',
-        data: {
-          labels: sortedResources.map(r => r.resource_uri),
-          datasets: [
-            {
-              label: 'p95 Latency (ms)',
-              data: sortedResources.map(r => r.p95),
-              backgroundColor: 'rgba(239, 68, 68, 0.6)',
-              borderColor: '#ef4444',
-              borderWidth: 1,
+      requestAnimationFrame(() => {
+        try {
+          // Double-check visibility after animation frame
+          if (canvas.offsetParent === null) {
+            console.warn('resourceSlownessChart canvas became hidden, aborting render');
+            return;
+          }
+
+          // Verify canvas is still in DOM and get valid context
+          const ctx = canvas.getContext('2d');
+          if (!ctx) {
+            console.error('Failed to get 2d context for resourceSlownessChart');
+            return;
+          }
+
+          const defaults = getChartDefaults();
+          const chart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels: sortedResources.map(r => r.resource_uri),
+              datasets: [
+                {
+                  label: 'p95 Latency (ms)',
+                  data: sortedResources.map(r => r.p95),
+                  backgroundColor: 'rgba(239, 68, 68, 0.6)',
+                  borderColor: '#ef4444',
+                  borderWidth: 1,
+                },
+                {
+                  label: 'p50 Latency (ms)',
+                  data: sortedResources.map(r => r.p50),
+                  backgroundColor: 'rgba(34, 197, 94, 0.6)',
+                  borderColor: '#22c55e',
+                  borderWidth: 1,
+                },
+              ],
             },
-            {
-              label: 'p50 Latency (ms)',
-              data: sortedResources.map(r => r.p50),
-              backgroundColor: 'rgba(34, 197, 94, 0.6)',
-              borderColor: '#22c55e',
-              borderWidth: 1,
-            },
-          ],
-        },
-        options: {
-          indexAxis: 'y',
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            title: {
-              display: true,
-              text: `Top 10 Slowest Resources (Last ${this.timeRange}h)`,
-            },
-            legend: {
-              display: true,
-              position: 'top',
-            },
-            tooltip: {
-              callbacks: {
-                label: function (context) {
-                  const resource = sortedResources[context.dataIndex];
-                  return [
-                    `${context.dataset.label}: ${context.parsed.x} ms`,
-                    `Avg: ${resource.avg_duration_ms} ms`,
-                    `Max: ${resource.max_duration_ms} ms`,
-                    `Fetches: ${resource.count}`
-                  ];
+            options: {
+              indexAxis: 'y',
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                title: {
+                  display: true,
+                  text: `Top 10 Slowest Resources (Last ${this.timeRange}h)`,
+                  color: defaults.titleColor,
+                },
+                legend: {
+                  display: true,
+                  position: 'top',
+                  labels: {
+                    color: defaults.color,
+                  },
+                },
+                tooltip: {
+                  callbacks: {
+                    label: function (context) {
+                      const resource = sortedResources[context.dataIndex];
+                      return [
+                        `${context.dataset.label}: ${context.parsed.x} ms`,
+                        `Avg: ${resource.avg_duration_ms} ms`,
+                        `Max: ${resource.max_duration_ms} ms`,
+                        `Fetches: ${resource.count}`
+                      ];
+                    },
+                  },
+                },
+              },
+              scales: {
+                x: {
+                  beginAtZero: true,
+                  title: {
+                    display: true,
+                    text: 'Latency (ms)',
+                    color: defaults.titleColor,
+                  },
+                  ticks: {
+                    color: defaults.tickColor,
+                  },
+                  grid: {
+                    color: defaults.gridColor,
+                  },
+                },
+                y: {
+                  ticks: {
+                    color: defaults.tickColor,
+                  },
+                  grid: {
+                    color: defaults.gridColor,
+                  },
                 },
               },
             },
-          },
-          scales: {
-            x: {
-              beginAtZero: true,
-              title: {
-                display: true,
-                text: 'Latency (ms)',
-              },
-            },
-          },
-        },
+          });
+          // Register with global registry
+          window.chartRegistry.register('resources-slowness', chart);
+          this.charts.resourceSlowness = chart;
+        } catch (e) {
+          console.error('Failed to create resource slowness chart:', e);
+        }
       });
-      // Register with global registry
-      window.chartRegistry.register('resources-slowness', chart);
-      this.charts.resourceSlowness = chart;
     },
     renderResourceErrorProneChart(data) {
       const canvas = document.getElementById('resourceErrorProneChart');
       if (!canvas) return;
+
+      // Check if canvas is visible before rendering
+      if (canvas.offsetParent === null) {
+        console.warn('resourceErrorProneChart canvas is hidden, deferring render');
+        return;
+      }
 
       // Destroy existing chart via global registry
       window.chartRegistry.destroy('resources-errorprone');
@@ -348,65 +441,108 @@ window.createResourcesController = function() {
         const ctx = canvas.getContext('2d');
         if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
         const parent = canvas.parentElement;
-        parent.innerHTML = '<p style="text-align: center; color: #10b981; padding: 2rem;">✓ No errors found - all resources fetched successfully!</p>';
+        if (parent) {
+          // Use safe DOM manipulation instead of innerHTML with static content
+          parent.textContent = '';
+          const p = document.createElement('p');
+          p.className = 'text-center text-emerald-500 p-8';
+          p.textContent = '✓ No errors found - all resources fetched successfully!';
+          parent.appendChild(p);
+        }
         return;
       }
 
-      const chart = new Chart(canvas, {
-        type: 'bar',
-        data: {
-          labels: sortedResources.map(r => r.resource_uri),
-          datasets: [
-            {
-              label: 'Error Rate (%)',
-              data: sortedResources.map(r => r.error_rate),
-              backgroundColor: 'rgba(239, 68, 68, 0.6)',
-              borderColor: '#ef4444',
-              borderWidth: 1,
+      requestAnimationFrame(() => {
+        try {
+          // Double-check visibility after animation frame
+          if (canvas.offsetParent === null) {
+            console.warn('resourceErrorProneChart canvas became hidden, aborting render');
+            return;
+          }
+
+          // Verify canvas is still in DOM and get valid context
+          const ctx = canvas.getContext('2d');
+          if (!ctx) {
+            console.error('Failed to get 2d context for resourceErrorProneChart');
+            return;
+          }
+
+          const defaults = getChartDefaults();
+          const chart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels: sortedResources.map(r => r.resource_uri),
+              datasets: [
+                {
+                  label: 'Error Rate (%)',
+                  data: sortedResources.map(r => r.error_rate),
+                  backgroundColor: 'rgba(239, 68, 68, 0.6)',
+                  borderColor: '#ef4444',
+                  borderWidth: 1,
+                },
+              ],
             },
-          ],
-        },
-        options: {
-          indexAxis: 'y',
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            title: {
-              display: true,
-              text: `Top 10 Error-Prone Resources (Last ${this.timeRange}h)`,
-            },
-            legend: {
-              display: false,
-            },
-            tooltip: {
-              callbacks: {
-                label: function (context) {
-                  const resource = sortedResources[context.dataIndex];
-                  return [
-                    `Error Rate: ${resource.error_rate}%`,
-                    `Errors: ${resource.error_count}`,
-                    `Total: ${resource.total_count}`,
-                    `Success: ${resource.total_count - resource.error_count}`
-                  ];
+            options: {
+              indexAxis: 'y',
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                title: {
+                  display: true,
+                  text: `Top 10 Error-Prone Resources (Last ${this.timeRange}h)`,
+                  color: defaults.titleColor,
+                },
+                legend: {
+                  display: false,
+                },
+                tooltip: {
+                  callbacks: {
+                    label: function (context) {
+                      const resource = sortedResources[context.dataIndex];
+                      return [
+                        `Error Rate: ${resource.error_rate}%`,
+                        `Errors: ${resource.error_count}`,
+                        `Total: ${resource.total_count}`,
+                        `Success: ${resource.total_count - resource.error_count}`
+                      ];
+                    },
+                  },
+                },
+              },
+              scales: {
+                x: {
+                  beginAtZero: true,
+                  max: 100,
+                  title: {
+                    display: true,
+                    text: 'Error Rate (%)',
+                    color: defaults.titleColor,
+                  },
+                  ticks: {
+                    color: defaults.tickColor,
+                  },
+                  grid: {
+                    color: defaults.gridColor,
+                  },
+                },
+                y: {
+                  ticks: {
+                    color: defaults.tickColor,
+                  },
+                  grid: {
+                    color: defaults.gridColor,
+                  },
                 },
               },
             },
-          },
-          scales: {
-            x: {
-              beginAtZero: true,
-              max: 100,
-              title: {
-                display: true,
-                text: 'Error Rate (%)',
-              },
-            },
-          },
-        },
+          });
+          // Register with global registry
+          window.chartRegistry.register('resources-errorprone', chart);
+          this.charts.resourceErrorProne = chart;
+        } catch (e) {
+          console.error('Failed to create resource error-prone chart:', e);
+        }
       });
-      // Register with global registry
-      window.chartRegistry.register('resources-errorprone', chart);
-      this.charts.resourceErrorProne = chart;
     },
     startAutoRefresh() {
       this.stopAutoRefresh();
@@ -421,11 +557,11 @@ window.createResourcesController = function() {
 
 <div class="resources-dashboard" x-data="createResourcesController()" x-init="init()">
   <!-- Header with filters -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-4">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-4">
     <div class="flex flex-wrap gap-4 items-end">
       <div class="flex-1 min-w-[200px]">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Time Range</label>
-        <select x-model="timeRange" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Time Range</label>
+        <select x-model="timeRange" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">
           <option value="1">Last 1 Hour</option>
           <option value="6">Last 6 Hours</option>
           <option value="24">Last 24 Hours</option>
@@ -434,8 +570,8 @@ window.createResourcesController = function() {
         </select>
       </div>
       <div class="flex-1 min-w-[200px]">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Results Limit</label>
-        <select x-model="limit" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Results Limit</label>
+        <select x-model="limit" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">
           <option value="10">Top 10</option>
           <option value="20">Top 20</option>
           <option value="50">Top 50</option>
@@ -443,68 +579,68 @@ window.createResourcesController = function() {
         </select>
       </div>
       <div class="flex-shrink-0">
-        <button @click="applyFilters()" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <button @click="applyFilters()" class="px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 transition-colors">
           Apply Filters
         </button>
       </div>
     </div>
-    <div x-show="loading" class="mt-3 text-sm text-gray-600">
+    <div x-show="loading" class="mt-3 text-sm text-gray-600 dark:text-gray-400">
       Loading resource metrics...
     </div>
-    <div x-show="error" class="mt-3 text-sm text-red-600" x-text="error"></div>
+    <div x-show="error" class="mt-3 text-sm text-red-600 dark:text-red-400" x-text="error"></div>
   </div>
 
   <!-- Summary Cards -->
   <div class="mb-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
     <!-- Overall Health Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4" :class="{
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4" :class="{
       'border-green-500': summaryCards.overallHealth === 'good',
       'border-yellow-500': summaryCards.overallHealth === 'warning',
       'border-red-500': summaryCards.overallHealth === 'critical'
     }">
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm font-medium text-gray-600">Overall Health</p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Overall Health</p>
           <p class="mt-2 text-3xl font-bold" :class="{
-            'text-green-600': summaryCards.overallHealth === 'good',
-            'text-yellow-600': summaryCards.overallHealth === 'warning',
-            'text-red-600': summaryCards.overallHealth === 'critical'
+            'text-green-600 dark:text-green-400': summaryCards.overallHealth === 'good',
+            'text-yellow-600 dark:text-yellow-400': summaryCards.overallHealth === 'warning',
+            'text-red-600 dark:text-red-400': summaryCards.overallHealth === 'critical'
           }" x-text="summaryCards.overallHealth === 'good' ? '🟢 Healthy' : summaryCards.overallHealth === 'warning' ? '🟡 Warning' : '🔴 Critical'"></p>
         </div>
       </div>
     </div>
 
     <!-- Most Used Resource Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-green-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-green-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Most Fetched</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.mostUsed?.name || 'N/A'"></p>
-          <p class="text-sm text-green-600 font-medium" x-text="summaryCards.mostUsed ? `${summaryCards.mostUsed.value} ${summaryCards.mostUsed.metric}` : ''"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Most Fetched</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.mostUsed?.name || 'N/A'"></p>
+          <p class="text-sm text-green-600 dark:text-green-400 font-medium" x-text="summaryCards.mostUsed ? `${summaryCards.mostUsed.value} ${summaryCards.mostUsed.metric}` : ''"></p>
         </div>
         <div class="text-3xl">📦</div>
       </div>
     </div>
 
     <!-- Slowest Resource Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-orange-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-orange-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Slowest Resource</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.slowest?.name || 'N/A'"></p>
-          <p class="text-sm text-orange-600 font-medium" x-text="summaryCards.slowest ? `${summaryCards.slowest.value} ${summaryCards.slowest.metric}` : ''"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Slowest Resource</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.slowest?.name || 'N/A'"></p>
+          <p class="text-sm text-orange-600 dark:text-orange-400 font-medium" x-text="summaryCards.slowest ? `${summaryCards.slowest.value} ${summaryCards.slowest.metric}` : ''"></p>
         </div>
         <div class="text-3xl">🐌</div>
       </div>
     </div>
 
     <!-- Most Error-Prone Resource Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-red-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-red-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Most Error-Prone</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.mostErrorProne?.name || 'None'"></p>
-          <p class="text-sm text-red-600 font-medium" x-text="summaryCards.mostErrorProne ? `${summaryCards.mostErrorProne.value}${summaryCards.mostErrorProne.metric}` : '0% errors'"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Most Error-Prone</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.mostErrorProne?.name || 'None'"></p>
+          <p class="text-sm text-red-600 dark:text-red-400 font-medium" x-text="summaryCards.mostErrorProne ? `${summaryCards.mostErrorProne.value}${summaryCards.mostErrorProne.metric}` : '0% errors'"></p>
         </div>
         <div class="text-3xl">⚠️</div>
       </div>
@@ -512,46 +648,46 @@ window.createResourcesController = function() {
   </div>
 
   <!-- Resource Usage Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="resourceUsageChart"></canvas>
     </div>
   </div>
 
   <!-- Top 10 Slowest Resources Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="resourceSlownessChart"></canvas>
     </div>
   </div>
 
   <!-- Top 10 Error-Prone Resources Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="resourceErrorProneChart"></canvas>
     </div>
   </div>
 
   <!-- Resource Performance Table -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Resource Performance Metrics</h3>
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Resource Performance Metrics</h3>
     <div class="overflow-x-auto">
-      <table id="resourcePerformanceTable" class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table id="resourcePerformanceTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700/50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Resource URI</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Count</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Min</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p50</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p90</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p95</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p99</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Max</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Resource URI</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Count</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Avg</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Min</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p50</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p90</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p95</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p99</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Max</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200"></tbody>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"></tbody>
       </table>
     </div>
   </div>

--- a/mcpgateway/templates/observability_stats.html
+++ b/mcpgateway/templates/observability_stats.html
@@ -1,19 +1,19 @@
 <!-- htmlhint doctype-first:false -->
-<div class="stats-grid">
-    <div class="stat-card success">
-        <div class="stat-label">Total Requests</div>
-        <div class="stat-value">{{ stats.total_traces }}<span class="stat-unit"></span></div>
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm dark:shadow-gray-900/30 border-l-4 border-emerald-500">
+        <div class="text-sm text-gray-600 dark:text-gray-400 mb-2">Total Requests</div>
+        <div class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.total_traces }}</div>
     </div>
-    <div class="stat-card success">
-        <div class="stat-label">Success Rate</div>
-        <div class="stat-value">{{ "%.1f"|format(stats.success_count / stats.total_traces * 100 if stats.total_traces > 0 else 0) }}<span class="stat-unit">%</span></div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm dark:shadow-gray-900/30 border-l-4 border-emerald-500">
+        <div class="text-sm text-gray-600 dark:text-gray-400 mb-2">Success Rate</div>
+        <div class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ "%.1f"|format(stats.success_count / stats.total_traces * 100 if stats.total_traces > 0 else 0) }}<span class="text-base text-gray-600 dark:text-gray-400 ml-1">%</span></div>
     </div>
-    <div class="stat-card error">
-        <div class="stat-label">Error Count</div>
-        <div class="stat-value">{{ stats.error_count }}<span class="stat-unit"></span></div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm dark:shadow-gray-900/30 border-l-4 border-red-500">
+        <div class="text-sm text-gray-600 dark:text-gray-400 mb-2">Error Count</div>
+        <div class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ stats.error_count }}</div>
     </div>
-    <div class="stat-card warning">
-        <div class="stat-label">Avg Response Time</div>
-        <div class="stat-value">{{ "%.0f"|format(stats.avg_duration_ms) }}<span class="stat-unit">ms</span></div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm dark:shadow-gray-900/30 border-l-4 border-amber-500">
+        <div class="text-sm text-gray-600 dark:text-gray-400 mb-2">Avg Response Time</div>
+        <div class="text-3xl font-bold text-gray-900 dark:text-gray-100">{{ "%.0f"|format(stats.avg_duration_ms) }}<span class="text-base text-gray-600 dark:text-gray-400 ml-1">ms</span></div>
     </div>
 </div>

--- a/mcpgateway/templates/observability_tools.html
+++ b/mcpgateway/templates/observability_tools.html
@@ -195,6 +195,7 @@ window.createToolsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'bar',
         data: {
@@ -217,6 +218,7 @@ window.createToolsController = function() {
             title: {
               display: true,
               text: `Tool Usage Frequency (Last ${this.timeRange}h)`,
+              color: defaults.titleColor,
             },
             legend: {
               display: false,
@@ -239,6 +241,21 @@ window.createToolsController = function() {
               title: {
                 display: true,
                 text: 'Number of Invocations',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            y: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -259,17 +276,17 @@ window.createToolsController = function() {
       tbody.innerHTML = data.tools
         .map(
           (tool, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${tool.tool_name}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${tool.count}</td>
-              <td class="px-4 py-2 text-sm text-orange-600 font-medium">${tool.avg_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-green-600">${tool.min_duration_ms} ms</td>
-              <td class="px-4 py-2 text-sm text-blue-600">${tool.p50} ms</td>
-              <td class="px-4 py-2 text-sm text-indigo-600">${tool.p90} ms</td>
-              <td class="px-4 py-2 text-sm text-purple-600">${tool.p95} ms</td>
-              <td class="px-4 py-2 text-sm text-pink-600">${tool.p99} ms</td>
-              <td class="px-4 py-2 text-sm text-red-600">${tool.max_duration_ms} ms</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${tool.tool_name}</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${tool.count}</td>
+              <td class="px-4 py-2 text-sm text-orange-600 dark:text-orange-400 font-medium">${tool.avg_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-green-600 dark:text-green-400">${tool.min_duration_ms} ms</td>
+              <td class="px-4 py-2 text-sm text-blue-600 dark:text-blue-400">${tool.p50} ms</td>
+              <td class="px-4 py-2 text-sm text-indigo-600 dark:text-indigo-400">${tool.p90} ms</td>
+              <td class="px-4 py-2 text-sm text-purple-600 dark:text-purple-400">${tool.p95} ms</td>
+              <td class="px-4 py-2 text-sm text-pink-600 dark:text-pink-400">${tool.p99} ms</td>
+              <td class="px-4 py-2 text-sm text-red-600 dark:text-red-400">${tool.max_duration_ms} ms</td>
             </tr>
           `
         )
@@ -282,12 +299,12 @@ window.createToolsController = function() {
       tbody.innerHTML = data.tools
         .map(
           (tool, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${tool.tool_name}</td>
-              <td class="px-4 py-2 text-sm text-gray-600">${tool.total_count}</td>
-              <td class="px-4 py-2 text-sm text-red-600 font-medium">${tool.error_count}</td>
-              <td class="px-4 py-2 text-sm text-red-700 font-bold">${tool.error_rate}%</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${tool.tool_name}</td>
+              <td class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">${tool.total_count}</td>
+              <td class="px-4 py-2 text-sm text-red-600 dark:text-red-400 font-medium">${tool.error_count}</td>
+              <td class="px-4 py-2 text-sm text-red-700 dark:text-red-300 font-bold">${tool.error_rate}%</td>
             </tr>
           `
         )
@@ -300,10 +317,10 @@ window.createToolsController = function() {
       tbody.innerHTML = data.chains
         .map(
           (chain, idx) => `
-            <tr>
-              <td class="px-4 py-2 text-sm text-gray-700">${idx + 1}</td>
-              <td class="px-4 py-2 text-sm font-mono text-gray-900">${chain.chain}</td>
-              <td class="px-4 py-2 text-sm text-blue-600 font-medium">${chain.count}</td>
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-400">${idx + 1}</td>
+              <td class="px-4 py-2 text-sm font-mono text-gray-900 dark:text-gray-200">${chain.chain}</td>
+              <td class="px-4 py-2 text-sm text-blue-600 dark:text-blue-400 font-medium">${chain.count}</td>
             </tr>
           `
         )
@@ -349,6 +366,7 @@ window.createToolsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'bar',
         data: {
@@ -378,10 +396,14 @@ window.createToolsController = function() {
             title: {
               display: true,
               text: `Top 10 Slowest Tools (Last ${this.timeRange}h)`,
+              color: defaults.titleColor,
             },
             legend: {
               display: true,
               position: 'top',
+              labels: {
+                color: defaults.color,
+              },
             },
             tooltip: {
               callbacks: {
@@ -403,6 +425,21 @@ window.createToolsController = function() {
               title: {
                 display: true,
                 text: 'Latency (ms)',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            y: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -446,7 +483,14 @@ window.createToolsController = function() {
         const ctx = canvas.getContext('2d');
         if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
         const parent = canvas.parentElement;
-        if (parent) parent.innerHTML = '<p style="text-align: center; color: #10b981; padding: 2rem;">✓ No errors found - all tools operating normally!</p>';
+        if (parent) {
+          // Use safe DOM manipulation instead of innerHTML with static content
+          parent.textContent = '';
+          const p = document.createElement('p');
+          p.className = 'text-center text-emerald-500 p-8';
+          p.textContent = '✓ No errors found - all tools operating normally!';
+          parent.appendChild(p);
+        }
         return;
       }
 
@@ -465,6 +509,7 @@ window.createToolsController = function() {
             return;
           }
 
+          const defaults = getChartDefaults();
           const chart = new Chart(ctx, {
         type: 'bar',
         data: {
@@ -487,6 +532,7 @@ window.createToolsController = function() {
             title: {
               display: true,
               text: `Top 10 Error-Prone Tools (Last ${this.timeRange}h)`,
+              color: defaults.titleColor,
             },
             legend: {
               display: false,
@@ -512,6 +558,21 @@ window.createToolsController = function() {
               title: {
                 display: true,
                 text: 'Error Rate (%)',
+                color: defaults.titleColor,
+              },
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
+              },
+            },
+            y: {
+              ticks: {
+                color: defaults.tickColor,
+              },
+              grid: {
+                color: defaults.gridColor,
               },
             },
           },
@@ -554,11 +615,11 @@ window.createToolsController = function() {
 
 <div class="tools-dashboard" x-data="createToolsController()" x-init="init()">
   <!-- Header with filters -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-4">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-4">
     <div class="flex flex-wrap gap-4 items-end">
       <div class="flex-1 min-w-[200px]">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Time Range</label>
-        <select x-model="timeRange" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Time Range</label>
+        <select x-model="timeRange" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">
           <option value="1">Last 1 Hour</option>
           <option value="6">Last 6 Hours</option>
           <option value="24">Last 24 Hours</option>
@@ -567,8 +628,8 @@ window.createToolsController = function() {
         </select>
       </div>
       <div class="flex-1 min-w-[200px]">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Results Limit</label>
-        <select x-model="limit" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Results Limit</label>
+        <select x-model="limit" class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">
           <option value="10">Top 10</option>
           <option value="20">Top 20</option>
           <option value="50">Top 50</option>
@@ -576,68 +637,68 @@ window.createToolsController = function() {
         </select>
       </div>
       <div class="flex-shrink-0">
-        <button @click="applyFilters()" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <button @click="applyFilters()" class="px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 transition-colors">
           Apply Filters
         </button>
       </div>
     </div>
-    <div x-show="loading" class="mt-3 text-sm text-gray-600">
+    <div x-show="loading" class="mt-3 text-sm text-gray-600 dark:text-gray-400">
       Loading tool metrics...
     </div>
-    <div x-show="error" class="mt-3 text-sm text-red-600" x-text="error"></div>
+    <div x-show="error" class="mt-3 text-sm text-red-600 dark:text-red-400" x-text="error"></div>
   </div>
 
   <!-- Summary Cards -->
   <div class="mb-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
     <!-- Overall Health Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4" :class="{
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4" :class="{
       'border-green-500': summaryCards.overallHealth === 'good',
       'border-yellow-500': summaryCards.overallHealth === 'warning',
       'border-red-500': summaryCards.overallHealth === 'critical'
     }">
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm font-medium text-gray-600">Overall Health</p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Overall Health</p>
           <p class="mt-2 text-3xl font-bold" :class="{
-            'text-green-600': summaryCards.overallHealth === 'good',
-            'text-yellow-600': summaryCards.overallHealth === 'warning',
-            'text-red-600': summaryCards.overallHealth === 'critical'
+            'text-green-600 dark:text-green-400': summaryCards.overallHealth === 'good',
+            'text-yellow-600 dark:text-yellow-400': summaryCards.overallHealth === 'warning',
+            'text-red-600 dark:text-red-400': summaryCards.overallHealth === 'critical'
           }" x-text="summaryCards.overallHealth === 'good' ? '🟢 Healthy' : summaryCards.overallHealth === 'warning' ? '🟡 Warning' : '🔴 Critical'"></p>
         </div>
       </div>
     </div>
 
     <!-- Most Used Tool Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-blue-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-blue-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Most Used Tool</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.mostUsed?.name || 'N/A'"></p>
-          <p class="text-sm text-blue-600 font-medium" x-text="summaryCards.mostUsed ? `${summaryCards.mostUsed.value} ${summaryCards.mostUsed.metric}` : ''"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Most Used Tool</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.mostUsed?.name || 'N/A'"></p>
+          <p class="text-sm text-blue-600 dark:text-blue-400 font-medium" x-text="summaryCards.mostUsed ? `${summaryCards.mostUsed.value} ${summaryCards.mostUsed.metric}` : ''"></p>
         </div>
         <div class="text-3xl">📊</div>
       </div>
     </div>
 
     <!-- Slowest Tool Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-orange-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-orange-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Slowest Tool</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.slowest?.name || 'N/A'"></p>
-          <p class="text-sm text-orange-600 font-medium" x-text="summaryCards.slowest ? `${summaryCards.slowest.value} ${summaryCards.slowest.metric}` : ''"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Slowest Tool</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.slowest?.name || 'N/A'"></p>
+          <p class="text-sm text-orange-600 dark:text-orange-400 font-medium" x-text="summaryCards.slowest ? `${summaryCards.slowest.value} ${summaryCards.slowest.metric}` : ''"></p>
         </div>
         <div class="text-3xl">🐌</div>
       </div>
     </div>
 
     <!-- Most Error-Prone Tool Card -->
-    <div class="bg-white rounded-lg shadow-sm p-6 border-l-4 border-red-500">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6 border-l-4 border-red-500">
       <div class="flex items-center justify-between">
         <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-600">Most Error-Prone</p>
-          <p class="mt-2 text-lg font-semibold text-gray-900 truncate" x-text="summaryCards.mostErrorProne?.name || 'None'"></p>
-          <p class="text-sm text-red-600 font-medium" x-text="summaryCards.mostErrorProne ? `${summaryCards.mostErrorProne.value}${summaryCards.mostErrorProne.metric}` : '0% errors'"></p>
+          <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Most Error-Prone</p>
+          <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" x-text="summaryCards.mostErrorProne?.name || 'None'"></p>
+          <p class="text-sm text-red-600 dark:text-red-400 font-medium" x-text="summaryCards.mostErrorProne ? `${summaryCards.mostErrorProne.value}${summaryCards.mostErrorProne.metric}` : '0% errors'"></p>
         </div>
         <div class="text-3xl">⚠️</div>
       </div>
@@ -645,83 +706,83 @@ window.createToolsController = function() {
   </div>
 
   <!-- Tool Usage Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="toolUsageChart"></canvas>
     </div>
   </div>
 
   <!-- Top 10 Slowest Tools Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="toolSlownessChart"></canvas>
     </div>
   </div>
 
   <!-- Top 10 Error-Prone Tools Chart -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <div style="height: 400px;">
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <div class="h-[400px]">
       <canvas id="toolErrorProneChart"></canvas>
     </div>
   </div>
 
   <!-- Tool Performance Table -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Tool Performance Metrics</h3>
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Tool Performance Metrics</h3>
     <div class="overflow-x-auto">
-      <table id="toolPerformanceTable" class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table id="toolPerformanceTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700/50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tool Name</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Count</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Min</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p50</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p90</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p95</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">p99</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Max</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Tool Name</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Count</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Avg</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Min</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p50</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p90</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p95</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">p99</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Max</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200"></tbody>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"></tbody>
       </table>
     </div>
   </div>
 
   <!-- Tool Error Rates Table -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Tool Error Rates</h3>
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Tool Error Rates</h3>
     <div class="overflow-x-auto">
-      <table id="toolErrorsTable" class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table id="toolErrorsTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700/50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tool Name</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total Count</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Error Count</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Error Rate</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Tool Name</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Total Count</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Error Count</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Error Rate</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200"></tbody>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"></tbody>
       </table>
     </div>
   </div>
 
   <!-- Tool Chains Table -->
-  <div class="mb-6 bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Common Tool Chains</h3>
-    <p class="text-sm text-gray-600 mb-4">Tools frequently invoked together in the same trace</p>
+  <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm dark:shadow-gray-900/30 p-6">
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Common Tool Chains</h3>
+    <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">Tools frequently invoked together in the same trace</p>
     <div class="overflow-x-auto">
-      <table id="toolChainsTable" class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table id="toolChainsTable" class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700/50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tool Chain</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Frequency</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Tool Chain</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Frequency</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200"></tbody>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"></tbody>
       </table>
     </div>
   </div>

--- a/mcpgateway/templates/observability_traces_list.html
+++ b/mcpgateway/templates/observability_traces_list.html
@@ -5,22 +5,22 @@
         hx-target="#trace-detail-content"
         hx-trigger="click"
         @click="selectedTrace = '{{ trace.trace_id }}'">
-        <td>{{ trace.start_time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-        <td><strong>{{ trace.http_method or 'N/A' }}</strong></td>
-        <td><code>{{ trace.name }}</code></td>
-        <td>
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">{{ trace.start_time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700"><strong>{{ trace.http_method or 'N/A' }}</strong></td>
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700"><code>{{ trace.name }}</code></td>
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">
             <span class="status-badge status-{{ trace.status }}">
                 {% if trace.status == 'ok' %}✓ {{ trace.http_status_code or 'OK' }}{% else %}✗ {{ trace.http_status_code or 'ERROR' }}{% endif %}
             </span>
         </td>
-        <td>
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">
             <span class="duration-badge {% if trace.duration_ms %}{% if trace.duration_ms < 100 %}duration-fast{% elif trace.duration_ms < 500 %}duration-medium{% else %}duration-slow{% endif %}{% endif %}">
                 {{ "%.2f"|format(trace.duration_ms) if trace.duration_ms else 'N/A' }} ms
             </span>
         </td>
-        <td>{{ trace.user_email or 'anonymous' }}</td>
-        <td>
-            <button class="obs-filter-btn" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;">
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">{{ trace.user_email or 'anonymous' }}</td>
+        <td class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">
+            <button class="px-2 py-1 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 cursor-pointer transition-all dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600">
                 View Details →
             </button>
         </td>


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Implements dark mode on the Observability tab for consistency and better UX.


https://github.com/user-attachments/assets/92fe4acc-e408-479f-8ea1-4174c121bbaf

Closes #2324

## 🔁 Reproduction Steps
1. Access the Admin UI
2. Enable Dark Mode
3. Navigate to the Observability tab
4. Switch between the different tabs

## 🐞 Root Cause
The classes, which were mostly regular CSS classes, had no dark mode overrides. The Chart.js was also not configured for switching colours when Dark Mode was enabled.

## 💡 Fix Description
Replaced the CSS classes with Tailwind utility classes, and added a script to configure chart colours.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 90 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
