### PR TITLE
fix: stabilize coverage suite and reduce warnings

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3639,7 +3639,7 @@ async def create_tool(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(ex))
         if isinstance(ex, (ValidationError, ValueError)):
             logger.error(f"Validation error while creating tool: {ex}")
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ErrorFormatter.format_validation_error(ex))
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ErrorFormatter.format_validation_error(ex))
         if isinstance(ex, IntegrityError):
             logger.error(f"Integrity error while creating tool: {ex}")
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=ErrorFormatter.format_database_error(ex))
@@ -3741,7 +3741,7 @@ async def update_tool(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(ex))
         if isinstance(ex, ValidationError):
             logger.error(f"Validation error while updating tool: {ex}")
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ErrorFormatter.format_validation_error(ex))
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ErrorFormatter.format_validation_error(ex))
         if isinstance(ex, IntegrityError):
             logger.error(f"Integrity error while updating tool: {ex}")
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=ErrorFormatter.format_database_error(ex))
@@ -4647,7 +4647,7 @@ async def create_prompt(
         if isinstance(e, ValidationError):
             # If there is a validation error, return a 422 Unprocessable Entity error
             logger.error(f"Validation error while creating prompt: {e}")
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ErrorFormatter.format_validation_error(e))
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ErrorFormatter.format_validation_error(e))
         if isinstance(e, IntegrityError):
             # If there is an integrity error, return a 409 Conflict error
             logger.error(f"Integrity error while creating prompt: {e}")
