### PR TITLE
fix: honor is_active field in token POST/PUT requests

### DIFF
--- a/mcpgateway/routers/tokens.py
+++ b/mcpgateway/routers/tokens.py
@@ -160,6 +160,7 @@ async def create_token(
             tags=request.tags,
             team_id=request.team_id,
             caller_permissions=caller_permissions,
+            is_active=request.is_active,
         )
 
         # Create TokenResponse for the token info
@@ -365,6 +366,7 @@ async def update_token(
             scope=scope,
             tags=request.tags,
             caller_permissions=caller_permissions,
+            is_active=request.is_active,
         )
 
         if not token:
@@ -632,6 +634,7 @@ async def create_team_token(
             tags=request.tags,
             team_id=team_id,  # This will validate team ownership
             caller_permissions=caller_permissions,
+            is_active=request.is_active,
         )
 
         # Create TokenResponse for the token info

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -6159,6 +6159,7 @@ class TokenCreateRequest(BaseModel):
         expires_in_days: Optional expiry in days
         scope: Optional token scoping configuration
         tags: Optional organizational tags
+        is_active: Token active status (defaults to True)
 
     Examples:
         >>> request = TokenCreateRequest(
@@ -6177,6 +6178,7 @@ class TokenCreateRequest(BaseModel):
     scope: Optional[TokenScopeRequest] = Field(None, description="Token scoping configuration")
     tags: List[str] = Field(default_factory=list, description="Organizational tags")
     team_id: Optional[str] = Field(None, description="Team ID for team-scoped tokens")
+    is_active: bool = Field(default=True, description="Token active status")
 
 
 class TokenUpdateRequest(BaseModel):
@@ -6187,6 +6189,7 @@ class TokenUpdateRequest(BaseModel):
         description: New token description
         scope: New token scoping configuration
         tags: New organizational tags
+        is_active: New token active status
 
     Examples:
         >>> request = TokenUpdateRequest(
@@ -6201,6 +6204,7 @@ class TokenUpdateRequest(BaseModel):
     description: Optional[str] = Field(None, description="New token description", max_length=1000)
     scope: Optional[TokenScopeRequest] = Field(None, description="New token scoping configuration")
     tags: Optional[List[str]] = Field(None, description="New organizational tags")
+    is_active: Optional[bool] = Field(None, description="New token active status")
 
 
 class TokenResponse(BaseModel):

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -372,6 +372,7 @@ class TokenCatalogService:
         tags: Optional[List[str]] = None,
         team_id: Optional[str] = None,
         caller_permissions: Optional[List[str]] = None,
+        is_active: bool = True,
     ) -> tuple[EmailApiToken, str]:
         """
         Create a new API token with team-level scoping and additional configurations.
@@ -398,6 +399,7 @@ class TokenCatalogService:
             team_id (Optional[str]): The team ID to which the token should be scoped. This is required for team-level scoping.
             caller_permissions (Optional[List[str]]): The permissions of the caller creating the token. Used for
                 scope containment validation to ensure the new token cannot have broader permissions than the caller.
+            is_active (bool): Whether the token should be created as active (default is True).
 
         Returns:
             tuple[EmailApiToken, str]: A tuple where the first element is the `EmailApiToken` database record and
@@ -488,7 +490,7 @@ class TokenCatalogService:
             time_restrictions=scope.time_restrictions if scope else {},
             usage_limits=scope.usage_limits if scope else {},
             # Token status
-            is_active=True,
+            is_active=is_active,
             created_at=utc_now(),
             last_used=None,
         )
@@ -603,6 +605,7 @@ class TokenCatalogService:
         scope: Optional[TokenScope] = None,
         tags: Optional[List[str]] = None,
         caller_permissions: Optional[List[str]] = None,
+        is_active: Optional[bool] = None,
     ) -> Optional[EmailApiToken]:
         """Update an existing token with scope containment validation.
 
@@ -614,6 +617,7 @@ class TokenCatalogService:
             scope: New scoping configuration
             tags: New tags
             caller_permissions: Caller's effective permissions for scope containment
+            is_active: New token active status
 
         Returns:
             Optional[EmailApiToken]: Updated token if found
@@ -649,6 +653,9 @@ class TokenCatalogService:
 
         if tags is not None:
             token.tags = tags
+
+        if is_active is not None:
+            token.is_active = is_active
 
         if scope:
             token.server_id = scope.server_id


### PR DESCRIPTION
## 🐛 Bug-fix PR

## 📌 Summary
API tokens could not be created or updated with `is_active=false`. The `is_active` field in POST/PUT request bodies was completely ignored, forcing all tokens to be active regardless of the intended state. This prevented programmatic management of inactive tokens and broke API contract expectations.

## 🔗Related Issue
Closes #2573 

## 🐞 Root Cause
Three layers were missing the `is_active` field:
1. **Schema Layer**: `TokenCreateRequest` and `TokenUpdateRequest` schemas didn't include `is_active` field
2. **Service Layer**: `create_token()` and `update_token()` methods hardcoded `is_active=True` instead of accepting parameter
3. **Router Layer**: Endpoints didn't extract or pass `is_active` from request to service

## 💡 Fix Description
Added `is_active` field through the complete request pipeline:
- **Schemas**: Added `is_active: bool = Field(default=True)` to `TokenCreateRequest` and `is_active: Optional[bool] = Field(None)` to `TokenUpdateRequest`
- **Service**: Modified method signatures to accept `is_active` parameter; changed DB INSERT from hardcoded to parameterized; added conditional update logic with None-check
- **Router**: Updated all 3 token endpoints (create, update, create_team) to pass `is_active=request.is_active`
- **Backward Compatibility**: Default values maintain existing behavior for clients not sending the field

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅     |
| Unit tests                            | `make test`          | ✅     |
| Coverage ≥ 90 %                       | `make coverage`      | ✅     |
| Manual regression no longer fails     | API curl tests       | ✅     |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
