### PR TITLE
[EPIC][UI][OBSERVABILITY]: Admin Overview redesign with actionable topology and health signals

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -462,7 +462,7 @@
           {% endif %}
 
           <!-- LLM Section -->
-          {% if llmchat_enabled or 'settings' not in hidden_sections %}
+          {% if llmchat_enabled %}
           <div class="sidebar-section mt-4" x-show="!sidebarCollapsed">
             <span class="px-3 text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">LLM</span>
           </div>
@@ -1846,8 +1846,8 @@
         </div>
         {% endif %}
 
-        {% if 'settings' not in hidden_sections %}
         <!-- LLM Settings Panel -->
+      {% if llmchat_enabled and 'settings' not in hidden_sections %}
       <div id="llm-settings-panel" class="tab-panel hidden">
         <div class="container mx-auto">
           <!-- Tab Navigation -->

--- a/mcpgateway/templates/overview_partial.html
+++ b/mcpgateway/templates/overview_partial.html
@@ -1,99 +1,96 @@
 <!-- htmlhint doctype-first:false -->
-<div class="space-y-6" x-data="overviewDashboard()" x-init="init()">
+<div class="space-y-6" x-data='overviewDashboard({{ topology_payload | tojson }})' x-init="init()">
+  <p class="sr-only" aria-live="polite" x-text="announcement"></p>
+
   <!-- Header -->
