### PR TITLE
fix(ui): standardize loading indicators on MCP Registry, Teams, API T…

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -6085,12 +6085,14 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
             </h3>
 
             <!-- Loading indicator -->
-            <div id="users-loading" class="htmx-indicator flex items-center justify-center p-8">
-              <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-              <span class="ml-3 text-gray-600 dark:text-gray-400">Loading users...</span>
+            <div id="users-loading" class="htmx-indicator">
+              <div class="flex items-center justify-center p-4">
+                <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                <span class="ml-2 text-gray-600 dark:text-gray-400">Loading users...</span>
+              </div>
             </div>
 
             <!-- Users list container -->


### PR DESCRIPTION
  ## 🔗 Related Issue                                                                                                         
  Closes #2946
 ---                                                                                                                         

  ## 📝 Summary
  Standardized the loading indicators on MCP Registry, Teams, API Tokens, and System Logs pages to use the same indigo SVG    
  spinner pattern used by Gateways, Tools, and other pages.

  Changes in `mcpgateway/templates/admin.html`:
  - **MCP Registry**: Replaced CSS border-based spinner with standard SVG spinner
  - **Teams**: Replaced small (h-5) spinner + animate-pulse text + extra note message with standard pattern
  - **API Tokens**: Fixed spacing inconsistency (`p-8`/`ml-3` → `p-4`/`ml-2`)
  - **System Logs**: Replaced plain "Loading..." text with standard SVG spinner

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix
  - [ ] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)
  - [ ] Other (describe below)

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | N/A (HTML only) |
  | Unit tests                | `make test`     | N/A (HTML only) |
  | Coverage ≥ 80%            | `make coverage` | N/A (HTML only) |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  This is an HTML-only change in a single template file. No Python code was modified, so lint/test/coverage are not affected. 

  Tested locally via Docker Compose by hard-reloading each affected page and verifying the loading spinner matches the        
  standard pattern on Gateways/Tools pages.