### PR TITLE
Fix/issue 2340 - eliminate RBAC middleware session accumulation under high load

### DIFF
--- a/tests/unit/mcpgateway/middleware/test_auth_method_propagation.py
+++ b/tests/unit/mcpgateway/middleware/test_auth_method_propagation.py
@@ -103,9 +103,6 @@ async def test_auth_method_in_user_context():
     mock_request.headers = {"user-agent": "TestAgent"}
     mock_request.cookies = {"jwt_token": "test-token"}
 
-    # Create mock database session
-    mock_db = MagicMock()
-
     # Create mock user
     mock_user = MagicMock()
     mock_user.email = "test@example.com"
@@ -116,23 +113,18 @@ async def test_auth_method_in_user_context():
     with patch("mcpgateway.middleware.rbac.get_current_user", new_callable=AsyncMock) as mock_get_user:
         mock_get_user.return_value = mock_user
 
-        # Mock the database dependency
-        with patch("mcpgateway.middleware.rbac.get_db") as mock_get_db:
-            mock_get_db.return_value = mock_db
+        # Call get_current_user_with_permissions
+        user_context = await get_current_user_with_permissions(
+            request=mock_request,
+            credentials=None,
+            jwt_token="test-token",
+        )
 
-            # Call get_current_user_with_permissions
-            user_context = await get_current_user_with_permissions(
-                request=mock_request,
-                credentials=None,
-                jwt_token="test-token",
-                db=mock_db,
-            )
-
-            # Verify user_context includes auth_method and request_id
-            assert user_context["auth_method"] == "simple_token"
-            assert user_context["request_id"] == "test-request-id"
-            assert user_context["email"] == "test@example.com"
-            assert user_context["full_name"] == "Test User"
-            assert user_context["is_admin"] is False
-            assert user_context["ip_address"] == "127.0.0.1"
-            assert user_context["user_agent"] == "TestAgent"
+        # Verify user_context includes auth_method and request_id
+        assert user_context["auth_method"] == "simple_token"
+        assert user_context["request_id"] == "test-request-id"
+        assert user_context["email"] == "test@example.com"
+        assert user_context["full_name"] == "Test User"
+        assert user_context["is_admin"] is False
+        assert user_context["ip_address"] == "127.0.0.1"
+        assert user_context["user_agent"] == "TestAgent"

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -36,15 +36,11 @@ async def test_get_current_user_with_permissions_cookie_token_success():
     mock_request.state = MagicMock(auth_method="jwt", request_id="req123")
 
     mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=True)
-    mock_db = MagicMock()
     with patch("mcpgateway.middleware.rbac.get_current_user", return_value=mock_user):
-        result = await rbac.get_current_user_with_permissions(mock_request, db=mock_db)
+        result = await rbac.get_current_user_with_permissions(mock_request)
         assert result["email"] == "user@example.com"
         assert result["auth_method"] == "jwt"
         assert result["request_id"] == "req123"
-        # Verify db.commit() and db.close() were called for session cleanup
-        mock_db.commit.assert_called_once()
-        mock_db.close.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin_catalog_htmx.py
+++ b/tests/unit/mcpgateway/test_admin_catalog_htmx.py
@@ -53,8 +53,8 @@ def client():
     # Override auth dependencies
     app.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
-    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None):
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test"}
 
     app.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -283,8 +283,8 @@ def test_client(app_with_temp_db):
     app_with_temp_db.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
     # Override get_current_user_with_permissions for RBAC system
-    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None):
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test"}
 
     app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -56,8 +56,8 @@ def test_client(app_with_temp_db):
 
     app_with_temp_db.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
-    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None):
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": None}
 
     app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -404,8 +404,8 @@ def test_client(app_with_temp_db):
     app_with_temp_db.dependency_overrides[get_current_user] = lambda credentials=None, db=None: mock_user
 
     # Override get_current_user_with_permissions for RBAC system
-    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None, db=None):
-        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test", "db": db}
+    def mock_get_current_user_with_permissions(request=None, credentials=None, jwt_token=None):
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test"}
 
     app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
 

--- a/tests/utils/rbac_mocks.py
+++ b/tests/utils/rbac_mocks.py
@@ -50,7 +50,7 @@ def create_mock_user_context(
         "ip_address": ip_address,
         "user_agent": user_agent,
         "auth_method": auth_method,
-        "db": MagicMock(),  # Mock database session
+        "db": None,  # Session closed; use endpoint's db param instead
     }
 
 


