### PR TITLE
fix(security): prevent admin UI from revealing gateway tokens

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -9855,7 +9855,7 @@ async def admin_get_gateway(gateway_id: str, db: Session = Depends(get_db), user
     """
     LOGGER.debug(f"User {get_user_email(user)} requested details for gateway ID {gateway_id}")
     try:
-        gateway = await gateway_service.get_gateway(db, gateway_id)
+        gateway = await gateway_service.get_gateway(db, gateway_id, include_unmasked=True)
         return gateway.model_dump(by_alias=True)
     except GatewayNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -3414,7 +3414,7 @@ class GatewayRead(BaseModelWithConfigDict):
 
         return self
 
-    def masked(self) -> "GatewayRead":
+    def masked(self, *, preserve_unmasked: bool = False) -> "GatewayRead":
         """
         Return a masked version of the model instance with sensitive authentication fields hidden.
 
@@ -3424,7 +3424,9 @@ class GatewayRead(BaseModelWithConfigDict):
         are present and not already masked.
 
         Args:
-            None
+            preserve_unmasked: If True, keep the ``_unmasked`` companion fields so that
+                privileged callers (e.g. the admin UI) can still reveal the original
+                values.  Defaults to False for safety.
 
         Returns:
             GatewayRead: A new instance of the GatewayRead model with sensitive authentication-related fields
@@ -3459,10 +3461,12 @@ class GatewayRead(BaseModelWithConfigDict):
             masked_data["oauth_config"] = _mask_oauth_config(masked_data["oauth_config"])
 
         # SECURITY: Never expose unmasked credentials in API responses
-        masked_data["auth_password_unmasked"] = None
-        masked_data["auth_token_unmasked"] = None
-        masked_data["auth_header_value_unmasked"] = None
-        masked_data["auth_headers_unmasked"] = None
+        # unless the caller explicitly opts in (e.g. admin UI)
+        if not preserve_unmasked:
+            masked_data["auth_password_unmasked"] = None
+            masked_data["auth_token_unmasked"] = None
+            masked_data["auth_header_value_unmasked"] = None
+            masked_data["auth_headers_unmasked"] = None
         return GatewayRead.model_validate(masked_data)
 
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2355,13 +2355,14 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
             )
             raise GatewayError(f"Failed to update gateway: {str(e)}")
 
-    async def get_gateway(self, db: Session, gateway_id: str, include_inactive: bool = True) -> GatewayRead:
+    async def get_gateway(self, db: Session, gateway_id: str, include_inactive: bool = True, include_unmasked: bool = False) -> GatewayRead:
         """Get a gateway by its ID.
 
         Args:
             db: Database session
             gateway_id: Gateway ID
             include_inactive: Whether to include inactive gateways
+            include_unmasked: Whether to preserve unmasked credential fields (for admin UI)
 
         Returns:
             GatewayRead object
@@ -2444,7 +2445,7 @@ class GatewayService:  # pylint: disable=too-many-instance-attributes
                 db=db,
             )
 
-            return GatewayRead.model_validate(self._prepare_gateway_for_read(gateway)).masked()
+            return GatewayRead.model_validate(self._prepare_gateway_for_read(gateway)).masked(preserve_unmasked=include_unmasked)
 
         raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -127,7 +127,7 @@ class _PassthroughMasked:
     def __init__(self, obj):
         self._obj = obj
 
-    def masked(self):
+    def masked(self, **kwargs):
         return self._obj
 
     def model_dump(self, **kw):


### PR DESCRIPTION
  ## Related Issue
  Closes #2968

  ---

  ## Summary
  The `masked()` method in `GatewayRead` was unconditionally setting all `_unmasked`      
  fields to `None`, which broke the admin UI "Show" toggle for gateway tokens, passwords, 
  and header values. This adds an opt-in `preserve_unmasked` parameter so the
  permission-gated admin endpoint can receive the real values while all other callers     
  remain unaffected.

  ---

  ## Type of Change
  - [x] Bug fix

  ---

  ## Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Unit tests (admin)        | `pytest tests/unit/mcpgateway/test_admin.py` | 775/775    
  passed |
  | Unit tests (schemas)      | `pytest tests/unit/mcpgateway/test_schemas.py` | 65/65    
  passed |
  | Doctests (gateway service)| `pytest --doctest-modules
  mcpgateway/services/gateway_service.py` | 25/25 passed |
  | Manual test               | Admin UI "Show" toggle | Working |

  ---

  ## Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ### Manual verification
<img width="992" height="1086" alt="Screenshot 2026-02-16 193227" src="https://github.com/user-attachments/assets/aee40b46-9e45-47c8-8c0f-77bc2e7f6a10" />
