### PR TITLE
perf(db): improve SQLAlchemy instrumentation thread safety

### DIFF
--- a/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
+++ b/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
@@ -128,7 +128,7 @@ def test_create_query_span_exception_does_not_raise(caplog):
     sa.logger.propagate = True
     with patch("mcpgateway.instrumentation.sqlalchemy._span_queue.put_nowait", side_effect=Exception("fail")):
         sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-    assert "Failed to enqueue span data" in caplog.text
+    assert "Failed to enqueue query span" in caplog.text
 
 
 def test_write_span_to_db_success():
@@ -303,126 +303,6 @@ def test_instrumentation_queue_init_with_settings_exception():
         assert queue._maxsize == 1000
 
 
-def test_write_span_to_db_setattr_exception():
-    """Test _write_span_to_db when clearing instrumentation context flag fails."""
-    span_data = {
-        "trace_id": "t1",
-        "name": "db.query.select",
-        "kind": "client",
-        "resource_type": "database",
-        "resource_name": "SELECT",
-        "start_attributes": {},
-        "end_attributes": {},
-        "status": "ok",
-        "duration_ms": 10.0,
-        "row_count": 1,
-    }
-
-    # Mock to make setattr fail in the finally block
-    original_setattr = setattr
-    call_count = [0]
-
-    def mock_setattr(obj, name, value):
-        call_count[0] += 1
-        if call_count[0] == 2 and name == "inside_span_creation" and value is False:
-            raise RuntimeError("setattr failed")
-        return original_setattr(obj, name, value)
-
-    with patch("mcpgateway.services.observability_service.ObservabilityService") as mock_service, \
-         patch("mcpgateway.db.SessionLocal") as mock_db, \
-         patch("mcpgateway.db.ObservabilitySpan", MagicMock()), \
-         patch("builtins.setattr", side_effect=mock_setattr):
-        sa._write_span_to_db(span_data)
-
-
-def test_create_query_span_fallback_put_none():
-    """Test _create_query_span when queue has no put method."""
-    # Create a mock queue without put_nowait
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait  # Remove put_nowait attribute
-    mock_queue.put = None  # Set put to None
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        # Should handle gracefully
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_returns_true(caplog):
-    """Test _create_query_span when fallback put returns True."""
-    import logging
-    caplog.set_level(logging.DEBUG)
-    sa.logger.setLevel(logging.DEBUG)
-    sa.logger.propagate = True
-
-    # Create a mock queue without put_nowait but with put returning True
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(return_value=True)
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Enqueued span for SELECT query" in caplog.text
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_returns_false(caplog):
-    """Test _create_query_span when fallback put returns False."""
-    # Create a mock queue without put_nowait but with put returning False
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(return_value=False)
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Span queue is full" in caplog.text
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_returns_none(caplog):
-    """Test _create_query_span when fallback put returns None."""
-    import logging
-    caplog.set_level(logging.DEBUG)
-    sa.logger.setLevel(logging.DEBUG)
-    sa.logger.propagate = True
-
-    # Create a mock queue without put_nowait but with put returning None
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(return_value=None)
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Enqueued span for SELECT query" in caplog.text
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_raises_exception(caplog):
-    """Test _create_query_span when fallback put raises exception."""
-    # Create a mock queue without put_nowait but with put raising exception
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(side_effect=RuntimeError("put failed"))
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Failed to enqueue span data" in caplog.text
-    finally:
-        sa._span_queue = original_queue
 def test_attach_trace_to_session_connection_without_info():
     session = MagicMock()
     session.bind = True


### PR DESCRIPTION
closes  #1689 
This pull request introduces a configurable, metrics-tracking background queue for deferred span writes in the SQLAlchemy observability instrumentation. The main goal is to improve reliability and monitoring of the span queue under load, making it easier to detect and diagnose dropped spans. It also exposes queue statistics via a new API endpoint and adds comprehensive unit tests for the new queue logic.

**Instrumentation queue improvements:**

* Added a new `InstrumentationQueue` class in `mcpgateway/instrumentation/sqlalchemy.py` that wraps a bounded queue, tracks dropped/total spans, and exposes drop rate and stats for monitoring. The queue size is configurable via the `INSTRUMENTATION_QUEUE_SIZE` environment variable and config setting. [[1]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R29-R188) [[2]](diffhunk://#diff-628a7ee520f2dc2401c177833a25b8e5eaf2cbc22a7ca51b4c0e3343a4c99815R1029-R1037) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR2044-R2047)
* Replaced the previous global queue with an instance of `InstrumentationQueue` and updated span enqueueing logic to use its non-blocking methods and metrics.

**Observability and API enhancements:**

* Added a new API endpoint `/observability/instrumentation/queue-stats` to expose queue statistics (total, dropped, drop rate, max size) for admin users, aiding in operational monitoring. [[1]](diffhunk://#diff-8089103e8f88b28a15cd0554ac6639149357deec17df4fe6e0f9f8bbd8be8539R843-R871) [[2]](diffhunk://#diff-8089103e8f88b28a15cd0554ac6639149357deec17df4fe6e0f9f8bbd8be8539L26-R26)

**Thread safety and bug fixes:**

* Changed query tracking from a global dict to thread-local storage to prevent race conditions between request and background threads. Updated all access patterns accordingly. [[1]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R29-R188) [[2]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3L168-R329) [[3]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3L195-R358)
* Improved recursion guard logic in span writing to ensure instrumentation hooks are not recursively triggered, with robust cleanup even on errors. [[1]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R199-R201) [[2]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R246-R251)

**Testing improvements:**

* Added a new test module `test_instrumentation_queue.py` with unit tests for all aspects of `InstrumentationQueue`, including drop rate, stats, and locking.
* Updated existing SQLAlchemy instrumentation tests to use the new thread-local and queue logic, ensuring correct isolation and cleanup between tests. [[1]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L20-R40) [[2]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L43-R60) [[3]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L62-R72) [[4]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L71-R83) [[5]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L87-R101) [[6]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L98-R119)