### PR TITLE
Fix macOS gunicorn worker crashes due to Objective-C fork safety

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -18,6 +18,12 @@ Reference: https://stackoverflow.com/questions/10855197/frequent-worker-timeout
 import os
 import platform
 
+# macOS fork safety fix: Must be set before any workers fork
+# On macOS, Objective-C is not fork-safe. When gunicorn forks workers after
+# certain libraries have initialized Objective-C, it causes crashes.
+if platform.system() == "Darwin":
+    os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
+
 # First-Party
 # Import Pydantic Settings singleton
 from mcpgateway.config import settings

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -45,6 +45,17 @@
 set -euo pipefail
 
 #────────────────────────────────────────────────────────────────────────────────
+# SECTION 0: macOS Fork Safety Fix
+# On macOS, Objective-C is not fork-safe. When gunicorn forks workers after
+# certain libraries (SSL, cryptography) have initialized Objective-C, it causes
+# crashes with "+[NSCharacterSet initialize] may have been in progress".
+# This disables the safety check that causes those crashes.
+#────────────────────────────────────────────────────────────────────────────────
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+fi
+
+#────────────────────────────────────────────────────────────────────────────────
 # SECTION 1: Script Location Detection
 # Determine the absolute path to this script's directory for relative path resolution
 #────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2926

## Summary

Fixes gunicorn worker crashes on macOS by setting `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`.

## Problem

On macOS, gunicorn workers crash with:

```
objc[53393]: +[NSCharacterSet initialize] may have been in progress in another thread when fork() was called.
We cannot safely call it or ignore it in the fork() child process. Crashing instead.
```

This occurs because macOS's Objective-C runtime is not fork-safe. When libraries like SSL or cryptography initialize Objective-C before gunicorn forks workers, the child processes crash.

While PR #2838 disabled `--preload` on macOS, this was insufficient as crashes can occur even without preloading.

## Solution

Set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` on macOS in two locations:

1. **run-gunicorn.sh** - At script start before any Python runs
2. **gunicorn.config.py** - At module import time before workers fork

This disables the Objective-C fork-safety check that causes SIGABRT crashes.

## Changes

- `run-gunicorn.sh`: Added Section 0 to set the environment variable on Darwin
- `gunicorn.config.py`: Added check at module level before imports

## Testing

- [x] Tested on macOS - workers start without crashes
- [x] No impact on Linux (change is Darwin-only)
