### PR TITLE
feat(ui): add roots to global search

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -10043,7 +10043,7 @@ async def admin_unified_search(
     tags: Optional[str] = Query(None, description="Tag filter expression (comma=OR, plus=AND)"),
     entity_types: Optional[str] = Query(
         None,
-        description="Comma-separated entity types to include (servers,gateways,tools,resources,prompts,agents,teams,users)",
+        description="Comma-separated entity types to include (servers,gateways,tools,resources,prompts,agents,teams,users,roots)",
     ),
     include_inactive: bool = False,
     limit: int = Query(8, ge=1, le=settings.pagination_max_page_size, description="Per-entity result limit"),
@@ -10060,10 +10060,15 @@ async def admin_unified_search(
 ):
     """Unified search across primary admin entities.
 
+    Searches servers, gateways, tools, resources, prompts, agents, teams, roots,
+    and optionally users (when the caller has ``admin.user_management`` permission).
+
     Args:
         q (str): Free-text search query.
         tags (Optional[str]): Tag filter expression (comma=OR, plus=AND).
         entity_types (Optional[str]): Optional comma-separated entity type list.
+            Supported values: servers, gateways, tools, resources, prompts,
+            agents, teams, users, roots.
         include_inactive (bool): Whether to include inactive entities.
         limit (int): Default per-entity limit for returned items.
         limit_per_type (Optional[int]): Optional alias overriding ``limit``.
@@ -10083,8 +10088,8 @@ async def admin_unified_search(
     normalized_entity_types = _normalize_tags_query(entity_types)
     tag_groups = _parse_tag_filter_groups(normalized_tags)
 
-    supported_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams", "users"]
-    default_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams"]
+    supported_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams", "users", "roots"]
+    default_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams", "roots"]
     selected_entity_types: list[str] = []
     if normalized_entity_types:
         for raw_entity_type in normalized_entity_types.split(","):
@@ -10256,6 +10261,17 @@ async def admin_unified_search(
             user=user,
         )
         grouped_results["users"] = typing_cast(list[dict[str, Any]], users_result.get("users", users_result.get("items", [])))
+
+    # Roots do not support tag filtering; only include when a text query exists.
+    if "roots" in selected_entity_types and search_query:
+        roots_result = await _safe_entity_search(
+            admin_search_roots,
+            "roots",
+            q=search_query,
+            limit=effective_limit,
+            user=user,
+        )
+        grouped_results["roots"] = typing_cast(list[dict[str, Any]], roots_result.get("roots", roots_result.get("items", [])))
 
     groups = []
     flat_items: list[dict[str, Any]] = []
@@ -11997,6 +12013,55 @@ async def admin_set_prompt_state(
     if is_inactive_checked.lower() == "true":
         return RedirectResponse(f"{root_path}/admin/?include_inactive=true#prompts", status_code=303)
     return RedirectResponse(f"{root_path}/admin#prompts", status_code=303)
+
+
+@admin_router.get("/roots/search", response_class=JSONResponse)
+@require_permission("admin.system_config", allow_admin_bypass=False)
+async def admin_search_roots(
+    q: str = Query("", description="Search query"),
+    limit: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Maximum number of results to return"),
+    user=Depends(get_current_user_with_permissions),
+) -> dict:
+    """Search roots by name or URI.
+
+    Roots are held in-memory by :class:`~mcpgateway.services.root_service.RootService`,
+    so this function fetches the full list before filtering.  In typical deployments the
+    number of registered roots is small (< 100), making the in-memory scan negligible.
+    If root counts grow substantially, consider adding filtering support directly to
+    :meth:`~mcpgateway.services.root_service.RootService.list_roots`.
+
+    Args:
+        q (str): Free-text search query matched against root name and URI.
+        limit (int): Maximum number of results to return.
+        user: Authenticated user context.
+
+    Returns:
+        dict: Unified search payload containing matching roots.
+
+    Examples:
+        >>> callable(admin_search_roots)
+        True
+        >>> admin_search_roots.__name__
+        'admin_search_roots'
+    """
+    search_query = _normalize_search_query(q)
+    # Defense-in-depth clamp: FastAPI validates ge/le at the HTTP layer, but direct
+    # Python calls (e.g. from admin_unified_search) bypass that validation.
+    limit = max(1, min(limit, settings.pagination_max_page_size))
+    all_roots = await root_service.list_roots()
+
+    # Single pass: convert URI once, filter and transform together, stop at limit.
+    results: list[dict[str, Any]] = []
+    for r in all_roots:
+        if len(results) >= limit:
+            break
+        uri_str = str(r.uri)
+        name_str = r.name or uri_str
+        if not search_query or search_query in uri_str.lower() or search_query in name_str.lower():
+            results.append({"id": uri_str, "name": name_str, "uri": uri_str})
+
+    LOGGER.debug(f"User {get_user_email(user)} searched roots with query '{search_query}': {len(results)} results")
+    return _build_search_response(entity_key="roots", entity_type="roots", items=results, query=search_query, tags="", tag_groups=[])
 
 
 @admin_router.get("/roots/export")

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -17866,6 +17866,7 @@ const GLOBAL_SEARCH_ENTITY_CONFIG = {
     },
     teams: { label: "Teams", tab: "teams", viewFunction: "showTeamEditModal" },
     users: { label: "Users", tab: "users", viewFunction: "showUserEditModal" },
+    roots: { label: "Roots", tab: "roots", viewFunction: "viewRoot" },
 };
 
 let globalSearchDebounceTimer = null;
@@ -17969,6 +17970,7 @@ async function runGlobalSearch(query) {
         "agents",
         "teams",
         "users",
+        "roots",
     ];
     const visibleEntityTypes = searchableEntityTypes.filter((entityType) => {
         if (entityType === "users" && !isAdminUser()) {
@@ -18086,6 +18088,12 @@ function initializeGlobalSearch() {
                 return;
             }
             if (event.key === "Enter") {
+                const currentValue = (input.value || "").trim();
+                if (!currentValue) {
+                    renderGlobalSearchMessage("Please enter a search term.");
+                    event.preventDefault();
+                    return;
+                }
                 const firstResult = document.querySelector(
                     "#global-search-results .global-search-result-item",
                 );

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -684,7 +684,7 @@
                 id="global-search-trigger"
                 onclick="openGlobalSearchModal()"
                 class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                title="Search across tools, prompts, resources, servers, gateways, and agents (Ctrl/Cmd+K)"
+                title="Search across tools, prompts, resources, servers, gateways, agents, and roots (Ctrl/Cmd+K)"
               >
                 <span>Search</span>
                 <span class="hidden sm:inline text-xs text-gray-500 dark:text-gray-400">Ctrl/Cmd+K</span>
@@ -830,7 +830,7 @@
                 <input
                   type="text"
                   id="global-search-input"
-                  placeholder="Search across servers, gateways, tools, resources, prompts, and agents..."
+                  placeholder="Search across servers, gateways, tools, resources, prompts, agents, and roots..."
                   class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   autocomplete="off"
                 />

--- a/mcpgateway/templates/observability_partial.html
+++ b/mcpgateway/templates/observability_partial.html
@@ -508,10 +508,10 @@ if (!window.getChartDefaults) {
     <div class="mb-8 pb-4 border-b-2 border-gray-200 dark:border-gray-700">
         <!-- Title and Filters Row -->
         <div class="flex justify-between items-center mb-4 flex-wrap gap-4">
-            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+            <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
                 <span>🔍</span>
                 Observability Dashboard
-            </h1>
+            </h2>
             <div class="flex gap-4 items-center" x-show="viewMode === 'traces'">
             <select
                 x-model="selectedQueryId"
@@ -776,7 +776,7 @@ if (!window.getChartDefaults) {
          @click.self="showSaveQueryModal = false">
         <div class="bg-white dark:bg-gray-800 rounded-lg max-w-2xl w-full mx-4 p-8 shadow-2xl">
             <div class="flex justify-between items-center mb-6 pb-4 border-b border-gray-200 dark:border-gray-700">
-                <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 m-0">💾 Save Query</h2>
+                <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 m-0">💾 Save Query</h3>
                 <button @click="showSaveQueryModal = false" class="bg-transparent border-0 text-2xl cursor-pointer text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">×</button>
             </div>
 

--- a/tests/js/admin-tabs.test.js
+++ b/tests/js/admin-tabs.test.js
@@ -323,7 +323,7 @@ describe("runGlobalSearch visible entity filtering", () => {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         const requestUrl = new URL(fetchSpy.mock.calls[0][0], "http://localhost");
         expect(requestUrl.searchParams.get("entity_types")).toBe(
-            "servers,gateways,resources,agents,users",
+            "servers,gateways,resources,agents,users,roots",
         );
     });
 
@@ -343,6 +343,7 @@ describe("runGlobalSearch visible entity filtering", () => {
             "agents",
             "teams",
             "users",
+            "roots",
         ];
         const fetchSpy = vi.spyOn(win, "fetchWithAuth");
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Roots are not show on global search.

closes #2998 

## 🔁 Reproduction Steps
1. Open the Admin UI
2. Start the open search (either clicking the button or using the shortcut)
3. Search for a root name.

## 🐞 Root Cause
The backend didn't support root searching, and neither did the frontend.

## 💡 Fix Description
Added endpoints to root search and the JS/HTML code to support it.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