@@ -4834,7 +4834,7 @@ async def update_prompt(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
         if isinstance(e, ValidationError):
             logger.error(f"Validation error while updating prompt: {e}")
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ErrorFormatter.format_validation_error(e))
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ErrorFormatter.format_validation_error(e))
         if isinstance(e, IntegrityError):
             logger.error(f"Integrity error while updating prompt: {e}")
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=ErrorFormatter.format_database_error(e))
@@ -5130,7 +5130,7 @@ async def register_gateway(
         if isinstance(ex, RuntimeError):
             return ORJSONResponse(content={"message": "Error during execution"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
         if isinstance(ex, ValidationError):
-            return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
+            return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=status.HTTP_422_UNPROCESSABLE_CONTENT)
         if isinstance(ex, IntegrityError):
             return ORJSONResponse(status_code=status.HTTP_409_CONFLICT, content=ErrorFormatter.format_database_error(ex))
         return ORJSONResponse(content={"message": "Unexpected error"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -5217,7 +5217,7 @@ async def update_gateway(
         if isinstance(ex, RuntimeError):
             return ORJSONResponse(content={"message": "Error during execution"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
         if isinstance(ex, ValidationError):
-            return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
+            return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=status.HTTP_422_UNPROCESSABLE_CONTENT)
         if isinstance(ex, IntegrityError):
             return ORJSONResponse(status_code=status.HTTP_409_CONFLICT, content=ErrorFormatter.format_database_error(ex))
         return ORJSONResponse(content={"message": "Unexpected error"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/mcpgateway/routers/rbac.py
+++ b/mcpgateway/routers/rbac.py
@@ -113,7 +113,7 @@ async def create_role(role_data: RoleCreateRequest, user=Depends(get_current_use
         logger.info(f"Role created: {role.id} by {user['email']}")
         db.commit()
         db.close()
-        return RoleResponse.from_orm(role)
+        return RoleResponse.model_validate(role)
 
     except ValueError as e:
         logger.error(f"Role creation validation error: {e}")
@@ -157,7 +157,7 @@ async def list_roles(
         db.commit()
         db.close()
 
-        return [RoleResponse.from_orm(role) for role in roles]
+        return [RoleResponse.model_validate(role) for role in roles]
 
     except Exception as e:
         logger.error(f"Failed to list roles: {e}")
@@ -194,7 +194,7 @@ async def get_role(role_id: str, user=Depends(get_current_user_with_permissions)
 
         db.commit()
         db.close()
-        return RoleResponse.from_orm(role)
+        return RoleResponse.model_validate(role)
 
     except HTTPException:
         raise
@@ -227,7 +227,7 @@ async def update_role(role_id: str, role_data: RoleUpdateRequest, user=Depends(g
     """
     try:
         role_service = RoleService(db)
-        role = await role_service.update_role(role_id, **role_data.dict(exclude_unset=True))
+        role = await role_service.update_role(role_id, **role_data.model_dump(exclude_unset=True))
 
         if not role:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
@@ -235,7 +235,7 @@ async def update_role(role_id: str, role_data: RoleUpdateRequest, user=Depends(g
         logger.info(f"Role updated: {role_id} by {user['email']}")
         db.commit()
         db.close()
-        return RoleResponse.from_orm(role)
+        return RoleResponse.model_validate(role)
 
     except HTTPException:
         raise
@@ -321,7 +321,7 @@ async def assign_role_to_user(user_email: str, assignment_data: UserRoleAssignRe
         logger.info(f"Role assigned: {assignment_data.role_id} to {user_email} by {user['email']}")
         db.commit()
         db.close()
-        return UserRoleResponse.from_orm(user_role)
+        return UserRoleResponse.model_validate(user_role)
 
     except ValueError as e:
         logger.error(f"Role assignment validation error: {e}")
@@ -364,7 +364,7 @@ async def get_user_roles(
         permission_service = PermissionService(db)
         user_roles = await permission_service.get_user_roles(user_email=user_email, scope=scope, include_expired=not active_only)
 
-        result = [UserRoleResponse.from_orm(user_role) for user_role in user_roles]
+        result = [UserRoleResponse.model_validate(user_role) for user_role in user_roles]
         db.commit()
         db.close()
         return result
@@ -555,7 +555,7 @@ async def get_my_roles(user=Depends(get_current_user_with_permissions), db: Sess
         permission_service = PermissionService(db)
         user_roles = await permission_service.get_user_roles(user_email=user["email"], include_expired=False)
 
-        result = [UserRoleResponse.from_orm(user_role) for user_role in user_roles]
+        result = [UserRoleResponse.model_validate(user_role) for user_role in user_roles]
         db.commit()
         db.close()
         return result

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -369,7 +369,7 @@ async def create_sso_provider(
     if existing:
         raise HTTPException(status_code=409, detail=f"SSO provider '{provider_data.id}' already exists")
 
-    provider = await sso_service.create_provider(provider_data.dict())
+    provider = await sso_service.create_provider(provider_data.model_dump())
 
     result = {
         "id": provider.id,
@@ -502,7 +502,7 @@ async def update_sso_provider(
     sso_service = SSOService(db)
 
     # Filter out None values
-    update_data = {k: v for k, v in provider_data.dict().items() if v is not None}
+    update_data = {k: v for k, v in provider_data.model_dump().items() if v is not None}
     if not update_data:
         raise HTTPException(status_code=400, detail="No update data provided")
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -3470,6 +3470,8 @@ class FederatedPrompt(BaseModelWithConfigDict):
 class RPCRequest(BaseModel):
     """MCP-compliant RPC request validation"""
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     jsonrpc: Literal["2.0"]
     method: str
     params: Optional[Dict[str, Any]] = None

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -1012,7 +1012,9 @@ class A2AAgentService:
                 # Update the slug when name changes
                 agent.slug = new_slug
             # Update fields
-            update_data = agent_data.model_dump(exclude_unset=True)
+            # Avoid `model_dump()` here: tests use `model_construct()` to create intentionally invalid
+            # payloads, and `model_dump()` emits serializer warnings when encountering unexpected types.
+            update_data = {field: getattr(agent_data, field) for field in agent_data.model_fields_set}
 
             # Track original auth_type and endpoint_url before updates
             original_auth_type = agent.auth_type

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -36,6 +36,10 @@ Examples:
     True
     >>> conflict_error.enabled
     True
+    >>>
+    >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+    >>> import asyncio
+    >>> asyncio.run(service._http_client.aclose())
 """
 
 # Standard
@@ -371,6 +375,10 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             0
             >>> hasattr(service, 'redis_url')
             True
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> import asyncio
+            >>> asyncio.run(service._http_client.aclose())
         """
         self._http_client = ResilientHttpClient(client_args={"timeout": settings.federation_timeout, "verify": not settings.skip_ssl_verify})
         self._health_check_interval = GW_HEALTH_CHECK_INTERVAL
@@ -702,6 +710,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             ...     asyncio.run(service.register_gateway(db, gateway))
             ... except Exception:
             ...     pass
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> asyncio.run(service._http_client.aclose())
         """
         visibility = "public" if visibility not in ("private", "team", "public") else visibility
         try:
@@ -1511,6 +1522,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             ...     empty_result, cursor = asyncio.run(service.list_gateways(db))
             ...     empty_result == [] and cursor is None
             True
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> asyncio.run(service._http_client.aclose())
         """
         # Check cache for first page only - only for public-only queries (no user/team filtering)
         # SECURITY: Only cache public-only results (token_teams=[]), never admin bypass or team-scoped
@@ -2379,6 +2393,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             ... except GatewayNotFoundError as e:
             ...     'Gateway not found: gateway_id' in str(e)
             True
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> asyncio.run(service._http_client.aclose())
         """
         # Use eager loading to avoid N+1 queries for relationships and team name
         gateway = db.execute(
@@ -2787,6 +2804,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             ...     asyncio.run(service.delete_gateway(db, 'gateway_id', 'user@example.com'))
             ... except Exception:
             ...     pass
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> asyncio.run(service._http_client.aclose())
         """
         try:
             # Find gateway with eager loading for deletion to avoid N+1 queries
@@ -3904,6 +3924,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             >>> service = GatewayService()
             >>> # Test parameter validation
             >>> import asyncio
+            >>> from unittest.mock import AsyncMock
+            >>> # Avoid opening a real SSE connection in doctests (it can leak anyio streams on failure paths)
+            >>> service.connect_to_sse_server = AsyncMock(side_effect=GatewayConnectionError("boom"))
             >>> async def test_params():
             ...     try:
             ...         await service._initialize_gateway("hello//")
@@ -3922,6 +3945,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             'SSE'
             >>> sig.parameters['authentication'].default is None
             True
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> asyncio.run(service._http_client.aclose())
         """
         try:
             if authentication is None:
@@ -4715,6 +4741,9 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             >>> import inspect
             >>> inspect.iscoroutinefunction(service._refresh_gateway_tools_resources_prompts)
             True
+            >>>
+            >>> # Cleanup long-lived clients created by the service to avoid ResourceWarnings in doctest runs
+            >>> asyncio.run(service._http_client.aclose())
         """
         result = {
             "tools_added": 0,

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -716,11 +716,11 @@ async def test_admin_delete_user_self_block():
 
 def test_emailuser_response_serialization_with_api_token():
     """Test EmailUserResponse serialization with API token user (regression test for #2700).
-    
+
     This test verifies that EmailUser objects created for API token authentication
     include all required fields (auth_provider, password_change_required) and can
     be successfully serialized to EmailUserResponse without validation errors.
-    
+
     Previously, creating EmailUser objects without these fields would cause 422
     validation errors when GET /auth/email/me tried to serialize the response.
     """
@@ -752,4 +752,3 @@ def test_emailuser_response_serialization_with_api_token():
     assert response.auth_provider == "api_token"
     assert response.password_change_required is False
     assert response.email_verified is True
-


### PR DESCRIPTION
Changes:
- Stabilize RedisEventStore tests under xdist by introducing per-store Redis key prefixing and using per-test prefixes in Redis fixtures.
- Hardening: hide user input in RPCRequest validation errors.
- Reduce noisy warnings: remove Pydantic v2 deprecations in RBAC/SSO routers, avoid serializer warnings in A2A update, fix un-awaited log storage scheduling, and dispose DB probe engines safely.
- Use HTTP_422_UNPROCESSABLE_CONTENT for validation errors.