### PR DESCRIPTION
### Problem

The RBAC middleware held database sessions open for the entire request duration via `Depends(get_db)`, causing critical performance degradation under high load:

**Load test results (4000 concurrent users, 10 workers):**

| Time     | RPS  | idle_in_tx (max age) | Notes                         |
| -------- | ---- | -------------------- | ----------------------------- |
| 22:51:43 | 2180 | 54 (3s)              | System starts healthy         |
| 22:52:17 | 462  | 54 (37s)             | RPS drops 79%, sessions aging |
| 22:52:51 | 251  | 51 (72s)             | RPS drops 88%, sessions stuck |
| 22:53:01 | 302  | 51 (81s)             | System severely degraded      |

**Root cause:**
`get_current_user_with_permissions()` opened a session at request start and kept it open until response completion, even though database access was only needed briefly for user lookup. Under high load, sessions accumulated faster than they could be released.

**Impact:**
All 346 authenticated endpoints were affected.

---

## Solution

Remove long-lived database sessions from RBAC middleware and use `fresh_db_session()` context manager for short-lived, on-demand database access:

**Before:**

```python
async def get_current_user_with_permissions(
    request: Request,
    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
    jwt_token: Optional[str] = Cookie(default=None),
    db: Session = Depends(get_db)  # ← Held for entire request
):
    user = db.execute(select(EmailUser).where(...))  # Brief DB use
    db.commit()
    db.close()  # Manual cleanup (ineffective with Depends)
    return {"email": user.email, "db": db, ...}  # Passes session downstream
```

**After:**

```python
async def get_current_user_with_permissions(
    request: Request,
    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
    jwt_token: Optional[str] = Cookie(default=None)
    # ← No db parameter
):
    with fresh_db_session() as db:  # ← Short-lived, auto-cleanup
        user = db.execute(select(EmailUser).where(...))
    return {"email": user.email, ...}  # ← No db in context
```

---

## Changes Made

1. **mcpgateway/middleware/rbac.py**

   - ✅ Removed `db: Session = Depends(get_db)` parameter from `get_current_user_with_permissions()`
   - ✅ Replaced with `fresh_db_session()` context manager for EmailUser lookup
   - ✅ Removed `"db": None` from all user context return dictionaries
   - ✅ Removed manual `db.commit()` and `db.close()` calls (context manager handles this)
   - ✅ Updated all permission decorators (`require_permission`, `require_admin_permission`, `require_any_permission`) to use `fresh_db_session()` when no endpoint session exists
   - ✅ Updated `PermissionChecker` class to use `fresh_db_session()` pattern
   - ✅ Added deprecation warnings to `get_db()` and `get_permission_service()` functions
2. **Test Files Updated**

   - Updated all test mocks to match new function signature (removed db parameter):
     - ✅ `tests/unit/mcpgateway/middleware/test_rbac.py`
     - ✅ `tests/unit/mcpgateway/middleware/test_auth_method_propagation.py`
     - ✅ `tests/unit/mcpgateway/utils/test_proxy_auth.py` (8 test methods)
     - ✅ `tests/unit/mcpgateway/test_main.py`
     - ✅ `tests/unit/mcpgateway/test_main_extended.py`
     - ✅ `tests/unit/mcpgateway/test_admin_catalog_htmx.py`

---

## Benefits

1. No session accumulation: Sessions created only when needed, closed immediately after use
2. Better performance under load: Prevents idle-in-transaction bottleneck
3. Reduced connection pool pressure: Sessions released 100-1000x faster (milliseconds vs seconds)
4. Backward compatible: Existing endpoints continue to work; decorators fall back to `fresh_db_session()` automatically
5. Cleaner code: Context manager pattern is more explicit and less error-prone than manual cleanup

---

## Expected Impact

After this fix, under 4000 concurrent users:

- ✅ idle_in_tx count should stay < 50 with max age < 5s
- ✅ RPS should remain stable over time (no degradation)
- ✅ No session accumulation pattern
- ✅ Query execution times stay consistent

---

## Related Issues

- Closes #2340
- Part of #2334 - Parent issue for endpoint handler session lifetime
- Related to #2335 - admin.py session lifetime (135 endpoints)
- Related to #2336 - main.py REST session lifetime (52 endpoints)

---

## Testing

Run the test suite to verify all RBAC tests pass with new session management:

```bash
make test
```