### PR TITLE
Consistent duplicate constraints/working in tools, prompts and resources

### DIFF
--- a/mcpgateway/alembic/versions/b1b2b3b4b5b6_fix_constraints.py
+++ b/mcpgateway/alembic/versions/b1b2b3b4b5b6_fix_constraints.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/b1b2b3b4b5b6_fix_constraints.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Alembic migration to fix constraints for resources and prompts to allow gateway namespacing,
+using team/owner/gateway composite constraints, plus partial indexes for local uniqueness.
+
+Revision ID: b1b2b3b4b5b6
+Revises: 4e6273136e56
+Create Date: 2026-01-26 13:01:00.000000
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "b1b2b3b4b5b6"
+down_revision: Union[str, Sequence[str], None] = "4e6273136e56"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def constraint_exists(inspector: sa.Inspector, table_name: str, constraint_name: str) -> bool:
+    """Check if a unique constraint exists on a table.
+
+    Args:
+        inspector: SQLAlchemy inspector instance.
+        table_name: Name of the table to inspect.
+        constraint_name: Name of the constraint to check.
+
+    Returns:
+        True if constraint exists, False if not or if check failed.
+    """
+    try:
+        unique_constraints = inspector.get_unique_constraints(table_name)
+        return any(uc["name"] == constraint_name for uc in unique_constraints)
+    except Exception:
+        # If introspection fails, return False so creates are attempted
+        return False
+
+
+def index_exists(inspector: sa.Inspector, table_name: str, index_name: str) -> bool:
+    """Check if an index exists on a table.
+
+    Args:
+        inspector: SQLAlchemy inspector instance.
+        table_name: Name of the table to inspect.
+        index_name: Name of the index to check.
+
+    Returns:
+        True if index exists, False if not or if check failed.
+    """
+    try:
+        indexes = inspector.get_indexes(table_name)
+        return any(idx["name"] == index_name for idx in indexes)
+    except Exception:
+        # If introspection fails, return False so creates are attempted
+        return False
+
+
+def _upgrade_resources(inspector: sa.Inspector) -> None:
+    """Update constraints for resources table.
+
+    Args:
+        inspector: SQLAlchemy inspector instance for database introspection.
+    """
+    if "resources" not in inspector.get_table_names():
+        print("Resources table not found. Skipping resources migration.")
+        return
+
+    print("Processing resources table constraints...")
+    with op.batch_alter_table("resources", schema=None) as batch_op:
+        # Drop old constraint if exists
+        if constraint_exists(inspector, "resources", "uq_team_owner_uri_resource"):
+            try:
+                batch_op.drop_constraint("uq_team_owner_uri_resource", type_="unique")
+                print("Dropped constraint uq_team_owner_uri_resource.")
+            except Exception as e:
+                print(f"Could not drop constraint uq_team_owner_uri_resource: {e}")
+
+        # Add new composite constraint if not exists
+        if not constraint_exists(inspector, "resources", "uq_team_owner_gateway_uri_resource"):
+            try:
+                batch_op.create_unique_constraint("uq_team_owner_gateway_uri_resource", ["team_id", "owner_email", "gateway_id", "uri"])
+                print("Created constraint uq_team_owner_gateway_uri_resource.")
+            except Exception as e:
+                print(f"Could not create constraint uq_team_owner_gateway_uri_resource (may already exist): {e}")
+        else:
+            print("Constraint uq_team_owner_gateway_uri_resource already exists, skipping create.")
+
+        # Add partial index for local resources if not exists
+        if not index_exists(inspector, "resources", "uq_team_owner_uri_resource_local"):
+            try:
+                batch_op.create_index(
+                    "uq_team_owner_uri_resource_local", ["team_id", "owner_email", "uri"], unique=True, postgresql_where=text("gateway_id IS NULL"), sqlite_where=text("gateway_id IS NULL")
+                )
+                print("Created index uq_team_owner_uri_resource_local.")
+            except Exception as e:
+                print(f"Could not create index uq_team_owner_uri_resource_local (may already exist): {e}")
+        else:
+            print("Index uq_team_owner_uri_resource_local already exists, skipping create.")
+
+
+def _upgrade_prompts(inspector: sa.Inspector) -> None:
+    """Update constraints for prompts table.
+
+    Args:
+        inspector: SQLAlchemy inspector instance for database introspection.
+    """
+    if "prompts" not in inspector.get_table_names():
+        print("Prompts table not found. Skipping prompts migration.")
+        return
+
+    print("Processing prompts table constraints...")
+    with op.batch_alter_table("prompts", schema=None) as batch_op:
+        # Drop old constraint if exists
+        if constraint_exists(inspector, "prompts", "uq_team_owner_name_prompt"):
+            try:
+                batch_op.drop_constraint("uq_team_owner_name_prompt", type_="unique")
+                print("Dropped constraint uq_team_owner_name_prompt.")
+            except Exception as e:
+                print(f"Could not drop constraint uq_team_owner_name_prompt: {e}")
+
+        # Add new composite constraint if not exists
+        if not constraint_exists(inspector, "prompts", "uq_team_owner_gateway_name_prompt"):
+            try:
+                batch_op.create_unique_constraint("uq_team_owner_gateway_name_prompt", ["team_id", "owner_email", "gateway_id", "name"])
+                print("Created constraint uq_team_owner_gateway_name_prompt.")
+            except Exception as e:
+                print(f"Could not create constraint uq_team_owner_gateway_name_prompt (may already exist): {e}")
+        else:
+            print("Constraint uq_team_owner_gateway_name_prompt already exists, skipping create.")
+
+        # Add partial index for local prompts if not exists
+        if not index_exists(inspector, "prompts", "uq_team_owner_name_prompt_local"):
+            try:
+                batch_op.create_index(
+                    "uq_team_owner_name_prompt_local", ["team_id", "owner_email", "name"], unique=True, postgresql_where=text("gateway_id IS NULL"), sqlite_where=text("gateway_id IS NULL")
+                )
+                print("Created index uq_team_owner_name_prompt_local.")
+            except Exception as e:
+                print(f"Could not create index uq_team_owner_name_prompt_local (may already exist): {e}")
+        else:
+            print("Index uq_team_owner_name_prompt_local already exists, skipping create.")
+
+
+def upgrade() -> None:
+    """Update unique constraints for Resources and Prompts.
+
+    1. Drop restrictive old constraints (if they exist).
+    2. Add new team-aware composite constraints (team, owner, gateway, id).
+    3. Add partial unique indexes for local items (gateway_id IS NULL).
+
+    Each table is processed independently - failure on one does not skip the other.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    _upgrade_resources(inspector)
+    _upgrade_prompts(inspector)
+
+
+def _downgrade_resources(inspector: sa.Inspector) -> None:
+    """Revert constraints for resources table.
+
+    Args:
+        inspector: SQLAlchemy inspector instance for database introspection.
+    """
+    if "resources" not in inspector.get_table_names():
+        print("Resources table not found. Skipping resources downgrade.")
+        return
+
+    print("Reverting resources table constraints...")
+    with op.batch_alter_table("resources", schema=None) as batch_op:
+        # Drop new index if exists
+        if index_exists(inspector, "resources", "uq_team_owner_uri_resource_local"):
+            try:
+                batch_op.drop_index("uq_team_owner_uri_resource_local")
+                print("Dropped index uq_team_owner_uri_resource_local.")
+            except Exception as e:
+                print(f"Could not drop index uq_team_owner_uri_resource_local: {e}")
+
+        # Drop new constraint if exists
+        if constraint_exists(inspector, "resources", "uq_team_owner_gateway_uri_resource"):
+            try:
+                batch_op.drop_constraint("uq_team_owner_gateway_uri_resource", type_="unique")
+                print("Dropped constraint uq_team_owner_gateway_uri_resource.")
+            except Exception as e:
+                print(f"Could not drop constraint uq_team_owner_gateway_uri_resource: {e}")
+
+        # Recreate old constraint if not exists
+        if not constraint_exists(inspector, "resources", "uq_team_owner_uri_resource"):
+            try:
+                batch_op.create_unique_constraint("uq_team_owner_uri_resource", ["team_id", "owner_email", "uri"])
+                print("Created constraint uq_team_owner_uri_resource.")
+            except Exception as e:
+                print(f"Could not create constraint uq_team_owner_uri_resource (may already exist): {e}")
+
+
+def _downgrade_prompts(inspector: sa.Inspector) -> None:
+    """Revert constraints for prompts table.
+
+    Args:
+        inspector: SQLAlchemy inspector instance for database introspection.
+    """
+    if "prompts" not in inspector.get_table_names():
+        print("Prompts table not found. Skipping prompts downgrade.")
+        return
+
+    print("Reverting prompts table constraints...")
+    with op.batch_alter_table("prompts", schema=None) as batch_op:
+        # Drop new index if exists
+        if index_exists(inspector, "prompts", "uq_team_owner_name_prompt_local"):
+            try:
+                batch_op.drop_index("uq_team_owner_name_prompt_local")
+                print("Dropped index uq_team_owner_name_prompt_local.")
+            except Exception as e:
+                print(f"Could not drop index uq_team_owner_name_prompt_local: {e}")
+
+        # Drop new constraint if exists
+        if constraint_exists(inspector, "prompts", "uq_team_owner_gateway_name_prompt"):
+            try:
+                batch_op.drop_constraint("uq_team_owner_gateway_name_prompt", type_="unique")
+                print("Dropped constraint uq_team_owner_gateway_name_prompt.")
+            except Exception as e:
+                print(f"Could not drop constraint uq_team_owner_gateway_name_prompt: {e}")
+
+        # Recreate old constraint if not exists
+        if not constraint_exists(inspector, "prompts", "uq_team_owner_name_prompt"):
+            try:
+                batch_op.create_unique_constraint("uq_team_owner_name_prompt", ["team_id", "owner_email", "name"])
+                print("Created constraint uq_team_owner_name_prompt.")
+            except Exception as e:
+                print(f"Could not create constraint uq_team_owner_name_prompt (may already exist): {e}")
+
+
+def downgrade() -> None:
+    """Revert constraints to original state.
+
+    Each table is processed independently - failure on one does not skip the other.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    _downgrade_resources(inspector)
+    _downgrade_prompts(inspector)

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -3216,7 +3216,8 @@ class Resource(Base):
     # Many-to-many relationship with Servers
     servers: Mapped[List["Server"]] = relationship("Server", secondary=server_resource_association, back_populates="resources")
     __table_args__ = (
-        UniqueConstraint("team_id", "owner_email", "uri", name="uq_team_owner_uri_resource"),
+        UniqueConstraint("team_id", "owner_email", "gateway_id", "uri", name="uq_team_owner_gateway_uri_resource"),
+        Index("uq_team_owner_uri_resource_local", "team_id", "owner_email", "uri", unique=True, postgresql_where=text("gateway_id IS NULL"), sqlite_where=text("gateway_id IS NULL")),
         Index("idx_resources_created_at_id", "created_at", "id"),
     )
 
