### PR TITLE
Handle empty auth headers in tool conversion to avoid StopIteration

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -726,12 +726,15 @@ class ToolService:
                 }
             elif tool.auth_type == "authheaders":
                 # Get first key
-                first_key = next(iter(decoded_auth_value))
-                tool_dict["auth"] = {
-                    "auth_type": "authheaders",
-                    "auth_header_key": first_key,
-                    "auth_header_value": settings.masked_auth_value if decoded_auth_value[first_key] else None,
-                }
+                if decoded_auth_value:
+                    first_key = next(iter(decoded_auth_value))
+                    tool_dict["auth"] = {
+                        "auth_type": "authheaders",
+                        "auth_header_key": first_key,
+                        "auth_header_value": settings.masked_auth_value if decoded_auth_value[first_key] else None,
+                    }
+                else:
+                    tool_dict["auth"] = None
             else:
                 tool_dict["auth"] = None
         elif not include_auth and has_encrypted_auth:


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #1430 

## 📌 Summary

This PR fixes a `StopIteration` crash in the `ToolService.convert_tool_to_read` method that occurs when listing tools that have `auth_type="authheaders"` but an empty or null authentication value in the database.

The crash happens because the code assumes that if `auth_type` is "authheaders", the `decoded_auth_value` dictionary will contain at least one key. When `decoded_auth_value` is empty (returned by decode_auth(None), calling `next(iter(decoded_auth_value))` raises `StopIteration`, causing a 500 Internal Server Error during `list_tools` operations.

This fix makes the service robust against such malformed or incomplete data states by explicitly checking if `decoded_auth_value` is truthy before attempting to access its keys.

## 🔁 Reproduction Steps

1. Create a tool with `auth_type="authheaders"`.
2. Manually modify the database (or use a script) to set its `auth_value` to `NULL` or an encrypted value that decrypts to `{}`.
3. Call `list_tools`.
4. Observe the `StopIteration` error in the logs.

A reproduction script `tests/reproduce_stop_iteration.py` was created to simulate this exact state.

## 🐞 Root Cause

The issue was located in `mcpgateway/services/tool_service.py` within the `convert_tool_to_read` method.

The `decode_auth` utility function returns an empty dictionary `{}` when the input is `None` (which is the case for tools with null `auth_value`. The code block for `authheaders` handling blindly attempted to get the first key from this dictionary:

```python
elif tool.auth_type == "authheaders":
    # Get first key
    first_key = next(iter(decoded_auth_value))  # <--- CRASH HERE if dict is empty
```

## 💡 Fix Description

The fix involves adding a check to verify that `decoded_auth_value` is not empty before accessing it.

```python
elif tool.auth_type == "authheaders":
    # Get first key
    if decoded_auth_value:  # <--- Safety check added
        first_key = next(iter(decoded_auth_value))
        tool_dict["auth"] = { ... }
    else:
        tool_dict["auth"] = None
```

If the auth value is empty, we effectively treat it as having no authentication configured (`tool_dict["auth"] = None`), which prevents the crash and allows the tool to be listed, albeit without auth headers (which is correct since none exist).



## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed