### PR TITLE
refactor(plugins): decouple plugin framework from gateway settings

### DIFF
--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -317,7 +317,7 @@ Kubernetes: `>=1.21.0-0`
 | mcpContextForge.config.PLUGINS_SERVER_SSL_ENABLED | string | `"false"` |  |
 | mcpContextForge.config.PLUGINS_SERVER_SSL_KEYFILE | string | `""` |  |
 | mcpContextForge.config.PLUGINS_SERVER_SSL_KEYFILE_PASSWORD | string | `""` |  |
-| mcpContextForge.config.PLUGINS_CONFIG_FILE | string | `"plugins/config.yaml"` | `PLUGIN_CONFIG_FILE` also accepted for backwards compatibility |
+| mcpContextForge.config.PLUGINS_CONFIG_FILE | string | not set (app default: `plugins/config.yaml`) | Set to override plugin config path. `PLUGIN_CONFIG_FILE` also accepted for backwards compatibility |
 | mcpContextForge.config.POLL_INTERVAL | string | `"1.0"` |  |
 | mcpContextForge.config.PORT | string | `"4444"` |  |
 | mcpContextForge.config.PROMPT_CACHE_SIZE | string | `"100"` |  |

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -573,8 +573,10 @@ mcpContextForge:
 
     # ─ Plugin Configuration ─
     PLUGINS_ENABLED: "false"         # enable the plugin framework
-    PLUGINS_CONFIG_FILE: "plugins/config.yaml" # path to main plugins configuration file (PLUGIN_CONFIG_FILE also accepted)
-    PLUGIN_CONFIG_FILE: "plugins/config.yaml" # path to main plugins configuration file (deprecated, use PLUGINS_CONFIG_FILE)
+    # PLUGINS_CONFIG_FILE: "plugins/config.yaml" # path to main plugins configuration file (PLUGIN_CONFIG_FILE also accepted)
+    # NOTE: intentionally not set here so that legacy PLUGIN_CONFIG_FILE overrides
+    # are not shadowed by the chart default.  The app falls back to
+    # "plugins/config.yaml" when neither env var is present.
     PLUGINS_CLIENT_MTLS_CA_BUNDLE: ""        # default CA bundle for external plugins (optional)
     PLUGINS_CLIENT_MTLS_CERTFILE: ""         # gateway client certificate for plugin mTLS
     PLUGINS_CLIENT_MTLS_KEYFILE: ""          # gateway client key for plugin mTLS (optional)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2397,9 +2397,9 @@ class LazySettingsWrapper:
             PluginsSettings: The plugin framework settings instance.
         """
         # First-Party
-        from mcpgateway.plugins.framework.settings import settings as _plugin_settings  # pylint: disable=import-outside-toplevel
+        from mcpgateway.plugins.framework.settings import get_settings as _get_plugin_settings  # pylint: disable=import-outside-toplevel
 
-        return _plugin_settings
+        return _get_plugin_settings()
 
     def __getattr__(self, key: str) -> Any:
         """Get the real settings object and forward to it

--- a/mcpgateway/plugins/framework/external/grpc/server/runtime.py
+++ b/mcpgateway/plugins/framework/external/grpc/server/runtime.py
@@ -46,7 +46,7 @@ from mcpgateway.plugins.framework.external.grpc.server.server import GrpcHealthS
 from mcpgateway.plugins.framework.external.grpc.tls_utils import create_server_credentials
 from mcpgateway.plugins.framework.external.mcp.server.server import ExternalPluginServer
 from mcpgateway.plugins.framework.models import GRPCServerConfig
-from mcpgateway.plugins.framework.settings import PluginsSettings
+from mcpgateway.plugins.framework.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +296,7 @@ Examples:
     )
 
     # Run the server
