### PR TITLE
chore: remove redundant ternary in log_aggregator.py

### DIFF
--- a/mcpgateway/services/log_aggregator.py
+++ b/mcpgateway/services/log_aggregator.py
@@ -870,7 +870,7 @@ class LogAggregator:
         if window_end is None and minutes_offset:
             reference = reference - timedelta(minutes=minutes_offset)
 
-        resolved_end = reference if window_end is None else reference
+        resolved_end = reference
 
         if window_start is None:
             resolved_start = resolved_end - window_delta


### PR DESCRIPTION
Closes #2367

## Description

Removed redundant conditional expression where both branches returned the same value.

## Changes

**Before:**
```python
resolved_end = reference if window_end is None else reference
```

**After:**
```python
resolved_end = reference
```

## Testing

- [x] `ruff check` passes
- [x] `pytest tests/unit/mcpgateway/services/test_log_aggregator_helpers.py` passes (2/2)
- [x] Code formatted with black/isort