### PR TITLE
chore(tests): remove unused PromptNotFoundError import

### DIFF
--- a/tests/unit/mcpgateway/services/test_authorization_access.py
+++ b/tests/unit/mcpgateway/services/test_authorization_access.py
@@ -23,7 +23,7 @@ import pytest
 from mcpgateway.db import Prompt as DbPrompt
 from mcpgateway.db import Resource as DbResource
 from mcpgateway.db import Tool as DbTool
-from mcpgateway.services.prompt_service import PromptNotFoundError, PromptService
+from mcpgateway.services.prompt_service import PromptService
 from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService
 from mcpgateway.services.tool_service import ToolNotFoundError, ToolService
 


### PR DESCRIPTION
## Summary

Remove unused import of `PromptNotFoundError` from `test_authorization_access.py`.

## Details

The import was flagged by ruff linter (F401) as it was never used in the file:
```
F401 [*] `mcpgateway.services.prompt_service.PromptNotFoundError` imported but unused
```

### Changes
- Removed unused `PromptNotFoundError` from the import statement in `tests/unit/mcpgateway/services/test_authorization_access.py`

## Testing

This is a minor cleanup with no functional impact. The import was never used in the test file.

Fixes #2382