### PR TITLE
Adding user info in plugin context and pass it to hooks

### DIFF
--- a/mcpgateway/plugins/framework/models.py
+++ b/mcpgateway/plugins/framework/models.py
@@ -13,7 +13,7 @@ the base plugin layer including configurations, and contexts.
 from enum import Enum
 import os
 from pathlib import Path
-from typing import Any, Generic, Optional, Self, TypeAlias, TypeVar
+from typing import Any, Generic, Optional, Self, TypeAlias, TypeVar, Union
 
 # Third-Party
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator, PrivateAttr, ValidationInfo
@@ -715,6 +715,7 @@ class PluginSettings(BaseModel):
         fail_on_plugin_error (bool): error when there is a plugin connectivity or ignore.
         enable_plugin_api (bool): enable or disable plugins globally.
         plugin_health_check_interval (int): health check interval check.
+        include_user_info (bool): if enabled user info is injected in plugin context
     """
 
     parallel_execution_within_band: bool = False
@@ -722,6 +723,7 @@ class PluginSettings(BaseModel):
     fail_on_plugin_error: bool = False
     enable_plugin_api: bool = False
     plugin_health_check_interval: int = 60
+    include_user_info: bool = False
 
 
 class Config(BaseModel):
@@ -808,7 +810,7 @@ class GlobalContext(BaseModel):
     """
 
     request_id: str
-    user: Optional[str] = None
+    user: Optional[Union[str, dict[str, Any]]] = None
     tenant_id: Optional[str] = None
     server_id: Optional[str] = None
     state: dict[str, Any] = Field(default_factory=dict)

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -2684,7 +2684,7 @@ class ToolService:
             if tool_gateway_id and isinstance(tool_gateway_id, str):
                 global_context.server_id = tool_gateway_id
             # Propagate user email to global context for plugin access
-            if app_user_email and isinstance(app_user_email, str):
+            if not plugin_global_context.user and app_user_email and isinstance(app_user_email, str):
                 global_context.user = app_user_email
         else:
             # Create new context (fallback when middleware didn't run)

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -13,6 +13,7 @@ plugin_settings:
   fail_on_plugin_error: false
   enable_plugin_api: true
   plugin_health_check_interval: 120
+  include_user_info: false
 
 plugins:
   # Argument Normalizer - stabilize inputs before anything else


### PR DESCRIPTION
### Description:
This pull request updates how user information is propagated from tool invocations from the UI to the Cedar plugin (and other potential plugins). Previously, only the user’s email address was included in the plugin context.

With this change, user information is now passed as a dictionary in the global plugin context, containing:

`full_name`: The user’s full name

`email`: The user’s email address

`is_admin`: A boolean flag indicating if the user has administrative privileges

As part of the authentication flow in auth.py, this dictionary is stored in `request.state.plugin_global_context`, making user attributes readily accessible to the Cedar RBAC plugin for policy enforcement.

This enhancement enables more granular access control decisions based on user attributes beyond email, aligning with the RBAC model implemented in the Cedar plugin.

For plugins to have this information,

added a key `include_user_info` in plugin_settings in `plugins/config.yaml` file for plugins

### Global plugin settings
```
plugin_settings:
  parallel_execution_within_band: true
  plugin_timeout: 120
  fail_on_plugin_error: false
  enable_plugin_api: true
  plugin_health_check_interval: 120
  include_user_info: true
```