### PR TITLE
chore: remove unused json_default function from llmchat_router

### DIFF
--- a/mcpgateway/routers/llmchat_router.py
+++ b/mcpgateway/routers/llmchat_router.py
@@ -802,65 +802,6 @@ async def token_streamer(chat_service: MCPChatService, message: str, user_id: st
         All exceptions are caught and converted to error events for client handling.
     """
 
-    def json_default(obj):
-        """
-        Default JSON serializer helper for non-serializable Python objects.
-
-        Intended for use as the `default` parameter of `json.dumps`. The
-        function tries common serialization patterns in the following order:
-
-        1. model_dump() for Pydantic v2 models
-        2. dict() for Pydantic v1 models
-        3. __dict__ for plain Python objects
-        4. Fallback to str(obj)
-
-        Args:
-            obj: An object that is not JSON serializable by default.
-
-        Returns:
-            A JSON-serializable representation of ``obj``.
-
-        Examples:
-            >>> class Simple:
-            ...     def __init__(self):
-            ...         self.x = 1
-            ...         self.y = 2
-            ...
-            >>> json_default(Simple())
-            {'x': 1, 'y': 2}
-
-            >>> class WithStr:
-            ...     def __str__(self):
-            ...         return "custom"
-            ...
-            >>> json_default(WithStr())
-            'custom'
-
-            >>> class PydanticV1Like:
-            ...     def dict(self):
-            ...         return {"a": 1}
-            ...
-            >>> json_default(PydanticV1Like())
-            {'a': 1}
-
-            >>> class PydanticV2Like:
-            ...     def model_dump(self):
-            ...         return {"b": 2}
-            ...
-            >>> json_default(PydanticV2Like())
-            {'b': 2}
-        """
-        # Try common patterns first
-        if hasattr(obj, "model_dump"):  # pydantic v2
-            return obj.model_dump()
-        if hasattr(obj, "dict"):  # pydantic v1
-            return obj.dict()
-        if hasattr(obj, "__dict__"):
-            return obj.__dict__
-
-        # Fallback: string representation
-        return str(obj)
-
     async def sse(event_type: str, data: Dict[str, Any]):
         """Format data as Server-Sent Event.
 


### PR DESCRIPTION
## Summary
Removes the unused `json_default` function from `llmchat_router.py`.

## Problem
The `json_default` function was defined but never called anywhere in the code. It only appeared in docstring examples but was never actually used for JSON serialization.

## Solution
Remove the dead code to reduce maintenance burden.

Fixes #2372