### PR TITLE
Fix Default Visibility to Reflect Selected Team Context

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -211,10 +211,12 @@ function updateDefaultVisibility() {
     visibilityPrefixes.forEach((prefix) => {
         const publicId = `[id="${prefix}-public"]`;
         const teamIdStr = `[id="${prefix}-team"]`;
+        const privateIdStr = `[id="${prefix}-private"]`;
 
         // Handle potential duplicate IDs using querySelectorAll
         const publicRadios = document.querySelectorAll(publicId);
         const teamRadios = document.querySelectorAll(teamIdStr);
+        const privateRadios = document.querySelectorAll(privateIdStr);
 
         if (hasTeam) {
             // Default to Team
@@ -229,8 +231,11 @@ function updateDefaultVisibility() {
                     radio.dispatchEvent(new Event("change", { bubbles: true }));
                 }
             });
-            // Reset public radios default state
+            // Reset public and private radios default state
             publicRadios.forEach((radio) => {
+                radio.defaultChecked = false;
+            });
+            privateRadios.forEach((radio) => {
                 radio.defaultChecked = false;
             });
         } else {
@@ -242,8 +247,11 @@ function updateDefaultVisibility() {
                     radio.dispatchEvent(new Event("change", { bubbles: true }));
                 }
             });
-            // Reset team radios default state
+            // Reset team and private radios default state
             teamRadios.forEach((radio) => {
+                radio.defaultChecked = false;
+            });
+            privateRadios.forEach((radio) => {
                 radio.defaultChecked = false;
             });
         }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5156,7 +5156,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       checked
                     />
                     <label
-                      for="edit-visibility-public"
+                      for="gateway-visibility-public"
                       class="ml-2 text-sm text-gray-700 dark:text-gray-400"
                       >🌍Public</label
                     >
@@ -5170,7 +5170,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       class="form-radio h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
                     />
                     <label
-                      for="edit-visibility-team"
+                      for="gateway-visibility-team"
                       class="ml-2 text-sm text-gray-700 dark:text-gray-400"
                       >👥Team</label
                     >
@@ -5184,7 +5184,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       class="form-radio h-5 w-5 text-indigo-600 dark:bg-gray-800 dark:border-gray-600"
                     />
                     <label
-                      for="edit-visibility-private"
+                      for="gateway-visibility-private"
                       class="ml-2 text-sm text-gray-700 dark:text-gray-400"
                       >🔒Private</label
                     >


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2920

## 📌 Summary
The forms for adding MCP servers, Virtual Servers, Tools, Prompts, Resources and A2A defaulted to "Public" visibility bydefault even when a team was selected in the header. This PR ensures the form correctly respects the active team context by setting the default visibility selection to "Team" when a team is selected in the header (team_id is present in the URL).

This change is specifically for better User Experience.


## 🔁 Reproduction Steps

1. Check the default selection for visibility for all the forms is "Public" when "All Teams" is selected in the header.
2. Now select a team from the dashboard header.
Before: The default selection still stays on "Public" even after a team is selected.
After: The default selection for visibility is switched to "Team" instead of "Public", since the user has switched to a Team, he is most likely to create a Team level resource.


## 🐞 Root Cause
The visibility radio buttons in all Create forms (Gateways, Virtual Servers, Tools, Prompts, Resources, A2A) were statically defaulted to "Public" in the HTML using the checked attribute.

Although the active team context (team_id) was reflected in the dashboard header and URL, the forms did not dynamically adjust their default visibility selection based on this context.

As a result:

When a user switched from "All Teams" to a specific Team, the URL contained team_id, but the form visibility default still remained "Public" due to static HTML configuration.
There was no JavaScript logic to read the team_id from the URL and override the default radio selection accordingly.
This caused a mismatch between:
The current team context, and the default visibility selection, leading to inconsistent and unintuitive UX.

## 💡 Fix Description

Introduced a new function updateDefaultVisibility() in admin.js that:

- Reads team_id from window.location.search
- Determines whether a team is active
- Iterates over all visibility radio groups

Sets the default selection dynamically:

- If team_id exists → default to "Team"
- If no team_id (All Teams) → default to "Public"

The function:

- Updates both checked and defaultChecked
- Dispatches a "change" event to ensure any listeners react correctly
- Handles potential duplicate IDs using querySelectorAll
- The function is invoked on DOMContentLoaded to ensure the correct default state is set when the page loads.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed