### PR TITLE
docs: fix rebrand errors where ContextForge replaced generic terms

### DIFF
--- a/docs/docs/architecture/roadmap.md
+++ b/docs/docs/architecture/roadmap.md
@@ -916,7 +916,7 @@
     - ✅ [**#2189**](https://github.com/IBM/mcp-context-forge/issues/2189) - [BUG][AUTH]: Multi-team users denied access to non-primary teams and cannot see public resources from other teams
     - ✅ [**#2192**](https://github.com/IBM/mcp-context-forge/issues/2192) - [BUG]: Token scoping
     - ✅ [**#2261**](https://github.com/IBM/mcp-context-forge/issues/2261) - [BUG]: JWT token creation divergence between CLI and API
-    - ✅ [**#2272**](https://github.com/IBM/mcp-context-forge/issues/2272) - [BUG]: Virtual server using an ContextForge authenticated with OAUTH2 is loosing tools
+    - ✅ [**#2272**](https://github.com/IBM/mcp-context-forge/issues/2272) - [BUG]: Virtual server using an MCP Gateway authenticated with OAUTH2 is loosing tools
     - ✅ [**#2273**](https://github.com/IBM/mcp-context-forge/issues/2273) - [BUG][UI]: Saving a virtual server configuration after edit fails
     - ✅ [**#2324**](https://github.com/IBM/mcp-context-forge/issues/2324) - [BUG]: Observability Dark Mode
     - ✅ [**#2329**](https://github.com/IBM/mcp-context-forge/issues/2329) - [BUG]: Tag filter returns 500 Exception for list tools api

--- a/docs/docs/best-practices/.pages
+++ b/docs/docs/best-practices/.pages
@@ -1,5 +1,5 @@
 nav:
-  - "Why use an ContextForge": selecting-an-mcp-gateway.md
+  - "Why use ContextForge": selecting-an-mcp-gateway.md
   - "📐 MCP Architecture Patterns": mcp-architecture-patterns.md
   - "⭐ Best Practices Guide": mcp-best-practices.md
   - "🔒 Input Validation": input-validation.md

--- a/docs/docs/best-practices/selecting-an-mcp-gateway.md
+++ b/docs/docs/best-practices/selecting-an-mcp-gateway.md
@@ -1,10 +1,10 @@
-# How ContextForge Fits the Criteria for Selecting an Enterprise ContextForge
+# How ContextForge Fits the Criteria for Selecting an Enterprise AI, Agent and MCP Gateway
 
 A practical framework for evaluating MCP gateways, and how ContextForge addresses each criterion.
 
 ---
 
-## Why an ContextForge?
+## Why ContextForge?
 
 Organizations deploying AI agents face fragmented tool ecosystems, inconsistent security controls, and no centralized governance across agent interactions. An MCP gateway provides the unified control plane: federating tools, enforcing policy, and delivering visibility across your AI infrastructure.
 
@@ -12,22 +12,22 @@ This framework outlines what to evaluate and why each criterion matters.
 
 ---
 
-## ContextForge Landscape
+## MCP Gateway Landscape
 
-The MCP gateway market has matured rapidly. Options range from managed SaaS platforms (Composio, MintMCP, Apigee ContextForge) to cloud-native solutions (Azure ContextForge, Docker ContextForge) to self-hosted open source (ContextForge, Lasso Security, Bifrost).
+The MCP gateway market has matured rapidly. Options range from managed SaaS platforms (Composio, MintMCP, Apigee MCP Hub) to cloud-native solutions (Azure API Management, Docker MCP Toolkit) to self-hosted open source (ContextForge, Lasso Security, Bifrost).
 
 ```mermaid
 flowchart TB
-    subgraph "ContextForge Options"
+    subgraph "MCP Gateway Options"
         direction TB
         subgraph managed["Managed SaaS"]
             composio["Composio"]
             mintmcp["MintMCP"]
-            apigee["Apigee ContextForge"]
+            apigee["Apigee MCP Hub"]
         end
         subgraph cloud["Cloud-Native"]
-            azure["Azure ContextForge"]
-            docker["Docker ContextForge"]
+            azure["Azure API Management"]
+            docker["Docker MCP Toolkit"]
         end
         subgraph selfhosted["Self-Hosted Open Source"]
             contextforge["ContextForge"]

--- a/docs/docs/using/clients/copilot.md
+++ b/docs/docs/using/clients/copilot.md
@@ -22,7 +22,7 @@ HTTP or require local stdio, you can insert the bundled **`mcpgateway.wrapper`**
 
 * **VS Code ≥ 1.99**
 * `"chat.mcp.enabled": true` in your *settings.json*
-* An ContextForge running (`make serve`, Docker, or container image)
+* ContextForge running (`make serve`, Docker, or container image)
 * A JWT or Basic credentials (`admin` / `changeme` in dev)
 
 ---


### PR DESCRIPTION
## Summary

- Fixes nonsensical text introduced by mechanical find-and-replace in PR #3091 (rebrand to ContextForge AI Gateway)
- ContextForge is a product name, not a generic noun — "Enterprise ContextForge", "Apigee ContextForge", "an ContextForge" don't make sense

## Changes

**`docs/docs/best-practices/selecting-an-mcp-gateway.md`** (6 fixes):
- Title: "Enterprise ContextForge" → "Enterprise AI, Agent and MCP Gateway"
- "Why an ContextForge?" → "Why ContextForge?"
- "ContextForge Landscape" → "MCP Gateway Landscape"
- Restored actual vendor product names: Apigee MCP Hub, Azure API Management, Docker MCP Toolkit
- Mermaid diagram subgraph: "ContextForge Options" → "MCP Gateway Options"

**`docs/docs/best-practices/.pages`** (1 fix):
- Nav label: "Why use an ContextForge" → "Why use ContextForge"

**`docs/docs/architecture/roadmap.md`** (1 fix):
- Issue #2272 title: restored original "MCP Gateway" (verified against actual GitHub issue)

**`docs/docs/using/clients/copilot.md`** (1 fix):
- "An ContextForge running" → "ContextForge running"

## Test plan

- [ ] Verify docs site renders correctly with `mkdocs serve`
- [ ] Confirm mermaid diagrams display proper vendor names