### PR TITLE
Enforce Token Expiration Policy via REQUIRE_TOKEN_EXPIRATION Setting

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2849,6 +2849,8 @@ async def admin_ui(
             "password_require_lowercase": getattr(settings, "password_require_lowercase", False),
             "password_require_numbers": getattr(settings, "password_require_numbers", False),
             "password_require_special": getattr(settings, "password_require_special", False),
+            # Token policy flags
+            "require_token_expiration": getattr(settings, "require_token_expiration", True),
         },
     )
 

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -26,6 +26,7 @@ from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.db import EmailApiToken, EmailUser, TokenRevocation, TokenUsageLog, utc_now
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.create_jwt_token import create_jwt_token
@@ -460,6 +461,10 @@ class TokenCatalogService:
         expires_at = None
         if expires_in_days:
             expires_at = utc_now() + timedelta(days=expires_in_days)
+
+        # Enforce expiration requirement if configured
+        if settings.require_token_expiration and not expires_at:
+            raise ValueError("Token expiration is required by server policy (REQUIRE_TOKEN_EXPIRATION=true). Please specify an expiration date for the token.")
 
         jti = str(uuid.uuid4())  # Unique JWT ID
         # Generate JWT token with all necessary claims

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -6168,6 +6168,9 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
                   Expires In (Days)
+                  {% if require_token_expiration %}
+                  <span class="text-red-500">*</span>
+                  {% endif %}
                 </label>
                 <input
                   type="number"
@@ -6175,9 +6178,23 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   min="1"
                   max="365"
                   value="30"
+                  {% if require_token_expiration %}required{% endif %}
+                  {% if require_token_expiration %}
+                  oninvalid="this.setCustomValidity('Expiration is required by server policy. Please enter the number of days (e.g., 30, 90, 365).')"
+                  oninput="this.setCustomValidity('')"
+                  {% endif %}
                   class="mt-1 px-1.5 block w-full border border-gray-300 rounded-md shadow-sm bg-gray-100 dark:bg-gray-700 dark:border-gray-600 text-gray-700 dark:text-gray-300"
                   placeholder="30"
                 />
+                {% if require_token_expiration %}
+                <p class="mt-1 text-xs text-red-600 dark:text-red-400 font-medium">
+                  Token expiration is required by server policy (REQUIRE_TOKEN_EXPIRATION=true).
+                </p>
+                {% else %}
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Leave empty for tokens that never expire
+                </p>
+                {% endif %}
               </div>
             </div>
             <div>


### PR DESCRIPTION
closes issue #2836 

This PR introduces support for enforcing a server policy that requires API tokens to have an expiration date. The enforcement is implemented at the service layer, reflected in the Admin UI, and covered with unit tests to ensure consistent behavior.

---

### **Key Changes**

#### **Backend Enforcement**

* Added validation to block token creation when expiration is required but not provided.
* Validation checks `REQUIRE_TOKEN_EXPIRATION` before allowing token creation.
* Clear error message is returned when policy is violated.

**Files Updated**

* `token_catalog_service.py`

---

#### **Admin UI Enhancements**

* Added visual indicator (*) when expiration is required.
* Made the "Expires In (Days)" field conditionally mandatory.
* Added helper text explaining expiration policy.

**Files Updated**

* `admin.html`

---

#### **Configuration Exposure**

* Exposed `require_token_expiration` setting through admin API.
* Allows UI to dynamically adjust behavior based on server configuration.

**Files Updated**

* `admin.py`

---

### **Behavior Scenarios**

* **REQUIRE_TOKEN_EXPIRATION = false**

  * Tokens can be created without expiration.

* **REQUIRE_TOKEN_EXPIRATION = true**

  * Token creation fails if expiration is missing.
  * Clear validation error is returned.

---

### **Testing**

* Updated existing tests to include expiration where required.
* Added new test cases covering:

  * Policy enabled/disabled scenarios
  * Tokens with and without expiration
  * Team and scoped token validation
  * Edge cases

---

### **Impact**

* Prevents creation of tokens without expiration when policy requires it.
* Improves UI clarity for admins.
* Ensures consistent enforcement across backend and frontend.