### PR TITLE
test(api): add regression coverage for prompt original_name during federation (#3087)

### DIFF
--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -3320,6 +3320,12 @@ async def test_register_gateway_creates_new_resources_and_prompts(gateway_servic
     assert len(added_gateway.resources) == 1
     assert len(added_gateway.prompts) == 1
 
+    # Regression: verify namespacing fields are set (issue #3087)
+    federated_prompt = added_gateway.prompts[0]
+    assert federated_prompt.original_name == "Prompt"
+    assert federated_prompt.custom_name == "Prompt"
+    assert federated_prompt.display_name == "Prompt"
+
 
 @pytest.mark.asyncio
 async def test_shutdown_releases_redis_leader_success():
@@ -3963,6 +3969,12 @@ class TestUpdateOrCreatePrompts:
         gw.visibility = "public"
         result = gateway_service._update_or_create_prompts(db, [prompt], gw, "test")
         assert len(result) == 1
+
+        # Regression: verify namespacing fields are set (issue #3087)
+        created = result[0]
+        assert created.original_name == "new-prompt"
+        assert created.custom_name == "new-prompt"
+        assert created.display_name == "new-prompt"
 
     def test_existing_prompt_updated(self, gateway_service, mock_gateway):
         existing = MagicMock()


### PR DESCRIPTION
  ---                                                                                                                         
  🔗 Related Issue                                                                                                            

  Closes #3087

  ---
  📝 Summary

  The NOT NULL constraint violation on prompts.original_name reported in #3087 was already fixed on main (gateway_service.py now explicitly sets original_name, custom_name, and display_name during federation prompt creation). However, there was no regression test coverage for this path, the equivalent tool federation test verified original_name but the prompt tests did not.

  This PR adds assertions to two test paths to prevent regression:
  - test_register_gateway_creates_new_resources_and_prompts — initial gateway registration
  - TestUpdateOrCreatePrompts::test_new_prompt_created — prompt refresh/rediscovery

  ---
  🏷️ Type of Change

  - Bug fix
  - Feature / Enhancement
  - Documentation
  - Refactor
  - Chore (deps, CI, tooling)
  - Other (describe below)

  ---
  ## 🧪 Verification   
                                                                                                          
  - ✅ Lint suite (`make lint`)
  - ✅ Unit tests (`make test`): 262 passed, 1 skipped                                                                       
  - ✅ Coverage ≥ 80% (`make coverage`)

  ---
  ✅ Checklist

  - Code formatted (make black isort pre-commit)
  - Tests added/updated for changes
  - Documentation updated (if applicable)
  - No secrets or credentials committed

  ---
  📓 Notes (optional)

  The bulk of the diff is isort/black reformatting of the existing test file. The actual test additions are ~8 lines of       
  assertions across two test functions.