### PR TITLE
fix(ui): add loading of missing JS libs to download-cdn-assets.sh

### DIFF
--- a/scripts/download-cdn-assets.sh
+++ b/scripts/download-cdn-assets.sh
@@ -10,7 +10,12 @@ STATIC_DIR="${SCRIPT_DIR}/../app/mcpgateway/static/vendor"
 # Create vendor directory structure
 mkdir -p "${STATIC_DIR}/tailwindcss"
 mkdir -p "${STATIC_DIR}/htmx"
+mkdir -p "${STATIC_DIR}/codemirror/addon/mode"
 mkdir -p "${STATIC_DIR}/codemirror/mode/javascript"
+mkdir -p "${STATIC_DIR}/codemirror/mode/python"
+mkdir -p "${STATIC_DIR}/codemirror/mode/shell"
+mkdir -p "${STATIC_DIR}/codemirror/mode/go"
+mkdir -p "${STATIC_DIR}/codemirror/mode/rust"
 mkdir -p "${STATIC_DIR}/codemirror/theme"
 mkdir -p "${STATIC_DIR}/alpinejs"
 mkdir -p "${STATIC_DIR}/chartjs"
@@ -34,8 +39,23 @@ echo "  ⬇️  CodeMirror 5.65.18..."
 curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.js" \
   -o "${STATIC_DIR}/codemirror/codemirror.min.js"
 
+curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/addon/mode/simple.min.js" \
+  -o "${STATIC_DIR}/codemirror/addon/mode/simple.min.js"
+
 curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/javascript/javascript.min.js" \
   -o "${STATIC_DIR}/codemirror/mode/javascript/javascript.min.js"
+
+curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/python/python.min.js" \
+  -o "${STATIC_DIR}/codemirror/mode/python/python.min.js"
+
+curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/shell/shell.min.js" \
+  -o "${STATIC_DIR}/codemirror/mode/shell/shell.min.js"
+
+curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/go/go.min.js" \
+  -o "${STATIC_DIR}/codemirror/mode/go/go.min.js"
+
+curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/rust/rust.min.js" \
+  -o "${STATIC_DIR}/codemirror/mode/rust/rust.min.js"
 
 curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.css" \
   -o "${STATIC_DIR}/codemirror/codemirror.min.css"
@@ -64,9 +84,6 @@ for font in fa-solid-900.woff2 fa-regular-400.woff2 fa-brands-400.woff2; do
   curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/${font}" \
     -o "${STATIC_DIR}/fontawesome/webfonts/${font}"
 done
-
-# Fix Font Awesome CSS paths for local serving (change ../webfonts to ./webfonts)
-sed -i 's|../webfonts|./webfonts|g' "${STATIC_DIR}/fontawesome/css/all.min.css"
 
 echo "✅ All CDN assets downloaded successfully to ${STATIC_DIR}"
 echo ""


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 90 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Loading dome js files fails with `MCPGATEWAY_UI_AIRGAPPED=True`

These files are defined in `admin.html` https://github.com/IBM/mcp-context-forge/blob/main/mcpgateway/templates/admin.html#L145 but missing in `scripts/download-cdn-assets.sh`

Also, the `sed` command in `scripts/download-cdn-assets.sh` is wrong:

Css loads from https://github.com/IBM/mcp-context-forge/blob/main/mcpgateway/templates/admin.html#L216C34-L216C92
`{{ root_path }}/static/vendor/fontawesome/css/all.min.css"`

And webfonts saves to

`{{ root_path }}/static/vendor/fontawesome/webfonts/*`

In `all.min.css` links should starts with `../`:

Correct url of webfonts in `all.min.css` is `url(../webfonts/fa-brands-400.woff2)`


## 🔁 Reproduction Steps
1. Run the container with `MCPGATEWAY_UI_AIRGAPPED=True` and open Chrome DevTools Network Tab

## 💡 Fix Description
Added links to missing files to `scripts/download-cdn-assets.sh`

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
