### PR TITLE
fix: resolve test pollution and pre-commit hook failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
       - id: detect-private-key
         name: 🔐 Detect Private Key
         description: Detects the presence of private keys.
+        exclude: (mcpgateway/utils/generate_keys|tests/unit/mcpgateway/utils/test_generate_keys|tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils)\.py
         types: [text]
 
   #   - repo: https://github.com/Yelp/detect-secrets
@@ -363,7 +364,7 @@ repos:
         description: Verifies test files in tests/ directories start with `test_`.
         language: python
         files: (^|/)tests/.+\.py$
-        exclude: ^tests/(.*/)?(pages|helpers|fuzzers|scripts|fixtures|migration|utils|manual|async|load)/.*\.py$
+        exclude: ^tests/(.*/)?(pages|helpers|fuzzers|scripts|fixtures|migration|utils|manual|async|load|populate)/.*\.py$
         args: [--pytest-test-first] # `test_.*\.py`
 
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-lite.yaml
+++ b/.pre-commit-lite.yaml
@@ -43,7 +43,7 @@ repos:
         name: 🔐 Detect Private Key
         description: Detects the presence of private keys.
         types: [text]
-        exclude: 'tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py|tests/unit/mcpgateway/utils/test_generate_keys.py'
+        exclude: 'mcpgateway/utils/generate_keys\.py|tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py|tests/unit/mcpgateway/utils/test_generate_keys.py'
 
   #   - repo: https://github.com/Yelp/detect-secrets
   #     rev: v1.5.0
@@ -370,7 +370,7 @@ repos:
         description: Verifies test files in tests/ directories start with `test_`.
         language: python
         files: (^|/)tests/.+\.py$
-        exclude: ^tests/(.*/)?(pages|helpers|fuzzers|scripts|fixtures|migration|utils|manual|async|load|loadtest|jmeter|client)/.*\.py$
+        exclude: ^tests/(.*/)?(pages|helpers|fuzzers|scripts|fixtures|migration|utils|manual|async|load|loadtest|jmeter|client|populate)/.*\.py$
         args: [--pytest-test-first] # `test_.*\.py`
 
   # - repo: https://github.com/pycqa/flake8
@@ -539,3 +539,4 @@ repos:
       - id: interrogate
         args: [--quiet, --fail-under=100]
         files: ^mcpgateway/
+        exclude: _pb2(_grpc)?\.py$

--- a/llms/mkdocs.md
+++ b/llms/mkdocs.md
@@ -45,7 +45,8 @@ Notes
 **Root-Level Helpers (Optional)**
 - Some repository-wide targets enrich docs content:
   - `make htmlcov` (root) writes coverage HTML to `docs/docs/coverage/`.
-  - `make coverage` (root) generates `docs/docs/test/unittest.md` and badges.
+  - `make coverage` (root) generates coverage HTML/XML/badge (does not update `unittest.md`).
+  - `make test-docs` (root) generates `docs/docs/test/unittest.md` with test results and coverage.
   - `make docs` (root) builds images/SBOM and copies `README.md` to `docs/docs/index.md`.
 
 **Quality & Linting**

--- a/tests/unit/mcpgateway/cache/test_session_registry.py
+++ b/tests/unit/mcpgateway/cache/test_session_registry.py
@@ -420,7 +420,7 @@ def test_sqlalchemy_importerror_isolated():
         importlib.reload(mcpgateway.cache.session_registry)
         assert not mcpgateway.cache.session_registry.SQLALCHEMY_AVAILABLE
 
-    # Cleanup: restore the original sys.modules entries
+    # Cleanup: restore the original sys.modules entries and reload to reset SQLALCHEMY_AVAILABLE
     if original_sqlalchemy is not None:
         sys.modules["sqlalchemy"] = original_sqlalchemy
     else:
@@ -430,6 +430,10 @@ def test_sqlalchemy_importerror_isolated():
         sys.modules["mcpgateway.cache.session_registry"] = original_my_module
     else:
         sys.modules.pop("mcpgateway.cache.session_registry", None)
+
+    import mcpgateway.cache.session_registry
+
+    importlib.reload(mcpgateway.cache.session_registry)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -3503,7 +3503,7 @@ async def test_streamable_http_auth_proxy_user_context_on_valid_jwt(monkeypatch)
 
 
 # ---------------------------------------------------------------------------
-# streamable_http_auth: positive team membership cache (Line 1844)
+# streamable_http_auth: positive team membership cache
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- **Fix flaky test**: `test_module_level_llm_and_toolops_router_success_paths` failed intermittently with `ValueError: Database backend requested but SQLAlchemy not installed` due to `SQLALCHEMY_AVAILABLE` state leaking from `test_sqlalchemy_importerror_isolated`. Fixed by reloading the module after cleanup and using `cache_type=memory` in `_import_fresh_main_module`.
- **Split `make coverage` / `make test-docs`**: `make coverage` no longer writes `docs/docs/test/unittest.md`, preventing unintended doc modifications. New `make test-docs` target generates it on demand.
- **Fix all pre-commit failures**: exclude `generate_keys.py` from private key detector, `tests/populate` from naming check, protobuf `_pb2*.py` from interrogate, remove placeholder citation, fix ruff warnings.

## Test plan
- [x] `make pre-commit` passes clean
- [x] `pytest test_main_extended.py::TestRemainingCoverageGaps` passes (47/47)
- [x] Running the leaking test before the affected test passes: `pytest test_sqlalchemy_importerror_isolated test_module_level_llm_and_toolops_router_success_paths`