### PR TITLE
 fix: Handle Empty String in iFrame Embedding Config options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1344,10 +1344,9 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # X-Frame-Options setting - Controls iframe embedding (also sets CSP frame-ancestors)
 # DENY: Prevents all iframe embedding (recommended for security) → frame-ancestors 'none'
 # SAMEORIGIN: Allows embedding from same domain only → frame-ancestors 'self'
-# "" (empty string): Allows all iframe embedding → frame-ancestors * file: http: https:
-# null or none: Completely removes iframe restrictions (no headers sent)
+# "" (empty string) / null / none: Removes iframe restrictions (no headers sent, allows embedding)
 # ALLOW-FROM uri: Allows specific domain (deprecated, use CSP instead)
-# ALLOW-ALL uri: Allows all (*, http, https)
+# ALLOW-ALL: Allows all embedding → frame-ancestors * file: http: https:
 #
 # Both X-Frame-Options header and CSP frame-ancestors directive are automatically synced.
 # Modern browsers prioritize CSP frame-ancestors over X-Frame-Options.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -655,17 +655,21 @@ class Settings(BaseSettings):
     @field_validator("x_frame_options")
     @classmethod
     def normalize_x_frame_options(cls, v: Optional[str]) -> Optional[str]:
-        """Convert string 'null' or 'none' to Python None to disable iframe restrictions.
+        """Convert string 'null', 'none', or empty/whitespace-only string to Python None to disable iframe restrictions.
 
         Args:
-            v: The x_frame_options value from environment/config
+            v: The X-Frame-Options value to normalize.
 
         Returns:
-            None if v is "null" or "none" (case-insensitive), otherwise returns v unchanged
+            None if v is None, an empty/whitespace-only string, or case-insensitive 'null'/'none';
+            otherwise returns the stripped string value.
         """
-        if isinstance(v, str) and v.lower() in ("null", "none"):
+        if v is None:
             return None
-        return v
+        val = v.strip()
+        if val == "" or val.lower() in ("null", "none"):
+            return None
+        return val
 
     x_content_type_options_enabled: bool = Field(default=True)
     x_xss_protection_enabled: bool = Field(default=True)

--- a/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
@@ -139,6 +139,34 @@ async def test_x_frame_options_none():
 
 
 @pytest.mark.asyncio
+async def test_x_frame_options_raw_empty_string():
+    """Test that raw empty string (bypassing config validator) is treated as None."""
+    mock, settings = _mock_settings()
+    settings.x_frame_options = ""
+    try:
+        middleware = SecurityHeadersMiddleware(app=None)
+        response = await middleware.dispatch(_make_request(), _call_next)
+        assert "X-Frame-Options" not in response.headers
+        assert "frame-ancestors" not in response.headers.get("Content-Security-Policy", "")
+    finally:
+        mock.stop()
+
+
+@pytest.mark.asyncio
+async def test_x_frame_options_raw_whitespace_string():
+    """Test that raw whitespace string (bypassing config validator) is treated as None."""
+    mock, settings = _mock_settings()
+    settings.x_frame_options = "   "
+    try:
+        middleware = SecurityHeadersMiddleware(app=None)
+        response = await middleware.dispatch(_make_request(), _call_next)
+        assert "X-Frame-Options" not in response.headers
+        assert "frame-ancestors" not in response.headers.get("Content-Security-Policy", "")
+    finally:
+        mock.stop()
+
+
+@pytest.mark.asyncio
 async def test_x_xss_protection():
     """Test X-XSS-Protection."""
     mock, settings = _mock_settings()

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -343,6 +343,23 @@ def test_x_frame_options_normal_value():
     assert s.x_frame_options == "DENY"
 
 
+def test_x_frame_options_empty_string_returns_none():
+    """Empty-string x_frame_options should be normalized to None (allow embedding)."""
+    s = Settings(x_frame_options="", _env_file=None)
+    assert s.x_frame_options is None
+
+
+def test_x_frame_options_whitespace_only_returns_none():
+    """Whitespace-only x_frame_options should be normalized to None (allow embedding)."""
+    s = Settings(x_frame_options="   ", _env_file=None)
+    assert s.x_frame_options is None
+
+
+def test_x_frame_options_none_value_returns_none():
+    """x_frame_options set to None should return None."""
+    s = Settings(x_frame_options=None, _env_file=None)
+    assert s.x_frame_options is None
+
 # --------------------------------------------------------------------------- #
 #                      parse_allowed_roots                                     #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## 🔗 Related Issue
Closes #2492

---

## 📝 Summary
This PR fixes X_FRAME_OPTIONS related middleware behavior not properly handling empty string values.

Key changes:
- Fixed middleware bug where empty string `""` was falling through to the default case and being treated like DENY (adding `frame-ancestors 'none'`), when it should allow all embedding (no frame-ancestors directive)
- Updated test cases in `test_security_middleware_comprehensive.py` to use `None` instead of `""` when testing disabled iframe restrictions, matching the config validator's behavior that converts empty strings to `None`
- Added test_x_frame_options_empty_string_returns_none 
 

The root cause was:
1. The middleware was incorrectly treating empty string `""` as an unknown value, defaulting to DENY behavior(adding frame-ancestors 'none') (blocking embedding)

All X_FRAME_OPTIONS now exhibit expected behaviour
---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification


Check | Command | Status
-- | -- | --
Lint suite | make lint | ✅ Passed (Pylint score: 10/10)
Unit tests | make test | ✅ Passed (all X_FRAME_OPTIONS tests)
Coverage ≥ 80% | make coverage | ✅ Passed (100% for modified files, 99%+ overal


---

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
Targeted local verification executed:
- `pytest tests/unit/mcpgateway/test_config.py -v` ✅
- ` pytest tests/security/test_security_middleware_comprehensive.py` ✅