### PR TITLE
fix(ci): reject placeholder secret values in validation step

### DIFF
--- a/.github/workflows/ibm-cloud-code-engine.yml
+++ b/.github/workflows/ibm-cloud-code-engine.yml
@@ -107,11 +107,15 @@ jobs:
           CF_DEFAULT_USER_PASSWORD: ${{ secrets.CF_DEFAULT_USER_PASSWORD }}
         run: |
           missing=()
+          placeholder=()
           for var in CF_IBM_CLOUD_API_KEY CF_JWT_SECRET_KEY CF_BASIC_AUTH_PASSWORD \
                      CF_AUTH_ENCRYPTION_SECRET CF_PLATFORM_ADMIN_PASSWORD \
                      CF_DEFAULT_USER_PASSWORD; do
-            if [ -z "${!var}" ]; then
+            val="${!var}"
+            if [ -z "$val" ]; then
               missing+=("$var")
+            elif [ "$val" = "-" ] || [ "$val" = "changeme" ] || [ "$val" = "CHANGE_ME" ]; then
+              placeholder+=("$var")
             fi
           done
           for var in IBM_CLOUD_REGION REGISTRY_HOSTNAME ICR_NAMESPACE \
@@ -123,6 +127,11 @@ jobs:
           done
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Required secrets/variables are empty or unconfigured: ${missing[*]}"
+            exit 1
+          fi
+          if [ ${#placeholder[@]} -gt 0 ]; then
+            echo "::error::Secrets contain placeholder values (e.g. '-', 'changeme'): ${placeholder[*]}"
+            echo "::error::Update these in GitHub → Settings → Environments → production → Secrets"
             exit 1
           fi
           echo "All required secrets and variables are present."


### PR DESCRIPTION
## Summary
- Hardens the validation step to reject placeholder secret values (`-`, `changeme`, `CHANGE_ME`) early, before building/pushing the Docker image (~3 min savings)
- The previous validation only checked for empty values, letting `-` placeholders through
- Also updated all 5 `CF_*` secrets in the production environment to strong random values (they were set to `-`)

## Root cause of #3096 failure
The GitHub Secrets in the `production` environment were set to `-` (single dash) as placeholders. The secret sync correctly wrote `-` to Code Engine, and the verification correctly caught it. Proof: every `-` in the CI log was masked as `***` (e.g., `us***south`, `***name`), which only happens when a secret value is literally `-`.

Closes #3096