### PR TITLE
2256_chore/fix-gatewayservice-uninitialized-services

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=wrong-import-position, import-outside-toplevel, no-name-in-module
 """Location: ./mcpgateway/main.py
 Copyright 2025
 SPDX-License-Identifier: Apache-2.0
@@ -124,19 +125,18 @@ from mcpgateway.services.cancellation_service import cancellation_service
 from mcpgateway.services.completion_service import CompletionService
 from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.export_service import ExportError, ExportService
-from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayDuplicateConflictError, GatewayError, GatewayNameConflictError, GatewayNotFoundError, GatewayService
+from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayDuplicateConflictError, GatewayError, GatewayNameConflictError, GatewayNotFoundError
 from mcpgateway.services.import_service import ConflictStrategy, ImportConflictError
 from mcpgateway.services.import_service import ImportError as ImportServiceError
 from mcpgateway.services.import_service import ImportService, ImportValidationError
 from mcpgateway.services.log_aggregator import get_log_aggregator
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.metrics import setup_metrics
-from mcpgateway.services.prompt_service import PromptError, PromptLockConflictError, PromptNameConflictError, PromptNotFoundError, PromptService
-from mcpgateway.services.resource_service import ResourceError, ResourceLockConflictError, ResourceNotFoundError, ResourceService, ResourceURIConflictError
-from mcpgateway.services.root_service import RootService
-from mcpgateway.services.server_service import ServerError, ServerLockConflictError, ServerNameConflictError, ServerNotFoundError, ServerService
+from mcpgateway.services.prompt_service import PromptError, PromptLockConflictError, PromptNameConflictError, PromptNotFoundError
+from mcpgateway.services.resource_service import ResourceError, ResourceLockConflictError, ResourceNotFoundError, ResourceURIConflictError
+from mcpgateway.services.server_service import ServerError, ServerLockConflictError, ServerNameConflictError, ServerNotFoundError
 from mcpgateway.services.tag_service import TagService
-from mcpgateway.services.tool_service import ToolError, ToolLockConflictError, ToolNameConflictError, ToolNotFoundError, ToolService
+from mcpgateway.services.tool_service import ToolError, ToolLockConflictError, ToolNameConflictError, ToolNotFoundError
 from mcpgateway.transports.sse_transport import SSETransport
 from mcpgateway.transports.streamablehttp_transport import SessionManagerWrapper, streamable_http_auth
 from mcpgateway.utils.db_isready import wait_for_db_ready
@@ -185,15 +185,17 @@ _config_file = _os.getenv("PLUGIN_CONFIG_FILE", settings.plugin_config_file)
 plugin_manager: PluginManager | None = PluginManager(_config_file) if _PLUGINS_ENABLED else None
 
 
-# Initialize services
-tool_service = ToolService()
-resource_service = ResourceService()
-prompt_service = PromptService()
-gateway_service = GatewayService()
-root_service = RootService()
+# First-Party - import module-level service singletons
+from mcpgateway.services.gateway_service import gateway_service  # noqa: E402
+from mcpgateway.services.prompt_service import prompt_service  # noqa: E402
+from mcpgateway.services.resource_service import resource_service  # noqa: E402
+from mcpgateway.services.root_service import root_service  # noqa: E402
+from mcpgateway.services.server_service import server_service  # noqa: E402
+from mcpgateway.services.tool_service import tool_service  # noqa: E402
+
+# Services that do not expose module-level singletons are instantiated here
 completion_service = CompletionService()
 sampling_handler = SamplingHandler()
-server_service = ServerService()
 tag_service = TagService()
 export_service = ExportService()
 import_service = ImportService()

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name, import-outside-toplevel, unused-import, no-name-in-module
 """Location: ./mcpgateway/services/a2a_service.py
 Copyright 2025
 SPDX-License-Identifier: Apache-2.0
@@ -31,7 +32,7 @@ from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.metrics_cleanup_service import delete_metrics_in_batches, pause_rollup_during_purge
 from mcpgateway.services.structured_logger import get_structured_logger
 from mcpgateway.services.team_management_service import TeamManagementService
-from mcpgateway.services.tool_service import ToolService
+
 from mcpgateway.utils.correlation_id import get_correlation_id
 from mcpgateway.utils.create_slug import slugify
 from mcpgateway.utils.pagination import unified_paginate
