### PR TITLE
[FIX][A2A]: Fix response serialization to produce valid JSON instead of Python repr

### DIFF
--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -22,6 +22,7 @@ have no heavy dependencies.
 from __future__ import annotations
 
 # Standard
+import json
 from contextlib import asynccontextmanager
 from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8956,9 +8957,6 @@ async def test_local_affinity_post_no_injection_without_server_url(monkeypatch):
 @pytest.mark.asyncio
 async def test_call_tool_rehydrate_unknown_type_produces_valid_json(monkeypatch):
     """When _rehydrate_content_items encounters an unknown content type dict, it should serialize as valid JSON."""
-    # Standard
-    import json
-
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import (
         call_tool,
@@ -9010,9 +9008,6 @@ async def test_call_tool_rehydrate_unknown_type_produces_valid_json(monkeypatch)
 @pytest.mark.asyncio
 async def test_call_tool_rehydrate_fallback_on_validation_error(monkeypatch):
     """When model_validate fails for a known type, fallback should produce valid JSON."""
-    # Standard
-    import json
-
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import (
         call_tool,
@@ -9066,9 +9061,6 @@ async def test_call_tool_rehydrate_fallback_on_validation_error(monkeypatch):
 @pytest.mark.asyncio
 async def test_call_tool_unknown_content_type_local_path(monkeypatch):
     """When local invoke returns unknown content type, it should serialize as valid JSON via orjson."""
-    # Standard
-    import json
-
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #2672

---

## 📌 Summary
Fixes response serialization across the gateway where `str()` was used instead of `orjson.dumps()` to convert Python dicts into `TextContent.text` fields. This produced Python repr output (`{'key': False}` with single quotes and Python booleans) instead of valid JSON (`{"key": false}`), causing downstream consumers to fail when parsing the text content.

## 🐞 Root Cause
When the gateway receives a JSON response (from A2A agents or forwarded MCP responses), the result is a Python dict. Multiple code paths wrapped this dict into `TextContent(type="text", text=str(response_data))`. Python's `str()` on a dict produces repr-style output with single quotes and `True`/`False` literals, which is not valid JSON.

This explains the DEV vs UAT trace discrepancy in the issue:
- **DEV** (valid): `"text": "{\"has_chart\": false, ...}"` — proper JSON
- **UAT** (broken): `"text": "{'has_chart': False, ...}"` — Python repr

## 💡 Fix Description
- **`mcpgateway/services/tool_service.py`**: Replace `str()` with `orjson.dumps().decode()` for dict/list values in A2A response wrapping paths (lines ~3810, ~4765) and REST error response handling (line ~3205). String values are passed through as-is to avoid double-encoding.
- **`mcpgateway/transports/streamablehttp_transport.py`**: Apply the same fix in `_rehydrate_content_items` for unknown content types and validation error fallbacks (line ~800), unknown content type serialization in `call_tool` (line ~914), and A2A response handling in `connect_to_streamablehttp_server` (lines ~3810, ~3842).

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    pass    |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
