### PR TITLE
refactor(plugins): decouple plugin framework data models

### DIFF
--- a/plugins/regex_filter/search_replace.py
+++ b/plugins/regex_filter/search_replace.py
@@ -119,11 +119,12 @@ class SearchReplacePlugin(Plugin):
             The result of the plugin's analysis, including whether the tool can proceed.
         """
         if payload.args:
+            modified_args = dict(payload.args)
             for pattern, replacement in self.__patterns:
-                for key in payload.args:
-                    if isinstance(payload.args[key], str):
-                        value = pattern.sub(replacement, payload.args[key])
-                        payload.args[key] = value
+                for key in modified_args:
+                    if isinstance(modified_args[key], str):
+                        modified_args[key] = pattern.sub(replacement, modified_args[key])
+            payload = payload.model_copy(update={"args": modified_args})
         return ToolPreInvokeResult(modified_payload=payload)
 
     async def tool_post_invoke(self, payload: ToolPostInvokePayload, context: PluginContext) -> ToolPostInvokeResult:
@@ -137,11 +138,12 @@ class SearchReplacePlugin(Plugin):
             The result of the plugin's analysis, including whether the tool result should proceed.
         """
         if payload.result and isinstance(payload.result, dict):
+            modified_result = dict(payload.result)
             for pattern, replacement in self.__patterns:
-                for key in payload.result:
-                    if isinstance(payload.result[key], str):
-                        value = pattern.sub(replacement, payload.result[key])
-                        payload.result[key] = value
+                for key in modified_result:
+                    if isinstance(modified_result[key], str):
+                        modified_result[key] = pattern.sub(replacement, modified_result[key])
+            payload = payload.model_copy(update={"result": modified_result})
         elif payload.result and isinstance(payload.result, str):
             result = payload.result
             for pattern, replacement in self.__patterns:

--- a/tests/unit/mcpgateway/plugins/framework/test_plugin_models.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_plugin_models.py
@@ -28,6 +28,7 @@ def _write_file(tmp_path: Path, name: str) -> str:
 
 def test_bool_parsing_via_settings(monkeypatch):
     """Bool fields on PluginsSettings handle true/false strings correctly."""
+    # First-Party
     from mcpgateway.plugins.framework.settings import PluginsSettings
 
     monkeypatch.setenv("PLUGINS_CLIENT_MTLS_VERIFY", "true")
@@ -196,3 +197,15 @@ def test_plugin_config_external_config_disallowed():
     mcp = MCPClientConfig(proto=TransportType.SSE, url="https://example.com")
     with pytest.raises(ValueError):
         PluginConfig(name="external", kind=EXTERNAL_PLUGIN_TYPE, config={"x": 1}, mcp=mcp)
+
+
+def test_transport_type_enum_parity():
+    """Ensure framework and common TransportType enums stay in sync."""
+    # First-Party
+    from mcpgateway.plugins.framework.models import TransportType as FrameworkTransportType
+
+    common_members = {m.name: m.value for m in TransportType}
+    framework_members = {m.name: m.value for m in FrameworkTransportType}
+    assert framework_members == common_members, (
+        f"TransportType enums diverged. " f"Common-only: {set(common_members) - set(framework_members)}, " f"Framework-only: {set(framework_members) - set(common_members)}"
+    )


### PR DESCRIPTION
## Summary

Eliminates reverse dependencies from the plugin framework (`mcpgateway/plugins/framework/`) back into the outer gateway package (`mcpgateway.common`, `mcpgateway.utils`), and introduces hook payload policies for controlled modification of plugin payloads. 

After this change, the plugin framework has **zero imports** from `mcpgateway.common` or `mcpgateway.utils`, making it viable as a standalone, extractable package.

This PR depends on #2829 (`refactor/plugins_settings`).

Closes: #2859

## Changes

### Protocol definitions for boundary types
- New `protocols.py` with `@runtime_checkable` `MessageLike` and `PromptResultLike` protocols
- Replaces concrete imports of `Message` and `PromptResult` from `mcpgateway.common.models`
- The framework never instantiates these types — protocols express the structural contract without creating a dependency

