### PR TITLE
2668 bug follow up rate limiter incorrect http status missing headers and feature gaps refs 2397

### DIFF
--- a/mcpgateway/plugins/framework/constants.py
+++ b/mcpgateway/plugins/framework/constants.py
@@ -63,7 +63,8 @@ PLUGIN_VIOLATION_CODE_MAPPING = {
     "PII_DETECTED": 422,  # Used when PII is detected in content (pii_filter plugin)
     "SENSITIVE_CONTENT": 422,  # Used when sensitive information is detected
     # Authentication & Authorization
-    "INVALID_TOKEN": 401,  # Used for invalid/expired tokens (simple_token_auth example)
+    "INVALID_TOKEN": 401,  # nosec B105 - Not a password; INVALID_TOKEN is a HTTP Status Code
+    # Used for invalid/expired tokens (simple_token_auth example)
     "API_KEY_REVOKED": 401,  # Used when API key has been revoked (custom_auth_example)
     "AUTH_REQUIRED": 401,  # Used when authentication is missing
     # Generic Violation Codes


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes #2668
Rate-limiting and other policy enforcement plugins needed the ability to return proper HTTP status codes (e.g., 429 Too Many Requests) and standard headers (e.g., Retry-After, X-RateLimit-*) when violations occur. Previously, all plugin violations returned HTTP 200 with JSON-RPC error payloads, making it impossible for:

   - Rate-limiting plugins to signal backoff periods to clients
   - Authorization plugins to return proper 403 Forbidden responses
   - Content moderation to return 422 Unprocessable Entity
   - Clients to implement proper retry logic based on HTTP semantics

This created a mismatch between HTTP-native clients expecting standard status codes and the gateway's JSON-RPC-centric error handling.

---

## 🔁 Reproduction Steps

1. Start the gateway with config.yaml
(e.g. make dev or python -m mcpgateway.main)

2. Repeatedly call a REST tool until rate limits are exceeded

3. Observe:
    - HTTP status
    - Response headers
    - JSON response body

## 🐞 Root Cause
Improper error code handling in plugin violation.

## 💡 Fix Description

This PR introduces a three-tier approach for determining HTTP status codes in plugin violation responses:

   1. Explicit Status (highest priority): Plugins can set http_status_code directly
   2. Code Mapping (fallback): Common violation codes map to appropriate HTTP statuses via PLUGIN_VIOLATION_CODE_MAPPING
   3. Default 200 (ultimate fallback): Maintains JSON-RPC compliance when no status is specified

### Key Changes

#### 1. Enhanced PluginViolation Model
   ```python
   class PluginViolation(BaseModel):
       # ... existing fields ...
       http_status_code: Optional[int] = None  # NEW: Explicit HTTP status
       http_headers: Optional[dict[str, str]] = None  # NEW: Custom headers (e.g., Retry-After)
   ```

#### 2. Violation Code Mapping (mcpgateway/plugins/framework/constants.py)
   ```python
   PLUGIN_VIOLATION_CODE_MAPPING = {
       "RATE_LIMIT": 429,              # Rate limiting
       "INVALID_URI": 400,             # Bad request
       "PROTOCOL_BLOCKED": 403,        # Forbidden
       "CONTENT_TOO_LARGE": 413,       # Payload too large
       "CONTENT_MODERATION": 422,      # Unprocessable entity
       "PII_DETECTED": 422,            # Sensitive data
       "INVALID_TOKEN": 401,           # Unauthorized
       # ... 20+ mappings total
   }
   ```

 #### 3. Updated Exception Handler (mcpgateway/main.py)
   ```python
   async def plugin_violation_exception_handler(_request: Request, exc: PluginViolationError):
       # Determine HTTP status: explicit → mapping → default 200
       http_status = exc.violation.http_status_code if exc.violation and exc.violation.http_status_code else None
       if not http_status:
           http_status = PLUGIN_VIOLATION_CODE_MAPPING.get(exc.violation.code, 200)

       # Add custom headers if provided
       headers = exc.violation.http_headers if exc.violation and exc.violation.http_headers else None
       response = ORJSONResponse(status_code=http_status, content={...})
       if headers:
           response.headers.update(headers)
       return response
   ```

   ---

   ## 🧪 Testing

   Added **8 comprehensive test cases** covering:

   ✅ Explicit http_status_code takes precedence over mapping
   ✅ Code mapping fallback (e.g., RATE_LIMIT → 429)
   ✅ Default to 200 for unknown codes (JSON-RPC compliance)
   ✅ HTTP headers properly propagated to response
   ✅ Multiple headers (Retry-After, X-RateLimit-*) included correctly
   ✅ Graceful handling when headers is None
   ✅ Backward compatibility with existing violations (no fields set)
   ✅ Doctest examples updated to reflect new behavior

   **Test Coverage:** All new code paths covered, including edge cases.

   ---

   ## 🔄 Backward Compatibility

   **✅ Fully Backward Compatible**

   - New fields are **optional** (Optional[int], Optional[dict[str, str]])
   - Existing plugins without these fields continue to work (default to HTTP 200)
   - JSON-RPC error structure unchanged
   - No breaking changes to public APIs

   ---

   ## 📝 Example Usage

   ### Rate-Limiting Plugin
   ```python
   return PluginViolation(
       reason="Rate limit exceeded",
       description="Too many requests from this client",
       code="RATE_LIMIT",
       http_status_code=429,  # Explicit status
       http_headers={
           "Retry-After": "60",
           "X-RateLimit-Limit": "100",
           "X-RateLimit-Remaining": "0",
           "X-RateLimit-Reset": "1737394800"
       }
   )
   ```

   **Response:**
   ```http
   HTTP/1.1 429 Too Many Requests
   Retry-After: 60
   X-RateLimit-Limit: 100
   X-RateLimit-Remaining: 0
   X-RateLimit-Reset: 1737394800

   {
     "error": {
       "code": -32602,
       "message": "Plugin Violation: Too many requests from this client",
       "data": {
         "description": "Too many requests from this client",
         "plugin_error_code": "RATE_LIMIT",
         ...
       }
     }
   }
   ```

---

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |     ✅   |
| Coverage ≥ 80 %                       | `make coverage`      |     ✅   |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Docstrings updated
- [x] Backward compatible
- [x] No breaking changes
- [x] Related issue linked (#2668)
- [x] Conventional commit message format
- [x] DCO sign-off included

---

This PR enables plugins to implement proper HTTP semantics for policy enforcement while maintaining full backward compatibility with the existing JSON-RPC error model.