@@ -3632,8 +3633,9 @@ class Prompt(Base):
     visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="public")
 
     __table_args__ = (
-        UniqueConstraint("team_id", "owner_email", "name", name="uq_team_owner_name_prompt"),
+        UniqueConstraint("team_id", "owner_email", "gateway_id", "name", name="uq_team_owner_gateway_name_prompt"),
         UniqueConstraint("gateway_id", "original_name", name="uq_gateway_id__original_name_prompt"),
+        Index("uq_team_owner_name_prompt_local", "team_id", "owner_email", "name", unique=True, postgresql_where=text("gateway_id IS NULL"), sqlite_where=text("gateway_id IS NULL")),
         Index("idx_prompts_created_at_id", "created_at", "id"),
     )
 


### PR DESCRIPTION
# 🐛 Bug-fix PR


Closes #2352

Reference: (Continuation of #2351)

## 📌 Summary
Updates the unique constraints for Resources and Prompts tables to support Gateway-level namespacing. Previously, these entities enforced uniqueness globally per Team/Owner (team_id, owner_email, uri/name). This prevented users from registering the same Gateway (e.g., using one-time auth) multiple times with different names, as the Resources/Prompts would collide.

This adds consistency with the working of tools, prompts and resources. 
Handles both scenarios, prompts and resources added with gateway and without gateway/directly.

## 🔁 Reproduction Steps

1. Enable "one-time auth" for Gateway registration.
2. Register a Gateway (e.g., http://example.com as "Gateway A") containing Resources and Prompts.
3. Register the same Gateway again (e.g., http://example.com as "Gateway B") for the same Team/User.
4. Observed Error: Registration fails with an IntegrityError (Unique Constraint Violation) for Resources (on uri) or Prompts (on name).
5. Expected Behavior: Registration succeeds; Resources/Prompts are duplicated but namespaced to their respective Gateway (similar to how Tools work).

## 🐞 Root Cause

Database Schema: The Resource table had a unique constraint on (team_id, owner_email, uri). The Prompt table had a unique constraint on (team_id, owner_email, name).

Logic: When a second Gateway attempted to sync the same Resources/Prompts, it tried to insert records with the same identifier for the same Team/Owner. Unlike Tools, which compute a namespaced name, Resources/Prompts utilize their raw identifiers, causing a collision at the database level.

## 💡 Fix Description

**1. Updated Constraints:** Modified `mcpgateway/db.py` to replace the restrictive team-level constraints with composite constraints that include gateway_id.

```python
# Resources: 
UniqueConstraint("team_id", "owner_email", "gateway_id", "uri")
```
```python
# Prompts: 
UniqueConstraint("team_id", "owner_email", "gateway_id", "name")
```


2. Added a Partial Unique Index specifically for local items (WHERE gateway_id IS NULL) to both Resources and Prompts:

| Scope   | Constraint / Index Type | Columns Included                                 | Condition                  | Purpose |
|---------|--------------------------|--------------------------------------------------|----------------------------|---------|
| Global  | Unique Constraint        | (team_id, owner_email, gateway_id, identifier)   | —                          | Handles federated items; allows duplicates across different gateways |
| Local   | Unique Index             | (team_id, owner_email, identifier)               | WHERE gateway_id IS NULL   | Strictly enforces uniqueness for local (non-gateway) items |


**3. Migration:** Added a new Alembic migration script (b1b2b3b4b5b6_fix_constraints.py) to apply these schema changes.

**4. Result:** 

1. Resources and Prompts are now unique per Gateway within a Team when added with one_time_auth constraint while registering a gateway. 
2. This maintains data integrity (preventing duplicates within a single Gateway) while allowing the same content to exist across multiple Gateways owned by the same Team.
3. When one-time-auth is disabled, it properly follows, the public/team/private level constraints for exact same gateway and highlights duplicate error in that case.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 90 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed