### PR TITLE
feat(auth): add reusable OAuth2 base helper library

### DIFF
--- a/mcpgateway/oauth2/__init__.py
+++ b/mcpgateway/oauth2/__init__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/oauth2/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Public exports for OAuth2 base library.
+"""
+
+# First-Party
+from mcpgateway.oauth2.base import (
+    OAuth2BaseLibrary,
+    apply_scope_modifications,
+    extract_claims,
+    normalize_scopes,
+    scopes_to_string,
+)
+from mcpgateway.oauth2.exceptions import (
+    OAuth2BaseError,
+    OAuth2DiscoveryError,
+    OAuth2TokenExchangeError,
+    OAuth2TokenRefreshError,
+    OAuth2TokenValidationError,
+)
+from mcpgateway.oauth2.models import (
+    OAuth2ValidationConfig,
+    RefreshTokenRequest,
+    TokenExchangeRequest,
+    TokenValidationResult,
+)
+
+__all__ = [
+    "OAuth2BaseError",
+    "OAuth2BaseLibrary",
+    "OAuth2DiscoveryError",
+    "OAuth2TokenExchangeError",
+    "OAuth2TokenRefreshError",
+    "OAuth2TokenValidationError",
+    "OAuth2ValidationConfig",
+    "RefreshTokenRequest",
+    "TokenExchangeRequest",
+    "TokenValidationResult",
+    "apply_scope_modifications",
+    "extract_claims",
+    "normalize_scopes",
+    "scopes_to_string",
+]

--- a/mcpgateway/oauth2/base.py
+++ b/mcpgateway/oauth2/base.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/oauth2/base.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Canonical OAuth2/OIDC helper functions for protocol operations.
+"""
+
+# Standard
+from typing import Any, Dict, List, Optional, cast
+from urllib.parse import urlencode
+
+# Third-Party
+import jwt
+
+# First-Party
+from mcpgateway.oauth2.exceptions import (
+    OAuth2DiscoveryError,
+    OAuth2TokenExchangeError,
+    OAuth2TokenRefreshError,
+    OAuth2TokenValidationError,
+)
+from mcpgateway.oauth2.models import (
+    OAuth2ValidationConfig,
+    RefreshTokenRequest,
+    TokenExchangeRequest,
+    TokenValidationResult,
+)
+from mcpgateway.services.http_client_service import get_http_client
+
+
+def normalize_scopes(scopes: str | List[str] | None) -> List[str]:
+    """Normalize OAuth scope input to a stable list."""
+    if scopes is None:
+        return []
+    if isinstance(scopes, str):
+        return [s for s in scopes.split(" ") if s]
+    return [s for s in scopes if s]
+
+
+def scopes_to_string(scopes: str | List[str] | None) -> str:
+    """Convert scopes to RFC-compatible space-delimited string."""
+    return " ".join(normalize_scopes(scopes))
+
+
+def apply_scope_modifications(base_scopes: str | List[str] | None, add: Optional[List[str]] = None, remove: Optional[List[str]] = None) -> List[str]:
+    """Apply additive/removal scope updates in canonical order."""
+    current = set(normalize_scopes(base_scopes))
+    if add:
+        current.update(normalize_scopes(add))
+    if remove:
+        for scope in normalize_scopes(remove):
+            current.discard(scope)
+    return sorted(current)
+
+
+def extract_claims(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract canonical claims from a token payload."""
+    raw_scope = payload.get("scope")
+    if raw_scope is None:
+        raw_scope = payload.get("scp")
+    scopes = normalize_scopes(cast(str | List[str] | None, raw_scope))
+    roles = payload.get("roles") or payload.get("groups") or []
+    if isinstance(roles, str):
+        roles = [roles]
+    return {
+        "sub": payload.get("sub"),
+        "iss": payload.get("iss"),
+        "aud": payload.get("aud"),
+        "azp": payload.get("azp"),
+        "email": payload.get("email"),
+        "client_id": payload.get("client_id"),
+        "scope": scopes,
+        "roles": roles,
+        "claims": payload,
+    }
+
+
+class OAuth2BaseLibrary:
+    """Reusable OAuth2/OIDC protocol helper methods."""
+
+    async def discover_authorization_server_metadata(self, issuer: str, timeout_seconds: float = 30.0) -> Dict[str, Any]:
+        """RFC 8414 authorization server metadata discovery."""
+        normalized_issuer = issuer.rstrip("/")
+        url = f"{normalized_issuer}/.well-known/oauth-authorization-server"
+        client = await get_http_client()
+        response = await client.get(url, timeout=timeout_seconds)
+        if response.status_code != 200:
+            raise OAuth2DiscoveryError(f"Authorization server metadata discovery failed for issuer {normalized_issuer} with status {response.status_code}")
+        metadata = response.json()
+        metadata_issuer = (metadata.get("issuer") or "").rstrip("/")
+        if metadata_issuer != normalized_issuer:
+            raise OAuth2DiscoveryError(f"Authorization server issuer mismatch: expected {normalized_issuer}, got {metadata.get('issuer')}")
+        return metadata
+
+    async def discover_oidc_metadata(self, issuer: str, timeout_seconds: float = 30.0) -> Dict[str, Any]:
+        """OIDC discovery document retrieval."""
+        normalized_issuer = issuer.rstrip("/")
+        url = f"{normalized_issuer}/.well-known/openid-configuration"
+        client = await get_http_client()
+        response = await client.get(url, timeout=timeout_seconds)
+        if response.status_code != 200:
+            raise OAuth2DiscoveryError(f"OIDC metadata discovery failed for issuer {normalized_issuer} with status {response.status_code}")
+        metadata = response.json()
+        metadata_issuer = (metadata.get("issuer") or "").rstrip("/")
+        if metadata_issuer != normalized_issuer:
+            raise OAuth2DiscoveryError(f"OIDC issuer mismatch: expected {normalized_issuer}, got {metadata.get('issuer')}")
+        return metadata
+
+    async def discover_protected_resource_metadata(self, resource_base_url: str, timeout_seconds: float = 30.0) -> Dict[str, Any]:
+        """RFC 9728 protected resource metadata discovery."""
+        normalized = resource_base_url.rstrip("/")
+        url = f"{normalized}/.well-known/oauth-protected-resource"
+        client = await get_http_client()
+        response = await client.get(url, timeout=timeout_seconds)
+        if response.status_code != 200:
+            raise OAuth2DiscoveryError(f"Protected resource metadata discovery failed for resource {normalized} with status {response.status_code}")
+        return response.json()
+
+    async def validate_token(self, token: str, config: OAuth2ValidationConfig) -> TokenValidationResult:
+        """Validate token via JWKS JWT validation or introspection fallback."""
+        if config.jwks_uri:
+            claims = self._validate_jwt_with_jwks(token, config)
+            return TokenValidationResult(active=True, claims=claims, source="jwt", scopes=normalize_scopes(cast(str | List[str] | None, claims.get("scope"))))
+
+        if config.introspection_endpoint:
+            return await self._validate_token_with_introspection(token, config)
+
+        raise OAuth2TokenValidationError("No token validation mechanism configured. Provide jwks_uri or introspection_endpoint.")
+
+    def _validate_jwt_with_jwks(self, token: str, config: OAuth2ValidationConfig) -> Dict[str, Any]:
+        """Validate JWT access token using RFC 8414/OIDC jwks_uri."""
+        try:
+            jwk_client = jwt.PyJWKClient(config.jwks_uri or "")
+            signing_key = jwk_client.get_signing_key_from_jwt(token)
+            options: Dict[str, Any] = {"verify_exp": config.require_exp}
+            decode_kwargs: Dict[str, Any] = {"key": signing_key.key, "algorithms": list(config.algorithms), "options": options, "leeway": config.leeway_seconds}
+            if config.audience:
+                decode_kwargs["audience"] = config.audience
+            if config.issuer:
+                decode_kwargs["issuer"] = config.issuer
+            return cast(Dict[str, Any], jwt.decode(token, **decode_kwargs))
+        except Exception as exc:
+            raise OAuth2TokenValidationError(f"JWT validation failed: {exc}") from exc
+
+    async def _validate_token_with_introspection(self, token: str, config: OAuth2ValidationConfig) -> TokenValidationResult:
+        """Validate token using RFC 7662 introspection endpoint."""
+        if not config.introspection_endpoint:
+            raise OAuth2TokenValidationError("Missing introspection endpoint for token introspection.")
+        data = {"token": token}
+        auth = None
+        if config.client_id and config.client_secret:
+            # Third-Party
+            import httpx  # pylint: disable=import-outside-toplevel
+
+            auth = httpx.BasicAuth(config.client_id, config.client_secret)
+        client = await get_http_client()
+        response = await client.post(config.introspection_endpoint, data=data, auth=auth)
+        if response.status_code != 200:
+            raise OAuth2TokenValidationError(f"Token introspection failed with status {response.status_code}")
+        payload = response.json()
+        if not payload.get("active", False):
+            return TokenValidationResult(active=False, claims=payload, source="introspection", scopes=normalize_scopes(cast(str | List[str] | None, payload.get("scope"))))
+        return TokenValidationResult(active=True, claims=payload, source="introspection", scopes=normalize_scopes(cast(str | List[str] | None, payload.get("scope"))))
+
+    async def exchange_token(self, request: TokenExchangeRequest) -> Dict[str, Any]:
+        """RFC 8693 token exchange helper."""
+        if not request.subject_token:
+            raise OAuth2TokenExchangeError("subject_token is required for token exchange.")
+        data: List[tuple[str, str]] = [
+            ("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange"),
+            ("subject_token", request.subject_token),
+            ("subject_token_type", request.subject_token_type),
+            ("client_id", request.client_id),
+        ]
+        if request.client_secret:
+            data.append(("client_secret", request.client_secret))
+        if request.requested_token_type:
+            data.append(("requested_token_type", request.requested_token_type))
+        if request.actor_token:
+            data.append(("actor_token", request.actor_token))
+        if request.actor_token_type:
+            data.append(("actor_token_type", request.actor_token_type))
+        if request.scope:
+            data.append(("scope", scopes_to_string(request.scope)))
+        for aud in request.audience or []:
+            data.append(("audience", aud))
+        for res in request.resource or []:
+            data.append(("resource", res))
+
+        client = await get_http_client()
+        response = await client.post(request.token_endpoint, data=data, timeout=request.timeout_seconds)
+        if response.status_code != 200:
+            raise OAuth2TokenExchangeError(f"Token exchange failed with status {response.status_code}: {response.text}")
+        body = response.json()
+        if "access_token" not in body:
+            raise OAuth2TokenExchangeError(f"Token exchange response missing access_token: {body}")
+        return body
+
+    async def refresh_token(self, request: RefreshTokenRequest) -> Dict[str, Any]:
+        """RFC 6749 refresh token grant helper."""
+        if not request.refresh_token:
+            raise OAuth2TokenRefreshError("refresh_token is required for refresh flow.")
+        data: List[tuple[str, str]] = [
+            ("grant_type", "refresh_token"),
+            ("refresh_token", request.refresh_token),
+            ("client_id", request.client_id),
+        ]
+        if request.client_secret:
+            data.append(("client_secret", request.client_secret))
+        if request.scope:
+            data.append(("scope", scopes_to_string(request.scope)))
+        for res in request.resource or []:
+            data.append(("resource", res))
+        client = await get_http_client()
+        response = await client.post(request.token_endpoint, data=data, timeout=request.timeout_seconds)
+        if response.status_code != 200:
+            raise OAuth2TokenRefreshError(f"Refresh token flow failed with status {response.status_code}: {response.text}")
+        body = response.json()
+        if "access_token" not in body:
+            raise OAuth2TokenRefreshError(f"Refresh response missing access_token: {body}")
+        return body
+
+    def build_authorization_url(
+        self,
+        authorization_endpoint: str,
+        client_id: str,
+        redirect_uri: str,
+        response_type: str = "code",
+        scope: Optional[List[str]] = None,
+        state: Optional[str] = None,
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None,
+        resource: Optional[List[str]] = None,
+    ) -> str:
+        """Build authorization URL including RFC 8707 resource indicators."""
+        params: List[tuple[str, str]] = [("response_type", response_type), ("client_id", client_id), ("redirect_uri", redirect_uri)]
+        if scope:
+            params.append(("scope", scopes_to_string(scope)))
+        if state:
+            params.append(("state", state))
+        if code_challenge:
+            params.append(("code_challenge", code_challenge))
+        if code_challenge_method:
+            params.append(("code_challenge_method", code_challenge_method))
+        for res in resource or []:
+            params.append(("resource", res))
+        return f"{authorization_endpoint}?{urlencode(params, doseq=True)}"

--- a/mcpgateway/oauth2/exceptions.py
+++ b/mcpgateway/oauth2/exceptions.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/oauth2/exceptions.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+OAuth2 base library exceptions.
+"""
+
+
+class OAuth2BaseError(Exception):
+    """Base exception for OAuth2 helper operations."""
+
+
+class OAuth2DiscoveryError(OAuth2BaseError):
+    """Raised when OAuth/OIDC metadata discovery fails."""
+
+
+class OAuth2TokenValidationError(OAuth2BaseError):
+    """Raised when token validation fails."""
+
+
+class OAuth2TokenExchangeError(OAuth2BaseError):
+    """Raised when OAuth 2.0 token exchange fails."""
+
+
+class OAuth2TokenRefreshError(OAuth2BaseError):
+    """Raised when refresh token grant fails."""

--- a/mcpgateway/oauth2/models.py
+++ b/mcpgateway/oauth2/models.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/oauth2/models.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Typed models for OAuth2 base helpers.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+
+@dataclass(slots=True)
+class OAuth2ValidationConfig:
+    """Configuration for token validation."""
+
+    issuer: Optional[str] = None
+    audience: Optional[str] = None
+    algorithms: Sequence[str] = ("RS256", "ES256", "HS256")
+    jwks_uri: Optional[str] = None
+    introspection_endpoint: Optional[str] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    require_exp: bool = True
+    leeway_seconds: int = 0
+
+
+@dataclass(slots=True)
+class TokenValidationResult:
+    """Canonical token validation response."""
+
+    active: bool
+    claims: Dict[str, Any] = field(default_factory=dict)
+    source: str = "none"  # jwt | introspection | none
+    scopes: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class OAuth2TokenRequest:
+    """Common fields for token endpoint operations."""
+
+    token_endpoint: str
+    client_id: str
+    client_secret: Optional[str] = None
+    timeout_seconds: float = 30.0
+
+
+@dataclass(slots=True)
+class TokenExchangeRequest(OAuth2TokenRequest):
+    """RFC 8693 token exchange request."""
+
+    subject_token: str = ""
+    subject_token_type: str = "urn:ietf:params:oauth:token-type:access_token"
+    requested_token_type: Optional[str] = None
+    actor_token: Optional[str] = None
+    actor_token_type: Optional[str] = None
+    scope: Optional[List[str]] = None
+    audience: Optional[List[str]] = None
+    resource: Optional[List[str]] = None
+
+
+@dataclass(slots=True)
+class RefreshTokenRequest(OAuth2TokenRequest):
+    """RFC 6749 refresh token request."""
+
+    refresh_token: str = ""
+    scope: Optional[List[str]] = None
+    resource: Optional[List[str]] = None

--- a/tests/unit/mcpgateway/oauth2/test_base.py
+++ b/tests/unit/mcpgateway/oauth2/test_base.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for OAuth2 base library."""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.oauth2 import (
+    OAuth2BaseLibrary,
+    OAuth2DiscoveryError,
+    OAuth2TokenExchangeError,
+    OAuth2TokenRefreshError,
+    OAuth2TokenValidationError,
+    OAuth2ValidationConfig,
+    RefreshTokenRequest,
+    TokenExchangeRequest,
+    apply_scope_modifications,
+    extract_claims,
+    normalize_scopes,
+    scopes_to_string,
+)
+
+
+def test_normalize_scopes():
+    assert normalize_scopes(None) == []
+    assert normalize_scopes("openid email profile") == ["openid", "email", "profile"]
+    assert normalize_scopes(["a", "", "b"]) == ["a", "b"]
+
+
+def test_scope_helpers():
+    assert scopes_to_string(["read", "write"]) == "read write"
+    assert apply_scope_modifications(["read"], add=["write"], remove=["read"]) == ["write"]
+
+
+def test_extract_claims():
+    payload = {"sub": "u1", "scope": "openid email", "roles": ["admin"], "email": "u@example.com"}
+    claims = extract_claims(payload)
+    assert claims["sub"] == "u1"
+    assert claims["scope"] == ["openid", "email"]
+    assert claims["roles"] == ["admin"]
+
+
+@pytest.fixture
+def oauth2_lib():
+    return OAuth2BaseLibrary()
+
+
+@pytest.mark.asyncio
+async def test_discover_authorization_server_metadata_success(oauth2_lib):
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"issuer": "https://issuer.example", "token_endpoint": "https://issuer.example/token"}
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        metadata = await oauth2_lib.discover_authorization_server_metadata("https://issuer.example")
+    assert metadata["token_endpoint"] == "https://issuer.example/token"
+
+
+@pytest.mark.asyncio
+async def test_discover_authorization_server_metadata_issuer_mismatch(oauth2_lib):
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"issuer": "https://other.example"}
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuth2DiscoveryError, match="issuer mismatch"):
+            await oauth2_lib.discover_authorization_server_metadata("https://issuer.example")
+
+
+@pytest.mark.asyncio
+async def test_discover_protected_resource_metadata_success(oauth2_lib):
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"resource": "https://rs.example"}
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        data = await oauth2_lib.discover_protected_resource_metadata("https://rs.example")
+    assert data["resource"] == "https://rs.example"
+
+
+@pytest.mark.asyncio
+async def test_validate_token_jwt_success(oauth2_lib):
+    config = OAuth2ValidationConfig(issuer="https://issuer.example", audience="api://default", jwks_uri="https://issuer.example/jwks")
+    with (
+        patch("mcpgateway.oauth2.base.jwt.PyJWKClient") as mock_jwk_client,
+        patch("mcpgateway.oauth2.base.jwt.decode", return_value={"sub": "u1", "scope": "openid profile"}) as mock_decode,
+    ):
+        mock_key = MagicMock()
+        mock_key.key = "test-key"
+        mock_jwk_client.return_value.get_signing_key_from_jwt.return_value = mock_key
+        result = await oauth2_lib.validate_token("jwt-token", config)
+    assert result.active is True
+    assert result.source == "jwt"
+    assert result.scopes == ["openid", "profile"]
+    mock_decode.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_validate_token_introspection_inactive(oauth2_lib):
+    config = OAuth2ValidationConfig(introspection_endpoint="https://issuer.example/introspect", client_id="cid", client_secret="sec")
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"active": False, "scope": "a b"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        result = await oauth2_lib.validate_token("opaque-token", config)
+    assert result.active is False
+    assert result.source == "introspection"
+    assert result.scopes == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_validate_token_missing_config(oauth2_lib):
+    with pytest.raises(OAuth2TokenValidationError, match="No token validation mechanism"):
+        await oauth2_lib.validate_token("t", OAuth2ValidationConfig())
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_success(oauth2_lib):
+    req = TokenExchangeRequest(
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="sec",
+        subject_token="subject",
+        scope=["read"],
+        audience=["aud1"],
+        resource=["https://rs.example"],
+    )
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"access_token": "new-token", "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        body = await oauth2_lib.exchange_token(req)
+    assert body["access_token"] == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_missing_access_token(oauth2_lib):
+    req = TokenExchangeRequest(token_endpoint="https://issuer.example/token", client_id="cid", subject_token="subject")
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"token_type": "Bearer"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuth2TokenExchangeError, match="missing access_token"):
+            await oauth2_lib.exchange_token(req)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_success(oauth2_lib):
+    req = RefreshTokenRequest(token_endpoint="https://issuer.example/token", client_id="cid", client_secret="sec", refresh_token="rt-1", scope=["read"], resource=["https://rs.example"])
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"access_token": "new-token", "refresh_token": "new-rt"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        body = await oauth2_lib.refresh_token(req)
+    assert body["access_token"] == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_missing_access_token(oauth2_lib):
+    req = RefreshTokenRequest(token_endpoint="https://issuer.example/token", client_id="cid", refresh_token="rt-1")
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"token_type": "Bearer"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch("mcpgateway.oauth2.base.get_http_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuth2TokenRefreshError, match="missing access_token"):
+            await oauth2_lib.refresh_token(req)
+
+
+def test_build_authorization_url_with_resource(oauth2_lib):
+    url = oauth2_lib.build_authorization_url(
+        authorization_endpoint="https://issuer.example/auth",
+        client_id="cid",
+        redirect_uri="https://app.example/cb",
+        scope=["openid", "profile"],
+        state="st",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+        resource=["https://resource-a.example", "https://resource-b.example"],
+    )
+    assert "resource=https%3A%2F%2Fresource-a.example" in url
+    assert "resource=https%3A%2F%2Fresource-b.example" in url


### PR DESCRIPTION
Introduce a canonical OAuth2/OIDC helper module for token validation, claims extraction, metadata discovery, token exchange/refresh, and scope operations so auth plugins can share consistent protocol logic. Add focused unit coverage for the new helper APIs and RFC-oriented behaviors.

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #

---

## 📝 Summary
  - `mcpgateway/oauth2/base.py`
  - `validate_token()` with JWKS JWT verification and introspection fallback
  - `extract_claims()` canonical claim mapping
  - `discover_authorization_server_metadata()` (RFC 8414)
  - `discover_oidc_metadata()` (OIDC discovery)
  - `discover_protected_resource_metadata()` (RFC 9728)
  - `exchange_token()` (RFC 8693)
  - `refresh_token()` (RFC 6749)
  - scope normalization/modification utilities
  - authorization URL builder with resource indicators (RFC 8707)
- `mcpgateway/oauth2/models.py` typed request/response config models
- `mcpgateway/oauth2/exceptions.py` unified OAuth2 error types
- `mcpgateway/oauth2/__init__.py` public exports
- `tests/unit/mcpgateway/oauth2/test_base.py` focused unit tests for helper APIs and error paths

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x ] No secrets or credentials committed

---

## 📓 Notes (optional)
 This PR delivers the OAuth2 base helper layer requested by #1434 and is designed to be consumed by plugin/auth flows in the #1422 epic.
- It is additive and does not remove existing OAuth manager/DCR behavior.