### PR TITLE
fix(ui): show toast notification when user deletion returns an error

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -1004,13 +1004,14 @@ function showErrorMessage(message, elementId = null) {
 
 // Handle HTMX after-request for user delete — extracts plain text from the
 // HTML error response and surfaces it via the toast notification system.
-function handleDeleteUserError(event) {
+// Exposed on window so inline hx-on::after-request handlers can call it.
+window.handleDeleteUserError = function (event) {
     if (!event.detail.successful) {
         const d = document.createElement("div");
         d.innerHTML = event.detail.xhr.responseText;
         showErrorMessage(d.textContent.trim() || "Error deleting user");
     }
-}
+};
 
 // Show success messages
 function showSuccessMessage(message) {


### PR DESCRIPTION
  ## 🔗 Related Issue
  Closes #3015

  ---

  ## 📝 Summary
  When deleting a user returns a 4xx error (e.g. self-deletion, last  
  admin, or DB error), the error HTML was silently discarded by HTMX  
  because the global `htmx:beforeSwap` handler does not allow swaps   
  for user delete responses. The error was never shown to the admin.  

  This fix attaches `hx-on::after-request` to the delete button in    
  both the Jinja template (`users_partial.html`) and the
  Python-generated card (`admin.py`). On any non-2xx response it      
  parses the error HTML, extracts the plain text, and calls the       
  already-existing `showErrorMessage()` function to display a toast.  
  No backend changes required.

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix

  ---

  ## 🧪 Verification

  | Check          | Command         | Status |
  |----------------|-----------------|--------|
  | Lint suite     | `make lint`     | ⏳     |
  | Unit tests     | `make test`     | ⏳     |
  | Coverage ≥ 80% | `make coverage` | ⏳     |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes
  Frontend-only fix. The `admin_delete_user` endpoint already returns 
  correct 400/403 responses with descriptive messages, this PR only  
  ensures those messages are surfaced to the user via the existing    
  toast system.