### PR TITLE
fix: simplify OSError handling (#2380)

### DIFF
--- a/mcpgateway/wrapper.py
+++ b/mcpgateway/wrapper.py
@@ -46,7 +46,6 @@ import argparse
 import asyncio
 from contextlib import suppress
 from dataclasses import dataclass
-import errno
 import logging
 import os
 import signal
@@ -212,10 +211,8 @@ def send_to_stdout(obj: Union[dict, str, bytes]) -> None:
             sys.stdout.write(line.decode("utf-8") + "\n")
             sys.stdout.flush()
     except OSError as e:
-        if e.errno in (errno.EPIPE, errno.EINVAL):
-            _mark_shutdown()
-        else:
-            _mark_shutdown()
+        logger.error("OS error: %s", e)
+        _mark_shutdown()
 
 
 def make_error(message: str, code: int = JSONRPC_INTERNAL_ERROR, data: Any = None) -> dict:


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Address #2380

---

## 📝 Summary
_What does this PR do and why?_
---
Simplifies OSError handling by removing redundant conditional logic and duplicate _mark_shutdown() calls.

Logically, this does:
- Catch any OSError
- Check if the error number (e.errno) is errno.EPIPE (broken pipe), or errno.EINVAL (invalid argument)
- If yes → call _mark_shutdown()
- If no → also call _mark_shutdown()
So regardless of the error type, _mark_shutdown() is always executed.

It’s safe because:

- Both branches (if and else) executed the exact same code.
- There was no logging, re-raising, branching, or special handling.
- No side effects depended on e.errno.

Test cases found

- test_send_to_stdout_json_and_str: PASSED
- test_send_to_stdout_oserror: PASSED
- test_send_to_stdout_oserror_other_errno: PASSED
- test_send_to_stdout_no_buffer_fallback: PASSED

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    Passed    |
| Unit tests                | `make test`     |     Passed       |
| Coverage ≥ 80%            | `make coverage` |   99%     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
