### PR TITLE
fix(mcp): propagate title field for tools, resources, and prompts

### DIFF
--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -3368,29 +3368,7 @@ async def test_register_gateway_creates_new_resources_and_prompts(gateway_servic
     assert added_gateway.resources[0].title == "Resource Title"
     assert len(added_gateway.prompts) == 1
     assert added_gateway.prompts[0].title == "Prompt Title"
-    monkeypatch.setattr("mcpgateway.services.gateway_service.get_for_update", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        "mcpgateway.services.gateway_service.GatewayRead.model_validate",
-        lambda x: MagicMock(masked=lambda: x),
-    )
 
-    gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [resource], [prompt]))
-    gateway_service._notify_gateway_added = AsyncMock()
-
-    await gateway_service.register_gateway(
-        db,
-        gateway,
-        team_id="team-1",
-        owner_email="owner@example.com",
-        created_by="creator@example.com",
-    )
-
-    added_gateway = db.add.call_args[0][0]
-    assert len(added_gateway.resources) == 1
-    assert added_gateway.resources[0].title == "Resource Title"
-    assert len(added_gateway.prompts) == 1
-    assert added_gateway.prompts[0].title == "Prompt Title"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -53,7 +53,14 @@ from mcpgateway.schemas import (
     AdminToolCreate,
     EventMessage,
     ListFilters,
+    PromptCreate,
+    PromptMetrics,
+    PromptRead,
+    PromptUpdate,
     ResourceCreate,
+    ResourceMetrics,
+    ResourceRead,
+    ResourceUpdate,
     ServerCreate,
     ServerMetrics,
     ServerRead,
@@ -63,6 +70,7 @@ from mcpgateway.schemas import (
     TeamCreateRequest,
     TeamUpdateRequest,
     ToolCreate,
+    ToolRead,
     ToolUpdate,
 )
 
@@ -1216,8 +1224,23 @@ class TestTitleSchemas:
         tool_read = ToolRead(
             id="1",
             name="test-tool",
+            originalName="test-tool-original",
             url="http://example.com",
             title="Read Tool Title",
+            description="Test Tool Description",
+            requestType="rpc",
+            integrationType="JSON",
+            headers={},
+            inputSchema={},
+            annotations={},
+            jsonpathFilter="",
+            auth={"type": "none"},
+            enabled=True,
+            reachable=True,
+            gatewayId="gw-1",
+            gatewaySlug="gw-1-slug",
+            customName="test-tool-custom",
+            customNameSlug="test-tool-custom-slug",
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
             metrics=ServerMetrics(
@@ -1242,6 +1265,10 @@ class TestTitleSchemas:
             uri="test://uri",
             name="test-resource",
             title="Read Resource Title",
+            description="Test Resource Description",
+            mimeType="text/plain",
+            size=1024,
+            enabled=True,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
             metrics=ResourceMetrics(
@@ -1255,7 +1282,11 @@ class TestTitleSchemas:
 
     def test_prompt_schemas_with_title(self):
         """Test PromptCreate, PromptUpdate, and PromptRead pass title field."""
-        prompt_create = PromptCreate(name="test-prompt", title="My Custom Prompt Title")
+        prompt_create = PromptCreate(
+            name="test-prompt",
+            title="My Custom Prompt Title",
+            template="Hello {{name}}"
+        )
         assert prompt_create.title == "My Custom Prompt Title"
 
         prompt_update = PromptUpdate(title="Updated Prompt Title")
@@ -1264,6 +1295,13 @@ class TestTitleSchemas:
         prompt_read = PromptRead(
             id="1",
             name="test-prompt",
+            originalName="test-prompt-original",
+            customName="test-prompt-custom",
+            customNameSlug="test-prompt-custom-slug",
+            description="Test Prompt Description",
+            template="Hello {{name}}",
+            arguments=[],
+            enabled=True,
             title="Read Prompt Title",
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #3050

## 📌 Summary
Fixed an issue where the title attribute supplied by MCP servers for Tools, Resources, and Prompts was being dropped by ContextForge. It ensures the complete end-to-end propagation of the title field from the gateway synchronization layer into the local database, UI templates, and outbound client endpoints.

## 🔁 Reproduction Steps

1. Connect an external MCP server to ContextForge that supplies a title attribute in its BaseMetadata payload (or annotations.title) for its exported Tools, Prompts, or Resources.
2. Complete gateway registration and allow ContextForge to sync these entities.
3. Fetch the bridged entities via the /tools, /resources, or /prompts list endpoints using another mcp client by connecting to the gateway.

Earlier: the title field was dropped and did not reach the upstream server.
Now : the title field is propagated to the client as well as visible in the Context Forge UI.

1. Response from the gateway in MCP inspector:
<img width="1178" height="554" alt="image" src="https://github.com/user-attachments/assets/8bb93e61-5501-413a-bc27-fd8aaf950ad1" />

2. Context Forge UI
Title is presented below the name
<img width="1194" height="456" alt="image" src="https://github.com/user-attachments/assets/cc92d852-612e-4c59-b930-6e931642bee5" />


## 🐞 Root Cause
The title column was missing from the SQLAlchemy database tables (db.py) and was also absent from the Pydantic API schemas (schemas.py). As a result, when external components synchronized with ContextForge via gateway_service.py (register_gateway), any title parameter provided was silently ignored.

The outbound data serialization pipelines streamablehttp and sse consequently had no title fields to forward.

## 💡 Fix Description

1. **Database & Schemas:**
Added an `Optional[str]` `title` column to the `Tool`, `Resource`, and `Prompt` SQLAlchemy models in `db.py`, and propagated it across all Create/Update/Read Pydantic schemas in `schemas.py`. An Alembic migration script was created to safely modify the existing tables.
2. **Gateway Synchronization:**
Updated `register_gateway` and related service methods in `gateway_service.py` to capture and persist the `title` when creating, updating, or reassigning `DbResource` and `DbPrompt` entities.
3. Refactored tool synchronization logic with a `_resolve_tool_title` helper to enforce MCP specification precedence (falling back from `annotations.title` to the underlying `title` attribute when necessary).
4. Implemented `title_changed` dirty-check logic to ensure rows are re-upserted when the upstream `title` value changes.
5. **Transport Endpoints:**
Refactored `list_tools`, `list_prompts`, and `list_resources` in `streamablehttp_transport.py` to retrieve the `title` from the database and serialize it correctly into downstream MCP-compliant classes.
6. **UI Templating:**
Updated `tools_partial.html`, `prompts_partial.html`, and `resources_partial.html` to gracefully render the italicized `title` beneath the entity name when successfully synchronized.
7. **Testing:**
Expanded test coverage across `test_db.py`, `test_schemas.py`, `test_gateway_service.py`, and `test_streamablehttp_transport.py`.

    * Ensuring Pydantic `MagicMock` type validations bypass schema enforcement without raising errors
    * Verifying `annotations.title` precedence logic
    * Confirming that transport-layer data loss no longer occurs


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     ✅   |
| Unit tests                            | `make test`          |     ✅   |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed