### PR TITLE
fix: return empty list instead of 404 when SSO is disabled

### DIFF
--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -109,9 +109,7 @@ async def list_sso_providers(
 
     Returns:
         List of enabled SSO providers with basic information.
-
-    Raises:
-        HTTPException: If SSO authentication is disabled
+        Returns empty list if SSO authentication is disabled.
 
     Examples:
         >>> import asyncio
@@ -119,7 +117,7 @@ async def list_sso_providers(
         True
     """
     if not settings.sso_enabled:
-        raise HTTPException(status_code=404, detail="SSO authentication is disabled")
+        return []
 
     sso_service = SSOService(db)
     providers = sso_service.list_enabled_providers()

--- a/mcpgateway/templates/login.html
+++ b/mcpgateway/templates/login.html
@@ -467,19 +467,13 @@
         try {
           const response = await fetch(window.ROOT_PATH + "/auth/sso/providers");
 
-          if (response.status === 404) {
-            // SSO not enabled, hide SSO section
-            document.getElementById("sso-section").style.display = "none";
-            document.getElementById("divider").style.display = "none";
-            return;
-          }
-
           if (!response.ok) throw new Error("Failed to load SSO providers");
 
           const providers = await response.json();
           const ssoContainer = document.getElementById("sso-providers");
 
           if (providers.length === 0) {
+            // SSO not enabled or no providers configured, hide SSO section
             document.getElementById("sso-section").style.display = "none";
             document.getElementById("divider").style.display = "none";
             return;


### PR DESCRIPTION
## Summary

Closes #2694

Fixes the 404 error on `/auth/sso/providers` when SSO is disabled, ensuring admin login works correctly regardless of the `SSO_ENABLED` setting.

## Problem

When `SSO_ENABLED=false`, the `/auth/sso/providers` endpoint returns a 404 error:

```
2026-02-04 16:48:23,192 - mcpgateway.services.structured_logger - WARNING - [http_gateway] Request completed: GET /auth/sso/providers - 404
```

While the frontend handles this gracefully by hiding SSO login buttons, the 404 errors:
- Clutter logs with unnecessary warnings
- Can trigger monitoring alerts
- Are not RESTful (GET on a collection should return empty list, not 404)

## Solution

Changed the `/auth/sso/providers` endpoint to return an empty list `[]` when SSO is disabled, instead of raising a 404 exception.

## Changes

- **mcpgateway/routers/sso.py**: Return empty list when `settings.sso_enabled` is False
- **mcpgateway/templates/login.html**: Removed redundant 404 check from JavaScript (empty list handling already exists)
- Updated docstring to reflect new behavior

## Testing

- ✅ With `SSO_ENABLED=false`: Endpoint returns `[]`, no 404 errors, login page shows email/password form only
- ✅ With `SSO_ENABLED=true`: Endpoint returns configured providers, SSO buttons display correctly
- ✅ Python syntax validation passed
- ✅ Backward compatible with existing frontend code

## Impact

- **Logs**: No more 404 warnings when SSO is disabled
- **Monitoring**: Reduced false-positive alerts
- **User Experience**: No change (frontend already handled both cases)
- **API**: More RESTful behavior (empty collection vs 404)
