### PR TITLE
Fix Orphaned Gateway Registration Bug along with Isolating Structured log Session and Handling Flush Errors

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12566,7 +12566,6 @@ async def admin_test_gateway(
                 "status_code": response.status_code,
                 "latency_ms": latency_ms,
             },
-            db=db,
         )
 
         return GatewayTestResponse(status_code=response.status_code, latency_ms=latency_ms, body=response_body)
@@ -12594,7 +12593,6 @@ async def admin_test_gateway(
                 "test_path": request.path,
                 "latency_ms": latency_ms,
             },
-            db=db,
         )
 
         return GatewayTestResponse(status_code=502, latency_ms=latency_ms, body={"error": "Request failed", "details": str(e)})
@@ -15192,16 +15190,13 @@ async def list_plugins(
                 "disabled_count": disabled_count,
                 "has_filters": any([search, mode, hook, tag]),
             },
-            db=db,
         )
 
         return PluginListResponse(plugins=plugins, total=len(plugins), enabled_count=enabled_count, disabled_count=disabled_count)
 
     except Exception as e:
         LOGGER.error(f"Error listing plugins: {e}")
-        structured_logger.error(
-            "Failed to list plugins in marketplace", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic", db=db
-        )
+        structured_logger.error("Failed to list plugins in marketplace", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -15253,7 +15248,6 @@ async def get_plugin_stats(request: Request, db: Session = Depends(get_db), user
                 "tags_count": len(stats.get("plugins_by_tag", {})),
                 "authors_count": len(stats.get("plugins_by_author", {})),
             },
-            db=db,
         )
 
         return PluginStatsResponse(**stats)
@@ -15261,7 +15255,7 @@ async def get_plugin_stats(request: Request, db: Session = Depends(get_db), user
     except Exception as e:
         LOGGER.error(f"Error getting plugin statistics: {e}")
         structured_logger.error(
-            "Failed to get plugin marketplace statistics", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic", db=db
+            "Failed to get plugin marketplace statistics", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic"
         )
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -15307,7 +15301,6 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
                 component="plugin_marketplace",
                 category="business_logic",
                 custom_fields={"plugin_name": name, "action": "view_details"},
-                db=db,
             )
             raise HTTPException(status_code=404, detail=f"Plugin '{name}' not found")
 
@@ -15330,7 +15323,6 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
                 "plugin_hooks": plugin.get("hooks", []),
                 "plugin_tags": plugin.get("tags", []),
             },
-            db=db,
         )
 
         # Create audit trail for plugin access
@@ -15345,7 +15337,7 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
     except Exception as e:
         LOGGER.error(f"Error getting plugin details: {e}")
         structured_logger.error(
-            f"Failed to get plugin details: '{name}'", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic", db=db
+            f"Failed to get plugin details: '{name}'", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic"
         )
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -472,15 +472,13 @@ def before_commit_handler(session):
     """Handler before commit to ensure transaction is in good state.
 
     This is called before COMMIT, ensuring any pending work is flushed.
+    If the flush fails, the exception is propagated so the commit also fails
+    and the caller's error handling (e.g. get_db rollback) can clean up properly.
 
     Args:
         session: The SQLAlchemy session about to commit.
     """
-    try:
-        session.flush()
-    except Exception:  # nosec B110
-        # If flush fails, the commit will also fail and trigger rollback
-        pass
+    session.flush()
 
 
 # ---------------------------------------------------------------------------

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -581,7 +581,6 @@ class PromptService:
                     "prompt_name": db_prompt.name,
                     "visibility": visibility,
                 },
-                db=db,
             )
 
             db_prompt.team = self._get_team_name(db, db_prompt.team_id)
@@ -615,7 +614,6 @@ class PromptService:
                 user_email=owner_email,
                 error=ie,
                 custom_fields={"prompt_name": prompt.name},
-                db=db,
             )
             raise ie
         except PromptNameConflictError as se:
@@ -629,7 +627,6 @@ class PromptService:
                 user_id=created_by,
                 user_email=owner_email,
                 custom_fields={"prompt_name": prompt.name, "visibility": visibility},
-                db=db,
             )
             raise se
         except Exception as e:
@@ -644,7 +641,6 @@ class PromptService:
                 user_email=owner_email,
                 error=e,
                 custom_fields={"prompt_name": prompt.name},
