### PR TITLE
feat(mcp): add secure code execution and virtual tool filesystem

### DIFF
--- a/mcpgateway/services/code_execution_service.py
+++ b/mcpgateway/services/code_execution_service.py
@@ -1888,7 +1888,7 @@ class CodeExecutionService:
                 return
             await client.set(redis_key, json.dumps(meta), ex=ttl)
         except Exception:  # pragma: no cover - Redis unavailable
-            pass
+            logger.debug("Redis session meta set failed for %s", redis_key, exc_info=True)
 
     async def _redis_delete_session_meta(self, redis_key: str) -> None:
         """Remove session metadata from Redis.  Silently ignores failures."""
@@ -1901,7 +1901,7 @@ class CodeExecutionService:
                 return
             await client.delete(redis_key)
         except Exception:  # pragma: no cover - Redis unavailable
-            pass
+            logger.debug("Redis session meta delete failed for %s", redis_key, exc_info=True)
 
     def _session_redis_key(self, server_id: str, user_email: str, language: str) -> str:
         """Build the Redis key for a code execution session."""


### PR DESCRIPTION
## Summary

This PR fully implements [EPIC][CORE]: Secure Code Execution & Virtual Tool Filesystem (MCP Code Mode) end-to-end, including core runtime, persistence, API surface, RBAC/scoping, Admin UI, configurability across all deployment surfaces, documentation
(including ADR + architecture/usage docs), and test coverage.

Closes: #2952

## What This Delivers

- Adds a first-class virtual server type: type=code_execution
- Adds policy-driven sandbox execution via synthetic meta-tools:
- shell_exec
- fs_browse
- Adds isolated virtual filesystem semantics per session:
- /tools
- /skills
- /scratch
- /results
- Adds policy controls:
- mount_rules
- sandbox_policy
- tokenization
- skills_scope
- skills_require_approval
- Adds persistent run/session/security/skills lifecycle support
- Adds replay + approval/revoke operational actions
- Adds complete feature-flag and config surface support
- Adds full Admin UI support for create/edit/preview/monitoring flows
- Adds complete documentation set for this major feature

## Core Backend Implementation

- Added mcpgateway/services/code_execution_service.py as the core orchestration layer
- Added runtime abstraction for Deno/Python execution
- Added configurable limits and controls for time/memory/cpu/disk/network/rate
- Added dangerous-pattern checks for Python/TypeScript
- Added mounted tool invocation bridge with permission enforcement
- Added tokenization support (bidirectional strategy)
- Added virtual filesystem mount/materialization and refresh behavior
- Added skills lifecycle and approval workflows
- Added replay support and structured security event recording
- Added optional Rust acceleration hooks for stub/catalog/search generation

## Data Model & Migration

- Extended servers with code mode fields:
- server_type
- stub_language
- mount_rules
- sandbox_policy
- tokenization
- skills_scope
- skills_require_approval
- Added persistent tables:
- code_execution_skills
- skill_approvals
- code_execution_runs
- Added Alembic migration:
- mcpgateway/alembic/versions/x7h8i9j0k1l2_add_code_execution_mode.py

## API, Permissions, and Scoping

- Added code mode APIs under server scope:
- GET /servers/{server_id}/code/runs
- GET /servers/{server_id}/code/sessions
- GET /servers/{server_id}/code/security-events
- POST /servers/{server_id}/code/runs/{run_id}/replay
- Added skills APIs:
- GET /servers/{server_id}/skills
- POST /servers/{server_id}/skills
- GET /servers/{server_id}/skills/approvals
- POST /servers/{server_id}/skills/approvals/{approval_id}/approve
- POST /servers/{server_id}/skills/approvals/{approval_id}/reject
- POST /servers/{server_id}/skills/{skill_id}/revoke
- Updated token scoping rules for all new code/skills endpoints
- Updated default role bootstrap to include skills.* permissions where appropriate
- Enforced feature flag guardrails (CODE_EXECUTION_ENABLED) in service + admin flows

## Admin UI & UX

- Added create/edit support for Server Type: code_execution
- Added code mode fields in forms:
- Stub Language
- Skills Scope
- Require skill approval
- Mount Rules (JSON)
- Sandbox Policy (JSON)
- Tokenization Policy (JSON)
- Added robust section toggle behavior for create/edit forms (including HTMX swap sync)
- Added Preview Virtual Server payload generation in create flow
- Added editable template insertion for JSON policy fields
- Upgraded JSON fields to CodeMirror-backed editing behavior
- Added code mode visual differentiation in servers list:
- row highlight
- ⚡ marker
- 💻 Code Mode badge
- Added code mode detail panel in server view modal:
- run history
- active sessions
- pending approvals + approve/reject actions
- skills + revoke action
- security events
- replay action

## Configurability & Feature Flags

Added full config support in:

- mcpgateway/config.py
- .env.example
- docker-compose.yml
- charts/mcp-stack/values.yaml
- charts/mcp-stack/values.schema.json
- docs/docs/config.schema.json
- docs/docs/manage/configuration.md

Coverage includes:

- master feature gate
- per-capability toggles (shell_exec, fs_browse, replay, rust acceleration, fallback)
- default sandbox/runtime/limits
- filesystem/tool pattern defaults
- tokenization defaults
- browse limits and persisted output limits
- dangerous pattern lists

Rollout defaults:

- config.py: code execution disabled by default
- .env.example: code execution disabled by default
- docker-compose.yml: code execution enabled by default for testing/dev convenience

## Documentation (Major Feature Set)

- Added ADR:
- docs/docs/architecture/adr/040-secure-code-execution-virtual-tool-filesystem.md
- Added architecture overview page:
- docs/docs/architecture/code-execution-virtual-tool-filesystem.md
- Added usage guide:
- docs/docs/using/code-execution-virtual-server.md
- Updated docs navigation and indexes (.pages + index files) to surface feature docs
- Updated security/features documentation to include code mode controls
- Updated README quick links and overview to prominently advertise MCP Code Mode

## Testing & Quality

- Added new unit coverage for core code execution behaviors:
- tests/unit/mcpgateway/services/test_code_execution_service.py
- Added service-level gating tests:
- tests/unit/mcpgateway/services/test_server_service.py
- Added admin form parsing/validation tests for code mode:
- tests/unit/mcpgateway/test_admin.py
- Added JS tests for UI behavior:
- tests/js/admin-forms.test.js
- Hardened Playwright reliability for admin UI race conditions:
- tests/playwright/conftest.py
- tests/playwright/entities/test_servers_extended.py
- tests/playwright/pages/gateways_page.py
- Addressed lint/static-analysis/docstring pipeline issues encountered during integration (flake8, pylint, lint-web, interrogate, bandit)

## Backward Compatibility

- Existing standard virtual server behavior remains unchanged
- Code mode fields are rejected/cleared when server type is standard
- Feature remains explicitly gateable via configuration
- Non-enabled deployments are protected by feature gate validation paths

## Migration Notes

- Apply DB migration to use persistent code mode entities:
- alembic upgrade head
- Ensure runtime prerequisites are available for selected policy/runtime (Deno and/or Python)
- Enable CODE_EXECUTION_ENABLED=true to activate code mode in non-compose environments