### PR TITLE
Enforce per-tool timeouts and enhanced circuit breaker plugin

### DIFF
--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -44,11 +44,25 @@ import re
 
 # Third-Party
 from fastapi import Response, status
-from prometheus_client import Gauge, REGISTRY
+from prometheus_client import Counter, Gauge, REGISTRY
 from prometheus_fastapi_instrumentator import Instrumentator
 
 # First-Party
 from mcpgateway.config import settings
+
+# Global Metrics
+# Exposed for import by services/plugins to increment counters
+tool_timeout_counter = Counter(
+    "tool_timeout_total",
+    "Total number of tool invocation timeouts",
+    ["tool_name"],
+)
+
+circuit_breaker_open_counter = Counter(
+    "circuit_breaker_open_total",
+    "Total number of times circuit breaker opened",
+    ["tool_name"],
+)
 
 
 def setup_metrics(app):

--- a/plugins/circuit_breaker/README.md
+++ b/plugins/circuit_breaker/README.md
@@ -1,12 +1,12 @@
 # Circuit Breaker Plugin
 
-Trips a per-tool breaker on high error rates or consecutive failures. Blocks calls during a cooldown period.
+Trips a per-tool breaker on high error rates or consecutive failures. Blocks calls during a cooldown period and implements half-open state for recovery testing.
 
-Hooks
-- tool_pre_invoke
-- tool_post_invoke
+## Hooks
+- `tool_pre_invoke` - Checks if circuit is open, blocks request or allows through
+- `tool_post_invoke` - Records success/failure, evaluates thresholds, updates state
 
-Configuration (example)
+## Configuration
 ```yaml
 - name: "CircuitBreaker"
   kind: "plugins.circuit_breaker.circuit_breaker.CircuitBreakerPlugin"
@@ -14,14 +14,66 @@ Configuration (example)
   mode: "enforce_ignore_error"
   priority: 70
   config:
-    error_rate_threshold: 0.5
-    window_seconds: 60
-    min_calls: 10
-    consecutive_failure_threshold: 5
-    cooldown_seconds: 60
-    tool_overrides: {}
+    error_rate_threshold: 0.5      # Fraction of failures to trip breaker (0-1)
+    window_seconds: 60             # Time window for error rate calculation
+    min_calls: 10                  # Minimum calls before evaluating error rate
+    consecutive_failure_threshold: 5  # Consecutive failures to trip breaker
+    cooldown_seconds: 60           # Duration circuit stays open
+    tool_overrides: {}             # Per-tool config overrides
 ```
 
-Notes
-- Error detection uses ToolResult.is_error when available, or a dict key "is_error".
-- Exposes metadata: failure rate, counts, open_until.
+## Features
+
+### Half-Open State
+After cooldown expires, the circuit transitions to half-open state:
+1. A single test request is allowed through
+2. If the test succeeds, the circuit fully closes
+3. If the test fails, the circuit immediately reopens for another cooldown
+
+### Timeout Integration
+Tool timeouts are counted as failures when `tool_service` sets the context flag `cb_timeout_failure`.
+
+### Metadata Exposed
+- `circuit_calls_in_window`: Total calls in sliding window
+- `circuit_failures_in_window`: Failed calls in window
+- `circuit_failure_rate`: Calculated failure rate (0-1)
+- `circuit_consecutive_failures`: Current consecutive failure count
+- `circuit_open_until`: Unix timestamp when circuit will close (0 if closed)
+- `circuit_half_open`: True if in half-open testing state
+- `circuit_retry_after_seconds`: Seconds until circuit closes (for retry headers)
+
+## Notes
+- Error detection uses `ToolResult.is_error` or dict keys `is_error`/`isError` (supports both snake_case and camelCase serialization)
+- Violation response includes `retry_after_seconds` for rate limiting headers
+
+## Example Scenario: Unstable Payment Gateway
+
+**Goal**: Prevent cascading failures when the `payment_api` tool becomes unstable, slow, or times out repeatedly.
+
+**Configuration**:
+```yaml
+config:
+  # 1. Base Strategy (General Tools)
+  window_seconds: 60
+  min_calls: 10
+  error_rate_threshold: 0.5
+  consecutive_failure_threshold: 5
+  cooldown_seconds: 30
+
+  # 2. Specific Strategy (Critical Payment Tool)
+  tool_overrides:
+    payment_api:
+      consecutive_failure_threshold: 2
+      cooldown_seconds: 120
+      min_calls: 3
+```
+
+**Configuration Breakdown & Reasons:**
+
+| Parameter | Value | Reason |
+|-----------|-------|--------|
+| **`window_seconds`** | `60` | **Sliding Window**: We only care about errors in the last minute. Failures from an hour ago shouldn't affect current availability. |
+| **`min_calls`** | `10` | **Sample Size**: Prevents tripping on the very first call of the day. We wait for 10 attempts (generic) or 3 (payment) to have statistical confidence before blocking. |
+| **`error_rate_threshold`** | `0.5` | **Threshold**: If 50% of calls fail (e.g., 5 out of 10), the service is likely overloaded. Stop sending requests to give it breathing room. |
+| **`consecutive_failure_threshold`** | `5` / `2` | **Fast Fail**: Even if the error rate is low, 5 hard failures in a row (e.g., 500 Internal Server Error) means it's down. **Override**: For `payment_api`, we stop after just 2 failures to avoid risking duplicate transactions or bad user experience. |
+| **`cooldown_seconds`** | `30` / `120` | **Recovery Time**: Wait 30 seconds before trying again (Half-Open state). **Override**: Payment systems often restart slowly; we give `payment_api` a full 2 minutes (120s) to recover to prevent "flapping" (rapidly opening/closing). |

