### PR TITLE
Remove redundant db calls in PermissionService

### DIFF
--- a/tests/unit/mcpgateway/services/test_permission_fallback.py
+++ b/tests/unit/mcpgateway/services/test_permission_fallback.py
@@ -56,7 +56,6 @@ class TestPermissionFallback:
         with (
             patch.object(permission_service, "_is_user_admin", return_value=False),
             patch.object(permission_service, "get_user_permissions", return_value=set()),
-            patch.object(permission_service, "_is_team_member", return_value=True),
             patch.object(permission_service, "_get_user_team_role", return_value="owner"),
         ):
             # Team owner should have full permissions on their team
@@ -71,7 +70,6 @@ class TestPermissionFallback:
         with (
             patch.object(permission_service, "_is_user_admin", return_value=False),
             patch.object(permission_service, "get_user_permissions", return_value=set()),
-            patch.object(permission_service, "_is_team_member", return_value=True),
             patch.object(permission_service, "_get_user_team_role", return_value="member"),
         ):
             # Team member should have read permissions
@@ -88,7 +86,7 @@ class TestPermissionFallback:
         with (
             patch.object(permission_service, "_is_user_admin", return_value=False),
             patch.object(permission_service, "get_user_permissions", return_value=set()),
-            patch.object(permission_service, "_is_team_member", return_value=False),
+            patch.object(permission_service, "_get_user_team_role", return_value=None),
         ):
             # Non-member should be denied all team-specific permissions
             assert await permission_service.check_permission("outsider@example.com", "teams.read", team_id="team-123") == False

--- a/tests/unit/mcpgateway/services/test_permission_service_comprehensive.py
+++ b/tests/unit/mcpgateway/services/test_permission_service_comprehensive.py
@@ -390,7 +390,7 @@ class TestTeamFallbackPermissions:
     @pytest.mark.asyncio
     async def test_team_fallback_unknown_role(self, permission_service):
         """Test fallback with unknown team role."""
-        with patch.object(permission_service, "_is_team_member", return_value=True), patch.object(permission_service, "_get_user_team_role", return_value="unknown"):
+        with patch.object(permission_service, "_get_user_team_role", return_value="unknown"):
             result = await permission_service._check_team_fallback_permissions("user@example.com", "teams.read", "team-123")
             assert result == False
 


### PR DESCRIPTION
# Bug-fix PR

Closes #2695

---

## Summary
Fixes redundant database queries in `PermissionService.check_permission()` that caused unnecessary performance overhead on every permission check.

Two separate redundancies were identified and fixed:
1. **UserRole table queried twice**: Once for permissions, again for audit logging
2. **EmailTeamMember table queried twice**: Once for membership check, again for role lookup

## Reproduction Steps

Issue: Redundant DB calls in permission checks

To observe the issue:
1. Enable query logging in SQLAlchemy
2. Call any endpoint that triggers `check_permission()` with `audit_enabled=True`
3. Observe duplicate `SELECT` statements for `user_roles` and `email_team_members` tables

## Root Cause

**Redundancy #1 (UserRole):**
- `check_permission()` called `get_user_permissions()` which internally called `_get_user_roles()` to fetch UserRole objects
- `get_user_permissions()` extracted only the permission strings and discarded the role objects
- Later, `_get_roles_for_audit()` called `_get_user_roles()` again to get role names for audit logging
- Same query executed twice per permission check when auditing enabled

**Redundancy #2 (EmailTeamMember):**
- `_check_team_fallback_permissions()` called `_is_team_member()` to check if user was a team member
- Then immediately called `_get_user_team_role()` to get the user's role
- Both methods queried the same `email_team_members` table with identical filters

## Fix Description

**Fix #1**: Modified `check_permission()` to:
- Call `_get_user_roles()` directly once
- Extract permissions inline from the fetched role objects
- Reuse the same role objects to build audit data (no second query)

**Fix #2**: Modified `_check_team_fallback_permissions()` to:
- Call only `_get_user_team_role()` which returns `None` if not a member
- Check for `None` instead of separate membership query
- Refactored `_is_team_member()` to delegate to `_get_user_team_role()` for backward compatibility

**DB Call Reduction:**

| User Type | Before | After | Saved |
|-----------|--------|-------|-------|
| Non-admin with audit | 5 | 3 | 2 |
| Non-admin (teams.* fallback) | 7 | 5 | 2 |
| Non-admin without audit | 3 | 2 | 1 |

## Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Pass   |
| Unit tests                            | `make test`          | Pass (50/50) |
| Coverage >= 80 %                      | `make coverage`      |        |
| Manual regression no longer fails     | Query logging shows single queries |        |

## MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
- [x] Updated tests to mock `_get_user_roles` instead of `get_user_permissions`
