### PR TITLE
fix: add keyboard onkeydown handlers to interactive elements

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -31308,3 +31308,18 @@ window.filterByRelationship = filterByRelationship;
 window.filterTeams = filterTeams;
 window.searchTeamSelector = searchTeamSelector;
 window.selectTeamFromSelector = selectTeamFromSelector;
+
+/**
+ * Handle keydown event when Enter or Space key is pressed
+ *
+ * @param {KeyboardEvent} event - the keyboard event triggered
+ * @param {function} callback - the function to call when Enter or Space is pressed
+ */
+function handleKeydown(event, callback) {
+    if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        callback(event);
+    }
+}
+
+window.handleKeydown = handleKeydown;

--- a/mcpgateway/templates/mcp_registry_partial.html
+++ b/mcpgateway/templates/mcp_registry_partial.html
@@ -176,7 +176,7 @@
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {% if is_all_selected %}bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border border-blue-300 dark:border-blue-700{% else %}bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200{% endif %} cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors"
           data-filter-type="category"
           data-filter-value=""
-          onclick="filterByCategory('')"
+          onclick="filterByCategory('')" onkeydown="handleKeydown(event, () => filterByCategory(''))" role="button" tabindex="0"
         >
           All Categories
           <span class="ml-1 text-xs {% if is_all_selected %}text-blue-600 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}"
@@ -190,7 +190,7 @@
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {% if is_selected %}bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border border-blue-300 dark:border-blue-700{% else %}bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200{% endif %} cursor-pointer hover:bg-blue-200 dark:hover:bg-gray-600 transition-colors"
           data-filter-type="category"
           data-filter-value="{{ category }}"
-          onclick="filterByCategory('{{ category }}')"
+          onclick="filterByCategory('{{ category }}')" onkeydown="handleKeydown(event, () => filterByCategory('{{ category }}'))" role="button" tabindex="0"
         >
           {{ category }}
           <span class="ml-1 text-xs {% if is_selected %}text-blue-600 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}"
@@ -226,7 +226,7 @@
           class="flex justify-between items-center p-2 {% if is_all_auth_selected %}bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800{% else %}bg-gray-50 dark:bg-gray-700{% endif %} rounded cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
           data-filter-type="auth"
           data-filter-value=""
-          onclick="filterByAuthType('')"
+          onclick="filterByAuthType('')" onkeydown="handleKeydown(event, () => filterByAuthType(''))" role="button" tabindex="0"
         >
           <span
             class="text-sm font-medium {% if is_all_auth_selected %}text-blue-700 dark:text-blue-300{% else %}text-gray-700 dark:text-gray-300{% endif %}"
@@ -245,7 +245,7 @@
           class="flex justify-between items-center p-2 {% if is_auth_selected %}bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800{% else %}bg-gray-50 dark:bg-gray-700{% endif %} rounded cursor-pointer hover:bg-blue-100 dark:hover:bg-gray-600 transition-colors"
           data-filter-type="auth"
           data-filter-value="{{ auth_type }}"
-          onclick="filterByAuthType('{{ auth_type }}')"
+          onclick="filterByAuthType('{{ auth_type }}')" onkeydown="handleKeydown(event, () => filterByAuthType('{{ auth_type }}'))" role="button" tabindex="0"
         >
           <span class="text-sm font-medium {% if is_auth_selected %}text-blue-700 dark:text-blue-300{% else %}text-gray-700 dark:text-gray-300{% endif %}"
             >{{ auth_type }}</span
@@ -284,7 +284,7 @@
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors border border-blue-300 dark:border-blue-700"
           data-filter-type="provider"
           data-filter-value=""
-          onclick="filterByProvider('')"
+          onclick="filterByProvider('')" onkeydown="handleKeydown(event, () => filterByProvider(''))" role="button" tabindex="0"
         >
           All Providers
           <span class="ml-1 text-xs text-blue-600 dark:text-blue-300"
@@ -297,7 +297,7 @@
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
           data-filter-type="provider"
           data-filter-value="{{ provider | lower }}"
-          onclick="filterByProvider('{{ provider | lower }}')"
+          onclick="filterByProvider('{{ provider | lower }}')" onkeydown="handleKeydown(event, () => filterByProvider('{{ provider | lower }}'))" role="button" tabindex="0"
         >
           {{ provider }}
           <span class="ml-1 text-xs text-gray-500 dark:text-gray-400"

--- a/mcpgateway/templates/overview_partial.html
+++ b/mcpgateway/templates/overview_partial.html
@@ -232,7 +232,7 @@
   <!-- Quick Stats Grid -->
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
     <!-- Virtual Servers Card -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('catalog')">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('catalog')" onkeydown="handleKeydown(event, () => showTab('catalog'))" tabindex="0" role="button" aria-label="View Virtual Servers">
       <div class="flex items-center justify-between">
         <div class="flex items-center">
           <div class="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg mr-3">