--- a/plugins/circuit_breaker/circuit_breaker.py
+++ b/plugins/circuit_breaker/circuit_breaker.py
@@ -46,12 +46,18 @@ class _ToolState:
         calls: Deque of call timestamps within the window.
         consecutive_failures: Count of consecutive failures.
         open_until: Unix timestamp when breaker closes; 0 if closed.
+        half_open: True if breaker is in half-open state (testing recovery).
+        half_open_in_flight: True if a probe request is currently in progress.
+        half_open_started: Timestamp when probe started (for stale probe detection).
     """
 
     failures: Deque[float]
     calls: Deque[float]
     consecutive_failures: int
     open_until: float  # epoch when breaker closes; 0 if closed
+    half_open: bool = False  # half-open state for recovery testing
+    half_open_in_flight: bool = False  # True when a probe request is in progress
+    half_open_started: float = 0.0  # timestamp when probe started
 
 
 class CircuitBreakerConfig(BaseModel):
@@ -97,7 +103,7 @@ def _get_state(tool: str) -> _ToolState:
     """
     st = _STATE.get(tool)
     if not st:
-        st = _ToolState(failures=deque(), calls=deque(), consecutive_failures=0, open_until=0.0)
+        st = _ToolState(failures=deque(), calls=deque(), consecutive_failures=0, open_until=0.0, half_open=False, half_open_in_flight=False, half_open_started=0.0)
         _STATE[tool] = st
     return st
 
@@ -127,12 +133,16 @@ def _is_error(result: Any) -> bool:
     Returns:
         True if result indicates an error, False otherwise.
     """
-    # ToolResult has is_error; otherwise look for common patterns
+    # ToolResult has is_error; when serialized with by_alias=True it becomes isError
     try:
         if hasattr(result, "is_error"):
             return bool(getattr(result, "is_error"))
-        if isinstance(result, dict) and "is_error" in result:
-            return bool(result.get("is_error"))
+        if isinstance(result, dict):
+            # Check both snake_case (direct) and camelCase (serialized with by_alias=True)
+            if "is_error" in result:
+                return bool(result.get("is_error"))
+            if "isError" in result:
+                return bool(result.get("isError"))
     except Exception:
         pass
     return False
@@ -162,23 +172,63 @@ class CircuitBreakerPlugin(Plugin):
         """
         tool = payload.name
         st = _get_state(tool)
+        cfg = _cfg_for(self._cfg, tool)
         now = _now()
