### PR TITLE
fix(ci): CE secret sync silently fails to overwrite existing values

### DIFF
--- a/.github/workflows/ibm-cloud-code-engine.yml
+++ b/.github/workflows/ibm-cloud-code-engine.yml
@@ -200,6 +200,11 @@ jobs:
           # Build .env from .env.example, replacing secret placeholders.
           # Uses Python to avoid shell quoting issues (sed delimiter
           # collisions with |, &, \) and grep exit-code edge cases.
+          #
+          # IMPORTANT: Output ONLY uncommented KEY=VALUE lines.
+          # CE's --from-env-file silently skips updates when the file
+          # contains comments, blank lines, or section headers from
+          # .env.example.  Stripping to clean KEY=VALUE lines fixes this.
           python3 -c "
           import os, sys
           replacements = {
@@ -214,18 +219,23 @@ jobs:
               lines = f.readlines()
           with open('.env.deploy', 'w') as out:
               for line in lines:
-                  stripped = line.lstrip()
-                  if '=' in stripped and not stripped.startswith('#'):
-                      key = stripped.split('=', 1)[0]
-                      if key in replacements:
-                          val = replacements[key]
-                          if '\n' in val or '\r' in val:
-                              print(f'::error::Secret for {key} contains embedded newlines')
-                              raise SystemExit(1)
-                          out.write(f'{key}={val}\n')
-                          replaced.add(key)
-                          continue
-                  out.write(line)
+                  stripped = line.strip()
+                  # Skip comments and blank lines — CE --from-env-file
+                  # needs a clean KEY=VALUE-only file to reliably update.
+                  if not stripped or stripped.startswith('#'):
+                      continue
+                  if '=' not in stripped:
+                      continue
+                  key = stripped.split('=', 1)[0]
+                  if key in replacements:
+                      val = replacements[key]
+                      if '\n' in val or '\r' in val:
+                          print(f'::error::Secret for {key} contains embedded newlines')
+                          raise SystemExit(1)
+                      out.write(f'{key}={val}\n')
+                      replaced.add(key)
+                  else:
+                      out.write(f'{stripped}\n')
           missing = set(replacements) - replaced
           if missing:
               print(f'::error::Keys not found in .env.example: {missing}')
@@ -233,20 +243,38 @@ jobs:
               sys.exit(1)
           "
 
-          echo "✅ Generated .env.deploy from template + GitHub Secrets"
+          echo "✅ Generated .env.deploy ($(wc -l < .env.deploy) KEY=VALUE lines)"
 
           # Update the secret if it exists, otherwise create it.
-          # 'secret update --from-env-file' merges keys (does not prune
-          # removed keys), so stale keys may linger if .env.example drops
-          # a variable. This is benign (unused env vars) and far safer
-          # than delete+create which leaves no secret if create fails.
           if ibmcloud ce secret get --name mcpgateway-dev > /dev/null 2>&1; then
             ibmcloud ce secret update --name mcpgateway-dev --from-env-file .env.deploy
           else
             ibmcloud ce secret create --name mcpgateway-dev --format generic --from-env-file .env.deploy
           fi
 
+          # Belt-and-suspenders: explicitly set each secret with --from-literal
+          # to guarantee overwrite regardless of --from-env-file parsing quirks.
+          ibmcloud ce secret update --name mcpgateway-dev \
+            --from-literal "JWT_SECRET_KEY=$CF_JWT_SECRET_KEY" \
+            --from-literal "BASIC_AUTH_PASSWORD=$CF_BASIC_AUTH_PASSWORD" \
+            --from-literal "AUTH_ENCRYPTION_SECRET=$CF_AUTH_ENCRYPTION_SECRET" \
+            --from-literal "PLATFORM_ADMIN_PASSWORD=$CF_PLATFORM_ADMIN_PASSWORD" \
+            --from-literal "DEFAULT_USER_PASSWORD=$CF_DEFAULT_USER_PASSWORD"
+
           echo "✅ Code Engine secret 'mcpgateway-dev' synced"
+
+          # Verify the 5 critical secrets are no longer placeholders
+          echo "🔍 Verifying secret values were updated..."
+          for key in JWT_SECRET_KEY BASIC_AUTH_PASSWORD AUTH_ENCRYPTION_SECRET \
+                     PLATFORM_ADMIN_PASSWORD DEFAULT_USER_PASSWORD; do
+            val=$(ibmcloud ce secret get --name mcpgateway-dev --decode -o json 2>/dev/null \
+                  | python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('$key',''))" 2>/dev/null || echo "")
+            if [ "$val" = "-" ] || [ -z "$val" ]; then
+              echo "::error::Secret key $key still has placeholder value after update"
+              exit 1
+            fi
+          done
+          echo "✅ All 5 secrets verified (no placeholders)"
 
       # -----------------------------------------------------------
       # 9️⃣  Deploy (create or update) Code Engine application


### PR DESCRIPTION
## Summary

- Fix `ibmcloud ce secret update --from-env-file` silently failing to overwrite existing secret values
- The `.env.deploy` file previously contained 800+ lines of comments/blank lines from `.env.example`, which caused CE's parser to skip updates while reporting success
- Strip `.env.deploy` to clean `KEY=VALUE` lines only (29 lines)
- Add explicit `--from-literal` overrides for the 5 critical secrets as belt-and-suspenders
- Add post-update verification that fails the workflow if any secret still holds a placeholder
- Also includes AGENTS.md updates (project overview, structure, env var defaults, issue/labeling guidelines)

## Root Cause

The Code Engine `--from-env-file` parser silently skips key updates when the input file contains comments (`#`), blank lines, or section headers. The previous workflow passed the full `.env.example` through to `.env.deploy` (800+ lines), causing CE to report `OK` while leaving stale `-` placeholder values in the `mcpgateway-dev` secret. This meant the app was bootstrapping with `-` as the admin password, JWT secret, and encryption key.

## Test plan

- [ ] Verify GitHub Actions workflow runs successfully on push to main
- [ ] Confirm `.env.deploy` log line shows ~29 KEY=VALUE lines (not 800+)
- [ ] Confirm `--from-literal` step runs without error
- [ ] Confirm verification step passes (no placeholder values)
- [ ] Confirm login works with the `CF_PLATFORM_ADMIN_PASSWORD` value