### PR TITLE
chore(ci): remove unused workflow_dispatch platforms input

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -40,11 +40,6 @@ on:
   schedule:
     - cron: "17 18 * * 2"  # Weekly rebuild (Tuesday 18:17 UTC) for CVE patches
   workflow_dispatch:
-    inputs:
-      platforms:
-        description: 'Platforms to build (comma-separated)'
-        required: false
-        default: 'linux/amd64,linux/arm64,linux/s390x,linux/ppc64le'
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #2207

The workflow already builds per-platform via the matrix (matrix.platform). The workflow_dispatch input 'platforms' was unused and is removed to reduce configuration drift.

Testing:
- actionlint .github/workflows/docker-multiplatform.yml
- GitHub checks: DCO