### PR TITLE
[FIX][UI]: Preserve edit server selections across infinite scroll pages and searches

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -9029,6 +9029,8 @@ function initToolSelect(
             );
             checkboxes.forEach((cb) => (cb.checked = false));
 
+            getEditSelections(selectId).clear();
+
             // Clear the "select all" flag
             const selectAllInput = container.querySelector(
                 'input[name="selectAllTools"]',
@@ -9451,6 +9453,8 @@ function initResourceSelect(
             );
             checkboxes.forEach((cb) => (cb.checked = false));
 
+            getEditSelections(selectId).clear();
+
             // Remove any select-all hidden inputs
             const selectAllInput = container.querySelector(
                 'input[name="selectAllResources"]',
@@ -9858,6 +9862,8 @@ function initPromptSelect(
                 'input[type="checkbox"]',
             );
             checkboxes.forEach((cb) => (cb.checked = false));
+
+            getEditSelections(selectId).clear();
 
             // Remove any select-all hidden inputs
             const selectAllInput = container.querySelector(
@@ -15769,8 +15775,8 @@ async function handleEditServerFormSubmit(e) {
                 });
 
             // Override FormData with the full store contents
+            formData.delete(fieldName);
             if (sel.size > 0) {
-                formData.delete(fieldName);
                 sel.forEach((uuid) => formData.append(fieldName, uuid));
             }
         });


### PR DESCRIPTION
# 🐛 Bug-fix PR

Fixes #3042 

---

## 📌 Summary
Fix three interrelated bugs in the "Edit Virtual Server" modal when a gateway has many tools, resources, or prompts. All three stem from tracking selection state only through DOM-visible checkboxes rather than a persistent in-memory store. Because the selector uses HTMX infinite scroll (20 items per page), anything not currently rendered in the DOM is invisible to the state-management code.

**Bugs fixed:**
1. **Performance / data loss on Save**: `FormData` only collects checked checkboxes currently in the DOM. Tools on unloaded scroll pages are silently dropped.
2. **Partial selection on modal open**: Only first-page tools appear selected; tools on pages 2+ show unchecked until scrolled to.
3. **Selections lost across searches**: Searching replaces the container HTML; previously-checked tools not in the original server associations are discarded.

## 🔁 Reproduction Steps
1. Create a virtual server with 30+ associated tools.
2. Open "Edit" for that server - observe only ~20 tools are checked (Bug 2).
3. Search "foo", select Tool X (not originally associated), then search "bar" - Tool X is now unchecked (Bug 3).
4. Scroll to load more tools, check some, then click "Save Changes" - only DOM-visible tools are saved (Bug 1).

## 🐞 Root Cause
Selection state was tracked exclusively via DOM checkboxes. The HTMX infinite scroll loads 20 items per page and appends them to the container. Tools/resources/prompts on pages not yet scrolled to have no DOM representation, so:
- `FormData(form)` misses them on save
- `setEditServerAssociations()` can only check what's in the DOM
- Search replace destroys checkbox state; restore only reads `data-server-tools` (original associations), ignoring user changes

Additionally, `server.associatedTools` returns tool **names** while the form submission needs **UUIDs**. Without the UUIDs upfront, off-screen tools can never be included in the form payload.

## 💡 Fix Description
Introduce a persistent in-memory selection store (`window.editServerSelections`) keyed by container ID, holding `Set<UUID>`:

1. **Backend (additive)**: Add `associated_tool_ids` (UUIDs) to `ServerRead` alongside existing `associated_tools` (names). One new field with default `[]`, one new line in `convert_server_to_read`.

2. **Store seeding**: On modal open in `editServer()`, reset the store and seed it from `server.associatedToolIds`, `server.associatedResources`, and `server.associatedPrompts`.

3. **Change listener**: Event delegation on each edit-server container updates the store on every checkbox change (add on check, delete on uncheck).

4. **afterSwap handlers**: When infinite scroll pages load and auto-check associated items, also add their UUIDs to the store.

5. **Search functions**: Before replacing container HTML, flush current DOM checked/unchecked state into the store. After loading search results, restore checkboxes from the store.

6. **Form submission**: In `handleEditServerFormSubmit`, sync DOM state to store, then override `FormData` with the full store contents - ensuring off-screen selections are included.

7. **Cleanup**: Reset the store when the edit modal closes.

**Key design decision**: All existing behavior is preserved unchanged - `hx-on::after-swap`, `hx-trigger="load"`, `setEditServerAssociations`, `initToolSelect`, the setTimeout restore block. The store is purely additive overlay, not a replacement.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   pass     |
| Unit tests                            | `make test`          |    pass    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
