### PR TITLE
fix(security): reject control characters in name validation and fix pagination schema consistency

### DIFF
--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -414,7 +414,7 @@ Kubernetes: `>=1.21.0-0`
 | mcpContextForge.config.VALIDATION_MAX_TEMPLATE_LENGTH | string | `"65536"` |  |
 | mcpContextForge.config.VALIDATION_MAX_URL_LENGTH | string | `"2048"` |  |
 | mcpContextForge.config.VALIDATION_MIDDLEWARE_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.VALIDATION_NAME_PATTERN | string | `"^[a-zA-Z0-9_.\\-\\s]+$"` |  |
+| mcpContextForge.config.VALIDATION_NAME_PATTERN | string | `"^[a-zA-Z0-9_.\\- ]+$"` |  |
 | mcpContextForge.config.VALIDATION_SAFE_URI_PATTERN | string | `"^[a-zA-Z0-9_\\-.:/?=&%{}]+$"` |  |
 | mcpContextForge.config.VALIDATION_STRICT | string | `"true"` |  |
 | mcpContextForge.config.VALIDATION_TOOL_METHOD_PATTERN | string | `"^[a-zA-Z][a-zA-Z0-9_\\./-]*$"` |  |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -3472,7 +3472,7 @@
       "type": "array"
     },
     "validation_name_pattern": {
-      "default": "^[a-zA-Z0-9_.\\-\\s]+$",
+      "default": "^[a-zA-Z0-9_.\\- ]+$",
       "title": "Validation Name Pattern",
       "type": "string"
     },

--- a/docs/docs/config.schema.json
+++ b/docs/docs/config.schema.json
@@ -3533,7 +3533,7 @@
       "type": "array"
     },
     "validation_name_pattern": {
-      "default": "^[a-zA-Z0-9_.\\-\\s]+$",
+      "default": "^[a-zA-Z0-9_.\\- ]+$",
       "title": "Validation Name Pattern",
       "type": "string"
     },

--- a/tests/unit/mcpgateway/validation/test_validators_advanced.py
+++ b/tests/unit/mcpgateway/validation/test_validators_advanced.py
@@ -386,6 +386,20 @@ def test_validate_name_invalid():
             SecurityValidator.validate_name(name, "Name")
 
 
+def test_validate_name_rejects_control_characters():
+    """EDGE-03: Control characters (\\n, \\t, \\r) must be rejected, not treated as whitespace."""
+    control_char_names = [
+        "test\nname",   # newline
+        "test\tname",   # tab
+        "test\rname",   # carriage return
+        "test\x0bname", # vertical tab
+        "test\x0cname", # form feed
+    ]
+    for name in control_char_names:
+        with pytest.raises(ValueError, match="can only contain letters, numbers"):
+            SecurityValidator.validate_name(name, "Name")
+
+
 def test_validate_name_length():
     """Test name length validation."""
     # At limit (100 chars)


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes two edge-case validation issues across 8 files: (1) control character bypass in name validation allowing newlines/tabs (6 files), and (2) pagination schema mismatch returning raw dicts instead of declared Pydantic models (1 file, 6 endpoints).

## 🔗 Related Issue

Closes #3028

## 🐞 Root Cause

1. **EDGE-03 (6 locations):** `validation_name_pattern` used `\s` which matches ALL whitespace including `\n`, `\t`, `\r`, allowing control characters to bypass validation
   - `mcpgateway/config.py:2098`
   - `charts/mcp-stack/values.yaml:630`
   - `tests/unit/mcpgateway/validation/test_validators_advanced.py:58`
   - `docs/config.schema.json` (stale default)
   - `docs/docs/config.schema.json` (stale default)
   - `charts/mcp-stack/README.md` (stale generated docs table)

2. **EDGE-01 (main.py:2506, 3176, 3639, 4163, 4646, 5134):** List endpoints with `include_pagination=True` constructed raw dicts manually instead of instantiating declared `CursorPaginated*Response` schemas, violating `response_model` contract

## 💡 Fix Description

### 1. EDGE-03: Control Character Bypass Fix

Changed `validation_name_pattern` from `r"^[a-zA-Z0-9_.\-\s]+$"` to `r"^[a-zA-Z0-9_.\- ]+$"` (literal space) to reject control characters while preserving space support. Updated in 6 locations for full consistency:

- `mcpgateway/config.py` (line 2098): Application default
- `charts/mcp-stack/values.yaml` (line 630): Kubernetes deployment config
- `tests/unit/mcpgateway/validation/test_validators_advanced.py` (line 58): Test settings
- `docs/config.schema.json`: JSON Schema default value
- `docs/docs/config.schema.json`: JSON Schema default value
- `charts/mcp-stack/README.md`: Helm chart docs table

Also added `test_validate_name_rejects_control_characters()` to explicitly cover `\n`, `\t`, `\r`, `\x0b`, `\x0c` rejection — the exact EDGE-03 regression scenario.

### 2. EDGE-01: Pagination Schema Fix

Replaced manual dict construction in 6 list endpoints (gateways, servers, tools, resources, prompts, a2a_agents) with proper Pydantic schema serialization:

**Before:**
```python
payload = {"gateways": [gateway.model_dump(by_alias=True) for gateway in data]}
if next_cursor:
    payload["nextCursor"] = next_cursor
return payload
```

**After:**
```python
serialized_data = [gateway.model_dump(by_alias=True) for gateway in data]
return CursorPaginatedGatewaysResponse.model_construct(gateways=serialized_data, next_cursor=next_cursor).model_dump(by_alias=True)
```

This ensures:
- Response matches declared `response_model` type
- Field aliases work correctly (`next_cursor` → `nextCursor`)
- `nextCursor: null` always present when no more pages (correct per MCP cursor spec)
- OpenAPI docs reflect actual response structure

## 🧪 Verification

| Check | Command | Result |
|---|---|---|
| Lint suite | `make lint` | Pass |
| Unit tests | `make test` | Pass |
| Coverage ≥ 90% | `make coverage` | Pass |
| EDGE-03 regression | `\n`/`\t` in name → 422 | Pass |
| EDGE-01 regression | `include_pagination=True` → proper schema object | Pass |

## 📐 MCP Compliance

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
