### PR TITLE
Fix Gateway Error Propagation & Frontend JSON Parse Issues

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5120,7 +5120,7 @@ async def register_gateway(
         )
     except Exception as ex:
         if isinstance(ex, GatewayConnectionError):
-            return ORJSONResponse(content={"message": "Unable to connect to gateway"}, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return ORJSONResponse(content={"message": str(ex)}, status_code=status.HTTP_502_BAD_GATEWAY)
         if isinstance(ex, ValueError):
             return ORJSONResponse(content={"message": "Unable to process input"}, status_code=status.HTTP_400_BAD_REQUEST)
         if isinstance(ex, GatewayNameConflictError):
@@ -5207,7 +5207,7 @@ async def update_gateway(
         if isinstance(ex, GatewayNotFoundError):
             return ORJSONResponse(content={"message": "Gateway not found"}, status_code=status.HTTP_404_NOT_FOUND)
         if isinstance(ex, GatewayConnectionError):
-            return ORJSONResponse(content={"message": "Unable to connect to gateway"}, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return ORJSONResponse(content={"message": str(ex)}, status_code=status.HTTP_502_BAD_GATEWAY)
         if isinstance(ex, ValueError):
             return ORJSONResponse(content={"message": "Unable to process input"}, status_code=status.HTTP_400_BAD_REQUEST)
         if isinstance(ex, GatewayNameConflictError):

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -126,8 +126,8 @@ class TestGatewayCreateErrorHandlers:
                 "description": "Test gateway",
             }
             response = test_client.post("/gateways/", json=gateway_data, headers=auth_headers)
-            assert response.status_code == 503
-            assert "Unable to connect" in response.json()["message"]
+            assert response.status_code == 502
+            assert "Connection failed" in response.json()["message"]
 
     def test_register_gateway_value_error(self, test_client, auth_headers):
         """Test ValueError handling in register_gateway."""
@@ -265,7 +265,8 @@ class TestGatewayUpdateErrorHandlers:
                 "description": "Updated gateway",
             }
             response = test_client.put("/gateways/test-id", json=gateway_data, headers=auth_headers)
-            assert response.status_code == 503
+            assert response.status_code == 502
+            assert "Connection failed" in response.json()["message"]
 
     def test_update_gateway_value_error(self, test_client, auth_headers):
         """Test ValueError handling in update_gateway."""


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2562

## 📌 Summary

This PR addresses two issues:

1.  **Backend Error Propagation:** Fixes an issue where specific backend errors (e.g., `401 Unauthorized` or `405 Method Not Allowed`) were masked by generic "Failed to initialize gateway" messages. This prevented users from seeing the actual cause of gateway registration failures allowing users to find the root cause of failure and fix it, instead of relying on backend logs.

2.  **Frontend JSON Parsing:** Fixes a frontend silent crash/error with  ("JSON.parse: unexpected character") that occurred when the server or a proxy returned an HTML response (e.g., error pages, auth redirects) instead of the expected JSON.
Root Cause documented here: https://github.com/IBM/mcp-context-forge/issues/2562#issuecomment-3816485639. 

## 🔁 Reproduction Steps
**1. Backend Error Propagation:**
- Attempt to register a gateway with invalid credentials (causing a 401).
- **Before:** Error message in UI/logs: `Failed to initialize gateway...`.
- **After:** Error message in UI/logs: `Failed to initialize gateway... Client error '401 Unauthorized'`.

**2. Frontend JSON Parse Error:**
- Trigger an HTML response for a form submission endpoint (e.g., `POST /admin/gateways`) by simulating a proxy error (502/504) or session expiry redirect.
- **Before:** The UI crashes or shows a console error: `SyntaxError: JSON.parse: unexpected character at line 1 column 1` because the code tried to parse `<html>...` as JSON.
- **After:** The UI correctly handles the non-JSON response and displays a user-friendly error message: "The server returned an unexpected response..."

## 🐞 Root Cause
**Backend:**
- The MCP SDK uses `anyio.TaskGroup` for concurrency, which wraps raised exceptions in a `BaseExceptionGroup`.
- The existing error handling code simply called `str(e)` on the caught exception, which returned the wrapper's generic message instead of the inner exception's detail.

**Frontend:**
- Multiple form handlers in `admin.js` directly awaited `response.json()` without validating the response status or `Content-Type`.
- If an upstream proxy or the server returned an HTML error page (common in enterprise variants or during outages), `response.json()` would fail with a syntax error, breaking the error handling flow.

## 💡 Fix Description
**Backend (`gateway_service.py`):**
- Updated `_initialize_gateway` to inspect caught exceptions.
- Implemented logic to unwrap `BaseExceptionGroup` and extract the root cause exception (matching patterns used elsewhere in `tool_service.py`).
- Ensures the actual HTTP error detail is propagated to the `GatewayConnectionError`.

**Frontend (`admin.js`):**
- Created a reusable helper function `safeParseJsonResponse(response, fallbackError)` that:
    1. Checks `response.ok` status first.
    2. Validates that the `Content-Type` header includes result "application/json".
    4. Throws a descriptive error if the response is not valid JSON, preventing the parse crash.
- Refactored **12 high-risk form handlers** (POST/PUT operations) to use this safe helper instead of direct `response.json()`:
    - Gateway (Add & Edit)
    - Resource (Add & Edit)
    - Prompt (Add & Edit)
    - Server (Add & Edit)
    - A2A Agent (Add & Edit)
    - Tool (Add & Edit)
    Note: There can be more occurrences where the safeParseJsonResponse can be used, but currently have targeted to the high impact ones in this PR.


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed