### PR TITLE
feat(rust): Add json_repair Rust plugin to bring behaviour parity with Python and benchmark perfomance

### DIFF
--- a/plugins_rust/json_repair/compare_performance.py
+++ b/plugins_rust/json_repair/compare_performance.py
@@ -63,18 +63,19 @@ class Scenario:
     """Single benchmark scenario."""
 
     name: str
-    payload: str
+    payloads: list[str]
 
 
-def _make_object_json(target_kb: int, repairable: bool) -> str:
+def _make_object_json(target_kb: int, repairable: bool, seed: int = 0) -> str:
     """Create deterministic object-like JSON-ish text around target size."""
     parts = []
     idx = 0
     while len(",".join(parts)) < target_kb * 1024:
+        key = f"k{seed}_{idx}"
         if repairable:
-            parts.append(f"'k{idx}': 'value_{idx}'")
+            parts.append(f"'{key}': 'value_{seed}_{idx}'")
         else:
-            parts.append(f'"k{idx}": "value_{idx}"')
+            parts.append(f'"{key}": "value_{seed}_{idx}"')
         idx += 1
 
     body = ",".join(parts)
@@ -83,46 +84,61 @@ def _make_object_json(target_kb: int, repairable: bool) -> str:
     return "{" + body + "}"
 
 
-def generate_scenarios() -> list[Scenario]:
+def _build_payload_variants(target_kb: int, repairable: bool, variants: int) -> list[str]:
+    """Create multiple payload variants with distinct keys to reduce parser key-cache effects."""
+    return [_make_object_json(target_kb, repairable=repairable, seed=i) for i in range(variants)]
+
+
+def generate_scenarios(payload_variants: int) -> list[Scenario]:
     """Build benchmark scenarios with realistic payload sizes."""
+    if payload_variants < 1:
+        raise ValueError("payload_variants must be >= 1")
+
+    def _missing_braces_variant(i: int) -> str:
+        return f'"a_{i}": {i + 1}, "b_{i}": {i + 2}'
+
     return [
-        Scenario("small_valid_1kb", _make_object_json(1, repairable=False)),
-        Scenario("small_repairable_1kb", _make_object_json(1, repairable=True)),
-        Scenario("medium_valid_5kb", _make_object_json(5, repairable=False)),
-        Scenario("medium_repairable_5kb", _make_object_json(5, repairable=True)),
-        Scenario("large_valid_50kb", _make_object_json(50, repairable=False)),
-        Scenario("large_repairable_50kb", _make_object_json(50, repairable=True)),
-        Scenario("xlarge_valid_500kb", _make_object_json(500, repairable=False)),
-        Scenario("xlarge_repairable_500kb", _make_object_json(500, repairable=True)),
-        Scenario("xxlarge_valid_1024kb", _make_object_json(1024, repairable=False)),
-        Scenario("xxlarge_repairable_1024kb", _make_object_json(1024, repairable=True)),
-        Scenario("unrepairable_text", "not-json-at-all " * 200),
-        Scenario("missing_braces", '"a": 1, "b": 2'),
+        Scenario("small_valid_1kb", _build_payload_variants(1, repairable=False, variants=payload_variants)),
+        Scenario("small_repairable_1kb", _build_payload_variants(1, repairable=True, variants=payload_variants)),
+        Scenario("medium_valid_5kb", _build_payload_variants(5, repairable=False, variants=payload_variants)),
+        Scenario("medium_repairable_5kb", _build_payload_variants(5, repairable=True, variants=payload_variants)),
+        Scenario("large_valid_50kb", _build_payload_variants(50, repairable=False, variants=payload_variants)),
+        Scenario("large_repairable_50kb", _build_payload_variants(50, repairable=True, variants=payload_variants)),
+        Scenario("xlarge_valid_500kb", _build_payload_variants(500, repairable=False, variants=payload_variants)),
+        Scenario("xlarge_repairable_500kb", _build_payload_variants(500, repairable=True, variants=payload_variants)),
+        Scenario("xxlarge_valid_1024kb", _build_payload_variants(1024, repairable=False, variants=payload_variants)),
+        Scenario("xxlarge_repairable_1024kb", _build_payload_variants(1024, repairable=True, variants=payload_variants)),
+        Scenario("unrepairable_text", [f"not-json-at-all {i} " * 200 for i in range(payload_variants)]),
+        Scenario("missing_braces", [_missing_braces_variant(i) for i in range(payload_variants)]),
     ]
 
 
