### PR TITLE
refactor(resource): ensure post-fetch hooks receive resolved gateway content

### DIFF
--- a/tests/unit/mcpgateway/services/test_resource_service_plugins.py
+++ b/tests/unit/mcpgateway/services/test_resource_service_plugins.py
@@ -486,7 +486,7 @@ class TestResourceServicePluginIntegration:
             )
 
         mock_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
-
+        service.invoke_resource = AsyncMock(return_value="Sensitive content")
         with pytest.raises(PluginViolationError) as exc_info:
             await service.read_resource(mock_db, "test://resource")
 

--- a/tests/unit/plugins/test_secrets_detection.py
+++ b/tests/unit/plugins/test_secrets_detection.py
@@ -2,8 +2,97 @@
 """Tests for secrets detection plugin regex patterns."""
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 
-from plugins.secrets_detection.secrets_detection import PATTERNS
+from mcpgateway.common.models import ResourceContent
+from mcpgateway.services.resource_service import ResourceService
+from mcpgateway.plugins.framework import PluginConfig, ResourceHookType
+from plugins.secrets_detection.secrets_detection import PATTERNS, SecretsDetectionPlugin
+
+
+@pytest.mark.asyncio
+async def test_resource_post_fetch_receives_resolved_content():
+    """
+    RESOURCE_POST_FETCH plugins should receive actual gateway content,
+    not template URIs.
+    """
+
+    captured = {}
+
+    # Subclass the real plugin to capture payload.content.text
+    class CaptureSecretsPlugin(SecretsDetectionPlugin):
+        async def resource_post_fetch(self, payload, context):
+            captured["text"] = payload.content.text
+            return await super().resource_post_fetch(payload, context)
+
+    plugin = CaptureSecretsPlugin(
+        PluginConfig(
+            name="secrets_detection",
+            kind="resource",
+            config={},
+        )
+    )
+
+    # Fake DB resource (template-like content)
+    fake_resource = MagicMock()
+    fake_resource.id = "res1"
+    fake_resource.uri = "file:///data/x.txt"
+    fake_resource.enabled = True
+    fake_resource.content = ResourceContent(
+        type="resource",
+        id="res1",
+        uri="file:///data/x.txt",
+        text="file:///data/x.txt",  # Simulate template URI in content
+    )
+
+    fake_db = MagicMock()
+    fake_db.get.return_value = fake_resource
+    fake_db.execute.return_value.scalar_one_or_none.return_value = fake_resource
+
+    service = ResourceService()
+
+    # Mock gateway resolution
+    service.invoke_resource = AsyncMock(return_value="actual file content")
+
+    # Minimal fake plugin manager
+    pm = MagicMock()
+    pm.has_hooks_for.return_value = True
+    pm._initialized = True
+
+    async def invoke_hook(
+        hook_type,
+        payload,
+        global_ctx,
+        local_contexts=None,
+        violations_as_exceptions=True,
+    ):
+        if hook_type == ResourceHookType.RESOURCE_POST_FETCH:
+            await plugin.resource_post_fetch(payload, global_ctx)
+        return MagicMock(modified_payload=None), None
+
+    pm.invoke_hook = invoke_hook
+    service._plugin_manager = pm
+
+    # Execute
+    result = await service.read_resource(
+        db=fake_db,
+        resource_id="res1",
+        resource_uri="file:///data/x.txt",
+    )
+
+    # Assertions
+
+    # Plugin must have been called
+    assert "text" in captured
+
+    # Plugin must NOT see template URI
+    assert captured["text"] != "file:///data/x.txt"
+
+    # Plugin MUST see resolved gateway content
+    assert captured["text"] == "actual file content"
+
+    # Returned ResourceContent must also be resolved
+    assert result.text == "actual file content"
 
 
 class TestAwsSecretPattern:


### PR DESCRIPTION
## Summary

Fixes Issue [2648](https://github.com/IBM/mcp-context-forge/issues/2648) by invoking resources before running post-fetch hooks.

### Changes

1. Execute RESOURCE_POST_FETCH hooks after gateway invocation
2. Refactor read_resource to resolve content first
3. Add explicit DB commit before network calls
4. Added test case under - `mcp-context-forge/tests/unit/plugins/test_secrets_detection.py`
     - to verify resolved content.text is passed to post-fetch hook
   