-        # Close breaker if cooldown elapsed
+
+        # Check if a probe request is already in flight during half-open state
+        # Only block if we're actually in half-open state (st.half_open is True)
+        # This prevents wedging if a later plugin blocks after we set half_open_in_flight
+        if st.half_open and st.half_open_in_flight:
+            # Check for stale probe (probe started but never completed)
+            # If probe has been in flight longer than cooldown, reset and allow new probe
+            probe_timeout = max(1, int(cfg.cooldown_seconds))
+            if st.half_open_started and (now - st.half_open_started) > probe_timeout:
+                # Stale probe detected - reset half-open state and reopen circuit
+                st.half_open = False
+                st.half_open_in_flight = False
+                st.half_open_started = 0.0
+                st.open_until = now + probe_timeout  # Reopen circuit
+            else:
+                # Another probe is already testing the circuit - block this request
+                return ToolPreInvokeResult(
+                    continue_processing=False,
+                    violation=PluginViolation(
+                        reason="Circuit half-open",
+                        description=f"Probe request in progress for tool '{tool}'",
+                        code="CIRCUIT_HALF_OPEN_PROBE_IN_FLIGHT",
+                        details={"retry_after_seconds": 1.0},
+                    ),
+                )
+
+        # Check if cooldown has elapsed - transition to half-open state
         if st.open_until and now >= st.open_until:
-            st.open_until = 0.0
-            st.consecutive_failures = 0
+            # Transition to half-open state (allow one test request)
+            st.half_open = True
+            st.half_open_in_flight = True  # Mark probe as in-flight
+            st.half_open_started = now  # Record when probe started for stale detection
+            st.open_until = 0.0  # Reset open_until so we allow this request through
+            # Note: consecutive_failures is NOT reset yet - that happens on successful call
+
+        # If still in open state (cooldown not elapsed), block the request
         if st.open_until and now < st.open_until:
+            retry_after_seconds = max(0.0, st.open_until - now)
             return ToolPreInvokeResult(
                 continue_processing=False,
                 violation=PluginViolation(
                     reason="Circuit open",
                     description=f"Breaker open for tool '{tool}' until {int(st.open_until)}",
                     code="CIRCUIT_OPEN",
-                    details={"open_until": st.open_until},
+                    details={
+                        "open_until": st.open_until,
+                        "retry_after_seconds": round(retry_after_seconds, 1),
+                    },
                 ),
             )
+
         # Record call timestamp for rate calculations in post hook context
         context.set_state("cb_call_time", now)
+        # Track if this is a half-open test request
+        context.set_state("cb_half_open_test", st.half_open)
         return ToolPreInvokeResult(continue_processing=True)
 
     async def tool_post_invoke(self, payload: ToolPostInvokePayload, context: PluginContext) -> ToolPostInvokeResult:
@@ -207,24 +257,66 @@ class CircuitBreakerPlugin(Plugin):
         # Record this call
         start_time = context.get_state("cb_call_time", now)
         st.calls.append(start_time)
+
+        # Determine if this is an error:
+        # 1. Check is_error on the result
+        # 2. Check for timeout flag in context (set by tool_service on timeout)
         error = _is_error(payload.result)
+        timeout_occurred = context.get_state("cb_timeout_failure", False)
+        if timeout_occurred:
+            error = True
+
+        # Check if this was a half-open test request
+        was_half_open_test = context.get_state("cb_half_open_test", False)
+
         if error:
             st.failures.append(start_time)
             st.consecutive_failures += 1
+
+            # If this was a half-open test request that failed, immediately reopen the circuit
+            if was_half_open_test:
+                st.half_open = False
+                st.half_open_in_flight = False  # Clear probe in-flight flag
+                st.half_open_started = 0.0  # Clear probe start time
+                st.open_until = now + max(1, int(cfg.cooldown_seconds))
+                try:
+                    from mcpgateway.services.metrics import circuit_breaker_open_counter
+                    circuit_breaker_open_counter.labels(tool_name=tool).inc()
+                except Exception:
+                    pass
         else:
+            # Success - reset consecutive failures
             st.consecutive_failures = 0
 
