### PR TITLE
[FIX][UI]: Display CRUD changes on Users and Teams pages without full reload

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -22824,8 +22824,8 @@ function handleAdminUserAction(event) {
             if (usersList && window.htmx) {
                 // Cache-bust with timestamp to bypass nginx proxy cache after mutation
                 const hxGet = usersList.getAttribute("hx-get") || "";
-                const sep = hxGet.includes("?") ? "&" : "?";
-                const url = `${hxGet}${sep}_t=${Date.now()}`;
+                const separator = hxGet.includes("?") ? "&" : "?";
+                const url = `${hxGet}${separator}_t=${Date.now()}`;
                 window.htmx.ajax("GET", url, {
                     target: "#users-list-container",
                     swap: "outerHTML",


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Fixes stale UI data on Teams and Users admin pages when running multiple gateway replicas behind nginx. The root cause was three layers of caching preventing CRUD changes from being reflected:

1. Cross-replica cache invalidation gap — `auth_cache` published invalidation messages to `mcpgw:auth:invalidate` but `CacheInvalidationSubscriber` only listened on `mcpgw:cache:invalidate`, so other replicas never cleared their in-memory auth caches.
2. Missing HTMX refresh triggers — Create team and delete user endpoints returned responses without `HX-Trigger` headers, so the frontend never knew to refresh the lists
3. Nginx/browser caching — Nginx's `proxy_cache_valid 200 5s` and add_header `Cache-Control "private, max-age=5"` always caused stale responses for all /admin GET requests. Since nginx overrides backend Cache-Control headers, this was solved client-side with `_t=Date.now()` cache-busting query parameters.
4. Removed all 6 Cache-Control/Pragma/Expires header additions from partial endpoints — these are unnecessary since the `_t=Date.now()` timestamp cache-busting in admin.js already bypasses both nginx proxy cache and browser cache

## 🔁 Reproduction Steps
Users Page
1. Go to http://localhost:8080/admin
2. Navigate to the Users page
3. Create, Edit, Delete User(s)
4. Observe that a new / updated / deleted user is not updated on the page. The page has to be reloaded to see the change.

Teams Page
1. Go to http://localhost:8080/admin
2. Navigate to the Teams page
3. Create, Edit, Activate / Deactivate, Delete Team(s)
4. Add / Remove members to / from Teams
5. Observe that a new / updated / deleted teams or updated members are not updated on the page. The page has to be reloaded to see the change.


## 🐞 Root Cause
CRUD operations on Users and Teams are cached behind the nginx 5s cache time. So when the operations are executed on the admin UI, the changes are not reflected on the UI. The whole page must be reloaded to see them. 

## 💡 Fix Description
 Changes by file

`mcpgateway/cache/registry_cache.py`

- Subscribe `CacheInvalidationSubscriber` to both `mcpgw:cache:invalidate` and `mcpgw:auth:invalidate` channels
- Route messages by channel in `_listen_loop`
- Add `_process_auth_invalidation()` to clear L1 in-memory auth caches (_user_cache, _team_cache, _role_cache, _teams_list_cache, _revocation_cache, _context_cache, _revoked_jtis) across replicas

`mcpgateway/admin.py`

- Add `HX-Trigger` header to `admin_create_team` to refresh teams list
- Add `HX-Trigger` header to `admin_delete_user` to refresh users list
- Add `_t` cache-busting timestamp to server-rendered `hx-get` URLs for members/non-members partials and their infinite scroll `next_page_url`

`mcpgateway/static/admin.js`

  - Add `_t=Date.now()` cache-busting to teams partial, users partial, members partial, non-members partial, team edit, user edit, and team members refresh fetches

`mcpgateway/templates/admin.html`

  - Add `_t` cache-busting to `loadTeamMembersView()`, `loadAddMembersView()`, and `editTeamSafe()` HTMX ajax calls

`mcpgateway/templates/users_partial.html`

- Add `hx-on::config-request` to dynamically append `_t` on the user edit button's `hx-get` request

`tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py`

- Update `FakePubSub` subscribe/unsubscribe signatures to accept `*channels` (matching the new two-channel subscription)

`tests/js/admin-search.test.js`

- Update user edit modal test assertions to use `expect.stringContaining()` to accommodate the `_t` query parameter

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
