### PR TITLE
[FIX][API]: Fix import endpoint JSON parameter handling

### DIFF
--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -4790,8 +4790,6 @@ class TestExportImportEndpoints:
         assert excinfo.value.status_code == 500
 
 
-
-
 class TestMessageEndpointElicitation:
     """Cover elicitation response handling."""
 


### PR DESCRIPTION
## 📌 Summary
Fixes issue #2960 by correcting JSON parameter handling in the `/import` endpoint. The endpoint was requiring double-wrapped JSON and silently ignoring parameters sent in the request body.

## :link: Related Issue
Closes: #2960 

## 🐞 Root Cause
**Location**: `mcpgateway/main.py` - `import_configuration()` function (lines 7017-7105)

**Problem**: FastAPI's automatic parameter handling with mixed complex/simple types caused two issues:
1. The `import_data` parameter (complex dict) was treated as a second body parameter, requiring clients to wrap it again: `{"import_data": {"import_data": {...}}}`
2. Simple parameters (`conflict_strategy`, `dry_run`, `rekey_secret`, `selected_entities`) were interpreted as query parameters instead of JSON body fields, causing them to be silently ignored when sent in the request body

## 💡 Fix Description
**Solution**: Changed from FastAPI's automatic parameter injection to manual Request body parsing using `orjson.loads()`.

**Key Changes**:
1. **Function signature**: Changed from individual parameters to single `Request` parameter
2. **Manual parsing**: Use `await request.body()` + `orjson.loads()` to parse JSON
3. **Error handling**: Added explicit validation for empty body, invalid JSON, and missing required fields
4. **Pattern alignment**: Now matches the admin endpoint pattern at `mcpgateway/admin.py:13720-13780`

**Before:**
```python
async def import_configuration(
    import_data: Dict[str, Any] = Body(...),
    conflict_strategy: str = "update",
    dry_run: bool = False,
    rekey_secret: Optional[str] = None,
    selected_entities: Optional[Dict[str, List[str]]] = None,
    ...
)
```

**After:**
```python
async def import_configuration(
    request: Request,
    db: Session = Depends(get_db),
    user=Depends(get_current_user_with_permissions),
) -> Dict[str, Any]:
    body_bytes = await request.body()
    body = orjson.loads(body_bytes)
    
    import_data = body.get("import_data")  # Required
    conflict_strategy = body.get("conflict_strategy", "update")
    dry_run = body.get("dry_run", False)
    rekey_secret = body.get("rekey_secret")
    selected_entities = body.get("selected_entities")
```

**Benefits**:
- Eliminates double-wrapping requirement (Bug 1 fixed)
- All parameters correctly read from JSON body (Bug 2 fixed)
- Better error messages (400 with specific details)
- Full control over parameter extraction

## 📁 Files Changed
1. `mcpgateway/main.py` (lines 7017-7105) - Core fix implementation
2. `tests/unit/mcpgateway/test_main_extended.py` (lines 4121-4230) - Test updates + new edge case coverage

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅     |
| Unit tests                            | `make test`          | ✅     |
| Coverage ≥ 90 %                       | `make coverage`      | ✅     |
| Manual regression no longer fails     | Live testing completed | ✅   |

### Test Coverage
**Changes to existing tests:**
- Updated 4 existing tests to use mock Request objects

**New tests added:**
- `test_import_configuration_empty_body` - HTTP 400
- `test_import_configuration_invalid_json` - HTTP 400
- `test_import_configuration_missing_import_data` - HTTP 400


## Manual Testing Results

#### ✅ Test 1: Bug 2 Fix - Parameters in JSON Body
```bash
curl -X POST "http://localhost:4444/import" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "import_data": {...},
    "dry_run": true,
    "conflict_strategy": "skip"
  }'
```
**Result**: `dry_run` parameter correctly read from JSON body - shows "Would import" warnings instead of actual imports. Before fix, this was silently ignored.

#### ✅ Test 2: Bug 1 Fix - Single Wrapper (No Double-Wrapping)
```bash
curl -X POST "http://localhost:4444/import" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "import_data": {
      "version": "2025-03-26",
      "entities": {...}
    },
    "conflict_strategy": "update"
  }'
```
**Result**: Raw export JSON with single `import_data` wrapper works correctly.

#### ✅ Test 3: Error Handling - Empty Body
```bash
curl -X POST "http://localhost:4444/import" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d ''
```
**Result**: HTTP 400 with message "Empty request body"

#### ✅ Test 4: Error Handling - Missing import_data
```bash
curl -X POST "http://localhost:4444/import" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"conflict_strategy": "update"}'
```
**Result**: HTTP 400 with message "Missing 'import_data' in request body"

#### ✅ Test 5: Error Handling - Invalid conflict_strategy
```bash
curl -X POST "http://localhost:4444/import" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"import_data": {...}, "conflict_strategy": "invalid"}'
```
**Result**: HTTP 400 with message "Invalid conflict strategy. Must be one of: ['skip', 'update', 'rename', 'fail']"

#### ✅ Final Test: Complete Import/Export Workflow
- Exported: 3 tools, 0 gateways, 1 server
- Imported with `dry_run=true`: Processed 1 item with no actual changes
- All parameters respected: `conflict_strategy=skip`, `dry_run=true`, `selected_entities` filter applied

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec (endpoint is gateway-specific, not MCP protocol)
- [x] No breaking change to MCP clients (fix restores expected behavior)

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
- [x] Backward compatible (CLI already sends correct format)