### PR TITLE
feat(auth): add OAuth header client credentials support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,8 +260,8 @@ This release delivers **enterprise security hardening**, **comprehensive RBAC im
 * **README Rationalization** ([#2365](https://github.com/IBM/mcp-context-forge/issues/2365)) - Streamlined and reorganized project README
 * **SonarQube Cleanup** ([#2367](https://github.com/IBM/mcp-context-forge/issues/2367), [#2371](https://github.com/IBM/mcp-context-forge/issues/2371), [#2372](https://github.com/IBM/mcp-context-forge/issues/2372), [#2377](https://github.com/IBM/mcp-context-forge/issues/2377), [#2382](https://github.com/IBM/mcp-context-forge/issues/2382)) - Fixed redundant ternary, removed dead code, replaced deprecated `datetime.utcnow()`, cleaned up unused imports
 
-#### OAuth Client Credentials Authentication
-* Added support for sending client credentials either in the request body (default behavior) or in the HTTP headers **for the Client Credentials grant type only**
+#### OAuth Client Authentication Handling
+* Added support for sending client credentials either in the request body (default behavior) or in the HTTP headers for the **Client Credentials** and **Password** grant types.
 * Configuration exposed via a UI dropdown selector
 * Enables compliance with environments enforcing strict security policies for sensitive credentials
 * Other OAuth grant types are not affected


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🚀 Summary (1-2 sentences)
_What does this PR add or change?_
This PR adds support for sending client credentials either in the request body (default behavior) or in the request headers for the **Client Credentials grant type only** for both Gateway and A2A registrations.

The option is configurable via a UI dropdown, allowing users to explicitly choose their preferred method.

This is required for compatibility with environments that enforce strict security policies and mandate that sensitive credentials be passed through HTTP headers.

Previously, client credentials were always sent in the request body.

References:
- [OAuth 2.0 - RFC 6749, Section 2.3](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3)

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [x] CHANGELOG updated (if user-facing)