-                db=db,
             )
             raise PromptError(f"Failed to register prompt: {str(e)}")
 
@@ -961,7 +957,6 @@ class PromptService:
                 "visibility": visibility,
                 "conflict_strategy": conflict_strategy,
             },
-            db=db,
         )
 
         return stats
@@ -1672,7 +1667,6 @@ class PromptService:
                         "tenant_id": tenant_id,
                         "server_id": server_id,
                     },
-                    db=db,
                 )
 
                 # Set success attributes on span
@@ -1904,7 +1898,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt.id),
                 custom_fields={"prompt_name": prompt.name, "version": prompt.version},
-                db=db,
             )
 
             prompt.team = self._get_team_name(db, prompt.team_id)
@@ -1932,7 +1925,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=pe,
-                db=db,
             )
             raise
         except IntegrityError as ie:
@@ -1948,7 +1940,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=ie,
-                db=db,
             )
             raise ie
         except PromptNotFoundError as e:
@@ -1964,7 +1955,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=e,
-                db=db,
             )
             raise e
         except PromptNameConflictError as pnce:
@@ -1980,7 +1970,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=pnce,
-                db=db,
             )
             raise pnce
         except Exception as e:
@@ -1995,7 +1984,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=e,
-                db=db,
             )
             raise PromptError(f"Failed to update prompt: {str(e)}")
 
@@ -2097,7 +2085,6 @@ class PromptService:
                     resource_type="prompt",
                     resource_id=str(prompt.id),
                     custom_fields={"prompt_name": prompt.name, "enabled": prompt.enabled},
-                    db=db,
                 )
 
             prompt.team = self._get_team_name(db, prompt.team_id)
@@ -2112,7 +2099,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=e,
-                db=db,
             )
             raise e
         except PromptLockConflictError:
@@ -2133,7 +2119,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=e,
-                db=db,
             )
             raise PromptError(f"Failed to set prompt state: {str(e)}")
 
@@ -2197,7 +2182,6 @@ class PromptService:
                 "prompt_name": prompt.name,
                 "include_inactive": include_inactive,
             },
-            db=db,
         )
 
         return prompt_data
@@ -2289,7 +2273,6 @@ class PromptService:
                     "prompt_name": prompt_name,
                     "purge_metrics": purge_metrics,
                 },
-                db=db,
             )
 
             # Invalidate cache after successful deletion
@@ -2313,7 +2296,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=pe,
-                db=db,
             )
             raise
         except Exception as e:
@@ -2329,7 +2311,6 @@ class PromptService:
                     resource_type="prompt",
                     resource_id=str(prompt_id),
                     error=e,
-                    db=db,
                 )
                 raise e
 
@@ -2343,7 +2324,6 @@ class PromptService:
                 resource_type="prompt",
                 resource_id=str(prompt_id),
                 error=e,
-                db=db,
             )
             raise PromptError(f"Failed to delete prompt: {str(e)}")
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -534,7 +534,6 @@ class ResourceService:
                     "resource_name": db_resource.name,
                     "visibility": visibility,
                 },
-                db=db,
             )
 
             db_resource.team = self._get_team_name(db, db_resource.team_id)
@@ -554,7 +553,6 @@ class ResourceService:
                 custom_fields={
                     "resource_uri": resource.uri,
                 },
-                db=db,
             )
             raise ie
         except ResourceURIConflictError as rce:
@@ -572,7 +570,6 @@ class ResourceService:
                     "resource_uri": resource.uri,
                     "visibility": visibility,
                 },
-                db=db,
             )
             raise rce
         except Exception as e:
@@ -590,7 +587,6 @@ class ResourceService:
                 custom_fields={
                     "resource_uri": resource.uri,
                 },
-                db=db,
             )
             raise ResourceError(f"Failed to register resource: {str(e)}")
 
@@ -847,7 +843,6 @@ class ResourceService:
                 "visibility": visibility,
                 "conflict_strategy": conflict_strategy,
             },
-            db=db,
         )
 
         return stats
@@ -2527,7 +2522,6 @@ class ResourceService:
                         "resource_uri": resource.uri,
                         "enabled": resource.enabled,
                     },
-                    db=db,
                 )
 
             resource.team = self._get_team_name(db, resource.team_id)
@@ -2543,7 +2537,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=e,
-                db=db,
             )
             raise e
         except ResourceLockConflictError:
@@ -2565,7 +2558,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=e,
-                db=db,
             )
             raise ResourceError(f"Failed to set resource state: {str(e)}")
 
@@ -2842,7 +2834,6 @@ class ResourceService:
                     "resource_uri": resource.uri,
                     "version": resource.version,
                 },
-                db=db,
             )
 
             return self.convert_resource_to_read(resource)
@@ -2859,7 +2850,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=pe,
-                db=db,
             )
             raise
         except IntegrityError as ie:
@@ -2877,7 +2867,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=ie,
-                db=db,
             )
             raise ie
         except ResourceURIConflictError as pe:
@@ -2894,7 +2883,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=pe,
-                db=db,
             )
             raise pe
         except Exception as e:
@@ -2910,7 +2898,6 @@ class ResourceService:
                     resource_type="resource",
                     resource_id=str(resource_id),
                     error=e,
-                    db=db,
                 )
                 raise e
 
@@ -2925,7 +2912,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=e,
-                db=db,
             )
             raise ResourceError(f"Failed to update resource: {str(e)}")
 
@@ -3042,7 +3028,6 @@ class ResourceService:
                     "resource_uri": resource_uri,
                     "purge_metrics": purge_metrics,
                 },
-                db=db,
             )
 
         except PermissionError as pe:
@@ -3058,7 +3043,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=pe,
-                db=db,
             )
             raise
         except ResourceNotFoundError as rnfe:
@@ -3073,7 +3057,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=rnfe,
-                db=db,
             )
             raise
         except Exception as e:
@@ -3089,7 +3072,6 @@ class ResourceService:
                 resource_type="resource",
                 resource_id=str(resource_id),
                 error=e,
-                db=db,
             )
             raise ResourceError(f"Failed to delete resource: {str(e)}")
 
@@ -3151,7 +3133,6 @@ class ResourceService:
                 "resource_uri": resource.uri,
                 "include_inactive": include_inactive,
             },
-            db=db,
         )
 
         return resource_read

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1059,7 +1059,6 @@ class ServerService:
                 "resource_count": len(getattr(server, "resources", []) or []),
                 "prompt_count": len(getattr(server, "prompts", []) or []),
             },