### Immutable payloads
- Promoted `PluginPayload` from a bare `TypeAlias = BaseModel` to a proper frozen base class (`ConfigDict(frozen=True, arbitrary_types_allowed=True)`)
- Enforces copy-on-write semantics — plugins use `model_copy(update={...})` instead of in-place mutation
- Eliminates the need for defensive deep copies in the executor

### Internal framework types
- Defined `TransportType` enum internally in `models.py` (was imported from `mcpgateway.common.models`)
- Created self-contained `SecurityValidator` in `validators.py` with only the two methods used by the framework (`validate_url`, path validation)
- Copied `ORJSONResponse` into `utils.py` (was imported from `mcpgateway.utils.orjson_response`)

### Hook payload policies
- New `hooks/policies.py` with `HookPayloadPolicy`, `DefaultHookPolicy`, and `apply_policy()` — the framework provides the mechanism
- New `mcpgateway/plugins/policy.py` — the gateway defines the concrete policies per hook type (tool, prompt, resource, agent)
- Policies are injected into `PluginManager` via dependency injection, keeping the framework decoupled from gateway-specific decisions
- `default_hook_policy` setting (`PLUGINS_DEFAULT_HOOK_POLICY` env var) controls behavior for hooks without explicit policies: `allow` (default, backwards compatible) or `deny` (strict mode)

### Policy enforcement in executor
- `PluginExecutor` applies per-plugin policy filtering after each plugin returns
- Only fields listed in `writable_fields` are accepted; all other modifications are silently reverted to the original values
- Hooks without a defined policy fall back to `default_hook_policy`

### JSON deserialization for `Any`-typed fields
- Added `StructuredData` model and `coerce_nested()` utility for recursive dict-to-object conversion
- Applied as a Pydantic field validator on `PromptPosthookPayload.result` so that external server flows (gRPC, MCP stdio, Unix socket, streamable HTTP) correctly reconstruct nested objects with attribute access

### Plugin updates for frozen payloads
- Updated vault, search-replace, PII filter, and Cedar plugins to use `model_copy(update={...})` instead of direct attribute assignment
- Updated test fixture `HeadersPlugin` to use the same pattern

## Files changed

| Action | File | Description |
|--------|------|-------------|
| New | `framework/protocols.py` | `MessageLike`, `PromptResultLike` protocol classes |
| New | `framework/validators.py` | Self-contained `SecurityValidator` subset |
| New | `framework/hooks/policies.py` | `HookPayloadPolicy`, `DefaultHookPolicy`, `apply_policy` |
| New | `plugins/policy.py` | Gateway-side `HOOK_PAYLOAD_POLICIES` dictionary |
| New | `tests/.../test_policies.py` | 20 tests: policies, protocols, frozen payloads, import isolation |
| Modified | `framework/models.py` | Internal `TransportType` enum, frozen `PluginPayload` base class |
| Modified | `framework/hooks/agents.py` | Use `Any` + protocol docs instead of `Message` import |
| Modified | `framework/hooks/prompts.py` | Use `Any` + field validator instead of `PromptResult` import |
| Modified | `framework/hooks/registry.py` | Minor import cleanup |
| Modified | `framework/manager.py` | Accept `hook_policies` via DI, enforce in executor loop |
| Modified | `framework/settings.py` | Add `default_hook_policy` field |
| Modified | `framework/utils.py` | Add `StructuredData`, `coerce_nested`, `ORJSONResponse` |
| Modified | `framework/__init__.py` | Inject `HOOK_PAYLOAD_POLICIES` when creating manager |
| Modified | `framework/external/mcp/client.py` | Import `TransportType` from framework |
| Modified | `framework/external/mcp/server/runtime.py` | Import `ORJSONResponse` from framework |
| Modified | `plugins/vault/vault_plugin.py` | Use `model_copy` for frozen payload compatibility |
| Modified | `plugins/regex_filter/search_replace.py` | Use `model_copy` for frozen payload compatibility |
| Modified | `plugins/pii_filter/pii_filter.py` | Use `model_copy` for frozen payload compatibility |
| Modified | `plugins/external/cedar/.../plugin.py` | Use `model_copy` for frozen payload compatibility |
| Modified | `tests/.../headers.py` | Use `model_copy` for frozen payload compatibility |

## Note to maintainer

Please merge #2829 first.