### PR TITLE
ADR-0039 documenting the decision to adopt a fully independent plugin crates architecture.

### DIFF
--- a/docs/docs/architecture/adr/.pages
+++ b/docs/docs/architecture/adr/.pages
@@ -41,3 +41,4 @@ nav:
   - 36 Bootstrap Custom Roles: 036-bootstrap-custom-roles.md
   - 37 External Plugin Stdio Launch: 037-external-plugin-stdio-launch.md
   - 38b Multi-Worker Session Affinity: 038-multi-worker-session-affinity.md
+  - 39 Adopt Fully Independent Plugin Crates Architecture: 039-adopt-fully-independent-plugin-crates-architecture.md

--- a/docs/docs/architecture/adr/039-adopt-fully-independent-plugin-crates-architecture.md
+++ b/docs/docs/architecture/adr/039-adopt-fully-independent-plugin-crates-architecture.md
@@ -1,0 +1,41 @@
+# ADR-0039: Adopt Fully Independent Plugin Crates Architecture
+
+## Context
+
+The current `pii_filter` plugin is not a separate crate and embeds PyO3 dependencies and macros directly. This couples plugin logic to Python bindings, making it difficult to add new plugins and increasing long-term maintenance costs as we expand support for both Rust and Python implementations.
+
+## Decision
+
+Adopt ** Fully Independent Plugin Crates** as the plugin architecture.
+
+- Each plugin lives in its own crate with its own versioning and types.
+- Plugins expose their own `#[pyfunction]` / `#[pymodule]`/ `#[pyclass]` for in-process usage (via maturin/pip packaging).
+- Plugin authors may choose in-process (PyO3) or out-of-process (gRPC/HTTP) execution.
+- Shared utilities, error conversions, or common adapters live in a separate shared crate if needed.
+- Strong isolation and self-containment for plugins.
+
+## Consequences
+
+### Positive
+- Clear ownership and strong isolation per plugin
+- Straightforward pip distribution for Python integration
+- Flexibility: in-process or remote execution per plugin
+- Reduced coupling between core and plugin code
+- Easier to add/maintain plugins independently
+
+### Negative
+- Minor boilerplate per plugin for bindings/API surface
+
+### Risks / Mitigations
+- Repetition in bindings → mitigate with shared helper crate when patterns emerge
+- Workspace uniformity → optional shared crate
+
+## Alternatives Considered
+
+- **Option 1: Rust API on top of Python API** — Rejected (creates duplicative public Rust contract, tight coupling)
+- **Option 3: Hybrid workspace with dedicated adapter crate** — Deferred (viable future evolution if many plugins justify shared adapters; little practical difference from Option 2 initially)
+- **Option 4: Only gRPC/HTTP** — Rejected (adds latency/complexity for local dev; not required for all use cases)
+
+## Related
+- Testing: Use shared Python-based integration tests across Rust and Python implementations
+- Issue: https://github.com/IBM/mcp-context-forge/issues/2730

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -41,5 +41,6 @@ This page tracks all significant design decisions made for the MCP Gateway proje
 | 0035  | Query Parameter Authentication for Gateways | Accepted | Security | 2026-01-19 |
 | 0037  | External Plugin STDIO Launch with Command/Env Overrides | Accepted | Extensibility | 2026-01-28 |
 | 0038  | Experimental Rust Transport Backend (Streamable HTTP) | Proposed | Performance | 2025-12-26 |
+| 0039  | Adopt Fully Independent Plugin Crates Architecture | Accepted | Architecture | 2026-02-13 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.


### PR DESCRIPTION
Adds ADR-0039 documenting the decision to adopt a fully independent plugin crates architecture.

## Changes

- Added ADR-0039 entry to the Architecture Decision Records index
- Documents the decision to use independent crates for each plugin with their own versioning and types
- Plugins can choose in-process (PyO3) or out-of-process (gRPC/HTTP) execution
- Provides clear ownership and strong isolation per plugin

## Related

- Issue: https://github.com/IBM/mcp-context-forge/issues/2730

