### PR TITLE
chore(ci): add additional local-first CI quality gates

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c5996e0193a3df57d695c1b8a1dec2a4c62e8730" # v2.3.3
     with:
       # CLI flags (line-split)
       scan-args: |-
@@ -69,7 +69,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c5996e0193a3df57d695c1b8a1dec2a4c62e8730" # v2.3.3
     with:
       scan-args: |-
         -r


### PR DESCRIPTION
## Summary
- add new local-first Make targets for diff-only secret scanning (`gitleaks`), dependency CVE scanning (`pip-audit` advisory and strict), changed-workflow security linting (`zizmor`), and typing telemetry (`mypy` + `pyrefly`)
- add dedicated GitHub workflows for each new grouped section so review is isolated and easy (`linting-security-extra`, `linting-security-secrets-diff`, `linting-security-pip-audit`, `linting-workflow-zizmor-changed`, `linting-typing-telemetry`)
- reactivate `osv-scanner.yml` from inactive, keep PR diff scanning blocking for new vulnerabilities, and keep scheduled/push full scan advisory
- pin action SHAs and set `persist-credentials: false` on checkouts for workflow security hygiene

## Local verification
- `make linting-security-extra`
- `make linting-security-secrets-diff`
- `make linting-security-pip-audit-advisory`
- `make linting-security-pip-audit-enforce` (expected fail with current vulns)
- `make linting-security-pip-audit-enforce PIP_AUDIT_IGNORE_IDS=CVE-2026-1703,PYSEC-2022-42969,CVE-2026-24486` (pass path)
- `make linting-workflow-zizmor-changed`
- `make linting-workflow-actionlint`
- `make linting-typing-telemetry`

Refs #2383