-        # Evaluate breaker
+            # If this was a half-open test request that succeeded, fully close the circuit
+            if was_half_open_test:
+                st.half_open = False
+                st.half_open_in_flight = False  # Clear probe in-flight flag
+                st.half_open_started = 0.0  # Clear probe start time
+                # Don't reset the window - keep tracking for ongoing health
+
+        # Evaluate breaker (only if not already open from half-open failure)
         calls = len(st.calls)
         failure_rate = (len(st.failures) / calls) if calls > 0 else 0.0
         should_open = False
-        if calls >= max(1, int(cfg.min_calls)) and failure_rate >= cfg.error_rate_threshold:
-            should_open = True
-        if st.consecutive_failures >= max(1, int(cfg.consecutive_failure_threshold)):
-            should_open = True
 
-        if should_open and not st.open_until:
-            st.open_until = now + max(1, int(cfg.cooldown_seconds))
+        if not st.open_until:  # Only evaluate if not already open
+            if calls >= max(1, int(cfg.min_calls)) and failure_rate >= cfg.error_rate_threshold:
+                should_open = True
+            if st.consecutive_failures >= max(1, int(cfg.consecutive_failure_threshold)):
+                should_open = True
+
+            if should_open:
+                st.open_until = now + max(1, int(cfg.cooldown_seconds))
+                try:
+                    from mcpgateway.services.metrics import circuit_breaker_open_counter
+                    circuit_breaker_open_counter.labels(tool_name=tool).inc()
+                except Exception:
+                    pass
+
+        # Compute retry_after_seconds for metadata
+        retry_after_seconds = max(0.0, st.open_until - now) if st.open_until else 0.0
+
         return ToolPostInvokeResult(
             metadata={
                 "circuit_calls_in_window": calls,
@@ -232,5 +324,7 @@ class CircuitBreakerPlugin(Plugin):
                 "circuit_failure_rate": round(failure_rate, 3),
                 "circuit_consecutive_failures": st.consecutive_failures,
                 "circuit_open_until": st.open_until or 0.0,
+                "circuit_half_open": st.half_open,
+                "circuit_retry_after_seconds": round(retry_after_seconds, 1),
             }
         )

