### PR TITLE
fix: allow backticks in tool descriptions for Markdown formatting

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -429,7 +429,9 @@ class ToolCreate(BaseModel):
         if v is None:
             return v
 
-        forbidden_patterns = ["&&", ";", "||", "$(", "`", "|", "> ", "< "]
+        # Note: backticks (`) are allowed as they are commonly used in Markdown
+        # for inline code examples in tool descriptions
+        forbidden_patterns = ["&&", ";", "||", "$(", "|", "> ", "< "]
         for pat in forbidden_patterns:
             if pat in v:
                 raise ValueError(f"Description contains unsafe characters: '{pat}'")


### PR DESCRIPTION
## Summary
Removes backtick from the forbidden patterns in tool description validation. Backticks are commonly used in Markdown for inline code examples and pose no security risk in descriptions.

## Problem
The gateway rejects tools with backticks in their descriptions (Issue #2576), blocking legitimate tools like Grafana's Loki query tools that use standard Markdown formatting:
- Code examples: `{app="foo"}`
- JSON examples: `{"streams": 5}`
- Parameter references: `labelName`

## Solution
Allow backticks in descriptions while maintaining other security patterns that prevent command injection (`&&`, `;`, `||`, `$(`, etc.).

## Testing
The existing validation tests still pass, and tools with Markdown-formatted descriptions can now be registered.

Fixes #2576