### PR TITLE
feat(ui): persist admin table filters across HTMX pagination and part…

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2295,6 +2295,7 @@
                 class="px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
                 Clear
               </button>
+              <span id="servers-filter-status" class="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" role="status"></span>
             </div>
 
             <!-- Hidden tag filter (for internal JavaScript usage) -->
@@ -3257,6 +3258,7 @@
                 class="px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
                 Clear
               </button>
+              <span id="tools-filter-status" class="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" role="status"></span>
             </div>
 
             <!-- Hidden tag filter for functionality -->
@@ -4270,6 +4272,7 @@
                 class="px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
                 Clear
               </button>
+              <span id="resources-filter-status" class="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" role="status"></span>
             </div>
 
             <!-- Hidden tag filter for functionality -->
@@ -4511,6 +4514,7 @@
                 class="px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
                 Clear
               </button>
+              <span id="prompts-filter-status" class="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" role="status"></span>
             </div>
 
             <!-- Hidden tag filter for functionality -->
@@ -4797,6 +4801,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                 class="px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
                 Clear
               </button>
+              <span id="gateways-filter-status" class="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" role="status"></span>
             </div>
 
             <!-- Hidden tag filter for functionality -->
@@ -6606,6 +6611,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                 class="px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
                 Clear
               </button>
+              <span id="agents-filter-status" class="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" role="status"></span>
             </div>
 
             <!-- Hidden tag filter for functionality -->

--- a/mcpgateway/templates/pagination_controls.html
+++ b/mcpgateway/templates/pagination_controls.html
@@ -121,9 +121,20 @@
     {% endfor %}
     {% endif %}
 
+    // Read live search/tag filters from URL (source of truth written by
+    // updatePanelSearchStateInUrl).  These override template-baked values so
+    // that pagination always reflects the user's current filter state.
+    const currentUrlParams = new URLSearchParams(window.location.search);
+    if (this.tableName) {
+      const livePrefix = this.tableName + '_';
+      const liveQuery = currentUrlParams.get(livePrefix + 'q');
+      const liveTags = currentUrlParams.get(livePrefix + 'tags');
+      if (liveQuery) url.searchParams.set('q', liveQuery);
+      if (liveTags) url.searchParams.set('tags', liveTags);
+    }
+
     // Preserve team_id from current URL (if present) - this ensures team filter
     // is maintained during pagination
-    const currentUrlParams = new URLSearchParams(window.location.search);
     const teamIdFromUrl = currentUrlParams.get('team_id');
     if (teamIdFromUrl) {
       url.searchParams.set('team_id', teamIdFromUrl);


### PR DESCRIPTION
  ## 🔗 Related Issue                                                                     
  Closes #2992
   ---                                                                                     

  ## 📝 Summary
  Persist admin table filters (search text, tag filters, "show inactive" toggles) across  
  HTMX pagination clicks and partial refreshes for all 6 admin tables.

  **Root cause:** `pagination_controls.html` `loadPage()` built HTMX request URLs using   
  template-baked `query_params` (static Jinja2 values). When pagination controls were     
  rendered before a search, clicking page 2 dropped the active filters.

  **Changes:**
  - **`pagination_controls.html`** — `loadPage()` now reads live namespaced `q`/`tags`    
  from the browser URL (source of truth written by `updatePanelSearchStateInUrl`),        
  overriding stale template-baked values.
  - **`admin.js`** — Added `htmx:afterSettle` listener that rehydrates search inputs from 
  URL state after content swaps. Added `updateFilterStatus()` for visible filtered row    
  count text.
  - **`admin.html`** — Added `aria-live="polite"` status spans next to all 6 table search 
  bars (servers, tools, resources, prompts, gateways, a2a-agents).

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix
  - [x] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)
  - [ ] Other (describe below)

  ---

  ## 🧪 Verification

  | Check                     | Command            | Status
                   |
  |---------------------------|--------------------|--------------------------------------
  -----------------|
  | JS tests (vitest)         | `npx vitest run`   | 583/584 pass (1 pre-existing locale  
  mismatch)         |
  | Unit tests                | `make test`        | 12,349/12,355 pass (6 pre-existing   
  stdio failures)    |
  | Lint suite                | `make lint`        | N/A — no Python files changed        
                   |
  | Coverage ≥ 80%            | `make coverage`    | N/A — no Python files changed        
                   |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [x] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)

  **Files changed (3):**

  | File | Lines | What |
  |------|-------|------|
  | `mcpgateway/templates/pagination_controls.html` | +13/−1 | Read live
  `{table}_q`/`{table}_tags` from URL in `loadPage()` |
  | `mcpgateway/static/admin.js` | +65 | `updateFilterStatus()` + `htmx:afterSettle`      
  rehydration listener |
  | `mcpgateway/templates/admin.html` | +6 | `aria-live` status spans on all 6 table      
  panels |