### PR TITLE
fix(schemas): widen ServerCapabilities capability fields from Dict[str, bool] to Dict[str, Any] to match MCP SDK permissive approach

### DIFF
--- a/mcpgateway/common/models.py
+++ b/mcpgateway/common/models.py
@@ -379,17 +379,17 @@ class ServerCapabilities(BaseModel):
     """Capabilities that a server may support.
 
     Attributes:
-        prompts (Optional[Dict[str, bool]]): Capability for prompt support.
-        resources (Optional[Dict[str, bool]]): Capability for resource support.
-        tools (Optional[Dict[str, bool]]): Capability for tool support.
+        prompts (Optional[Dict[str, Any]]): Capability for prompt support.
+        resources (Optional[Dict[str, Any]]): Capability for resource support.
+        tools (Optional[Dict[str, Any]]): Capability for tool support.
         logging (Optional[Dict[str, Any]]): Capability for logging support.
         completions (Optional[Dict[str, Any]]): Capability for completion support.
         experimental (Optional[Dict[str, Dict[str, Any]]]): Experimental capabilities.
     """
 
-    prompts: Optional[Dict[str, bool]] = None
-    resources: Optional[Dict[str, bool]] = None
-    tools: Optional[Dict[str, bool]] = None
+    prompts: Optional[Dict[str, Any]] = None
+    resources: Optional[Dict[str, Any]] = None
+    tools: Optional[Dict[str, Any]] = None
     logging: Optional[Dict[str, Any]] = None
     completions: Optional[Dict[str, Any]] = None
     experimental: Optional[Dict[str, Dict[str, Any]]] = None


### PR DESCRIPTION
  ## 🔗 Related Issue                                                                                                           Closes #3063                                                                                                                                                                                                                                                ---                                                                                                                                                                                                                                                         ## 📝 Summary                                                                                                               
  The MCP SDK's `ToolsCapability` uses `extra: "allow"`, so MCP servers can return arbitrary extra fields in their
  capabilities response. Our `ServerCapabilities` model typed `prompts`, `resources`, and `tools` as `Dict[str, bool]`, which 
  rejects non-boolean values during `PydanticGateway.model_validate()` when plugins are enabled. Widened these three fields to
   `Dict[str, Any]` to match the SDK's permissive approach.

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | ✅      |
  | Unit tests                | `make test`     | ✅      |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  Single file change (`mcpgateway/common/models.py`). Existing tests continue to pass since boolean values are valid `Any`. No
   new tests needed as the fix is purely relaxing a type constraint.