### PR TITLE
fix: ovelapping Authorize and Fetch Tool buttons on MCP servers page

### DIFF
--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -2,7 +2,7 @@
 <table id="gateways-table" class="min-w-full divide-y divide-gray-200">
   <thead class="bg-gray-50 dark:bg-gray-700">
     <tr>
-      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Actions</th>
+      <th class="px-6 py-3 text-center text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Actions</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">S. No.</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Name</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider w-24">URL</th>


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes https://github.com/IBM/mcp-context-forge/issues/2681

## 📌 Summary
Before, the buttons of `Authorize` and `Fetch Tool` overlapped each other in one row. Now they are displayed in a separate row.

<img width="1702" height="968" alt="Screenshot 2026-02-05 at 10 58 10" src="https://github.com/user-attachments/assets/478b7e2f-cb14-499b-a6d9-4d1b959541ae" />
<img width="1460" height="226" alt="Screenshot 2026-02-05 at 10 58 22" src="https://github.com/user-attachments/assets/7654649a-2259-4e08-877e-954f8bc6a9cb" />


## 🔁 Reproduction Steps
1. Go to the MCP Registry page
2. Select for OAuth2.1 Auth type
3. Hit the `Add Server` button in Asana
4. Go back to the MCP Servers page
5. Check on the `Show Inactive` checkbox and observe that the buttons are not overlapped

## 🐞 Root Cause
The buttons of `Authorize` and `Fetch Tool` overlap each other. They were in one line, and there was not enough space for two of them.

## 💡 Fix Description
Now we display each button in a separate row instead of both in a single row. 


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     ✅     |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