--- a/tests/unit/plugins/test_circuit_breaker.py
+++ b/tests/unit/plugins/test_circuit_breaker.py
@@ -1,0 +1,430 @@
+# -*- coding: utf-8 -*-
+"""Tests for Circuit Breaker Plugin.
+
+Verifies all functionality:
+1. Closed state - allows requests
+2. Opens on consecutive failures
+3. Opens on error rate threshold
+4. Blocks requests when open
+5. Half-open state - allows probe request
+6. Closes on successful probe
+7. Reopens on failed probe
+8. Timeout failures trigger circuit breaker
+9. retry_after_seconds calculation
+10. Per-tool configuration overrides
+"""
+
+import asyncio
+import pytest
+import time
+from unittest.mock import MagicMock, patch
+
+# Import the circuit breaker components
+from plugins.circuit_breaker.circuit_breaker import (
+    CircuitBreakerPlugin,
+    CircuitBreakerConfig,
+    _ToolState,
+    _STATE,
+    _get_state,
+    _cfg_for,
+    _is_error,
+)
+from mcpgateway.plugins.framework import (
+    PluginConfig,
+    PluginContext,
+    ToolPreInvokePayload,
+    ToolPostInvokePayload,
+    GlobalContext,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    """Clear circuit breaker state before each test."""
+    _STATE.clear()
+    yield
+    _STATE.clear()
+
+
+@pytest.fixture
+def plugin():
+    """Create a circuit breaker plugin with test configuration."""
+    config = PluginConfig(
+        id="test-cb",
+        kind="circuit_breaker",
+        name="Test Circuit Breaker",
+        enabled=True,
+        order=0,
+        config={
+            "error_rate_threshold": 0.5,
+            "window_seconds": 60,
+            "min_calls": 3,
+            "consecutive_failure_threshold": 3,
+            "cooldown_seconds": 30,
+        },
+    )
+    return CircuitBreakerPlugin(config)
+
+
+@pytest.fixture
+def context():
+    """Create a plugin context for testing."""
+    global_ctx = GlobalContext(request_id="test-request-123")
+    return PluginContext(plugin_id="test-cb", global_context=global_ctx)
+
+
+class TestCircuitBreakerClosedState:
+    """Test circuit breaker in closed state."""
+
+    @pytest.mark.asyncio
+    async def test_allows_requests_when_closed(self, plugin, context):
+        """Closed circuit should allow requests through."""
+        payload = ToolPreInvokePayload(name="test_tool", args={})
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        assert result.continue_processing is True
+        assert result.violation is None
+
+    @pytest.mark.asyncio
+    async def test_records_call_timestamp(self, plugin, context):
+        """Pre-invoke should record call timestamp in context."""
+        payload = ToolPreInvokePayload(name="test_tool", args={})
+        await plugin.tool_pre_invoke(payload, context)
+
+        call_time = context.get_state("cb_call_time")
+        assert call_time is not None
+        assert abs(call_time - time.time()) < 1  # Within 1 second
+
+
+class TestCircuitBreakerOpening:
+    """Test circuit breaker opening conditions."""
+
+    @pytest.mark.asyncio
+    async def test_opens_on_consecutive_failures(self, plugin, context):
+        """Circuit should open after consecutive_failure_threshold failures."""
+        tool = "test_tool"
+
+        # Simulate 3 consecutive failures
+        for _ in range(3):
+            pre_payload = ToolPreInvokePayload(name=tool, args={})
+            await plugin.tool_pre_invoke(pre_payload, context)
+
+            post_payload = ToolPostInvokePayload(name=tool, result={"is_error": True})
+            result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Check circuit is now open
+        assert result.metadata["circuit_open_until"] > 0
+        assert result.metadata["circuit_consecutive_failures"] == 3
+
+    @pytest.mark.asyncio
+    async def test_opens_on_error_rate_threshold(self, plugin, context):
+        """Circuit should open when error rate exceeds threshold."""
+        tool = "test_tool"
+
+        # Simulate 3 calls (min_calls): 2 failures, 1 success = 66% error rate > 50% threshold
+        for i in range(3):
+            pre_payload = ToolPreInvokePayload(name=tool, args={})
+            await plugin.tool_pre_invoke(pre_payload, context)
+
+            is_error = i < 2  # First 2 are failures
+            post_payload = ToolPostInvokePayload(name=tool, result={"is_error": is_error})
+            result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Check circuit is now open
+        assert result.metadata["circuit_open_until"] > 0
+        assert result.metadata["circuit_failure_rate"] >= 0.5
+
+
+class TestCircuitBreakerOpenState:
+    """Test circuit breaker in open state."""
+
+    @pytest.mark.asyncio
+    async def test_blocks_requests_when_open(self, plugin, context):
+        """Open circuit should block requests."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.open_until = time.time() + 30  # Open for 30 seconds
+
+        payload = ToolPreInvokePayload(name=tool, args={})
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        assert result.continue_processing is False
+        assert result.violation is not None
+        assert result.violation.code == "CIRCUIT_OPEN"
+
+    @pytest.mark.asyncio
+    async def test_returns_retry_after_seconds(self, plugin, context):
+        """Open circuit should return retry_after_seconds in violation details."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.open_until = time.time() + 30  # Open for 30 seconds
+
+        payload = ToolPreInvokePayload(name=tool, args={})
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        assert result.violation is not None
+        assert "retry_after_seconds" in result.violation.details
+        assert result.violation.details["retry_after_seconds"] > 0
+        assert result.violation.details["retry_after_seconds"] <= 30
+
+
+class TestCircuitBreakerHalfOpenState:
+    """Test circuit breaker half-open state."""
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_half_open_after_cooldown(self, plugin, context):
+        """Circuit should transition to half-open after cooldown."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.open_until = time.time() - 1  # Cooldown elapsed
+        st.consecutive_failures = 5
+
+        payload = ToolPreInvokePayload(name=tool, args={})
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        # Should allow request through (half-open)
+        assert result.continue_processing is True
+        assert st.half_open is True
+        assert context.get_state("cb_half_open_test") is True
+
+    @pytest.mark.asyncio
+    async def test_closes_on_successful_probe(self, plugin, context):
+        """Half-open circuit should close on successful probe."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.half_open = True
+        st.consecutive_failures = 5
+
+        # Set context for half-open test
+        context.set_state("cb_half_open_test", True)
+        context.set_state("cb_call_time", time.time())
+
+        # Successful probe
+        post_payload = ToolPostInvokePayload(name=tool, result={"is_error": False})
+        result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Circuit should be fully closed
+        assert st.half_open is False
+        assert st.consecutive_failures == 0
+        assert result.metadata["circuit_open_until"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_reopens_on_failed_probe(self, plugin, context):
+        """Half-open circuit should reopen immediately on failed probe."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.half_open = True
+        st.consecutive_failures = 5
+
+        # Set context for half-open test
+        context.set_state("cb_half_open_test", True)
+        context.set_state("cb_call_time", time.time())
+
+        # Failed probe
+        post_payload = ToolPostInvokePayload(name=tool, result={"is_error": True})
+        with patch("mcpgateway.services.metrics.circuit_breaker_open_counter") as mock_counter:
+            mock_counter.labels.return_value.inc = MagicMock()
+            result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Circuit should be reopened
+        assert st.half_open is False
+        assert result.metadata["circuit_open_until"] > time.time()
+
+    @pytest.mark.asyncio
+    async def test_blocks_concurrent_probes_during_half_open(self, plugin, context):
+        """Only one probe should be allowed during half-open state."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.half_open = True  # Must be in half-open state
+        st.half_open_in_flight = True  # Simulate a probe already in progress
+        st.half_open_started = time.time()  # Probe started recently
+        st.consecutive_failures = 5
+
+        payload = ToolPreInvokePayload(name=tool, args={})
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        # Should block - another probe is in flight
+        assert result.continue_processing is False
+        assert result.violation is not None
+        assert result.violation.code == "CIRCUIT_HALF_OPEN_PROBE_IN_FLIGHT"
+
+    @pytest.mark.asyncio
+    async def test_stale_probe_detection_resets_half_open(self, plugin, context):
+        """Stale probe (longer than cooldown) should reset and allow new probe."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.half_open = True
+        st.half_open_in_flight = True
+        st.half_open_started = time.time() - 120  # Probe started 2 minutes ago (stale)
+        st.consecutive_failures = 5
+
+        payload = ToolPreInvokePayload(name=tool, args={})
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        # Stale probe should be reset, circuit reopened
+        assert st.half_open is False
+        assert st.half_open_in_flight is False
+        assert st.open_until > 0  # Circuit should be reopened
+
+    @pytest.mark.asyncio
+    async def test_clears_in_flight_flag_on_probe_success(self, plugin, context):
+        """Successful probe should clear the in-flight flag."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.half_open = True
+        st.half_open_in_flight = True
+        st.consecutive_failures = 5
+
+        context.set_state("cb_half_open_test", True)
+        context.set_state("cb_call_time", time.time())
+
+        post_payload = ToolPostInvokePayload(name=tool, result={"is_error": False})
+        await plugin.tool_post_invoke(post_payload, context)
+
+        # In-flight flag should be cleared
+        assert st.half_open_in_flight is False
+
+    @pytest.mark.asyncio
+    async def test_clears_in_flight_flag_on_probe_failure(self, plugin, context):
+        """Failed probe should clear the in-flight flag."""
+        tool = "test_tool"
+        st = _get_state(tool)
+        st.half_open = True
+        st.half_open_in_flight = True
+        st.consecutive_failures = 5
+
+        context.set_state("cb_half_open_test", True)
+        context.set_state("cb_call_time", time.time())
+
+        post_payload = ToolPostInvokePayload(name=tool, result={"is_error": True})
+        with patch("mcpgateway.services.metrics.circuit_breaker_open_counter") as mock_counter:
+            mock_counter.labels.return_value.inc = MagicMock()
+            await plugin.tool_post_invoke(post_payload, context)
+
+        # In-flight flag should be cleared
+        assert st.half_open_in_flight is False
+
+
+class TestTimeoutIntegration:
+    """Test timeout integration with circuit breaker."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_counted_as_failure(self, plugin, context):
+        """Timeout flag should be counted as failure."""
+        tool = "test_tool"
+
+        # Set timeout flag (as tool_service would do)
+        context.set_state("cb_timeout_failure", True)
+        context.set_state("cb_call_time", time.time())
+
+        # Post-invoke with a technically successful result but timeout flag set
+        post_payload = ToolPostInvokePayload(name=tool, result={"is_error": False})
+        result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Should count as failure
+        assert result.metadata["circuit_failures_in_window"] == 1
+        assert result.metadata["circuit_consecutive_failures"] == 1
+
+
+class TestPerToolOverrides:
+    """Test per-tool configuration overrides."""
+
+    @pytest.mark.asyncio
+    async def test_tool_override_applied(self, context):
+        """Per-tool overrides should be applied correctly."""
+        config = PluginConfig(
+            id="test-cb",
+            kind="circuit_breaker",
+            name="Test Circuit Breaker",
+            enabled=True,
+            order=0,
+            config={
+                "consecutive_failure_threshold": 5,
+                "tool_overrides": {
+                    "critical_tool": {"consecutive_failure_threshold": 10}
+                },
+            },
+        )
+        plugin = CircuitBreakerPlugin(config)
+
+        # Simulate 5 failures on critical_tool (should NOT open - needs 10)
+        for _ in range(5):
+            pre_payload = ToolPreInvokePayload(name="critical_tool", args={})
+            await plugin.tool_pre_invoke(pre_payload, context)
+
+            post_payload = ToolPostInvokePayload(name="critical_tool", result={"is_error": True})
+            result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Circuit should still be closed (needs 10 failures)
+        assert result.metadata["circuit_open_until"] == 0.0
+        assert result.metadata["circuit_consecutive_failures"] == 5
+
+
+class TestHelperFunctions:
+    """Test helper functions."""
+
+    def test_is_error_with_dict(self):
+        """_is_error should detect error in dict result."""
+        assert _is_error({"is_error": True}) is True
+        assert _is_error({"is_error": False}) is False
+        assert _is_error({"success": True}) is False
+
+    def test_is_error_with_camel_case(self):
+        """_is_error should detect error in camelCase (serialized via by_alias=True)."""
+        # When ToolResult.model_dump(by_alias=True) is used, is_error becomes isError
+        assert _is_error({"isError": True}) is True
+        assert _is_error({"isError": False}) is False
+        # snake_case takes precedence if both present
+        assert _is_error({"is_error": True, "isError": False}) is True
+
+    def test_is_error_with_object(self):
+        """_is_error should detect error in object result."""
+        class MockResult:
+            is_error = True
+
+        assert _is_error(MockResult()) is True
+        MockResult.is_error = False
+        assert _is_error(MockResult()) is False
+
+    def test_cfg_for_with_override(self):
+        """_cfg_for should merge tool overrides."""
+        base_cfg = CircuitBreakerConfig(
+            consecutive_failure_threshold=5,
+            tool_overrides={"special_tool": {"consecutive_failure_threshold": 10}},
+        )
+
+        merged = _cfg_for(base_cfg, "special_tool")
+        assert merged.consecutive_failure_threshold == 10
+
+        default = _cfg_for(base_cfg, "regular_tool")
+        assert default.consecutive_failure_threshold == 5
+
+
+class TestWindowEviction:
+    """Test time window eviction logic."""
+
+    @pytest.mark.asyncio
+    async def test_old_entries_evicted(self, plugin, context):
+        """Old call/failure entries should be evicted after window expires."""
+        tool = "test_tool"
+        st = _get_state(tool)
+
+        # Add old entries (outside window)
+        old_time = time.time() - 120  # 2 minutes ago
+        st.calls.append(old_time)
+        st.failures.append(old_time)
+
+        # Make a new call
+        pre_payload = ToolPreInvokePayload(name=tool, args={})
+        await plugin.tool_pre_invoke(pre_payload, context)
+
+        post_payload = ToolPostInvokePayload(name=tool, result={"is_error": False})
+        result = await plugin.tool_post_invoke(post_payload, context)
+
+        # Old entries should be evicted
+        assert result.metadata["circuit_calls_in_window"] == 1
+        assert result.metadata["circuit_failures_in_window"] == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #2078

---

## 🚀 Summary (1-2 sentences)
This PR implements strict per-tool timeout enforcement for all transports (REST, SSE, StreamableHTTP) and significantly enhances the `CircuitBreakerPlugin` with half-open states, retry headers, and granular configuration overrides.

All failure logic is decoupled via the Plugin System:

ToolService: Executes requests, enforces strict limits (Timeouts), reports status.
CircuitBreakerPlugin: Decides if a request should be attempted based on history.

---

### Configurations for timeout:
1. Global Tool Call Timeout :
```bash
# Env Variable: 
TOOL_TIMEOUT 
```

2. Per Tool Timeout in `Tool Schema`:
```bash
timeout_ms 
```

Example Precedence Calculation:

| Tool   | timeout_ms value | Global timeout used | Effective timeout | Notes |
|--------|------------------|---------------------|-------------------|-------|
| Tool A | 10000            | Ignored             | 10 seconds        | Explicit timeout overrides global |
| Tool B | None             | TOOL_TIMEOUT = 60   | 60 seconds        | Falls back to global timeout |
| Tool C | 0                | TOOL_TIMEOUT = 60   | 60 seconds        | 0 treated as not set, uses global |
---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)

### Key Changes
1.  **Strict Timeout Enforcement (tool_service.py)**:
    *   Wrapped all tool invocations (REST, SSE, StreamableHTTP, A2A) in `asyncio.wait_for`.
    *   Ensures per-tool `timeout_ms` overrides global settings.
    *   **Fix**: Modified get_httpx_client_factory
4.  **Circuit Breaker Enhancements (`plugins/circuit_breaker.py`)**:
    *   **Half-Open State**: Allows single "probe" request after cooldown. Success closes circuit; failure re-opens it.
    *   **Retry-After**: Returns precise `retry_after_seconds` in violation response.
    *   **Timeout Handling**: Timeouts now explicitly trigger the circuit breaker via `cb_timeout_failure` context flag.
5.  **Metrics**:
    *   Added `tool_timeout_total` and `circuit_breaker_open_total` Prometheus counters.

```mermaid
flowchart TD
    Client -->|Invoke Tool| Gateway(ToolService)
    Gateway -->|1. check| CB[CircuitBreakerPlugin]
    CB -- Open? --> Reject[429 / Blocked]
    CB -- Closed? --> Gateway
    
    Gateway -->|2. Invoke w/ Timeout| Tool[External Tool]
    
    Tool -- Success --> Gateway
    Gateway -->|3. Record Success| CB
    
    Tool -- Timeout/Error --> Gateway
    Gateway -- Flag: cb_timeout_failure --> CB
    Gateway -->|4. Record Failure| CB
    CB -- Trip Threshold? --> CBState[Open Circuit]

```

---

### Feature Map & Implementation Details:

| Feature Request              | Implementation Mechanism                                                                                                   | Location                                      |
|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
| Strict Timeout Enforcement  | Wrapped invocations in `asyncio.wait_for`. Prioritizes tool-specific `timeout_ms` over global default.                     | mcpgateway/services/tool_service.py            |
| Circuit Breaker Logic       | Plugin-based implementation using sliding window for error rates and consecutive failure counters.                        | plugins/circuit_breaker/circuit_breaker.py    |
| Timeouts Count as Failures  | Core catches `TimeoutError` and sets context flag. Plugin reads flag and counts as failure even without HTTP status.       | tool_service.py (Setter), circuit_breaker.py (Getter) |
| Half-Open State             | Probe logic allows 1 request after cooldown. Success closes circuit; failure re-opens immediately.                        | circuit_breaker.py (tool_pre_invoke)           |
| Retry-After Header          | Calculates `open_until - now` and returns exact seconds in violation details.                                               | circuit_breaker.py                             |
| Granular / Per-Tool Config  | `tool_overrides` map allows custom thresholds for critical tools (e.g., higher patience for Payment APIs).               | plugins/config.yaml                            |
| Metrics                     | Added `tool_timeout_total` and `circuit_breaker_open_total` Prometheus counters.                                          | mcpgateway/services/metrics.py                 |


### Verification
Unit Tests: Added TestToolTimeoutsAndRetries covering state transitions, timeout precedence, and plugin logic.