### PR TITLE
fix(plugins): update external plugin Containerfiles and test configs

### DIFF
--- a/plugins/external/llmguard/.dockerignore
+++ b/plugins/external/llmguard/.dockerignore
@@ -181,7 +181,7 @@ podman-compose*.yaml
 # 8. Build tools and CI/CD configurations
 #----------------------------------------------------------------------
 # Testing configurations
-# since tests are run in the llmguardplugin-testing container, we need 
+# since tests are run in the llmguardplugin-testing container, we need
 # .coveragerc to properly run coverage tests.
 # .coveragerc
 .pylintrc


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3046

---

## 📝 Summary

### Problem(s): 
- External plugin Containerfiles missing or using stale mcp-contextforge-gateway install
- Package conflict between pytest-env and pytest-dotenv
- llmguard build error during execution of cache_tokenizers.py.
- coverage tests not displayed when run in container
- when running the llmguardplugintesting container, the default redis host should be, 'redis'
- llmguardplugin Containerfile erroneously copying tests folder contents to the root folder in `llmguardplugin-testing`
### Fixes:
- Containerfiles updated to install mcp-contextforge-gateway branch main per bug report. 
- pytest-dotenv dependencies removed.
- Added `ENV TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor` to llmguard's containerfile per workaround for issue: https://github.com/pytorch/pytorch/issues/140765
- Updated pytest.ini to update --cov parameter.
- Updated the redis_host default value in test_llmguardplugin.py
- llmguardplugin containerfile updated to remove tests folder copy to container root.
- llmguardplugin `.coveragerc` updated to properly select test targets, and `.dockerignore` updated so that .coveragerc copies into container for testing.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |     ✅   |
| Unit tests                | `make test`     |     ✅   |
| Coverage ≥ 80%            | `make coverage` |  ✅      |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