-    config_path = args.config or PluginsSettings().config_path
+    config_path = args.config or get_settings().config_path
     try:
         asyncio.run(
             run_server(

--- a/mcpgateway/plugins/framework/external/mcp/server/runtime.py
+++ b/mcpgateway/plugins/framework/external/mcp/server/runtime.py
@@ -72,7 +72,7 @@ import uvicorn
 # First-Party
 from mcpgateway.plugins.framework import ExternalPluginServer, MCPServerConfig
 from mcpgateway.plugins.framework.constants import GET_PLUGIN_CONFIG, GET_PLUGIN_CONFIGS, INVOKE_HOOK, MCP_SERVER_INSTRUCTIONS, MCP_SERVER_NAME
-from mcpgateway.plugins.framework.settings import PluginsSettings
+from mcpgateway.plugins.framework.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -485,7 +485,7 @@ async def run() -> None:
     # Determine transport type from environment variable or auto-detect
     # Auto-detect: if stdin is not a TTY (i.e., it's being piped), use stdio mode
     # First-Party
-    transport = PluginsSettings().transport
+    transport = get_settings().transport
     if transport is None:
         # Auto-detect based on stdin
         if not sys.stdin.isatty():

--- a/mcpgateway/plugins/framework/external/mcp/server/server.py
+++ b/mcpgateway/plugins/framework/external/mcp/server/server.py
@@ -75,7 +75,7 @@ from mcpgateway.plugins.framework.errors import convert_exception_to_error, Plug
 from mcpgateway.plugins.framework.loader.config import ConfigLoader
 from mcpgateway.plugins.framework.manager import PluginManager
 from mcpgateway.plugins.framework.models import GRPCServerConfig, MCPServerConfig, PluginContext
-from mcpgateway.plugins.framework.settings import PluginsSettings
+from mcpgateway.plugins.framework.settings import get_settings
 
 P = TypeVar("P", bound=BaseModel)
 
@@ -97,7 +97,7 @@ class ExternalPluginServer:
             >>> server is not None
             True
         """
-        self._config_path = config_path or PluginsSettings().config_path or os.path.join(".", "resources", "plugins", "config.yaml")
+        self._config_path = config_path or get_settings().config_path or os.path.join(".", "resources", "plugins", "config.yaml")
         self._config = ConfigLoader.load_config(self._config_path, use_jinja=False)
         self._plugin_manager = PluginManager(self._config_path)
 

--- a/mcpgateway/plugins/framework/external/unix/server/runtime.py
+++ b/mcpgateway/plugins/framework/external/unix/server/runtime.py
@@ -31,7 +31,7 @@ import sys
 
 # First-Party
 from mcpgateway.plugins.framework.external.unix.server.server import run_server
-from mcpgateway.plugins.framework.settings import PluginsSettings
+from mcpgateway.plugins.framework.settings import get_settings
 
 # Configure logging
 logging.basicConfig(
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 async def run() -> None:
     """Main entry point for the Unix socket server."""
-    s = PluginsSettings()
+    s = get_settings()
     config_path = s.config_path or os.path.join(".", "resources", "plugins", "config.yaml")
     socket_path = s.unix_socket_path or "/tmp/mcpgateway-plugins.sock"  # nosec B108 - configurable via env var
 

--- a/mcpgateway/plugins/framework/models.py
+++ b/mcpgateway/plugins/framework/models.py
@@ -301,7 +301,7 @@ class MCPClientTLSConfig(MCPTransportTLSConfigBase):
         if s.client_mtls_ca_bundle:
             data["ca_bundle"] = s.client_mtls_ca_bundle
         if s.client_mtls_keyfile_password is not None:
-            data["keyfile_password"] = s.client_mtls_keyfile_password
+            data["keyfile_password"] = s.client_mtls_keyfile_password.get_secret_value()
         if s.client_mtls_verify is not None:
             data["verify"] = s.client_mtls_verify
         if s.client_mtls_check_hostname is not None:
@@ -339,7 +339,7 @@ class MCPServerTLSConfig(MCPTransportTLSConfigBase):
         if s.server_ssl_ca_certs:
             data["ca_bundle"] = s.server_ssl_ca_certs
         if s.server_ssl_keyfile_password is not None:
-            data["keyfile_password"] = s.server_ssl_keyfile_password
+            data["keyfile_password"] = s.server_ssl_keyfile_password.get_secret_value()
         if s.server_ssl_cert_reqs is not None:
             data["ssl_cert_reqs"] = s.server_ssl_cert_reqs
 
@@ -686,7 +686,7 @@ class GRPCClientTLSConfig(MCPTransportTLSConfigBase):
         if s.grpc_client_mtls_ca_bundle:
             data["ca_bundle"] = s.grpc_client_mtls_ca_bundle
         if s.grpc_client_mtls_keyfile_password is not None:
-            data["keyfile_password"] = s.grpc_client_mtls_keyfile_password
+            data["keyfile_password"] = s.grpc_client_mtls_keyfile_password.get_secret_value()
         if s.grpc_client_mtls_verify is not None:
             data["verify"] = s.grpc_client_mtls_verify
 
@@ -741,7 +741,7 @@ class GRPCServerTLSConfig(MCPTransportTLSConfigBase):
         if s.grpc_server_ssl_ca_certs:
             data["ca_bundle"] = s.grpc_server_ssl_ca_certs
         if s.grpc_server_ssl_keyfile_password is not None:
-            data["keyfile_password"] = s.grpc_server_ssl_keyfile_password
+            data["keyfile_password"] = s.grpc_server_ssl_keyfile_password.get_secret_value()
         if s.grpc_server_ssl_client_auth:
             data["client_auth"] = s.grpc_server_ssl_client_auth
 

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -218,6 +218,9 @@ class TestToolServiceHelpersExtended:
         mock_pm.assert_called_once()
 
         monkeypatch.setenv("PLUGINS_ENABLED", "no")
+        from mcpgateway.plugins.framework.settings import settings as plugin_settings  # pylint: disable=import-outside-toplevel
+
+        plugin_settings.cache_clear()
         with patch("mcpgateway.services.tool_service.PluginManager") as mock_pm:
             service = ToolService()
         assert service._plugin_manager is None

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -357,8 +357,6 @@ class TestInitializeShutdown:
     def test_init_plugins_enabled_env_true(self, monkeypatch):
         """PLUGINS_ENABLED=true env should enable plugin manager."""
         monkeypatch.setenv("PLUGINS_ENABLED", "true")
-        from mcpgateway.plugins.framework.settings import PluginsSettings
-        monkeypatch.setattr("mcpgateway.plugins.framework.settings.settings", PluginsSettings())
         with patch("mcpgateway.services.tool_service.PluginManager") as mock_pm:
             service = ToolService()
         assert service._plugin_manager is not None
@@ -367,8 +365,6 @@ class TestInitializeShutdown:
     def test_init_plugins_enabled_env_false(self, monkeypatch):
         """PLUGINS_ENABLED=false env should disable plugin manager."""
         monkeypatch.setenv("PLUGINS_ENABLED", "false")
-        from mcpgateway.plugins.framework.settings import PluginsSettings
-        monkeypatch.setattr("mcpgateway.plugins.framework.settings.settings", PluginsSettings())
         with patch("mcpgateway.services.tool_service.PluginManager") as mock_pm:
             service = ToolService()
         assert service._plugin_manager is None
@@ -377,8 +373,6 @@ class TestInitializeShutdown:
     def test_init_plugins_enabled_env_on(self, monkeypatch):
         """PLUGINS_ENABLED=on env should enable plugin manager."""
         monkeypatch.setenv("PLUGINS_ENABLED", "on")
-        from mcpgateway.plugins.framework.settings import PluginsSettings
-        monkeypatch.setattr("mcpgateway.plugins.framework.settings.settings", PluginsSettings())
         with patch("mcpgateway.services.tool_service.PluginManager") as mock_pm:
             service = ToolService()
         assert service._plugin_manager is not None
@@ -386,8 +380,6 @@ class TestInitializeShutdown:
     def test_init_plugins_enabled_env_off(self, monkeypatch):
         """PLUGINS_ENABLED=off env should disable plugin manager."""
         monkeypatch.setenv("PLUGINS_ENABLED", "off")
-        from mcpgateway.plugins.framework.settings import PluginsSettings
-        monkeypatch.setattr("mcpgateway.plugins.framework.settings.settings", PluginsSettings())
         with patch("mcpgateway.services.tool_service.PluginManager") as mock_pm:
             service = ToolService()
         assert service._plugin_manager is None


### PR DESCRIPTION
## Description

Introduces a self-contained `PluginsSettings` configuration class for the plugin framework, eliminating all `os.environ` reads and imports from `mcpgateway.config.settings` and `mcpgateway.services.http_client_service`. The plugin framework now owns its configuration and can operate independently of the gateway.

Closes: #2831 

### Problem

Multiple plugin framework modules imported `settings` from `mcpgateway.config`, the MCP client imported HTTP helpers from `mcpgateway.services.http_client_service`, and every `from_env()` factory method in `models.py` read `os.environ` directly with hand-rolled boolean parsing. This created tight coupling from the plugin framework back into the gateway — the opposite of the desired direction for ADR-019 modular architecture.

### Solution

- Created `mcpgateway/plugins/framework/settings.py` with a `PluginsSettings` class using `pydantic_settings` and the `PLUGINS_` env var prefix
- Consolidated **all** plugin-related env var reads into `PluginsSettings`: core config, HTTP client tuning, SSL/TLS (mTLS client, server SSL, gRPC client/server TLS), server bind, transport runtime, Unix socket, and CLI options
- Replaced `get_http_timeout()` and `get_default_verify()` calls in the MCP client with direct usage of `settings.httpx_*` and `settings.skip_ssl_verify`
- Migrated all `from_env()` factory methods in `models.py` (`MCPClientTLSConfig`, `MCPServerTLSConfig`, `MCPServerConfig`, `GRPCClientTLSConfig`, `GRPCServerTLSConfig`, `GRPCServerConfig`, `UnixSocketServerConfig`) from raw `os.environ` reads to `PluginsSettings`
- Removed duplicate `_parse_bool()` static methods from `MCPTransportTLSConfigBase` and `MCPServerConfig` (pydantic handles type coercion)
- Updated `get_plugin_manager()`, `cli.py`, and all external server runtimes (MCP, gRPC, Unix) to use the framework's own settings
- Added `settings.plugins` property on `LazySettingsWrapper` so gateway code accesses plugin settings via `settings.plugins.enabled` instead of `settings.plugins_enabled`
- Simplified gateway services (`main.py`, `admin.py`, `prompt_service.py`, `resource_service.py`, `tool_service.py`) by replacing manual `os.getenv("PLUGINS_ENABLED")` parsing with `settings.plugins.enabled`
- Removed `plugins_enabled` and `plugin_config_file` fields from gateway `Settings` class
- Removed unused `PYTHON` constant from `constants.py`
- Standardized env var naming: `PLUGIN_CONFIG_FILE` → `PLUGINS_CONFIG_FILE` (legacy name supported via `AliasChoices` for backwards compatibility)

### Configuration mapping

Field names are chosen so that the `PLUGINS_` env prefix produces clean env var names (e.g., field `enabled` → `PLUGINS_ENABLED`).

| Gateway env var | Plugin framework env var | Default | Notes |
|---|---|---|---|
| `PLUGINS_ENABLED` | `PLUGINS_ENABLED` | `false` | Shared |
| `PLUGIN_CONFIG_FILE` | `PLUGINS_CONFIG_FILE` | `plugins/config.yaml` | Legacy alias supported |
| `HTTPX_CONNECT_TIMEOUT` | `PLUGINS_HTTPX_CONNECT_TIMEOUT` | `5.0` | Scoped to plugins |
| `HTTPX_READ_TIMEOUT` | `PLUGINS_HTTPX_READ_TIMEOUT` | `120.0` | Scoped to plugins |
| `SKIP_SSL_VERIFY` | `PLUGINS_SKIP_SSL_VERIFY` | `false` | Scoped to plugins |
| `PLUGINS_CLI_COMPLETION` | `PLUGINS_CLI_COMPLETION` | `false` | Shared |
| `PLUGINS_CLI_MARKUP_MODE` | `PLUGINS_CLI_MARKUP_MODE` | (none) | Shared |
| _(various `PLUGINS_*`)_ | _(see `PluginsSettings` for full list: mTLS, server SSL, gRPC TLS, server bind, transport, Unix socket)_ | | |

## Changes

### Core

| File | Change |
|------|--------|
| `mcpgateway/plugins/framework/settings.py` | **New** — `PluginsSettings` class with `PLUGINS_` env prefix covering all plugin framework configuration (HTTP client, TLS/mTLS, server bind, transport, CLI) |
| `mcpgateway/plugins/framework/models.py` | Migrated all 7 `from_env()` factory methods from `os.environ` reads to `PluginsSettings`; removed duplicate `_parse_bool()` methods |
| `mcpgateway/plugins/framework/__init__.py` | `get_plugin_manager()` uses `mcpgateway.plugins.framework.settings` instead of `mcpgateway.config` |
| `mcpgateway/plugins/framework/external/mcp/client.py` | Replaced `mcpgateway.config.settings` and `mcpgateway.services.http_client_service` imports with framework settings; `httpx.Timeout` built from `settings.httpx_*` values |
| `mcpgateway/plugins/framework/constants.py` | Removed unused `PYTHON` constant |
| `mcpgateway/plugins/tools/cli.py` | Replaced `mcpgateway.config.settings` with `mcpgateway.plugins.framework.settings` |

### External server runtimes

| File | Change |
|------|--------|
| `mcpgateway/plugins/framework/external/mcp/server/runtime.py` | `PLUGINS_TRANSPORT` env var read replaced with `PluginsSettings().transport` |
| `mcpgateway/plugins/framework/external/mcp/server/server.py` | `PLUGINS_CONFIG_PATH` env var read replaced with `PluginsSettings().config_path` |
| `mcpgateway/plugins/framework/external/grpc/server/runtime.py` | `PLUGINS_CONFIG_PATH` env var read replaced with `PluginsSettings().config_path` |
| `mcpgateway/plugins/framework/external/unix/server/runtime.py` | `PLUGINS_CONFIG_PATH` and `UNIX_SOCKET_PATH` env var reads replaced with `PluginsSettings()` |

### Gateway integration

| File | Change |
|------|--------|
| `mcpgateway/config.py` | Removed `plugins_enabled` and `plugin_config_file` fields from `Settings`; added `settings.plugins` property on `LazySettingsWrapper` |
| `mcpgateway/main.py` | Replaced manual `os.getenv("PLUGINS_ENABLED")` parsing with `settings.plugins.enabled` / `settings.plugins.config_file` |
| `mcpgateway/admin.py` | `settings.plugins_enabled` → `settings.plugins.enabled` |
| `mcpgateway/services/prompt_service.py` | Replaced manual env var parsing with `settings.plugins.enabled` / `settings.plugins.config_file` |
| `mcpgateway/services/resource_service.py` | Replaced manual env var parsing with `settings.plugins.enabled` / `settings.plugins.config_file` |
| `mcpgateway/services/tool_service.py` | Replaced manual env var parsing with `settings.plugins.enabled` / `settings.plugins.config_file` |
| `mcpgateway/tools/builder/common.py` | `PLUGIN_CONFIG_FILE` → `PLUGINS_CONFIG_FILE` in K8s manifest generation |

### Documentation and configuration

| File | Change |
|------|--------|
| `.env.example` | Consolidated all `PLUGINS_*` env vars into a single "Plugin Framework Settings" section with descriptions |
| `docs/docs/manage/configuration.md` | Added "Plugin Framework (Standalone) Settings" reference table |
| `docs/docs/using/plugins/index.md` | Updated quick-start with `PLUGINS_CONFIG_FILE`; added standalone settings note |
| `docs/docs/using/plugins/grpc-transport.md` | Added `PLUGINS_CONFIG_FILE` alongside `PLUGIN_CONFIG_FILE` |
| `docs/docs/architecture/adr/019-modular-architecture-split.md` | Added `PLUGINS_CONFIG_FILE` |
| `charts/mcp-stack/values.yaml` | Renamed `PLUGIN_CONFIG_FILE` → `PLUGINS_CONFIG_FILE`; added standalone framework settings |
| `charts/mcp-stack/templates/deployment-mcpgateway.yaml` | Updated volume mount to prefer `PLUGINS_CONFIG_FILE` with fallback |
| `charts/mcp-stack/README.md` | Updated Helm values table |
| `plugins/AGENTS.md` | `PLUGIN_CONFIG_FILE` → `PLUGINS_CONFIG_FILE` |
| `plugins/README.md` | Added `PLUGINS_CONFIG_FILE` |
| `AGENTS.md` | `PLUGIN_CONFIG_FILE` → `PLUGINS_CONFIG_FILE` |

### Tests

| File | Change |
|------|--------|
| `tests/unit/.../framework/test_settings.py` | **New** — 23 tests: default values, `PLUGINS_`-prefixed env var overrides, legacy alias (`PLUGIN_CONFIG_FILE`), module singleton stability |
| `tests/unit/.../framework/test_plugin_models.py` | Updated `from_env()` tests to use `PLUGINS_`-prefixed env vars via `PluginsSettings` |
| `tests/unit/.../framework/test_plugin_models_coverage.py` | Updated `from_env()` tests for `PluginsSettings` migration |
| `tests/unit/.../grpc/test_grpc_models.py` | Updated gRPC `from_env()` tests for `PluginsSettings` migration |
| `tests/unit/.../services/test_tool_service_coverage.py` | Updated plugin-enabled tests to monkeypatch `PluginsSettings` singleton |
| `tests/unit/.../services/test_resource_service_plugins.py` | Updated plugin-enabled tests to monkeypatch `PluginsSettings` singleton |
| `tests/unit/.../integration/test_cross_hook_context_sharing.py` | Minor import adjustment |
| `tests/unit/.../integration/test_resource_plugin_integration.py` | Minor import adjustment |
| `tests/unit/.../middleware/test_http_auth_integration.py` | Minor import adjustment |
