### PR TITLE
fix: remove HX-Retarget headers in team creation error handlers

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4049,8 +4049,6 @@ async def admin_create_team(
     if not getattr(settings, "email_auth_enabled", False):
         error_content = '<div class="text-red-500 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">Email authentication is disabled</div>'
         response = HTMLResponse(content=error_content, status_code=403)
-        response.headers["HX-Retarget"] = "#create-team-error"
-        response.headers["HX-Reswap"] = "innerHTML"
         return response
 
     try:
@@ -4065,8 +4063,6 @@ async def admin_create_team(
                 content='<div class="text-red-500 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">Team name is required</div>',
                 status_code=400,
             )
-            response.headers["HX-Retarget"] = "#create-team-error"
-            response.headers["HX-Reswap"] = "innerHTML"
             return response
 
         # Create team
@@ -4100,9 +4096,6 @@ async def admin_create_team(
             content=f'<div class="text-red-500 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">{html.escape(error_text)}</div>',
             status_code=400,
         )
-        # Retarget to error container instead of teams list
-        response.headers["HX-Retarget"] = "#create-team-error"
-        response.headers["HX-Reswap"] = "innerHTML"
         return response
     except IntegrityError as e:
         LOGGER.error(f"Error creating team for admin {user}: {e}")
@@ -4111,8 +4104,6 @@ async def admin_create_team(
         else:
             error_content = f'<div class="text-red-500 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">Database error: {html.escape(str(e))}</div>'
         response = HTMLResponse(content=error_content, status_code=400)
-        response.headers["HX-Retarget"] = "#create-team-error"
-        response.headers["HX-Reswap"] = "innerHTML"
         return response
     except Exception as e:
         LOGGER.error(f"Error creating team for admin {user}: {e}")
@@ -4120,8 +4111,6 @@ async def admin_create_team(
             content=f'<div class="text-red-500 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">Error creating team: {html.escape(str(e))}</div>',
             status_code=400,
         )
-        response.headers["HX-Retarget"] = "#create-team-error"
-        response.headers["HX-Reswap"] = "innerHTML"
         return response
 
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -5055,7 +5055,6 @@ async def test_admin_create_team_disabled(monkeypatch, mock_request, mock_db, al
     response = await admin_create_team(request=mock_request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 403
-    assert response.headers["HX-Retarget"] == "#create-team-error"
 
 
 @pytest.mark.asyncio
@@ -5067,7 +5066,6 @@ async def test_admin_create_team_missing_name(monkeypatch, mock_db, allow_permis
     response = await admin_create_team(request=request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 400
-    assert response.headers["HX-Retarget"] == "#create-team-error"
 
 
 @pytest.mark.asyncio
@@ -5118,7 +5116,6 @@ async def test_admin_create_team_validation_error_message_cleaned(monkeypatch, m
     response = await admin_create_team(request=request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 400
-    assert response.headers["HX-Retarget"] == "#create-team-error"
     body = response.body.decode()
     assert "Team name cannot be empty" in body
     assert "Value error," not in body
@@ -5140,7 +5137,6 @@ async def test_admin_create_team_integrity_error_non_unique(monkeypatch, mock_db
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 400
     assert "Database error:" in response.body.decode()
-    assert response.headers["HX-Retarget"] == "#create-team-error"
 
 
 @pytest.mark.asyncio
@@ -5159,7 +5155,6 @@ async def test_admin_create_team_unexpected_exception(monkeypatch, mock_db, allo
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 400
     assert "Error creating team" in response.body.decode()
-    assert response.headers["HX-Retarget"] == "#create-team-error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# 🐛 Bug-fix PR
---

## 📌 Summary
The team creation form's  has `hx-target=#create-team-error`, all error handlers in `admin_create_team()` still send `HX-Retarget: #create-team-error` and `HX-Reswap: innerHTML` headers. These headers are now redundant — they retarget to the element that is already the form's default target.

Closes #2800 

## 🔁 Reproduction Steps
1. Read mcpgateway/admin.py lines 4025-4101
2. Observe that the form's hx-target is #create-team-error (set in admin.html:14157)
3. Observe all error handlers set HX-Retarget: #create-team-error — same target


## 💡 Fix Description
Removed the redundant HX-Retarget and HX-Reswap headers from all error handlers (lines 4028-4029, 4044-4045, 4080-4081, 4090-4091, 4099-4100), since the form already targets #create-team-error

#### Changes Made:

1. `mcpgateway/admin.py` - Removed redundant headers from 5 error handlers:
       - Line 4028-4029: Email auth disabled error (403)
       - Line 4044-4045: Missing team name error (400)
       - Line 4080-4081: Validation error (400) + removed obsolete comment
       - Line 4090-4091: IntegrityError (400)
       - Line 4099-4100: Generic Exception (400)

2. `tests/unit/mcpgateway/test_admin.py` - Removed 5 redundant test assertions:
       - test_admin_create_team_disabled
       - test_admin_create_team_missing_name
       - test_admin_create_team_validation_error_message_cleaned
       - test_admin_create_team_integrity_error_non_unique
       - test_admin_create_team_unexpected_exception


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   ✅     |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
