### PR TITLE
test: add Playwright E2E tests for security, teams, entities, and operations

### DIFF
--- a/tests/playwright/entities/test_entity_lifecycle.py
+++ b/tests/playwright/entities/test_entity_lifecycle.py
@@ -1,0 +1,761 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Entity Lifecycle E2E Tests (REST API).
+
+Tests full CRUD lifecycle + activate/deactivate for tools, resources, prompts,
+and servers via the REST API. Complements the existing browser-based entity tests.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import os
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
+
+
+def _make_jwt(email: str, is_admin: bool = False, teams=None) -> str:
+    return _create_jwt_token(
+        {"sub": email},
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+    )
+
+
+@pytest.fixture(scope="module")
+def admin_api(playwright: Playwright):
+    """Admin-authenticated API context."""
+    token = _make_jwt("admin@example.com", is_admin=True)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def viewer_api(playwright: Playwright):
+    """Viewer (non-admin, no RBAC roles) API context for permission checks."""
+    email = f"viewer-entity-{uuid.uuid4().hex[:8]}@example.com"
+    token = _make_jwt(email, is_admin=False)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+class TestToolLifecycle:
+    """Full CRUD + activate/deactivate lifecycle for tools via REST API."""
+
+    def test_create_tool(self, admin_api: APIRequestContext):
+        """Admin can create a REST tool."""
+        name = f"lifecycle-tool-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Lifecycle test tool",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        assert resp.status in (200, 201), f"Create tool failed: {resp.status} {resp.text()}"
+        tool = resp.json()
+        assert tool["name"] == name
+
+        # Cleanup
+        admin_api.delete(f"/tools/{tool['id']}")
+
+    def test_list_tools(self, admin_api: APIRequestContext):
+        """Admin can list tools."""
+        resp = admin_api.get("/tools/")
+        assert resp.status == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    def test_get_tool(self, admin_api: APIRequestContext):
+        """Admin can get a specific tool."""
+        name = f"get-tool-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Get test",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create tool failed: {create_resp.status} {create_resp.text()}"
+        tool = create_resp.json()
+
+        resp = admin_api.get(f"/tools/{tool['id']}")
+        assert resp.status == 200
+        fetched = resp.json()
+        assert fetched["name"] == name
+
+        admin_api.delete(f"/tools/{tool['id']}")
+
+    def test_update_tool(self, admin_api: APIRequestContext):
+        """Admin can update a tool's description."""
+        name = f"update-tool-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Original",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create tool failed: {create_resp.status} {create_resp.text()}"
+        tool = create_resp.json()
+
+        resp = admin_api.put(f"/tools/{tool['id']}", data={"description": "Updated description"})
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["description"] == "Updated description"
+
+        admin_api.delete(f"/tools/{tool['id']}")
+
+    def test_deactivate_tool(self, admin_api: APIRequestContext):
+        """Admin can deactivate a tool via state endpoint."""
+        name = f"deact-tool-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Deactivate test",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create tool failed: {create_resp.status} {create_resp.text()}"
+        tool = create_resp.json()
+
+        resp = admin_api.post(f"/tools/{tool['id']}/state?activate=false")
+        assert resp.status == 200
+
+        # Verify inactive (should not appear in default list)
+        list_resp = admin_api.get("/tools/")
+        tool_ids = [t["id"] for t in list_resp.json()]
+        assert tool["id"] not in tool_ids
+
+        admin_api.delete(f"/tools/{tool['id']}")
+
+    def test_reactivate_tool(self, admin_api: APIRequestContext):
+        """Admin can reactivate a deactivated tool."""
+        name = f"react-tool-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Reactivate test",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create tool failed: {create_resp.status} {create_resp.text()}"
+        tool = create_resp.json()
+
+        # Deactivate then reactivate
+        admin_api.post(f"/tools/{tool['id']}/state?activate=false")
+        resp = admin_api.post(f"/tools/{tool['id']}/state?activate=true")
+        assert resp.status == 200
+
+        # Verify active again
+        list_resp = admin_api.get("/tools/")
+        tool_ids = [t["id"] for t in list_resp.json()]
+        assert tool["id"] in tool_ids
+
+        admin_api.delete(f"/tools/{tool['id']}")
+
+    def test_delete_tool(self, admin_api: APIRequestContext):
+        """Admin can delete a tool."""
+        name = f"del-tool-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Delete test",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create tool failed: {create_resp.status} {create_resp.text()}"
+        tool = create_resp.json()
+
+        resp = admin_api.delete(f"/tools/{tool['id']}")
+        assert resp.status == 200
+
+        # Verify deleted
+        get_resp = admin_api.get(f"/tools/{tool['id']}")
+        assert get_resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+
+
+class TestResourceLifecycle:
+    """Full CRUD + activate/deactivate lifecycle for resources."""
+
+    def test_create_resource(self, admin_api: APIRequestContext):
+        """Admin can create a resource."""
+        name = f"lifecycle-res-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post(
+            "/resources/",
+            data={
+                "resource": {
+                    "uri": f"file:///test/{name}.txt",
+                    "name": name,
+                    "description": "Lifecycle test resource",
+                    "mimeType": "text/plain",
+                    "content": "test content",
+                },
+                "team_id": None,
+            },
+        )
+        assert resp.status in (200, 201), f"Create resource failed: {resp.status} {resp.text()}"
+        resource = resp.json()
+        assert resource["name"] == name
+
+        admin_api.delete(f"/resources/{resource['id']}")
+
+    def test_list_resources(self, admin_api: APIRequestContext):
+        """Admin can list resources."""
+        resp = admin_api.get("/resources/")
+        assert resp.status == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    def test_get_resource_info(self, admin_api: APIRequestContext):
+        """Admin can get resource info."""
+        name = f"get-res-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/resources/",
+            data={
+                "resource": {
+                    "uri": f"file:///test/{name}.txt",
+                    "name": name,
+                    "description": "Get test",
+                    "mimeType": "text/plain",
+                    "content": "test content",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create resource failed: {create_resp.status} {create_resp.text()}"
+        resource = create_resp.json()
+
+        resp = admin_api.get(f"/resources/{resource['id']}/info")
+        assert resp.status == 200
+        fetched = resp.json()
+        assert fetched["name"] == name
+
+        admin_api.delete(f"/resources/{resource['id']}")
+
+    def test_update_resource(self, admin_api: APIRequestContext):
+        """Admin can update a resource."""
+        name = f"update-res-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/resources/",
+            data={
+                "resource": {
+                    "uri": f"file:///test/{name}.txt",
+                    "name": name,
+                    "description": "Original",
+                    "mimeType": "text/plain",
+                    "content": "test content",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create resource failed: {create_resp.status} {create_resp.text()}"
+        resource = create_resp.json()
+
+        resp = admin_api.put(f"/resources/{resource['id']}", data={"description": "Updated resource"})
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["description"] == "Updated resource"
+
+        admin_api.delete(f"/resources/{resource['id']}")
+
+    def test_deactivate_resource(self, admin_api: APIRequestContext):
+        """Admin can deactivate a resource."""
+        name = f"deact-res-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/resources/",
+            data={
+                "resource": {
+                    "uri": f"file:///test/{name}.txt",
+                    "name": name,
+                    "description": "Deactivate test",
+                    "mimeType": "text/plain",
+                    "content": "test content",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create resource failed: {create_resp.status} {create_resp.text()}"
+        resource = create_resp.json()
+
+        resp = admin_api.post(f"/resources/{resource['id']}/state?activate=false")
+        assert resp.status == 200
+
+        # Verify inactive
+        list_resp = admin_api.get("/resources/")
+        res_ids = [r["id"] for r in list_resp.json()]
+        assert resource["id"] not in res_ids
+
+        admin_api.delete(f"/resources/{resource['id']}")
+
+    def test_reactivate_resource(self, admin_api: APIRequestContext):
+        """Admin can reactivate a resource."""
+        name = f"react-res-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/resources/",
+            data={
+                "resource": {
+                    "uri": f"file:///test/{name}.txt",
+                    "name": name,
+                    "description": "Reactivate test",
+                    "mimeType": "text/plain",
+                    "content": "test content",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create resource failed: {create_resp.status} {create_resp.text()}"
+        resource = create_resp.json()
+
+        admin_api.post(f"/resources/{resource['id']}/state?activate=false")
+        resp = admin_api.post(f"/resources/{resource['id']}/state?activate=true")
+        assert resp.status == 200
+
+        list_resp = admin_api.get("/resources/")
+        res_ids = [r["id"] for r in list_resp.json()]
+        assert resource["id"] in res_ids
+
+        admin_api.delete(f"/resources/{resource['id']}")
+
+    def test_delete_resource(self, admin_api: APIRequestContext):
+        """Admin can delete a resource."""
+        name = f"del-res-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/resources/",
+            data={
+                "resource": {
+                    "uri": f"file:///test/{name}.txt",
+                    "name": name,
+                    "description": "Delete test",
+                    "mimeType": "text/plain",
+                    "content": "test content",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create resource failed: {create_resp.status} {create_resp.text()}"
+        resource = create_resp.json()
+
+        resp = admin_api.delete(f"/resources/{resource['id']}")
+        assert resp.status == 200
+
+        get_resp = admin_api.get(f"/resources/{resource['id']}/info")
+        assert get_resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+
+class TestPromptLifecycle:
+    """Full CRUD + activate/deactivate lifecycle for prompts."""
+
+    def test_create_prompt(self, admin_api: APIRequestContext):
+        """Admin can create a prompt."""
+        name = f"lifecycle-prompt-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post(
+            "/prompts/",
+            data={
+                "prompt": {
+                    "name": name,
+                    "description": "Lifecycle test prompt",
+                    "template": "Tell me about {{topic}}",
+                    "arguments": [{"name": "topic", "description": "The topic", "required": True}],
+                },
+                "team_id": None,
+            },
+        )
+        assert resp.status in (200, 201), f"Create prompt failed: {resp.status} {resp.text()}"
+        prompt = resp.json()
+        assert prompt["name"] == name
+
+        admin_api.delete(f"/prompts/{prompt['id']}")
+
+    def test_list_prompts(self, admin_api: APIRequestContext):
+        """Admin can list prompts."""
+        resp = admin_api.get("/prompts/")
+        assert resp.status == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    def test_get_prompt(self, admin_api: APIRequestContext):
+        """Admin can get a prompt (returns rendered MCP messages)."""
+        name = f"get-prompt-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/prompts/",
+            data={
+                "prompt": {
+                    "name": name,
+                    "description": "Get test",
+                    "template": "Test prompt template",
+                    "arguments": [],
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create prompt failed: {create_resp.status} {create_resp.text()}"
+        prompt = create_resp.json()
+
+        # GET /prompts/{id} returns rendered MCP messages, not raw metadata
+        resp = admin_api.get(f"/prompts/{prompt['id']}")
+        assert resp.status == 200
+        fetched = resp.json()
+        assert "messages" in fetched or "description" in fetched
+
+        admin_api.delete(f"/prompts/{prompt['id']}")
+
+    def test_update_prompt(self, admin_api: APIRequestContext):
+        """Admin can update a prompt."""
+        name = f"update-prompt-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/prompts/",
+            data={
+                "prompt": {
+                    "name": name,
+                    "description": "Original",
+                    "template": "Test prompt template",
+                    "arguments": [],
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create prompt failed: {create_resp.status} {create_resp.text()}"
+        prompt = create_resp.json()
+
+        resp = admin_api.put(f"/prompts/{prompt['id']}", data={"description": "Updated prompt"})
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["description"] == "Updated prompt"
+
+        admin_api.delete(f"/prompts/{prompt['id']}")
+
+    def test_deactivate_prompt(self, admin_api: APIRequestContext):
+        """Admin can deactivate a prompt."""
+        name = f"deact-prompt-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/prompts/",
+            data={
+                "prompt": {
+                    "name": name,
+                    "description": "Deactivate test",
+                    "template": "Test prompt template",
+                    "arguments": [],
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create prompt failed: {create_resp.status} {create_resp.text()}"
+        prompt = create_resp.json()
+
+        resp = admin_api.post(f"/prompts/{prompt['id']}/state?activate=false")
+        assert resp.status == 200
+
+        list_resp = admin_api.get("/prompts/")
+        prompt_ids = [p["id"] for p in list_resp.json()]
+        assert prompt["id"] not in prompt_ids
+
+        admin_api.delete(f"/prompts/{prompt['id']}")
+
+    def test_reactivate_prompt(self, admin_api: APIRequestContext):
+        """Admin can reactivate a prompt."""
+        name = f"react-prompt-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/prompts/",
+            data={
+                "prompt": {
+                    "name": name,
+                    "description": "Reactivate test",
+                    "template": "Test prompt template",
+                    "arguments": [],
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create prompt failed: {create_resp.status} {create_resp.text()}"
+        prompt = create_resp.json()
+
+        admin_api.post(f"/prompts/{prompt['id']}/state?activate=false")
+        resp = admin_api.post(f"/prompts/{prompt['id']}/state?activate=true")
+        assert resp.status == 200
+
+        list_resp = admin_api.get("/prompts/")
+        prompt_ids = [p["id"] for p in list_resp.json()]
+        assert prompt["id"] in prompt_ids
+
+        admin_api.delete(f"/prompts/{prompt['id']}")
+
+    def test_delete_prompt(self, admin_api: APIRequestContext):
+        """Admin can delete a prompt."""
+        name = f"del-prompt-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/prompts/",
+            data={
+                "prompt": {
+                    "name": name,
+                    "description": "Delete test",
+                    "template": "Test prompt template",
+                    "arguments": [],
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create prompt failed: {create_resp.status} {create_resp.text()}"
+        prompt = create_resp.json()
+
+        resp = admin_api.delete(f"/prompts/{prompt['id']}")
+        assert resp.status == 200
+
+        get_resp = admin_api.get(f"/prompts/{prompt['id']}")
+        assert get_resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Servers
+# ---------------------------------------------------------------------------
+
+
+class TestServerLifecycle:
+    """Full CRUD + activate/deactivate lifecycle for virtual servers."""
+
+    def test_create_server(self, admin_api: APIRequestContext):
+        """Admin can create a virtual server."""
+        name = f"lifecycle-srv-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post(
+            "/servers/",
+            data={
+                "server": {
+                    "name": name,
+                    "description": "Lifecycle test server",
+                    "icon": "https://example.com/icon.png",
+                },
+                "team_id": None,
+            },
+        )
+        assert resp.status in (200, 201), f"Create server failed: {resp.status} {resp.text()}"
+        server = resp.json()
+        assert server["name"] == name
+
+        admin_api.delete(f"/servers/{server['id']}")
+
+    def test_list_servers(self, admin_api: APIRequestContext):
+        """Admin can list servers."""
+        resp = admin_api.get("/servers/")
+        assert resp.status == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    def test_get_server(self, admin_api: APIRequestContext):
+        """Admin can get a specific server."""
+        name = f"get-srv-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/servers/",
+            data={
+                "server": {
+                    "name": name,
+                    "description": "Get test",
+                    "icon": "https://example.com/icon.png",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create server failed: {create_resp.status} {create_resp.text()}"
+        server = create_resp.json()
+
+        resp = admin_api.get(f"/servers/{server['id']}")
+        assert resp.status == 200
+        fetched = resp.json()
+        assert fetched["name"] == name
+
+        admin_api.delete(f"/servers/{server['id']}")
+
+    def test_update_server(self, admin_api: APIRequestContext):
+        """Admin can update a server."""
+        name = f"update-srv-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/servers/",
+            data={
+                "server": {
+                    "name": name,
+                    "description": "Original",
+                    "icon": "https://example.com/icon.png",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create server failed: {create_resp.status} {create_resp.text()}"
+        server = create_resp.json()
+
+        resp = admin_api.put(f"/servers/{server['id']}", data={"description": "Updated server"})
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["description"] == "Updated server"
+
+        admin_api.delete(f"/servers/{server['id']}")
+
+    def test_deactivate_server(self, admin_api: APIRequestContext):
+        """Admin can deactivate a server."""
+        name = f"deact-srv-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/servers/",
+            data={
+                "server": {
+                    "name": name,
+                    "description": "Deactivate test",
+                    "icon": "https://example.com/icon.png",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create server failed: {create_resp.status} {create_resp.text()}"
+        server = create_resp.json()
+
+        resp = admin_api.post(f"/servers/{server['id']}/state?activate=false")
+        assert resp.status == 200
+
+        list_resp = admin_api.get("/servers/")
+        srv_ids = [s["id"] for s in list_resp.json()]
+        assert server["id"] not in srv_ids
+
+        admin_api.delete(f"/servers/{server['id']}")
+
+    def test_reactivate_server(self, admin_api: APIRequestContext):
+        """Admin can reactivate a server."""
+        name = f"react-srv-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/servers/",
+            data={
+                "server": {
+                    "name": name,
+                    "description": "Reactivate test",
+                    "icon": "https://example.com/icon.png",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create server failed: {create_resp.status} {create_resp.text()}"
+        server = create_resp.json()
+
+        admin_api.post(f"/servers/{server['id']}/state?activate=false")
+        resp = admin_api.post(f"/servers/{server['id']}/state?activate=true")
+        assert resp.status == 200
+
+        list_resp = admin_api.get("/servers/")
+        srv_ids = [s["id"] for s in list_resp.json()]
+        assert server["id"] in srv_ids
+
+        admin_api.delete(f"/servers/{server['id']}")
+
+    def test_delete_server(self, admin_api: APIRequestContext):
+        """Admin can delete a server."""
+        name = f"del-srv-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/servers/",
+            data={
+                "server": {
+                    "name": name,
+                    "description": "Delete test",
+                    "icon": "https://example.com/icon.png",
+                },
+                "team_id": None,
+            },
+        )
+        assert create_resp.status in (200, 201), f"Create server failed: {create_resp.status} {create_resp.text()}"
+        server = create_resp.json()
+
+        resp = admin_api.delete(f"/servers/{server['id']}")
+        assert resp.status == 200
+
+        get_resp = admin_api.get(f"/servers/{server['id']}")
+        assert get_resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# RBAC Permission Checks (cross-entity)
+# ---------------------------------------------------------------------------
+
+
+class TestEntityRBACPermissions:
+    """Verify that unprivileged users are denied entity mutations."""
+
+    @pytest.mark.parametrize(
+        "entity,body",
+        [
+            ("tools", {"tool": {"name": "deny-tool", "url": "https://httpbin.org/post", "integration_type": "REST", "request_type": "POST"}, "team_id": None}),
+            ("resources", {"resource": {"uri": "file:///deny.txt", "name": "deny-res", "mimeType": "text/plain", "content": "denied"}, "team_id": None}),
+            ("prompts", {"prompt": {"name": "deny-prompt", "description": "denied", "template": "denied", "arguments": []}, "team_id": None}),
+            ("servers", {"server": {"name": "deny-srv", "icon": "https://example.com/icon.png"}, "team_id": None}),
+        ],
+    )
+    def test_unprivileged_user_cannot_create(self, viewer_api: APIRequestContext, entity: str, body: dict):
+        """User without create permission is denied."""
+        resp = viewer_api.post(f"/{entity}/", data=body)
+        assert resp.status in (401, 403), f"Unprivileged create on {entity} should be denied, got {resp.status}"

--- a/tests/playwright/operations/__init__.py
+++ b/tests/playwright/operations/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Operations E2E test package."""

--- a/tests/playwright/operations/conftest.py
+++ b/tests/playwright/operations/conftest.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for operations E2E tests."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+from typing import Generator
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
+
+
+def _make_jwt(email: str, is_admin: bool = False, teams=None) -> str:
+    return _create_jwt_token(
+        {"sub": email},
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+    )
+
+
+@pytest.fixture(scope="module")
+def admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Admin-authenticated API context."""
+    token = _make_jwt("admin@example.com", is_admin=True)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def non_admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Non-admin API context for permission checks."""
+    token = _make_jwt("nonadmin-ops@example.com", is_admin=False)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()

--- a/tests/playwright/operations/test_export_import.py
+++ b/tests/playwright/operations/test_export_import.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export/Import E2E Tests.
+
+Tests the export and import workflow including full export, selective export,
+import with conflict strategies, and permission checks.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+class TestExport:
+    """Test export functionality."""
+
+    def test_full_export(self, admin_api: APIRequestContext):
+        """Admin can perform a full export."""
+        resp = admin_api.get("/export")
+        assert resp.status == 200
+        data = resp.json()
+        assert "entities" in data
+
+    def test_export_with_type_filter(self, admin_api: APIRequestContext):
+        """Admin can export specific entity types."""
+        resp = admin_api.get("/export?types=tools,servers")
+        assert resp.status == 200
+        data = resp.json()
+        assert "entities" in data
+
+    def test_export_includes_inactive(self, admin_api: APIRequestContext):
+        """Admin can export including inactive entities."""
+        resp = admin_api.get("/export?include_inactive=true")
+        assert resp.status == 200
+
+    @pytest.mark.xfail(reason="Server bug: 'Tool' object has no attribute 'rate_limit' (#2916)", strict=True)
+    def test_selective_export(self, admin_api: APIRequestContext):
+        """Admin can perform a selective export by entity IDs."""
+        name = f"export-tool-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/tools/",
+            data={
+                "tool": {
+                    "name": name,
+                    "url": "https://httpbin.org/post",
+                    "description": "Export test",
+                    "integration_type": "REST",
+                    "request_type": "POST",
+                },
+                "team_id": None,
+            },
+        )
+        tool = create_resp.json()
+
+        resp = admin_api.post("/export/selective", data={"tools": [tool["id"]]})
+        assert resp.status == 200
+
+        admin_api.delete(f"/tools/{tool['id']}")
+
+    def test_non_admin_cannot_export(self, non_admin_api: APIRequestContext):
+        """Non-admin user is denied export."""
+        resp = non_admin_api.get("/export")
+        assert resp.status in (401, 403), f"Non-admin export should be denied, got {resp.status}"
+
+
+class TestImport:
+    """Test import functionality."""
+
+    def test_dry_run_import(self, admin_api: APIRequestContext):
+        """Admin can dry-run an import to preview changes."""
+        export_resp = admin_api.get("/export?types=servers")
+        if export_resp.status != 200:
+            pytest.skip("Export not available")
+        export_data = export_resp.json()
+
+        # Import endpoint expects body wrapped in import_data
+        resp = admin_api.post("/import?dry_run=true&conflict_strategy=skip", data={"import_data": export_data})
+        assert resp.status == 200
+        result = resp.json()
+        assert "status" in result or "results" in result
+
+    def test_import_with_skip_strategy(self, admin_api: APIRequestContext):
+        """Admin can import with skip conflict strategy."""
+        export_resp = admin_api.get("/export?types=servers")
+        if export_resp.status != 200:
+            pytest.skip("Export not available")
+        export_data = export_resp.json()
+
+        resp = admin_api.post("/import?conflict_strategy=skip", data={"import_data": export_data})
+        assert resp.status == 200
+
+    def test_import_status_list(self, admin_api: APIRequestContext):
+        """Admin can list import statuses."""
+        resp = admin_api.get("/import/status")
+        assert resp.status == 200
+
+    def test_non_admin_cannot_import(self, non_admin_api: APIRequestContext):
+        """Non-admin user is denied import."""
+        resp = non_admin_api.post("/import", data={})
+        assert resp.status in (401, 403, 422), f"Non-admin import should be denied, got {resp.status}"

--- a/tests/playwright/operations/test_llm_config.py
+++ b/tests/playwright/operations/test_llm_config.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LLM Configuration E2E Tests.
+
+Tests LLM provider and model management endpoints.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def _llm_config_available(admin_api: APIRequestContext) -> bool:
+    """Check if LLM configuration endpoints are available."""
+    resp = admin_api.get("/providers")
+    return resp.status != 404
+
+
+class TestLLMProviderLifecycle:
+    """Test LLM provider CRUD lifecycle."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_unavailable(self, admin_api: APIRequestContext):
+        if not _llm_config_available(admin_api):
+            pytest.skip("LLM configuration endpoints not available")
+
+    def test_create_provider(self, admin_api: APIRequestContext):
+        """Admin can create an LLM provider."""
+        name = f"test-provider-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post(
+            "/providers",
+            data={
+                "name": name,
+                "provider_type": "openai",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test-key-not-real",
+            },
+        )
+        assert resp.status in (200, 201), f"Create provider failed: {resp.status} {resp.text()}"
+        provider = resp.json()
+        assert provider["name"] == name
+
+        # Cleanup
+        admin_api.delete(f"/providers/{provider['id']}")
+
+    def test_list_providers(self, admin_api: APIRequestContext):
+        """Admin can list LLM providers."""
+        resp = admin_api.get("/providers")
+        assert resp.status == 200
+
+    def test_get_provider(self, admin_api: APIRequestContext):
+        """Admin can get a specific provider."""
+        name = f"get-provider-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/providers",
+            data={
+                "name": name,
+                "provider_type": "openai",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test-key-not-real",
+            },
+        )
+        provider = create_resp.json()
+
+        resp = admin_api.get(f"/providers/{provider['id']}")
+        assert resp.status == 200
+        fetched = resp.json()
+        assert fetched["name"] == name
+
+        admin_api.delete(f"/providers/{provider['id']}")
+
+    def test_update_provider(self, admin_api: APIRequestContext):
+        """Admin can update a provider."""
+        name = f"update-provider-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/providers",
+            data={
+                "name": name,
+                "provider_type": "openai",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test-key-not-real",
+            },
+        )
+        provider = create_resp.json()
+
+        resp = admin_api.patch(f"/providers/{provider['id']}", data={"name": f"{name}-updated"})
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["name"] == f"{name}-updated"
+
+        admin_api.delete(f"/providers/{provider['id']}")
+
+    def test_deactivate_provider(self, admin_api: APIRequestContext):
+        """Admin can deactivate a provider."""
+        name = f"deact-provider-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/providers",
+            data={
+                "name": name,
+                "provider_type": "openai",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test-key-not-real",
+            },
+        )
+        provider = create_resp.json()
+
+        resp = admin_api.post(f"/providers/{provider['id']}/state?activate=false")
+        assert resp.status == 200
+
+        admin_api.delete(f"/providers/{provider['id']}")
+
+    def test_delete_provider(self, admin_api: APIRequestContext):
+        """Admin can delete a provider."""
+        name = f"del-provider-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post(
+            "/providers",
+            data={
+                "name": name,
+                "provider_type": "openai",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test-key-not-real",
+            },
+        )
+        provider = create_resp.json()
+
+        resp = admin_api.delete(f"/providers/{provider['id']}")
+        assert resp.status in (200, 204)
+
+    def test_non_admin_cannot_manage_providers(self, non_admin_api: APIRequestContext):
+        """Non-admin user is denied provider management."""
+        resp = non_admin_api.get("/providers")
+        assert resp.status in (401, 403), f"Non-admin provider access should be denied, got {resp.status}"
+
+
+class TestGatewayModels:
+    """Test public gateway models endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_unavailable(self, admin_api: APIRequestContext):
+        if not _llm_config_available(admin_api):
+            pytest.skip("LLM configuration endpoints not available")
+
+    def test_list_gateway_models(self, admin_api: APIRequestContext):
+        """Authenticated user can list available gateway models."""
+        resp = admin_api.get("/gateway/models")
+        assert resp.status == 200
+        data = resp.json()
+        assert isinstance(data, dict)

--- a/tests/playwright/operations/test_observability.py
+++ b/tests/playwright/operations/test_observability.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Observability & Metrics E2E Tests.
+
+Tests health endpoints, metrics, and observability endpoints.
+Observability endpoints may be disabled in test env (gracefully skipped).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def _observability_available(admin_api: APIRequestContext) -> bool:
+    """Check if observability endpoints are enabled."""
+    resp = admin_api.get("/observability/stats?hours=1")
+    return resp.status != 404
+
+
+class TestHealthEndpoints:
+    """Test public health and readiness endpoints."""
+
+    def test_health_check(self, admin_api: APIRequestContext):
+        """Health endpoint returns status."""
+        resp = admin_api.get("/health")
+        assert resp.status == 200
+        data = resp.json()
+        assert data["status"] in ("healthy", "unhealthy")
+
+    def test_readiness_check(self, admin_api: APIRequestContext):
+        """Readiness endpoint returns status."""
+        resp = admin_api.get("/ready")
+        assert resp.status == 200
+        data = resp.json()
+        assert data["status"] in ("ready", "not ready")
+
+    def test_security_health(self, admin_api: APIRequestContext):
+        """Security health endpoint returns score and checks."""
+        resp = admin_api.get("/health/security")
+        assert resp.status == 200
+        data = resp.json()
+        assert "status" in data
+        assert "score" in data or "checks" in data
+
+
+class TestMetrics:
+    """Test metrics endpoints."""
+
+    def test_get_metrics(self, admin_api: APIRequestContext):
+        """Admin can retrieve aggregated metrics."""
+        resp = admin_api.get("/metrics")
+        assert resp.status == 200
+        data = resp.json()
+        assert isinstance(data, dict)
+
+    def test_non_admin_cannot_get_metrics(self, non_admin_api: APIRequestContext):
+        """Non-admin user is denied metrics access."""
+        resp = non_admin_api.get("/metrics")
+        assert resp.status in (401, 403), f"Non-admin metrics should be denied, got {resp.status}"
+
+
+class TestObservability:
+    """Test observability endpoints (may be disabled)."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_unavailable(self, admin_api: APIRequestContext):
+        if not _observability_available(admin_api):
+            pytest.skip("Observability not enabled in test environment")
+
+    def test_get_stats(self, admin_api: APIRequestContext):
+        """Admin can retrieve observability stats."""
+        resp = admin_api.get("/observability/stats?hours=1")
+        assert resp.status == 200
+        data = resp.json()
+        assert "total_traces" in data or isinstance(data, dict)
+
+    def test_list_traces(self, admin_api: APIRequestContext):
+        """Admin can list traces."""
+        resp = admin_api.get("/observability/traces?limit=5")
+        assert resp.status == 200
+
+    def test_query_performance(self, admin_api: APIRequestContext):
+        """Admin can query performance analytics."""
+        resp = admin_api.get("/observability/analytics/query-performance?hours=1")
+        assert resp.status == 200

--- a/tests/playwright/security/__init__.py
+++ b/tests/playwright/security/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Security E2E test package."""

--- a/tests/playwright/security/conftest.py
+++ b/tests/playwright/security/conftest.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for security E2E tests."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import os
+from typing import Generator
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
+TEST_PASSWORD = "SecureTestPass123!"
+
+
+def _make_jwt(email: str, is_admin: bool = False, teams=None) -> str:
+    """Create a JWT token for testing."""
+    return _create_jwt_token(
+        {"sub": email},
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+    )
+
+
+@pytest.fixture(scope="module")
+def admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Admin-authenticated API context for security tests."""
+    token = _make_jwt("admin@example.com", is_admin=True)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def non_admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Non-admin API context for permission denial tests."""
+    token = _make_jwt("nonadmin-security@example.com", is_admin=False, teams=[])
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def anon_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Unauthenticated API context."""
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture
+def temp_user(admin_api: APIRequestContext):
+    """Create a temporary test user, yield email, then delete."""
+    email = f"test-{uuid.uuid4().hex[:8]}@example.com"
+    resp = admin_api.post(
+        "/auth/email/admin/users",
+        data={"email": email, "password": TEST_PASSWORD, "full_name": "Temp Test User"},
+    )
+    assert resp.status in (200, 201), f"Failed to create temp user: {resp.status}"
+    yield email
+    try:
+        admin_api.delete(f"/auth/email/admin/users/{email}")
+    except Exception:
+        pass

--- a/tests/playwright/security/test_rbac_admin.py
+++ b/tests/playwright/security/test_rbac_admin.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RBAC Admin E2E Tests.
+
+Tests role CRUD, user role assignment/revocation, and permission checks
+through the /rbac REST API endpoints.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+# Local
+from .conftest import TEST_PASSWORD
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Role CRUD Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRoleLifecycle:
+    """Test custom role create/read/update/delete operations."""
+
+    @pytest.fixture(scope="class")
+    def custom_role(self, admin_api: APIRequestContext):
+        """Create a custom role for lifecycle tests, cleanup after class."""
+        role_data = {
+            "name": f"test-role-{uuid.uuid4().hex[:8]}",
+            "description": "E2E test custom role",
+            "scope": "global",
+            "permissions": ["tools.read", "resources.read"],
+        }
+        resp = admin_api.post("/rbac/roles", data=role_data)
+        assert resp.status in (200, 201), f"Failed to create role: {resp.status} {resp.text()}"
+        role = resp.json()
+        yield role
+        try:
+            admin_api.delete(f"/rbac/roles/{role['id']}")
+        except Exception:
+            pass
+
+    def test_create_custom_role(self, admin_api: APIRequestContext):
+        """Admin can create a custom role."""
+        role_data = {
+            "name": f"create-role-{uuid.uuid4().hex[:8]}",
+            "description": "Temporary role",
+            "scope": "global",
+            "permissions": ["tools.read"],
+        }
+        resp = admin_api.post("/rbac/roles", data=role_data)
+        assert resp.status in (200, 201)
+        role = resp.json()
+        assert role["name"] == role_data["name"]
+        assert "tools.read" in role["permissions"]
+        # Cleanup
+        admin_api.delete(f"/rbac/roles/{role['id']}")
+
+    def test_list_roles_includes_builtin(self, admin_api: APIRequestContext):
+        """Role list includes built-in system roles."""
+        resp = admin_api.get("/rbac/roles")
+        assert resp.status == 200
+        roles = resp.json()
+        role_names = [r["name"] for r in roles]
+        assert "platform_admin" in role_names
+        assert "viewer" in role_names
+
+    def test_get_role_details(self, admin_api: APIRequestContext, custom_role: dict):
+        """Get specific role details by ID."""
+        resp = admin_api.get(f"/rbac/roles/{custom_role['id']}")
+        assert resp.status == 200
+        role = resp.json()
+        assert role["id"] == custom_role["id"]
+        assert role["name"] == custom_role["name"]
+
+    def test_update_role_permissions(self, admin_api: APIRequestContext, custom_role: dict):
+        """Admin can update a custom role's permissions."""
+        resp = admin_api.put(
+            f"/rbac/roles/{custom_role['id']}",
+            data={"permissions": ["tools.read", "resources.read", "prompts.read"]},
+        )
+        assert resp.status == 200
+        updated = resp.json()
+        assert "prompts.read" in updated["permissions"]
+
+    @pytest.mark.xfail(reason="Server bug: incorrect SQLAlchemy query in delete_role (#2917)", strict=True)
+    def test_delete_custom_role(self, admin_api: APIRequestContext):
+        """Admin can delete a custom role."""
+        resp = admin_api.post(
+            "/rbac/roles",
+            data={"name": f"del-role-{uuid.uuid4().hex[:8]}", "description": "Delete me", "scope": "global", "permissions": ["tools.read"]},
+        )
+        assert resp.status in (200, 201)
+        role_id = resp.json()["id"]
+
+        del_resp = admin_api.delete(f"/rbac/roles/{role_id}")
+        assert del_resp.status == 200
+
+    @pytest.mark.xfail(reason="Server bug: system role delete returns 500 instead of 400 (#2917)", strict=True)
+    def test_system_role_delete_returns_400(self, admin_api: APIRequestContext):
+        """Deleting a system role should return 400, not 500."""
+        resp = admin_api.get("/rbac/roles")
+        roles = resp.json()
+        pa_role = next((r for r in roles if r["name"] == "platform_admin"), None)
+        assert pa_role is not None, "platform_admin role not found"
+
+        del_resp = admin_api.delete(f"/rbac/roles/{pa_role['id']}")
+        assert del_resp.status == 400, f"System role delete should return 400, got {del_resp.status}"
+
+
+# ---------------------------------------------------------------------------
+# Role Assignment
+# ---------------------------------------------------------------------------
+
+
+class TestRoleAssignment:
+    """Test assigning and revoking roles from users."""
+
+    @pytest.fixture(scope="class")
+    def assignment_user(self, admin_api: APIRequestContext):
+        """Create a user for role assignment tests."""
+        email = f"assign-{uuid.uuid4().hex[:8]}@example.com"
+        resp = admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": email, "password": TEST_PASSWORD, "full_name": "Assignment User"},
+        )
+        assert resp.status in (200, 201)
+        yield email
+        try:
+            admin_api.delete(f"/auth/email/admin/users/{email}")
+        except Exception:
+            pass
+
+    @pytest.fixture(scope="class")
+    def assignment_role(self, admin_api: APIRequestContext):
+        """Create a role for assignment tests."""
+        resp = admin_api.post(
+            "/rbac/roles",
+            data={"name": f"assign-role-{uuid.uuid4().hex[:8]}", "description": "For assignment", "scope": "global", "permissions": ["tools.read"]},
+        )
+        assert resp.status in (200, 201)
+        role = resp.json()
+        yield role
+        try:
+            admin_api.delete(f"/rbac/roles/{role['id']}")
+        except Exception:
+            pass
+
+    def test_assign_role_to_user(self, admin_api: APIRequestContext, assignment_user: str, assignment_role: dict):
+        """Admin can assign a role to a user."""
+        resp = admin_api.post(
+            f"/rbac/users/{assignment_user}/roles",
+            data={"role_id": assignment_role["id"], "scope": "global"},
+        )
+        assert resp.status in (200, 201), f"Failed to assign role: {resp.status} {resp.text()}"
+
+    def test_list_user_roles(self, admin_api: APIRequestContext, assignment_user: str, assignment_role: dict):
+        """Admin can list a user's assigned roles."""
+        # Ensure assignment exists
+        admin_api.post(
+            f"/rbac/users/{assignment_user}/roles",
+            data={"role_id": assignment_role["id"], "scope": "global"},
+        )
+        resp = admin_api.get(f"/rbac/users/{assignment_user}/roles")
+        assert resp.status == 200
+        roles = resp.json()
+        role_ids = [r.get("role_id") or r.get("id") for r in roles]
+        assert assignment_role["id"] in role_ids
+
+    def test_revoke_user_role(self, admin_api: APIRequestContext, assignment_user: str, assignment_role: dict):
+        """Admin can revoke a role from a user."""
+        # Ensure assignment exists
+        admin_api.post(
+            f"/rbac/users/{assignment_user}/roles",
+            data={"role_id": assignment_role["id"], "scope": "global"},
+        )
+        resp = admin_api.delete(f"/rbac/users/{assignment_user}/roles/{assignment_role['id']}?scope=global")
+        assert resp.status in (200, 204), f"Failed to revoke role: {resp.status} {resp.text()}"
+
+
+# ---------------------------------------------------------------------------
+# Permission Checks
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionChecks:
+    """Test permission query and denial endpoints."""
+
+    def test_get_available_permissions(self, admin_api: APIRequestContext):
+        """List all available system permissions."""
+        resp = admin_api.get("/rbac/permissions/available")
+        assert resp.status == 200
+        data = resp.json()
+        # Response format: {"all_permissions": [...], "permissions_by_resource": {...}, "total_count": N}
+        perms = data.get("all_permissions", data if isinstance(data, list) else [])
+        assert len(perms) > 0, "Expected at least one permission"
+        assert any("tools" in str(p) for p in perms)
+
+    def test_non_admin_denied_role_create(self, non_admin_api: APIRequestContext):
+        """Non-admin user cannot create roles."""
+        resp = non_admin_api.post(
+            "/rbac/roles",
+            data={"name": "should-fail", "description": "Fail", "scope": "global", "permissions": ["tools.read"]},
+        )
+        assert resp.status in (401, 403), f"Non-admin should be denied role creation, got {resp.status}"

--- a/tests/playwright/security/test_sso_management.py
+++ b/tests/playwright/security/test_sso_management.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSO Provider Management E2E Tests.
+
+Tests SSO provider CRUD operations through the /auth/sso/admin REST API.
+These tests are skipped if SSO endpoints are not available in the test environment.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+logger = logging.getLogger(__name__)
+
+SSO_ADMIN_PATH = "/auth/sso/admin/providers"
+
+
+def _make_provider_data(provider_id: str | None = None) -> dict:
+    """Generate test SSO provider configuration."""
+    pid = provider_id or f"test-sso-{uuid.uuid4().hex[:8]}"
+    return {
+        "id": pid,
+        "name": pid,
+        "display_name": "Test SSO Provider",
+        "provider_type": "oidc",
+        "client_id": "test-client-id",
+        "client_secret": "test-client-secret",
+        "authorization_url": "https://auth.example.com/authorize",
+        "token_url": "https://auth.example.com/token",
+        "userinfo_url": "https://auth.example.com/userinfo",
+        "scope": "openid profile email",
+    }
+
+
+def _sso_available(admin_api: APIRequestContext) -> bool:
+    """Check if SSO admin endpoints are available."""
+    resp = admin_api.get(SSO_ADMIN_PATH)
+    return resp.status != 404
+
+
+# ---------------------------------------------------------------------------
+# SSO Provider CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestSSOProviderLifecycle:
+    """Test SSO provider create/read/update/delete operations."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_sso_unavailable(self, admin_api: APIRequestContext):
+        """Skip all tests in this class if SSO endpoints are not available."""
+        if not _sso_available(admin_api):
+            pytest.skip("SSO admin endpoints not available in this environment")
+
+    @pytest.fixture(scope="class")
+    def sso_provider(self, admin_api: APIRequestContext):
+        """Create an SSO provider for lifecycle tests, cleanup after class."""
+        if not _sso_available(admin_api):
+            pytest.skip("SSO admin endpoints not available in this environment")
+        data = _make_provider_data()
+        resp = admin_api.post(SSO_ADMIN_PATH, data=data)
+        assert resp.status in (200, 201), f"Failed to create SSO provider: {resp.status} {resp.text()}"
+        provider = resp.json()
+        yield provider
+        try:
+            admin_api.delete(f"{SSO_ADMIN_PATH}/{data['id']}")
+        except Exception:
+            pass
+
+    def test_create_sso_provider(self, admin_api: APIRequestContext):
+        """Admin can create an OIDC SSO provider."""
+        data = _make_provider_data()
+        resp = admin_api.post(SSO_ADMIN_PATH, data=data)
+        assert resp.status in (200, 201)
+        # Cleanup
+        admin_api.delete(f"{SSO_ADMIN_PATH}/{data['id']}")
+
+    def test_list_sso_providers(self, admin_api: APIRequestContext, sso_provider: dict):
+        """Admin can list all SSO providers."""
+        resp = admin_api.get(SSO_ADMIN_PATH)
+        assert resp.status == 200
+        providers = resp.json()
+        assert isinstance(providers, list)
+
+    def test_update_sso_provider(self, admin_api: APIRequestContext, sso_provider: dict):
+        """Admin can update an SSO provider's display name."""
+        provider_id = sso_provider.get("id") or sso_provider.get("name")
+        resp = admin_api.put(
+            f"{SSO_ADMIN_PATH}/{provider_id}",
+            data={"display_name": "Updated SSO Provider"},
+        )
+        assert resp.status == 200
+
+    def test_delete_sso_provider(self, admin_api: APIRequestContext):
+        """Admin can delete an SSO provider."""
+        data = _make_provider_data()
+        admin_api.post(SSO_ADMIN_PATH, data=data)
+        resp = admin_api.delete(f"{SSO_ADMIN_PATH}/{data['id']}")
+        assert resp.status in (200, 204)
+
+    def test_non_admin_denied_sso_create(self, non_admin_api: APIRequestContext):
+        """Non-admin user cannot create SSO providers."""
+        data = _make_provider_data()
+        resp = non_admin_api.post(SSO_ADMIN_PATH, data=data)
+        assert resp.status in (401, 403), f"Non-admin should be denied, got {resp.status}"

--- a/tests/playwright/security/test_token_lifecycle.py
+++ b/tests/playwright/security/test_token_lifecycle.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Token Lifecycle E2E Tests.
+
+Tests API token create/read/update/revoke operations through the /tokens REST API.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def _get_token_id(resp_json: dict) -> str | None:
+    """Extract token ID from create or get response."""
+    # Create response: {"access_token": "...", "token": {"id": "...", ...}}
+    # Get response: {"id": "...", ...}
+    token_obj = resp_json.get("token", resp_json)
+    return token_obj.get("id") or token_obj.get("token_id")
+
+
+def _get_token_name(resp_json: dict) -> str | None:
+    """Extract token name from response."""
+    token_obj = resp_json.get("token", resp_json)
+    return token_obj.get("name")
+
+
+# ---------------------------------------------------------------------------
+# Token CRUD Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestTokenLifecycle:
+    """Test API token create/list/update/revoke operations."""
+
+    @pytest.fixture(scope="class")
+    def lifecycle_token(self, admin_api: APIRequestContext):
+        """Create a token for lifecycle tests, cleanup after class."""
+        token_name = f"lifecycle-token-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post("/tokens", data={"name": token_name, "expires_in_days": 30})
+        assert resp.status in (200, 201), f"Failed to create token: {resp.status} {resp.text()}"
+        data = resp.json()
+        token_id = _get_token_id(data)
+        yield {"id": token_id, "name": token_name, "raw": data}
+        try:
+            if token_id:
+                admin_api.delete(f"/tokens/{token_id}")
+        except Exception:
+            pass
+
+    def test_create_token(self, admin_api: APIRequestContext):
+        """Admin can create an API token."""
+        token_name = f"create-token-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.post("/tokens", data={"name": token_name, "expires_in_days": 7})
+        assert resp.status in (200, 201)
+        data = resp.json()
+        assert _get_token_name(data) == token_name
+        assert data.get("access_token"), "Raw access_token should be returned on creation"
+        # Cleanup
+        token_id = _get_token_id(data)
+        if token_id:
+            admin_api.delete(f"/tokens/{token_id}")
+
+    def test_list_tokens(self, admin_api: APIRequestContext, lifecycle_token: dict):
+        """Created token appears in token list."""
+        resp = admin_api.get("/tokens")
+        assert resp.status == 200
+        data = resp.json()
+        # Response format: {"tokens": [...], "total": N, "limit": N, "offset": N}
+        tokens = data.get("tokens", data if isinstance(data, list) else [])
+        token_ids = [t.get("id") or t.get("token_id") for t in tokens]
+        assert lifecycle_token["id"] in token_ids
+
+    def test_get_token_details(self, admin_api: APIRequestContext, lifecycle_token: dict):
+        """Get specific token details by ID."""
+        resp = admin_api.get(f"/tokens/{lifecycle_token['id']}")
+        assert resp.status == 200
+
+    def test_update_token(self, admin_api: APIRequestContext, lifecycle_token: dict):
+        """Admin can update a token's name."""
+        new_name = f"updated-{uuid.uuid4().hex[:8]}"
+        resp = admin_api.put(f"/tokens/{lifecycle_token['id']}", data={"name": new_name})
+        assert resp.status == 200
+        updated = resp.json()
+        assert _get_token_name(updated) == new_name
+
+    def test_revoke_token(self, admin_api: APIRequestContext):
+        """Admin can revoke a token."""
+        token_name = f"revoke-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post("/tokens", data={"name": token_name, "expires_in_days": 1})
+        assert create_resp.status in (200, 201)
+        token_id = _get_token_id(create_resp.json())
+        resp = admin_api.delete(f"/tokens/{token_id}")
+        assert resp.status in (200, 204)
+
+    def test_admin_list_all_tokens(self, admin_api: APIRequestContext):
+        """Admin can list all tokens across all users."""
+        resp = admin_api.get("/tokens/admin/all")
+        assert resp.status == 200
+        data = resp.json()
+        tokens = data.get("tokens", data if isinstance(data, list) else [])
+        assert isinstance(tokens, list)
+
+
+# ---------------------------------------------------------------------------
+# Token Permission Denial
+# ---------------------------------------------------------------------------
+
+
+class TestTokenPermissions:
+    """Test that non-admin users have limited token access."""
+
+    def test_non_admin_denied_admin_token_list(self, non_admin_api: APIRequestContext):
+        """Non-admin user cannot list all tokens."""
+        resp = non_admin_api.get("/tokens/admin/all")
+        assert resp.status in (401, 403), f"Non-admin should be denied admin token list, got {resp.status}"

--- a/tests/playwright/security/test_user_management.py
+++ b/tests/playwright/security/test_user_management.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""User Management E2E Tests.
+
+Tests the complete user lifecycle through the REST API and admin endpoints:
+create, list, get, update, activate/deactivate, force password change, delete.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext
+import pytest
+
+# Local
+from .conftest import TEST_PASSWORD
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# User CRUD Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestUserLifecycle:
+    """Test user create/read/update/delete operations."""
+
+    @pytest.fixture(scope="class")
+    def lifecycle_email(self, admin_api: APIRequestContext):
+        """Create a user for lifecycle tests, yield email, cleanup after class."""
+        email = f"lifecycle-{uuid.uuid4().hex[:8]}@example.com"
+        resp = admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": email, "password": TEST_PASSWORD, "full_name": "Lifecycle User"},
+        )
+        assert resp.status in (200, 201), f"Failed to create lifecycle user: {resp.status}"
+        yield email
+        try:
+            admin_api.delete(f"/auth/email/admin/users/{email}")
+        except Exception:
+            pass
+
+    def test_create_user(self, admin_api: APIRequestContext):
+        """Admin can create a new user via API."""
+        email = f"create-{uuid.uuid4().hex[:8]}@example.com"
+        resp = admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": email, "password": TEST_PASSWORD, "full_name": "Create Test"},
+        )
+        assert resp.status in (200, 201)
+        body = resp.json()
+        assert body["email"] == email
+        # Cleanup
+        admin_api.delete(f"/auth/email/admin/users/{email}")
+
+    def test_list_users_includes_created(self, admin_api: APIRequestContext, lifecycle_email: str):
+        """Created user appears in the admin user list."""
+        resp = admin_api.get("/auth/email/admin/users")
+        assert resp.status == 200
+        users = resp.json()
+        emails = [u["email"] for u in users]
+        assert lifecycle_email in emails
+
+    def test_get_user_details(self, admin_api: APIRequestContext, lifecycle_email: str):
+        """Get specific user details by email."""
+        resp = admin_api.get(f"/auth/email/admin/users/{lifecycle_email}")
+        assert resp.status == 200
+        user = resp.json()
+        assert user["email"] == lifecycle_email
+        assert user["full_name"] == "Lifecycle User"
+
+    def test_update_user(self, admin_api: APIRequestContext, lifecycle_email: str):
+        """Update user's full name."""
+        resp = admin_api.put(
+            f"/auth/email/admin/users/{lifecycle_email}",
+            data={"full_name": "Updated Lifecycle User"},
+        )
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["full_name"] == "Updated Lifecycle User"
+
+    def test_delete_user(self, admin_api: APIRequestContext):
+        """Admin can delete a user."""
+        email = f"delete-{uuid.uuid4().hex[:8]}@example.com"
+        admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": email, "password": TEST_PASSWORD, "full_name": "Delete Me"},
+        )
+        resp = admin_api.delete(f"/auth/email/admin/users/{email}")
+        assert resp.status in (200, 204)
+        # Verify deleted
+        get_resp = admin_api.get(f"/auth/email/admin/users/{email}")
+        assert get_resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# User Activation / Deactivation
+# ---------------------------------------------------------------------------
+
+
+class TestUserActivation:
+    """Test user activate/deactivate/force-password-change operations."""
+
+    def test_deactivate_user(self, admin_api: APIRequestContext, temp_user: str):
+        """Admin can deactivate a user."""
+        resp = admin_api.put(
+            f"/auth/email/admin/users/{temp_user}",
+            data={"is_active": False},
+        )
+        assert resp.status == 200
+        user = resp.json()
+        assert user.get("is_active") is False
+
+    def test_deactivated_user_cannot_login(self, admin_api: APIRequestContext, anon_api: APIRequestContext):
+        """A deactivated user cannot log in."""
+        # Create and deactivate a user
+        email = f"deact-login-{uuid.uuid4().hex[:8]}@example.com"
+        admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": email, "password": TEST_PASSWORD, "full_name": "Deactivated"},
+        )
+        admin_api.put(f"/auth/email/admin/users/{email}", data={"is_active": False})
+
+        # Try to login as deactivated user
+        login_resp = anon_api.post(
+            "/auth/email/login",
+            data={"email": email, "password": TEST_PASSWORD},
+        )
+        assert login_resp.status in (401, 403), f"Deactivated user should be denied login, got {login_resp.status}"
+
+        # Cleanup
+        admin_api.delete(f"/auth/email/admin/users/{email}")
+
+    def test_reactivate_user(self, admin_api: APIRequestContext, temp_user: str):
+        """Admin can reactivate a deactivated user."""
+        # Deactivate
+        admin_api.put(f"/auth/email/admin/users/{temp_user}", data={"is_active": False})
+        # Reactivate
+        resp = admin_api.put(f"/auth/email/admin/users/{temp_user}", data={"is_active": True})
+        assert resp.status == 200
+        user = resp.json()
+        assert user.get("is_active") is True
+
+    def test_force_password_change(self, admin_api: APIRequestContext, temp_user: str):
+        """Admin can force a user to change their password on next login."""
+        resp = admin_api.put(
+            f"/auth/email/admin/users/{temp_user}",
+            data={"password_change_required": True},
+        )
+        assert resp.status == 200
+        user = resp.json()
+        assert user.get("password_change_required") is True
+
+
+# ---------------------------------------------------------------------------
+# Permission Denial
+# ---------------------------------------------------------------------------
+
+
+class TestUserManagementPermissions:
+    """Test that non-admin users are denied user management operations."""
+
+    def test_non_admin_denied_create_user(self, non_admin_api: APIRequestContext):
+        """Non-admin user cannot create users."""
+        resp = non_admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": "should-fail@example.com", "password": TEST_PASSWORD, "full_name": "Fail"},
+        )
+        assert resp.status in (401, 403), f"Non-admin should be denied, got {resp.status}"
+
+    def test_non_admin_denied_list_users(self, non_admin_api: APIRequestContext):
+        """Non-admin user cannot list all users."""
+        resp = non_admin_api.get("/auth/email/admin/users")
+        assert resp.status in (401, 403), f"Non-admin should be denied, got {resp.status}"
+
+    def test_unauthenticated_denied_user_management(self, anon_api: APIRequestContext):
+        """Unauthenticated requests are denied user management."""
+        resp = anon_api.get("/auth/email/admin/users")
+        assert resp.status in (401, 403), f"Unauthenticated should be denied, got {resp.status}"

--- a/tests/playwright/teams/__init__.py
+++ b/tests/playwright/teams/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Team collaboration E2E test package."""

--- a/tests/playwright/teams/conftest.py
+++ b/tests/playwright/teams/conftest.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for team collaboration E2E tests."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import os
+from typing import Generator
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
+TEST_PASSWORD = "SecureTestPass123!"
+
+
+def _make_jwt(email: str, is_admin: bool = False, teams=None) -> str:
+    """Create a JWT token for testing."""
+    return _create_jwt_token(
+        {"sub": email},
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+    )
+
+
+def create_test_user(admin_api: APIRequestContext, email: str) -> bool:
+    """Create a test user in the database. Returns True on success or already-exists."""
+    resp = admin_api.post(
+        "/auth/email/admin/users",
+        data={"email": email, "password": TEST_PASSWORD, "full_name": f"Test User {email.split('@')[0]}"},
+    )
+    return resp.status in (200, 201, 409)
+
+
+def delete_test_user(admin_api: APIRequestContext, email: str) -> None:
+    """Delete a test user (best-effort, may fail if user has team memberships)."""
+    try:
+        admin_api.delete(f"/auth/email/admin/users/{email}")
+    except Exception:
+        pass
+
+
+def invite_and_accept(admin_api: APIRequestContext, playwright: Playwright, team_id: str, email: str) -> dict:
+    """Invite a user to a team and accept the invitation. Returns the invitation data."""
+    inv_resp = admin_api.post(f"/teams/{team_id}/invitations", data={"email": email, "role": "member"})
+    assert inv_resp.status in (200, 201), f"Failed to invite {email}: {inv_resp.status} {inv_resp.text()}"
+    inv_data = inv_resp.json()
+    invitation_token = inv_data["token"]
+
+    # Accept as the invited user
+    user_jwt = _make_jwt(email, is_admin=False)
+    user_ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {user_jwt}", "Accept": "application/json"},
+    )
+    accept_resp = user_ctx.post(f"/teams/invitations/{invitation_token}/accept")
+    user_ctx.dispose()
+    assert accept_resp.status == 200, f"Failed to accept invitation: {accept_resp.status}"
+    return inv_data
+
+
+@pytest.fixture(scope="module")
+def admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Admin-authenticated API context for team tests."""
+    token = _make_jwt("admin@example.com", is_admin=True)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def private_team(admin_api: APIRequestContext):
+    """Create a private team for invitation tests, cleanup after module."""
+    team_name = f"priv-team-{uuid.uuid4().hex[:8]}"
+    resp = admin_api.post("/teams/", data={"name": team_name, "description": "E2E invite tests", "visibility": "private"})
+    assert resp.status in (200, 201), f"Failed to create private team: {resp.status}"
+    team = resp.json()
+    yield team
+    try:
+        admin_api.delete(f"/teams/{team['id']}")
+    except Exception:
+        pass
+
+
+@pytest.fixture(scope="module")
+def public_team(admin_api: APIRequestContext):
+    """Create a public team for join request tests, cleanup after module."""
+    team_name = f"pub-team-{uuid.uuid4().hex[:8]}"
+    resp = admin_api.post("/teams/", data={"name": team_name, "description": "E2E join tests", "visibility": "public"})
+    assert resp.status in (200, 201), f"Failed to create public team: {resp.status}"
+    team = resp.json()
+    yield team
+    try:
+        admin_api.delete(f"/teams/{team['id']}")
+    except Exception:
+        pass

--- a/tests/playwright/teams/test_team_invitations.py
+++ b/tests/playwright/teams/test_team_invitations.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Team Invitation E2E Tests.
+
+Tests the invitation workflow: send, list, accept, cancel, and permission checks.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+
+# Local
+from .conftest import _make_jwt, BASE_URL, create_test_user, delete_test_user
+
+logger = logging.getLogger(__name__)
+
+
+class TestTeamInvitations:
+    """Test team invitation send/accept/cancel workflow."""
+
+    def test_send_invitation(self, admin_api: APIRequestContext, private_team: dict):
+        """Team owner can send an invitation to a user."""
+        email = f"invite-send-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+
+        resp = admin_api.post(
+            f"/teams/{private_team['id']}/invitations",
+            data={"email": email, "role": "member"},
+        )
+        assert resp.status in (200, 201)
+        inv = resp.json()
+        assert inv["email"] == email
+        assert inv["role"] == "member"
+        assert inv["token"], "Invitation should include a token"
+        assert inv["is_active"] is True
+
+        # Cleanup
+        admin_api.delete(f"/teams/invitations/{inv['id']}")
+        delete_test_user(admin_api, email)
+
+    def test_list_pending_invitations(self, admin_api: APIRequestContext, private_team: dict):
+        """Team owner can list pending invitations."""
+        email = f"invite-list-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+        inv_resp = admin_api.post(f"/teams/{private_team['id']}/invitations", data={"email": email, "role": "member"})
+        assert inv_resp.status in (200, 201), f"Failed to create invitation: {inv_resp.status} {inv_resp.text()}"
+
+        resp = admin_api.get(f"/teams/{private_team['id']}/invitations")
+        assert resp.status == 200
+        invitations = resp.json()
+        assert isinstance(invitations, list)
+        emails = [i["email"] for i in invitations]
+        assert email in emails
+
+        # Cleanup
+        inv_id = next(i["id"] for i in invitations if i["email"] == email)
+        admin_api.delete(f"/teams/invitations/{inv_id}")
+        delete_test_user(admin_api, email)
+
+    def test_accept_invitation(self, admin_api: APIRequestContext, private_team: dict, playwright: Playwright):
+        """Invited user can accept an invitation and become a team member."""
+        email = f"invite-accept-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+
+        # Send invitation
+        inv_resp = admin_api.post(f"/teams/{private_team['id']}/invitations", data={"email": email, "role": "member"})
+        assert inv_resp.status in (200, 201), f"Failed to create invitation: {inv_resp.status} {inv_resp.text()}"
+        invitation_token = inv_resp.json()["token"]
+
+        # Accept as the invited user
+        user_jwt = _make_jwt(email, is_admin=False)
+        user_ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={"Authorization": f"Bearer {user_jwt}", "Accept": "application/json"},
+        )
+        accept_resp = user_ctx.post(f"/teams/invitations/{invitation_token}/accept")
+        user_ctx.dispose()
+        assert accept_resp.status == 200
+
+        # Verify user is now a member
+        members_resp = admin_api.get(f"/teams/{private_team['id']}/members")
+        members = members_resp.json()
+        member_list = members if isinstance(members, list) else members.get("members", [])
+        member_emails = [m["user_email"] for m in member_list]
+        assert email in member_emails
+
+        # Cleanup
+        admin_api.delete(f"/teams/{private_team['id']}/members/{email}")
+        delete_test_user(admin_api, email)
+
+    def test_cancel_invitation(self, admin_api: APIRequestContext, private_team: dict):
+        """Team owner can cancel a pending invitation."""
+        email = f"invite-cancel-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+        inv_resp = admin_api.post(f"/teams/{private_team['id']}/invitations", data={"email": email, "role": "member"})
+        assert inv_resp.status in (200, 201), f"Failed to create invitation: {inv_resp.status} {inv_resp.text()}"
+        inv_id = inv_resp.json()["id"]
+
+        # Cancel the invitation
+        cancel_resp = admin_api.delete(f"/teams/invitations/{inv_id}")
+        assert cancel_resp.status == 200
+
+        # Verify invitation is no longer listed
+        list_resp = admin_api.get(f"/teams/{private_team['id']}/invitations")
+        inv_ids = [i["id"] for i in list_resp.json()]
+        assert inv_id not in inv_ids
+
+        delete_test_user(admin_api, email)
+
+    def test_non_owner_cannot_invite(self, admin_api: APIRequestContext, private_team: dict, playwright: Playwright):
+        """A non-owner member cannot send invitations."""
+        # Create and add a member
+        member_email = f"member-noinvite-{uuid.uuid4().hex[:8]}@example.com"
+        invitee_email = f"target-noinvite-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, member_email)
+        create_test_user(admin_api, invitee_email)
+
+        # Add member via invitation
+        inv_resp = admin_api.post(f"/teams/{private_team['id']}/invitations", data={"email": member_email, "role": "member"})
+        assert inv_resp.status in (200, 201), f"Failed to create invitation: {inv_resp.status} {inv_resp.text()}"
+        inv_token = inv_resp.json()["token"]
+        member_jwt = _make_jwt(member_email, is_admin=False)
+        member_ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={"Authorization": f"Bearer {member_jwt}", "Accept": "application/json"},
+        )
+        member_ctx.post(f"/teams/invitations/{inv_token}/accept")
+
+        # Try to invite as member (should be denied)
+        invite_resp = member_ctx.post(
+            f"/teams/{private_team['id']}/invitations",
+            data={"email": invitee_email, "role": "member"},
+        )
+        member_ctx.dispose()
+        assert invite_resp.status in (403, 422), f"Non-owner should be denied invite, got {invite_resp.status}"
+
+        # Cleanup
+        admin_api.delete(f"/teams/{private_team['id']}/members/{member_email}")
+        delete_test_user(admin_api, member_email)
+        delete_test_user(admin_api, invitee_email)

--- a/tests/playwright/teams/test_team_join_requests.py
+++ b/tests/playwright/teams/test_team_join_requests.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Team Join Request E2E Tests.
+
+Tests the join request workflow: request, list, approve, reject.
+Join requests only work for public-visibility teams.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+
+# Local
+from .conftest import _make_jwt, BASE_URL, create_test_user, delete_test_user
+
+logger = logging.getLogger(__name__)
+
+
+class TestTeamJoinRequests:
+    """Test team join request workflow."""
+
+    def _make_join_request(self, playwright: Playwright, team_id: str, email: str) -> dict:
+        """Submit a join request as the given user. Returns the request data."""
+        user_jwt = _make_jwt(email, is_admin=False)
+        user_ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={"Authorization": f"Bearer {user_jwt}", "Accept": "application/json"},
+        )
+        resp = user_ctx.post(f"/teams/{team_id}/join", data={"message": "Please let me join"})
+        status = resp.status
+        data = resp.json()
+        user_ctx.dispose()
+        assert status == 200, f"Join request failed: {status}"
+        return data
+
+    def test_request_to_join_public_team(self, admin_api: APIRequestContext, public_team: dict, playwright: Playwright):
+        """User can request to join a public team."""
+        email = f"join-req-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+
+        req_data = self._make_join_request(playwright, public_team["id"], email)
+        assert req_data["status"] == "pending"
+        assert req_data["user_email"] == email
+
+        # Cleanup: reject the request (by deleting it)
+        admin_api.delete(f"/teams/{public_team['id']}/join-requests/{req_data['id']}")
+        delete_test_user(admin_api, email)
+
+    def test_list_join_requests(self, admin_api: APIRequestContext, public_team: dict, playwright: Playwright):
+        """Team owner can list pending join requests."""
+        email = f"join-list-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+        req_data = self._make_join_request(playwright, public_team["id"], email)
+
+        resp = admin_api.get(f"/teams/{public_team['id']}/join-requests")
+        assert resp.status == 200
+        requests = resp.json()
+        assert isinstance(requests, list)
+        req_emails = [r["user_email"] for r in requests]
+        assert email in req_emails
+
+        # Cleanup
+        admin_api.delete(f"/teams/{public_team['id']}/join-requests/{req_data['id']}")
+        delete_test_user(admin_api, email)
+
+    def test_approve_join_request(self, admin_api: APIRequestContext, public_team: dict, playwright: Playwright):
+        """Team owner can approve a join request, making the user a member."""
+        email = f"join-approve-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+        req_data = self._make_join_request(playwright, public_team["id"], email)
+
+        # Approve
+        approve_resp = admin_api.post(f"/teams/{public_team['id']}/join-requests/{req_data['id']}/approve")
+        assert approve_resp.status == 200
+
+        # Verify user is now a member
+        members_resp = admin_api.get(f"/teams/{public_team['id']}/members")
+        members = members_resp.json()
+        member_list = members if isinstance(members, list) else members.get("members", [])
+        member_emails = [m["user_email"] for m in member_list]
+        assert email in member_emails
+
+        # Cleanup
+        admin_api.delete(f"/teams/{public_team['id']}/members/{email}")
+        delete_test_user(admin_api, email)
+
+    def test_private_team_join_request_denied(self, admin_api: APIRequestContext, private_team: dict, playwright: Playwright):
+        """Users cannot request to join private teams."""
+        email = f"join-priv-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, email)
+
+        user_jwt = _make_jwt(email, is_admin=False)
+        user_ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={"Authorization": f"Bearer {user_jwt}", "Accept": "application/json"},
+        )
+        resp = user_ctx.post(f"/teams/{private_team['id']}/join", data={"message": "Let me in"})
+        user_ctx.dispose()
+        assert resp.status == 403, f"Private team join should be denied, got {resp.status}"
+
+        delete_test_user(admin_api, email)

--- a/tests/playwright/teams/test_team_member_roles.py
+++ b/tests/playwright/teams/test_team_member_roles.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Team Member Role E2E Tests.
+
+Tests member role changes, member removal, and leaving teams.
+Team roles are "owner" or "member" (distinct from RBAC roles).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# Local
+from .conftest import _make_jwt, BASE_URL, create_test_user, delete_test_user, invite_and_accept
+
+logger = logging.getLogger(__name__)
+
+
+class TestTeamMemberRoles:
+    """Test team member role changes and member management."""
+
+    @pytest.fixture
+    def team_with_member(self, admin_api: APIRequestContext, playwright: Playwright):
+        """Create a team with a member, yield both, cleanup after test."""
+        team_name = f"role-team-{uuid.uuid4().hex[:8]}"
+        team_resp = admin_api.post("/teams/", data={"name": team_name, "description": "Role tests", "visibility": "private"})
+        assert team_resp.status in (200, 201)
+        team = team_resp.json()
+
+        member_email = f"role-member-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, member_email)
+        invite_and_accept(admin_api, playwright, team["id"], member_email)
+
+        yield {"team": team, "member_email": member_email}
+
+        # Cleanup
+        try:
+            admin_api.delete(f"/teams/{team['id']}/members/{member_email}")
+        except Exception:
+            pass
+        try:
+            admin_api.delete(f"/teams/{team['id']}")
+        except Exception:
+            pass
+        delete_test_user(admin_api, member_email)
+
+    def test_update_member_role_to_owner(self, admin_api: APIRequestContext, team_with_member: dict):
+        """Team owner can promote a member to owner."""
+        team_id = team_with_member["team"]["id"]
+        member = team_with_member["member_email"]
+
+        resp = admin_api.put(
+            f"/teams/{team_id}/members/{member}",
+            data={"role": "owner"},
+        )
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["role"] == "owner"
+
+    def test_demote_owner_to_member(self, admin_api: APIRequestContext, team_with_member: dict):
+        """Team owner can demote another owner back to member."""
+        team_id = team_with_member["team"]["id"]
+        member = team_with_member["member_email"]
+
+        # First promote to owner
+        admin_api.put(f"/teams/{team_id}/members/{member}", data={"role": "owner"})
+
+        # Then demote back to member
+        resp = admin_api.put(f"/teams/{team_id}/members/{member}", data={"role": "member"})
+        assert resp.status == 200
+        updated = resp.json()
+        assert updated["role"] == "member"
+
+    def test_remove_member(self, admin_api: APIRequestContext, team_with_member: dict):
+        """Team owner can remove a member from the team."""
+        team_id = team_with_member["team"]["id"]
+        member = team_with_member["member_email"]
+
+        resp = admin_api.delete(f"/teams/{team_id}/members/{member}")
+        assert resp.status == 200
+
+        # Verify member is removed
+        members_resp = admin_api.get(f"/teams/{team_id}/members")
+        members = members_resp.json()
+        member_list = members if isinstance(members, list) else members.get("members", [])
+        member_emails = [m["user_email"] for m in member_list]
+        assert member not in member_emails
+
+    def test_member_leaves_team(self, admin_api: APIRequestContext, team_with_member: dict, playwright: Playwright):
+        """A member can voluntarily leave a team."""
+        team_id = team_with_member["team"]["id"]
+        member = team_with_member["member_email"]
+
+        # Leave as the member
+        member_jwt = _make_jwt(member, is_admin=False)
+        member_ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={"Authorization": f"Bearer {member_jwt}", "Accept": "application/json"},
+        )
+        resp = member_ctx.delete(f"/teams/{team_id}/leave")
+        member_ctx.dispose()
+        assert resp.status == 200
+
+    def test_list_team_members(self, admin_api: APIRequestContext, team_with_member: dict):
+        """Team owner can list all team members."""
+        team_id = team_with_member["team"]["id"]
+
+        resp = admin_api.get(f"/teams/{team_id}/members")
+        assert resp.status == 200
+        members = resp.json()
+        member_list = members if isinstance(members, list) else members.get("members", [])
+        assert len(member_list) >= 2  # owner + added member
+
+    def test_non_owner_cannot_change_roles(self, admin_api: APIRequestContext, team_with_member: dict, playwright: Playwright):
+        """A regular member cannot change other members' roles."""
+        team_id = team_with_member["team"]["id"]
+        member = team_with_member["member_email"]
+
+        # Add a second member
+        second_email = f"second-{uuid.uuid4().hex[:8]}@example.com"
+        create_test_user(admin_api, second_email)
+        invite_and_accept(admin_api, playwright, team_id, second_email)
+
+        # Try to change role as the first member (non-owner)
+        member_jwt = _make_jwt(member, is_admin=False)
+        member_ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={"Authorization": f"Bearer {member_jwt}", "Accept": "application/json"},
+        )
+        resp = member_ctx.put(f"/teams/{team_id}/members/{second_email}", data={"role": "owner"})
+        member_ctx.dispose()
+        assert resp.status in (403, 422), f"Non-owner should be denied role change, got {resp.status}"
+
+        # Cleanup
+        admin_api.delete(f"/teams/{team_id}/members/{second_email}")
+        delete_test_user(admin_api, second_email)


### PR DESCRIPTION
## Summary
- Adds 88 REST API E2E tests organized into 4 test groups covering security, teams, entity lifecycle, and operations
- Tests exercise RBAC admin, token lifecycle, user management, SSO, team invitations/join requests/member roles, CRUD + state management for all entity types, export/import, observability, and LLM config
- Known server bugs tracked as `xfail(strict=True)` referencing #2916 and #2917

## Test Groups

| Group | Tests | Coverage |
|-------|-------|----------|
| `security/` | 30 + 2 xfail | RBAC role CRUD, role assignment, token lifecycle, user management, SSO providers |
| `teams/` | 15 | Invitations, join requests, member roles, leave team, permission checks |
| `entities/` | 32 | Tools/resources/prompts/servers CRUD, activate/deactivate, RBAC denial |
| `operations/` | 13 + 1 xfail | Export/import, health/readiness, metrics, observability, LLM config |

## Test plan
- [x] `pytest tests/playwright/security/ -v` — 30 passed, 5 skipped, 2 xfailed
- [x] `pytest tests/playwright/teams/ -v` — 15 passed
- [x] `pytest tests/playwright/entities/test_entity_lifecycle.py -v` — 32 passed
- [x] `pytest tests/playwright/operations/ -v` — 13 passed, 8 skipped, 1 xfailed
- [x] Combined run: 88 passed, 16 skipped, 3 xfailed
- [x] `make test-ui-headless` picks up all new tests

Closes #2387