### PR TITLE
fix: plugin runtime defaults and tag normalization

### DIFF
--- a/mcpgateway/plugins/framework/constants.py
+++ b/mcpgateway/plugins/framework/constants.py
@@ -8,6 +8,10 @@ Plugins constants file.
 This module stores a collection of plugin constants used throughout the framework.
 """
 
+# Standard
+import os
+import sys
+
 # Model constants.
 # Specialized plugin types.
 EXTERNAL_PLUGIN_TYPE = "external"
@@ -22,7 +26,7 @@ CWD = "cwd"
 UDS = "uds"
 
 NAME = "name"
-PYTHON = "python"
+PYTHON = os.environ.get("MCP_PYTHON", sys.executable)
 PLUGIN_NAME = "plugin_name"
 PAYLOAD = "payload"
 CONTEXT = "context"

--- a/mcpgateway/plugins/framework/manager.py
+++ b/mcpgateway/plugins/framework/manager.py
@@ -580,6 +580,11 @@ class PluginManager:
                 logger.debug("Plugin manager already initialized")
                 return
 
+            # Defensive cleanup: registry should be empty when not initialized
+            if self._registry.plugin_count:
+                logger.debug("Plugin registry not empty before initialize; clearing stale plugins")
+                await self._registry.shutdown()
+
             plugins = self._config.plugins if self._config and self._config.plugins else []
             loaded_count = 0
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1812,7 +1812,7 @@ class ResourceRead(BaseModelWithConfigDict):
     updated_at: datetime
     enabled: bool
     metrics: Optional[ResourceMetrics] = Field(None, description="Resource metrics (may be None in list operations)")
-    tags: List[Dict[str, str]] = Field(default_factory=list, description="Tags for categorizing the resource")
+    tags: List[str] = Field(default_factory=list, description="Tags for categorizing the resource")
 
     # Comprehensive metadata for audit tracking
     created_by: Optional[str] = Field(None, description="Username who created this entity")
@@ -6879,7 +6879,7 @@ class GrpcServiceRead(BaseModel):
     last_reflection: Optional[datetime] = Field(None, description="Last reflection timestamp")
 
     # Tags
-    tags: List[Dict[str, str]] = Field(default_factory=list, description="Service tags")
+    tags: List[str] = Field(default_factory=list, description="Service tags")
 
     # Timestamps
     created_at: datetime = Field(..., description="Creation timestamp")

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -331,7 +331,21 @@ class ResourceService:
         else:
             resource_dict["metrics"] = None
 
-        resource_dict["tags"] = resource.tags or []
+        raw_tags = resource.tags or []
+        normalized_tags = []
+        for tag in raw_tags:
+            if isinstance(tag, str):
+                normalized_tags.append(tag)
+                continue
+            if isinstance(tag, dict):
+                label = tag.get("label") or tag.get("name")
+                if label:
+                    normalized_tags.append(label)
+                continue
+            label = getattr(tag, "label", None) or getattr(tag, "name", None)
+            if label:
+                normalized_tags.append(label)
+        resource_dict["tags"] = normalized_tags
         resource_dict["team"] = getattr(resource, "team", None)
 
         # Include metadata fields for proper API response


### PR DESCRIPTION
## Summary
- allow overriding external plugin runtime with MCP_PYTHON
- clear the plugin registry before re-init to avoid stale entries
- normalize resource/service tags to string lists and align schema