### PR TITLE
fix(ui): uncomment .hidden CSS rule to prevent FOUC on tab panels

### DIFF
--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -166,9 +166,9 @@
     display: none;
 }
 
-/* .hidden {
+.hidden {
   display: none;
-} */
+}
 
 /* Modal z-index to prevent sticky header overlap */
 .fixed.z-10 {


### PR DESCRIPTION
## Description
Uncommented the `.hidden { display: none; }` rule in `admin.css` that was causing a Flash of Unstyled Content (FOUC) on page load.

## Problem
Until Tailwind CSS loads via CDN/JIT, the `hidden` class had no effect, causing all tab panels to be briefly visible. This was especially noticeable with the ToolOps panel which has `hx-trigger="load"` and starts fetching content immediately.

## Solution
Uncommented the CSS rule at lines 169-171 in `mcpgateway/static/admin.css` to provide immediate styling before Tailwind loads.

## Testing
- Verified that the `.hidden` class is used extensively throughout `admin.html` (161 occurrences)
- The fix ensures all hidden elements remain hidden during page load

Closes #2933