### PR TITLE
[FIX][PLUGINS]: Allow external plugins to be tested without symbolic link and config hack

### DIFF
--- a/tests/performance/test_plugins_performance.py
+++ b/tests/performance/test_plugins_performance.py
@@ -31,8 +31,8 @@ import io
 import logging
 import os
 import pstats
-import sys
 from pstats import SortKey
+import sys
 from typing import Any, Dict, Tuple
 
 # Disable security warnings
@@ -228,6 +228,9 @@ async def profile_all_plugins(manager: PluginManager, show_details: bool = False
     for plugin_config in manager.config.plugins:
         if plugin_config.mode != "disabled":
             plugin_ref = manager.get_plugin(plugin_config.name)
+            if plugin_ref is None:
+                print(f"  Warning: Enabled plugin '{plugin_config.name}' not found in registry, skipping")
+                continue
             plugins_info.append((plugin_config.name, plugin_ref.hooks))
 
     print(f"\nProfiling {len(plugins_info)} enabled plugins...")


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #

---

## 📝 Summary
Previously, running performance benchmarks on external plugins required soft linking the external plugin's plugin-manifest.yaml folder to the project root, and adding the plugins spec from resources/plugins/config.yaml to tests/performance/plugins/config.yaml.  This process was counter-intuitive and inconsistent with how external plugins are registered.   

External plugins can now be registered in `tests/performance/plugins/config.yaml` the same way they are registered in `plugins/config.yaml`

E.g. for the LLMGuardPlugin:

```yaml
  - name: "LLMGuardPlugin"
    kind: "external"
    mode: "enforce"  # Don't fail if the server is unavailable
    priority: 20 # adjust the priority
    mcp:
      proto: STREAMABLEHTTP
      url: http://127.0.0.1:8001/mcp
```

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
