### PR TITLE
2874 - Add HX-Redirect header to HTMX on auth fail

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -46,7 +46,7 @@ from fastapi.background import BackgroundTasks
 from fastapi.exception_handlers import request_validation_exception_handler as fastapi_default_validation_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader
@@ -1466,7 +1466,7 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
             error_param: Optional error parameter for login redirect URL.
 
         Returns:
-            RedirectResponse for HTML/HTMX requests, ORJSONResponse for API requests.
+            Response with HX-Redirect for HTMX requests, RedirectResponse for HTML requests, ORJSONResponse for API requests.
         """
         accept_header = request.headers.get("accept", "")
         is_htmx = request.headers.get("hx-request") == "true"
@@ -1474,6 +1474,8 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
             login_url = f"{root_path}/admin/login" if root_path else "/admin/login"
             if error_param:
                 login_url = f"{login_url}?error={error_param}"
+            if is_htmx:
+                return Response(status_code=200, headers={"HX-Redirect": login_url})
             return RedirectResponse(url=login_url, status_code=302)
         return ORJSONResponse(status_code=status_code, content={"detail": detail})
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
When an HTMX partial request hit AdminAuthMiddleware with an expired or invalid session, the 302 redirect was swapped into the active tab content instead of performing a full-page navigation. HTMX intercepts XHR 302 responses and treats the response body as swap content.

Return a 200 response with HX-Redirect header for HTMX requests, which instructs HTMX to perform a client-side full-page redirect to the login page. Non-HTMX and API request flows are unchanged.

Closes #2874

## 🔁 Reproduction Steps
1. Log in and navigate to any admin module tab.
2. Open browser DevTools → Application → Cookies.
3. Delete or modify the `jwt_token` cookie to an invalid value.
4. Click any HTMX-powered link/tab within the admin panel.
5. **Observe:** Login form appears inside the tab content.

## 🐞 Root Cause
**File:** `mcpgateway/main.py`, lines 1457–1478 — `AdminAuthMiddleware._error_response()`

```python
is_htmx = request.headers.get("hx-request") == "true"
if "text/html" in accept_header or is_htmx:
    login_url = f"{root_path}/admin/login" if root_path else "/admin/login"
    if error_param:
        login_url = f"{login_url}?error={error_param}"
    return RedirectResponse(url=login_url, status_code=302)  # <-- BUG
```

The method already detects HTMX requests (`is_htmx`) but treats them identically to regular browser HTML requests. HTMX does **not** follow standard 302 redirects as full-page navigations — it treats the response body as content to swap into the target element.

HTMX supports a special `HX-Redirect` response header that instructs the client to perform a full-page redirect. This header is not being used.

## 💡 Fix Description
Return a 200 response with HX-Redirect header for HTMX requests, which instructs HTMX to perform a client-side full-page redirect to the login page. Non-HTMX and API request flows are unchanged.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
