### PR TITLE
fix(auth): cache full team objects in get_user_teams (fixes #3005)

### DIFF
--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -20,7 +20,7 @@ Examples:
 # Standard
 import asyncio
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 # Third-Party
@@ -952,9 +952,6 @@ class TeamManagementService:
                                 dt = datetime.fromisoformat(value)
                                 # Ensure timezone-aware (UTC) to match DB model
                                 if dt.tzinfo is None:
-                                    # Standard
-                                    from datetime import timezone
-
                                     dt = dt.replace(tzinfo=timezone.utc)
                                 team_data[key] = dt
                         teams.append(CachedTeamData(**team_data))


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3005

---

## 📝 Summary
_What does this PR do and why?_
This PR optimizes the authentication hot-path by extending the get_user_teams cache to store full Team objects (serialized) instead of only team IDs. On cache hits, downstream request handlers can now consume full team data without performing additional DB lookups, significantly reducing DB round-trips under high concurrency.

Key changes:

- Store serialised Team objects in auth_cache for get_user_teams.
- Prime cache using the request's existing DB session (avoid repeated fresh_db_session() calls).
- Update callers to read Team objects from cache and fall back to DB only on miss/partial data.
- Update unit tests to reflect the new changes in teams objects  


Performance Impact:

- Before: Cache hit → Returns IDs → Query DB for team details
- After: Cache hit → Returns full team objects → No DB query needed
- Cache hit: Reconstruct EmailTeam objects from cached dictionaries

Cache miss: Serialize team objects to dictionaries before caching

Handles datetime serialization using isoformat()

Code Changes: 

1. mcpgateway/cache/auth_cache.py

- get_user_teams(): Return type changed from Optional[List[str]] → Optional[List[Dict[str, Any]]]
- set_user_teams(): Parameter changed from team_ids: List[str] → teams: List[Dict[str, Any]]

2. mcpgateway/services/team_management_service.py

- Cache hit: Reconstruct EmailTeam objects from cached dictionaries
- Cache miss: Serialize team objects to dictionaries before caching
- Handles datetime serialization using isoformat()


3. Updated Existing Tests
- test_team_management_service.py: Updated test_get_user_teams_cache_hit_with_objects
- test_team_management_service_coverage.py: Updated test_cache_hit_with_objects


---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   PASS     |
| Unit tests                | `make test`     |      PASS       |
| Coverage ≥ 80%            | `make coverage` |    99%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
