### PR TITLE
fix(auth): allow removing non-last admin users

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -7002,9 +7002,8 @@ async def admin_get_user_edit(
                 {"" if is_editing_self else f'''<div>
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                         <input type="checkbox" name="is_admin" id="admin-field" {"checked" if user_obj.is_admin else ""}
-                               class="mr-2" onchange="disableAdminProtection();"> Administrator
+                               class="mr-2"> Administrator
                     </label>
-                    <input type="hidden" name="disable_admin_protection" :value="!is_admin" id="disable-admin-protection-field">
                 </div>'''}
                 <div>
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">New Password (leave empty to keep current)</label>
@@ -7084,7 +7083,6 @@ async def admin_update_user(
         is_admin = form.get("is_admin") == "on"
         password = form.get("password")
         confirm_password = form.get("confirm_password")
-        disable_admin_protection = form.get("disable_admin_protection")
 
         # Validate password confirmation if password is being changed
         if password and password != confirm_password:
@@ -7119,7 +7117,7 @@ async def admin_update_user(
             if not is_valid:
                 return HTMLResponse(content=f'<div class="text-red-500">Password validation failed: {error_msg}</div>', status_code=400, headers={"HX-Retarget": "#edit-user-error"})
 
-        await auth_service.update_user(email=decoded_email, full_name=full_name, is_admin=is_admin, password=password, admin_origin_source="ui", disable_admin_protection=disable_admin_protection)
+        await auth_service.update_user(email=decoded_email, full_name=full_name, is_admin=is_admin, password=password, admin_origin_source="ui", requesting_user_email=current_user_email)
 
         # Return success message with auto-close and refresh
         success_html = """

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -783,7 +783,7 @@ async def update_user(user_email: str, user_request: AdminUserUpdateRequest, cur
             password_change_required=user_request.password_change_required,
             password=user_request.password,
             admin_origin_source="api",
-            disable_admin_protection=user_request.disable_admin_protection,
+            requesting_user_email=current_user_ctx["email"],
         )
 
         logger.info(f"Admin {current_user_ctx['email']} updated user: {user.email}")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5606,7 +5606,6 @@ class AdminUserUpdateRequest(BaseModel):
         is_active: Whether account is active
         password_change_required: Whether user must change password on next login
         password: New password (admin can reset without old password)
-        disable_admin_protection: Whether user wants to remove admin protection when removing admin privileges
 
     Examples:
         >>> request = AdminUserUpdateRequest(
@@ -5627,7 +5626,6 @@ class AdminUserUpdateRequest(BaseModel):
     is_active: Optional[bool] = Field(None, description="Whether account is active")
     password_change_required: Optional[bool] = Field(None, description="Whether user must change password on next login")
     password: Optional[str] = Field(None, min_length=8, description="New password (admin reset)")
-    disable_admin_protection: Optional[bool] = Field(None, description="Whether user wants to remove admin protection when removing admin")
 
 
 class ErrorResponse(BaseModel):

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -290,9 +290,6 @@ document.addEventListener("DOMContentLoaded", function () {
     initializePasswordValidation();
     initializeAddMembersForms();
 
-    //Explicitly allow an admin to revoke another user's admin access. This bypasses the default admin-protection safeguard
-    initializeDisableAdminProtection();
-
     // Event delegation for team member search - server-side search for unified view
     // This handler is initialized here for early binding, but the actual search logic
     // is in performUserSearch() which is attached when the form is initialized
@@ -22847,7 +22844,6 @@ function registerAdminActionListeners() {
     document.body.addEventListener("htmx:afterSwap", function (event) {
         initializeAddMembersForms(event.target);
         initializePasswordValidation(event.target);
-        initializeDisableAdminProtection(event.target);
         const target = event.target;
         if (
             target &&
@@ -22865,7 +22861,6 @@ function registerAdminActionListeners() {
     document.body.addEventListener("htmx:load", function (event) {
         initializeAddMembersForms(event.target);
         initializePasswordValidation(event.target);
-        initializeDisableAdminProtection(event.target);
     });
 }
 
@@ -23401,32 +23396,9 @@ function validatePasswordMatch() {
     }
 }
 
-function initializeDisableAdminProtection(root = document) {
-    if (
-        root?.querySelector?.("#admin-field") ||
-        document.getElementById("admin-field")
-    ) {
-        disableAdminProtection();
-    }
-}
-
-function disableAdminProtection() {
-    const admin = document.getElementById("admin-field");
-    const hiddenDisableAdminOverride = document.getElementById(
-        "disable-admin-protection-field",
-    );
-
-    if (!admin || !hiddenDisableAdminOverride) {
-        return;
-    }
-
-    hiddenDisableAdminOverride.value = !admin.checked ? "on" : "";
-}
-
 // Expose password validation function to global scope
 window.validatePasswordMatch = validatePasswordMatch;
 window.validatePasswordRequirements = validatePasswordRequirements;
-window.disableAdminProtection = disableAdminProtection;
 
 // ===================================================================
 // SELECTIVE IMPORT FUNCTIONS

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -582,7 +582,7 @@ async def test_admin_get_update_delete_user():
             password_change_required=None,
             password="newPassword123!",
             admin_origin_source="api",
-            disable_admin_protection=None,
+            requesting_user_email="admin@example.com",
         )
 
         delete_response = await email_auth.delete_user("user@example.com", current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
@@ -632,7 +632,7 @@ async def test_admin_update_user_without_full_name_and_is_admin():
             password_change_required=None,
             password=None,
             admin_origin_source="api",
-            disable_admin_protection=None,
+            requesting_user_email="admin@example.com",
         )
 
 


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes # https://github.com/IBM/mcp-context-forge/issues/2808

---

## 📝 Summary
_What does this PR do and why?_

This PR fixes thes issue When an admin user tries to remove the admin privileges from the other admin user, API returns error message. It should not return an error message untill it is the last admin.

Key Changes:
- Updated the admin permission removal logic, to check first if it is the last admin. If it is last admin then admin permission cannot be removed.
- if the requesting admin is trying to self demote itself using api or UI, then an error message will be shown
- Lastly, if admin tries to demote other admin and it is not the last admin in system then it should be allowed to do it. 

The root cause was: There is a flag in config called 'protect_all_admins'. This flag is set to true by in configuration. Hence, it was restricting other admins to demote other admins. 

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |  ✅ Passed (Pylint score: 10/10)      |
| Unit tests                | `make test`     | ✅ Passed (updated unit tests with the changes)        |
| Coverage ≥ 80%            | `make coverage` | ✅ Passed (100% for modified files, 99%+ overal        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
