### PR TITLE
fix(ui): Display prompt_id in admin panel prompts page

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4710,6 +4710,10 @@ async function viewPrompt(promptName) {
         <div class="grid grid-cols-2 gap-6 mb-6">
           <div class="space-y-3">
             <div>
+              <span id="prompt-id-label" class="font-medium text-gray-700 dark:text-gray-300">Prompt ID:</span>
+              <div class="mt-1 prompt-id text-sm font-mono text-indigo-600 dark:text-indigo-400" aria-labelledby="prompt-id-label"></div>
+            </div>
+            <div>
               <span class="font-medium text-gray-700 dark:text-gray-300">Display Name:</span>
               <div class="mt-1 prompt-display-name font-medium"></div>
             </div>
@@ -4859,6 +4863,7 @@ async function viewPrompt(promptName) {
                 }
             };
 
+            setText(".prompt-id", prompt.id || "N/A");
             setText(".prompt-display-name", promptLabel);
             setText(".prompt-name", prompt.name || "N/A");
             setText(".prompt-original-name", prompt.originalName || "N/A");

--- a/mcpgateway/templates/prompts_partial.html
+++ b/mcpgateway/templates/prompts_partial.html
@@ -6,6 +6,7 @@
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-12">S. No.</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-36">Gateway Name</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+      <th id="prompt-id-header" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-48">Prompt ID</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Description</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-20">Tags</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-20">Owner</th>
@@ -51,6 +52,9 @@
         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
           <div>{{ prompt_label }}</div>
           <div class="text-xs text-gray-500 dark:text-gray-400 font-mono">{{ prompt_tech_name }}</div>
+        </td>
+        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 w-48" aria-labelledby="prompt-id-header">
+          <div class="font-mono text-xs">{{ prompt.id }}</div>
         </td>
         <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300">{% set clean_desc = (prompt.description or "") | replace('\n', ' ') | replace('\r', ' ') %} {% set refactor_desc = clean_desc | striptags | trim | escape %} {% if refactor_desc | length is greaterthan 220 %} {{ refactor_desc[:400] + "..." }} {% else %} {{ refactor_desc }} {% endif %}</td>
         <td class="px-6 py-4 whitespace-nowrap">{% if prompt.tags %} {% for tag in prompt.tags %}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1">{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}</span>{% endfor %} {% else %}<span class="text-gray-500 dark:text-gray-300 text-xs">None</span>{% endif %}</td>


### PR DESCRIPTION
Closes #2656 

## 🐛 Bug Fix: Display Prompt ID in Admin UI

### Summary
Adds prompt_id visibility to the MCP Gateway admin panel's Prompts page, enabling developers to easily identify prompt IDs for plugin configuration without requiring direct database queries.


#### 1. **Prompts Table** (`mcpgateway/templates/prompts_partial.html`)
- Added "Prompt ID" column header between "Name" and "Description"

#### 2. **View Prompt Modal** (`mcpgateway/static/admin.js`)
- Added "Prompt ID" field as the first item in the view dialog
- Populated via `setText(".prompt-id", prompt.id || "N/A")`

### Visual Changes

**Before:**
- Prompt ID: ❌ Not visible anywhere
- Developers: Had to query database directly

**After:**
- Prompt ID: ✅ Visible in table and view dialog
- Developers: Can copy ID directly from UI

### Testing Recommendations

```bash
# 1. Start the development server
make dev

# 2. Navigate to http://localhost:8000/admin
# 3. Go to Prompts tab
# 4. Verify:
#    - New "Prompt ID" column appears in table
#    - Click "View" on any prompt
#    - Verify "Prompt ID" appears as first field in modal
```

### Files Modified
- `mcpgateway/templates/prompts_partial.html` - Added table column
- `mcpgateway/static/admin.js` - Added view modal field

