### PR TITLE
feat(security): implement environment-aware defaults and fail-closed secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2667,14 +2667,14 @@ PLUGINS_CLI_MARKUP_MODE=rich
 
 # ------------------------------------------------------------------------------
 # SECURITY-CRITICAL: Values below MUST be changed for production deployments!
-# Defaults are for LOCAL DEVELOPMENT ONLY. Using defaults in production 
+# Defaults are for LOCAL DEVELOPMENT ONLY. Using defaults in production
 # exposes your deployment to full compromise.
 #
 # Generate secure keys using: python -m mcpgateway.scripts.init_secrets
 # Manual fallback: python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
 # ------------------------------------------------------------------------------
 
-# REQUIRE_STRONG_SECRETS: 
+# REQUIRE_STRONG_SECRETS:
 # Defaults to TRUE if ENVIRONMENT=production.
 # If set to true, the gateway will FAIL TO START if critical secrets are weak or missing.
 # Set to false only for local testing. NOT RECOMMENDED for production!


### PR DESCRIPTION
## Related Issue
Partially addresses #2595 . Implements US-1 (Environment-Aware Defaults) and US-2 (Fail-Closed on Unconfigured Secrets).

---

## Summary
This PR implements the **Fail-Closed** security mechanism for **US-2**. It ensures the Gateway terminates execution if critical security secrets are missing, unconfigured, or weak when running in production mode.

**Key Changes:**

### Environment-Aware Enforcement (US-1)
- **Dynamic Defaults:** Implemented `default_factory` for `require_strong_secrets`, automatically enabling enforcement (`true`) in `production` and disabling it (`false`) in `development`.
- **Audit Logging:** Added explicit security audit logs when enforcement is manually overridden in production environments.

### Fail-Closed Mechanism (US-2)
- **Sentinel & Weak Secret Detection:** Added logic to block execution if `JWT_SECRET_KEY` or `AUTH_ENCRYPTION_SECRET` are missing, weak, or set to default values.
- **Enforcement Logic:** Enhanced `get_settings()` to trigger a `SystemExit` in production mode when critical security risks are detected.
- **Remediation Guidance:** Implemented clear error messaging with specific error codes, pointing operators to the `init_secrets` script and official IBM security docs.

### Documentation & Testing
- **Docs Update:** Updated `.env.example`, `CHANGELOG.md`, and `configuration.md` to document the new environment-aware behavior and breaking changes.
- **Automated Testing:** Added 6 comprehensive unit tests in `tests/test_config_security.py` covering all environment-specific scenarios.

---

## Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)

---

## Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | Pass   |
| Unit tests                | `make test`     | Pass   |
| Coverage ≥ 80%            | `make coverage` | Pass   |

*Note: Verified specifically with `pytest tests/test_config_security.py`.*

---

## Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (References added in logs)
- [x] No secrets or credentials committed

---

## Notes
Manual verification performed:
1. `ENVIRONMENT=production` with empty secrets correctly triggers `SystemExit(1)`.
2. `ENVIRONMENT=development` correctly proceeds with warnings.
3. Remediation logs point to `init_secrets` script and official IBM documentation.