### PR TITLE
fix: reduce Playwright test flakiness with condition-based waits

### DIFF
--- a/tests/playwright/entities/test_agents.py
+++ b/tests/playwright/entities/test_agents.py
@@ -150,7 +150,7 @@ class TestAgentsEntity:
 
         # Select OAuth to reveal grant type field
         agents_page.set_auth_type("oauth")
-        agents_page.page.wait_for_timeout(500)
+        agents_page.wait_for_visible(agents_page.auth_oauth_fields)
 
         # Get grant type options
         options = agents_page.oauth_grant_type_select.locator("option")
@@ -228,7 +228,7 @@ class TestAgentsEntity:
 
         # Select basic auth
         agents_page.set_auth_type("basic")
-        agents_page.page.wait_for_timeout(500)
+        agents_page.wait_for_visible(agents_page.auth_basic_fields)
 
         # Verify username field
         username_name = agents_page.auth_username_input.get_attribute("name")
@@ -247,7 +247,7 @@ class TestAgentsEntity:
 
         # Select bearer auth
         agents_page.set_auth_type("bearer")
-        agents_page.page.wait_for_timeout(500)
+        agents_page.wait_for_visible(agents_page.auth_bearer_fields)
 
         # Verify token field
         token_name = agents_page.auth_token_input.get_attribute("name")
@@ -262,7 +262,7 @@ class TestAgentsEntity:
 
         # Select query param auth
         agents_page.set_auth_type("query_param")
-        agents_page.page.wait_for_timeout(500)
+        agents_page.wait_for_visible(agents_page.auth_query_param_fields)
 
         # Verify security warning is visible
         warning = agents_page.auth_query_param_fields.locator("text=Security Warning")
@@ -282,9 +282,10 @@ class TestAgentsEntity:
         # Navigate to agents tab
         agents_page.navigate_to_agents_tab()
 
-        # Select auth type
+        # Select auth type and wait for fields to appear
         agents_page.set_auth_type(auth_type)
-        agents_page.page.wait_for_timeout(500)
+        auth_fields_map = {"basic": agents_page.auth_basic_fields, "bearer": agents_page.auth_bearer_fields, "query_param": agents_page.auth_query_param_fields}
+        agents_page.wait_for_visible(auth_fields_map[auth_type])
 
         # Verify expected fields are present - scope to agents panel to avoid strict mode violations
         # (multiple forms on page with same field names)

--- a/tests/playwright/entities/test_tools.py
+++ b/tests/playwright/entities/test_tools.py
@@ -25,18 +25,11 @@ class TestToolsCRUD:
         # Go to the Global Tools tab
         tools_page.navigate_to_tools_tab()
 
-        # Add a small delay to ensure the UI has time to update
-        tools_page.page.wait_for_timeout(500)
-
         # Fill the form using Page Object properties
         tools_page.fill_locator(tools_page.tool_name_input, test_tool_data["name"])
-        tools_page.page.wait_for_timeout(300)
         tools_page.fill_locator(tools_page.tool_url_input, test_tool_data["url"])
-        tools_page.page.wait_for_timeout(300)
         tools_page.fill_locator(tools_page.tool_description_input, test_tool_data["description"])
-        tools_page.page.wait_for_timeout(300)
         tools_page.tool_integration_type_select.select_option(test_tool_data["integrationType"])
-        tools_page.page.wait_for_timeout(300)
 
         # Submit the form and assert success response
         with tools_page.page.expect_response(lambda response: "/admin/tools" in response.url and response.request.method == "POST") as response_info:
@@ -57,13 +50,9 @@ class TestToolsCRUD:
 
         # Create tool first using Page Object properties
         tools_page.fill_locator(tools_page.tool_name_input, test_tool_data["name"])
-        tools_page.page.wait_for_timeout(300)
         tools_page.fill_locator(tools_page.tool_url_input, test_tool_data["url"])
-        tools_page.page.wait_for_timeout(300)
         tools_page.fill_locator(tools_page.tool_description_input, test_tool_data["description"])
-        tools_page.page.wait_for_timeout(300)
         tools_page.tool_integration_type_select.select_option(test_tool_data["integrationType"])
