### PR TITLE
fix: Add session reconnection logic to MCP external plugin client

### DIFF
--- a/tests/unit/mcpgateway/plugins/framework/external/mcp/test_client_reconnect.py
+++ b/tests/unit/mcpgateway/plugins/framework/external/mcp/test_client_reconnect.py
@@ -359,5 +359,3 @@ class TestInvokeHookWithReconnection:
 
                 # Verify error is about connection, not reconnection
                 assert "Connection lost" in str(exc_info.value.error.message) or "Reconnection failed" in str(exc_info.value.error.message)
-
-# Made with Bob


### PR DESCRIPTION
## fix: Add session reconnection logic to MCP external plugin client

## Description

### Problem
External MCP plugin adapter fails when the plugin server restarts (Issue #2796). The MCP client creates a session once at initialization and has no reconnection logic. When the remote plugin restarts, the stale `ClientSession` returns errors (typically HTTP 404 → `McpError("Session terminated")`) with no recovery path.

### Solution
Implemented automatic reconnection with exponential backoff, following the Unix socket client pattern for consistency.

### Changes

#### 1. Configuration (`mcpgateway/plugins/framework/models.py`)
- Added `reconnect_attempts` (default: 3) field to `MCPClientConfig`
- Added `reconnect_delay` (default: 0.1s) field to `MCPClientConfig`
- Mirrors the configuration pattern from `UnixSocketClientConfig`

#### 2. Core Implementation (`mcpgateway/plugins/framework/external/mcp/client.py`)
- Added reconnection instance variables to `ExternalPlugin.__init__`
- Implemented `_cleanup_session()` helper method to reset session state
- Implemented `_reconnect_session()` with exponential backoff
- Updated `invoke_hook()` with hybrid error detection:
  - Catches `McpError` from mcp library for protocol errors
  - Catches `PluginError` with "session terminated" message
  - Retries once after successful reconnection
- Wired up reconnect config in `initialize()` method

#### 3. Tests (`tests/unit/mcpgateway/plugins/framework/external/mcp/test_client_reconnect.py`)
- Created 12 comprehensive test cases covering:
  - Configuration loading and defaults
  - Session cleanup behavior
  - Reconnection success/failure scenarios
  - Exponential backoff verification
  - Error detection and retry logic
  - Both HTTP and STDIO transport support

### Key Features
- ✅ Automatic reconnection on session termination
- ✅ Exponential backoff: `delay = reconnect_delay * attempt`
- ✅ Configurable per plugin
- ✅ Transport agnostic (STREAMABLEHTTP and STDIO)
- ✅ Single retry after reconnection to avoid cascading delays
- ✅ Comprehensive error handling (hybrid detection)
- ✅ Feature parity with Unix socket client
- ✅ Backward compatible (default values)

### Testing
- All 12 new reconnection tests passing

### Files Changed
```
 mcpgateway/plugins/framework/external/mcp/client.py                   
 mcpgateway/plugins/framework/models.py                                 
 tests/unit/mcpgateway/plugins/framework/external/mcp/test_client_reconnect.py 
```

### Closes
Fixes #2796

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (inline docstrings)
- [x] Tests added for new functionality
- [x] All new tests passing
- [x] No breaking changes
- [x] Signed commits (DCO)

### Additional Notes
The implementation follows the existing Unix socket client reconnection pattern (`mcpgateway/plugins/framework/external/unix/client.py:134-201`) for consistency across the codebase.