-            db=db,
         )
 
         self._audit_trail.log_action(

--- a/mcpgateway/services/structured_logger.py
+++ b/mcpgateway/services/structured_logger.py
@@ -18,12 +18,9 @@ import socket
 import traceback
 from typing import Any, Dict, List, Optional, Union
 
-# Third-Party
-from sqlalchemy.orm import Session
-
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.db import SessionLocal, StructuredLogEntry
+from mcpgateway.db import fresh_db_session, StructuredLogEntry
 from mcpgateway.services.performance_tracker import get_performance_tracker
 from mcpgateway.utils.correlation_id import get_correlation_id
 
@@ -159,19 +156,18 @@ class LogRouter:
         self.database_enabled = getattr(settings, "structured_logging_database_enabled", True)
         self.external_enabled = getattr(settings, "structured_logging_external_enabled", False)
 
-    def route(self, entry: Dict[str, Any], db: Optional[Session] = None) -> None:
+    def route(self, entry: Dict[str, Any]) -> None:
         """Route log entry to configured destinations.
 
         Args:
             entry: Log entry to route
-            db: Optional database session
         """
         # Always log to standard Python logger
         self._log_to_python_logger(entry)
 
         # Persist to database if enabled
         if self.database_enabled:
-            self._persist_to_database(entry, db)
+            self._persist_to_database(entry)
 
         # Send to external systems if enabled
         if self.external_enabled:
@@ -196,124 +192,112 @@ class LogRouter:
 
         logger.log(level, log_message, extra=extra)
 
-    def _persist_to_database(self, entry: Dict[str, Any], db: Optional[Session] = None) -> None:
+    def _persist_to_database(self, entry: Dict[str, Any]) -> None:
         """Persist log entry to database.
+
+        Always uses a fresh, independent database session to avoid accidentally
+        committing unrelated pending objects from the caller's session.
 
         Args:
             entry: Log entry
-            db: Optional database session
         """
-        should_close = False
-        if db is None:
-            db = SessionLocal()
-            should_close = True
-
         try:
-            # Build error_details JSON from error-related fields
-            error_details = None
-            if any([entry.get("error_type"), entry.get("error_message"), entry.get("error_stack_trace"), entry.get("error_context")]):
-                error_details = {
-                    "error_type": entry.get("error_type"),
-                    "error_message": entry.get("error_message"),
-                    "error_stack_trace": entry.get("error_stack_trace"),
-                    "error_context": entry.get("error_context"),
+            with fresh_db_session() as log_db:
+                # Build error_details JSON from error-related fields
+                error_details = None
+                if any([entry.get("error_type"), entry.get("error_message"), entry.get("error_stack_trace"), entry.get("error_context")]):
+                    error_details = {
+                        "error_type": entry.get("error_type"),
+                        "error_message": entry.get("error_message"),
+                        "error_stack_trace": entry.get("error_stack_trace"),
+                        "error_context": entry.get("error_context"),
+                    }
+
+                # Build performance_metrics JSON from performance-related fields
+                performance_metrics = None
+                perf_fields = {
+                    "database_query_count": entry.get("database_query_count"),
+                    "database_query_duration_ms": entry.get("database_query_duration_ms"),
+                    "cache_hits": entry.get("cache_hits"),
+                    "cache_misses": entry.get("cache_misses"),
+                    "external_api_calls": entry.get("external_api_calls"),
+                    "external_api_duration_ms": entry.get("external_api_duration_ms"),
+                    "memory_usage_mb": entry.get("memory_usage_mb"),
+                    "cpu_usage_percent": entry.get("cpu_usage_percent"),
                 }
+                if any(v is not None for v in perf_fields.values()):
+                    performance_metrics = {k: v for k, v in perf_fields.items() if v is not None}
 
-            # Build performance_metrics JSON from performance-related fields
-            performance_metrics = None
-            perf_fields = {
-                "database_query_count": entry.get("database_query_count"),
-                "database_query_duration_ms": entry.get("database_query_duration_ms"),
-                "cache_hits": entry.get("cache_hits"),
-                "cache_misses": entry.get("cache_misses"),
-                "external_api_calls": entry.get("external_api_calls"),
-                "external_api_duration_ms": entry.get("external_api_duration_ms"),
-                "memory_usage_mb": entry.get("memory_usage_mb"),
-                "cpu_usage_percent": entry.get("cpu_usage_percent"),
-            }
-            if any(v is not None for v in perf_fields.values()):
-                performance_metrics = {k: v for k, v in perf_fields.items() if v is not None}
+                # Build threat_indicators JSON from security-related fields
+                threat_indicators = None
+                security_fields = {
+                    "security_event_type": entry.get("security_event_type"),
+                    "security_threat_score": entry.get("security_threat_score"),
+                    "security_action_taken": entry.get("security_action_taken"),
+                }
+                if any(v is not None for v in security_fields.values()):
+                    threat_indicators = {k: v for k, v in security_fields.items() if v is not None}
 
-            # Build threat_indicators JSON from security-related fields
-            threat_indicators = None
-            security_fields = {
-                "security_event_type": entry.get("security_event_type"),
-                "security_threat_score": entry.get("security_threat_score"),
-                "security_action_taken": entry.get("security_action_taken"),
-            }
-            if any(v is not None for v in security_fields.values()):
-                threat_indicators = {k: v for k, v in security_fields.items() if v is not None}
+                # Build context JSON from remaining fields
+                context_fields = {
+                    "team_id": entry.get("team_id"),
+                    "request_query": entry.get("request_query"),
+                    "request_headers": entry.get("request_headers"),
+                    "request_body_size": entry.get("request_body_size"),
+                    "response_status_code": entry.get("response_status_code"),
+                    "response_body_size": entry.get("response_body_size"),
+                    "response_headers": entry.get("response_headers"),
+                    "business_event_type": entry.get("business_event_type"),
+                    "business_entity_type": entry.get("business_entity_type"),
+                    "business_entity_id": entry.get("business_entity_id"),
+                    "resource_type": entry.get("resource_type"),
+                    "resource_id": entry.get("resource_id"),
+                    "resource_action": entry.get("resource_action"),
+                    "category": entry.get("category"),
+                    "custom_fields": entry.get("custom_fields"),
+                    "tags": entry.get("tags"),
+                    "metadata": entry.get("metadata"),
+                }
+                context = {k: v for k, v in context_fields.items() if v is not None}
 
-            # Build context JSON from remaining fields
-            context_fields = {
-                "team_id": entry.get("team_id"),
-                "request_query": entry.get("request_query"),
-                "request_headers": entry.get("request_headers"),
-                "request_body_size": entry.get("request_body_size"),
-                "response_status_code": entry.get("response_status_code"),
-                "response_body_size": entry.get("response_body_size"),
-                "response_headers": entry.get("response_headers"),
-                "business_event_type": entry.get("business_event_type"),
-                "business_entity_type": entry.get("business_entity_type"),
-                "business_entity_id": entry.get("business_entity_id"),
-                "resource_type": entry.get("resource_type"),
-                "resource_id": entry.get("resource_id"),
-                "resource_action": entry.get("resource_action"),
-                "category": entry.get("category"),
-                "custom_fields": entry.get("custom_fields"),
-                "tags": entry.get("tags"),
-                "metadata": entry.get("metadata"),
-            }
-            context = {k: v for k, v in context_fields.items() if v is not None}
+                # Determine if this is a security event
+                is_security_event = entry.get("is_security_event", False) or bool(threat_indicators)
+                security_severity = entry.get("security_severity")
 
-            # Determine if this is a security event
-            is_security_event = entry.get("is_security_event", False) or bool(threat_indicators)
-            security_severity = entry.get("security_severity")
+                log_entry = StructuredLogEntry(
+                    timestamp=entry.get("timestamp", datetime.now(timezone.utc)),
+                    level=entry.get("level", "INFO"),
+                    component=entry.get("component"),
+                    message=entry.get("message", ""),
+                    correlation_id=entry.get("correlation_id"),
+                    request_id=entry.get("request_id"),
+                    trace_id=entry.get("trace_id"),
+                    span_id=entry.get("span_id"),
+                    user_id=entry.get("user_id"),
+                    user_email=entry.get("user_email"),
+                    client_ip=entry.get("client_ip"),
+                    user_agent=entry.get("user_agent"),
+                    request_method=entry.get("request_method"),
+                    request_path=entry.get("request_path"),
+                    duration_ms=entry.get("duration_ms"),
+                    operation_type=entry.get("operation_type"),
+                    is_security_event=is_security_event,
+                    security_severity=security_severity,
+                    threat_indicators=threat_indicators,
+                    context=context if context else None,
+                    error_details=error_details,
+                    performance_metrics=performance_metrics,
+                    hostname=entry.get("hostname"),
+                    process_id=entry.get("process_id"),
+                    thread_id=entry.get("thread_id"),
+                    environment=entry.get("environment", getattr(settings, "environment", "development")),
+                    version=entry.get("version", getattr(settings, "version", "unknown")),
+                )
 
-            log_entry = StructuredLogEntry(
-                timestamp=entry.get("timestamp", datetime.now(timezone.utc)),
-                level=entry.get("level", "INFO"),
-                component=entry.get("component"),
-                message=entry.get("message", ""),
-                correlation_id=entry.get("correlation_id"),
-                request_id=entry.get("request_id"),
-                trace_id=entry.get("trace_id"),
-                span_id=entry.get("span_id"),
-                user_id=entry.get("user_id"),
-                user_email=entry.get("user_email"),
-                client_ip=entry.get("client_ip"),
-                user_agent=entry.get("user_agent"),
-                request_method=entry.get("request_method"),
-                request_path=entry.get("request_path"),
-                duration_ms=entry.get("duration_ms"),
-                operation_type=entry.get("operation_type"),
-                is_security_event=is_security_event,
-                security_severity=security_severity,
-                threat_indicators=threat_indicators,
-                context=context if context else None,
-                error_details=error_details,
-                performance_metrics=performance_metrics,
-                hostname=entry.get("hostname"),
-                process_id=entry.get("process_id"),
-                thread_id=entry.get("thread_id"),
-                environment=entry.get("environment", getattr(settings, "environment", "development")),
-                version=entry.get("version", getattr(settings, "version", "unknown")),
-            )
-
-            db.add(log_entry)
-            db.commit()
+                log_db.add(log_entry)
 
         except Exception as e:
             logger.error(f"Failed to persist log entry to database: {e}", exc_info=True)
-            # Also print to console for immediate visibility
-            print(f"ERROR persisting log to database: {e}")
-            traceback.print_exc()
-            if db:
-                db.rollback()
-
-        finally:
-            if should_close:
-                db.close()  # Commit/rollback already handled above
 
     def _send_to_external(self, entry: Dict[str, Any]) -> None:
         """Send log entry to external systems.
@@ -350,7 +334,6 @@ class StructuredLogger:
         duration_ms: Optional[float] = None,
         custom_fields: Optional[Dict[str, Any]] = None,
         tags: Optional[List[str]] = None,
-        db: Optional[Session] = None,
         **kwargs: Any,
     ) -> None:
         """Log a structured message.
@@ -366,7 +349,6 @@ class StructuredLogger:
             duration_ms: Operation duration
             custom_fields: Additional custom fields
             tags: Log tags
-            db: Optional database session
             **kwargs: Additional fields to include
         """
         # Early termination if log level is below configured threshold
@@ -401,7 +383,7 @@ class StructuredLogger:
         entry = self.enricher.enrich(entry)
 
         # Route to destinations
-        self.router.route(entry, db)
+        self.router.route(entry)
 
     def debug(self, message: str, **kwargs: Any) -> None:
         """Log debug message.

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1196,7 +1196,6 @@ class ToolService:
                     "visibility": visibility,
                     "integration_type": db_tool.integration_type,
                 },
-                db=db,
             )
 
             # Refresh db_tool after logging commits (they expire the session objects)
@@ -1230,7 +1229,6 @@ class ToolService:
                 custom_fields={
                     "tool_name": tool.name,
                 },
-                db=db,
             )
             raise ie
         except ToolNameConflictError as tnce:
@@ -1249,7 +1247,6 @@ class ToolService:
                     "tool_name": tool.name,
                     "visibility": visibility,
                 },
-                db=db,
             )
             raise tnce
         except Exception as e:
@@ -1267,7 +1264,6 @@ class ToolService:
                 custom_fields={
                     "tool_name": tool.name,
                 },
-                db=db,
             )
             raise ToolError(f"Failed to register tool: {str(e)}")
 
@@ -2243,7 +2239,6 @@ class ToolService:
                 "tool_name": tool.name,
                 "include_metrics": bool(getattr(tool_read, "metrics", {})),
             },
-            db=db,
         )
 
         return tool_read
@@ -2340,7 +2335,6 @@ class ToolService:
                     "tool_name": tool_name,
                     "purge_metrics": purge_metrics,
                 },
-                db=db,
             )
 
             # Invalidate cache after successful deletion
@@ -2372,7 +2366,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=pe,
-                db=db,
             )
             raise
         except Exception as e:
@@ -2388,7 +2381,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=e,
-                db=db,
             )
             raise ToolError(f"Failed to delete tool: {str(e)}")
 
@@ -2518,7 +2510,6 @@ class ToolService:
                         "enabled": tool.enabled,
                         "reachable": tool.reachable,
                     },
-                    db=db,
                 )
 
             return self.convert_tool_to_read(tool, requesting_user_email=getattr(tool, "owner_email", None))
@@ -2533,7 +2524,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=e,
-                db=db,
             )
             raise e
         except ToolLockConflictError:
@@ -2555,7 +2545,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=e,
-                db=db,
             )
             raise ToolError(f"Failed to set tool state: {str(e)}")
 
@@ -4180,7 +4169,6 @@ class ToolService:
                     "tool_name": tool.name,
                     "version": tool.version,
                 },
-                db=db,
             )
 
             # Invalidate cache after successful update
@@ -4209,7 +4197,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=pe,
-                db=db,
             )
             raise
         except IntegrityError as ie:
@@ -4227,7 +4214,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=ie,
-                db=db,
             )
             raise ie
         except ToolNotFoundError as tnfe:
@@ -4244,7 +4230,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=tnfe,
-                db=db,
             )
             raise tnfe
         except ToolNameConflictError as tnce:
@@ -4262,7 +4247,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=tnce,
-                db=db,
             )
             raise tnce
         except Exception as ex:
@@ -4279,7 +4263,6 @@ class ToolService:
                 resource_type="tool",
                 resource_id=tool_id,
                 error=ex,
-                db=db,
             )
             raise ToolError(f"Failed to update tool: {str(ex)}")
 

--- a/tests/unit/mcpgateway/test_db.py
+++ b/tests/unit/mcpgateway/test_db.py
@@ -1619,12 +1619,13 @@ def test_reset_connection_on_reset_swallows_rollback_failure():
     db.reset_connection_on_reset(Conn(), None, None)
 
 