-        tools_page.page.wait_for_timeout(300)
         with tools_page.page.expect_response(lambda response: "/admin/tools" in response.url and response.request.method == "POST") as response_info:
             tools_page.click_locator(tools_page.add_tool_btn)
         response = response_info.value

--- a/tests/playwright/pages/admin_utils.py
+++ b/tests/playwright/pages/admin_utils.py
@@ -9,7 +9,6 @@ Shared utility functions for admin page interactions.
 
 # Standard
 import logging
-import time
 
 # Third-Party
 from playwright.sync_api import Page
@@ -45,8 +44,8 @@ def find_entity_by_name(page: Page, endpoint: str, name: str, retries: int = 5):
         Entity dict if found, None otherwise
     """
     headers = _get_auth_headers(page)
-    for _ in range(retries):
-        cache_bust = str(int(time.time() * 1000))
+    for attempt in range(retries):
+        cache_bust = str(attempt)
         url = f"/admin/{endpoint}?per_page=500&cache_bust={cache_bust}"
         response = page.request.get(url, headers=headers)
         if response.ok:
@@ -61,7 +60,7 @@ def find_entity_by_name(page: Page, endpoint: str, name: str, retries: int = 5):
                     return item
         else:
             logger.warning("find_entity_by_name: %s returned status=%d: %s", endpoint, response.status, response.text()[:200])
-        time.sleep(0.5)
+        page.wait_for_timeout(500)
     return None
 
 

--- a/tests/playwright/pages/agents_page.py
+++ b/tests/playwright/pages/agents_page.py
@@ -334,7 +334,7 @@ class AgentsPage(BasePage):
             password: Basic auth password
         """
         self.set_auth_type("basic")
-        self.page.wait_for_timeout(300)  # Wait for fields to appear
+        self.wait_for_visible(self.auth_basic_fields)
         self.fill_locator(self.auth_username_input, username)
         self.fill_locator(self.auth_password_input, password)
 
@@ -345,7 +345,7 @@ class AgentsPage(BasePage):
             token: Bearer token
         """
         self.set_auth_type("bearer")
-        self.page.wait_for_timeout(300)  # Wait for field to appear
+        self.wait_for_visible(self.auth_bearer_fields)
         self.fill_locator(self.auth_token_input, token)
 
     def fill_query_param_auth(self, param_key: str, param_value: str) -> None:
@@ -356,7 +356,7 @@ class AgentsPage(BasePage):
             param_value: Query parameter value
         """
         self.set_auth_type("query_param")
-        self.page.wait_for_timeout(300)  # Wait for fields to appear
+        self.wait_for_visible(self.auth_query_param_fields)
         self.fill_locator(self.auth_query_param_key_input, param_key)
         self.fill_locator(self.auth_query_param_value_input, param_value)
 