-  <div class="flex justify-between items-center">
-    <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 flex items-center">
-      <svg class="h-8 w-8 mr-3 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
-      </svg>
-      System Overview
-    </h2>
-    <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
-      <span class="flex items-center">
-        <svg class="h-4 w-4 mr-1 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-        </svg>
-        Uptime: {% set hours = uptime_seconds // 3600 %}{% set minutes = (uptime_seconds % 3600) // 60 %}{% if hours > 0 %}{{ hours }}h {{ minutes }}m{% else %}{{ minutes }}m {{ uptime_seconds % 60 }}s{% endif %}
-      </span>
-      <span>v{{ version }}</span>
+  <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+    <div>
+      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">System Overview</h2>
+      <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Operational topology with health signals and direct drilldowns.</p>
+      <div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-600 dark:text-gray-300">
+        <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+          Uptime:
+          {% set hours = uptime_seconds // 3600 %}
+          {% set minutes = (uptime_seconds % 3600) // 60 %}
+          {% if hours > 0 %}
+          {{ hours }}h {{ minutes }}m
+          {% else %}
+          {{ minutes }}m {{ uptime_seconds % 60 }}s
+          {% endif %}
+        </span>
+        <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-gray-700 dark:text-gray-200">v{{ version }}</span>
+        <span class="inline-flex items-center rounded-full px-3 py-1 font-medium" :class="freshnessBadgeClass()">
+          <span x-text="freshnessLabel()"></span>
+        </span>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <div class="text-sm text-gray-600 dark:text-gray-300">
+        Last updated:
+        <time x-text="formatTimestamp(lastUpdatedIso)"></time>
+      </div>
+      <label for="overview-drilldown-range" class="text-sm font-medium text-gray-700 dark:text-gray-200">Drilldown range</label>
+      <select
+        id="overview-drilldown-range"
+        class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+        x-model="selectedTimeRange"
+        @change="announceTimeRangeChange()"
+      >
+        <option value="1h">Last hour</option>
+        <option value="6h">Last 6 hours</option>
+        <option value="24h">Last 24 hours</option>
+        <option value="7d">Last 7 days</option>
+      </select>
+      <button
+        type="button"
+        class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+        @click="refreshHealthSignals()"
+      >
+        Refresh Health
+      </button>
     </div>
   </div>
 
-  <!-- Key Metrics Cards -->
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-    <!-- Total Executions -->
-    <div class="bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20 rounded-lg p-4 border border-blue-200 dark:border-blue-800 shadow-sm">
-      <div class="flex items-center justify-between">
-        <div>
-          <div class="text-2xl font-bold text-blue-900 dark:text-blue-100">{{ "{:,}".format(total_executions|int) }}</div>
-          <div class="text-sm text-blue-700 dark:text-blue-300 mt-1">Total Executions</div>
-        </div>
-        <div class="text-blue-500 dark:text-blue-400">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
-          </svg>
-        </div>
-      </div>
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="rounded-xl border border-blue-200 bg-gradient-to-br from-blue-50 to-blue-100 p-4 shadow-sm dark:border-blue-800 dark:from-blue-900/20 dark:to-blue-800/20">
+      <div class="text-2xl font-bold text-blue-900 dark:text-blue-100">{{ "{:,}".format(total_executions|int) }}</div>
+      <div class="mt-1 text-sm font-medium text-blue-700 dark:text-blue-300">Total Executions</div>
+      <div class="mt-2 text-xs text-blue-700/80 dark:text-blue-300/80">{{ metrics_window_label }}</div>
     </div>
 
-    <!-- Success Rate -->
-    <div class="bg-gradient-to-br from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 rounded-lg p-4 border border-green-200 dark:border-green-800 shadow-sm">
-      <div class="flex items-center justify-between">
-        <div>
-          <div class="text-2xl font-bold text-green-900 dark:text-green-100">{{ "%.1f"|format(success_rate) }}%</div>
-          <div class="text-sm text-green-700 dark:text-green-300 mt-1">Success Rate</div>
-        </div>
-        <div class="text-green-500 dark:text-green-400">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-          </svg>
-        </div>
-      </div>
+    <div class="rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-emerald-100 p-4 shadow-sm dark:border-emerald-800 dark:from-emerald-900/20 dark:to-emerald-800/20">
+      <div class="text-2xl font-bold text-emerald-900 dark:text-emerald-100">{{ "%.1f"|format(success_rate) }}%</div>
+      <div class="mt-1 text-sm font-medium text-emerald-700 dark:text-emerald-300">Success Rate</div>
+      <div class="mt-2 text-xs text-emerald-700/80 dark:text-emerald-300/80">{{ health_window_label }}</div>
     </div>
 
-    <!-- Avg Latency -->
-    <div class="bg-gradient-to-br from-amber-50 to-amber-100 dark:from-amber-900/20 dark:to-amber-800/20 rounded-lg p-4 border border-amber-200 dark:border-amber-800 shadow-sm">
-      <div class="flex items-center justify-between">
-        <div>
-          <div class="text-2xl font-bold text-amber-900 dark:text-amber-100">{{ "%.0f"|format(avg_latency_ms) }}ms</div>
-          <div class="text-sm text-amber-700 dark:text-amber-300 mt-1">Avg Latency</div>
-        </div>
-        <div class="text-amber-500 dark:text-amber-400">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-          </svg>
-        </div>
-      </div>
+    <div class="rounded-xl border border-amber-200 bg-gradient-to-br from-amber-50 to-amber-100 p-4 shadow-sm dark:border-amber-800 dark:from-amber-900/20 dark:to-amber-800/20">
+      <div class="text-2xl font-bold text-amber-900 dark:text-amber-100">{{ "%.0f"|format(avg_latency_ms) }}ms</div>
+      <div class="mt-1 text-sm font-medium text-amber-700 dark:text-amber-300">Average Latency</div>
+      <div class="mt-2 text-xs text-amber-700/80 dark:text-amber-300/80">Context: latest aggregate execution path</div>
     </div>
 
-    <!-- Active Entities -->
-    <div class="bg-gradient-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20 rounded-lg p-4 border border-purple-200 dark:border-purple-800 shadow-sm">
-      <div class="flex items-center justify-between">
-        <div>
-          <div class="text-2xl font-bold text-purple-900 dark:text-purple-100">{{ servers_active + tools_active + prompts_active + resources_active }}</div>
-          <div class="text-sm text-purple-700 dark:text-purple-300 mt-1">Active Entities</div>
-        </div>
-        <div class="text-purple-500 dark:text-purple-400">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
-          </svg>
-        </div>
-      </div>
+    <div class="rounded-xl border border-violet-200 bg-gradient-to-br from-violet-50 to-violet-100 p-4 shadow-sm dark:border-violet-800 dark:from-violet-900/20 dark:to-violet-800/20">
+      <div class="text-2xl font-bold text-violet-900 dark:text-violet-100">{{ servers_active + gateways_active + tools_active + prompts_active + resources_active + (a2a_active if a2a_enabled else 0) }}</div>
+      <div class="mt-1 text-sm font-medium text-violet-700 dark:text-violet-300">Active Entities</div>
+      <div class="mt-2 text-xs text-violet-700/80 dark:text-violet-300/80">Inputs + outputs currently enabled</div>
     </div>
   </div>
 
-  <!-- Architecture Flow Diagram -->
-  <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 overflow-x-auto">
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Architecture Flow</h3>
+  <!-- Topology Map (Classic) -->
+  <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 overflow-x-auto">
+    <div class="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Topology Map</h3>
+      <p class="text-sm text-gray-600 dark:text-gray-300">Classic visual topology retained for quick at-a-glance architecture context.</p>
+    </div>
     <div class="min-w-[800px]">
       <svg id="overview-architecture" class="w-full" viewBox="0 0 900 440" xmlns="http://www.w3.org/2000/svg">
-        <!-- Definitions for gradients and markers -->
         <defs>
-          <!-- Arrow marker -->
           <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
             <polygon points="0 0, 10 3.5, 0 7" class="fill-gray-400 dark:fill-gray-500"/>
           </marker>
-          <!-- Animated dash pattern -->
           <style>
             @keyframes dash {
               to { stroke-dashoffset: -20; }
@@ -105,43 +102,26 @@
           </style>
         </defs>
 
-        <!-- INPUT SECTION - Virtual Servers -->
         <g class="input-section">
-          <!-- Section Label -->
           <text x="80" y="30" class="fill-gray-500 dark:fill-gray-400 text-xs font-semibold" text-anchor="middle">INPUTS</text>
-
-          <!-- Virtual Servers Box -->
           <rect x="20" y="120" width="120" height="140" rx="8" class="fill-blue-50 dark:fill-blue-900/30 stroke-blue-300 dark:stroke-blue-700" stroke-width="2"/>
           <text x="80" y="150" class="fill-blue-700 dark:fill-blue-300 text-sm font-semibold" text-anchor="middle">Virtual Servers</text>
           <text x="80" y="175" class="fill-blue-600 dark:fill-blue-400 text-xs" text-anchor="middle">🔗</text>
-
-          <!-- Count Badge -->
           <rect x="55" y="190" width="50" height="24" rx="12" class="fill-blue-500"/>
           <text x="80" y="207" class="fill-white text-sm font-bold" text-anchor="middle">{{ servers_active }}/{{ servers_total }}</text>
           <text x="80" y="235" class="fill-blue-600 dark:fill-blue-400 text-xs" text-anchor="middle">active</text>
         </g>
 
-        <!-- CENTER SECTION - ContextForge -->
         <g class="center-section">
-          <!-- Section Label -->
           <text x="450" y="30" class="fill-gray-500 dark:fill-gray-400 text-xs font-semibold" text-anchor="middle">GATEWAY</text>
-
-          <!-- Main ContextForge Box -->
           <rect x="320" y="60" width="260" height="260" rx="12" class="fill-indigo-50 dark:fill-indigo-900/20 stroke-indigo-400 dark:stroke-indigo-600" stroke-width="3"/>
-
-          <!-- ContextForge Header -->
           <rect x="320" y="60" width="260" height="50" rx="12" class="fill-indigo-500"/>
           <rect x="320" y="90" width="260" height="20" class="fill-indigo-500"/>
           <text x="450" y="92" class="fill-white text-base font-bold" text-anchor="middle">ContextForge</text>
-
-          <!-- Plugins Section -->
           <text x="340" y="140" class="fill-indigo-700 dark:fill-indigo-300 text-sm font-semibold">Middleware (Plugins)</text>
-
-          <!-- Plugin badges -->
           <rect x="340" y="155" width="220" height="30" rx="6" class="fill-purple-100 dark:fill-purple-900/30 stroke-purple-300 dark:stroke-purple-700" stroke-width="1"/>
           <text x="450" y="175" class="fill-purple-700 dark:fill-purple-300 text-xs" text-anchor="middle">{{ plugins_enabled }} / {{ plugins_total }} plugins enabled</text>
 
-          <!-- Hook badges -->
           {% for hook, count in plugins_by_hook.items() %}
           {% if loop.index <= 4 %}
           <rect x="{{ 340 + ((loop.index0 % 2) * 110) }}" y="{{ 195 + ((loop.index0 // 2) * 35) }}" width="100" height="28" rx="4" class="fill-gray-100 dark:fill-gray-700 stroke-gray-300 dark:stroke-gray-600" stroke-width="1"/>
@@ -149,7 +129,6 @@
           {% endif %}
           {% endfor %}
 
-          <!-- Features row -->
           <g transform="translate(340, 275)">
             <rect width="60" height="24" rx="4" class="fill-green-100 dark:fill-green-900/30"/>
             <text x="30" y="16" class="fill-green-700 dark:fill-green-300 text-xs" text-anchor="middle">Auth</text>
@@ -160,63 +139,43 @@
           </g>
         </g>
 
-        <!-- INFRASTRUCTURE SECTION - Below ContextForge -->
         <g class="infrastructure-section">
-          <!-- Section Label -->
           <text x="450" y="345" class="fill-gray-500 dark:fill-gray-400 text-xs font-semibold" text-anchor="middle">INFRASTRUCTURE</text>
-
-          <!-- Database Status -->
           <rect x="335" y="355" width="110" height="45" rx="6" class="{% if db_reachable %}fill-green-50 dark:fill-green-900/30 stroke-green-300 dark:stroke-green-700{% else %}fill-red-50 dark:fill-red-900/30 stroke-red-300 dark:stroke-red-700{% endif %}" stroke-width="2"/>
           <text x="390" y="375" class="{% if db_reachable %}fill-green-700 dark:fill-green-300{% else %}fill-red-700 dark:fill-red-300{% endif %} text-xs font-semibold" text-anchor="middle">{{ db_dialect | capitalize }}</text>
           <text x="390" y="392" class="{% if db_reachable %}fill-green-600 dark:fill-green-400{% else %}fill-red-600 dark:fill-red-400{% endif %} text-xs" text-anchor="middle">{% if db_reachable %}Connected{% else %}Disconnected{% endif %}</text>
-
-          <!-- Cache Status -->
           <rect x="455" y="355" width="110" height="45" rx="6" class="{% if cache_type == 'redis' %}{% if redis_reachable %}fill-green-50 dark:fill-green-900/30 stroke-green-300 dark:stroke-green-700{% else %}fill-red-50 dark:fill-red-900/30 stroke-red-300 dark:stroke-red-700{% endif %}{% else %}fill-gray-50 dark:fill-gray-700 stroke-gray-300 dark:stroke-gray-600{% endif %}" stroke-width="2"/>
           <text x="510" y="375" class="{% if cache_type == 'redis' %}{% if redis_reachable %}fill-green-700 dark:fill-green-300{% else %}fill-red-700 dark:fill-red-300{% endif %}{% else %}fill-gray-700 dark:fill-gray-300{% endif %} text-xs font-semibold" text-anchor="middle">{{ cache_type | capitalize }}</text>
           <text x="510" y="392" class="{% if cache_type == 'redis' %}{% if redis_reachable %}fill-green-600 dark:fill-green-400{% else %}fill-red-600 dark:fill-red-400{% endif %}{% else %}fill-gray-500 dark:fill-gray-400{% endif %} text-xs" text-anchor="middle">{% if cache_type == 'redis' %}{% if redis_reachable %}Connected{% else %}Disconnected{% endif %}{% else %}In-Memory{% endif %}</text>
-
-          <!-- Connection line from ContextForge to Infrastructure -->
           <line x1="450" y1="320" x2="450" y2="355" class="stroke-gray-300 dark:stroke-gray-600" stroke-width="2" stroke-dasharray="4,4"/>
         </g>
 
-        <!-- OUTPUT SECTION -->
         <g class="output-section">
-          <!-- Section Label -->
           <text x="780" y="30" class="fill-gray-500 dark:fill-gray-400 text-xs font-semibold" text-anchor="middle">OUTPUTS</text>
-
-          <!-- MCP Servers -->
           <rect x="700" y="50" width="120" height="55" rx="6" class="fill-teal-50 dark:fill-teal-900/30 stroke-teal-300 dark:stroke-teal-700" stroke-width="2"/>
           <text x="760" y="72" class="fill-teal-700 dark:fill-teal-300 text-xs font-semibold" text-anchor="middle">MCP Servers</text>
           <text x="760" y="92" class="fill-teal-600 dark:fill-teal-400 text-sm font-bold" text-anchor="middle">{{ gateways_active }}/{{ gateways_total }}</text>
 
           {% if a2a_enabled %}
-          <!-- A2A Agents -->
           <rect x="700" y="115" width="120" height="55" rx="6" class="fill-orange-50 dark:fill-orange-900/30 stroke-orange-300 dark:stroke-orange-700" stroke-width="2"/>
           <text x="760" y="137" class="fill-orange-700 dark:fill-orange-300 text-xs font-semibold" text-anchor="middle">A2A Agents</text>
           <text x="760" y="157" class="fill-orange-600 dark:fill-orange-400 text-sm font-bold" text-anchor="middle">{{ a2a_active }}/{{ a2a_total }}</text>
           {% endif %}
 
-          <!-- Tools -->
           <rect x="700" y="180" width="120" height="55" rx="6" class="fill-rose-50 dark:fill-rose-900/30 stroke-rose-300 dark:stroke-rose-700" stroke-width="2"/>
           <text x="760" y="202" class="fill-rose-700 dark:fill-rose-300 text-xs font-semibold" text-anchor="middle">Tools</text>
           <text x="760" y="222" class="fill-rose-600 dark:fill-rose-400 text-sm font-bold" text-anchor="middle">{{ tools_active }}/{{ tools_total }}</text>
 
-          <!-- Prompts -->
           <rect x="700" y="245" width="120" height="55" rx="6" class="fill-cyan-50 dark:fill-cyan-900/30 stroke-cyan-300 dark:stroke-cyan-700" stroke-width="2"/>
           <text x="760" y="267" class="fill-cyan-700 dark:fill-cyan-300 text-xs font-semibold" text-anchor="middle">Prompts</text>
           <text x="760" y="287" class="fill-cyan-600 dark:fill-cyan-400 text-sm font-bold" text-anchor="middle">{{ prompts_active }}/{{ prompts_total }}</text>
 
-          <!-- Resources -->
           <rect x="700" y="310" width="120" height="55" rx="6" class="fill-lime-50 dark:fill-lime-900/30 stroke-lime-300 dark:stroke-lime-700" stroke-width="2"/>
           <text x="760" y="332" class="fill-lime-700 dark:fill-lime-300 text-xs font-semibold" text-anchor="middle">Resources</text>
           <text x="760" y="352" class="fill-lime-600 dark:fill-lime-400 text-sm font-bold" text-anchor="middle">{{ resources_active }}/{{ resources_total }}</text>
         </g>
 
-        <!-- CONNECTION LINES -->
-        <!-- Input to Center -->
         <line x1="140" y1="190" x2="320" y2="190" class="stroke-gray-400 dark:stroke-gray-500 flow-line" stroke-width="2" marker-end="url(#arrowhead)"/>
-
-        <!-- Center to Outputs -->
         <line x1="580" y1="77" x2="700" y2="77" class="stroke-gray-400 dark:stroke-gray-500 flow-line" stroke-width="2" marker-end="url(#arrowhead)"/>
         {% if a2a_enabled %}
         <line x1="580" y1="142" x2="700" y2="142" class="stroke-gray-400 dark:stroke-gray-500 flow-line" stroke-width="2" marker-end="url(#arrowhead)"/>
@@ -229,70 +188,122 @@
     </div>
   </div>
 
-  <!-- Quick Stats Grid -->
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-    <!-- Virtual Servers Card -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('catalog')" onkeydown="handleKeydown(event, () => showTab('catalog'))" tabindex="0" role="button" aria-label="View Virtual Servers">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center">
-          <div class="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg mr-3">
-            <svg class="h-6 w-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
-            </svg>
-          </div>
-          <div>
-            <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">Virtual Servers</h4>
-            <p class="text-xs text-gray-500 dark:text-gray-400">Composite MCP endpoints</p>
-          </div>
-        </div>
-        <div class="text-right">
-          <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">{{ servers_total }}</div>
-          <div class="text-xs text-green-600 dark:text-green-400">{{ servers_active }} active</div>
-        </div>
-      </div>
+  <!-- Actionable Topology -->
+  <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <div class="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Actionable Topology</h3>
+      <p class="text-sm text-gray-600 dark:text-gray-300">Click any node or flow to open filtered diagnostics for the selected time range.</p>
     </div>
 
-    <!-- Tools Card -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('tools')" onkeydown="handleKeydown(event, () => showTab('tools'))" tabindex="0" role="button" aria-label="View Tools">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center">
-          <div class="p-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg mr-3">
-            <svg class="h-6 w-6 text-rose-600 dark:text-rose-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
+    <div class="grid gap-4 lg:grid-cols-3">
+      <template x-for="node in flowNodes" :key="node.id">
+        <button
+          type="button"
+          class="w-full rounded-xl border p-4 text-left transition focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          :class="healthCardClass(node.status)"
+          @click="activateDrilldown(node.drilldown)"
+          @keydown.enter.prevent="activateDrilldown(node.drilldown)"
+          @keydown.space.prevent="activateDrilldown(node.drilldown)"
+          :aria-label="nodeAriaLabel(node)"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <h4 class="text-base font-semibold text-gray-900 dark:text-gray-100" x-text="node.title"></h4>
+              <p class="mt-1 text-xs text-gray-600 dark:text-gray-300" x-text="node.subtitle"></p>
+            </div>
+            <span class="inline-flex rounded-full px-2.5 py-1 text-xs font-semibold" :class="healthBadgeClass(node.status)" x-text="healthLabel(node.status)"></span>
           </div>
-          <div>
-            <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">Tools</h4>
-            <p class="text-xs text-gray-500 dark:text-gray-400">Registered tool endpoints</p>
+          <div class="mt-4 grid grid-cols-3 gap-3 text-center">
+            <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/50">
+              <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Active</div>
+              <div class="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100" x-text="formatRatio(node.active, node.total)"></div>
+            </div>
+            <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/50">
+              <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Success</div>
+              <div class="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100" x-text="formatPercent(node.successRate)"></div>
+            </div>
+            <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/50">
+              <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Latency</div>
+              <div class="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100" x-text="formatLatency(node.latencyMs)"></div>
+            </div>
           </div>
-        </div>
-        <div class="text-right">
-          <div class="text-2xl font-bold text-rose-600 dark:text-rose-400">{{ tools_total }}</div>
-          <div class="text-xs text-green-600 dark:text-green-400">{{ tools_active }} active</div>
-        </div>
-      </div>
+        </button>
+      </template>
     </div>
 
-    <!-- Plugins Card -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 cursor-pointer hover:shadow-md transition-shadow" onclick="showTab('plugins')" onkeydown="handleKeydown(event, () => showTab('plugins'))" tabindex="0" role="button" aria-label="View Plugins">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center">
-          <div class="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg mr-3">
-            <svg class="h-6 w-6 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
-            </svg>
+    <div class="mt-4 grid gap-3 md:grid-cols-2">
+      <template x-for="edge in flowEdges" :key="edge.id">
+        <button
+          type="button"
+          class="w-full rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-left transition hover:border-indigo-400 hover:bg-indigo-50 dark:border-gray-600 dark:bg-gray-700/40 dark:hover:border-indigo-500 dark:hover:bg-indigo-900/20"
+          @click="activateDrilldown(edge.drilldown)"
+          @keydown.enter.prevent="activateDrilldown(edge.drilldown)"
+          @keydown.space.prevent="activateDrilldown(edge.drilldown)"
+          :aria-label="edgeAriaLabel(edge)"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100" x-text="edge.title"></h4>
+              <p class="mt-1 text-xs text-gray-600 dark:text-gray-300" x-text="edge.subtitle"></p>
+            </div>
+            <span class="inline-flex rounded-full px-2.5 py-1 text-xs font-semibold" :class="healthBadgeClass(edge.status)" x-text="healthLabel(edge.status)"></span>
           </div>
-          <div>
-            <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">Plugins</h4>
-            <p class="text-xs text-gray-500 dark:text-gray-400">Middleware extensions</p>
+          <div class="mt-3 grid grid-cols-3 gap-3 text-center">
+            <div class="rounded-lg bg-white p-2 dark:bg-gray-800/70">
+              <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Throughput</div>
+              <div class="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100" x-text="formatNumber(edge.throughput)"></div>
+            </div>
+            <div class="rounded-lg bg-white p-2 dark:bg-gray-800/70">
+              <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Success</div>
+              <div class="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100" x-text="formatPercent(edge.successRate)"></div>
+            </div>
+            <div class="rounded-lg bg-white p-2 dark:bg-gray-800/70">
+              <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Latency</div>
+              <div class="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100" x-text="formatLatency(edge.latencyMs)"></div>
+            </div>
           </div>
-        </div>
-        <div class="text-right">
-          <div class="text-2xl font-bold text-purple-600 dark:text-purple-400">{{ plugins_total }}</div>
-          <div class="text-xs text-green-600 dark:text-green-400">{{ plugins_enabled }} enabled</div>
-        </div>
+        </button>
+      </template>
+    </div>
+
+    <div class="mt-4 grid gap-3 md:grid-cols-2">
+      <div class="rounded-lg border p-3" :class="healthCardClass(topologyInfrastructure.database.status)">
+        <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">Database</div>
+        <div class="mt-1 text-sm text-gray-700 dark:text-gray-200" x-text="topologyInfrastructure.database.label"></div>
+        <div class="mt-2 text-xs text-gray-600 dark:text-gray-300" x-text="topologyInfrastructure.database.detail"></div>
+      </div>
+      <div class="rounded-lg border p-3" :class="healthCardClass(topologyInfrastructure.cache.status)">
+        <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">Cache</div>
+        <div class="mt-1 text-sm text-gray-700 dark:text-gray-200" x-text="topologyInfrastructure.cache.label"></div>
+        <div class="mt-2 text-xs text-gray-600 dark:text-gray-300" x-text="topologyInfrastructure.cache.detail"></div>
       </div>
     </div>
+  </div>
+
+  <!-- Quick Jumps -->
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+    <button type="button" class="rounded-lg bg-white p-4 text-left shadow transition hover:shadow-md dark:bg-gray-800" @click="activateDrilldown({ tab: 'catalog', entity: 'servers' })">
+      <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Virtual Servers</div>
+      <div class="mt-2 text-2xl font-bold text-blue-600 dark:text-blue-400">{{ servers_total }}</div>
+      <div class="text-xs text-gray-500 dark:text-gray-400">{{ servers_active }} active</div>
+    </button>
+
+    <button type="button" class="rounded-lg bg-white p-4 text-left shadow transition hover:shadow-md dark:bg-gray-800" @click="activateDrilldown({ tab: 'tools', entity: 'tools' })">
+      <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Tools</div>
+      <div class="mt-2 text-2xl font-bold text-rose-600 dark:text-rose-400">{{ tools_total }}</div>
+      <div class="text-xs text-gray-500 dark:text-gray-400">{{ tools_active }} active</div>
+    </button>
+
+    <button type="button" class="rounded-lg bg-white p-4 text-left shadow transition hover:shadow-md dark:bg-gray-800" @click="activateDrilldown({ tab: 'plugins', entity: 'plugins' })">
+      <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Plugins</div>
+      <div class="mt-2 text-2xl font-bold text-purple-600 dark:text-purple-400">{{ plugins_total }}</div>
+      <div class="text-xs text-gray-500 dark:text-gray-400">{{ plugins_enabled }} enabled</div>
+    </button>
+
+    <button type="button" class="rounded-lg bg-white p-4 text-left shadow transition hover:shadow-md dark:bg-gray-800" @click="activateDrilldown({ tab: 'observability', entity: 'overview', viewMode: 'traces', statusFilter: 'all' })">
+      <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Observability</div>
+      <div class="mt-2 text-2xl font-bold text-emerald-600 dark:text-emerald-400" x-text="selectedTimeRange.toUpperCase()"></div>
+      <div class="text-xs text-gray-500 dark:text-gray-400">Open filtered diagnostics</div>
+    </button>
   </div>
 </div>

--- a/tests/playwright/test_autocomplete.py
+++ b/tests/playwright/test_autocomplete.py
@@ -67,6 +67,8 @@ class TestAutocompleteAttributes:
 
     def test_llm_provider_api_key_has_autocomplete_off(self, admin_page: AdminPage):
         """LLM provider API key field should not trigger browser autofill."""
+        if admin_page.page.locator("#tab-llm-settings").count() == 0:
+            pytest.skip("LLM settings tab not available in this UI configuration.")
         admin_page.sidebar.click_tab_by_id("tab-llm-settings", "llm-settings-panel")
         api_key_input = admin_page.page.locator("#llm-provider-api-key")
         expect(api_key_input).to_have_attribute("autocomplete", "off")


### PR DESCRIPTION
## Summary
- redesign the Admin Overview with actionable topology cards driven by aggregated health signals
- preserve the classic topology map for architecture-at-a-glance context
- add robust overview drilldown routing into Observability (URL state + post-settle application)
- fix early page-init failure in `admin.js` caused by binding to `document.body` before it exists
- gate LLM Settings UI rendering by `llmchat_enabled` to avoid `/admin/llm/*` partial 404s when disabled
- expand JS/unit coverage for overview drilldown, health refresh behavior, helper metrics, and feature-flag context
- make the Playwright autocomplete test resilient when LLM Settings is intentionally unavailable

Closes #2991
