### PR TITLE
chore: replace deprecated datetime.utcnow() with timezone-aware datetime

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -29,7 +29,7 @@ Structure:
 # Standard
 import asyncio
 from contextlib import asynccontextmanager, suppress
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 import hashlib
 import os as _os  # local alias to avoid collisions
@@ -6259,7 +6259,7 @@ async def security_health(request: Request):
             "ui_protected": security_status["ui_protected"],
         },
         "warning_count": len(security_status["warnings"]),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
     # Include warnings only if authenticated or in dev mode


### PR DESCRIPTION
## Summary
Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`.

## Problem
`datetime.utcnow()` is deprecated in Python 3.12 as it returns a naive datetime without timezone information, which can cause timezone-related bugs.

## Solution
- Added `timezone` to the import from `datetime`
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)`

This returns a timezone-aware datetime that properly handles UTC.

Fixes #2377