### PR TITLE
chore(sonar): remove dead store max_duration

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -14915,7 +14915,6 @@ def _get_latency_heatmap_postgresql(db: Session, cutoff_time: datetime, hours: i
     # Handle case where all durations are the same
     if latency_range == 0:
         latency_range = 1.0
-        max_duration = min_duration + 1.0
 
     time_range_minutes = hours * 60
     latency_bucket_size = latency_range / latency_buckets


### PR DESCRIPTION
Fixes #2371

Removes a dead store flagged by Sonar (python:S1854): max_duration was reassigned in the latency_range==0 branch but never used after.

Testing:
- python -m compileall mcpgateway