@@ -477,7 +478,9 @@ class A2AAgentService:
             # even if tool creation fails (e.g., due to visibility or permission issues)
             tool_db = None
             try:
-                tool_service = ToolService()
+                # First-Party
+                from mcpgateway.services.tool_service import tool_service
+
                 tool_db = await tool_service.create_tool_from_a2a_agent(
                     db=db,
                     agent=new_agent,
@@ -1150,7 +1153,9 @@ class A2AAgentService:
             # Wrap in try/except to handle tool sync failures gracefully - the agent
             # update is the primary operation and should succeed even if tool sync fails
             try:
-                tool_service = ToolService()
+                # First-Party
+                from mcpgateway.services.tool_service import tool_service
+
                 await tool_service.update_tool_from_a2a_agent(
                     db=db,
                     agent=agent,
@@ -1276,7 +1281,9 @@ class A2AAgentService:
             agent_name = agent.name
 
             # Delete the associated tool before deleting the agent
-            tool_service = ToolService()
+            # First-Party
+            from mcpgateway.services.tool_service import tool_service
+
             await tool_service.delete_tool_from_a2a_agent(db=db, agent=agent, user_email=user_email, purge_metrics=purge_metrics)
 
             if purge_metrics:

--- a/mcpgateway/services/export_service.py
+++ b/mcpgateway/services/export_service.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=import-outside-toplevel,no-name-in-module
 """Location: ./mcpgateway/services/export_service.py
 Copyright 2025
 SPDX-License-Identifier: Apache-2.0
@@ -31,12 +32,8 @@ from mcpgateway.db import Prompt as DbPrompt
 from mcpgateway.db import Resource as DbResource
 from mcpgateway.db import Server as DbServer
 from mcpgateway.db import Tool as DbTool
-from mcpgateway.services.gateway_service import GatewayService
-from mcpgateway.services.prompt_service import PromptService
-from mcpgateway.services.resource_service import ResourceService
-from mcpgateway.services.root_service import RootService
-from mcpgateway.services.server_service import ServerService
-from mcpgateway.services.tool_service import ToolService
+
+# Service singletons are imported lazily in __init__ to avoid circular imports
 
 logger = logging.getLogger(__name__)
 
@@ -126,12 +123,23 @@ class ExportService:
 
     def __init__(self):
         """Initialize the export service with required dependencies."""
-        self.gateway_service = GatewayService()
-        self.tool_service = ToolService()
-        self.resource_service = ResourceService()
-        self.prompt_service = PromptService()
-        self.server_service = ServerService()
-        self.root_service = RootService()
+        # Use globally-exported singletons from service modules so they
+        # share initialized EventService/Redis clients created at app startup.
+        # Import lazily to avoid circular import at module load time.
+        # First-Party
+        from mcpgateway.services.gateway_service import gateway_service
+        from mcpgateway.services.prompt_service import prompt_service
+        from mcpgateway.services.resource_service import resource_service
+        from mcpgateway.services.root_service import root_service
+        from mcpgateway.services.server_service import server_service
+        from mcpgateway.services.tool_service import tool_service
+
+        self.gateway_service = gateway_service
+        self.tool_service = tool_service
+        self.resource_service = resource_service
+        self.prompt_service = prompt_service
+        self.server_service = server_service
+        self.root_service = root_service
 
     async def initialize(self) -> None:
         """Initialize the export service."""

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -2616,3 +2616,28 @@ class PromptService:
 
         metrics_cache.invalidate("prompts")
         metrics_cache.invalidate_prefix("top_prompts:")
+
+
+# Lazy singleton - created on first access, not at module import time.
+# This avoids instantiation when only exception classes are imported.
+_prompt_service_instance = None  # pylint: disable=invalid-name
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ for lazy singleton creation.
+
+    Args:
+        name: The attribute name being accessed.
+
+    Returns:
+        The prompt_service singleton instance if name is "prompt_service".
+
+    Raises:
+        AttributeError: If the attribute name is not "prompt_service".
+    """
+    global _prompt_service_instance  # pylint: disable=global-statement
+    if name == "prompt_service":
+        if _prompt_service_instance is None:
+            _prompt_service_instance = PromptService()
+        return _prompt_service_instance
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -3494,3 +3494,28 @@ class ResourceService:
 
         metrics_cache.invalidate("resources")
         metrics_cache.invalidate_prefix("top_resources:")
+
+
+# Lazy singleton - created on first access, not at module import time.
+# This avoids instantiation when only exception classes are imported.
+_resource_service_instance = None  # pylint: disable=invalid-name
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ for lazy singleton creation.
+
+    Args:
+        name: The attribute name being accessed.
+
+    Returns:
+        The resource_service singleton instance if name is "resource_service".
+
+    Raises:
+        AttributeError: If the attribute name is not "resource_service".
+    """
+    global _resource_service_instance  # pylint: disable=global-statement
+    if name == "resource_service":
+        if _resource_service_instance is None:
+            _resource_service_instance = ResourceService()
+        return _resource_service_instance
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcpgateway/services/root_service.py
+++ b/mcpgateway/services/root_service.py
@@ -368,3 +368,28 @@ class RootService:
                 await queue.put(event)
             except Exception as e:
                 logger.error(f"Failed to notify subscriber: {e}")
+
+
+# Lazy singleton - created on first access, not at module import time.
+# This avoids instantiation when only exception classes are imported.
+_root_service_instance = None  # pylint: disable=invalid-name
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ for lazy singleton creation.
+
+    Args:
+        name: The attribute name being accessed.
+
+    Returns:
+        The root_service singleton instance if name is "root_service".
+
+    Raises:
+        AttributeError: If the attribute name is not "root_service".
+    """
+    global _root_service_instance  # pylint: disable=global-statement
+    if name == "root_service":
+        if _root_service_instance is None:
+            _root_service_instance = RootService()
+        return _root_service_instance
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1953,3 +1953,28 @@ class ServerService:
 
         logger.debug(f"Returning OAuth protected resource metadata for server {server_id}")
         return response_data
+
+
+# Lazy singleton - created on first access, not at module import time.
+# This avoids instantiation when only exception classes are imported.
+_server_service_instance = None  # pylint: disable=invalid-name
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ for lazy singleton creation.
+
+    Args:
+        name: The attribute name being accessed.
+
+    Returns:
+        The server_service singleton instance if name is "server_service".
+
+    Raises:
+        AttributeError: If the attribute name is not "server_service".
+    """
+    global _server_service_instance  # pylint: disable=global-statement
+    if name == "server_service":
+        if _server_service_instance is None:
+            _server_service_instance = ServerService()
+        return _server_service_instance
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4326,3 +4326,28 @@ class ToolService:
             return http_response.json()
 
         raise Exception(f"HTTP {http_response.status_code}: {http_response.text}")
+
+
+# Lazy singleton - created on first access, not at module import time.
+# This avoids instantiation when only exception classes are imported.
+_tool_service_instance = None  # pylint: disable=invalid-name
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ for lazy singleton creation.
+
+    Args:
+        name: The attribute name being accessed.
+
+    Returns:
+        The tool_service singleton instance if name is "tool_service".
+
+    Raises:
+        AttributeError: If the attribute name is not "tool_service".
+    """
+    global _tool_service_instance  # pylint: disable=global-statement
+    if name == "tool_service":
+        if _tool_service_instance is None:
+            _tool_service_instance = ToolService()
+        return _tool_service_instance
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/mcpgateway/services/test_a2a_query_param_auth.py
+++ b/tests/unit/mcpgateway/services/test_a2a_query_param_auth.py
@@ -140,10 +140,10 @@ class TestA2AQueryParamAuthRegistration:
         mock_read.masked.return_value = mock_read
         monkeypatch.setattr(a2a_service, "convert_agent_to_read", Mock(return_value=mock_read))
 
-        # Mock ToolService.create_tool_from_a2a_agent
-        with patch("mcpgateway.services.a2a_service.ToolService") as mock_tool_service:
-            mock_tool_service.return_value.create_tool_from_a2a_agent = AsyncMock(return_value=None)
+        # Mock tool_service.create_tool_from_a2a_agent using the singleton
+        from mcpgateway.services.tool_service import tool_service
 
+        with patch.object(tool_service, "create_tool_from_a2a_agent", new=AsyncMock(return_value=None)):
             agent_create = A2AAgentCreate(
                 name="tavily_agent",
                 endpoint_url="https://api.tavily.com/a2a",
@@ -190,9 +190,10 @@ class TestA2AQueryParamAuthRegistration:
         mock_read.masked.return_value = mock_read
         monkeypatch.setattr(a2a_service, "convert_agent_to_read", Mock(return_value=mock_read))
 
-        with patch("mcpgateway.services.a2a_service.ToolService") as mock_tool_service:
-            mock_tool_service.return_value.create_tool_from_a2a_agent = AsyncMock(return_value=None)
+        # Mock tool_service.create_tool_from_a2a_agent using the singleton
+        from mcpgateway.services.tool_service import tool_service
 
+        with patch.object(tool_service, "create_tool_from_a2a_agent", new=AsyncMock(return_value=None)):
             agent_create = A2AAgentCreate(
                 name="test_agent",
                 endpoint_url="https://api.example.com/a2a",
@@ -244,9 +245,10 @@ class TestA2AQueryParamAuthUpdate:
             mock_read.masked.return_value = mock_read
             monkeypatch.setattr(a2a_service, "convert_agent_to_read", Mock(return_value=mock_read))
 
-            with patch("mcpgateway.services.a2a_service.ToolService") as mock_tool_service:
-                mock_tool_service.return_value.update_tool_from_a2a_agent = AsyncMock()
+            # Mock tool_service.update_tool_from_a2a_agent using the singleton
+            from mcpgateway.services.tool_service import tool_service
 
+            with patch.object(tool_service, "update_tool_from_a2a_agent", new=AsyncMock()):
                 agent_update = A2AAgentUpdate(
                     auth_type="query_param",
                     auth_query_param_key="tavilyApiKey",
@@ -289,9 +291,10 @@ class TestA2AQueryParamAuthUpdate:
             mock_read.masked.return_value = mock_read
             monkeypatch.setattr(a2a_service, "convert_agent_to_read", Mock(return_value=mock_read))
 
-            with patch("mcpgateway.services.a2a_service.ToolService") as mock_tool_service:
-                mock_tool_service.return_value.update_tool_from_a2a_agent = AsyncMock()
+            # Mock tool_service.update_tool_from_a2a_agent using the singleton
+            from mcpgateway.services.tool_service import tool_service
 
+            with patch.object(tool_service, "update_tool_from_a2a_agent", new=AsyncMock()):
                 agent_update = A2AAgentUpdate(
                     auth_type="bearer",
                     auth_token="my-bearer-token",

--- a/tests/unit/mcpgateway/services/test_row_level_locking.py
+++ b/tests/unit/mcpgateway/services/test_row_level_locking.py
@@ -439,9 +439,12 @@ class TestA2AServiceLocking:
         agent_update = MagicMock(spec=A2AAgentUpdate)
         agent_update.model_dump.return_value = {"description": "Updated"}
 
+        # Mock tool_service.update_tool_from_a2a_agent using the singleton
+        from mcpgateway.services.tool_service import tool_service
+
         with patch("mcpgateway.services.a2a_service.get_for_update", return_value=mock_agent) as mock_get:
             with patch("mcpgateway.services.a2a_service._get_registry_cache"):
-                with patch("mcpgateway.services.a2a_service.ToolService"):
+                with patch.object(tool_service, "update_tool_from_a2a_agent", new=AsyncMock()):
                     try:
                         await service.update_agent(db, "agent-id", agent_update)
                     except Exception:


### PR DESCRIPTION
Signed-off-by: NAYANAR <nayana.r7813@gmail.com>

Closes #2256 

This change refactors GatewayService to reuse the globally-initialized service singletons (ToolService, PromptService, ResourceService) instead of creating private, uninitialized instances.
By importing the module-level services created and initialized in mcpgateway.main, all gateway operations now share the same EventService/Redis client.
This ensures events such as activate/deactivate propagate correctly across workers and reach Redis subscribers.
The fix resolves silent event drops caused by missing initialize() calls on locally constructed services.
Lazy imports are used to avoid circular dependencies while preserving correct initialization order.
Cross-worker UI updates and subscriber notifications now behave as intended.

Teating

python - <<'PY'import asynciofrom mcpgateway.services.tool_service import tool_serviceasync def test():    async def sub():        async for ev in tool_service.subscribe_events():            print('RECEIVED_EVENT', ev)            return    async def pub():        await asyncio.sleep(0.2)        await tool_service._publish_event({'type': 'test_event', 'data': {'ok': True}})    await asyncio.gather(sub(), pub())asyncio.run(test())PY

python - <<'PY'import mcpgateway.main as mainfrom mcpgateway.services.tool_service import tool_service as svcprint('tool_service is main.tool_service ->', svc is main.tool_service)PY