### PR TITLE
fix(testing): accept 409 Conflict in Locust state change endpoints

### DIFF
--- a/tests/loadtest/locustfile.py
+++ b/tests/loadtest/locustfile.py
@@ -1257,8 +1257,9 @@ class WriteAPIUser(BaseUser):
                 name="/servers/[id]/state",
                 catch_response=True,
             ) as response:
-                # 403/404 are acceptable - entity may not exist or may be read-only
-                self._validate_json_response(response, allowed_codes=[200, 403, 404])
+                # 403/404 acceptable - entity may not exist or may be read-only
+                # 409 acceptable - concurrent state changes due to optimistic locking
+                self._validate_json_response(response, allowed_codes=[200, 403, 404, 409])
 
     @task(2)
     @tag("api", "write", "state")
@@ -1272,8 +1273,9 @@ class WriteAPIUser(BaseUser):
                 name="/tools/[id]/state",
                 catch_response=True,
             ) as response:
-                # 403/404 are acceptable - entity may not exist or may be read-only
-                self._validate_json_response(response, allowed_codes=[200, 403, 404])
+                # 403/404 acceptable - entity may not exist or may be read-only
+                # 409 acceptable - concurrent state changes due to optimistic locking
+                self._validate_json_response(response, allowed_codes=[200, 403, 404, 409])
 
     @task(2)
     @tag("api", "write", "state")
@@ -1287,8 +1289,9 @@ class WriteAPIUser(BaseUser):
                 name="/resources/[id]/state",
                 catch_response=True,
             ) as response:
-                # 403/404 are acceptable - entity may not exist or may be read-only
-                self._validate_json_response(response, allowed_codes=[200, 403, 404])
+                # 403/404 acceptable - entity may not exist or may be read-only
+                # 409 acceptable - concurrent state changes due to optimistic locking
+                self._validate_json_response(response, allowed_codes=[200, 403, 404, 409])
 
     @task(2)
     @tag("api", "write", "state")
@@ -1302,8 +1305,9 @@ class WriteAPIUser(BaseUser):
                 name="/prompts/[id]/state",
                 catch_response=True,
             ) as response:
-                # 403/404 are acceptable - entity may not exist or may be read-only
-                self._validate_json_response(response, allowed_codes=[200, 403, 404])
+                # 403/404 acceptable - entity may not exist or may be read-only
+                # 409 acceptable - concurrent state changes due to optimistic locking
+                self._validate_json_response(response, allowed_codes=[200, 403, 404, 409])
 
     @task(2)
     @tag("api", "write", "state")
@@ -1317,8 +1321,9 @@ class WriteAPIUser(BaseUser):
                 name="/gateways/[id]/state",
                 catch_response=True,
             ) as response:
-                # 403/404/502 are acceptable - gateway may not exist or may be unreachable
-                self._validate_json_response(response, allowed_codes=[200, 403, 404])
+                # 403/404 acceptable - gateway may not exist or may be unreachable
+                # 409 acceptable - concurrent state changes due to optimistic locking
+                self._validate_json_response(response, allowed_codes=[200, 403, 404, 409])
 
     @task(2)
     @tag("api", "write", "resources")


### PR DESCRIPTION
## Summary

- Add 409 to allowed response codes for all 5 state change endpoints in Locust load test
- Update comments to explain why 409 is acceptable (concurrent state changes due to optimistic locking)

## Problem

When running `make load-test-ui` with 4000 concurrent users, the test reported ~100+ false failures:

```
CatchResponseError('Expected [200, 403, 404], got 409')
```

The 409 errors occur due to race conditions when multiple users try to toggle the same entity's state simultaneously. The server correctly returns 409 Conflict to prevent lost updates - this is proper optimistic locking behavior, not a failure.

## Solution

Added 409 to allowed_codes for:
- `set_server_state()` - `/servers/[id]/state`
- `set_tool_state()` - `/tools/[id]/state`
- `set_resource_state()` - `/resources/[id]/state`
- `set_prompt_state()` - `/prompts/[id]/state`
- `set_gateway_state()` - `/gateways/[id]/state`

## Verification

After the fix, load test shows **0 failures** for all state endpoints:

| Endpoint | Requests | Failures |
|----------|----------|----------|
| `/servers/[id]/state` | 87 | 0 |
| `/tools/[id]/state` | 74 | 0 |
| `/resources/[id]/state` | 91 | 0 |
| `/prompts/[id]/state` | 81 | 0 |
| `/gateways/[id]/state` | 87 | 0 |

Closes #2566