-def benchmark_python(payload: str, iterations: int, warmup: int) -> tuple[list[float], str | None]:
+def benchmark_python(payloads: list[str], iterations: int, warmup: int) -> tuple[list[float], str | None]:
     """Benchmark Python repair function."""
-    for _ in range(warmup):
+    for i in range(warmup):
+        payload = payloads[i % len(payloads)]
         PY_IMPL._repair(payload)
 
     times: list[float] = []
     output: str | None = None
-    for _ in range(iterations):
+    for i in range(iterations):
+        payload = payloads[i % len(payloads)]
         start = time.perf_counter()
         output = PY_IMPL._repair(payload)
         times.append(time.perf_counter() - start)
     return times, output
 
 
-def benchmark_rust(payload: str, iterations: int, warmup: int, rust_repair: Callable[[str], str | None]) -> tuple[list[float], str | None]:
+def benchmark_rust(payloads: list[str], iterations: int, warmup: int, rust_repair: Callable[[str], str | None]) -> tuple[list[float], str | None]:
     """Benchmark Rust repair function."""
-    for _ in range(warmup):
+    for i in range(warmup):
+        payload = payloads[i % len(payloads)]
         rust_repair(payload)
 
     times: list[float] = []
     output: str | None = None
-    for _ in range(iterations):
+    for i in range(iterations):
+        payload = payloads[i % len(payloads)]
         start = time.perf_counter()
         output = rust_repair(payload)
         times.append(time.perf_counter() - start)
