### PR TITLE
feat(charts): add optional compose profile parity components to helm

### DIFF
--- a/charts/mcp-stack/templates/benchmark-stack.yaml
+++ b/charts/mcp-stack/templates/benchmark-stack.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.benchmark.enabled .Values.benchmark.server.enabled }}
+{{- $fullName := include "mcp-stack.fullname" . -}}
+{{- $startPort := int .Values.benchmark.server.service.startPort -}}
+{{- $serverCount := int .Values.benchmark.server.service.serverCount -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-benchmark-server
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-benchmark-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-benchmark-server
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-benchmark-server
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: benchmark-server
+          image: "{{ .Values.benchmark.server.image.repository }}:{{ .Values.benchmark.server.image.tag }}"
+          imagePullPolicy: {{ .Values.benchmark.server.image.pullPolicy }}
+          args:
+            - "-transport={{ .Values.benchmark.server.transport }}"
+            - "-server-count={{ .Values.benchmark.server.service.serverCount }}"
+            - "-start-port={{ .Values.benchmark.server.service.startPort }}"
+            - "-tools={{ .Values.benchmark.server.tools }}"
+            - "-resources={{ .Values.benchmark.server.resources }}"
+            - "-prompts={{ .Values.benchmark.server.prompts }}"
+          ports:
+            {{- range $i, $_ := until $serverCount }}
+            - name: p{{ add $startPort $i }}
+              containerPort: {{ add $startPort $i }}
+            {{- end }}
+          resources:
+{{- toYaml .Values.benchmark.server.resourcesLimits | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-benchmark-server
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-benchmark-server
+spec:
+  type: {{ .Values.benchmark.server.service.type }}
+  selector:
+    app: {{ $fullName }}-benchmark-server
+  ports:
+    {{- range $i, $_ := until $serverCount }}
+    - name: p{{ add $startPort $i }}
+      port: {{ add $startPort $i }}
+      targetPort: {{ add $startPort $i }}
+      protocol: TCP
+    {{- end }}
+{{- end }}

--- a/charts/mcp-stack/templates/configmap-monitoring.yaml
+++ b/charts/mcp-stack/templates/configmap-monitoring.yaml
@@ -1,0 +1,238 @@
+{{- if .Values.monitoring.enabled }}
+{{- $prometheusName := printf "%s-prometheus" (include "mcp-stack.fullname" .) -}}
+{{- $lokiName := printf "%s-loki" (include "mcp-stack.fullname" .) -}}
+{{- $tempoName := printf "%s-tempo" (include "mcp-stack.fullname" .) -}}
+{{- $pgExporterName := printf "%s-postgres-exporter" (include "mcp-stack.fullname" .) -}}
+{{- $redisExporterName := printf "%s-redis-exporter" (include "mcp-stack.fullname" .) -}}
+{{- $pgbouncerExporterName := printf "%s-pgbouncer-exporter" (include "mcp-stack.fullname" .) -}}
+{{- $nginxExporterName := printf "%s-nginx-exporter" (include "mcp-stack.fullname" .) -}}
+{{- $cadvisorName := printf "%s-cadvisor" (include "mcp-stack.fullname" .) -}}
+{{- $gatewayName := printf "%s-mcpgateway" (include "mcp-stack.fullname" .) -}}
+{{- $gatewayPort := .Values.mcpContextForge.service.port -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-prometheus-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $prometheusName }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+
+      - job_name: postgresql
+        static_configs:
+          - targets: ["{{ $pgExporterName }}:{{ .Values.monitoring.postgresExporter.service.port }}"]
+
+      - job_name: redis
+        static_configs:
+          - targets: ["{{ $redisExporterName }}:{{ .Values.monitoring.redisExporter.service.port }}"]
+
+      - job_name: pgbouncer
+        static_configs:
+          - targets: ["{{ $pgbouncerExporterName }}:{{ .Values.monitoring.pgbouncerExporter.service.port }}"]
+
+      - job_name: nginx
+        static_configs:
+          - targets: ["{{ $nginxExporterName }}:{{ .Values.monitoring.nginxExporter.service.port }}"]
+
+      - job_name: cadvisor
+        static_configs:
+          - targets: ["{{ $cadvisorName }}:{{ .Values.monitoring.cadvisor.service.port }}"]
+
+      - job_name: mcpgateway
+        metrics_path: /metrics/prometheus
+        static_configs:
+          - targets: ["{{ $gatewayName }}:{{ $gatewayPort }}"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-loki-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $lokiName }}
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+
+    query_range:
+      results_cache:
+        cache:
+          embedded_cache:
+            enabled: true
+            max_size_mb: 100
+
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      retention_period: 168h
+      ingestion_rate_mb: 16
+      ingestion_burst_size_mb: 32
+
+    compactor:
+      working_directory: /loki/compactor
+      compaction_interval: 10m
+      retention_enabled: true
+      retention_delete_delay: 2h
+      delete_request_store: filesystem
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-tempo-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $tempoName }}
+data:
+  tempo.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3200
+
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+
+    ingester:
+      trace_idle_period: 10s
+      max_block_duration: 5m
+
+    compactor:
+      compaction:
+        block_retention: 24h
+
+    storage:
+      trace:
+        backend: local
+        local:
+          path: /var/tempo/traces
+        wal:
+          path: /var/tempo/wal
+
+    search_enabled: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-promtail-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://{{ $lokiName }}:{{ .Values.monitoring.loki.service.port }}/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: node
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-grafana-datasources
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+data:
+  datasources.yaml: |
+    apiVersion: 1
+
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://{{ $prometheusName }}:{{ .Values.monitoring.prometheus.service.port }}
+        isDefault: true
+        editable: true
+
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://{{ $lokiName }}:{{ .Values.monitoring.loki.service.port }}
+        editable: true
+
+      - name: Tempo
+        uid: tempo
+        type: tempo
+        access: proxy
+        url: http://{{ $tempoName }}:{{ .Values.monitoring.tempo.service.queryPort }}
+        editable: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-grafana-dashboards
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: MCP Gateway Dashboards
+        orgId: 1
+        folder: MCP Gateway
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 30
+        options:
+          path: /etc/grafana/provisioning/dashboards
+{{- end }}

--- a/charts/mcp-stack/templates/configmap-nginx-proxy.yaml
+++ b/charts/mcp-stack/templates/configmap-nginx-proxy.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.nginxProxy.enabled }}
+{{- $gatewayServiceName := .Values.nginxProxy.config.gatewayServiceName | default (printf "%s-mcpgateway" (include "mcp-stack.fullname" .)) -}}
+{{- $gatewayServicePort := .Values.nginxProxy.config.gatewayServicePort | default .Values.mcpContextForge.service.port -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-nginx-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-nginx
+data:
+  nginx.conf: |
+    worker_processes auto;
+
+    events {
+      worker_connections {{ .Values.nginxProxy.config.workerConnections }};
+    }
+
+    http {
+      include /etc/nginx/mime.types;
+      default_type application/octet-stream;
+      sendfile on;
+      keepalive_timeout {{ .Values.nginxProxy.config.keepaliveTimeout }};
+
+      server_tokens off;
+      client_max_body_size {{ .Values.nginxProxy.config.clientMaxBodySize }};
+
+      {{- if .Values.nginxProxy.config.cache.enabled }}
+      proxy_cache_path {{ .Values.nginxProxy.config.cache.path }} levels=1:2 keys_zone=mcp_cache:100m max_size={{ .Values.nginxProxy.config.cache.maxSize }} inactive={{ .Values.nginxProxy.config.cache.inactive }} use_temp_path=off;
+      {{- end }}
+
+      upstream gateway_upstream {
+        server {{ $gatewayServiceName }}:{{ $gatewayServicePort }};
+        keepalive 32;
+      }
+
+      server {
+        listen 80;
+
+        location = /health {
+          access_log off;
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        location = /nginx_status {
+          stub_status on;
+          access_log off;
+          allow all;
+        }
+
+        location / {
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Connection "";
+
+          proxy_connect_timeout 30s;
+          proxy_read_timeout {{ .Values.nginxProxy.config.proxyReadTimeout }};
+          proxy_send_timeout {{ .Values.nginxProxy.config.proxySendTimeout }};
+          send_timeout {{ .Values.nginxProxy.config.sendTimeout }};
+
+          {{- if .Values.nginxProxy.config.cache.enabled }}
+          proxy_cache mcp_cache;
+          proxy_cache_revalidate on;
+          proxy_cache_min_uses 1;
+          proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+          proxy_cache_lock on;
+          proxy_cache_background_update on;
+          proxy_cache_valid 200 1m;
+          proxy_cache_valid 404 10s;
+          add_header X-Cache-Status $upstream_cache_status;
+          {{- end }}
+
+          proxy_pass http://gateway_upstream;
+        }
+      }
+    }
+{{- end }}

--- a/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
+++ b/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
@@ -37,6 +37,14 @@ spec:
         - name: mcp-fast-time-server
           image: "{{ .Values.mcpFastTimeServer.image.repository }}:{{ .Values.mcpFastTimeServer.image.tag }}"
           imagePullPolicy: {{ .Values.mcpFastTimeServer.image.pullPolicy }}
+          {{- if .Values.mcpFastTimeServer.command }}
+          command:
+{{- toYaml .Values.mcpFastTimeServer.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.mcpFastTimeServer.args }}
+          args:
+{{- toYaml .Values.mcpFastTimeServer.args | nindent 12 }}
+          {{- end }}
 
           # ─── Service port exposed inside the pod ───
           ports:

--- a/charts/mcp-stack/templates/deployment-nginx-proxy.yaml
+++ b/charts/mcp-stack/templates/deployment-nginx-proxy.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.nginxProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-nginx
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "mcp-stack.fullname" . }}-nginx
+  template:
+    metadata:
+      labels:
+        app: {{ include "mcp-stack.fullname" . }}-nginx
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      {{- if .Values.nginxProxy.sysctls }}
+      securityContext:
+        sysctls:
+          {{- range .Values.nginxProxy.sysctls }}
+          {{- $parts := splitList "=" . }}
+          - name: {{ index $parts 0 | quote }}
+            value: {{ index $parts 1 | quote }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: nginx
+          image: "{{ .Values.nginxProxy.image.repository }}:{{ .Values.nginxProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.nginxProxy.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+
+          {{- with .Values.nginxProxy.probes.readiness }}
+          readinessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.nginxProxy.probes.liveness }}
+          livenessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+
+          resources:
+{{- toYaml .Values.nginxProxy.resources | nindent 12 }}
+
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "mcp-stack.fullname" . }}-nginx-config
+        - name: nginx-cache
+          {{- if .Values.nginxProxy.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-stack.fullname" . }}-nginx-cache
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}

--- a/charts/mcp-stack/templates/inspector.yaml
+++ b/charts/mcp-stack/templates/inspector.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.inspector.enabled }}
+{{- $fullName := include "mcp-stack.fullname" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-inspector
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-inspector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-inspector
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-inspector
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: mcp-inspector
+          image: "{{ .Values.inspector.image.repository }}:{{ .Values.inspector.image.tag }}"
+          imagePullPolicy: {{ .Values.inspector.image.pullPolicy }}
+          ports:
+            - name: ui
+              containerPort: {{ .Values.inspector.service.uiPort }}
+            - name: api
+              containerPort: {{ .Values.inspector.service.apiPort }}
+          env:
+            {{- range $key, $val := .Values.inspector.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          resources:
+{{- toYaml .Values.inspector.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-inspector
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-inspector
+spec:
+  type: {{ .Values.inspector.service.type }}
+  selector:
+    app: {{ $fullName }}-inspector
+  ports:
+    - name: ui
+      port: {{ .Values.inspector.service.uiPort }}
+      targetPort: {{ .Values.inspector.service.uiPort }}
+      protocol: TCP
+    - name: api
+      port: {{ .Values.inspector.service.apiPort }}
+      targetPort: {{ .Values.inspector.service.apiPort }}
+      protocol: TCP
+{{- end }}

--- a/charts/mcp-stack/templates/monitoring-stack.yaml
+++ b/charts/mcp-stack/templates/monitoring-stack.yaml
@@ -1,0 +1,858 @@
+{{- if .Values.monitoring.enabled }}
+{{- $fullName := include "mcp-stack.fullname" . -}}
+{{- $postgresSecretName := include "mcp-stack.postgresSecretName" . | trim -}}
+{{- $postgresHost := "" -}}
+{{- $postgresPort := "" -}}
+{{- $postgresDB := "" -}}
+{{- if .Values.postgres.external.enabled -}}
+  {{- if .Values.postgres.external.existingSecret -}}
+    {{- $postgresHost = "$(POSTGRES_HOST)" -}}
+    {{- $postgresPort = "$(POSTGRES_PORT)" -}}
+    {{- $postgresDB = "$(POSTGRES_DB)" -}}
+  {{- else -}}
+    {{- $postgresHost = .Values.postgres.external.host -}}
+    {{- $postgresPort = (.Values.postgres.external.port | toString) -}}
+    {{- $postgresDB = .Values.postgres.external.database -}}
+  {{- end -}}
+{{- else -}}
+  {{- $postgresHost = printf "%s-postgres" $fullName -}}
+  {{- $postgresPort = (.Values.postgres.service.port | toString) -}}
+  {{- $postgresDB = .Values.mcpContextForge.env.postgres.db -}}
+{{- end -}}
+
+{{- $redisAddr := "" -}}
+{{- if .Values.redis.external.enabled -}}
+  {{- if .Values.redis.external.url -}}
+    {{- $redisAddr = .Values.redis.external.url -}}
+  {{- else if .Values.redis.external.host -}}
+    {{- $redisAddr = printf "redis://%s:%v" .Values.redis.external.host .Values.redis.external.port -}}
+  {{- end -}}
+{{- else -}}
+  {{- $redisAddr = printf "redis://%s-redis:%v" $fullName .Values.redis.service.port -}}
+{{- end -}}
+
+{{- $pgbouncerHost := printf "%s-pgbouncer" $fullName -}}
+{{- $pgbouncerPort := .Values.pgbouncer.service.port -}}
+
+{{- $nginxScrapeUri := .Values.monitoring.nginxExporter.scrapeUri -}}
+{{- if not $nginxScrapeUri -}}
+  {{- if .Values.tls.enabled -}}
+    {{- $nginxScrapeUri = printf "http://%s-nginx-tls:%v/nginx_status" $fullName .Values.tls.service.httpPort -}}
+  {{- else -}}
+    {{- $nginxScrapeUri = printf "http://%s-nginx:%v/nginx_status" $fullName .Values.nginxProxy.service.port -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if and .Values.monitoring.postgresExporter.enabled (or .Values.postgres.enabled .Values.postgres.external.enabled) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-postgres-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-postgres-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-postgres-exporter
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-postgres-exporter
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: postgres-exporter
+          image: "{{ .Values.monitoring.postgresExporter.image.repository }}:{{ .Values.monitoring.postgresExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.postgresExporter.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.postgresExporter.service.port }}
+          env:
+            {{- if and .Values.postgres.external.enabled .Values.postgres.external.existingSecret }}
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ .Values.postgres.external.hostKey | default "host" }}
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ .Values.postgres.external.portKey | default "port" }}
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ .Values.postgres.external.databaseKey | default "dbname" }}
+            {{- end }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ if .Values.postgres.external.enabled }}{{ .Values.postgres.external.userKey | default "user" }}{{ else }}POSTGRES_USER{{ end }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ if .Values.postgres.external.enabled }}{{ .Values.postgres.external.passwordKey | default "password" }}{{ else }}POSTGRES_PASSWORD{{ end }}
+            - name: DATA_SOURCE_NAME
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ $postgresHost }}:{{ $postgresPort }}/{{ $postgresDB }}?sslmode=disable"
+            - name: PG_EXPORTER_AUTO_DISCOVER_DATABASES
+              value: "true"
+          resources:
+{{- toYaml .Values.monitoring.postgresExporter.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-postgres-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-postgres-exporter
+spec:
+  type: {{ .Values.monitoring.postgresExporter.service.type }}
+  selector:
+    app: {{ $fullName }}-postgres-exporter
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.postgresExporter.service.port }}
+      targetPort: {{ .Values.monitoring.postgresExporter.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if and .Values.monitoring.redisExporter.enabled (or .Values.redis.enabled .Values.redis.external.enabled) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-redis-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-redis-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-redis-exporter
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-redis-exporter
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: redis-exporter
+          image: "{{ .Values.monitoring.redisExporter.image.repository }}:{{ .Values.monitoring.redisExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.redisExporter.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.redisExporter.service.port }}
+          env:
+            - name: REDIS_ADDR
+              value: {{ $redisAddr | quote }}
+          resources:
+{{- toYaml .Values.monitoring.redisExporter.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-redis-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-redis-exporter
+spec:
+  type: {{ .Values.monitoring.redisExporter.service.type }}
+  selector:
+    app: {{ $fullName }}-redis-exporter
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.redisExporter.service.port }}
+      targetPort: {{ .Values.monitoring.redisExporter.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if and .Values.monitoring.pgbouncerExporter.enabled .Values.pgbouncer.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-pgbouncer-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-pgbouncer-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-pgbouncer-exporter
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-pgbouncer-exporter
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: pgbouncer-exporter
+          image: "{{ .Values.monitoring.pgbouncerExporter.image.repository }}:{{ .Values.monitoring.pgbouncerExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.pgbouncerExporter.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.pgbouncerExporter.service.port }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ if .Values.postgres.external.enabled }}{{ .Values.postgres.external.userKey | default "user" }}{{ else }}POSTGRES_USER{{ end }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresSecretName }}
+                  key: {{ if .Values.postgres.external.enabled }}{{ .Values.postgres.external.passwordKey | default "password" }}{{ else }}POSTGRES_PASSWORD{{ end }}
+            - name: PGBOUNCER_EXPORTER_CONNECTION_STRING
+              value: "postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ $pgbouncerHost }}:{{ $pgbouncerPort }}/pgbouncer?sslmode=disable"
+          resources:
+{{- toYaml .Values.monitoring.pgbouncerExporter.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-pgbouncer-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-pgbouncer-exporter
+spec:
+  type: {{ .Values.monitoring.pgbouncerExporter.service.type }}
+  selector:
+    app: {{ $fullName }}-pgbouncer-exporter
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.pgbouncerExporter.service.port }}
+      targetPort: {{ .Values.monitoring.pgbouncerExporter.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if and .Values.monitoring.nginxExporter.enabled (or .Values.nginxProxy.enabled .Values.tls.enabled .Values.monitoring.nginxExporter.scrapeUri) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-nginx-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-nginx-exporter
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-nginx-exporter
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: nginx-exporter
+          image: "{{ .Values.monitoring.nginxExporter.image.repository }}:{{ .Values.monitoring.nginxExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.nginxExporter.image.pullPolicy }}
+          args:
+            - "-nginx.scrape-uri={{ $nginxScrapeUri }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.nginxExporter.service.port }}
+          resources:
+{{- toYaml .Values.monitoring.nginxExporter.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-nginx-exporter
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-exporter
+spec:
+  type: {{ .Values.monitoring.nginxExporter.service.type }}
+  selector:
+    app: {{ $fullName }}-nginx-exporter
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.nginxExporter.service.port }}
+      targetPort: {{ .Values.monitoring.nginxExporter.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if .Values.monitoring.cadvisor.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-cadvisor
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-cadvisor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-cadvisor
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-cadvisor
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: cadvisor
+          image: "{{ .Values.monitoring.cadvisor.image.repository }}:{{ .Values.monitoring.cadvisor.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.cadvisor.image.pullPolicy }}
+          securityContext:
+            privileged: {{ .Values.monitoring.cadvisor.privileged }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.cadvisor.service.port }}
+          volumeMounts:
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+            - name: var-run
+              mountPath: /var/run
+              readOnly: true
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: docker
+              mountPath: /var/lib/docker
+              readOnly: true
+          resources:
+{{- toYaml .Values.monitoring.cadvisor.resources | nindent 12 }}
+      volumes:
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: var-run
+          hostPath:
+            path: /var/run
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: docker
+          hostPath:
+            path: /var/lib/docker
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-cadvisor
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-cadvisor
+spec:
+  type: {{ .Values.monitoring.cadvisor.service.type }}
+  selector:
+    app: {{ $fullName }}-cadvisor
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.cadvisor.service.port }}
+      targetPort: {{ .Values.monitoring.cadvisor.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if .Values.monitoring.prometheus.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-prometheus
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-prometheus
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-prometheus
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: prometheus
+          image: "{{ .Values.monitoring.prometheus.image.repository }}:{{ .Values.monitoring.prometheus.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.prometheus.image.pullPolicy }}
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time={{ .Values.monitoring.prometheus.retention }}"
+            - "--web.enable-lifecycle"
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.prometheus.service.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+            - name: data
+              mountPath: /prometheus
+          resources:
+{{- toYaml .Values.monitoring.prometheus.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-prometheus-config
+        - name: data
+          {{- if .Values.monitoring.prometheus.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-prometheus-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-prometheus
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-prometheus
+spec:
+  type: {{ .Values.monitoring.prometheus.service.type }}
+  selector:
+    app: {{ $fullName }}-prometheus
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.prometheus.service.port }}
+      targetPort: {{ .Values.monitoring.prometheus.service.port }}
+      protocol: TCP
+{{- if .Values.monitoring.prometheus.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-prometheus-data
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-prometheus
+spec:
+  accessModes:
+    {{- range .Values.monitoring.prometheus.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.monitoring.prometheus.persistence.size }}
+  {{- if .Values.monitoring.prometheus.persistence.storageClassName }}
+  storageClassName: {{ .Values.monitoring.prometheus.persistence.storageClassName }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.monitoring.loki.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-loki
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-loki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-loki
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-loki
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: loki
+          image: "{{ .Values.monitoring.loki.image.repository }}:{{ .Values.monitoring.loki.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.loki.image.pullPolicy }}
+          args:
+            - "-config.file=/etc/loki/local-config.yaml"
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.loki.service.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/local-config.yaml
+              subPath: loki-config.yaml
+            - name: data
+              mountPath: /loki
+          resources:
+{{- toYaml .Values.monitoring.loki.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-loki-config
+        - name: data
+          {{- if .Values.monitoring.loki.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-loki-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-loki
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-loki
+spec:
+  type: {{ .Values.monitoring.loki.service.type }}
+  selector:
+    app: {{ $fullName }}-loki
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.loki.service.port }}
+      targetPort: {{ .Values.monitoring.loki.service.port }}
+      protocol: TCP
+{{- if .Values.monitoring.loki.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-loki-data
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-loki
+spec:
+  accessModes:
+    {{- range .Values.monitoring.loki.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.monitoring.loki.persistence.size }}
+  {{- if .Values.monitoring.loki.persistence.storageClassName }}
+  storageClassName: {{ .Values.monitoring.loki.persistence.storageClassName }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.monitoring.tempo.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-tempo
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-tempo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-tempo
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-tempo
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: tempo
+          image: "{{ .Values.monitoring.tempo.image.repository }}:{{ .Values.monitoring.tempo.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.tempo.image.pullPolicy }}
+          args:
+            - "-config.file=/etc/tempo/tempo.yaml"
+          ports:
+            - name: query
+              containerPort: {{ .Values.monitoring.tempo.service.queryPort }}
+            - name: otlp-grpc
+              containerPort: {{ .Values.monitoring.tempo.service.grpcPort }}
+            - name: otlp-http
+              containerPort: {{ .Values.monitoring.tempo.service.httpPort }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tempo/tempo.yaml
+              subPath: tempo.yaml
+            - name: data
+              mountPath: /var/tempo
+          resources:
+{{- toYaml .Values.monitoring.tempo.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-tempo-config
+        - name: data
+          {{- if .Values.monitoring.tempo.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-tempo-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-tempo
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-tempo
+spec:
+  type: {{ .Values.monitoring.tempo.service.type }}
+  selector:
+    app: {{ $fullName }}-tempo
+  ports:
+    - name: query
+      port: {{ .Values.monitoring.tempo.service.queryPort }}
+      targetPort: {{ .Values.monitoring.tempo.service.queryPort }}
+      protocol: TCP
+    - name: grpc
+      port: {{ .Values.monitoring.tempo.service.grpcPort }}
+      targetPort: {{ .Values.monitoring.tempo.service.grpcPort }}
+      protocol: TCP
+    - name: http
+      port: {{ .Values.monitoring.tempo.service.httpPort }}
+      targetPort: {{ .Values.monitoring.tempo.service.httpPort }}
+      protocol: TCP
+{{- if .Values.monitoring.tempo.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-tempo-data
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-tempo
+spec:
+  accessModes:
+    {{- range .Values.monitoring.tempo.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.monitoring.tempo.persistence.size }}
+  {{- if .Values.monitoring.tempo.persistence.storageClassName }}
+  storageClassName: {{ .Values.monitoring.tempo.persistence.storageClassName }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.monitoring.promtail.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-promtail
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-promtail
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-promtail
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-promtail
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: promtail
+          image: "{{ .Values.monitoring.promtail.image.repository }}:{{ .Values.monitoring.promtail.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.promtail.image.pullPolicy }}
+          args:
+            - "-config.file=/etc/promtail/promtail.yaml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail/promtail.yaml
+              subPath: promtail.yaml
+          resources:
+{{- toYaml .Values.monitoring.promtail.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-promtail-config
+{{- end }}
+
+{{- if .Values.monitoring.grafana.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-grafana
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-grafana
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-grafana
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: grafana
+          image: "{{ .Values.monitoring.grafana.image.repository }}:{{ .Values.monitoring.grafana.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.grafana.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.monitoring.grafana.service.port }}
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: {{ .Values.monitoring.grafana.adminPassword | quote }}
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: {{ .Values.monitoring.grafana.allowSignUp | quote }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+              subPath: datasources.yaml
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
+              subPath: dashboards.yaml
+          resources:
+{{- toYaml .Values.monitoring.grafana.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.monitoring.grafana.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-grafana-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: datasources
+          configMap:
+            name: {{ $fullName }}-grafana-datasources
+        - name: dashboard-provider
+          configMap:
+            name: {{ $fullName }}-grafana-dashboards
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-grafana
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-grafana
+spec:
+  type: {{ .Values.monitoring.grafana.service.type }}
+  selector:
+    app: {{ $fullName }}-grafana
+  ports:
+    - name: http
+      port: {{ .Values.monitoring.grafana.service.port }}
+      targetPort: {{ .Values.monitoring.grafana.service.port }}
+      protocol: TCP
+{{- if .Values.monitoring.grafana.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-grafana-data
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-grafana
+spec:
+  accessModes:
+    {{- range .Values.monitoring.grafana.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.monitoring.grafana.persistence.size }}
+  {{- if .Values.monitoring.grafana.persistence.storageClassName }}
+  storageClassName: {{ .Values.monitoring.grafana.persistence.storageClassName }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/mcp-stack/templates/nginx-proxy-pvc.yaml
+++ b/charts/mcp-stack/templates/nginx-proxy-pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.nginxProxy.enabled .Values.nginxProxy.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-nginx-cache
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-nginx
+spec:
+  accessModes:
+    {{- range .Values.nginxProxy.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.nginxProxy.persistence.size }}
+  {{- if .Values.nginxProxy.persistence.storageClassName }}
+  storageClassName: {{ .Values.nginxProxy.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-stack/templates/registration-jobs.yaml
+++ b/charts/mcp-stack/templates/registration-jobs.yaml
@@ -1,0 +1,440 @@
+{{- $fullName := include "mcp-stack.fullname" . -}}
+{{- $gatewayHost := printf "%s-mcpgateway" $fullName -}}
+{{- $gatewayPort := .Values.mcpContextForge.service.port -}}
+{{- $registrationEnabled := .Values.testing.registration.enabled -}}
+{{- $registrationImage := printf "%s:%s" .Values.testing.registration.image.repository .Values.testing.registration.image.tag -}}
+
+{{- if and $registrationEnabled .Values.testing.fastTime.register.enabled .Values.mcpFastTimeServer.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-register-fast-time
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registration
+    app.kubernetes.io/part-of: testing
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.testing.registration.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.testing.registration.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-stack.labels" . | nindent 8 }}
+        app.kubernetes.io/component: registration
+    spec:
+      restartPolicy: {{ .Values.testing.registration.restartPolicy }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: register-fast-time
+          image: {{ $registrationImage | quote }}
+          imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+
+              python3 - <<'PY'
+              import time
+              import urllib.request
+
+              targets = [
+                  ("gateway", "http://{{ $gatewayHost }}:{{ $gatewayPort }}/health", 90),
+                  ("fast_time_server", "http://{{ $fullName }}-mcp-fast-time-server:80/health", 60),
+              ]
+
+              for name, url, tries in targets:
+                  for _ in range(tries):
+                      try:
+                          with urllib.request.urlopen(url, timeout=2) as response:
+                              if response.status == 200:
+                                  break
+                      except Exception:
+                          pass
+                      time.sleep(2)
+                  else:
+                      raise SystemExit(f"{name} failed health check: {url}")
+              PY
+
+              export TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username {{ .Values.testing.registration.jwt.username | quote }} --exp {{ .Values.testing.registration.jwt.expirationMinutes | quote }} --secret {{ .Values.testing.registration.jwt.secret | quote }} --algo HS256 2>/dev/null)"
+
+              python3 - <<'PY'
+              import json
+              import os
+              import time
+              import urllib.error
+              import urllib.request
+
+              gateway_name = "{{ .Values.testing.fastTime.register.gatewayName }}"
+              gateway_url = "http://{{ $fullName }}-mcp-fast-time-server:80{{ .Values.testing.fastTime.register.gatewayPath }}"
+              transport = "{{ .Values.testing.fastTime.register.transport }}"
+              create_virtual_server = "{{ .Values.testing.fastTime.register.createVirtualServer }}".lower() == "true"
+              virtual_server_id = "{{ .Values.testing.fastTime.register.virtualServerId }}"
+              virtual_server_name = "{{ .Values.testing.fastTime.register.virtualServerName }}"
+              virtual_server_description = "{{ .Values.testing.fastTime.register.virtualServerDescription }}"
+
+              token = os.environ["TOKEN"]
+              base = "http://{{ $gatewayHost }}:{{ $gatewayPort }}"
+
+              def api_request(method: str, path: str, payload=None):
+                  url = f"{base}{path}"
+                  body = json.dumps(payload).encode("utf-8") if payload is not None else None
+                  req = urllib.request.Request(url, data=body, method=method)
+                  req.add_header("Authorization", f"Bearer {token}")
+                  req.add_header("Content-Type", "application/json")
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      raw = resp.read().decode("utf-8")
+                      if not raw:
+                          return {}
+                      return json.loads(raw)
+
+              gateways = api_request("GET", "/gateways")
+              for gateway in gateways:
+                  if gateway.get("name") == gateway_name:
+                      try:
+                          api_request("DELETE", f"/gateways/{gateway['id']}")
+                      except Exception:
+                          pass
+
+              created = api_request("POST", "/gateways", {"name": gateway_name, "url": gateway_url, "transport": transport})
+              gateway_id = created.get("id")
+
+              if create_virtual_server and gateway_id:
+                  for _ in range(30):
+                      time.sleep(1)
+                      try:
+                          tools = api_request("GET", "/tools")
+                          if any(tool.get("gatewayId") == gateway_id for tool in tools):
+                              break
+                      except Exception:
+                          pass
+
+                  tools = api_request("GET", "/tools")
+                  resources = api_request("GET", "/resources")
+                  prompts = api_request("GET", "/prompts")
+
+                  tool_ids = [tool["id"] for tool in tools if tool.get("gatewayId") == gateway_id]
+                  resource_ids = [resource["id"] for resource in resources]
+                  prompt_ids = [prompt["id"] for prompt in prompts]
+
+                  try:
+                      api_request("DELETE", f"/servers/{virtual_server_id}")
+                  except Exception:
+                      pass
+
+                  payload = {
+                      "server": {
+                          "id": virtual_server_id,
+                          "name": virtual_server_name,
+                          "description": virtual_server_description,
+                          "associated_tools": tool_ids,
+                          "associated_resources": resource_ids,
+                          "associated_prompts": prompt_ids,
+                      }
+                  }
+                  api_request("POST", "/servers", payload)
+
+              print("fast_time registration complete")
+              PY
+{{- end }}
+
+{{- if and .Values.testing.enabled $registrationEnabled .Values.testing.fastTest.register.enabled .Values.testing.fastTestServer.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-register-fast-test
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registration
+    app.kubernetes.io/part-of: testing
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.testing.registration.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.testing.registration.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-stack.labels" . | nindent 8 }}
+        app.kubernetes.io/component: registration
+    spec:
+      restartPolicy: {{ .Values.testing.registration.restartPolicy }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: register-fast-test
+          image: {{ $registrationImage | quote }}
+          imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+
+              python3 - <<'PY'
+              import time
+              import urllib.request
+
+              targets = [
+                  ("gateway", "http://{{ $gatewayHost }}:{{ $gatewayPort }}/health", 90),
+                  ("fast_test_server", "http://{{ $fullName }}-fast-test-server:{{ .Values.testing.fastTestServer.service.port }}/health", 60),
+              ]
+
+              for name, url, tries in targets:
+                  for _ in range(tries):
+                      try:
+                          with urllib.request.urlopen(url, timeout=2) as response:
+                              if response.status == 200:
+                                  break
+                      except Exception:
+                          pass
+                      time.sleep(2)
+                  else:
+                      raise SystemExit(f"{name} failed health check: {url}")
+              PY
+
+              export TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username {{ .Values.testing.registration.jwt.username | quote }} --exp {{ .Values.testing.registration.jwt.expirationMinutes | quote }} --secret {{ .Values.testing.registration.jwt.secret | quote }} --algo HS256 2>/dev/null)"
+
+              python3 - <<'PY'
+              import json
+              import os
+              import urllib.request
+
+              token = os.environ["TOKEN"]
+              base = "http://{{ $gatewayHost }}:{{ $gatewayPort }}"
+              gateway_name = "{{ .Values.testing.fastTest.register.gatewayName }}"
+              gateway_url = "http://{{ $fullName }}-fast-test-server:{{ .Values.testing.fastTestServer.service.port }}{{ .Values.testing.fastTest.register.gatewayPath }}"
+              transport = "{{ .Values.testing.fastTest.register.transport }}"
+
+              def api_request(method: str, path: str, payload=None):
+                  url = f"{base}{path}"
+                  body = json.dumps(payload).encode("utf-8") if payload is not None else None
+                  req = urllib.request.Request(url, data=body, method=method)
+                  req.add_header("Authorization", f"Bearer {token}")
+                  req.add_header("Content-Type", "application/json")
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      raw = resp.read().decode("utf-8")
+                      return json.loads(raw) if raw else {}
+
+              gateways = api_request("GET", "/gateways")
+              for gateway in gateways:
+                  if gateway.get("name") == gateway_name:
+                      try:
+                          api_request("DELETE", f"/gateways/{gateway['id']}")
+                      except Exception:
+                          pass
+
+              api_request("POST", "/gateways", {"name": gateway_name, "url": gateway_url, "transport": transport})
+              print("fast_test registration complete")
+              PY
+{{- end }}
+
+{{- if and .Values.testing.enabled $registrationEnabled .Values.testing.a2a.register.enabled .Values.testing.a2aEchoAgent.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-register-a2a-echo
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registration
+    app.kubernetes.io/part-of: testing
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.testing.registration.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.testing.registration.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-stack.labels" . | nindent 8 }}
+        app.kubernetes.io/component: registration
+    spec:
+      restartPolicy: {{ .Values.testing.registration.restartPolicy }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: register-a2a-echo
+          image: {{ $registrationImage | quote }}
+          imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+
+              python3 - <<'PY'
+              import time
+              import urllib.request
+
+              targets = [
+                  ("gateway", "http://{{ $gatewayHost }}:{{ $gatewayPort }}/health", 90),
+                  ("a2a_echo_agent", "http://{{ $fullName }}-a2a-echo-agent:{{ .Values.testing.a2aEchoAgent.service.port }}/health", 60),
+              ]
+
+              for name, url, tries in targets:
+                  for _ in range(tries):
+                      try:
+                          with urllib.request.urlopen(url, timeout=2) as response:
+                              if response.status == 200:
+                                  break
+                      except Exception:
+                          pass
+                      time.sleep(2)
+                  else:
+                      raise SystemExit(f"{name} failed health check: {url}")
+              PY
+
+              export TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username {{ .Values.testing.registration.jwt.username | quote }} --exp {{ .Values.testing.registration.jwt.expirationMinutes | quote }} --secret {{ .Values.testing.registration.jwt.secret | quote }} --algo HS256 2>/dev/null)"
+
+              python3 - <<'PY'
+              import json
+              import os
+              import urllib.request
+
+              token = os.environ["TOKEN"]
+              base = "http://{{ $gatewayHost }}:{{ $gatewayPort }}"
+              agent_name = "{{ .Values.testing.a2a.register.name }}"
+
+              def api_request(method: str, path: str, payload=None):
+                  url = f"{base}{path}"
+                  body = json.dumps(payload).encode("utf-8") if payload is not None else None
+                  req = urllib.request.Request(url, data=body, method=method)
+                  req.add_header("Authorization", f"Bearer {token}")
+                  req.add_header("Content-Type", "application/json")
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      raw = resp.read().decode("utf-8")
+                      return json.loads(raw) if raw else {}
+
+              agents = api_request("GET", "/a2a")
+              if isinstance(agents, dict):
+                  agents = agents.get("agents", agents.get("items", []))
+
+              for agent in agents:
+                  if agent.get("name") == agent_name and agent.get("id"):
+                      try:
+                          api_request("DELETE", f"/a2a/{agent['id']}")
+                      except Exception:
+                          pass
+
+              payload = {
+                  "agent": {
+                      "name": agent_name,
+                      "description": "{{ .Values.testing.a2a.register.description }}",
+                      "endpoint_url": "http://{{ $fullName }}-a2a-echo-agent:{{ .Values.testing.a2aEchoAgent.service.port }}{{ .Values.testing.a2a.register.endpointPath }}",
+                      "agent_type": "jsonrpc",
+                      "protocol_version": "{{ .Values.testing.a2a.register.protocolVersion }}",
+                      "capabilities": {"echo": True, "preferredTransport": "JSONRPC"},
+                      "tags": ["testing", "a2a", "echo"],
+                  },
+                  "visibility": "{{ .Values.testing.a2a.register.visibility }}",
+              }
+
+              api_request("POST", "/a2a", payload)
+              print("a2a echo registration complete")
+              PY
+{{- end }}
+
+{{- if and .Values.benchmark.enabled .Values.benchmark.register.enabled $registrationEnabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-register-benchmark
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registration
+    app.kubernetes.io/part-of: benchmark
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.testing.registration.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.testing.registration.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-stack.labels" . | nindent 8 }}
+        app.kubernetes.io/component: registration
+    spec:
+      restartPolicy: {{ .Values.testing.registration.restartPolicy }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: register-benchmark
+          image: {{ $registrationImage | quote }}
+          imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+
+              python3 - <<'PY'
+              import time
+              import urllib.request
+
+              url = "http://{{ $gatewayHost }}:{{ $gatewayPort }}/health"
+              for _ in range(90):
+                  try:
+                      with urllib.request.urlopen(url, timeout=2) as response:
+                          if response.status == 200:
+                              break
+                  except Exception:
+                      pass
+                  time.sleep(2)
+              else:
+                  raise SystemExit(f"gateway failed health check: {url}")
+              PY
+
+              sleep 5
+
+              export TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username {{ .Values.testing.registration.jwt.username | quote }} --exp {{ .Values.testing.registration.jwt.expirationMinutes | quote }} --secret {{ .Values.testing.registration.jwt.secret | quote }} --algo HS256 2>/dev/null)"
+
+              python3 - <<'PY'
+              import json
+              import os
+              import urllib.error
+              import urllib.request
+
+              token = os.environ["TOKEN"]
+              base = "http://{{ $gatewayHost }}:{{ $gatewayPort }}"
+              start_port = int("{{ .Values.benchmark.register.startPort }}")
+              server_count = int("{{ .Values.benchmark.register.serverCount }}")
+              gateway_prefix = "{{ .Values.benchmark.register.gatewayPrefix }}"
+              transport = "{{ .Values.benchmark.register.transport }}"
+
+              def api_request(method: str, path: str, payload=None):
+                  url = f"{base}{path}"
+                  body = json.dumps(payload).encode("utf-8") if payload is not None else None
+                  req = urllib.request.Request(url, data=body, method=method)
+                  req.add_header("Authorization", f"Bearer {token}")
+                  req.add_header("Content-Type", "application/json")
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      raw = resp.read().decode("utf-8")
+                      return json.loads(raw) if raw else {}
+
+              for port in range(start_port, start_port + server_count):
+                  name = f"{gateway_prefix}{port}"
+                  payload = {
+                      "name": name,
+                      "url": f"http://{{ $fullName }}-benchmark-server:{port}/mcp",
+                      "transport": transport,
+                  }
+                  try:
+                      api_request("POST", "/gateways", payload)
+                  except urllib.error.HTTPError as exc:
+                      if exc.code != 409:
+                          raise
+
+              print("benchmark registration complete")
+              PY
+{{- end }}

--- a/charts/mcp-stack/templates/service-nginx-proxy.yaml
+++ b/charts/mcp-stack/templates/service-nginx-proxy.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.nginxProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-stack.fullname" . }}-nginx
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ include "mcp-stack.fullname" . }}-nginx
+spec:
+  type: {{ .Values.nginxProxy.service.type }}
+  selector:
+    app: {{ include "mcp-stack.fullname" . }}-nginx
+  ports:
+    - name: http
+      port: {{ .Values.nginxProxy.service.port }}
+      targetPort: 80
+      protocol: TCP
+{{- end }}

--- a/charts/mcp-stack/templates/testing-stack.yaml
+++ b/charts/mcp-stack/templates/testing-stack.yaml
@@ -1,0 +1,364 @@
+{{- if .Values.testing.enabled }}
+{{- $fullName := include "mcp-stack.fullname" . -}}
+{{- $gatewaySvc := printf "%s-mcpgateway" $fullName -}}
+{{- $gatewayPort := .Values.mcpContextForge.service.port -}}
+{{- $locustHost := .Values.testing.locust.host -}}
+{{- if not $locustHost -}}
+  {{- if .Values.nginxProxy.enabled -}}
+    {{- $locustHost = printf "http://%s-nginx:%v" $fullName .Values.nginxProxy.service.port -}}
+  {{- else if .Values.tls.enabled -}}
+    {{- $locustHost = printf "http://%s-nginx-tls:%v" $fullName .Values.tls.service.httpPort -}}
+  {{- else -}}
+    {{- $locustHost = printf "http://%s:%v" $gatewaySvc $gatewayPort -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if .Values.testing.fastTestServer.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-fast-test-server
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-fast-test-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-fast-test-server
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-fast-test-server
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: fast-test-server
+          image: "{{ .Values.testing.fastTestServer.image.repository }}:{{ .Values.testing.fastTestServer.image.tag }}"
+          imagePullPolicy: {{ .Values.testing.fastTestServer.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.testing.fastTestServer.service.port }}
+          env:
+            {{- range $key, $val := .Values.testing.fastTestServer.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- with .Values.testing.fastTestServer.probes.readiness }}
+          readinessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.testing.fastTestServer.probes.liveness }}
+          livenessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+          resources:
+{{- toYaml .Values.testing.fastTestServer.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-fast-test-server
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-fast-test-server
+spec:
+  type: {{ .Values.testing.fastTestServer.service.type }}
+  selector:
+    app: {{ $fullName }}-fast-test-server
+  ports:
+    - name: http
+      port: {{ .Values.testing.fastTestServer.service.port }}
+      targetPort: {{ .Values.testing.fastTestServer.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if .Values.testing.a2aEchoAgent.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-a2a-echo-agent
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-a2a-echo-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-a2a-echo-agent
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-a2a-echo-agent
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: a2a-echo-agent
+          image: "{{ .Values.testing.a2aEchoAgent.image.repository }}:{{ .Values.testing.a2aEchoAgent.image.tag }}"
+          imagePullPolicy: {{ .Values.testing.a2aEchoAgent.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.testing.a2aEchoAgent.service.port }}
+          env:
+            {{- range $key, $val := .Values.testing.a2aEchoAgent.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- with .Values.testing.a2aEchoAgent.probes.readiness }}
+          readinessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.testing.a2aEchoAgent.probes.liveness }}
+          livenessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+          resources:
+{{- toYaml .Values.testing.a2aEchoAgent.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-a2a-echo-agent
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-a2a-echo-agent
+spec:
+  type: {{ .Values.testing.a2aEchoAgent.service.type }}
+  selector:
+    app: {{ $fullName }}-a2a-echo-agent
+  ports:
+    - name: http
+      port: {{ .Values.testing.a2aEchoAgent.service.port }}
+      targetPort: {{ .Values.testing.a2aEchoAgent.service.port }}
+      protocol: TCP
+{{- end }}
+
+{{- if and .Values.testing.locust.enabled (not .Values.testing.locust.script.existingConfigMap) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-locust-script
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-locust
+    app.kubernetes.io/component: loadtest
+data:
+  {{ .Values.testing.locust.script.key }}: |
+{{ .Values.testing.locust.script.inline | nindent 4 }}
+{{- end }}
+
+{{- if .Values.testing.locust.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-locust
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-locust
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-locust
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-locust
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      initContainers:
+        - name: generate-jwt
+          image: "{{ .Values.testing.registration.image.repository }}:{{ .Values.testing.registration.image.tag }}"
+          imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token \
+                --username {{ .Values.testing.registration.jwt.username | quote }} \
+                --exp {{ .Values.testing.registration.jwt.expirationMinutes | quote }} \
+                --secret {{ .Values.testing.registration.jwt.secret | quote }} \
+                --algo HS256 2>/dev/null)
+              printf "%s" "$TOKEN" > /tokens/gateway.jwt
+          volumeMounts:
+            - name: token-volume
+              mountPath: /tokens
+      containers:
+        - name: locust
+          image: "{{ .Values.testing.locust.image.repository }}:{{ .Values.testing.locust.image.tag }}"
+          imagePullPolicy: {{ .Values.testing.locust.image.pullPolicy }}
+          ports:
+            - name: web
+              containerPort: {{ .Values.testing.locust.service.port }}
+          env:
+            - name: HOME
+              value: /tmp
+            - name: LOCUST_MODE
+              value: {{ .Values.testing.locust.mode | quote }}
+            - name: LOCUST_USERS
+              value: {{ .Values.testing.locust.users | quote }}
+            - name: LOCUST_SPAWN_RATE
+              value: {{ .Values.testing.locust.spawnRate | quote }}
+            - name: LOCUST_RUN_TIME
+              value: {{ .Values.testing.locust.runTime | quote }}
+            - name: LOCUST_EXPECT_WORKERS
+              value: {{ .Values.testing.locust.expectWorkers | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              export MCPGATEWAY_BEARER_TOKEN="$(cat /tokens/gateway.jwt)"
+              MODE="${LOCUST_MODE:-master}"
+              if [ "$MODE" = "headless" ]; then
+                exec locust -f /mnt/locust/{{ .Values.testing.locust.script.key }} \
+                  --host={{ $locustHost | quote }} \
+                  --users="${LOCUST_USERS:-100}" \
+                  --spawn-rate="${LOCUST_SPAWN_RATE:-10}" \
+                  --run-time="${LOCUST_RUN_TIME:-5m}" \
+                  --headless \
+                  --only-summary
+              fi
+
+              exec locust -f /mnt/locust/{{ .Values.testing.locust.script.key }} \
+                --host={{ $locustHost | quote }} \
+                --web-host=0.0.0.0 \
+                --web-port={{ .Values.testing.locust.service.port }} \
+                --master \
+                --expect-workers="${LOCUST_EXPECT_WORKERS:-1}" \
+                --class-picker
+          volumeMounts:
+            - name: token-volume
+              mountPath: /tokens
+            - name: locust-script
+              mountPath: /mnt/locust
+          resources:
+{{- toYaml .Values.testing.locust.resources | nindent 12 }}
+      volumes:
+        - name: token-volume
+          emptyDir: {}
+        - name: locust-script
+          configMap:
+            name: {{ .Values.testing.locust.script.existingConfigMap | default (printf "%s-locust-script" $fullName) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-locust
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-locust
+spec:
+  type: {{ .Values.testing.locust.service.type }}
+  selector:
+    app: {{ $fullName }}-locust
+  ports:
+    - name: web
+      port: {{ .Values.testing.locust.service.port }}
+      targetPort: {{ .Values.testing.locust.service.port }}
+      protocol: TCP
+{{- if and .Values.testing.locust.worker.enabled (gt (.Values.testing.locust.worker.replicaCount | int) 0) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-locust-worker
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-locust-worker
+spec:
+  replicas: {{ .Values.testing.locust.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-locust-worker
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-locust-worker
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      initContainers:
+        - name: generate-jwt
+          image: "{{ .Values.testing.registration.image.repository }}:{{ .Values.testing.registration.image.tag }}"
+          imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token \
+                --username {{ .Values.testing.registration.jwt.username | quote }} \
+                --exp {{ .Values.testing.registration.jwt.expirationMinutes | quote }} \
+                --secret {{ .Values.testing.registration.jwt.secret | quote }} \
+                --algo HS256 2>/dev/null)
+              printf "%s" "$TOKEN" > /tokens/gateway.jwt
+          volumeMounts:
+            - name: token-volume
+              mountPath: /tokens
+      containers:
+        - name: locust-worker
+          image: "{{ .Values.testing.locust.image.repository }}:{{ .Values.testing.locust.image.tag }}"
+          imagePullPolicy: {{ .Values.testing.locust.image.pullPolicy }}
+          env:
+            - name: HOME
+              value: /tmp
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              export MCPGATEWAY_BEARER_TOKEN="$(cat /tokens/gateway.jwt)"
+              exec locust -f /mnt/locust/{{ .Values.testing.locust.script.key }} \
+                --host={{ $locustHost | quote }} \
+                --worker \
+                --master-host={{ $fullName }}-locust
+          volumeMounts:
+            - name: token-volume
+              mountPath: /tokens
+            - name: locust-script
+              mountPath: /mnt/locust
+          resources:
+{{- toYaml .Values.testing.locust.resources | nindent 12 }}
+      volumes:
+        - name: token-volume
+          emptyDir: {}
+        - name: locust-script
+          configMap:
+            name: {{ .Values.testing.locust.script.existingConfigMap | default (printf "%s-locust-script" $fullName) }}
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/mcp-stack/templates/tls-stack.yaml
+++ b/charts/mcp-stack/templates/tls-stack.yaml
@@ -1,0 +1,250 @@
+{{- if .Values.tls.enabled }}
+{{- $fullName := include "mcp-stack.fullname" . -}}
+{{- $gatewayService := printf "%s-mcpgateway" $fullName -}}
+{{- $gatewayPort := .Values.mcpContextForge.service.port -}}
+{{- $tlsSecretName := .Values.tls.certificate.existingSecret | default (printf "%s-nginx-tls-cert" $fullName) -}}
+
+{{- if and (not .Values.tls.certificate.existingSecret) .Values.tls.certificate.selfSigned.enabled }}
+{{- $cert := genSelfSignedCert .Values.tls.certificate.selfSigned.commonName .Values.tls.certificate.selfSigned.ipAddresses .Values.tls.certificate.selfSigned.dnsNames (.Values.tls.certificate.selfSigned.durationDays | int) -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $tlsSecretName }}
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-tls
+  type: kubernetes.io/tls
+data:
+  {{ .Values.tls.certificate.certKey }}: {{ $cert.Cert | b64enc }}
+  {{ .Values.tls.certificate.privateKeyKey }}: {{ $cert.Key | b64enc }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-nginx-tls-config
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-tls
+data:
+  nginx.conf: |
+    worker_processes auto;
+
+    events {
+      worker_connections 8192;
+    }
+
+    http {
+      include /etc/nginx/mime.types;
+      default_type application/octet-stream;
+      sendfile on;
+      keepalive_timeout 65;
+      server_tokens off;
+
+      proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mcp_cache:100m max_size=1g inactive=10m use_temp_path=off;
+
+      upstream gateway_upstream {
+        server {{ $gatewayService }}:{{ $gatewayPort }};
+        keepalive 32;
+      }
+
+      server {
+        listen 80;
+
+        location = /health {
+          access_log off;
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        location = /nginx_status {
+          stub_status on;
+          access_log off;
+          allow all;
+        }
+
+        {{- if .Values.tls.forceHttps }}
+        location / {
+          return 301 https://$host$request_uri;
+        }
+        {{- else }}
+        location / {
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Connection "";
+          proxy_cache mcp_cache;
+          proxy_cache_revalidate on;
+          proxy_cache_min_uses 1;
+          proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+          proxy_cache_lock on;
+          proxy_cache_background_update on;
+          proxy_cache_valid 200 1m;
+          proxy_cache_valid 404 10s;
+          add_header X-Cache-Status $upstream_cache_status;
+          proxy_pass http://gateway_upstream;
+        }
+        {{- end }}
+      }
+
+      server {
+        listen 443 ssl;
+        ssl_certificate /etc/nginx/certs/{{ .Values.tls.certificate.certKey }};
+        ssl_certificate_key /etc/nginx/certs/{{ .Values.tls.certificate.privateKeyKey }};
+
+        location = /health {
+          access_log off;
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        location = /nginx_status {
+          stub_status on;
+          access_log off;
+          allow all;
+        }
+
+        location / {
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Connection "";
+          proxy_cache mcp_cache;
+          proxy_cache_revalidate on;
+          proxy_cache_min_uses 1;
+          proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+          proxy_cache_lock on;
+          proxy_cache_background_update on;
+          proxy_cache_valid 200 1m;
+          proxy_cache_valid 404 10s;
+          add_header X-Cache-Status $upstream_cache_status;
+          proxy_pass http://gateway_upstream;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-nginx-tls
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-tls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullName }}-nginx-tls
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}-nginx-tls
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
+      {{- end }}
+      {{- if .Values.tls.sysctls }}
+      securityContext:
+        sysctls:
+          {{- range .Values.tls.sysctls }}
+          {{- $parts := splitList "=" . }}
+          - name: {{ index $parts 0 | quote }}
+            value: {{ index $parts 1 | quote }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: nginx-tls
+          image: "{{ .Values.tls.image.repository }}:{{ .Values.tls.image.tag }}"
+          imagePullPolicy: {{ .Values.tls.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.tls.service.httpPort }}
+            - name: https
+              containerPort: {{ .Values.tls.service.httpsPort }}
+          {{- with .Values.tls.probes.readiness }}
+          readinessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tls.probes.liveness }}
+          livenessProbe:
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+          {{- end }}
+          resources:
+{{- toYaml .Values.tls.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: certs
+              mountPath: /etc/nginx/certs
+              readOnly: true
+            - name: cache
+              mountPath: /var/cache/nginx
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-nginx-tls-config
+        - name: certs
+          secret:
+            secretName: {{ $tlsSecretName }}
+        - name: cache
+          {{- if .Values.tls.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-nginx-tls-cache
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-nginx-tls
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-tls
+spec:
+  type: {{ .Values.tls.service.type }}
+  selector:
+    app: {{ $fullName }}-nginx-tls
+  ports:
+    - name: http
+      port: {{ .Values.tls.service.httpPort }}
+      targetPort: {{ .Values.tls.service.httpPort }}
+      protocol: TCP
+    - name: https
+      port: {{ .Values.tls.service.httpsPort }}
+      targetPort: {{ .Values.tls.service.httpsPort }}
+      protocol: TCP
+{{- if .Values.tls.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-nginx-tls-cache
+  labels:
+    {{- include "mcp-stack.labels" . | nindent 4 }}
+    app: {{ $fullName }}-nginx-tls
+spec:
+  accessModes:
+    {{- range .Values.tls.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.tls.persistence.size }}
+  {{- if .Values.tls.persistence.storageClassName }}
+  storageClassName: {{ .Values.tls.persistence.storageClassName }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -1859,6 +1859,22 @@
           "maximum": 65535,
           "default": 8080
         },
+        "command": {
+          "type": "array",
+          "description": "Optional command override",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "args": {
+          "type": "array",
+          "description": "Optional args override",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
         "ingress": {
           "type": "object",
           "description": "Fast Time Server ingress configuration",
@@ -1943,6 +1959,36 @@
         }
       },
       "additionalProperties": false
+    },
+    "nginxProxy": {
+      "type": "object",
+      "description": "Optional nginx reverse-proxy profile values",
+      "additionalProperties": true
+    },
+    "monitoring": {
+      "type": "object",
+      "description": "Optional monitoring profile values",
+      "additionalProperties": true
+    },
+    "testing": {
+      "type": "object",
+      "description": "Optional testing profile values",
+      "additionalProperties": true
+    },
+    "benchmark": {
+      "type": "object",
+      "description": "Optional benchmark profile values",
+      "additionalProperties": true
+    },
+    "tls": {
+      "type": "object",
+      "description": "Optional TLS profile values",
+      "additionalProperties": true
+    },
+    "inspector": {
+      "type": "object",
+      "description": "Optional MCP inspector profile values",
+      "additionalProperties": true
     }
   },
   "$defs": {

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -1421,6 +1421,13 @@ mcpFastTimeServer:
     tag: "latest"
     pullPolicy: IfNotPresent
   port: 8080
+  # Docker Compose parity flags (optional override)
+  command: []
+  args:
+    - -transport=dual
+    - -listen=0.0.0.0
+    - -port=8080
+    - -log-level=info
 
   # Ingress example (leave as-is if you already have it)
   ingress:
@@ -1465,3 +1472,586 @@ mcpFastTimeServer:
     requests:
       cpu: 25m
       memory: 10Mi
+
+########################################################################
+# COMPOSE PARITY - Optional docker-compose profile components
+# All sections below are disabled by default and can be enabled selectively.
+########################################################################
+
+########################################################################
+# NGINX PROXY - Reverse proxy / cache layer in front of the gateway
+########################################################################
+nginxProxy:
+  enabled: false
+
+  image:
+    repository: mcpgateway/nginx-cache
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  # Nginx cache persistence
+  persistence:
+    enabled: true
+    storageClassName: ""
+    accessModes: [ReadWriteOnce]
+    size: 2Gi
+
+  # Optional sysctls applied to the nginx pod
+  sysctls:
+    - net.ipv4.tcp_fin_timeout=15
+    - net.ipv4.ip_local_port_range=1024 65535
+
+  resources:
+    limits:
+      cpu: "4"
+      memory: 1Gi
+    requests:
+      cpu: "2"
+      memory: 512Mi
+
+  probes:
+    readiness:
+      type: http
+      path: /health
+      port: 80
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+    liveness:
+      type: http
+      path: /health
+      port: 80
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+
+  config:
+    workerConnections: 8192
+    keepaliveTimeout: 65
+    clientMaxBodySize: 25m
+    proxyReadTimeout: 300s
+    proxySendTimeout: 300s
+    sendTimeout: 300s
+
+    cache:
+      enabled: true
+      path: /var/cache/nginx
+      maxSize: 1g
+      inactive: 10m
+
+########################################################################
+# MONITORING STACK - Prometheus/Grafana/Loki/Tempo + exporters
+########################################################################
+monitoring:
+  enabled: false
+
+  postgresExporter:
+    enabled: true
+    image:
+      repository: quay.io/prometheuscommunity/postgres-exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 9187
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+  redisExporter:
+    enabled: true
+    image:
+      repository: oliver006/redis_exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 9121
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+  pgbouncerExporter:
+    enabled: true
+    image:
+      repository: prometheuscommunity/pgbouncer-exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 9127
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+  nginxExporter:
+    enabled: true
+    image:
+      repository: nginx/nginx-prometheus-exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 9113
+    # If empty, chart auto-targets in-cluster nginx proxy service
+    scrapeUri: ""
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+  cadvisor:
+    enabled: true
+    image:
+      repository: gcr.io/cadvisor/cadvisor
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 8080
+    privileged: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  prometheus:
+    enabled: true
+    image:
+      repository: prom/prometheus
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 9090
+    retention: 7d
+    persistence:
+      enabled: true
+      storageClassName: ""
+      accessModes: [ReadWriteOnce]
+      size: 8Gi
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 256Mi
+
+  loki:
+    enabled: true
+    image:
+      repository: grafana/loki
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 3100
+    persistence:
+      enabled: true
+      storageClassName: ""
+      accessModes: [ReadWriteOnce]
+      size: 8Gi
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+
+  tempo:
+    enabled: true
+    image:
+      repository: grafana/tempo
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      queryPort: 3200
+      grpcPort: 4317
+      httpPort: 4318
+    persistence:
+      enabled: true
+      storageClassName: ""
+      accessModes: [ReadWriteOnce]
+      size: 8Gi
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+
+  promtail:
+    enabled: true
+    image:
+      repository: grafana/promtail
+      tag: latest
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  grafana:
+    enabled: true
+    image:
+      repository: grafana/grafana
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 3000
+    adminPassword: changeme
+    allowSignUp: false
+    persistence:
+      enabled: true
+      storageClassName: ""
+      accessModes: [ReadWriteOnce]
+      size: 5Gi
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+
+########################################################################
+# TESTING PROFILE - fast-test server, A2A echo agent, locust, auto-register
+########################################################################
+testing:
+  enabled: false
+
+  registration:
+    enabled: true
+    image:
+      repository: mcpgateway/mcpgateway
+      tag: latest
+      pullPolicy: IfNotPresent
+    backoffLimit: 2
+    activeDeadlineSeconds: 600
+    restartPolicy: Never
+    jwt:
+      username: admin@example.com
+      expirationMinutes: 10080
+      secret: my-test-key
+
+  fastTime:
+    register:
+      enabled: false
+      gatewayName: fast_time
+      gatewayPath: /http
+      transport: STREAMABLEHTTP
+      createVirtualServer: true
+      virtualServerId: 9779b6698cbd4b4995ee04a4fab38737
+      virtualServerName: Fast Time Server
+      virtualServerDescription: Virtual server exposing Fast Time MCP tools/resources/prompts
+
+  fastTestServer:
+    enabled: true
+    image:
+      repository: mcpgateway/fast-test-server
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 8880
+    env:
+      BIND_ADDRESS: 0.0.0.0:8880
+      RUST_LOG: info
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 128Mi
+    probes:
+      readiness:
+        type: http
+        path: /health
+        port: 8880
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 3
+      liveness:
+        type: http
+        path: /health
+        port: 8880
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 3
+
+  fastTest:
+    register:
+      enabled: true
+      gatewayName: fast_test
+      gatewayPath: /mcp
+      transport: STREAMABLEHTTP
+
+  a2aEchoAgent:
+    enabled: true
+    image:
+      repository: mcpgateway/a2a-echo-agent
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 9100
+    env:
+      A2A_ECHO_ADDR: 0.0.0.0:9100
+      A2A_ECHO_NAME: a2a-echo-agent
+      A2A_ECHO_LOG_LEVEL: info
+    resources:
+      limits:
+        cpu: "1"
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 64Mi
+    probes:
+      readiness:
+        type: http
+        path: /health
+        port: 9100
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 3
+      liveness:
+        type: http
+        path: /health
+        port: 9100
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 3
+
+  a2a:
+    register:
+      enabled: true
+      name: a2a-echo-agent
+      description: Lightweight A2A echo agent for Kubernetes testing
+      endpointPath: /
+      protocolVersion: 0.3.0
+      visibility: public
+
+  locust:
+    enabled: true
+    image:
+      repository: locustio/locust
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 8089
+    mode: master
+    users: 100
+    spawnRate: 10
+    runTime: 5m
+    expectWorkers: 1
+    host: ""
+    worker:
+      enabled: true
+      replicaCount: 1
+    script:
+      existingConfigMap: ""
+      key: locustfile.py
+      inline: |
+        from locust import HttpUser, between, task
+
+        class MCPGatewaySmokeUser(HttpUser):
+            wait_time = between(1, 3)
+
+            @task(3)
+            def health(self):
+                self.client.get("/health", name="GET /health")
+
+            @task(2)
+            def ready(self):
+                self.client.get("/ready", name="GET /ready")
+
+            @task(1)
+            def version(self):
+                self.client.get("/version", name="GET /version")
+
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 128Mi
+
+########################################################################
+# BENCHMARK PROFILE - benchmark MCP server + auto registration
+########################################################################
+benchmark:
+  enabled: false
+
+  server:
+    enabled: true
+    image:
+      repository: mcpgateway/benchmark-server
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      startPort: 9000
+      serverCount: 10
+    transport: http
+    tools: 50
+    resources: 20
+    prompts: 10
+    resourcesLimits:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 256Mi
+
+  register:
+    enabled: true
+    gatewayPrefix: benchmark-
+    transport: STREAMABLEHTTP
+    startPort: 9000
+    serverCount: 10
+
+########################################################################
+# TLS PROFILE - TLS-enabled nginx frontend and cert management
+########################################################################
+tls:
+  enabled: false
+
+  forceHttps: false
+
+  image:
+    repository: mcpgateway/nginx-cache
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    httpPort: 80
+    httpsPort: 443
+
+  persistence:
+    enabled: true
+    storageClassName: ""
+    accessModes: [ReadWriteOnce]
+    size: 2Gi
+
+  resources:
+    limits:
+      cpu: "4"
+      memory: 1Gi
+    requests:
+      cpu: "2"
+      memory: 512Mi
+
+  probes:
+    readiness:
+      type: http
+      path: /health
+      port: 80
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+    liveness:
+      type: http
+      path: /health
+      port: 80
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+
+  sysctls:
+    - net.ipv4.tcp_fin_timeout=15
+    - net.ipv4.ip_local_port_range=1024 65535
+
+  certificate:
+    existingSecret: ""
+    certKey: tls.crt
+    privateKeyKey: tls.key
+    selfSigned:
+      enabled: true
+      commonName: localhost
+      dnsNames:
+        - localhost
+        - gateway
+        - nginx
+      ipAddresses:
+        - 127.0.0.1
+      durationDays: 365
+
+########################################################################
+# INSPECTOR PROFILE - MCP Inspector client UI
+########################################################################
+inspector:
+  enabled: false
+
+  image:
+    repository: ghcr.io/modelcontextprotocol/inspector
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    uiPort: 6274
+    apiPort: 6277
+
+  env:
+    HOST: 0.0.0.0
+    MCP_AUTO_OPEN_ENABLED: "false"
+    DANGEROUSLY_OMIT_AUTH: "true"
+
+  resources:
+    limits:
+      cpu: "1"
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi


### PR DESCRIPTION
## Summary
- add docker-compose parity profile blocks to charts/mcp-stack/values.yaml with optional features disabled by default
- add optional Helm resources for nginx proxy, monitoring stack, testing stack, benchmark stack, TLS frontend, inspector, and registration jobs
- add fast-time server command/args parity support in deployment values/template
- extend values schema for the new top-level optional profile keys

## Validation
- helm lint . --strict
- helm lint . --strict with all new profile flags enabled
- helm template --debug --dry-run with defaults
- helm template --debug --dry-run with all new profile flags enabled