### PR TITLE
docs(quickstart): add 5-minute quick-start with PowerShell examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ContextForge MCP Gateway is a feature-rich gateway, proxy and MCP Registry that 
 
 | Resource | Description |
 |----------|-------------|
-| **[5-Minute Setup](docs/QUICKSTART.md)** | Get started fast — uvx, Docker, Compose, or local dev |
+| **[5-Minute Setup](docs/QUICKSTART.md)** | Get started fast — uvx + first API call (Bash/PowerShell) |
 | **[Getting Help](https://github.com/IBM/mcp-context-forge/issues/2504)** | Support options, FAQ, community channels |
 | **[Issue Guide](https://github.com/IBM/mcp-context-forge/issues/2502)** | How to file bugs, request features, contribute |
 | **[Full Documentation](https://ibm.github.io/mcp-context-forge/)** | Complete guides, tutorials, API reference |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -33,6 +33,11 @@ $Env:PLATFORM_ADMIN_FULL_NAME="Platform Administrator"
 uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
 ```
 
+Once the gateway starts, open:
+
+- Admin UI: http://localhost:4444/admin
+- API Docs: http://localhost:4444/docs (requires JWT bearer token for API calls)
+
 ---
 
 ## 2. Your First API Call
@@ -78,5 +83,5 @@ To set up your local development environment:
 uv sync
 
 # Or using Make
-make install
+make install-dev
 ```


### PR DESCRIPTION
Partially addresses #2503

Adds a concise 5-minute quick-start guide covering uvx and local dev setup.
Includes Windows PowerShell equivalents and clarifies that the project uses pyproject.toml + uv (no root requirements.txt).