### PR TITLE
feat(plugins): add Source Scanner plugin scaffold with Semgrep integration

### DIFF
--- a/mcpgateway/routers/source_scanner_router.py
+++ b/mcpgateway/routers/source_scanner_router.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./mcpgateway/routers/source_scanner_router.py
 
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 

--- a/plugins/source_scanner/__init__.py
+++ b/plugins/source_scanner/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/__init__.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi
 

--- a/plugins/source_scanner/config.py
+++ b/plugins/source_scanner/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/config.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 
@@ -97,6 +97,7 @@ class SourceScannerConfig(BaseModel):
     cache_ttl_hours: int = 168  # 1 week
 
     def model_post_init(self, __context: Any) -> None:
+        """Merge nested scanner configuration into top-level fields after validation."""
         # If user provides config.scanners.*, merge into top-level fields
         if self.scanners is not None:
             self.semgrep = self.scanners.semgrep

--- a/plugins/source_scanner/errors.py
+++ b/plugins/source_scanner/errors.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/errors.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi
+
+Shared exception types for Source Scanner Plugin.
+"""
+
+# Future
+from __future__ import annotations
+
+
+class SourceScannerError(Exception):
+    """Base exception for source scanner plugin."""
+
+
+class RepoFetchError(SourceScannerError):
+    """Repository fetch/clone operation failed."""
+
+
+class CloneTimeoutError(RepoFetchError):
+    """Git clone operation timed out."""
+
+
+class RepoSizeLimitError(RepoFetchError):
+    """Repository exceeds size limit."""
+
+
+class CheckoutError(RepoFetchError):
+    """Git checkout operation failed."""
+
+
+class ScannerError(SourceScannerError):
+    """Scanner execution failed."""
+
+
+class ScannerTimeoutError(ScannerError):
+    """Scanner execution timed out."""
+
+
+class ScannerNotFoundError(ScannerError):
+    """Scanner executable not found."""
+
+
+class ParseError(SourceScannerError):
+    """Failed to parse scanner output."""
+
+
+class PolicyError(SourceScannerError):
+    """Policy evaluation failed."""

--- a/plugins/source_scanner/language_detector.py
+++ b/plugins/source_scanner/language_detector.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -- coding: utf-8 --
+"""
+Location: ./plugins/source_scanner/language_detector.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Ayo
+
+"""
+
+# Standard
+import logging
+from pathlib import Path
+from typing import List, Set
+
+logger = logging.getLogger(__name__)
+
+
+class LanguageDetector:
+    """Detect programming languages in a repo"""
+
+    EXTENSION_MAP = {
+        ".py": "python",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".jsx": "javascript",
+        ".tsx": "typescript",
+        ".java": "java",
+        ".go": "go",
+        ".rs": "rust",
+        ".rb": "ruby",
+        ".php": "php",
+        ".c": "c",
+        ".cpp": "cpp",
+        ".cs": "csharp",
+    }
+
+    def detect(self, repo_path: str) -> List[str]:
+        """
+        Detect languages in repository
+
+        Args:
+            repo_path: Path to repository
+
+        Returns:
+            List of detected language names (e.f., ["Python", "javascript"])
+        """
+        path = Path(repo_path)
+        languages: Set[str] = set()
+
+        for file_path in path.rglob("*"):
+            if file_path.is_file():
+                ext = file_path.suffix.lower()
+                if ext in self.EXTENSION_MAP:
+                    languages.add(self.EXTENSION_MAP[ext])
+
+        detected = sorted(list(languages))
+        logger.info(f"Detected languages: {detected}")
+        return detected

--- a/plugins/source_scanner/policy.py
+++ b/plugins/source_scanner/policy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/policy.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 

--- a/plugins/source_scanner/repo_fetcher.py
+++ b/plugins/source_scanner/repo_fetcher.py
@@ -2,8 +2,121 @@
 # -- coding: utf-8 --
 """
 Location: ./plugins/source_scanner/repo_fetcher.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
-Authors:
+Authors: Ayo, Agnetha
 
