### PR TITLE
feat(api): add PATCH endpoint for user updates

### DIFF
--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -797,7 +797,7 @@ async def update_user_deprecated(
         HTTPException: If user not found or update fails
     """
     result = await update_user_delegate(user_email, user_request, current_user_ctx, db)
-    deprecation_date = "@" + str(int(datetime(2026, 2, 24, 23, 59, 59, tzinfo=UTC).timestamp()))
+    deprecation_date = "@" + str(int(datetime(2026, 3, 31, 23, 59, 59, tzinfo=UTC).timestamp()))
     response.headers["Deprecation"] = deprecation_date
     response.headers["Sunset"] = "Sun, 16 Aug 2026 23:59:59 UTC"
     return result

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -598,7 +598,7 @@ async def test_admin_get_update_delete_user():
             password="newPassword123!",
             admin_origin_source="api",
         )
-        assert response_input.headers["deprecation"] == "@1771977599"
+        assert response_input.headers["deprecation"] == "@1775001599"
         assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 UTC"
         #----------->
 


### PR DESCRIPTION

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #2754

---

## 📝 Summary
- Added Deprecation and Sunset headers for PUT route with reference to https://datatracker.ietf.org/doc/rfc9745/. 
- Both PATCH and PUT will exist till Sun, 16 Aug 2026 23:59:59 UTC; after which PUT will be removed completely
- Made both PUT and PATCH call same delegated function to maintain the behavior and cover all the test cases.
- Didn't make changes to Admin UI, since it uses POST and not PUT
- Appropriate comments are made in the code for removal guidance in future
- A condition is inserted to fail tests after sunset period to make sure PUT endpoint is removed.


---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    passes all linters    |
| Unit tests                | `make test`     |    all unit + integration tests green    |
| Coverage ≥ 80%            | `make coverage` |    98%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## Acceptance Criteria
- [x] PATCH /auth/email/admin/users/{email} works with partial payloads
- [x] PUT /auth/email/admin/users/{email} still works but returns Deprecation header
- [x] OpenAPI docs show PUT as deprecated with migration guidance
- [x] Integration tests (scripts/test_email_auth_api.py) updated to use PATCH
- [x] Unit tests cover both endpoints
 