### PR TITLE
Fix injection of server_id in internally-forwarded streamable HTTP requests

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1861,7 +1861,7 @@ class SessionManagerWrapper:
                 # Inject server_id from URL path into params for /rpc routing
                 if match:
                     server_id = match.group("server_id")
-                    if "params" not in json_body:
+                    if not isinstance(json_body.get("params"), dict):
                         json_body["params"] = {}
                     json_body["params"]["server_id"] = server_id
                     # Re-serialize body with injected server_id
@@ -2013,7 +2013,7 @@ class SessionManagerWrapper:
                         # Inject server_id from URL path into params for /rpc routing
                         if match:
                             server_id = match.group("server_id")
-                            if "params" not in json_body:
+                            if not isinstance(json_body.get("params"), dict):
                                 json_body["params"] = {}
                             json_body["params"]["server_id"] = server_id
                             # Re-serialize body with injected server_id

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -5525,6 +5525,68 @@ async def test_forwarded_post_injects_server_id_with_existing_params(monkeypatch
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params_value,params_json",
+    [
+        ("null", b'{"jsonrpc":"2.0","method":"tools/list","params":null,"id":1}'),
+        ("empty list", b'{"jsonrpc":"2.0","method":"tools/list","params":[],"id":1}'),
+    ],
+)
+async def test_forwarded_post_injects_server_id_with_non_dict_params(monkeypatch, params_value, params_json):
+    """Test internally-forwarded POST handles non-dict params (null, list) gracefully.
+
+    Verifies that params is coerced to a dict and server_id is injected
+    instead of crashing with TypeError and falling through to the SDK path.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not fall through to SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-123-def-456"
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        f"/servers/{server_id}/mcp",
+        method="POST",
+        headers=[(b"x-forwarded-internally", b"true")],
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{"tools":[]},"id":1}'
+
+    with patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, _make_receive(params_json), send)
+
+        # Must reach /rpc (not fall through to SDK)
+        mock_client.post.assert_called_once()
+        posted_content = mock_client.post.call_args.kwargs["content"]
+        posted_json = orjson.loads(posted_content)
+
+        assert isinstance(posted_json["params"], dict), f"params should be dict, was {type(posted_json['params'])}"
+        assert posted_json["params"]["server_id"] == server_id
+
+    await wrapper.shutdown()
+    assert messages[0]["status"] == 200
+
+
+@pytest.mark.asyncio
 async def test_forwarded_post_no_server_id_in_url_no_injection(monkeypatch):
     """Test internally-forwarded POST without server_id pattern in URL does not inject server_id.
 
@@ -5678,6 +5740,76 @@ async def test_local_affinity_post_injects_server_id_regression(monkeypatch):
         posted_json = orjson.loads(posted_content)
 
         assert "params" in posted_json
+        assert posted_json["params"]["server_id"] == server_id
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params_value,params_json",
+    [
+        ("null", b'{"jsonrpc":"2.0","method":"tools/list","params":null,"id":1}'),
+        ("empty list", b'{"jsonrpc":"2.0","method":"tools/list","params":[],"id":1}'),
+    ],
+)
+async def test_local_affinity_post_injects_server_id_with_non_dict_params(monkeypatch, params_value, params_json):
+    """Test local-owner affinity POST handles non-dict params (null, list) gracefully.
+
+    Mirrors the forwarded-branch test to ensure parity between both injection paths.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1")])
+    receive = _make_receive(params_json)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_streamable_http_session_owner = AsyncMock(return_value="worker-1")
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=mock_pool),
+        patch("mcpgateway.services.mcp_session_pool.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.mcp_session_pool.MCPSessionPool", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        posted_content = mock_client.post.call_args.kwargs["content"]
+        posted_json = orjson.loads(posted_content)
+
+        assert isinstance(posted_json["params"], dict), f"params should be dict, was {type(posted_json['params'])}"
         assert posted_json["params"]["server_id"] == server_id
 
     await wrapper.shutdown()


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #3018

## 📌 Summary
When a Streamable HTTP POST request is forwarded between workers via the internal affinity mechanism (x-forwarded-internally=true), the server_id from the URL path (/servers/{id}/mcp) was not injected into the JSON-RPC params before posting to /rpc. This caused /rpc routing to fall into the unscoped list_tools path instead of the server-scoped list_server_tools path, breaking multi-tenant isolation in multi-worker deployments.

Why this matters: In production deployments with multiple workers and session affinity enabled, clients would receive tools from ALL servers instead of just the requested server, violating tenant isolation.

## 🔁 Reproduction Steps

Prerequisites:

- Multi-worker deployment with MCPGATEWAY_SESSION_AFFINITY_ENABLED=true
- At least 2 registered MCP servers with different tools

Steps:

1. Establish a stateful MCP session on Worker A via /servers/{server_id}/mcp/
2. Send a tools/list request that gets routed to Worker B (cross-worker forward)
3. Worker B forwards the request internally with x-forwarded-internally: true
4. The forwarded request posts to /rpc without params.server_id
5. /rpc routes to unscoped handler → returns tools from all servers instead of just {server_id}

Expected: Only tools from the requested server
Actual: Tools from all servers (multi-tenant isolation broken)

## 🐞 Root Cause

The internally-forwarded branch (lines 1850-1873) was missing the server_id injection logic that was added to the local-owner branch in PR #2974.
Location: mcpgateway/transports/streamablehttp_transport.py:1850-1873
The match variable (containing the extracted server_id from the URL path) was available but not used in this branch.

## 💡 Fix Description
Added the same server_id injection logic to the internally-forwarded branch that already existed in the local-owner branch.

Key changes:

Inject server_id from URL path (lines 1861-1868):

```python
# Inject server_id from URL path into params for /rpc routing
if match:
    server_id = match.group("server_id")
    if "params" not in json_body:
        json_body["params"] = {}
    if server_id:
        json_body["params"]["server_id"] = server_id
        # Re-serialize body with injected server_id
        body = orjson.dumps(json_body)
        logger.debug(
            f"[HTTP_AFFINITY_FORWARDED] Injected server_id {server_id} into /rpc params"
        )

```

Added comprehensive test coverage in test_streamablehttp_transport.py:

test_forwarded_post_injects_server_id_from_url - Verifies the fix
test_forwarded_post_no_server_id_in_url_no_injection - Edge case without server_id
test_forwarded_post_notification_no_server_id_injection - Notification handling
test_local_affinity_post_injects_server_id_regression - Regression test

Design points:

Mirrors the existing pattern in the local-owner branch (lines 2003-2010) for consistency
Uses the existing match variable captured at line 1776
Placed after notification handling (line 1859) and before httpx client call (line 1869)
Added debug logging for observability
All 251 transport tests pass with no regressions
Impact: Restores proper server-scoped routing and multi-tenant isolation in multi-worker deployments.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed