### PR TITLE
Improved Tool Schema Validation for Broader MCP Server Compatibility

### DIFF
--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5231,17 +5231,33 @@ def validate_tool_schema(mapper, connection, target):
         connection: The database connection.
         target: The target object being validated.
 
-    Raises:
-        ValueError: If the tool input schema is invalid.
     """
     # You can use mapper and connection later, if required.
     _ = mapper
     _ = connection
+
+    allowed_validator_names = {
+        "Draft4Validator",
+        "Draft6Validator",
+        "Draft7Validator",
+        "Draft201909Validator",
+        "Draft202012Validator",
+    }
+
     if hasattr(target, "input_schema"):
+        schema = target.input_schema
+        if schema is None:
+            return
+
         try:
-            jsonschema.Draft7Validator.check_schema(target.input_schema)
+            validator = jsonschema.validators.validator_for(schema)
+
+            if validator.__name__ not in allowed_validator_names:
+                logger.warning(f"Unsupported JSON Schema draft: {validator.__name__}")
+
+            validator.check_schema(schema)
         except jsonschema.exceptions.SchemaError as e:
-            raise ValueError(f"Invalid tool input schema: {str(e)}") from e
+            logger.warning(f"Invalid tool input schema: {str(e)}")
 
 
 def validate_tool_name(mapper, connection, target):
@@ -5275,17 +5291,33 @@ def validate_prompt_schema(mapper, connection, target):
         connection: The database connection.
         target: The target object being validated.
 
-    Raises:
-        ValueError: If the prompt argument schema is invalid.
     """
     # You can use mapper and connection later, if required.
     _ = mapper
     _ = connection
+
+    allowed_validator_names = {
+        "Draft4Validator",
+        "Draft6Validator",
+        "Draft7Validator",
+        "Draft201909Validator",
+        "Draft202012Validator",
+    }
+
     if hasattr(target, "argument_schema"):
+        schema = target.argument_schema
+        if schema is None:
+            return
+
         try:
-            jsonschema.Draft7Validator.check_schema(target.argument_schema)
+            validator = jsonschema.validators.validator_for(schema)
+
+            if validator.__name__ not in allowed_validator_names:
+                logger.warning(f"Unsupported JSON Schema draft: {validator.__name__}")
+
+            validator.check_schema(schema)
         except jsonschema.exceptions.SchemaError as e:
-            raise ValueError(f"Invalid prompt argument schema: {str(e)}") from e
+            logger.warning(f"Invalid prompt argument schema: {str(e)}")
 
 
 # Register validation listeners

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -438,10 +438,16 @@ def get_user_email_from_context() -> str:
     return str(user) if user else "unknown"
 
 
-@mcp_app.call_tool()
+@mcp_app.call_tool(validate_input=False)
 async def call_tool(name: str, arguments: dict) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
     """
     Handles tool invocation via the MCP Server.
+
+    Note: validate_input=False disables the MCP SDK's built-in JSON Schema validation.
+    This is necessary because the SDK uses jsonschema.validate() which internally calls
+    check_schema() with the default validator. Schemas using older draft features
+    (e.g., Draft 4 style exclusiveMinimum: true) fail this validation. The gateway
+    handles schema validation separately in tool_service.py with multi-draft support.
 
     This function supports the MCP protocol's tool calling with structured content validation.
     It can return either unstructured content only, or both unstructured and structured content


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes #2322

This PR fixes an issue with the validation of JSON Schemas attached to tools during insert/update operations causing failure of registration of some MCP servers in Context Forge Gateway. 

Previously, only Draft 7 schemas were checked, and invalid schemas would raise a ValueError. The new implementation:

- Detects the correct schema draft automatically.
- Supports multiple drafts (Draft 4, 6, 7, 2019-09, 2020-12).
- Logs warnings for unsupported drafts or invalid schemas instead of raising exceptions.

This improves stability and provides better visibility into schema issues.

---

## 🔁 Reproduction Steps

1. Create or update a tool with an Draft4 (or any other than draft7) JSON Schema.
2. Trigger an insert or update operation.
3. Observe a runtime jsonschema.SchemaError or unclear failure behavior.

## 🐞 Root Cause

- Always used Draft 7 validator, ignoring other schema drafts.
- Raised a ValueError for invalid schemas, potentially crashing the operation.


## 💡 Fix Description

1. Use jsonschema.validators.validator_for to detect the appropriate validator.
2. Validate schemas explicitly via check_schema.
3. **Supported draft check:** Verifies the detected validator is one of the explicitly supported drafts:
    1. Draft 4
    2. Draft 6
    3. Draft 7
    4. Draft 2019-09
    5. Draft 2020-12
4. Logs a warning if the schema uses an unsupported or unknown draft.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed