### PR TITLE
2689 - Loading spinners upkeep

### DIFF
--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -1184,3 +1184,16 @@ nav[class*="-mb-px"]::-webkit-scrollbar-thumb:hover {
         gap: 0.5rem;
     }
 }
+
+/* Override HTMX's default "show all indicators on any request" behavior
+   This prevents spinners from showing during background /trace requests */
+body.htmx-request .htmx-indicator {
+    visibility: hidden;
+}
+
+/* Only show indicators when explicitly targeted via hx-indicator attribute
+   HTMX adds htmx-request class to the indicator when it's the target.
+   Use higher specificity to override the rule above. */
+body.htmx-request .htmx-indicator.htmx-request {
+    visibility: visible;
+}

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2192,14 +2192,7 @@
                  hx-trigger="load"
                  hx-swap="outerHTML"
                  hx-indicator="#servers-loading">
-              <!-- Loading placeholder -->
-              <div class="flex items-center justify-center p-8">
-                <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                <span class="ml-3 text-gray-600 dark:text-gray-400">Loading servers...</span>
-              </div>
+
             </div>
           </div>
 
@@ -3147,14 +3140,7 @@
                  hx-trigger="load"
                  hx-swap="outerHTML"
                  hx-indicator="#tools-loading">
-              <!-- Loading placeholder -->
-              <div class="flex items-center justify-center p-8">
-                <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                <span class="ml-3 text-gray-600 dark:text-gray-400">Loading tools...</span>
-              </div>
+
             </div>
           </div>
 
@@ -3898,12 +3884,19 @@
               </div>
 
               <!-- This div will be the target for the HTMX initial load and subsequent swaps -->
-              <div id="tool-ops-main-content-wrapper" hx-get="{{ root_path }}/admin/tool-ops/partial" hx-trigger="load" hx-swap="innerHTML">
-                  <!-- Initial loading spinner will be here, and replaced by the partial's content -->
-                  <div id="tool-ops-loading-indicator" class="flex items-center justify-center p-4">
-                    <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mr-4"></div>
-                    <span class="text-gray-600 dark:text-gray-400">Loading tools...</span>
-                  </div>
+              <div id="tool-ops-main-content-wrapper" hx-get="{{ root_path }}/admin/tool-ops/partial" hx-trigger="load" hx-swap="innerHTML" hx-indicator="#tool-ops-loading-indicator">
+
+              </div>
+
+              <!-- Loading Indicator for HTMX -->
+              <div id="tool-ops-loading-indicator" class="htmx-indicator">
+                <div class="flex items-center justify-center p-4">
+                  <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  <span class="ml-2 text-gray-600 dark:text-gray-400">Loading tools...</span>
+                </div>
               </div>
 
             </div>
@@ -4160,11 +4153,19 @@
             >
               <!-- initial content will be swapped out by HTMX on load -->
             </div>
-            <!-- Loading indicator for resources HTMX requests -->
-            <div id="resources-loading" style="display:none">
-              <div class="spinner"></div>
+          </div>
+
+          <!-- Loading Indicator for HTMX -->
+          <div id="resources-loading" class="htmx-indicator">
+            <div class="flex items-center justify-center p-4">
+              <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span class="ml-2 text-gray-600 dark:text-gray-400">Loading resources...</span>
             </div>
           </div>
+
           <!-- Placeholder for out-of-band pagination controls (injected by partial) -->
           <div id="resources-pagination-controls"></div>
         </div>
@@ -4389,27 +4390,19 @@
               hx-swap="outerHTML"
               hx-indicator="#prompts-loading"
             >
-              <!-- initial content will be swapped out by HTMX on load -->
-              <div class="text-center py-4 text-gray-500 dark:text-gray-400">
-                <svg class="animate-spin h-5 w-5 text-purple-600 dark:text-purple-400 inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                <span class="ml-2">Loading prompts...</span>
-              </div>
-            </div>
 
-            <!-- Loading Indicator for HTMX (Prompts) -->
-            <div id="prompts-loading" class="htmx-indicator" style="display:none">
-              <div class="flex items-center justify-center p-4">
-                <svg class="animate-spin h-8 w-8 text-purple-600 dark:text-purple-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                <span class="ml-2 text-gray-600 dark:text-gray-400">Loading prompts...</span>
-              </div>
             </div>