-def test_before_commit_handler_flush_failure_is_swallowed():
+def test_before_commit_handler_flush_failure_propagates():
     class DummySession:
         def flush(self):
             raise RuntimeError("boom")
 
-    db.before_commit_handler(DummySession())
+    with pytest.raises(RuntimeError, match="boom"):
+        db.before_commit_handler(DummySession())
 
 
 # --- Slug/name refresh helpers ---


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2987

## 📌 Summary
Fixes a bug where gateway registration failures (e.g., tool schema validation errors) leave orphaned gateway records in the database, blocking subsequent registration attempts with the same name. 

The root cause is missing db.rollback() calls in exception handlers, along with two other contributing issues: 

  - the structured logger committing the caller's dirty session.
  - the before_commit_handler silently swallowing flush exceptions.

Key changes:
  - Added db.rollback() to 13 exception handlers across 4 methods in gateway_service.py
  - IMPORTANT ONE: Isolated structured logger DB persistence using fresh_db_session()
  - Made before_commit_handler propagate flush exceptions instead of swallowing them
  - Updated all affected tests to match new behavior

## 🔁 Reproduction Steps
  1. Register a gateway with a tool that has an invalid schema (e.g., missing required inputSchema field)
  2. Registration fails with a validation error (expected)
  3. Attempt to register the same gateway name again
  4. Bug: Second registration fails with "Gateway name already exists" even though the first registration failed
  5. The orphaned gateway record has no tools associated with it

## 🐞 Root Cause
Three issues combine to cause the bug:

1. **Primary cause**: Missing `db.rollback()` in exception handlers: 
In `register_gateway()`, after `db.add(db_gateway)` and `db.flush()` succeed (persisting the gateway row), tool validation fails during `db.flush()` of tool records. The except* handlers catch the error but never call `db.rollback()`, leaving the gateway object in the session's dirty state.

2. **Contributing factor 1:** `before_commit_handler` swallows exceptions: 
db.py's `before_commit_handler` wraps `session.flush()` in a bare except Exception: pass, silently discarding any flush failure during commit. This means even when `db.commit()` is eventually called, the failed flush doesn't cause the commit to fail.

3. **Contributing factor 2**: Structured logger commits caller's session: 
`structured_logger._persist_to_database()` was called with the caller's db session and called `db.add(log_entry)` + `db.commit()` on it. This inadvertently committed the orphaned gateway record along with the log entry.

The chain: `db.flush()` fails on tools -> exception handler skips rollback -> `structured_logger.log(db=db)` calls `db.commit()` on same session -> before_commit_handler swallows re-flush failure -> gateway record persisted without tools -> name permanently reserved.

## 💡 Fix Description

1. Added `db.rollback()` to all exception handlers (`gateway_service.py`)    
    Added explicit `db.rollback()` calls before any logging or re-raising in all exception handlers across 4 methods:    
    - register_gateway - 7 except* handlers (validation errors, integrity errors, connection errors, timeout errors, general exceptions)   
    - `update_gateway` - 3 exception handlers (name conflict, not found, integrity error)   
    - `set_gateway_state` - 1 exception handler (permission error)   
    - `fetch_tools_after_oauth` - 2 exception handlers (connection error, general exception)    
    `db.rollback()` is always safe to call - it's a no-op on a clean session with no pending changes.    

2. Isolated structured logger persistence (structured_logger.py)    
    Changed `_persist_to_database()` to use `fresh_db_session()` instead of the caller's session. This ensures:   
    - Log persistence can never accidentally commit the caller's dirty state   
    - Logs are persisted even when the business transaction fails   
    - A broken caller session doesn't prevent log persistence   
    - Complete session lifecycle isolation (`fresh_db_session` handles commit/rollback/close)    

3. Propagate flush exceptions in before_commit_handler (db.py)    
    Removed the bare except Exception: pass from before_commit_handler. The handler now simply calls `session.flush()` without catching exceptions, so flush failures properly cause the commit to fail, triggering rollback in `get_db()`.    

4. Updated tests    
    - `test_structured_logger.py` - Updated 7 tests to mock fresh_db_session instead of mock_db; replaced 2 tests with fresh-session-aware equivalents   
    - `test_logging_service_comprehensive.py` - Updated 2 tests for fresh_db_session pattern   
    - `test_db.py` - Updated before_commit_handler test to verify exception propagation instead of swallowing



## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed