### PR TITLE
fix: prevent browser autofill on admin config forms

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1260,6 +1260,7 @@
                         <input
                           type="password"
                           id="import-rekey-secret"
+                          autocomplete="off"
                           placeholder="New encryption secret (optional)"
                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
                         />
@@ -1885,7 +1886,7 @@
                           API Key
                           <span id="llm-provider-api-key-required" class="text-red-500 hidden">*</span>
                         </label>
-                        <input type="password" id="llm-provider-api-key" name="api_key" class="mt-1 px-1.5 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white sm:text-sm" placeholder="Leave blank to keep existing">
+                        <input type="password" id="llm-provider-api-key" name="api_key" autocomplete="off" class="mt-1 px-1.5 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white sm:text-sm" placeholder="Leave blank to keep existing">
                       </div>
                       <div>
                         <label for="llm-provider-api-base" class="block text-sm font-medium text-gray-700 dark:text-gray-300">API Base URL</label>
@@ -2098,6 +2099,7 @@
                   <input
                     type="password"
                     id="modal-api-key"
+                    autocomplete="off"
                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                     placeholder="Enter your API key"
                     required
@@ -3711,6 +3713,7 @@
                   <input
                     type="text"
                     name="auth_username"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -3721,6 +3724,7 @@
                   <input
                     type="password"
                     name="auth_password"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -3733,6 +3737,7 @@
                   <input
                     type="password"
                     name="auth_token"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -5242,6 +5247,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="password"
                       name="auth_query_param_value"
                       id="auth-query-param-value-gw"
+                      autocomplete="off"
                       data-sensitive-label="API key"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                     />
@@ -5265,6 +5271,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   <input
                     type="text"
                     name="auth_username"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -5277,6 +5284,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="password"
                       name="auth_password"
                       id="auth-password-gw"
+                      autocomplete="off"
                       data-sensitive-label="password"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                     />
@@ -5302,6 +5310,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="password"
                       name="auth_token"
                       id="auth-token-gw"
+                      autocomplete="off"
                       data-sensitive-label="token"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                     />
@@ -5426,6 +5435,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     <input
                       type="password"
                       name="oauth_client_secret"
+                      autocomplete="off"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       placeholder="Leave empty for auto-registration via DCR"
                     />
@@ -5444,6 +5454,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="text"
                       name="oauth_username"
                       id="oauth-username-gw"
+                      autocomplete="off"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       placeholder="systemadmin@system.com"
                     />
@@ -5462,6 +5473,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="password"
                       name="oauth_password"
                       id="oauth-password-gw"
+                      autocomplete="off"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       placeholder="Enter password"
                     />
@@ -5887,6 +5899,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     type="email"
                     name="email"
                     required
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full border-gray-300 rounded-md shadow-sm bg-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300"
                     placeholder="user@example.com"
                   />
@@ -5901,6 +5914,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     type="text"
                     name="full_name"
                     required
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full border-gray-300 rounded-md shadow-sm bg-gray-200 dark:bg-gray-700 dark:border-gray-600 text-gray-700 dark:text-gray-300"
                     placeholder="John Smith"
                   />
@@ -5919,6 +5933,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     name="password"
                     required
                     minlength="8"
+                    autocomplete="off"
                     oninput="validateNewUserPassword()"
                     class="mt-1 px-1.5 block w-full border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300"
                     placeholder="Strong password"
@@ -6683,6 +6698,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   <input
                     type="text"
                     name="auth_username"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -6693,6 +6709,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   <input
                     type="password"
                     name="auth_password"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -6706,6 +6723,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   <input
                     type="password"
                     name="auth_token"
+                    autocomplete="off"
                     class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   />
                 </div>
@@ -6783,6 +6801,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="password"
                       name="auth_query_param_value"
                       id="auth-query-param-value-a2a"
+                      autocomplete="off"
                       data-sensitive-label="API key"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                     />
@@ -6866,6 +6885,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     <input
                       type="password"
                       name="oauth_client_secret"
+                      autocomplete="off"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       placeholder="Leave empty for auto-registration via DCR"
                     />
@@ -6884,6 +6904,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="text"
                       name="oauth_username"
                       id="oauth-username-a2a"
+                      autocomplete="off"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       placeholder="systemadmin@system.com"
                     />
@@ -6902,6 +6923,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       type="password"
                       name="oauth_password"
                       id="oauth-password-a2a"
+                      autocomplete="off"
                       class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       placeholder="Enter password"
                     />
@@ -8386,6 +8408,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           type="text"
                           name="auth_username"
                           id="edit-auth-username"
+                          autocomplete="off"
                           class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         />
                       </div>
@@ -8398,6 +8421,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           type="password"
                           name="auth_password"
                           id="edit-auth-password"
+                          autocomplete="off"
                           class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                           placeholder="********"
                         />
@@ -8413,6 +8437,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           type="password"
                           name="auth_token"
                           id="edit-auth-token"
+                          autocomplete="off"
                           class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                           placeholder="********"
                         />
@@ -9575,6 +9600,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="password"
                             name="auth_query_param_value"
                             id="auth-query-param-value-gw-edit"
+                            autocomplete="off"
                             data-sensitive-label="API key"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                           />
@@ -9598,6 +9624,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         <input
                           type="text"
                           name="auth_username"
+                          autocomplete="off"
                           class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                         />
                       </div>
@@ -9610,6 +9637,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           type="password"
                           name="auth_password"
                           id="auth-password-gw-edit"
+                          autocomplete="off"
                           data-sensitive-label="password"
                           class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                         />
@@ -9635,6 +9663,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           type="password"
                           name="auth_token"
                           id="auth-token-gw-edit"
+                          autocomplete="off"
                           data-sensitive-label="token"
                           class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                         />
@@ -9765,6 +9794,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="password"
                             name="oauth_client_secret"
                             id="oauth-client-secret-gw-edit"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                             placeholder="Leave empty for auto-registration via DCR"
                           />
@@ -9786,6 +9816,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="text"
                             name="oauth_username"
                             id="oauth-username-gw-edit"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                             placeholder="systemadmin@system.com"
                           />
@@ -9804,6 +9835,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="password"
                             name="oauth_password"
                             id="oauth-password-gw-edit"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                             placeholder="Enter password"
                           />
@@ -10058,6 +10090,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           <input
                             type="text"
                             name="auth_username"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm
                                   focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                           />
@@ -10067,6 +10100,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           <input
                             type="password"
                             name="auth_password"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm
                                   focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                           />
@@ -10080,6 +10114,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           <input
                             type="password"
                             name="auth_token"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm
                                   focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                           />
@@ -10142,6 +10177,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                               type="password"
                               name="auth_query_param_value"
                               id="auth-query-param-value-a2a-edit"
+                              autocomplete="off"
                               data-sensitive-label="API key"
                               class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 pr-16"
                             />
@@ -10235,6 +10271,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="password"
                             name="oauth_client_secret"
                             id="oauth-client-secret-a2a-edit"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                             placeholder="Leave empty for auto-registration via DCR"
                           />
@@ -10257,6 +10294,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="text"
                             name="oauth_username"
                             id="oauth-username-a2a-edit"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                             placeholder="systemadmin@system.com"
                           />
@@ -10279,6 +10317,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="password"
                             name="oauth_password"
                             id="oauth-password-a2a-edit"
+                            autocomplete="off"
                             class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                             placeholder="Enter password"
                           />
@@ -14425,6 +14464,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                   type="email"
                   id="invite-email"
                   name="email"
+                  autocomplete="off"
                   class="mt-1 px-1.5 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white"
                   placeholder="user@example.com"
                 />

--- a/mcpgateway/templates/mcp_registry_partial.html
+++ b/mcpgateway/templates/mcp_registry_partial.html
@@ -622,6 +622,7 @@
         <input
           type="password"
           id="modal-api-key"
+          autocomplete="off"
           class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           placeholder="Enter your API key"
         />


### PR DESCRIPTION
## Summary
- Added `autocomplete="off"` to **43 sensitive input fields** across admin UI configuration forms to prevent browsers from randomly populating fields with saved credentials
- Affected fields include gateway auth (basic, bearer, OAuth, query param), A2A agent auth, LLM provider API keys, user creation forms, team invite email, and server registration modals
- Login forms (`login.html`, `change-password-required.html`) already had correct `autocomplete` attributes and were not modified

## Test plan
- [ ] Open admin UI in browser with saved credentials
- [ ] Verify gateway create/edit forms no longer show autofill suggestions on auth fields
- [ ] Verify A2A agent create/edit forms no longer show autofill suggestions
- [ ] Verify user creation form fields are not autofilled
- [ ] Verify LLM provider API key field is not autofilled
- [ ] Verify login form still works correctly with browser autofill