+Handles git clone, checkout and workspace cleanup
 """
+
+# Standard
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Callable, Optional, Tuple
+
+# Local
+from .errors import CloneTimeoutError, RepoFetchError, RepoSizeLimitError
+from .utils.exec import run_command
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Workspace:
+    """Cloned repo workspace"""
+
+    path: str
+    commit_sha: str
+
+
+class RepoFetcher:
+    """Fetch and manage repo workspaces"""
+
+    async def fetch(
+        self,
+        repo_url: str,
+        ref: Optional[str] = None,
+        clone_timeout: int = 120,
+        max_size_mb: Optional[int] = 500,
+    ) -> Tuple[Workspace, Callable[[], None]]:
+        """
+        Clone repository and checkout ref.
+
+        Args:
+            repo_url: Git repository URL
+            ref: Branch/tag/commit to checkout (default: default branch)
+            clone_timeout: Timeout for clone operation in seconds
+            max_size_mb: Maximum repo size in MB (None = no limit)
+
+        Returns:
+            Tuple of (Workspace, cleanup_function)
+
+        Raises:
+            CloneTimeoutError: If clone exceeds timeout
+            RepoSizeLimitError: If repo exceeds size limit
+            RepoFetchError: For other fetch failures
+        """
+        temp_dir = tempfile.mkdtemp(prefix="source_scanner_")
+
+        try:
+            logger.info(f"Cloning {repo_url} to {temp_dir}")
+
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd.extend(["--branch", ref])
+            cmd.extend(["--", repo_url, temp_dir])
+
+            result = await run_command(cmd, timeout_seconds=clone_timeout)
+
+            if result.timed_out:
+                raise CloneTimeoutError(f"Clone exceeded {clone_timeout}s timeout")
+
+            if result.returncode != 0:
+                raise RepoFetchError(f"Clone failed: {result.stderr}")
+
+            if max_size_mb:
+                size_mb = self._get_dir_size_mb(temp_dir)
+                if size_mb > max_size_mb:
+                    raise RepoSizeLimitError(f"Repository size {size_mb}MB exceeds limit {max_size_mb}MB")
+            commit_sha = await self._get_commit_sha(temp_dir)
+
+            workspace = Workspace(path=temp_dir, commit_sha=commit_sha)
+
+            def cleanup_fn() -> None:
+                self._cleanup(temp_dir)
+
+            logger.info(f"Repository cloned successfully: {commit_sha}")
+            return workspace, cleanup_fn
+
+        except Exception:
+            # Cleanup on failure
+            self._cleanup(temp_dir)
+            raise
+
+    async def _get_commit_sha(self, repo_path: str) -> str:
+        """Get current commit SHA."""
+        result = await run_command(["git", "rev-parse", "HEAD"], cwd=repo_path, timeout_seconds=5)
+
+        if result.returncode != 0:
+            return "unknown"
+
+        return result.stdout.strip()
+
+    def _get_dir_size_mb(self, path: str) -> float:
+        """Calculate directory size in MB."""
+        total = 0
+        for entry in Path(path).rglob("*"):
+            if entry.is_file():
+                total += entry.stat().st_size
+        return total / (1024 * 1024)
+
+    def _cleanup(self, path: str) -> None:
+        """Remove temporary directory."""
+        try:
+            shutil.rmtree(path, ignore_errors=True)
+            logger.debug(f"Cleaned up {path}")
+        except Exception as e:
+            logger.warning(f"Failed to cleanup {path}: {e}")

--- a/plugins/source_scanner/scanners/__init__.py
+++ b/plugins/source_scanner/scanners/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/scanners/__init__.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi
 

--- a/plugins/source_scanner/source_scanner.py
+++ b/plugins/source_scanner/source_scanner.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/source_scanner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi
+
+Source Scanner Plugin.
+Performs static analysis on MCP server source code using Semgrep and Bandit
+to detect security vulnerabilities before deployment.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import Optional
+
+# First-Party
+from mcpgateway.plugins.framework import (
+    CatalogPreDeployPayload,
+    CatalogPreDeployResult,
+    Plugin,
+    PluginConfig,
+    PluginContext,
+    ServerPreRegisterPayload,
+    ServerPreRegisterResult,
+)
+
+# Local
+from .config import SourceScannerConfig
+from .errors import SourceScannerError
+from .policy import PolicyChecker
+from .types import Finding, ScanResult, ScanSummary
+
+# from pydantic import BaseModel, Field
+
+
+# Components (to be imported when implemented)
+# from .repo_fetcher import RepoFetcher
+# from .language_detector import LanguageDetector
+# from .scanners.semgrep_runner import SemgrepRunner
+# from .scanners.bandit_runner import BanditRunner
+# from .parsing.normalizer import ParserNormalizer
+# from .storage.repository import ScanRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SourceScannerPlugin(Plugin):
+    """Scan MCP server source code for security vulnerabilities.
+
+    Workflow:
+        1. Extract repo_url and ref from payload
+        2. Check cache (if enabled)
+        3. Clone repository (RepoFetcher)
+        4. Detect languages (LanguageDetector)
+        5. Run scanners (Semgrep, Bandit)
+        6. Normalize findings (ParserNormalizer)
+        7. Calculate summary
+        8. Evaluate policy (PolicyChecker)
+        9. Store results (if enabled)
+        10. Cleanup temporary files
+        11. Return decision (block/allow)
+    """
+
+    def __init__(self, config: PluginConfig) -> None:
+        """Initialize the source scanner plugin.
+
+        Args:
+            config: Plugin configuration.
+        """
+        # super().__init__(config)
+        self._cfg = SourceScannerConfig(**(config.config or {}))
+
+        # Initialize components
+        # TODO: Uncomment when components are implemented
+        # self._repo_fetcher = RepoFetcher()
+        # self._language_detector = LanguageDetector()
+        # self._semgrep_runner = SemgrepRunner()
+        # self._bandit_runner = BanditRunner()
+        # self._normalizer = ParserNormalizer()
+        # self._policy_checker = PolicyChecker()
+        # self._scan_repo_store = ScanRepository() if self._cfg.cache_by_commit else None
+
+        # logger.info(
+            # "SourceScannerPlugin initialized",
+            # extra={
+                # "semgrep_enabled": self._cfg.semgrep.enabled,
+                # "bandit_enabled": self._cfg.bandit.enabled,
+                # "severity_threshold": self._cfg.severity_threshold,
+                # "fail_on_critical": self._cfg.fail_on_critical,
+            # },
+        # )
+
+    async def _scan_workflow(
+        self,
+        repo_url: str,
+        ref: Optional[str] = None,
+    ) -> ScanResult:
+        """Execute complete scan workflow.
+
+        Args:
+            repo_url: Repository URL to scan.
+            ref: Branch/tag/commit reference.
+
+        Returns:
+            Complete scan results with findings and policy decision.
+
+        Raises:
+            SourceScannerError: If scan workflow fails.
+        """
+        logger.info(f"Starting scan for {repo_url} (ref={ref})")
+
+        cleanup_fn = None
+
+        try:
+            # Step 1: Check cache (if enabled)
+            # TODO: if self._cfg.cache_by_commit and self._scan_repo_store:
+            #           cached = await self._scan_repo_store.get_by_commit(repo_url, commit_sha)
+            #           if cached and not expired:
+            #               return cached
+
+            # Step 2: Clone & Checkout
+            # TODO: workspace, cleanup_fn = await self._repo_fetcher.fetch(
+            #           repo_url=repo_url,
+            #           ref=ref,
+            #           clone_timeout=self._cfg.clone_timeout_seconds,
+            #           max_size_mb=self._cfg.max_repo_size_mb,
+            #       )
+            # TODO: commit_sha = workspace.commit_sha
+
+            # Step 3: Detect languages
+            # TODO: languages = self._language_detector.detect(workspace.path)
+            languages = []  # placeholder
+
+            # Step 4: Run scanners
+            # findings_by_scanner: list[list[Finding]] = []
+
+            # Run Semgrep (if enabled)
+            # if self._cfg.semgrep.enabled:
+                # logger.info("Running Semgrep scanner")
+                # TODO: findings = await self._semgrep_runner.run(
+                #           repo_path=workspace.path,
+                #           config=self._cfg.semgrep,
+                #           timeout_s=self._cfg.scan_timeout_seconds,
+                #       )
+                # TODO: findings_by_scanner.append(findings)
+
+            # Run Bandit (if Python detected and enabled)
+            # if "python" in languages and self._cfg.bandit.enabled:
+                # logger.info("Running Bandit scanner")
+                # TODO: findings = await self._bandit_runner.run(
+                #           repo_path=workspace.path,
+                #           config=self._cfg.bandit,
+                #           timeout_s=self._cfg.scan_timeout_seconds,
+                #       )
+                # TODO: findings_by_scanner.append(findings)
+
+            # Step 5: Merge & Deduplicate
+            # TODO: merged_findings = self._normalizer.merge_dedup(findings_by_scanner)
+            merged_findings = []  # placeholder
+
+            # Step 6: Calculate summary
+            summary = ScanSummary(
+                error_count=sum(1 for f in merged_findings if f.severity == "ERROR"),
+                warning_count=sum(1 for f in merged_findings if f.severity == "WARNING"),
+                info_count=sum(1 for f in merged_findings if f.severity == "INFO"),
+            )
+
+            logger.info(
+                "Scan summary",
+                extra={
+                    "errors": summary.error_count,
+                    "warnings": summary.warning_count,
+                    "info": summary.info_count,
+                },
+            )
+
+            # Step 7: Evaluate policy
+            decision = self._policy_checker.evaluate(
+                findings=merged_findings,
+                threshold=self._cfg.severity_threshold,
+                fail_on_critical=self._cfg.fail_on_critical,
+            )
+
+            # Step 8: Build result
+            result = ScanResult(
+                repo_url=repo_url,
+                ref=ref,
+                commit_sha=None,  # TODO: workspace.commit_sha
+                languages=languages,
+                findings=merged_findings,
+                summary=summary,
+                blocked=decision.blocked,
+                block_reason=decision.reason,
+            )
+
+            # Step 9: Store results (if cache enabled)
+            # TODO: if self._cfg.cache_by_commit and self._scan_repo_store:
+            #           await self._scan_repo_store.save(result)
+
+            logger.info(
+                "Scan complete",
+                extra={
+                    "blocked": result.blocked,
+                    "findings_count": len(result.findings),
+                },
+            )
+
+            return result
+
+        except SourceScannerError as e:
+            logger.error(f"Scan failed: {e}", exc_info=True)
+            raise
+        except Exception as e:
+            logger.error(f"Unexpected error during scan: {e}", exc_info=True)
+            raise SourceScannerError(f"Scan failed: {e}") from e
+        finally:
+            # Step 10: Cleanup
+            if cleanup_fn:
+                try:
+                    cleanup_fn()
+                    logger.debug("Cleanup completed")
+                except Exception as e:
+                    logger.warning(f"Cleanup failed: {e}")
+
+    async def server_pre_register(
+        self,
+        payload: ServerPreRegisterPayload,
+        context: PluginContext,
+    ) -> ServerPreRegisterResult:
+        """Scan source code before server registration.
+
+        Args:
+            payload: Server registration payload.
+            context: Plugin execution context.
+
+        Returns:
+            Result blocking if critical findings exist, or allowing.
+        """
+        logger.info("server_pre_register hook triggered")
+
+        try:
+            # TODO: Extract repo_url and ref from payload
+            # Example payload structure (to be confirmed):
+            # payload.server.source = {
+            #     "type": "github",
+            #     "repo": "https://github.com/org/mcp-server",
+            #     "ref": "main"  # or branch/tag/commit
+            # }
+
+            # TODO: repo_url = payload.server.source.get("repo")
+            # TODO: ref = payload.server.source.get("ref")
+
+            # TODO: if not repo_url:
+            #           logger.warning("No repo_url in payload, allowing registration")
+            #           return ServerPreRegisterResult(continue_processing=True)
+
+            # TODO: result = await self._scan_workflow(repo_url, ref)
+
+            # TODO: if result.blocked:
+            #           return ServerPreRegisterResult(
+            #               continue_processing=False,
+            #               violation=PluginViolation(
+            #                   reason="Security vulnerabilities detected",
+            #                   description=result.block_reason or "Critical findings in source code",
+            #                   code="SOURCE_SCAN_BLOCKED",
+            #                   details={
+            #                       "findings_count": len(result.findings),
+            #                       "error_count": result.summary.error_count,
+            #                       "warning_count": result.summary.warning_count,
+            #                   },
+            #               ),
+            #           )
+
+            # Placeholder: allow all registrations until implemented
+            logger.warning("server_pre_register not fully implemented, allowing")
+            # NOTE: Current implementation is fail-open.
+            # Enforce-mode scan failure behavior will be configurable.
+            return ServerPreRegisterResult(continue_processing=True)
+
+        except Exception as e:
+            logger.error(f"server_pre_register failed: {e}", exc_info=True)
+            # Fail open: allow registration but log error
+            # NOTE: Current implementation is fail-open.
+            # Enforce-mode scan failure behavior will be configurable.
+            return ServerPreRegisterResult(continue_processing=True)
+
+    async def catalog_pre_deploy(
+        self,
+        payload: CatalogPreDeployPayload,
+        context: PluginContext,
+    ) -> CatalogPreDeployResult:
+        """Scan source code before catalog deployment.
+
+        Args:
+            payload: Catalog deployment payload.
+            context: Plugin execution context.
+
+        Returns:
+            Result blocking if critical findings exist, or allowing.
+        """
+        logger.info("catalog_pre_deploy hook triggered")
+
+        try:
+            # TODO: Extract repo_url and ref from payload
+            # Example payload structure (to be confirmed):
+            # payload.catalog.source = {
+            #     "type": "github",
+            #     "repo": "https://github.com/org/mcp-catalog",
+            #     "ref": "main"
+            # }
+
+            # TODO: repo_url = payload.catalog.source.get("repo")
+            # TODO: ref = payload.catalog.source.get("ref")
+
+            # TODO: if not repo_url:
+            #           logger.warning("No repo_url in payload, allowing deployment")
+            #           return CatalogPreDeployResult(continue_processing=True)
+
+            # TODO: result = await self._scan_workflow(repo_url, ref)
+
+            # TODO: if result.blocked:
+            #           return CatalogPreDeployResult(
+            #               continue_processing=False,
+            #               violation=PluginViolation(
+            #                   reason="Security vulnerabilities detected",
+            #                   description=result.block_reason or "Critical findings in source code",
+            #                   code="SOURCE_SCAN_BLOCKED",
+            #                   details={
+            #                       "findings_count": len(result.findings),
+            #                       "error_count": result.summary.error_count,
+            #                       "warning_count": result.summary.warning_count,
+            #                   },
+            #               ),
+            #           )
+
+            # Placeholder: allow all deployments until implemented
+            logger.warning("catalog_pre_deploy not fully implemented, allowing")
+            return CatalogPreDeployResult(continue_processing=True)
+
+        except Exception as e:
+            logger.error(f"catalog_pre_deploy failed: {e}", exc_info=True)
+            # Fail open: allow deployment but log error
+            return CatalogPreDeployResult(continue_processing=True)

--- a/plugins/source_scanner/storage/__init__.py
+++ b/plugins/source_scanner/storage/__init__.py
@@ -1,7 +1,7 @@
 #!usr/bin/env python
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/storage/__init__.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 

--- a/plugins/source_scanner/storage/models.py
+++ b/plugins/source_scanner/storage/models.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/storage/models.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 
@@ -48,6 +48,7 @@ class ScanRecord(Base):
     )
 
     def __repr__(self) -> str:
+        """Return a concise string representation of the scan record."""
         commit_val = getattr(self, "commit_sha", None)
         commit_display: str | None = commit_val[:8] if commit_val else None
         return f"<ScanRecord(id={self.id}, repo={self.repo_url}, commit={commit_display})>"
@@ -80,4 +81,5 @@ class FindingRecord(Base):
     )
 
     def __repr__(self) -> str:
+        """Return a concise string representation of the finding."""
         return f"<FindingRecord(id={self.id}, scanner={self.scanner}, rule={self.rule_id}, severity={self.severity})>"

--- a/plugins/source_scanner/storage/repository.py
+++ b/plugins/source_scanner/storage/repository.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/storage/repository.py
 
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 

--- a/plugins/source_scanner/types.py
+++ b/plugins/source_scanner/types.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/types.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 

--- a/plugins/source_scanner/utils/__init__.py
+++ b/plugins/source_scanner/utils/__init__.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Location: ./plugins/source_scanner/utils/__init__.py
-Copyright 2025
+"""Location: ./plugins/source_scanner/language_detector.py
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Ayo
 
