### PR TITLE
fix: re-raise asyncio.CancelledError after cleanup (S7497)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11388,6 +11388,7 @@ async def admin_events(request: Request, _user=Depends(get_current_user_with_per
                 for logging error messages.
 
         Raises:
+            asyncio.CancelledError: If the task is cancelled externally.
             Exception: Any unexpected exception raised while iterating over the
                 generator will be caught, logged, and suppressed.
 
@@ -11416,8 +11417,6 @@ async def admin_events(request: Request, _user=Depends(get_current_user_with_per
         try:
             async for event in generator:
                 await event_queue.put(event)
-        except asyncio.CancelledError:
-            pass  # Task cancelled normally
         except Exception as e:
             LOGGER.error(f"Error in {source_name} event subscription: {e}")
 
@@ -11526,6 +11525,7 @@ async def admin_events(request: Request, _user=Depends(get_current_user_with_per
 
         except asyncio.CancelledError:
             LOGGER.debug("SSE Stream cancelled")
+            raise
         except Exception as e:
             LOGGER.error(f"SSE Stream error: {e}")
         finally:

--- a/mcpgateway/cache/registry_cache.py
+++ b/mcpgateway/cache/registry_cache.py
@@ -657,7 +657,11 @@ class CacheInvalidationSubscriber:
         logger.info("CacheInvalidationSubscriber stopped")
 
     async def _listen_loop(self) -> None:
-        """Background loop that listens for and processes invalidation messages."""
+        """Background loop that listens for and processes invalidation messages.
+
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
+        """
         logger.debug("CacheInvalidationSubscriber listen loop started")
         try:
             while self._started and not (self._stop_event and self._stop_event.is_set()):
@@ -681,6 +685,7 @@ class CacheInvalidationSubscriber:
                     await asyncio.sleep(0.1)
         except asyncio.CancelledError:
             logger.debug("CacheInvalidationSubscriber listen loop cancelled")
+            raise
         finally:
             logger.debug("CacheInvalidationSubscriber listen loop exited")
 

--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -408,6 +408,9 @@ class SessionRegistry(SessionBackend):
 
         This prevents memory leaks from tasks that eventually complete after
         being moved to _stuck_tasks during escalation.
+
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
         """
         reap_interval = 30.0  # seconds
         retry_timeout = 2.0  # seconds for retry cancellation
@@ -460,7 +463,7 @@ class SessionRegistry(SessionBackend):
 
             except asyncio.CancelledError:
                 logger.debug("Stuck task reaper cancelled")
-                break
+                raise
             except Exception as e:
                 logger.error(f"Error in stuck task reaper: {e}")
 
@@ -1517,6 +1520,9 @@ class SessionRegistry(SessionBackend):
 
         The task also verifies that local sessions still exist in the database
         and removes them locally if they've been deleted elsewhere.
+
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
         """
         logger.info("Starting database cleanup task")
         while True:
@@ -1569,7 +1575,7 @@ class SessionRegistry(SessionBackend):
 
             except asyncio.CancelledError:
                 logger.info("Database cleanup task cancelled")
-                break
+                raise
             except Exception as e:
                 logger.error(f"Error in database cleanup task: {e}")
                 await asyncio.sleep(600)  # Sleep longer on error
@@ -1666,6 +1672,9 @@ class SessionRegistry(SessionBackend):
         Runs periodically (every minute) to check all local sessions and remove
         those that are no longer connected. This prevents memory leaks from
         accumulating disconnected transport objects.
+
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
         """
         logger.info("Starting memory cleanup task")
         while True:
@@ -1687,7 +1696,7 @@ class SessionRegistry(SessionBackend):
 
             except asyncio.CancelledError:
                 logger.info("Memory cleanup task cancelled")
-                break
+                raise
             except Exception as e:
                 logger.error(f"Error in memory cleanup task: {e}")
                 await asyncio.sleep(300)  # Sleep longer on error

--- a/mcpgateway/reverse_proxy.py
+++ b/mcpgateway/reverse_proxy.py
@@ -511,24 +511,24 @@ class ReverseProxyClient:
             LOGGER.error(f"Error handling gateway message: {e}")
 
     async def _keepalive_loop(self) -> None:
-        """Send periodic keepalive messages."""
-        try:
-            while self.state == ConnectionState.CONNECTED:
-                await asyncio.sleep(self.keepalive_interval)
+        """Send periodic keepalive messages.
 
-                heartbeat = {
-                    "type": MessageType.HEARTBEAT.value,
-                    "sessionId": self.session_id,
-                }
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
+        """
+        while self.state == ConnectionState.CONNECTED:
+            await asyncio.sleep(self.keepalive_interval)
 
-                try:
-                    await self._send_to_gateway(orjson.dumps(heartbeat).decode())
-                except Exception as e:
-                    LOGGER.warning(f"Keepalive failed: {e}")
-                    break
+            heartbeat = {
+                "type": MessageType.HEARTBEAT.value,
+                "sessionId": self.session_id,
+            }
 
-        except asyncio.CancelledError:
-            pass
+            try:
+                await self._send_to_gateway(orjson.dumps(heartbeat).decode())
+            except Exception as e:
+                LOGGER.warning(f"Keepalive failed: {e}")
+                break
 
     async def disconnect(self) -> None:
         """Disconnect from gateway and stop local server."""

--- a/mcpgateway/routers/reverse_proxy.py
+++ b/mcpgateway/routers/reverse_proxy.py
@@ -488,6 +488,9 @@ async def sse_endpoint(
 
         Yields:
             dict: SSE event data.
+
+        Raises:
+            asyncio.CancelledError: If the generator is cancelled.
         """
         try:
             # Send initial connection event
@@ -499,7 +502,7 @@ async def sse_endpoint(
                 yield {"event": "keepalive", "data": orjson.dumps({"timestamp": datetime.now(tz=timezone.utc).isoformat()}).decode()}
 
         except asyncio.CancelledError:
-            pass
+            raise
 
     return StreamingResponse(
         event_generator(),

--- a/mcpgateway/services/elicitation_service.py
+++ b/mcpgateway/services/elicitation_service.py
@@ -220,14 +220,18 @@ class ElicitationService:
         return [e for e in self._pending.values() if session_id in (e.upstream_session_id, e.downstream_session_id)]
 
     async def _cleanup_loop(self):
-        """Background task to periodically clean up expired elicitations."""
+        """Background task to periodically clean up expired elicitations.
+
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
+        """
         while True:
             try:
                 await asyncio.sleep(60)  # Run every minute
                 await self._cleanup_expired()
             except asyncio.CancelledError:
                 logger.info("Elicitation cleanup loop cancelled")
-                break
+                raise
             except Exception as e:
                 logger.error(f"Error in elicitation cleanup loop: {e}", exc_info=True)
 

--- a/mcpgateway/services/notification_service.py
+++ b/mcpgateway/services/notification_service.py
@@ -514,6 +514,9 @@ class NotificationService:
 
         Continuously runs until shutdown is triggered, picking up pending
         refreshes from the queue and executing them.
+
+        Raises:
+            asyncio.CancelledError: If the task is cancelled during shutdown.
         """
         logger.info("NotificationService refresh worker started")
 
@@ -533,7 +536,7 @@ class NotificationService:
 
             except asyncio.CancelledError:
                 logger.debug("Refresh worker cancelled")
-                break
+                raise
             except Exception as e:
                 logger.exception("Error in refresh worker: %s", e)
 

--- a/mcpgateway/transports/sse_transport.py
+++ b/mcpgateway/transports/sse_transport.py
@@ -695,6 +695,9 @@ class SSETransport(Transport):
 
             Yields:
                 SSE event as bytes (pre-formatted SSE frame)
+
+            Raises:
+                asyncio.CancelledError: If the generator is cancelled.
             """
             # Send the endpoint event first
             yield _build_sse_frame(b"endpoint", endpoint_url.encode(), settings.sse_retry_timeout)
@@ -806,6 +809,7 @@ class SSETransport(Transport):
             except asyncio.CancelledError:
                 logger.info("SSE event generator cancelled: %s", self._session_id)
                 self._client_gone.set()
+                raise
             except GeneratorExit:
                 logger.info("SSE generator exit: %s", self._session_id)
                 self._client_gone.set()

--- a/mcpgateway/transports/stdio_transport.py
+++ b/mcpgateway/transports/stdio_transport.py
@@ -190,6 +190,7 @@ class StdioTransport(Transport):
             Received messages
 
         Raises:
+            asyncio.CancelledError: If the receive loop is cancelled.
             RuntimeError: If transport is not connected
 
         Examples:
@@ -226,8 +227,6 @@ class StdioTransport(Transport):
                 message = orjson.loads(line.strip())
                 yield message
 
-            except asyncio.CancelledError:
-                break
             except Exception as e:
                 logger.error(f"Failed to receive message: {e}")
                 continue

--- a/tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py
+++ b/tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py
@@ -363,7 +363,7 @@ class TestCacheInvalidationSubscriber:
         sleep.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_listen_loop_cancelled_error_is_swallowed(self, cache_subscriber):
+    async def test_listen_loop_cancelled_error_is_reraised(self, cache_subscriber):
         stop_event = asyncio.Event()
 
         class CancelPubSub:
@@ -374,7 +374,8 @@ class TestCacheInvalidationSubscriber:
         cache_subscriber._stop_event = stop_event
         cache_subscriber._started = True
 
-        await cache_subscriber._listen_loop()
+        with pytest.raises(asyncio.CancelledError):
+            await cache_subscriber._listen_loop()
 
     @pytest.mark.asyncio
     async def test_process_invalidation_error_path(self, cache_subscriber):

--- a/tests/unit/mcpgateway/cache/test_session_registry_coverage.py
+++ b/tests/unit/mcpgateway/cache/test_session_registry_coverage.py
@@ -347,7 +347,8 @@ class TestReapStuckTasksEdgeCases:
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
             with patch("mcpgateway.cache.session_registry.asyncio.wait_for", fake_wait_for):
-                await registry._reap_stuck_tasks()
+                with pytest.raises(asyncio.CancelledError):
+                    await registry._reap_stuck_tasks()
 
         assert "can_cancel" not in registry._stuck_tasks
 
@@ -383,7 +384,8 @@ class TestReapStuckTasksEdgeCases:
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
             with patch("mcpgateway.cache.session_registry.asyncio.wait_for", fake_wait_for):
-                await registry._reap_stuck_tasks()
+                with pytest.raises(asyncio.CancelledError):
+                    await registry._reap_stuck_tasks()
 
         assert "ce_stuck" not in registry._stuck_tasks
 
@@ -420,7 +422,8 @@ class TestReapStuckTasksEdgeCases:
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
             with patch("mcpgateway.cache.session_registry.asyncio.wait_for", fake_wait_for):
-                await registry._reap_stuck_tasks()
+                with pytest.raises(asyncio.CancelledError):
+                    await registry._reap_stuck_tasks()
 
         assert "Error during stuck task reap for ue_stuck" in caplog.text
 
@@ -446,7 +449,8 @@ class TestReapStuckTasksEdgeCases:
                 raise asyncio.CancelledError()
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
-            await registry._reap_stuck_tasks()
+            with pytest.raises(asyncio.CancelledError):
+                await registry._reap_stuck_tasks()
 
         # Should have slept at least once (continue path)
         assert call_count["n"] >= 1
@@ -474,7 +478,8 @@ class TestReapStuckTasksEdgeCases:
                 raise asyncio.CancelledError()
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
-            await registry._reap_stuck_tasks()
+            with pytest.raises(asyncio.CancelledError):
+                await registry._reap_stuck_tasks()
 
         assert "done_ok" not in registry._stuck_tasks
         assert "Reaped 1 completed stuck tasks" in caplog.text
@@ -510,7 +515,8 @@ class TestReapStuckTasksEdgeCases:
             registry._stuck_tasks = MagicMock()
             registry._stuck_tasks.__bool__ = Mock(return_value=True)
             registry._stuck_tasks.items = Mock(side_effect=RuntimeError("reaper boom"))
-            await registry._reap_stuck_tasks()
+            with pytest.raises(asyncio.CancelledError):
+                await registry._reap_stuck_tasks()
 
         assert "Error in stuck task reaper" in caplog.text
 
@@ -540,7 +546,8 @@ class TestReapStuckTasksEdgeCases:
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
             with patch("mcpgateway.cache.session_registry.asyncio.wait_for", fake_wait_for):
-                await registry._reap_stuck_tasks()
+                with pytest.raises(asyncio.CancelledError):
+                    await registry._reap_stuck_tasks()
 
         assert "Stuck tasks remaining: 1" in caplog.text
 
@@ -2392,7 +2399,8 @@ class TestReapStuckTasksDoneException:
                 raise asyncio.CancelledError()
 
         with patch("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep):
-            await registry._reap_stuck_tasks()
+            with pytest.raises(asyncio.CancelledError):
+                await registry._reap_stuck_tasks()
 
         assert "failed_done" not in registry._stuck_tasks
         assert "Reaped 1 completed stuck tasks" in caplog.text

--- a/tests/unit/mcpgateway/cache/test_session_registry_extended.py
+++ b/tests/unit/mcpgateway/cache/test_session_registry_extended.py
@@ -1044,7 +1044,8 @@ class TestRespondTaskCancellation:
         monkeypatch.setattr("mcpgateway.cache.session_registry.asyncio.sleep", fake_sleep)
         monkeypatch.setattr("mcpgateway.cache.session_registry.asyncio.wait_for", fake_wait_for)
 
-        await registry._reap_stuck_tasks()
+        with pytest.raises(asyncio.CancelledError):
+            await registry._reap_stuck_tasks()
 
         assert "done" not in registry._stuck_tasks
         assert "pending" in registry._stuck_tasks

--- a/tests/unit/mcpgateway/routers/test_reverse_proxy.py
+++ b/tests/unit/mcpgateway/routers/test_reverse_proxy.py
@@ -765,7 +765,7 @@ class TestHTTPEndpoints:
             manager.sessions.clear()
 
     def test_sse_endpoint_handles_cancelled_error(self, mock_websocket):
-        """SSE generator should swallow CancelledError and stop."""
+        """SSE generator should re-raise CancelledError after yielding connected event."""
         session = ReverseProxySession("test-session", mock_websocket, "test-user")
         session.server_info = {"name": "test-server"}
         manager.sessions["test-session"] = session
@@ -781,7 +781,7 @@ class TestHTTPEndpoints:
                 response = await sse_endpoint("test-session", DummyRequest(), credentials="test-user")
                 agen = response.body_iterator
                 first = await agen.__anext__()
-                with pytest.raises(StopAsyncIteration):
+                with pytest.raises(asyncio.CancelledError):
                     await agen.__anext__()
                 return first
 

--- a/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
+++ b/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
@@ -1402,7 +1402,8 @@ class TestStartRpcListener:
                 with patch("mcpgateway.services.mcp_session_pool.WORKER_ID", "worker-1"):
                     with patch.object(pool, "_execute_forwarded_request", new_callable=AsyncMock, return_value={"result": {"ok": True}}) as mock_exec_rpc:
                         with patch.object(pool, "_execute_forwarded_http_request", new_callable=AsyncMock) as mock_exec_http:
-                            await pool.start_rpc_listener()
+                            with pytest.raises(asyncio.CancelledError):
+                                await pool.start_rpc_listener()
 
         # Subscribe/unsubscribe to worker-specific channels
         mock_pubsub.subscribe.assert_awaited_once_with("mcpgw:pool_rpc:worker-1", "mcpgw:pool_http:worker-1")
@@ -1475,7 +1476,8 @@ class TestStartRpcListener:
             with patch("mcpgateway.utils.redis_client.get_redis_client", new_callable=AsyncMock, return_value=mock_redis):
                 with patch("mcpgateway.services.mcp_session_pool.WORKER_ID", "worker-1"):
                     with patch.object(pool, "_execute_forwarded_request", new_callable=AsyncMock) as mock_exec:
-                        await pool.start_rpc_listener()
+                        with pytest.raises(asyncio.CancelledError):
+                            await pool.start_rpc_listener()
 
         mock_exec.assert_not_awaited()
         mock_redis.publish.assert_not_awaited()

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -13434,8 +13434,9 @@ class TestMaintenanceMisc:
         monkeypatch.setattr("mcpgateway.admin.asyncio.wait_for", fake_wait_for, raising=True)
 
         response = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
-        chunks = [chunk async for chunk in response.body_iterator]
-        assert chunks == []
+        with pytest.raises(asyncio.CancelledError):
+            async for _ in response.body_iterator:
+                pass
 
     @pytest.mark.asyncio
     async def test_admin_events_unexpected_exception_logged(self, monkeypatch, allow_permission, mock_db):

--- a/tests/unit/mcpgateway/transports/test_sse_transport.py
+++ b/tests/unit/mcpgateway/transports/test_sse_transport.py
@@ -653,7 +653,7 @@ async def test_create_sse_response_event_generator_cancelled_sets_client_gone(mo
     response = await transport.create_sse_response(request)
     generator = response.body_iterator
     _ = await anext(generator)
-    with pytest.raises(StopAsyncIteration):
+    with pytest.raises(asyncio.CancelledError):
         await anext(generator)
     assert transport._client_gone.is_set()
 

--- a/tests/unit/mcpgateway/transports/test_stdio_transport.py
+++ b/tests/unit/mcpgateway/transports/test_stdio_transport.py
@@ -153,7 +153,7 @@ async def test_receive_message_handles_json_decode_error(transport, caplog):
 
 @pytest.mark.asyncio
 async def test_receive_message_handles_cancelled_error(transport):
-    """receive_message should break on CancelledError."""
+    """receive_message should re-raise CancelledError."""
 
     class CancelReader:
         async def readline(self):
@@ -161,8 +161,9 @@ async def test_receive_message_handles_cancelled_error(transport):
 
     transport._stdin_reader = CancelReader()  # type: ignore[attr-defined]
     transport._connected = True  # type: ignore[attr-defined]
-    msgs = [m async for m in transport.receive_message()]
-    assert msgs == []
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in transport.receive_message():
+            pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Re-raise `asyncio.CancelledError` in 13 locations across transports, caches, and services where it was previously swallowed (via `pass` or `break`), preventing proper task cancellation propagation which caused hanging tasks and zombie connections during shutdown
- Add `try/finally` in `mcp_session_pool._rpc_listener` to ensure `pubsub.unsubscribe` cleanup runs even when `CancelledError` propagates
- Update 16 tests to expect `CancelledError` to propagate instead of being silently swallowed
- Intentionally preserve the standard `task.cancel(); await task; except CancelledError: pass` pattern in shutdown methods where cancellation is self-initiated

Closes #2163