@@ -372,7 +372,7 @@ class AgentsPage(BasePage):
             scopes: Space-separated OAuth scopes
         """
         self.set_auth_type("oauth")
-        self.page.wait_for_timeout(300)  # Wait for fields to appear
+        self.wait_for_visible(self.auth_oauth_fields)
 
         self.oauth_grant_type_select.select_option(grant_type)
 

--- a/tests/playwright/pages/base_page.py
+++ b/tests/playwright/pages/base_page.py
@@ -98,6 +98,25 @@ class BasePage:
         """Wait for API response."""
         return self.page.wait_for_response(url_pattern)
 
+    # ==================== Search/Filter Utilities ====================
+
+    def wait_for_count_change(self, locator: Locator, previous_count: int, timeout: int | None = None) -> int:
+        """Wait for a locator's element count to differ from a previous value.
+
+        Useful after search/filter operations where the row count should change.
+        Falls back to a short delay if the count doesn't change (e.g., empty results).
+
+        Returns:
+            The new count.
+        """
+        deadline = (timeout or self.timeout) // 100
+        for _ in range(deadline):
+            current = locator.count()
+            if current != previous_count:
+                return current
+            self.page.wait_for_timeout(100)
+        return locator.count()
+
     # ==================== Screenshot ====================
 
     def take_screenshot(self, name: str) -> None:

--- a/tests/playwright/test_admin_ui.py
+++ b/tests/playwright/test_admin_ui.py
@@ -60,7 +60,9 @@ class TestAdminUI:
 
         # Search for non-existent server
         admin_page.search_servers("nonexistentserver123")
-        admin_page.page.wait_for_timeout(500)
+
+        # Wait for filtering to take effect
+        admin_page.wait_for_count_change(admin_page.server_items, initial_count, timeout=5000)
 
         # Should show no results or fewer results
         search_count = admin_page.get_server_count()

--- a/tests/playwright/test_api_integration.py
+++ b/tests/playwright/test_api_integration.py
@@ -45,7 +45,8 @@ class TestAPIIntegration:
 
         # Wait for tool test modal and dynamic form field generation
         expect(page.locator("#tool-test-modal")).to_be_visible(timeout=10000)
-        page.wait_for_timeout(1000)
+        # Wait for dynamic form fields to be generated from schema
+        page.wait_for_selector("#tool-test-form-fields", state="visible", timeout=10000)
 
         # Fill any dynamically generated form fields (schema-based)
         form_fields = page.locator("#tool-test-form-fields input")

--- a/tests/playwright/test_htmx_interactions.py
+++ b/tests/playwright/test_htmx_interactions.py
@@ -205,8 +205,8 @@ class TestHTMXInteractions:
         # Type a search term that likely won't match
         servers_page.search_servers("xyznonexistentserver123")
 
-        # Wait a moment for any filtering to apply
-        servers_page.page.wait_for_timeout(500)
+        # Wait for filtering to take effect (count should change)
+        servers_page.wait_for_count_change(servers_page.server_items, initial_rows, timeout=5000)
 
         # Check if the table has been filtered
         filtered_visible = servers_page.server_items.locator(":visible").count()
@@ -214,7 +214,9 @@ class TestHTMXInteractions:
 
         # Clear search
         servers_page.clear_search()
-        servers_page.page.wait_for_timeout(500)
+
+        # Wait for rows to be restored
+        servers_page.wait_for_count_change(servers_page.server_items, filtered_visible, timeout=5000)
 
         # Verify rows are restored
         restored_rows = servers_page.server_items.count()

--- a/tests/playwright/test_organization.py
+++ b/tests/playwright/test_organization.py
@@ -32,15 +32,13 @@ class TestTeams:
         response = response_info.value
         assert response.status < 400
 
-        # Workaround: Auto-refresh doesn't work, so wait and reload the page
-        team_page.page.wait_for_timeout(2000)
-        team_page.page.reload()
-        team_page.page.wait_for_timeout(1000)
+        # Workaround: Auto-refresh doesn't work, so reload the page
+        team_page.page.wait_for_load_state("domcontentloaded")
+        team_page.page.reload(wait_until="domcontentloaded")
 
         # Search for the team to bring it into view (handles pagination)
         team_search = team_page.page.locator("#team-search")
         team_search.fill(team_name)
-        team_page.page.wait_for_timeout(1000)
 
         # Wait for team to be visible in the list after search
         team_page.wait_for_team_visible(team_name)
@@ -49,7 +47,6 @@ class TestTeams:
         team_page.delete_team(team_name)
 
         # Verify it's gone
-        team_page.page.wait_for_timeout(1000)
         team_page.wait_for_team_hidden(team_name)
 
     def test_manage_members_button(self, team_page):
@@ -61,15 +58,13 @@ class TestTeams:
         with team_page.page.expect_response(lambda response: "/admin/teams" in response.url and response.request.method == "POST"):
             team_page.create_team(team_name)
 
-        # Wait and reload to see the new team
-        team_page.page.wait_for_timeout(2000)
-        team_page.page.reload()
-        team_page.page.wait_for_timeout(1000)
+        # Reload to see the new team
+        team_page.page.wait_for_load_state("domcontentloaded")
+        team_page.page.reload(wait_until="domcontentloaded")
 
         # Search for the team
         team_search = team_page.page.locator("#team-search")
         team_search.fill(team_name)
-        team_page.page.wait_for_timeout(1000)
 
         # Verify team is visible
         team_page.wait_for_team_visible(team_name)
@@ -95,12 +90,11 @@ class TestTeams:
         if close_btn.count() > 0:
             close_btn.first.click()
         else:
-            # Alternative: click the X button or backdrop
+            # Alternative: close via JavaScript
             team_page.page.evaluate("document.getElementById('team-edit-modal').classList.add('hidden')")
 
         # Cleanup
         team_page.delete_team(team_name)
-        team_page.page.wait_for_timeout(1000)
 
     def test_edit_settings_button(self, team_page):
         """Test Edit Settings button opens team settings editor."""
@@ -111,15 +105,13 @@ class TestTeams:
         with team_page.page.expect_response(lambda response: "/admin/teams" in response.url and response.request.method == "POST"):
             team_page.create_team(team_name)
 
-        # Wait and reload to see the new team
-        team_page.page.wait_for_timeout(2000)
-        team_page.page.reload()
-        team_page.page.wait_for_timeout(1000)
+        # Reload to see the new team
+        team_page.page.wait_for_load_state("domcontentloaded")
+        team_page.page.reload(wait_until="domcontentloaded")
 
         # Search for the team
         team_search = team_page.page.locator("#team-search")
         team_search.fill(team_name)
-        team_page.page.wait_for_timeout(1000)
 
         # Verify team is visible
         team_page.wait_for_team_visible(team_name)
@@ -156,7 +148,6 @@ class TestTeams:
 
         # Cleanup
         team_page.delete_team(team_name)
-        team_page.page.wait_for_timeout(1000)
 
     def test_delete_team_button_in_card(self, team_page):
         """Test Delete Team button in team card with confirmation."""
@@ -167,15 +158,13 @@ class TestTeams:
         with team_page.page.expect_response(lambda response: "/admin/teams" in response.url and response.request.method == "POST"):
             team_page.create_team(team_name)
 
-        # Wait and reload to see the new team
-        team_page.page.wait_for_timeout(2000)
-        team_page.page.reload()
-        team_page.page.wait_for_timeout(1000)
+        # Reload to see the new team
+        team_page.page.wait_for_load_state("domcontentloaded")
+        team_page.page.reload(wait_until="domcontentloaded")
 
         # Search for the team
         team_search = team_page.page.locator("#team-search")
         team_search.fill(team_name)
-        team_page.page.wait_for_timeout(1000)
 
         # Verify team is visible
         team_page.wait_for_team_visible(team_name)
@@ -184,17 +173,12 @@ class TestTeams:
         team_page.delete_team(team_name)
 
         # Verify team is deleted
-        team_page.page.wait_for_timeout(1000)
         team_page.wait_for_team_hidden(team_name)
 
 
 class TestTokens:
     """Tests for API Token management features."""
 
-    @pytest.mark.xfail(
-        reason="Server bug: RBAC _derive_team_from_payload crashes on TokenCreateRequest " "named 'request' (AttributeError: 'TokenCreateRequest' has no attribute 'headers')",
-        strict=False,
-    )
     def test_create_and_revoke_token(self, tokens_page):
         """Test creating and revoking an API token."""
         # Go to Tokens tab


### PR DESCRIPTION
## Summary
- Replace 20+ arbitrary `wait_for_timeout` calls with proper Playwright condition-based waits (`wait_for_visible`, `wait_for_selector`, `expect`, `wait_for_load_state`, `wait_for_count_change`)
- Fix broken `_wait_for_login_response` in conftest.py — `page.wait_for_response()` doesn't exist in Playwright Python sync API; replaced with `page.expect_response()` context manager wrapping login submission
- Narrow `except Exception` to `except PlaywrightTimeoutError` in 4 locations to surface real errors instead of silently swallowing them
- Remove stale `@pytest.mark.xfail` from `test_create_and_revoke_token` (test passes reliably)
- Replace `time.sleep()` with `page.wait_for_timeout()` in `admin_utils.py`
- Add `wait_for_count_change()` helper to `BasePage` for search/filter result waiting

## Test plan
- [x] Full Playwright test suite: 191 passed, 22 skipped, 0 failed (was 190 passed + 1 xpassed)