@@ -150,7 +166,7 @@ def run_scenario(scenario: Scenario, iterations: int, warmup: int, rust_repair: 
     print(f"Scenario: {scenario.name}")
     print("=" * 72)
 
-    py_times, py_output = benchmark_python(scenario.payload, iterations, warmup)
+    py_times, py_output = benchmark_python(scenario.payloads, iterations, warmup)
     py_mean, py_median, py_stdev = _summarize(py_times)
     print(f"Python: {py_mean:.3f} ms ±{py_stdev:.3f} (median: {py_median:.3f})")
 
@@ -158,7 +174,7 @@ def run_scenario(scenario: Scenario, iterations: int, warmup: int, rust_repair: 
         print("Rust: not available")
         return
 
-    rust_times, rust_output = benchmark_rust(scenario.payload, iterations, warmup, rust_repair)
+    rust_times, rust_output = benchmark_rust(scenario.payloads, iterations, warmup, rust_repair)
     rust_mean, rust_median, rust_stdev = _summarize(rust_times)
     speedup = py_mean / rust_mean if rust_mean > 0 else 0.0
     print(f"Rust:   {rust_mean:.3f} ms ±{rust_stdev:.3f} (median: {rust_median:.3f})")
@@ -173,8 +189,14 @@ def run_scenario(scenario: Scenario, iterations: int, warmup: int, rust_repair: 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="json_repair Python vs Rust benchmark")
-    parser.add_argument("--iterations", type=int, default=10000, help="Iterations per scenario")
+    parser.add_argument("--iterations", type=int, default=3000, help="Iterations per scenario")
     parser.add_argument("--warmup", type=int, default=100, help="Warmup iterations per scenario")
+    parser.add_argument(
+        "--payload-variants",
+        type=int,
+        default=32,
+        help="Number of distinct payload variants to rotate per scenario (1 keeps the original same-input loop).",
+    )
     return parser.parse_args()
 
 
@@ -193,8 +215,9 @@ def main() -> int:
     print(f"Python: {sys.version.split()[0]}")
     print(f"Rust available: {'yes' if rust_repair is not None else 'no'}")
     print(f"Iterations: {args.iterations} (+{args.warmup} warmup)")
+    print(f"Payload variants per scenario: {args.payload_variants}")
 
-    for scenario in generate_scenarios():
+    for scenario in generate_scenarios(args.payload_variants):
         run_scenario(scenario, args.iterations, args.warmup, rust_repair)
 
     print("\n" + "=" * 72)


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #3080
- Depends on PR: #2999  
- ⚠️ Do not merge yet

**Note**: This branch is currently based on PR #2999 due to structural changes introduced there.
Basing this PR on #2999 ensures that the diff accurately reflects only the changes introduced here, without being obscured by unrelated prior modifications.

---

## 📝 Summary

This PR adds a Rust implementation for `json_repair` and integrates it into the
existing plugin workflow while maintaining strict behavior parity with the
Python implementation.

### What’s included

- Added new Rust crate: `plugins_rust/json_repair`
- Implemented repair logic with parity for:
  - trailing comma repair
  - single-quote JSON-ish repair
  - missing outer braces repair
  - multiline JSON-ish input handling
- Added Rust unit tests covering parity scenarios
- Added Criterion benchmarks for:
  - fixed repair cases
  - batch processing
  - text size scaling
  - early-exit vs full repair path
- Added and cleaned benchmark comparison script comments
  (`compare_performance.py`)

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

TBD


## Benchmarks

#### 📈 Performance Comparison
Run below commands:
- python plugins_rust/json_repair/compare_performance.py

<details>
<summary><strong>compare_performance.py results (Python vs Rust)</strong></summary>

### Environment
- Python: 3.13.12
- Rust available: yes
- Iterations: 10,000 (+100 warmup)

### High-level summary
- Python + `orjson` is consistently faster across all tested input sizes.
- Rust shows predictable scaling but has higher constant overhead, likely dominated by
  Python↔Rust (PyO3) boundary costs and repeated parse checks.
- Speedups are < 1.0× in all scenarios (i.e., Rust is slower end-to-end for this workload).

### Detailed results

```text
========================================================================
Scenario: small_valid_1kb
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.007 ms ±0.001 (median: 0.007)
Speedup: 0.17x

========================================================================
Scenario: small_repairable_1kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.004)
Rust:   0.016 ms ±0.001 (median: 0.016)
Speedup: 0.29x

========================================================================
Scenario: medium_valid_5kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.005)
Rust:   0.036 ms ±0.002 (median: 0.037)
Speedup: 0.13x

========================================================================
Scenario: medium_repairable_5kb
========================================================================
Python: 0.019 ms ±0.002 (median: 0.019)
Rust:   0.079 ms ±0.011 (median: 0.078)
Speedup: 0.24x

========================================================================
Scenario: large_valid_50kb
========================================================================
Python: 0.042 ms ±0.003 (median: 0.041)
Rust:   0.359 ms ±0.014 (median: 0.358)
Speedup: 0.12x

========================================================================
Scenario: large_repairable_50kb
========================================================================
Python: 0.227 ms ±0.015 (median: 0.226)
Rust:   0.777 ms ±0.029 (median: 0.776)
Speedup: 0.29x

========================================================================
Scenario: xlarge_valid_500kb
========================================================================
Python: 0.385 ms ±0.014 (median: 0.385)
Rust:   3.956 ms ±0.148 (median: 3.953)
Speedup: 0.10x

========================================================================
Scenario: xlarge_repairable_500kb
========================================================================
Python: 2.165 ms ±0.120 (median: 2.140)
Rust:   8.579 ms ±0.268 (median: 8.557)
Speedup: 0.25x

========================================================================
Scenario: xxlarge_valid_1024kb
========================================================================
Python: 0.811 ms ±0.028 (median: 0.808)
Rust:   8.840 ms ±0.294 (median: 8.828)
Speedup: 0.09x

========================================================================
Scenario: xxlarge_repairable_1024kb
========================================================================
Python: 4.241 ms ±0.177 (median: 4.209)
Rust:   18.558 ms ±0.592 (median: 18.511)
Speedup: 0.23x

========================================================================
Scenario: unrepairable_text
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.000 ms ±0.000 (median: 0.000)
Speedup: 2.60x

========================================================================
Scenario: missing_braces
========================================================================
Python: 0.000 ms ±0.000 (median: 0.000)
Rust:   0.000 ms ±0.000 (median: 0.000)
Speedup: 0.96x

========================================================================
Benchmark complete
========================================================================
```

Interpretation

The current Python path benefits from orjson (already Rust-backed) without crossing
an FFI boundary.

The Rust path is valuable for correctness parity, benchmarking, and future optimization,
but is not yet competitive as the default execution path.

These benchmarks support keeping Python + orjson as the default while continuing to
invest in Rust-side optimizations.

</details> 


<details>
<summary><strong>Python vs Rust benchmark results</strong></summary>

### Environment
- Python: 3.13.12
- Rust available: yes
- Iterations: 10,000 (+100 warmup)
- Payload variants per scenario: 32

### Results

```text
========================================================================
Scenario: small_valid_1kb
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.005 ms ±0.001 (median: 0.005)
Speedup: 0.21x

========================================================================
Scenario: small_repairable_1kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.005)
Rust:   0.012 ms ±0.001 (median: 0.012)
Speedup: 0.43x

========================================================================
Scenario: medium_valid_5kb
========================================================================
Python: 0.004 ms ±0.000 (median: 0.004)
Rust:   0.029 ms ±0.002 (median: 0.028)
Speedup: 0.15x

========================================================================
Scenario: medium_repairable_5kb
========================================================================
Python: 0.021 ms ±0.001 (median: 0.021)
Rust:   0.062 ms ±0.003 (median: 0.062)
Speedup: 0.34x

========================================================================
Scenario: large_valid_50kb
========================================================================
Python: 0.038 ms ±0.003 (median: 0.037)
Rust:   0.308 ms ±0.018 (median: 0.301)
Speedup: 0.12x

========================================================================
Scenario: large_repairable_50kb
========================================================================
Python: 0.205 ms ±0.007 (median: 0.202)
Rust:   0.670 ms ±0.031 (median: 0.661)
Speedup: 0.31x

========================================================================
Scenario: xlarge_valid_500kb
========================================================================
Python: 0.356 ms ±0.012 (median: 0.353)
Rust:   3.361 ms ±0.211 (median: 3.311)
Speedup: 0.11x

========================================================================
Scenario: xlarge_repairable_500kb
========================================================================
Python: 1.906 ms ±0.089 (median: 1.887)
Rust:   7.134 ms ±0.424 (median: 7.005)
Speedup: 0.27x

========================================================================
Scenario: xxlarge_valid_1024kb
========================================================================
Python: 0.713 ms ±0.030 (median: 0.709)
Rust:   7.160 ms ±0.473 (median: 6.994)
Speedup: 0.10x

========================================================================
Scenario: xxlarge_repairable_1024kb
========================================================================
Python: 3.719 ms ±0.151 (median: 3.677)
Rust:   15.071 ms ±0.988 (median: 14.711)
Speedup: 0.25x

========================================================================
Scenario: unrepairable_text
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.000 ms ±0.000 (median: 0.001)
Speedup: 2.65x

========================================================================
Scenario: missing_braces
========================================================================
Python: 0.000 ms ±0.000 (median: 0.001)
Rust:   0.001 ms ±0.000 (median: 0.001)
Speedup: 0.99x

========================================================================
Benchmark complete
========================================================================
```

Notes

Python + orjson is faster for all valid and repairable JSON scenarios.

Rust shows a clear advantage only for early-exit unrepairable text.

Results reinforce keeping Python as the default path, with Rust retained for
parity, benchmarking, and future optimization work.

</details> 


<details>
<summary><strong>Python vs Rust benchmark results, Iterations: 3,000 (+100 warmup),Payload variants per scenario: 32 </strong></summary>

### Environment
- Python: 3.13.12
- Rust available: yes
- Iterations: 3,000 (+100 warmup)
- Payload variants per scenario: 32

### Results

```text
========================================================================
Scenario: small_valid_1kb
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.005 ms ±0.000 (median: 0.005)
Speedup: 0.21x

========================================================================
Scenario: small_repairable_1kb
========================================================================
Python: 0.005 ms ±0.000 (median: 0.005)
Rust:   0.012 ms ±0.001 (median: 0.012)
Speedup: 0.45x

========================================================================
Scenario: medium_valid_5kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.005)
Rust:   0.029 ms ±0.002 (median: 0.029)
Speedup: 0.16x

========================================================================
Scenario: medium_repairable_5kb
========================================================================
Python: 0.021 ms ±0.001 (median: 0.021)
Rust:   0.063 ms ±0.004 (median: 0.062)
Speedup: 0.34x

========================================================================
Scenario: large_valid_50kb
========================================================================
Python: 0.039 ms ±0.002 (median: 0.039)
Rust:   0.315 ms ±0.014 (median: 0.310)
Speedup: 0.12x

========================================================================
Scenario: large_repairable_50kb
========================================================================
Python: 0.204 ms ±0.006 (median: 0.202)
Rust:   0.677 ms ±0.074 (median: 0.670)
Speedup: 0.30x

========================================================================
Scenario: xlarge_valid_500kb
========================================================================
Python: 0.356 ms ±0.013 (median: 0.353)
Rust:   3.376 ms ±0.193 (median: 3.312)
Speedup: 0.11x

========================================================================
Scenario: xlarge_repairable_500kb
========================================================================
Python: 1.902 ms ±0.064 (median: 1.886)
Rust:   7.145 ms ±0.368 (median: 7.019)
Speedup: 0.27x

========================================================================
Scenario: xxlarge_valid_1024kb
========================================================================
Python: 0.720 ms ±0.022 (median: 0.715)
Rust:   7.168 ms ±0.435 (median: 7.002)
Speedup: 0.10x

========================================================================
Scenario: xxlarge_repairable_1024kb
========================================================================
Python: 3.730 ms ±0.142 (median: 3.688)
Rust:   15.075 ms ±0.958 (median: 14.746)
Speedup: 0.25x

========================================================================
Scenario: unrepairable_text
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.000 ms ±0.000 (median: 0.001)
Speedup: 2.59x

========================================================================
Scenario: missing_braces
========================================================================
Python: 0.000 ms ±0.000 (median: 0.001)
Rust:   0.001 ms ±0.000 (median: 0.001)
Speedup: 0.98x

========================================================================
Benchmark complete
========================================================================
```

Notes

Python + orjson remains faster for all valid and repairable JSON cases.

Rust shows a clear advantage only for early-exit unrepairable input.

Results support keeping Python as the default path, with Rust retained for
parity, benchmarking, and future optimization work.

</details> 

#### 🧪 Rust Bench Results

Run below commands:
- cd plugins_rust/json_repair
- cargo bench --bench json_repair

<details>
<summary><strong>cargo bench --bench json_repair (Criterion output)</strong></summary>

### Environment
- Crate: `plugins_rust/json_repair`
- Command: `cargo bench --bench json_repair`
- Backend: Criterion (plotters fallback, gnuplot not found)
- Build: `bench` profile (optimized + debuginfo)

### High-level observations
- Benchmarks show **expected linear scaling** across input sizes.
- Valid-path throughput is consistently higher than repairable-path throughput.
- Several micro-benchmarks report minor regressions or improvements, largely within
  expected noise thresholds for Criterion.
- Early-exit path (already-valid JSON) shows **measurable improvement** over the
  full repair path.

### Raw Criterion output

```text
repair_cases/valid/0
time:   [111.45 ns 113.61 ns 116.01 ns]
thrpt:  [106.87 MiB/s 109.12 MiB/s 111.24 MiB/s]
No change in performance detected.

repair_cases/valid/1
time:   [388.35 ns 397.90 ns 408.58 ns]
thrpt:  [123.71 MiB/s 127.03 MiB/s 130.15 MiB/s]
No change in performance detected.

repair_cases/valid/2
time:   [389.11 ns 392.41 ns 395.69 ns]
thrpt:  [103.64 MiB/s 104.50 MiB/s 105.39 MiB/s]
Change within noise threshold.

repair_cases/valid/3
time:   [242.63 ns 243.83 ns 244.91 ns]
thrpt:  [198.59 MiB/s 199.47 MiB/s 200.46 MiB/s]
Performance has regressed.

repair_cases/repairable/0
time:   [536.83 ns 540.90 ns 544.88 ns]
thrpt:  [29.754 MiB/s 29.973 MiB/s 30.200 MiB/s]
Performance has regressed.

repair_cases/repairable/1
time:   [262.37 ns 267.04 ns 271.76 ns]
thrpt:  [56.148 MiB/s 57.140 MiB/s 58.157 MiB/s]
Performance has regressed.

repair_cases/repairable/2
time:   [278.67 ns 282.12 ns 285.22 ns]
thrpt:  [60.186 MiB/s 60.847 MiB/s 61.600 MiB/s]
Change within noise threshold.

repair_cases/repairable/3
time:   [440.10 ns 444.28 ns 447.90 ns]
thrpt:  [29.809 MiB/s 30.052 MiB/s 30.337 MiB/s]
Performance has regressed.

repair_cases/unrepairable/0
time:   [156.96 ns 158.75 ns 160.49 ns]
thrpt:  [89.135 MiB/s 90.109 MiB/s 91.138 MiB/s]
No change in performance detected.

repair_cases/unrepairable/1
time:   [126.39 ns 128.78 ns 131.42 ns]
thrpt:  [253.98 MiB/s 259.20 MiB/s 264.10 MiB/s]
Performance has regressed.

repair_cases/unrepairable/2
time:   [183.34 ns 184.72 ns 186.01 ns]
thrpt:  [158.93 MiB/s 160.05 MiB/s 161.26 MiB/s]
No change in performance detected.

repair_cases/unrepairable/3
time:   [132.25 ns 133.33 ns 134.15 ns]
thrpt:  [7.1091 MiB/s 7.1528 MiB/s 7.2113 MiB/s]
No change in performance detected.

batch_processing/mixed_batch
time:   [3.5575 µs 3.5967 µs 3.6375 µs]
thrpt:  [80.489 MiB/s 81.401 MiB/s 82.300 MiB/s]
No change in performance detected.

text_sizes/valid_kb/*
thrpt range: ~113–132 MiB/s

text_sizes/repairable_kb/*
thrpt range: ~56–63 MiB/s

early_exit_vs_full_path/already_valid_early_exit
thrpt: [107.17 MiB/s 108.53 MiB/s 110.35 MiB/s]
Performance has improved.

early_exit_vs_full_path/repairable_full_path
thrpt: [32.042 MiB/s 32.185 MiB/s 32.307 MiB/s]
Performance has improved.
```

**Interpretation**

Criterion results confirm stable behavior and predictable scaling.

Regressions/improvements are mostly small and consistent with micro-benchmark noise.

Early-exit optimization is effective and worth preserving.

These benches are useful for tracking Rust-side optimizations over time, even
though Rust is not yet the default execution path.

</details> 

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Default path rationale (benchmark-driven)

- This PR follows the standard plugin pattern: Python as the default path,
  Rust as an optional accelerated path with safe fallback.
- Default behavior is driven by measured results, not assumptions.
- For `json_repair`, current benchmarks support Python + `orjson` as the
  default path.

### Why this is currently the best default

- Python already uses `orjson` (Rust-backed), providing a highly optimized
  baseline.
- The Rust extension introduces Python↔Rust (PyO3) boundary overhead and
  currently relies on `serde_json` for parse checks.
- End-to-end benchmarks show Rust is slower for valid and repairable inputs
  across tested sizes (1 KB to 1 MB), with only narrow wins for tiny
  unrepairable inputs.
- Therefore, Python + `orjson` remains the faster and lower-complexity
  production default at this time.

### Rust benchmark snapshot

- Criterion benchmarks show expected linear scaling.
- Valid-path throughput is consistently higher than repairable-path throughput.
- Observed throughput ranges in size benchmarks:
  - valid: ~115–128 MiB/s
  - repairable: ~57–63 MiB/s
- These results justify keeping Rust benchmarks for optimization tracking,
  while keeping default-path decisions evidence-based.

### Future optimization opportunities (Rust path)

1. Evaluate `simd-json` for parse-check workloads (with platform and complexity
   trade-offs).
2. Reduce parse attempts via cheap pre-parse byte-level guards.
3. Lower allocation overhead in transforms (single-pass scanners where feasible).
4. Amortize FFI overhead with batching APIs (repair multiple strings per call).

Any change to the default execution path should remain benchmark-driven.