### PR TITLE
fix: remove duplicate loading spinner on A2A agents page

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -6381,14 +6381,6 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                    hx-trigger="load"
                    hx-swap="outerHTML"
                    hx-indicator="#agents-loading">
-                <!-- Loading placeholder -->
-                <div class="flex items-center justify-center p-8">
-                  <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                  <span class="ml-3 text-gray-600 dark:text-gray-400">Loading agents...</span>
-                </div>
               </div>
             </div>
 


### PR DESCRIPTION
  ## 🔗 Related Issue

 Closes #2887
                                                                                                                              
  ---

  ## 📝 Summary
  Remove inline placeholder spinner from `#agents-table` div, keeping only the HTMX `#agents-loading` indicator. This matches 
  the pattern already used for servers and tools tabs (commit 6b3283e4).

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix
  - [ ] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)
  - [ ] Other (describe below)

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | N/A (HTML template only) |
  | Unit tests                | `make test`     | N/A (HTML template only) |
  | Coverage ≥ 80%            | `make coverage` | N/A (HTML template only) |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  Single-line HTML removal — no Python code changed, so lint/test/coverage are not affected.