### PR TITLE
fix: whitelist /rpc endpoint for server-scoped tokens

### DIFF
--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -326,7 +326,7 @@ class TokenScopingMiddleware:
                 return path_server_id == server_id
 
         # If no server ID found in path, allow general endpoints
-        general_endpoints = ["/health", "/metrics", "/openapi.json", "/docs", "/redoc"]
+        general_endpoints = ["/health", "/metrics", "/openapi.json", "/docs", "/redoc", "/rpc"]
 
         # Check exact root path separately
         if request_path == "/":

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -65,6 +65,12 @@ class TestTokenScopingMiddleware:
             result = middleware._check_server_restriction(path, "server-123")
             assert result == True, f"Path {path} should remain whitelisted"
 
+    def test_rpc_endpoint_whitelisted_for_server_scoped_tokens(self, middleware):
+        """Test that /rpc endpoint is whitelisted for server-scoped tokens."""
+        # The /rpc endpoint is required for MCP protocol operations (SSE transport)
+        result = middleware._check_server_restriction("/rpc", "server-123")
+        assert result == True, "/rpc endpoint should be whitelisted for server-scoped tokens"
+
     @pytest.mark.asyncio
     async def test_canonical_permissions_used_in_map(self, middleware):
         """Test that permission map uses canonical Permissions constants (Issue 5 fix)."""


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Server-scoped tokens cannot access the `/rpc` endpoint, preventing SSE transport and WebSocket relay from functioning. This PR adds `/rpc` to the general endpoints whitelist to allow server-scoped tokens to make MCP protocol requests.

## 🔗  Related Issue
Closes #2192 

## 🐞 Root Cause
In `mcpgateway/middleware/token_scoping.py`, the `_check_server_restriction` function:
1. Checks if `/rpc` matches any server path pattern → NO
2. Checks if `/rpc` is in `general_endpoints` → NO (not listed)
3. Returns `False` → HTTP 403

The `/rpc` endpoint is a core JSON-RPC endpoint used for:
- Direct POST requests for MCP operations
- WebSocket relay (proxies requests to `/rpc`)
- Internal RPC handling

Without `/rpc` in the whitelist, server-scoped tokens are denied access despite needing it for MCP protocol operations.

## 💡 Fix Description
Added `/rpc` to the `general_endpoints` list in `mcpgateway/middleware/token_scoping.py` (line 328):

```python
general_endpoints = ["/health", "/metrics", "/openapi.json", "/docs", "/redoc", "/rpc"]