### PR TITLE
fix(rpc): use configurable internal RPC URL for self-calls in hybrid mesh deployments

### DIFF
--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -202,6 +202,17 @@ def test_internal_rpc_url_hybrid_cloud_mesh():
     assert s.internal_rpc_url == "http://gateway.internal.mesh:4444/gateway/rpc"
 
 
+def test_internal_rpc_url_invalid_url_value_error(caplog):
+    """Test internal_rpc_url falls back gracefully and logs an error when ValueError is raised."""
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        s = Settings(port=4444, app_root_path="/api", internal_rpc_host="http://[::1/rpc", _env_file=None)
+        assert s.internal_rpc_url == "http://http://[::1/rpc:4444/api/rpc"
+
+    assert "Invalid internal RPC host: http://[::1/rpc" in caplog.text
+
+
 # --------------------------------------------------------------------------- #
 #                           get_settings LRU cache                            #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #3049

## 📌 Summary

Fixed a bug where the MCP Gateway fails to make internal RPC calls in hybrid cloud mesh deployments. The gateway was using client-provided URLs (e.g., `http://192.168.0.10:4444` via mesh gateway) for internal self-calls, which are not resolvable from the gateway's network environment (e.g., `10.x.x.x` internal network). This caused SSE sessions, WebSocket connections, and session pool operations to fail when the gateway needed to call its own `/rpc` endpoint.

**Why this matters**: In hybrid cloud mesh architectures, clients access the gateway through a mesh gateway URL that is only valid from the client's network perspective. The gateway itself must use its internal network address for self-calls, not the client's external URL.

## 🔁 Reproduction Steps

**Issue**: Gateway fails in hybrid cloud mesh when making internal RPC calls

**Minimal reproduction**:
1. Deploy MCP Gateway in a hybrid cloud mesh environment where:
   - Clients access gateway via mesh gateway: `http://192.168.0.10:4444`
   - Gateway's internal network address: `http://10.0.0.5:4444`
