### PR TITLE
chore: remove redundant conditional in form body handling

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -10961,12 +10961,7 @@ async def admin_test_gateway(
             if content_type == "application/x-www-form-urlencoded":
                 # Set proper content type header and use data parameter for form encoding
                 headers["Content-Type"] = "application/x-www-form-urlencoded"
-                if isinstance(request.body, str):
-                    # Body is already form-encoded
-                    request_kwargs["data"] = request.body
-                else:
-                    # Body is a dict, convert to form data
-                    request_kwargs["data"] = request.body
+                request_kwargs["data"] = request.body
             else:
                 # Default to JSON
                 headers["Content-Type"] = "application/json"


### PR DESCRIPTION
This PR removes a redundant conditional in `mcpgateway/admin.py` where both
branches performed identical operations.

The change resolves Sonar rule `python:S3923` by simplifying the logic
without altering any existing behavior.

- No functional changes
- No impact on runtime behavior
- Improves code clarity and maintainability




Fixes (#2369 )