### PR TITLE
fix: constrain Team Manage Members modal height to viewport (#2930)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4233,7 +4233,7 @@ async def admin_view_team_members(
                         <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Current Members</h5>
                         <div
                             id="team-members-container-{team.id}"
-                            class="border border-gray-300 dark:border-gray-600 rounded-md p-3 max-h-32 overflow-y-auto dark:bg-gray-700"
+                            class="border border-gray-300 dark:border-gray-600 rounded-md p-3 max-h-64 overflow-y-auto dark:bg-gray-700"
                             data-per-page="{per_page}"
                             hx-get="{root_path}/admin/teams/{team.id}/members/partial?page={page}&per_page={per_page}"
                             hx-trigger="load delay:100ms"
@@ -4249,7 +4249,7 @@ async def admin_view_team_members(
                         <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Users to Add</h5>
                         <div
                             id="team-non-members-container-{team.id}"
-                            class="border border-gray-300 dark:border-gray-600 rounded-md p-3 max-h-32 overflow-y-auto dark:bg-gray-700"
+                            class="border border-gray-300 dark:border-gray-600 rounded-md p-3 max-h-64 overflow-y-auto dark:bg-gray-700"
                             data-per-page="{per_page}"
                             hx-get="{root_path}/admin/teams/{team.id}/non-members/partial?page=1&per_page={per_page}"
                             hx-trigger="load delay:200ms"
@@ -4388,7 +4388,7 @@ async def admin_add_team_members_view(
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Available Users</label>
                             <div
                                 id="user-selector-container-{team.id}"
-                                class="border border-gray-300 dark:border-gray-600 rounded-md p-3 max-h-32 overflow-y-auto dark:bg-gray-700"
+                                class="border border-gray-300 dark:border-gray-600 rounded-md p-3 max-h-64 overflow-y-auto dark:bg-gray-700"
                                 hx-get="{root_path}/admin/users/partial?page=1&per_page=20&render=selector&team_id={team.id}"
                                 hx-trigger="load"
                                 hx-swap="innerHTML"

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -14489,7 +14489,8 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
           >&#8203;</span
         >
         <div
-          class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full sm:p-6"
+          class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg px-4 pt-5 pb-4 text-left shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full sm:p-6"
+          style="max-height: 90vh; overflow-y: auto"
         >
           <div id="team-edit-modal-content">
             <!-- Content will be loaded here -->


### PR DESCRIPTION
  ## 🔗 Related Issue                                                                                                           Closes #2930
                                                                                                                              
  ---                                                                                                                         

  ## 📝 Summary
  Fix the Team Manage Members modal height automatically expanding when scrolling through the "Users to Add" section, which   
  pushed the "Save Changes" button off-screen.

  **Changes:**
  - Cap the modal at `90vh` with `overflow-y: auto` so it never outgrows the viewport
  - Remove `overflow-hidden` from the modal container which was clipping content
  - Increase inner list containers from `max-h-32` to `max-h-64` for better usability while keeping them scrollable

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix
  - [ ] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)
  - [ ] Other (describe below)

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | N/A (HTML/CSS only) |
  | Unit tests                | `make test`     | N/A (HTML/CSS only) |
  | Coverage ≥ 80%            | `make coverage` | N/A (HTML/CSS only) |
  | Manual regression         | Steps below     | ✅ Passed |

  **Manual testing:**
  1. Created 25+ users
  2. Created a team, clicked Manage Members
  3. Scrolled through "Users to Add" — modal stays constrained
  4. Save Changes button remains visible and clickable

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [ ] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  Used inline `style="max-height: 90vh; overflow-y: auto"` instead of Tailwind's `max-h-[90vh]` because the airgapped Tailwind
   build does not support arbitrary bracket values.

<img width="2025" height="1338" alt="Screenshot 2026-02-13 201813" src="https://github.com/user-attachments/assets/289e7431-13ec-45fa-b0ab-26bb9b2a9c1f" />