@@ -253,7 +253,7 @@
     </div>
 
     <!-- Tools Card -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('tools')">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('tools')" onkeydown="handleKeydown(event, () => showTab('tools'))" tabindex="0" role="button" aria-label="View Tools">
       <div class="flex items-center justify-between">
         <div class="flex items-center">
           <div class="p-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg mr-3">
@@ -275,7 +275,7 @@
     </div>
 
     <!-- Plugins Card -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('plugins')">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('plugins')" onkeydown="handleKeydown(event, () => showTab('plugins'))" tabindex="0" role="button" aria-label="View Plugins">
       <div class="flex items-center justify-between">
         <div class="flex items-center">
           <div class="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg mr-3">

--- a/mcpgateway/templates/plugins_partial.html
+++ b/mcpgateway/templates/plugins_partial.html
@@ -80,7 +80,7 @@
       <div class="space-y-2">
         <div
           class="flex justify-between items-center p-2 bg-indigo-50 rounded dark:bg-indigo-900/20 cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-900/30 transition-colors border border-indigo-200 dark:border-indigo-800"
-          onclick="filterByHook('')"
+          onclick="filterByHook('')" onkeydown="handleKeydown(event, () => filterByHook(''))" role="button" tabindex="0"
         >
           <span
             class="text-sm font-medium text-indigo-700 dark:text-indigo-300"
@@ -95,7 +95,7 @@
         {% for hook, count in stats.plugins_by_hook.items() %}
         <div
           class="flex justify-between items-center p-2 bg-gray-50 rounded dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
-          onclick="filterByHook('{{ hook }}')"
+          onclick="filterByHook('{{ hook }}')" onkeydown="handleKeydown(event, () => filterByHook('{{ hook }}'))" role="button" tabindex="0"
         >
           <span class="text-sm font-medium text-gray-700 dark:text-gray-300"
             >{{ hook.replace('_', ' ').title() }}</span
@@ -131,7 +131,7 @@
       <div class="flex flex-wrap gap-2">
         <span
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200 cursor-pointer hover:bg-indigo-200 dark:hover:bg-indigo-800 transition-colors border border-indigo-300 dark:border-indigo-700"
-          onclick="filterByTag('')"
+          onclick="filterByTag('')" onkeydown="handleKeydown(event, () => filterByTag(''))" role="button" tabindex="0"
         >
           All Tags
           <span class="ml-1 text-xs text-indigo-600 dark:text-indigo-300"
@@ -141,7 +141,7 @@
         {% for tag, count in stats.plugins_by_tag.items() %}
         <span
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-          onclick="filterByTag('{{ tag }}')"
+          onclick="filterByTag('{{ tag }}')" onkeydown="handleKeydown(event, () => filterByTag('{{ tag }}'))" role="button" tabindex="0"
         >
           {{ tag }}
           <span class="ml-1 text-xs text-gray-500 dark:text-gray-400"
@@ -173,7 +173,7 @@
       <div class="flex flex-wrap gap-2">
         <span
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200 cursor-pointer hover:bg-indigo-200 dark:hover:bg-indigo-800 transition-colors border border-indigo-300 dark:border-indigo-700"
-          onclick="filterByAuthor('')"
+          onclick="filterByAuthor('')" onkeydown="handleKeydown(event, () => filterByAuthor(''))" role="button" tabindex="0"
         >
           All Authors
           <span class="ml-1 text-xs text-indigo-600 dark:text-indigo-300"
@@ -183,7 +183,7 @@
         {% for author, count in stats.plugins_by_author.items() %}
         <span
           class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-          onclick="filterByAuthor('{{ author }}')"
+          onclick="filterByAuthor('{{ author }}')" onkeydown="handleKeydown(event, () => filterByAuthor('{{ author }}'))" role="button" tabindex="0"
         >
           {{ author }}
           <span class="ml-1 text-xs text-gray-500 dark:text-gray-400"


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 Issue
Closes https://github.com/IBM/mcp-context-forge/issues/2167

---

## 🚀 Summary 
Add `onkeydown` handler (`onkeypress` handler is deprecated) to the HTML elements (`div` and `span`) that have `onclick` handlers to support keyboard users.

Now that we have added the handlers, we can switch to the interactive elements (div, span) on Overview, MCP Registery and Plugins pages with the `Tab` key:

https://github.com/user-attachments/assets/c0fa8c16-0a54-4d74-8347-69fa38a9f516

---

## 🧪 Checks

- [x] `make lint-web` passes

