### PR TITLE
feat: add MCP Inspector to docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -921,7 +921,7 @@ monitoring-clean:                          ## Stop and remove all monitoring dat
 
 testing-up:                                ## Start testing stack (fast_test_server + registration)
 	@echo "🧪 Starting testing stack (fast_test_server)..."
-	$(COMPOSE_CMD_MONITOR) --profile testing up -d
+	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector up -d
 	@echo ""
 	@echo "✅ Testing stack started!"
 	@echo ""
@@ -931,22 +931,64 @@ testing-up:                                ## Start testing stack (fast_test_ser
 	@echo "      • REST time:     http://localhost:9080/api/time"
 	@echo "      • Health:        http://localhost:9080/health"
 	@echo ""
+	@echo "   🔍 MCP Inspector:   http://localhost:6274"
+	@echo ""
 	@echo "   📝 Registered as 'fast_test' gateway in MCP Gateway"
 	@echo ""
 	@echo "   Run load test: cd mcp-servers/rust/fast-test-server && make locust-mcp"
 
 testing-down:                              ## Stop testing stack
 	@echo "🧪 Stopping testing stack..."
-	$(COMPOSE_CMD_MONITOR) --profile testing down --remove-orphans
+	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector down --remove-orphans
 	@echo "✅ Testing stack stopped."
 
 testing-status:                            ## Show status of testing services
 	@echo "🧪 Testing stack status:"
-	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(fast_test)" || \
+	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(fast_test|mcp_inspector)" || \
 		echo "   No testing services running. Start with 'make testing-up'"
 
 testing-logs:                              ## Show testing stack logs
-	$(COMPOSE_CMD_MONITOR) --profile testing logs -f --tail=100
+	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector logs -f --tail=100
+
+# =============================================================================
+# help: 🔍 MCP INSPECTOR (Interactive MCP Client)
+# help: inspector-up           - Start MCP Inspector (http://localhost:6274)
+# help: inspector-down         - Stop MCP Inspector
+# help: inspector-logs         - Show MCP Inspector logs
+# help: inspector-status       - Show status of MCP Inspector
+
+.PHONY: inspector-up inspector-down inspector-logs inspector-status
+
+inspector-up:                              ## Start MCP Inspector (interactive MCP client)
+	@echo "🔍 Starting MCP Inspector..."
+	$(COMPOSE_CMD_MONITOR) --profile inspector up -d
+	@echo ""
+	@echo "✅ MCP Inspector started!"
+	@echo ""
+	@echo "   🔍 Inspector UI:  http://localhost:6274"
+	@echo ""
+	@echo "   To connect to the gateway's virtual server:"
+	@echo "      1. Select transport: Streamable HTTP"
+	@echo "      2. Enter URL: http://nginx:80/servers/9779b6698cbd4b4995ee04a4fab38737/mcp"
+	@echo "      3. Add header — Authorization: Bearer <token>"
+	@echo ""
+	@echo "   Generate a JWT token:"
+	@echo "      python -m mcpgateway.utils.create_jwt_token \\"
+	@echo "        --username admin@example.com --exp 10080 --secret my-test-key --algo HS256"
+	@echo ""
+
+inspector-down:                            ## Stop MCP Inspector
+	@echo "🔍 Stopping MCP Inspector..."
+	$(COMPOSE_CMD_MONITOR) --profile inspector down --remove-orphans
+	@echo "✅ MCP Inspector stopped."
+
+inspector-logs:                            ## Show MCP Inspector logs
+	$(COMPOSE_CMD_MONITOR) --profile inspector logs -f --tail=100
+
+inspector-status:                          ## Show status of MCP Inspector
+	@echo "🔍 MCP Inspector status:"
+	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(mcp_inspector)" || \
+		echo "   Not running. Start with 'make inspector-up'"
 
 # =============================================================================
 # help: 🤖 A2A DEMO AGENTS (Issue #2002 Authentication Testing)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@
 #  --profile monitoring:  Adds Prometheus, Grafana, Loki, exporters
 #  --profile benchmark:   Adds benchmark MCP servers for load testing
 #  --profile tls:         Enables HTTPS via nginx_tls (auto-generates certs)
+#  --profile inspector:   Adds MCP Inspector client (http://localhost:6274)
 #
 #  TLS Quick Start:
 #    make compose-tls                    # HTTP:8080 + HTTPS:8443
@@ -1697,3 +1698,42 @@ services:
           cpus: '2'
           memory: 512M
     profiles: ["tls"]
+
+###############################################################################
+#  MCP INSPECTOR - Interactive MCP client for debugging and testing
+#  Usage: make inspector-up  (or: docker compose --profile inspector up -d)
+#  Access: http://localhost:6274
+#
+#  Connect to the gateway's virtual server from the Inspector UI:
+#    1. Transport: Streamable HTTP
+#    2. URL: http://nginx:80/servers/9779b6698cbd4b4995ee04a4fab38737/mcp
+#    3. Add header:  Authorization: Bearer <your-jwt-token>
+#
+#  Generate a JWT token:
+#    python -m mcpgateway.utils.create_jwt_token \
+#      --username admin@example.com --exp 10080 --secret my-test-key --algo HS256
+###############################################################################
+
+  mcp_inspector:
+    image: ghcr.io/modelcontextprotocol/inspector:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "6274:6274"    # Inspector web UI
+      - "6277:6277"    # Inspector MCP proxy server
+    environment:
+      - HOST=0.0.0.0                   # Bind to all interfaces (required in Docker)
+      - MCP_AUTO_OPEN_ENABLED=false    # Don't attempt to open browser in container
+      - DANGEROUSLY_OMIT_AUTH=true     # Skip proxy token (safe: local dev only)
+    depends_on:
+      gateway:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    profiles: ["inspector"]


### PR DESCRIPTION
## Summary

- Add [MCP Inspector](https://github.com/modelcontextprotocol/inspector) (`ghcr.io/modelcontextprotocol/inspector`) as a docker-compose service behind the `inspector` profile
- Add Makefile targets: `inspector-up`, `inspector-down`, `inspector-logs`, `inspector-status`
- Include inspector in `make testing-up` so the testing stack ships with an interactive MCP client out of the box

## Usage

```bash
# Standalone
make inspector-up        # http://localhost:6274

# Or as part of the testing stack
make testing-up
```

Then in the Inspector UI:
1. Select transport: **Streamable HTTP**
2. URL: `http://nginx:80/servers/9779b6698cbd4b4995ee04a4fab38737/mcp`
3. Add header `Authorization: Bearer <jwt-token>`

Closes #2198