-Utils package
 """

--- a/plugins/source_scanner/utils/exec.py
+++ b/plugins/source_scanner/utils/exec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/utils/exec.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 
@@ -33,12 +33,14 @@ class ExecResult:
         stderr: str,
         timed_out: bool = False,
     ) -> None:
+        """Create an execution result container for a completed command."""
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
         self.timed_out = timed_out
 
     def __repr__(self) -> str:
+        """Return a summary string of the execution result."""
         return f"ExecResult(returncode={self.returncode}, " f"timed_out={self.timed_out}, " f"stdout_len={len(self.stdout)}, " f"stderr_len={len(self.stderr)})"
 
 

--- a/tests/unit/plugins/test_source_scanner/__init__.py
+++ b/tests/unit/plugins/test_source_scanner/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 Location: tests/unit/plugins/test_source_scanner/__init__.py
-Copyright: 2025
+Copyright: 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Yaser
 Unit tests for MCP Source Scanner Plugin.

--- a/tests/unit/plugins/test_source_scanner/conftest.py
+++ b/tests/unit/plugins/test_source_scanner/conftest.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 Location: tests/unit/plugins/test_source_scanner/__init__.py
-Copyright: 2025
+Copyright: 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Yaser
 Unit tests for MCP Source Scanner Plugin.

--- a/tests/unit/plugins/test_source_scanner/test_config.py
+++ b/tests/unit/plugins/test_source_scanner/test_config.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_config.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.config import BanditConfig, ScannersConfig, SemgrepConfig, SourceScannerConfig
+
+
+def test_semgrep_config_defaults() -> None:
+    config = SemgrepConfig()
+
+    assert config.enabled is True
+    assert config.rulesets == ["p/security-audit", "p/owasp-top-ten", "p/python", "p/javascript"]
+    assert config.extra_args == []
+    assert config.timeout_seconds == 600
+
+
+def test_bandit_config_defaults() -> None:
+    config = BanditConfig()
+
+    assert config.enabled is True
+    assert config.severity == "medium"
+    assert config.confidence == "medium"
+
+
+def test_scanners_config_defaults() -> None:
+    config = ScannersConfig()
+
+    assert isinstance(config.semgrep, SemgrepConfig)
+    assert isinstance(config.bandit, BanditConfig)
+
+
+def test_source_scanner_config_defaults() -> None:
+    config = SourceScannerConfig()
+
+    assert isinstance(config.semgrep, SemgrepConfig)
+    assert isinstance(config.bandit, BanditConfig)
+    assert config.severity_threshold == "WARNING"
+    assert config.fail_on_critical is True
+    assert config.clone_timeout_seconds == 120
+    assert config.scan_timeout_seconds == 600
+    assert config.max_repo_size_mb == 500
+    assert config.github_token_env == "GITHUB_TOKEN"
+    assert config.cache_by_commit is True
+    assert config.cache_ttl_hours == 168
+
+
+def test_source_scanner_config_merges_scanners() -> None:
+    scanners = ScannersConfig(
+        semgrep=SemgrepConfig(enabled=False, rulesets=["p/python"], extra_args=["--strict"], timeout_seconds=123),
+        bandit=BanditConfig(enabled=False, severity="low", confidence="high"),
+    )
+    config = SourceScannerConfig(
+        scanners=scanners,
+        semgrep=SemgrepConfig(enabled=True, rulesets=["p/security-audit"], extra_args=[], timeout_seconds=999),
+        bandit=BanditConfig(enabled=True, severity="high", confidence="low"),
+    )
+
+    assert config.semgrep.enabled is False
+    assert config.semgrep.rulesets == ["p/python"]
+    assert config.semgrep.extra_args == ["--strict"]
+    assert config.semgrep.timeout_seconds == 123
+    assert config.bandit.enabled is False
+    assert config.bandit.severity == "low"
+    assert config.bandit.confidence == "high"

--- a/tests/unit/plugins/test_source_scanner/test_errors.py
+++ b/tests/unit/plugins/test_source_scanner/test_errors.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_errors.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.errors import (
+    CheckoutError,
+    CloneTimeoutError,
+    ParseError,
+    PolicyError,
+    RepoFetchError,
+    RepoSizeLimitError,
+    ScannerError,
+    ScannerNotFoundError,
+    ScannerTimeoutError,
+    SourceScannerError,
+)
+
+
+def test_exception_hierarchy() -> None:
+    assert issubclass(RepoFetchError, SourceScannerError)
+    assert issubclass(CloneTimeoutError, RepoFetchError)
+    assert issubclass(RepoSizeLimitError, RepoFetchError)
+    assert issubclass(CheckoutError, RepoFetchError)
+
+    assert issubclass(ScannerError, SourceScannerError)
+    assert issubclass(ScannerTimeoutError, ScannerError)
+    assert issubclass(ScannerNotFoundError, ScannerError)
+
+    assert issubclass(ParseError, SourceScannerError)
+    assert issubclass(PolicyError, SourceScannerError)

--- a/tests/unit/plugins/test_source_scanner/test_exec.py
+++ b/tests/unit/plugins/test_source_scanner/test_exec.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_exec.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# Standard
+import sys
+
+# Third-Party
+import pytest
+
+# First-Party
+from plugins.source_scanner.utils.exec import ExecResult, run_command
+
+
+def test_exec_result_repr() -> None:
+    result = ExecResult(returncode=0, stdout="out", stderr="err", timed_out=False)
+
+    text = repr(result)
+
+    assert "returncode=0" in text
+    assert "timed_out=False" in text
+    assert "stdout_len=3" in text
+    assert "stderr_len=3" in text
+
+
+@pytest.mark.asyncio
+async def test_run_command_success() -> None:
+    result = await run_command([sys.executable, "-c", "print('hello')"])
+
+    assert result.returncode == 0
+    assert result.timed_out is False
+    assert "hello" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_run_command_captures_stderr() -> None:
+    result = await run_command([sys.executable, "-c", "import sys; sys.stderr.write('oops')"])
+
+    assert result.returncode == 0
+    assert result.timed_out is False
+    assert "oops" in result.stderr
+
+
+@pytest.mark.asyncio
+async def test_run_command_timeout() -> None:
+    result = await run_command([sys.executable, "-c", "import time; time.sleep(1)"], timeout_seconds=0.01)
+
+    assert result.timed_out is True
+    assert result.returncode != 0

--- a/tests/unit/plugins/test_source_scanner/test_policy.py
+++ b/tests/unit/plugins/test_source_scanner/test_policy.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_policy.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.policy import PolicyChecker
+from plugins.source_scanner.types import Finding
+
+
+def _finding(severity: str) -> Finding:
+    return Finding(
+        scanner="semgrep",
+        severity=severity,  # type: ignore[arg-type]
+        rule_id="rule",
+        message="issue",
+        file_path="app.py",
+        line=1,
+    )
+
+
+def test_policy_blocks_on_threshold_violation() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("ERROR"), _finding("WARNING"), _finding("INFO")]
+
+    decision = checker.evaluate(findings, threshold="WARNING", fail_on_critical=True)
+
+    assert decision.blocked is True
+    assert decision.reason is not None
+    assert "Policy threshold WARNING violated" in decision.reason
+    assert "1 ERROR" in decision.reason
+    assert "1 WARNING" in decision.reason
+    assert "1 INFO" in decision.reason
+
+
+def test_policy_allows_when_no_violations() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("WARNING"), _finding("INFO")]
+
+    decision = checker.evaluate(findings, threshold="ERROR", fail_on_critical=True)
+
+    assert decision.blocked is False
+    assert decision.reason is None
+
+
+def test_policy_audit_mode_never_blocks() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("ERROR")]
+
+    decision = checker.evaluate(findings, threshold="ERROR", fail_on_critical=False)
+
+    assert decision.blocked is False
+
+
+def test_policy_unknown_threshold_defaults_to_warning() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("WARNING")]
+
+    decision = checker.evaluate(findings, threshold="unknown", fail_on_critical=True)
+
+    assert decision.blocked is True
+    assert decision.reason is not None
+
+
+def test_policy_info_threshold_includes_info() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("INFO")]
+
+    decision = checker.evaluate(findings, threshold="INFO", fail_on_critical=True)
+
+    assert decision.blocked is True

--- a/tests/unit/plugins/test_source_scanner/test_storage_models.py
+++ b/tests/unit/plugins/test_source_scanner/test_storage_models.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_storage_models.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.storage.models import FindingRecord, ScanRecord
+
+
+def test_scan_record_repr_includes_short_commit() -> None:
+    record = ScanRecord(repo_url="https://example.com/repo.git", commit_sha="abcdef1234567890")
+
+    result = repr(record)
+
+    assert "commit=abcdef12" in result
+    assert "repo=https://example.com/repo.git" in result
+
+
+def test_scan_record_table_columns_include_expected_fields() -> None:
+    columns = {column.name for column in ScanRecord.__table__.columns}
+
+    assert "repo_url" in columns
+    assert "commit_sha" in columns
+    assert "created_at" in columns
+    assert "blocked" in columns
+
+
+def test_finding_record_repr_includes_key_fields() -> None:
+    finding = FindingRecord(
+        scan_id=1,
+        scanner="semgrep",
+        severity="ERROR",
+        rule_id="rule.id",
+        message="Issue found",
+    )
+
+    result = repr(finding)
+
+    assert "scanner=semgrep" in result
+    assert "rule=rule.id" in result
+    assert "severity=ERROR" in result
+
+
+def test_finding_record_has_dedup_unique_constraint() -> None:
+    constraint_names = {constraint.name for constraint in FindingRecord.__table__.constraints if constraint.name}
+
+    assert "uq_finding_scan_dedup" in constraint_names

--- a/tests/unit/plugins/test_source_scanner/test_storage_repository.py
+++ b/tests/unit/plugins/test_source_scanner/test_storage_repository.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_storage_repository.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# Standard
+from typing import Optional
+from unittest.mock import MagicMock, Mock
+
+# Third-Party
+import pytest
+
+# First-Party
+from plugins.source_scanner.storage.models import ScanRecord
+from plugins.source_scanner.storage.repository import ScanRepository
+from plugins.source_scanner.types import Finding
+
+
+@pytest.fixture
+def mock_db() -> MagicMock:
+    """Mock SQLAlchemy Session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def repository(mock_db: MagicMock) -> ScanRepository:
+    """Create ScanRepository with mocked database."""
+    return ScanRepository(mock_db)
+
+
+def _create_finding(
+    scanner: str = "semgrep",
+    severity: str = "ERROR",
+    rule_id: str = "rule.id",
+    message: str = "Issue found",
+    file_path: Optional[str] = "app.py",
+    line: Optional[int] = 10,
+) -> Finding:
+    """Helper to create Finding objects."""
+    return Finding(
+        scanner=scanner,
+        severity=severity,  # type: ignore[arg-type]
+        rule_id=rule_id,
+        message=message,
+        file_path=file_path,
+        line=line,
+    )
+
+
+class TestScanRepositoryCreateScan:
+    """Tests for create_scan method."""
+
+    def test_create_scan_with_findings(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test creating a scan record with findings."""
+        findings = [
+            _create_finding(severity="ERROR"),
+            _create_finding(severity="WARNING"),
+            _create_finding(severity="INFO"),
+        ]
+
+        # Mock the scan object returned after flush
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.query.return_value.filter.return_value.first.return_value = None  # type: ignore[attr-defined]
+        repository.db.flush = MagicMock(side_effect=lambda: setattr(mock_scan, "id", 1))
+
+        repository.create_scan(
+            repo_url="https://github.com/test/repo.git",
+            ref="main",
+            commit_sha="abc123def456",
+            languages=["python", "javascript"],
+            findings=findings,
+            blocked=False,
+            block_reason=None,
+        )
+
+        # Verify db.add was called for scan
+        assert isinstance(repository.db.add, MagicMock) and repository.db.add.call_count >= 1
+        # Verify db.commit was called
+        assert isinstance(repository.db.commit, MagicMock) and repository.db.commit.call_count >= 1
+
+    def test_create_scan_counts_severity(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test that create_scan correctly counts findings by severity."""
+        findings = [
+            _create_finding(severity="ERROR"),
+            _create_finding(severity="ERROR"),
+            _create_finding(severity="WARNING"),
+            _create_finding(severity="INFO"),
+            _create_finding(severity="INFO"),
+            _create_finding(severity="INFO"),
+        ]
+
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.flush = MagicMock(side_effect=lambda: setattr(mock_scan, "id", 1))
+
+        repository.create_scan(
+            repo_url="https://github.com/test/repo.git",
+            ref="main",
+            commit_sha="abc123def456",
+            languages=[],
+            findings=findings,
+            blocked=False,
+            block_reason=None,
+        )
+
+        # Verify ScanRecord was created with correct counts
+        assert isinstance(repository.db.add, MagicMock) and repository.db.add.call_count >= 1
+
+
+class TestScanRepositoryGetScan:
+    """Tests for get_scan_by_id method."""
+
+    def test_get_scan_by_id_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving scan by ID when it exists."""
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.query.return_value.filter.return_value.first.return_value = mock_scan  # type: ignore[attr-defined]
+
+        result = repository.get_scan_by_id(1)
+
+        assert result == mock_scan
+        repository.db.query.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_get_scan_by_id_not_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving scan by ID when it does not exist."""
+        repository.db.query.return_value.filter.return_value.first.return_value = None  # type: ignore[attr-defined]
+
+        result = repository.get_scan_by_id(999)
+
+        assert result is None
+
+
+class TestScanRepositoryGetFindings:
+    """Tests for get_findings_for_scan method."""
+
+    def test_get_findings_for_scan_sorted(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test that findings are sorted by severity and file_path."""
+        findings = [
+            Mock(severity="INFO", file_path="z.py"),
+            Mock(severity="ERROR", file_path="b.py"),
+            Mock(severity="WARNING", file_path="a.py"),
+        ]
+
+        repository.db.query.return_value.filter.return_value.all.return_value = findings  # type: ignore[attr-defined]
+
+        result = repository.get_findings_for_scan(1)
+
+        # Verify sorting: ERROR (0), WARNING (1), INFO (2)
+        assert result[0].severity == "ERROR"
+        assert result[1].severity == "WARNING"
+        assert result[2].severity == "INFO"
+
+    def test_get_findings_for_scan_empty(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test getting findings when scan has none."""
+        repository.db.query.return_value.filter.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        result = repository.get_findings_for_scan(1)
+
+        assert result == []
+
+
+class TestScanRepositoryGetLatestScan:
+    """Tests for get_latest_scan_for_commit method."""
+
+    def test_get_latest_scan_for_commit_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving latest scan for a commit."""
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.commit_sha = "abc123"
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_scan  # type: ignore[attr-defined]
+
+        result = repository.get_latest_scan_for_commit("https://github.com/test/repo", "abc123")
+
+        assert result == mock_scan
+
+    def test_get_latest_scan_for_commit_not_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving latest scan when none exists."""
+        repository.db.query.return_value.filter.return_value.order_by.return_value.first.return_value = None  # type: ignore[attr-defined]
+
+        result = repository.get_latest_scan_for_commit("https://github.com/test/repo", "abc123")
+
+        assert result is None
+
+
+class TestScanRepositoryGetScansForRepo:
+    """Tests for get_scans_for_repo method."""
+
+    def test_get_scans_for_repo_with_pagination(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving scans with pagination."""
+        mock_scans = [Mock(spec=ScanRecord) for _ in range(3)]
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = mock_scans  # type: ignore[attr-defined]
+
+        result = repository.get_scans_for_repo("https://github.com/test/repo", limit=10, offset=0)
+
+        assert len(result) == 3
+        assert result == mock_scans
+
+    def test_get_scans_for_repo_default_pagination(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test that default pagination limits to 10."""
+        repository.db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        repository.get_scans_for_repo("https://github.com/test/repo")
+
+        # Verify limit(10) was called with default
+        repository.db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.assert_called_with(10)  # type: ignore[attr-defined]
+
+
+class TestScanRepositoryGetFindingsBySeverity:
+    """Tests for get_findings_by_severity method."""
+
+    def test_get_findings_by_severity_error(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving ERROR-level findings."""
+        mock_findings = [Mock(severity="ERROR") for _ in range(2)]
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = mock_findings  # type: ignore[attr-defined]
+
+        result = repository.get_findings_by_severity(1, "ERROR")
+
+        assert len(result) == 2
+
+    def test_get_findings_by_severity_warning(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving WARNING-level findings."""
+        mock_findings = [Mock(severity="WARNING") for _ in range(1)]
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = mock_findings  # type: ignore[attr-defined]
+
+        result = repository.get_findings_by_severity(1, "WARNING")
+
+        assert len(result) == 1
+
+    def test_get_findings_by_severity_empty(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving findings of specific severity when none exist."""
+        repository.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        result = repository.get_findings_by_severity(1, "ERROR")
+
+        assert result == []
+
+
+class TestScanRepositoryDeleteScan:
+    """Tests for delete_scan method."""
+
+    def test_delete_scan_success(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test deleting a scan that exists."""
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.query.return_value.filter.return_value.first.return_value = mock_scan  # type: ignore[attr-defined]
+        repository.db.delete = MagicMock()  # type: ignore[attr-defined]
+        repository.db.commit = MagicMock()  # type: ignore[attr-defined]
+
+        result = repository.delete_scan(1)
+
+        assert result is True
+        repository.db.delete.assert_called_once_with(mock_scan)
+        repository.db.commit.assert_called()
+
+    def test_delete_scan_not_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test deleting a scan that does not exist."""
+        repository.db.query.return_value.filter.return_value.first.return_value = None  # type: ignore[attr-defined]
+        repository.db.delete = MagicMock()  # type: ignore[attr-defined]
+
+        result = repository.delete_scan(999)
+
+        assert result is False
+        repository.db.delete.assert_not_called()


### PR DESCRIPTION
## Issue
issue #2217 

## 📝 Summary
This PR updates the Source Scanner Plugin based on feedback from the previous draft PR and adds new functionality.

---

## Update/fixes
- Semgrep runner updated: uses utils.exec.run_command, replaced print() with logging, updated copyright headers to 2026.
- Addressed issues raised in review from the scaffold PR (sync/async alignment, subprocess safety, temp repo handling).

---

## New functionality
- LanguageDetector implemented for detecting repository languages.
- RepoFetcher implemented for cloning repositories in a reusable way.
- source_scanner.py added: contains the main plugin class and hooks (mostly commented code; will be uncommented as Bandit runner and other components are completed).

## Remaining / follow-up
- Bandit runner is nearly complete but still requires tweaks.
- Parsing/normalizer module is not yet finished.
- Tests for Bandit runner and language detection need to be completed.
- Full test coverage is not yet achieved (coverage currently ~42%).
- REPOSITORY_AVAILABLE = True still hardcoded, plan is for it to be dynamically determined
- Admin UI

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   passes     |
| Unit tests                | `make test`     |   passing for implemented files     | 
| Coverage ≥ 80%            | `make coverage` |    42%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---
