### PR TITLE
fix: preserve team_id filter during pagination

### DIFF
--- a/mcpgateway/templates/pagination_controls.html
+++ b/mcpgateway/templates/pagination_controls.html
@@ -78,7 +78,7 @@
     newParams.set(prefix + 'page', page);
     newParams.set(prefix + 'size', this.perPage);
     if (includeInactive !== undefined) {
-      newParams.set(prefix + 'inactive', includeInactive);
+      newParams.set(prefix + 'inactive', includeInactive.toString());
     }
 
     const newUrl = currentUrl.pathname + '?' + newParams.toString() + currentUrl.hash;
@@ -120,6 +120,14 @@
     {% endif %}
     {% endfor %}
     {% endif %}
+
+    // Preserve team_id from current URL (if present) - this ensures team filter
+    // is maintained during pagination
+    const currentUrlParams = new URLSearchParams(window.location.search);
+    const teamIdFromUrl = currentUrlParams.get('team_id');
+    if (teamIdFromUrl) {
+      url.searchParams.set('team_id', teamIdFromUrl);
+    }
 
     // Update browser URL for bookmarking/sharing (with namespaced params)
     this.updateBrowserUrl(page, includeInactive);


### PR DESCRIPTION
Closes #2932

## Summary
- Fix team filter being lost when paginating through admin UI resources (tools, servers, gateways, resources, prompts, agents)
- Added JavaScript to read team_id from current URL and preserve it in pagination requests

## Root Cause
The pagination_controls.html template was not preserving team_id when building pagination URLs. Only include_inactive was being preserved in query_params.

## Test Plan
- [x] Verified pagination tests pass
- [x] Test manually: select team filter, navigate to next page, verify team filter is preserved