2. Client establishes SSE connection to `/sse/{session_id}`
3. Client sends a message that requires the gateway to call its own `/rpc` endpoint
4. **Bug**: Gateway attempts to call `http://192.168.0.10:4444/rpc` (client's URL)
5. **Result**: Connection fails because `192.168.0.10` is not resolvable from gateway's `10.x.x.x` network

**Affected code paths**:
- SSE session message handling (`session_registry.py`)
- WebSocket message forwarding (`main.py`)
- Session pool RPC forwarding (`mcp_session_pool.py`)
- Streamable HTTP transport (`streamablehttp_transport.py`)

## 🐞 Root Cause

### Primary Issue: URL Parsing from Client Context

In `mcpgateway/cache/session_registry.py` (lines 1964-1975), the code was parsing the `base_url` parameter (provided by the client) to construct the internal RPC URL:

```python
# BEFORE (BROKEN):
parsed_url = urlparse(base_url)  # base_url = "http://192.168.0.10:4444/servers/123"
path_parts = parsed_url.path.split("/")
if "/servers/" in parsed_url.path:
    servers_index = path_parts.index("servers")
    root_path = "/" + "/".join(path_parts[1:servers_index]).strip("/")
else:
    root_path = parsed_url.path.rstrip("/")

root_url = f"{parsed_url.scheme}://{parsed_url.netloc}{root_path}"
rpc_url = root_url + "/rpc"  # Results in: http://192.168.0.10:4444/rpc
```

**Why this fails**:
1. `base_url` comes from the client's HTTP request context
2. In hybrid cloud mesh, this URL is only valid from the client's network
3. The gateway's internal network cannot resolve `192.168.0.10`
4. The gateway needs to use its own internal address: `10.0.0.5`

### Secondary Issues: Hardcoded Localhost

Similar patterns existed in other files using hardcoded `localhost` or `127.0.0.1`:

- `mcp_session_pool.py`: `f"http://127.0.0.1:{settings.port}/rpc"`
- `streamablehttp_transport.py`: `f"http://127.0.0.1:{settings.port}/rpc"` (2 locations)
- `main.py`: `f"http://localhost:{settings.port}{settings.app_root_path}/rpc"`

While these work in standard deployments, they fail in containerized environments where the service name (e.g., `gateway-service`) must be used instead of `localhost`.

## 💡 Fix Description

### Solution: Configurable Internal RPC URL

Introduced a new configuration system that separates client-facing URLs from internal self-call URLs:

#### 1. Configuration Layer (`mcpgateway/config.py`)

**Added two new configuration elements**:

```python
internal_rpc_host: str = Field(
    default="127.0.0.1",
    description=(
        "Internal host for RPC calls made by the gateway to itself. "
        "Use 127.0.0.1 (default) for standard deployments. "
        "In containerized environments with custom networking, set to the service's internal hostname. "
        "Never use client-provided URLs as they may not be resolvable in the gateway's network."
    ),
)

@property
def internal_rpc_url(self) -> str:
    """Get the internal RPC endpoint URL for self-calls."""
    if "/rpc" in self.internal_rpc_host:
        return self.internal_rpc_host  # Full URL provided
    return f"http://{self.internal_rpc_host}:{self.port}{self.app_root_path}/rpc"
```

**Design decisions**:
- **Default `127.0.0.1`**: Maintains backward compatibility with existing deployments
- **Property method**: Automatically constructs full URL with port and root path
- **Full URL passthrough**: Supports advanced scenarios where full URL is provided
- **No breaking changes**: Existing deployments work without configuration changes

#### 2. Session Registry Fix (`mcpgateway/cache/session_registry.py`)

**Replaced 20+ lines of URL parsing with single line**:

```python
# AFTER (FIXED):
rpc_url = settings.internal_rpc_url
logger.info(f"SSE RPC: Making internal call to {rpc_url} with method={method}, params={params}")
```

**Benefits**:
- Eliminates fragile URL parsing logic
- Uses correct internal network address
- Works in all deployment scenarios
- Clear intent: "internal call" vs "client URL"

#### 3. Standardization Across Codebase

**Updated all internal RPC call sites** to use `settings.internal_rpc_url`:

- `mcp_session_pool.py`: Session pool RPC forwarding
- `streamablehttp_transport.py`: Message and events endpoints (2 locations)
- `main.py`: WebSocket RPC forwarding

**Consistency benefits**:
- Single source of truth for internal RPC URL
- Easier to maintain and debug
- Uniform behavior across all transports

#### 4. Environment Configuration (`.env.example`)

**Added comprehensive documentation**:

```bash
# Internal RPC host for self-calls (default: 127.0.0.1)
# Use this when the gateway needs to make RPC calls to itself.
# In hybrid cloud mesh scenarios, client URLs may not be resolvable
# from the gateway's network, so we use localhost by default.
# For containerized environments with custom networking, set to the
# service's internal hostname (e.g., "gateway-service").
# INTERNAL_RPC_HOST=127.0.0.1
# or
# Complete rpc url for hybird cloud mesh scenarios
# INTERNAL_RPC_HOST=http://gateway-service:4444/rpc
```

### Key Design Points

#### 1. Separation of Concerns
- **Client-facing URLs**: Used for external access (from clients)
- **Internal URLs**: Used for self-calls (within gateway's network)
- **Never mix the two**: Client URLs may not be resolvable internally

#### 2. Deployment Flexibility
- **Standard**: `127.0.0.1` (default, no config needed)
- **Containerized**: Service name (e.g., `gateway-service`)
- **Hybrid cloud mesh**: Internal IP (e.g., `10.0.0.5`)
- **Advanced**: Full URL with custom path

#### 3. Backward Compatibility
- Default behavior unchanged
- No breaking changes to existing deployments
- Opt-in configuration for advanced scenarios

#### 4. Code Simplification
- Removed complex URL parsing logic
- Single source of truth for internal RPC URL
- Easier to understand and maintain



---

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed