### PR TITLE
feat(db): standardize UUID format to hyphenated representation across all models

### DIFF
--- a/mcpgateway/alembic/versions/71e35d2065b6_convert_hex_uuids_to_hyphenated.py
+++ b/mcpgateway/alembic/versions/71e35d2065b6_convert_hex_uuids_to_hyphenated.py
@@ -100,7 +100,14 @@ def upgrade() -> None:
 
     # Helper function to build UUID hyphenation SQL based on database dialect
     def build_hyphenate_uuid_sql(column_name: str) -> str:
-        """Build database-agnostic SQL to convert hex UUID to hyphenated format."""
+        """Build database-agnostic SQL to convert hex UUID to hyphenated format.
+
+        Args:
+            column_name: The name of the column containing the UUID to hyphenate.
+
+        Returns:
+            SQL expression string that converts a 32-char hex UUID to hyphenated format.
+        """
         if dialect == "postgresql":
             # PostgreSQL: substring() and ||
             return (


### PR DESCRIPTION
## **Resolves**

Closes #1324

---

## ⚠️ **Breaking Changes**
 This PR changes UUID format from 32-char hex to 36-char hyphenated.
 API accepts both formats during transition period.
---

## **Issue Summary**

The codebase used inconsistent UUID string representations:

- **Hyphenated format** (36 chars): `550e8400-e29b-41d4-a716-446655440000` (6 models)
- **Hex format** (32 chars): `550e8400e29b41d4a716446655440000` (18 models)

This inconsistency caused:

- Data representation confusion
- API clients handling different formats per entity
- Potential foreign key constraint mismatches
- Deviation from RFC 4122 standard UUID representation

---

## **Solution**

Standardized all UUID primary keys to the **hyphenated format** (`str(uuid.uuid4())`) across all 18 affected models, as recommended in issue #1324. This approach:

- ✅ Ensures consistency across the codebase
- ✅ Maintains RFC 4122 compliance
- ✅ Improves data readability and debuggability
- ✅ Defers performance optimization (native UUID types) until PostgreSQL 18 is production-stable

---

## **Changes Made**

### **1. Model Definitions** (mcpgateway/db.py)

Updated 12 models from hex (`uuid.uuid4().hex`) to hyphenated format (`str(uuid.uuid4())`):

| Model                  | Line | Column Type Change               |
| ---------------------- | ---- | -------------------------------- |
| EmailTeam              | 834  | `String(32)` → `String(36)` |
| EmailTeamMember        | 943  | `String(32)` → `String(36)` |
| EmailTeamMemberHistory | 1009 | `String(32)` → `String(36)` |
| EmailTeamInvitation    | 1078 | `String(32)` → `String(36)` |
| EmailTeamJoinRequest   | 1181 | `String(32)` → `String(36)` |
| Tool                   | 1565 | `String(32)` → `String(36)` |
| Server                 | 2275 | `String(32)` → `String(36)` |
| Gateway                | 2431 | `String(32)` → `String(36)` |
| A2AAgent               | 2555 | `String(32)` → `String(36)` |
| GrpcService            | 2689 | `String(32)` → `String(36)` |
| OAuthToken             | 2780 | `String(32)` → `String(36)` |
| OAuthState             | 2805 | `String(32)` → `String(36)` |

**Note:** 6 models (Role, UserRole, PendingUserApproval, RegisteredOAuthClient, EmailApiToken, SSOAuthSession) already used hyphenated format and required no changes.

### **2. Database Migration** (Alembic)

**File:** `mcpgateway/alembic/versions/*71e35d2065b6_convert_hex_uuids_to_hyphenated.py`

Converts existing hex UUIDs to hyphenated format:

```python
UPDATE table_name SET id =
  CONCAT(
    SUBSTR(id, 1, 8), '-',
    SUBSTR(id, 9, 4), '-',
    SUBSTR(id, 13, 4), '-',
    SUBSTR(id, 17, 4), '-',
    SUBSTR(id, 21)
  )
WHERE id NOT LIKE '%-%-%-%-'  # Idempotent: skip if already converted
```

Handles all 12 affected tables and their foreign key relationships.

### **3. Validation Updates** (mcpgateway/common/validators.py)

- Updated UUID pattern matching to expect 36-character hyphenated format
- Ensures validation consistency across API endpoints

### **4. Schema Updates** (mcpgateway/schemas.py)

- Updated Pydantic models to reflect 36-character UUID fields
- Ensures API serialization consistency

### **5. Test Updates** (6 files)

Updated all test assertions to expect hyphenated UUIDs:

- `tests/mcpgateway/services/test_server_service.py`
- `tests/mcpgateway/test_display_name_uuid_features.py`
- `tests/unit/mcpgateway/test_admin.py`
- `tests/unit/mcpgateway/test_admin_module.py`

---

## **Migration Details**

### **Idempotent Pattern**

The migration checks if conversion already occurred using `WHERE id NOT LIKE '%-%-%-%-'` to safely handle:

- Fresh databases (skip conversion, use models directly)
- Partial migrations (re-run safely)
- Multiple database runs

### **Database Support**

- ✅ SQLite (uses `SUBSTR` + `CONCAT`)
- ✅ PostgreSQL (uses `substring` + `concatenation`)

---

## **Testing**

✅ All existing tests updated and passing:

```bash

# Format
make autoflake isort black pre-commit

# Unit Test
make doctest test lint-web flake8 bandit interrogate pylint verify

make coverage

# Delete existing volume
make clean    
                    
# Create production docker image
make docker-prod      

# Run the gateway - Access it http://localhost:8080          
make compose-lite-up Or make compose-up

# Run load test UI - Access it http://localhost:8089
make load-test-ui

# [OPTIONAL] Run monitoring - Access it http://localhost:3000
make monitoring-lite-up Or make monitoring-up
```

Verification scripts validate:

- UUID format consistency across all models
- Foreign key relationships preserved
- No data loss during migration
- Round-trip conversion accuracy

---

## **Benefits**

1. **Consistency**: Single UUID representation across entire codebase
2. **Standards Compliance**: RFC 4122 hyphenated format is industry standard
3. **Debuggability**: UUIDs are immediately recognizable in logs and database queries
4. **API Clarity**: Clients no longer handle multiple UUID formats per entity
5. **Future-Proof**: Foundation for eventual migration to native PostgreSQL UUID type

---

## **Storage Overhead**

- **Hyphenated format**: 36 bytes per ID (4 bytes increase from hex)
- Trade-off: Accepted per issue recommendation to defer performance optimization until PostgreSQL 18 stability

### **Future Optimization Options**

- Native PostgreSQL UUID type (16 bytes) once stable
- Binary UUID storage with API-level string conversion
- Integer IDs for high-volume tables (if federation allows)

## **Migration Runbook**

### **Rollback (if needed)**

```bash
cd mcpgateway
alembic downgrade -1  # Reverts to previous revision
```

---

## **Related Issues**

- #1324 — UUID format inconsistency tracking issue
- Follows recommendation from issue discussion to use hyphenated format until PostgreSQL 18 is production-stable

---
