### PR TITLE
fix(ui): reinit Alpine.js on OOB-swapped pagination controls after fi…

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -18515,7 +18515,8 @@ function initializeTabState() {
         }
     });
 
-    // Enable toggles after HTMX swaps complete
+    // Enable toggles after HTMX swaps complete and re-initialize Alpine.js
+    // components on OOB-swapped pagination controls.
     document.body.addEventListener("htmx:afterSettle", (event) => {
         document
             .querySelectorAll(".show-inactive-toggle[disabled]")
@@ -18525,28 +18526,27 @@ function initializeTabState() {
                     checkbox.disabled = false;
                 }
             });
-    });
 
-    // Re-initialize Alpine.js components on pagination controls after HTMX
-    // OOB swaps.  When htmx.ajax() swaps a table partial that includes an
-    // out-of-band pagination-controls div, Alpine may not automatically
-    // detect the new x-data element (race with MutationObserver).  This
-    // ensures the page-info text, navigation buttons and per-page selector
-    // all render correctly after every settle.
-    document.body.addEventListener("htmx:afterSettle", function () {
-        if (!window.Alpine || typeof window.Alpine.initTree !== "function") {
-            return;
+        // Re-initialize Alpine.js components on pagination controls after
+        // HTMX OOB swaps.  When htmx.ajax() swaps a table partial that
+        // includes an out-of-band pagination-controls div, Alpine may not
+        // automatically detect the new x-data element (race with
+        // MutationObserver).  This ensures the page-info text, navigation
+        // buttons and per-page selector all render correctly after every
+        // settle.
+        if (window.Alpine && typeof window.Alpine.initTree === "function") {
+            document
+                .querySelectorAll('[id$="-pagination-controls"]')
+                .forEach(function (el) {
+                    // Only act on elements that contain an uninitialised
+                    // Alpine component (i.e. x-data present but no
+                    // _x_dataStack yet).
+                    const xDataEl = el.querySelector("[x-data]");
+                    if (xDataEl && !xDataEl._x_dataStack) {
+                        window.Alpine.initTree(el);
+                    }
+                });
         }
-        document
-            .querySelectorAll('[id$="-pagination-controls"]')
-            .forEach(function (el) {
-                // Only act on elements that contain an uninitialised Alpine
-                // component (i.e. x-data present but no _x_dataStack yet).
-                var xDataEl = el.querySelector("[x-data]");
-                if (xDataEl && !xDataEl._x_dataStack) {
-                    window.Alpine.initTree(el);
-                }
-            });
     });
 }
 


### PR DESCRIPTION
🔗 Related Issue                                                                                                                           
  Closes #3039                                                                                                                

  ---
  📝 Summary

  When filtering/searching table items in the admin panel, pagination controls (page info text, navigation buttons) were not  
  rendering. This was caused by two issues:

  1. Alpine.js not reinitializing after HTMX OOB swaps, When loadSearchablePanel() fires htmx.ajax(), the response OOB-swaps 
  the pagination controls div, but Alpine.js's MutationObserver doesn't reliably detect and initialize the new x-data
  component. Added an htmx:afterSettle listener that explicitly calls Alpine.initTree() on uninitialized pagination controls. 
  2. Wrong swap style,  pagination_controls.html defaults hx_swap to innerHTML, but partial templates return full <table>     
  elements, causing nested tables with duplicate IDs. Set hx_swap = 'outerHTML' across all partial templates and initial      
  renders in admin.html.

  ---
  🏷️ Type of Change

  - Bug fix
  - Feature / Enhancement
  - Documentation
  - Refactor
  - Chore (deps, CI, tooling)
  - Other (describe below)

  ---
  🧪 Verification

  ┌────────────────┬───────────────┬────────┐
  │     Check      │    Command    │ Status │
  ├────────────────┼───────────────┼────────┤
  │ Lint suite     │ make lint     │        │
  ├────────────────┼───────────────┼────────┤
  │ Unit tests     │ make test     │        │
  ├────────────────┼───────────────┼────────┤
  │ Coverage ≥ 80% │ make coverage │        │
  └────────────────┴───────────────┴────────┘

  ---
  ✅ Checklist

  - Code formatted (make black isort pre-commit)
  - Tests added/updated for changes
  - Documentation updated (if applicable)
  - No secrets or credentials committed

  ---
  📓 Notes (optional)

  Files changed:
  - mcpgateway/static/admin.js — Added Alpine.js reinitialization listener for pagination controls after HTMX settles
  - mcpgateway/templates/admin.html — Set hx_swap = 'outerHTML' for 5 initial pagination renders
  - 7 partial templates (tools, servers, resources, prompts, gateways, agents, tokens) — Added {% set hx_swap = 'outerHTML' %}
   (matching existing pattern in users_partial.html)

  Screenshots:
<img width="2201" height="780" alt="Screenshot 2026-02-18 200323" src="https://github.com/user-attachments/assets/50fe5a03-c616-419a-830b-b999122f270c" />
<img width="2236" height="445" alt="Screenshot 2026-02-18 200333" src="https://github.com/user-attachments/assets/970fc213-12c4-4aa1-8bec-68c9e194e892" />

  