### PR TITLE
fix: increase stdio buffer limit to prevent LimitOverrunError

### DIFF
--- a/mcpgateway/translate.py
+++ b/mcpgateway/translate.py
@@ -174,6 +174,11 @@ except ImportError:
     DEFAULT_SSL_VERIFY = True  # Verify SSL by default when config unavailable
 
 KEEP_ALIVE_INTERVAL = DEFAULT_KEEP_ALIVE_INTERVAL  # seconds - from config or fallback to 30
+
+# Buffer limit for subprocess stdout (default 64KB is too small for large tool responses)
+# Set to 16MB to handle tools that return large amounts of data (e.g., search results)
+STDIO_BUFFER_LIMIT = 16 * 1024 * 1024  # 16MB
+
 __all__ = ["main"]  # for console-script entry-point
 
 
@@ -415,6 +420,7 @@ class StdIOEndpoint:
             stdout=asyncio.subprocess.PIPE,
             stderr=sys.stderr,  # passthrough for visibility
             env=env,  # 🔑 Add environment variable support
+            limit=STDIO_BUFFER_LIMIT,  # Increase buffer limit for large tool responses
         )
 
         # Explicit error checking


### PR DESCRIPTION
## Summary
Increases the asyncio subprocess buffer limit from the default 64KB to 16MB to handle tools that return large responses.

## Problem
When using `mcpgateway.translate` (via `cforge run`) with tools that return large results, the bridge crashes with `LimitOverrunError`:

```
asyncio.exceptions.LimitOverrunError: Separator is found, but chunk is longer than limit
ValueError: Separator is found, but chunk is longer than limit
```

This happens because the default asyncio buffer limit (64KB) is exceeded when tools return large amounts of data (e.g., GitHub search results).

## Solution
- Add `STDIO_BUFFER_LIMIT` constant set to 16MB
- Pass this limit to `asyncio.create_subprocess_exec()`

## Testing
Tested with the GitHub MCP server running searches that return many results.

Fixes #2591