+          </div>
 
+          <!-- Loading Indicator for HTMX -->
+          <div id="prompts-loading" class="htmx-indicator">
+            <div class="flex items-center justify-center p-4">
+              <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span class="ml-2 text-gray-600 dark:text-gray-400">Loading prompts...</span>
+            </div>
           </div>
 
           <!-- Placeholder for out-of-band pagination controls (injected by partial) -->
@@ -4679,14 +4672,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                  hx-trigger="load"
                  hx-swap="outerHTML"
                  hx-indicator="#gateways-loading">
-              <!-- Loading placeholder -->
-              <div class="flex items-center justify-center p-8">
-                <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                <span class="ml-3 text-gray-600 dark:text-gray-400">Loading gateways...</span>
-              </div>
+
             </div>
           </div>
 

--- a/mcpgateway/templates/toolops_partial.html
+++ b/mcpgateway/templates/toolops_partial.html
@@ -1,9 +1,4 @@
 <!-- htmlhint doctype-first:false -->
-<div id="tool-ops-loading-indicator" class="flex items-center justify-center p-4 htmx-indicator" style="display: none;">
-  <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mr-4"></div>
-  <span class="text-gray-600 dark:text-gray-400">Loading tools...</span>
-</div>
-
 <div class="overflow-x-auto" id="tool-ops-table-container">
     <table class="min-w-full divide-y divide-gray-200 text-sm" id="toolTable">
         <thead class="bg-gray-50">


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
This PR addresses multiple loading spinner issues in the admin UI:

### Before - Double spinner:

https://github.com/user-attachments/assets/d28d6e07-43f5-40fa-ae88-682db09e5e3c

### After:

https://github.com/user-attachments/assets/bb214210-d750-4ddf-abe9-f2025ca92f10

### Before - Colateral spinner:

https://github.com/user-attachments/assets/305fe04b-7ca8-4d46-bbbf-d4fb1cd3191b

### After:

https://github.com/user-attachments/assets/67162587-52eb-495b-82e7-81595bb46e7c

### Before - Missing spinner:

https://github.com/user-attachments/assets/b4a219d2-fba8-4306-b13e-debe01287083

### After:

https://github.com/user-attachments/assets/b4f0e8cd-ed0a-4f35-9b75-d62f896abb5c

### Before - Different spinner:

https://github.com/user-attachments/assets/a93ffd7e-2ad5-4198-a28f-f644e3280213

### After:

https://github.com/user-attachments/assets/1d6c0f21-6bea-49d6-b10a-ea6eddf962c2

Fixes #2689

## 🔁 Reproduction Steps
1. Access the Admin UI
2. On each panel, refresh the page.
3. Observe the loading spinner

## 🐞 Root Cause
There was a redundant initial placeholder spinner on some of the panels. Some were missing the `hx-indicator` attribute.

## 💡 Fix Description
1. Fixed double loading spinners on initial page load/refresh
   - Removed redundant initial placeholder spinners from Gateways, Catalog, Tools, and Tool Operations panels
   - Now relies solely on HTMX indicators for loading states
   - Affected files: mcpgateway/templates/admin.html

2. Fixed spurious spinners triggered by background requests
   - Added CSS rules to prevent all .htmx-indicator elements from showing on unrelated requests
   - Scoped indicators to specific panels (#catalog-panel, #tools-panel, #gateways-panel, etc.)
   - Only show indicators when explicitly targeted via hx-indicator attribute
   - Prevents spinners from appearing during background /trace observability requests
   - Affected files: mcpgateway/static/admin.css

3. Standardized Resources panel loading indicator
   - Replaced simple spinner div with proper HTMX indicator matching other panels
   - Added animated SVG spinner with "Loading resources..." text
   - Affected files: mcpgateway/templates/admin.html

4. Aligned Prompts panel implementation with other panels
   - Removed dual loading state (inline + external indicator)
   - Standardized to single external HTMX indicator for consistency
   - Removed style="display:none" attribute, now controlled by CSS
   - Affected files: mcpgateway/templates/admin.html

All panels now have consistent loading behavior:
- Single loading indicator per panel
- No spurious spinners on background requests
- Proper HTMX indicator visibility control via CSS

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
