### PR TITLE
fix: propagate error messages in /mcp endpoint responses

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -468,7 +468,8 @@ async def call_tool(name: str, arguments: dict) -> List[Union[types.TextContent,
         - List return → CallToolResult with content only
         - Tuple return → CallToolResult with both content and structuredContent fields
 
-        Logs and returns an empty list on failure.
+    Raises:
+        Exception: Re-raised after logging to allow MCP SDK to convert to JSON-RPC error response.
 
     Examples:
         >>> # Test call_tool function signature
@@ -639,7 +640,9 @@ async def call_tool(name: str, arguments: dict) -> List[Union[types.TextContent,
             return unstructured
     except Exception as e:
         logger.exception(f"Error calling tool '{name}': {e}")
-        return []
+        # Re-raise the exception so the MCP SDK can properly convert it to an error response
+        # This ensures error details are propagated to the client instead of returning empty results
+        raise
 
 
 @mcp_app.list_tools()

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -261,7 +261,7 @@ async def test_call_tool_no_content(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_call_tool_exception(monkeypatch, caplog):
-    """Test call_tool returns [] and logs exception on error."""
+    """Test call_tool re-raises exception after logging for proper MCP SDK error handling."""
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service
 
@@ -275,8 +275,8 @@ async def test_call_tool_exception(monkeypatch, caplog):
     monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(side_effect=Exception("fail!")))
 
     with caplog.at_level("ERROR"):
-        result = await call_tool("mytool", {"foo": "bar"})
-        assert result == []
+        with pytest.raises(Exception, match="fail!"):
+            await call_tool("mytool", {"foo": "bar"})
         assert "Error calling tool 'mytool': fail!" in caplog.text
 
 


### PR DESCRIPTION
## Summary
Fixes error propagation in the `/mcp` endpoint tool invocation handler.

## Problem
When using `server/<server-id>/mcp` endpoint for tool invocations, exceptions (e.g., 401 unauthorized errors) resulted in empty responses instead of actual error messages.

The previous code caught all exceptions and returned an empty list:
```python
except Exception as e:
    logger.exception(f"Error calling tool '{name}': {e}")
    return []
```

## Solution
Re-raise exceptions after logging so the MCP SDK can properly convert them to JSON-RPC error responses:
```python
except Exception as e:
    logger.exception(f"Error calling tool '{name}': {e}")
    raise
```

This ensures clients receive proper error messages instead of empty results.

## Testing
Verified that errors are now properly returned in the response body instead of empty results.

Fixes #2570