### PR TITLE
fix(a2a): cascade agent state changes to associated MCP tools

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -1261,7 +1261,7 @@ class A2AAgentService:
                     await cache.invalidate_tools()
                     tool_lookup_cache = _get_tool_lookup_cache()
                     if agent.tool and agent.tool.name:
-                        await tool_lookup_cache.invalidate(agent.tool.name)
+                        await tool_lookup_cache.invalidate(agent.tool.name, gateway_id=str(agent.tool.gateway_id) if agent.tool.gateway_id else None)
             except Exception:
                 logger.warning("Failed to cascade tool state for A2A agent %s (tool_id=%s)", agent.id, agent.tool_id, exc_info=True)
 

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -2669,7 +2669,7 @@ class TestSetAgentStateToolCascade:
 
     async def test_cascade_deactivates_tool(self, service, mock_db, monkeypatch):
         """Deactivating agent with tool_id cascades to tool (lines 1236-1240)."""
-        agent = SimpleNamespace(id="a1", enabled=True, name="ag", reachable=True, tool_id="t1", tool=SimpleNamespace(name="my-tool"))
+        agent = SimpleNamespace(id="a1", enabled=True, name="ag", reachable=True, tool_id="t1", tool=SimpleNamespace(name="my-tool", gateway_id="gw1"))
         mock_db.execute.return_value.scalar_one_or_none.return_value = agent
         mock_db.commit = MagicMock()
         mock_db.refresh = MagicMock()
@@ -2697,11 +2697,11 @@ class TestSetAgentStateToolCascade:
         assert agent.enabled is False
         assert mock_db.execute.call_count == 2
         dummy_cache.invalidate_tools.assert_awaited_once()
-        dummy_tool_lookup_cache.invalidate.assert_awaited_once_with("my-tool")
+        dummy_tool_lookup_cache.invalidate.assert_awaited_once_with("my-tool", gateway_id="gw1")
 
     async def test_cascade_activates_tool(self, service, mock_db, monkeypatch):
         """Activating agent with tool_id cascades to tool."""
-        agent = SimpleNamespace(id="a1", enabled=False, name="ag", reachable=True, tool_id="t1", tool=SimpleNamespace(name="my-tool"))
+        agent = SimpleNamespace(id="a1", enabled=False, name="ag", reachable=True, tool_id="t1", tool=SimpleNamespace(name="my-tool", gateway_id="gw1"))
         mock_db.execute.return_value.scalar_one_or_none.return_value = agent
         mock_db.commit = MagicMock()
         mock_db.refresh = MagicMock()
@@ -2728,7 +2728,37 @@ class TestSetAgentStateToolCascade:
 
         assert agent.enabled is True
         dummy_cache.invalidate_tools.assert_awaited_once()
-        dummy_tool_lookup_cache.invalidate.assert_awaited_once_with("my-tool")
+        dummy_tool_lookup_cache.invalidate.assert_awaited_once_with("my-tool", gateway_id="gw1")
+
+    async def test_cascade_deactivates_tool_no_gateway_id(self, service, mock_db, monkeypatch):
+        """Deactivating agent with tool that has no gateway_id passes gateway_id=None."""
+        agent = SimpleNamespace(id="a1", enabled=True, name="ag", reachable=True, tool_id="t1", tool=SimpleNamespace(name="my-tool", gateway_id=None))
+        mock_db.execute.return_value.scalar_one_or_none.return_value = agent
+        mock_db.commit = MagicMock()
+        mock_db.refresh = MagicMock()
+        service.convert_agent_to_read = MagicMock(return_value=MagicMock())
+
+        tool_update_result = MagicMock()
+        tool_update_result.rowcount = 1
+        execute_results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=agent)),
+            tool_update_result,
+        ]
+        mock_db.execute.side_effect = execute_results
+
+        dummy_cache = SimpleNamespace(
+            invalidate_agents=AsyncMock(),
+            invalidate_tools=AsyncMock(),
+        )
+        monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: dummy_cache)
+
+        dummy_tool_lookup_cache = SimpleNamespace(invalidate=AsyncMock())
+        monkeypatch.setattr("mcpgateway.services.a2a_service._get_tool_lookup_cache", lambda: dummy_tool_lookup_cache)
+
+        await service.set_agent_state(mock_db, "a1", activate=False)
+
+        assert agent.enabled is False
+        dummy_tool_lookup_cache.invalidate.assert_awaited_once_with("my-tool", gateway_id=None)
 
     async def test_cascade_no_tool_id_skips_update(self, service, mock_db, monkeypatch):
         """Agent without tool_id skips tool cascade."""


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

When an A2A agent is deactivated, its associated tool remains active in the database — appearing in virtual server tool listings and still invocable. This is inconsistent with gateway deactivation, which cascades to all child tools, prompts, and resources.

This PR cascades A2A agent activation/deactivation to the associated MCP tool, adds the missing "Enable/Disable A2A Agent" API documentation, and brings `a2a_service.py` unit test coverage to 100%.

Closes #2997

## 🔁 Reproduction Steps
1. Go to http://localhost:8080/admin/?agents_inactive=true&agents_page=1#a2a-agents
2. Set as Inactive an Agent
3. Check Tools and Virtual Server

## 🐞 Root Cause

The root cause was that `set_agent_state()` in `a2a_service.py` only updated the agent's own enabled field and never touched the associated tool record. Unlike `gateway_service.py:set_gateway_state()`, which bulk-updates all child tools/prompts/resources when a gateway is toggled, the A2A code path simply didn't have any cascade logic — the tool's enabled column stayed unchanged regardless of the agent's state.

## 💡 Fix Description

https://github.com/user-attachments/assets/3559c2ce-25ab-4400-b83e-0033decfb976

 Bug fix

- `mcpgateway/services/a2a_service.py`: After toggling `agent.enabled` in `set_agent_state()`, cascade the new state to the agent's associated tool via a single `UPDATE` statement. The `WHERE DbTool.enabled != activate` guard avoids redundant commits when the tool already matches the desired state. This mirrors the existing pattern in `gateway_service.py:set_gateway_state()`.

 Test fixes

- `tests/unit/mcpgateway/services/test_a2a_service.py`: Added `tool_id=None` to two existing `SimpleNamespace` agent mocks (test_set_state_permission_allowed, test_set_state_with_reachable) that broke because the new cascade code accesses agent.tool_id.

 New Unit Tests (12 tests, coverage 94% → 100%)

- TestSetAgentStateToolCascade (4 tests): Deactivation cascades to tool, activation cascades to tool, no-op when tool_id is None, no commit when tool already matches state.
- TestUpdateAgentQueryParamAuth (7 tests): Switching away from query_param clears params, switching to query_param encrypts key/value, value-only rotation reuses existing key, masked placeholder with same/different key, None value no-op, plain string value path.
- TestListAgentsCacheAttributeError (1 test): AttributeError during cache set is silently skipped.
- Add extra tests to get `100%` coverage on a2a_service.py

 Documentation

- docs/docs/using/agents/a2a.md: New "Lifecycle Management > Agent-Tool State Cascade" section explaining the linked lifecycle between A2A agents and their tools.
- docs/docs/manage/api-usage.md: New "Enable/Disable A2A Agent" subsection with API examples and a "State Cascade" admonition note.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     ✅    |
| Unit tests                            | `make test`          |    ✅     |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅     |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
