### PR TITLE
perf(db): improve SQLAlchemy instrumentation thread safety

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3581,6 +3581,10 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # Enable event logging within spans
 # OBSERVABILITY_EVENTS_ENABLED=true
 
+# Size of the background instrumentation queue used for deferred span writes.
+# Increase this if you see frequent span drops under load. Default: 1000
+# INSTRUMENTATION_QUEUE_SIZE=1000
+
 # =============================================================================
 # Performance Tracking Thresholds
 # =============================================================================

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1851,6 +1851,15 @@ class Settings(BaseSettings):
     # Enable span events
     observability_events_enabled: bool = Field(default=True, description="Enable event logging within spans")
 
+    # Size of the background instrumentation queue used for deferred span writes.
+    # Controls how many span records can be buffered before they are dropped.
+    # Set via environment variable `INSTRUMENTATION_QUEUE_SIZE`.
+    instrumentation_queue_size: int = Field(
+        default=1000,
+        ge=1,
+        description="Maximum number of spans to buffer in the instrumentation queue (default: 1000)",
+    )
+
     # Correlation ID Settings
     correlation_id_enabled: bool = Field(default=True, description="Enable automatic correlation ID tracking for requests")
     correlation_id_header: str = Field(default="X-Correlation-ID", description="HTTP header name for correlation ID")

--- a/mcpgateway/instrumentation/sqlalchemy.py
+++ b/mcpgateway/instrumentation/sqlalchemy.py
@@ -247,8 +247,8 @@ def _write_span_to_db(span_data: dict) -> None:
         # Clear recursion guard even if errors occurred
         try:
             setattr(_instrumentation_context, "inside_span_creation", False)
-        except Exception:
-            pass
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f"Failed to clear instrumentation context flag: {e}")
 
 
 def _span_writer_worker() -> None:

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -853,3 +853,36 @@ def _get_query_performance_python(db: Session, cutoff_time: datetime, hours: int
         "min_duration_ms": round(durations[0], 2),
         "max_duration_ms": round(durations[-1], 2),
     }
+
+
+
+@router.get("/instrumentation/queue-stats")
+@require_permission("admin.system_config")
+async def get_instrumentation_queue_stats(_user=Depends(get_current_user_with_permissions)):
+    """Get instrumentation queue statistics.
+
+    Returns metrics about the background span queue including:
+    - Total spans processed
+    - Dropped spans count
+    - Drop rate (percentage)
+    - Queue max size
+
+    This helps monitor observability data reliability under load.
+
+    Returns:
+        dict: Queue statistics including total, dropped, drop_rate, and maxsize
+
+    Examples:
+        >>> import asyncio
+        >>> import mcpgateway.routers.observability as obs
+        >>> from mcpgateway.config import settings
+        >>> async def run_queue_stats():
+        ...     stats = await obs.get_instrumentation_queue_stats(_user={"email": settings.platform_admin_email, "db": None})
+        ...     return "total" in stats and "drop_rate" in stats
+        >>> asyncio.run(run_queue_stats())
+        True
+    """
+    # First-Party
+    from mcpgateway.instrumentation.sqlalchemy import _span_queue
+
+    return _span_queue.stats

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -30,6 +30,7 @@ from mcpgateway.common.query_params import (
     QueryUserIdentifier,
 )
 from mcpgateway.db import SessionLocal
+from mcpgateway.instrumentation.sqlalchemy import _span_queue
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.schemas import ObservabilitySpanRead, ObservabilityTraceRead, ObservabilityTraceWithSpans
 from mcpgateway.services.observability_service import ObservabilityService

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -33,6 +33,7 @@ from mcpgateway.db import SessionLocal
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.schemas import ObservabilitySpanRead, ObservabilityTraceRead, ObservabilityTraceWithSpans
 from mcpgateway.services.observability_service import ObservabilityService
+from mcpgateway.instrumentation.sqlalchemy import _span_queue
 
 logger = logging.getLogger(__name__)
 
@@ -881,7 +882,4 @@ async def get_instrumentation_queue_stats(_user=Depends(get_current_user_with_pe
         >>> asyncio.run(run_queue_stats())
         True
     """
-    # First-Party
-    from mcpgateway.instrumentation.sqlalchemy import _span_queue
-
     return _span_queue.stats

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -34,7 +34,6 @@ from mcpgateway.instrumentation.sqlalchemy import _span_queue
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.schemas import ObservabilitySpanRead, ObservabilityTraceRead, ObservabilityTraceWithSpans
 from mcpgateway.services.observability_service import ObservabilityService
-from mcpgateway.instrumentation.sqlalchemy import _span_queue
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -855,7 +855,6 @@ def _get_query_performance_python(db: Session, cutoff_time: datetime, hours: int
     }
 
 
-
 @router.get("/instrumentation/queue-stats")
 @require_permission("admin.system_config")
 async def get_instrumentation_queue_stats(_user=Depends(get_current_user_with_permissions)):

--- a/tests/unit/mcpgateway/instrumentation/test_instrumentation_queue.py
+++ b/tests/unit/mcpgateway/instrumentation/test_instrumentation_queue.py
@@ -25,7 +25,97 @@ def test_queue_drop_rate_when_full():
     # Cleanup: drain queue
     try:
         while True:
-            q.get(timeout=0)
+            q.get(timeout=0.001)
+            q.task_done()
+    except queue.Empty:
+        pass
+
+
+def test_queue_stats_property():
+    """Test that stats property returns all metrics in one call."""
+    q = InstrumentationQueue(maxsize=100)
+
+    # Initial stats
+    stats = q.stats
+    assert stats["total"] == 0
+    assert stats["dropped"] == 0
+    assert stats["drop_rate"] == 0.0
+    assert stats["maxsize"] == 100
+
+    # Add some items
+    assert q.put({"span": "data1"}) is True
+    assert q.put({"span": "data2"}) is True
+
+    stats = q.stats
+    assert stats["total"] == 2
+    assert stats["dropped"] == 0
+    assert stats["drop_rate"] == 0.0
+    assert stats["maxsize"] == 100
+
+    # Cleanup
+    try:
+        while True:
+            q.get(timeout=0.001)
+            q.task_done()
+    except queue.Empty:
+        pass
+
+
+def test_queue_stats_with_drops():
+    """Test stats property when queue has drops."""
+    q = InstrumentationQueue(maxsize=2)
+
+    # Fill queue
+    assert q.put({"a": 1}) is True
+    assert q.put({"a": 2}) is True
+
+    # Try to add more (should drop)
+    assert q.put({"a": 3}) is False
+    assert q.put({"a": 4}) is False
+
+    stats = q.stats
+    assert stats["total"] == 4
+    assert stats["dropped"] == 2
+    assert stats["drop_rate"] == 0.5
+    assert stats["maxsize"] == 2
+
+    # Cleanup
+    try:
+        while True:
+            q.get(timeout=0.001)
+            q.task_done()
+    except queue.Empty:
+        pass
+
+
+def test_queue_put_optimized_lock():
+    """Test that optimized put() method works correctly."""
+    q = InstrumentationQueue(maxsize=10)
+
+    # Successful puts should increment total only
+    for i in range(5):
+        assert q.put({"item": i}) is True
+
+    assert q.stats["total"] == 5
+    assert q.stats["dropped"] == 0
+
+    # Fill the queue
+    for i in range(5, 10):
+        assert q.put({"item": i}) is True
+
+    # Now it's full - drops should increment both counters
+    assert q.put({"item": 10}) is False
+    assert q.put({"item": 11}) is False
+
+    stats = q.stats
+    assert stats["total"] == 12
+    assert stats["dropped"] == 2
+    assert stats["drop_rate"] == 2.0 / 12.0
+
+    # Cleanup
+    try:
+        while True:
+            q.get(timeout=0.001)
             q.task_done()
     except queue.Empty:
         pass

--- a/tests/unit/mcpgateway/instrumentation/test_instrumentation_queue.py
+++ b/tests/unit/mcpgateway/instrumentation/test_instrumentation_queue.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for InstrumentationQueue in SQLAlchemy instrumentation."""
+
+import queue
+
+from mcpgateway.instrumentation.sqlalchemy import InstrumentationQueue
+
+
+def test_queue_drop_rate_when_full():
+    q = InstrumentationQueue(maxsize=2)
+
+    assert q.drop_rate == 0.0
+
+    # Put two items - should succeed
+    assert q.put({"a": 1}) is True
+    assert q.put({"a": 2}) is True
+
+    # Now queue is full; next put should be dropped
+    assert q.put({"a": 3}) is False
+
+    # Total should be 3, dropped 1 -> drop_rate = 1/3
+    dr = q.drop_rate
+    assert dr == 1.0 / 3.0
+
+    # Cleanup: drain queue
+    try:
+        while True:
+            q.get(timeout=0)
+            q.task_done()
+    except queue.Empty:
+        pass

--- a/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
+++ b/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
@@ -133,7 +133,7 @@ def test_create_query_span_exception_does_not_raise(caplog):
     sa.logger.propagate = True
     with patch("mcpgateway.instrumentation.sqlalchemy._span_queue.put_nowait", side_effect=Exception("fail")):
         sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-    assert "Failed to enqueue span data" in caplog.text
+    assert "Failed to enqueue query span" in caplog.text
 
 
 def test_write_span_to_db_success():
@@ -323,126 +323,6 @@ def test_instrumentation_queue_init_with_settings_exception():
         assert queue._maxsize == 1000
 
 
-def test_write_span_to_db_setattr_exception():
-    """Test _write_span_to_db when clearing instrumentation context flag fails."""
-    span_data = {
-        "trace_id": "t1",
-        "name": "db.query.select",
-        "kind": "client",
-        "resource_type": "database",
-        "resource_name": "SELECT",
-        "start_attributes": {},
-        "end_attributes": {},
-        "status": "ok",
-        "duration_ms": 10.0,
-        "row_count": 1,
-    }
-
-    # Mock to make setattr fail in the finally block
-    original_setattr = setattr
-    call_count = [0]
-
-    def mock_setattr(obj, name, value):
-        call_count[0] += 1
-        if call_count[0] == 2 and name == "inside_span_creation" and value is False:
-            raise RuntimeError("setattr failed")
-        return original_setattr(obj, name, value)
-
-    with patch("mcpgateway.services.observability_service.ObservabilityService") as mock_service, \
-         patch("mcpgateway.db.SessionLocal") as mock_db, \
-         patch("mcpgateway.db.ObservabilitySpan", MagicMock()), \
-         patch("builtins.setattr", side_effect=mock_setattr):
-        sa._write_span_to_db(span_data)
-
-
-def test_create_query_span_fallback_put_none():
-    """Test _create_query_span when queue has no put method."""
-    # Create a mock queue without put_nowait
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait  # Remove put_nowait attribute
-    mock_queue.put = None  # Set put to None
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        # Should handle gracefully
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_returns_true(caplog):
-    """Test _create_query_span when fallback put returns True."""
-    import logging
-    caplog.set_level(logging.DEBUG)
-    sa.logger.setLevel(logging.DEBUG)
-    sa.logger.propagate = True
-
-    # Create a mock queue without put_nowait but with put returning True
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(return_value=True)
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Enqueued span for SELECT query" in caplog.text
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_returns_false(caplog):
-    """Test _create_query_span when fallback put returns False."""
-    # Create a mock queue without put_nowait but with put returning False
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(return_value=False)
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Span queue is full" in caplog.text
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_returns_none(caplog):
-    """Test _create_query_span when fallback put returns None."""
-    import logging
-    caplog.set_level(logging.DEBUG)
-    sa.logger.setLevel(logging.DEBUG)
-    sa.logger.propagate = True
-
-    # Create a mock queue without put_nowait but with put returning None
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(return_value=None)
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Enqueued span for SELECT query" in caplog.text
-    finally:
-        sa._span_queue = original_queue
-
-
-def test_create_query_span_fallback_put_raises_exception(caplog):
-    """Test _create_query_span when fallback put raises exception."""
-    # Create a mock queue without put_nowait but with put raising exception
-    mock_queue = MagicMock()
-    del mock_queue.put_nowait
-    mock_queue.put = MagicMock(side_effect=RuntimeError("put failed"))
-
-    original_queue = sa._span_queue
-    try:
-        sa._span_queue = mock_queue
-        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-        assert "Failed to enqueue span data" in caplog.text
-    finally:
-        sa._span_queue = original_queue
 def test_attach_trace_to_session_connection_without_info():
     session = MagicMock()
     session.bind = True

--- a/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
+++ b/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
@@ -305,6 +305,144 @@ def test_attach_trace_to_session_no_bind_noop():
     session.connection.assert_not_called()
 
 
+
+
+def test_instrumentation_queue_init_with_settings_exception():
+    """Test InstrumentationQueue initialization when settings access fails."""
+    # Mock getattr to raise exception when accessing instrumentation_queue_size
+    original_getattr = getattr
+    
+    def mock_getattr(obj, name, default=None):
+        if name == "instrumentation_queue_size":
+            raise Exception("settings error")
+        return original_getattr(obj, name, default) if default is not None else original_getattr(obj, name)
+    
+    with patch("builtins.getattr", side_effect=mock_getattr):
+        queue = sa.InstrumentationQueue()
+        # Should fall back to default 1000
+        assert queue._maxsize == 1000
+
+
+def test_write_span_to_db_setattr_exception():
+    """Test _write_span_to_db when clearing instrumentation context flag fails."""
+    span_data = {
+        "trace_id": "t1",
+        "name": "db.query.select",
+        "kind": "client",
+        "resource_type": "database",
+        "resource_name": "SELECT",
+        "start_attributes": {},
+        "end_attributes": {},
+        "status": "ok",
+        "duration_ms": 10.0,
+        "row_count": 1,
+    }
+    
+    # Mock to make setattr fail in the finally block
+    original_setattr = setattr
+    call_count = [0]
+    
+    def mock_setattr(obj, name, value):
+        call_count[0] += 1
+        if call_count[0] == 2 and name == "inside_span_creation" and value is False:
+            raise RuntimeError("setattr failed")
+        return original_setattr(obj, name, value)
+    
+    with patch("mcpgateway.services.observability_service.ObservabilityService") as mock_service, \
+         patch("mcpgateway.db.SessionLocal") as mock_db, \
+         patch("mcpgateway.db.ObservabilitySpan", MagicMock()), \
+         patch("builtins.setattr", side_effect=mock_setattr):
+        sa._write_span_to_db(span_data)
+
+
+def test_create_query_span_fallback_put_none():
+    """Test _create_query_span when queue has no put method."""
+    # Create a mock queue without put_nowait
+    mock_queue = MagicMock()
+    del mock_queue.put_nowait  # Remove put_nowait attribute
+    mock_queue.put = None  # Set put to None
+    
+    original_queue = sa._span_queue
+    try:
+        sa._span_queue = mock_queue
+        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
+        # Should handle gracefully
+    finally:
+        sa._span_queue = original_queue
+
+
+def test_create_query_span_fallback_put_returns_true(caplog):
+    """Test _create_query_span when fallback put returns True."""
+    import logging
+    caplog.set_level(logging.DEBUG)
+    sa.logger.setLevel(logging.DEBUG)
+    sa.logger.propagate = True
+    
+    # Create a mock queue without put_nowait but with put returning True
+    mock_queue = MagicMock()
+    del mock_queue.put_nowait
+    mock_queue.put = MagicMock(return_value=True)
+    
+    original_queue = sa._span_queue
+    try:
+        sa._span_queue = mock_queue
+        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
+        assert "Enqueued span for SELECT query" in caplog.text
+    finally:
+        sa._span_queue = original_queue
+
+
+def test_create_query_span_fallback_put_returns_false(caplog):
+    """Test _create_query_span when fallback put returns False."""
+    # Create a mock queue without put_nowait but with put returning False
+    mock_queue = MagicMock()
+    del mock_queue.put_nowait
+    mock_queue.put = MagicMock(return_value=False)
+    
+    original_queue = sa._span_queue
+    try:
+        sa._span_queue = mock_queue
+        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
+        assert "Span queue is full" in caplog.text
+    finally:
+        sa._span_queue = original_queue
+
+
+def test_create_query_span_fallback_put_returns_none(caplog):
+    """Test _create_query_span when fallback put returns None."""
+    import logging
+    caplog.set_level(logging.DEBUG)
+    sa.logger.setLevel(logging.DEBUG)
+    sa.logger.propagate = True
+    
+    # Create a mock queue without put_nowait but with put returning None
+    mock_queue = MagicMock()
+    del mock_queue.put_nowait
+    mock_queue.put = MagicMock(return_value=None)
+    
+    original_queue = sa._span_queue
+    try:
+        sa._span_queue = mock_queue
+        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
+        assert "Enqueued span for SELECT query" in caplog.text
+    finally:
+        sa._span_queue = original_queue
+
+
+def test_create_query_span_fallback_put_raises_exception(caplog):
+    """Test _create_query_span when fallback put raises exception."""
+    # Create a mock queue without put_nowait but with put raising exception
+    mock_queue = MagicMock()
+    del mock_queue.put_nowait
+    mock_queue.put = MagicMock(side_effect=RuntimeError("put failed"))
+    
+    original_queue = sa._span_queue
+    try:
+        sa._span_queue = mock_queue
+        sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
+        assert "Failed to enqueue span data" in caplog.text
+    finally:
+        sa._span_queue = original_queue
 def test_attach_trace_to_session_connection_without_info():
     session = MagicMock()
     session.bind = True

--- a/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
+++ b/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
@@ -270,7 +270,9 @@ def test_after_cursor_execute_handles_rowcount_exception_and_no_trace():
     conn = MagicMock()
     conn.info = {}
     conn_id = id(conn)
-    sa._query_tracking[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
+    if not hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map = {}
+    sa._query_tracking.map[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
 
     class Cursor:
         @property
@@ -278,20 +280,22 @@ def test_after_cursor_execute_handles_rowcount_exception_and_no_trace():
             raise RuntimeError("no rowcount")
 
     sa._after_cursor_execute(conn, Cursor(), "SELECT * FROM users", None, None, False)
-    assert sa._span_queue.empty()
+    assert sa._span_queue._queue.empty()
 
 
 def test_after_cursor_execute_negative_rowcount_skips_assignment():
     conn = MagicMock()
     conn.info = {}
     conn_id = id(conn)
-    sa._query_tracking[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
+    if not hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map = {}
+    sa._query_tracking.map[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
 
     cursor = MagicMock()
     cursor.rowcount = -1
 
     sa._after_cursor_execute(conn, cursor, "SELECT * FROM users", None, None, False)
-    assert sa._span_queue.empty()
+    assert sa._span_queue._queue.empty()
 
 
 def test_attach_trace_to_session_no_bind_noop():

--- a/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
+++ b/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
@@ -311,12 +311,12 @@ def test_instrumentation_queue_init_with_settings_exception():
     """Test InstrumentationQueue initialization when settings access fails."""
     # Mock getattr to raise exception when accessing instrumentation_queue_size
     original_getattr = getattr
-    
+
     def mock_getattr(obj, name, default=None):
         if name == "instrumentation_queue_size":
             raise Exception("settings error")
         return original_getattr(obj, name, default) if default is not None else original_getattr(obj, name)
-    
+
     with patch("builtins.getattr", side_effect=mock_getattr):
         queue = sa.InstrumentationQueue()
         # Should fall back to default 1000
@@ -337,17 +337,17 @@ def test_write_span_to_db_setattr_exception():
         "duration_ms": 10.0,
         "row_count": 1,
     }
-    
+
     # Mock to make setattr fail in the finally block
     original_setattr = setattr
     call_count = [0]
-    
+
     def mock_setattr(obj, name, value):
         call_count[0] += 1
         if call_count[0] == 2 and name == "inside_span_creation" and value is False:
             raise RuntimeError("setattr failed")
         return original_setattr(obj, name, value)
-    
+
     with patch("mcpgateway.services.observability_service.ObservabilityService") as mock_service, \
          patch("mcpgateway.db.SessionLocal") as mock_db, \
          patch("mcpgateway.db.ObservabilitySpan", MagicMock()), \
@@ -361,7 +361,7 @@ def test_create_query_span_fallback_put_none():
     mock_queue = MagicMock()
     del mock_queue.put_nowait  # Remove put_nowait attribute
     mock_queue.put = None  # Set put to None
-    
+
     original_queue = sa._span_queue
     try:
         sa._span_queue = mock_queue
@@ -377,12 +377,12 @@ def test_create_query_span_fallback_put_returns_true(caplog):
     caplog.set_level(logging.DEBUG)
     sa.logger.setLevel(logging.DEBUG)
     sa.logger.propagate = True
-    
+
     # Create a mock queue without put_nowait but with put returning True
     mock_queue = MagicMock()
     del mock_queue.put_nowait
     mock_queue.put = MagicMock(return_value=True)
-    
+
     original_queue = sa._span_queue
     try:
         sa._span_queue = mock_queue
@@ -398,7 +398,7 @@ def test_create_query_span_fallback_put_returns_false(caplog):
     mock_queue = MagicMock()
     del mock_queue.put_nowait
     mock_queue.put = MagicMock(return_value=False)
-    
+
     original_queue = sa._span_queue
     try:
         sa._span_queue = mock_queue
@@ -414,12 +414,12 @@ def test_create_query_span_fallback_put_returns_none(caplog):
     caplog.set_level(logging.DEBUG)
     sa.logger.setLevel(logging.DEBUG)
     sa.logger.propagate = True
-    
+
     # Create a mock queue without put_nowait but with put returning None
     mock_queue = MagicMock()
     del mock_queue.put_nowait
     mock_queue.put = MagicMock(return_value=None)
-    
+
     original_queue = sa._span_queue
     try:
         sa._span_queue = mock_queue
@@ -435,7 +435,7 @@ def test_create_query_span_fallback_put_raises_exception(caplog):
     mock_queue = MagicMock()
     del mock_queue.put_nowait
     mock_queue.put = MagicMock(side_effect=RuntimeError("put failed"))
-    
+
     original_queue = sa._span_queue
     try:
         sa._span_queue = mock_queue

--- a/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
+++ b/tests/unit/mcpgateway/instrumentation/test_sqlalchemy.py
@@ -18,21 +18,27 @@ import mcpgateway.instrumentation.sqlalchemy as sa
 
 @pytest.fixture(autouse=True)
 def reset_globals():
-    sa._query_tracking.clear()
+    # Reset thread-local storage by clearing the map attribute if it exists
+    if hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map.clear()
     sa._instrumentation_context = threading.local()
-    sa._span_queue = queue.Queue(maxsize=2)
+    # Reset to a fresh InstrumentationQueue with small maxsize for testing
+    sa._span_queue = sa.InstrumentationQueue(maxsize=2)
     sa._shutdown_event.clear()
     sa._span_writer_thread = None
     yield
-    sa._query_tracking.clear()
+    # Clean up after test
+    if hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map.clear()
 
 
 def test_before_cursor_execute_stores_tracking():
     conn = MagicMock()
     sa._before_cursor_execute(conn, None, "SELECT * FROM test", {"id": 1}, None, False)
     conn_id = id(conn)
-    assert conn_id in sa._query_tracking
-    tracking = sa._query_tracking[conn_id]
+    assert hasattr(sa._query_tracking, "map")
+    assert conn_id in sa._query_tracking.map
+    tracking = sa._query_tracking.map[conn_id]
     assert tracking["statement"] == "SELECT * FROM test"
     assert "start_time" in tracking
 
@@ -41,16 +47,18 @@ def test_after_cursor_execute_no_tracking():
     conn = MagicMock()
     sa._after_cursor_execute(conn, None, "SELECT * FROM test", None, None, False)
     # Should not raise or enqueue anything
-    assert sa._span_queue.empty()
+    assert sa._span_queue._queue.empty()
 
 
 def test_after_cursor_execute_inside_span_creation_skips():
     conn = MagicMock()
     conn_id = id(conn)
-    sa._query_tracking[conn_id] = {"start_time": time.time(), "statement": "SELECT 1", "parameters": None, "executemany": False}
+    if not hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map = {}
+    sa._query_tracking.map[conn_id] = {"start_time": time.time(), "statement": "SELECT 1", "parameters": None, "executemany": False}
     sa._instrumentation_context.inside_span_creation = True
     sa._after_cursor_execute(conn, MagicMock(), "SELECT 1", None, None, False)
-    assert sa._span_queue.empty()
+    assert sa._span_queue._queue.empty()
 
 
 def test_after_cursor_execute_observability_table_skips(caplog):
@@ -61,7 +69,9 @@ def test_after_cursor_execute_observability_table_skips(caplog):
     sa.logger.propagate = True
     conn = MagicMock()
     conn_id = id(conn)
-    sa._query_tracking[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM observability_spans", "parameters": None, "executemany": False}
+    if not hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map = {}
+    sa._query_tracking.map[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM observability_spans", "parameters": None, "executemany": False}
     sa._after_cursor_execute(conn, MagicMock(), "SELECT * FROM observability_spans", None, None, False)
     assert "Skipping instrumentation" in caplog.text
 
@@ -70,7 +80,9 @@ def test_after_cursor_execute_with_trace_id_calls_create_query_span():
     conn = MagicMock()
     conn.info = {"trace_id": "abc123"}
     conn_id = id(conn)
-    sa._query_tracking[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
+    if not hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map = {}
+    sa._query_tracking.map[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
     with patch.object(sa, "_create_query_span") as mock_create:
         sa._after_cursor_execute(conn, MagicMock(rowcount=5), "SELECT * FROM users", None, None, False)
         mock_create.assert_called_once()
@@ -87,7 +99,9 @@ def test_after_cursor_execute_without_trace_id_logs_debug(caplog):
     conn = MagicMock()
     conn.info = {}
     conn_id = id(conn)
-    sa._query_tracking[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
+    if not hasattr(sa._query_tracking, "map"):
+        sa._query_tracking.map = {}
+    sa._query_tracking.map[conn_id] = {"start_time": time.time(), "statement": "SELECT * FROM users", "parameters": None, "executemany": False}
     sa._after_cursor_execute(conn, MagicMock(rowcount=5), "SELECT * FROM users", None, None, False)
     assert "Query executed without trace context" in caplog.text
 
@@ -99,13 +113,14 @@ def test_create_query_span_enqueues_successfully(caplog):
     sa.logger.setLevel(logging.DEBUG)
     sa.logger.propagate = True
     sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-    assert not sa._span_queue.empty()
+    assert not sa._span_queue._queue.empty()
     assert "Enqueued span" in caplog.text
 
 
 def test_create_query_span_queue_full_warns(caplog):
-    sa._span_queue = queue.Queue(maxsize=1)
-    sa._span_queue.put({"dummy": "data"})
+    # Create a new queue with maxsize=1 and fill it
+    sa._span_queue = sa.InstrumentationQueue(maxsize=1)
+    sa._span_queue._queue.put({"dummy": "data"})
     sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
     assert "Span queue is full" in caplog.text
 
@@ -118,7 +133,7 @@ def test_create_query_span_exception_does_not_raise(caplog):
     sa.logger.propagate = True
     with patch("mcpgateway.instrumentation.sqlalchemy._span_queue.put_nowait", side_effect=Exception("fail")):
         sa._create_query_span("trace123", "SELECT * FROM test", 10.0, 5, False)
-    assert "Failed to enqueue query span" in caplog.text
+    assert "Failed to enqueue span data" in caplog.text
 
 
 def test_write_span_to_db_success():


### PR DESCRIPTION
> **Note:** This PR was re-created from #2327 due to repository maintenance. Your code and branch are intact. @rakdutta please verify everything looks good.

closes  #1689 
This pull request introduces a configurable, metrics-tracking background queue for deferred span writes in the SQLAlchemy observability instrumentation. The main goal is to improve reliability and monitoring of the span queue under load, making it easier to detect and diagnose dropped spans. It also exposes queue statistics via a new API endpoint and adds comprehensive unit tests for the new queue logic.

**Instrumentation queue improvements:**

* Added a new `InstrumentationQueue` class in `mcpgateway/instrumentation/sqlalchemy.py` that wraps a bounded queue, tracks dropped/total spans, and exposes drop rate and stats for monitoring. The queue size is configurable via the `INSTRUMENTATION_QUEUE_SIZE` environment variable and config setting. [[1]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R29-R188) [[2]](diffhunk://#diff-628a7ee520f2dc2401c177833a25b8e5eaf2cbc22a7ca51b4c0e3343a4c99815R1029-R1037) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR2044-R2047)
* Replaced the previous global queue with an instance of `InstrumentationQueue` and updated span enqueueing logic to use its non-blocking methods and metrics.

**Observability and API enhancements:**

* Added a new API endpoint `/observability/instrumentation/queue-stats` to expose queue statistics (total, dropped, drop rate, max size) for admin users, aiding in operational monitoring. [[1]](diffhunk://#diff-8089103e8f88b28a15cd0554ac6639149357deec17df4fe6e0f9f8bbd8be8539R843-R871) [[2]](diffhunk://#diff-8089103e8f88b28a15cd0554ac6639149357deec17df4fe6e0f9f8bbd8be8539L26-R26)

**Thread safety and bug fixes:**

* Changed query tracking from a global dict to thread-local storage to prevent race conditions between request and background threads. Updated all access patterns accordingly. [[1]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R29-R188) [[2]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3L168-R329) [[3]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3L195-R358)
* Improved recursion guard logic in span writing to ensure instrumentation hooks are not recursively triggered, with robust cleanup even on errors. [[1]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R199-R201) [[2]](diffhunk://#diff-38d9b9e49875118425f2b6590c467c4dbdfb7c76258aa42f82967881675955b3R246-R251)

**Testing improvements:**

* Added a new test module `test_instrumentation_queue.py` with unit tests for all aspects of `InstrumentationQueue`, including drop rate, stats, and locking.
* Updated existing SQLAlchemy instrumentation tests to use the new thread-local and queue logic, ensuring correct isolation and cleanup between tests. [[1]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L20-R40) [[2]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L43-R60) [[3]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L62-R72) [[4]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L71-R83) [[5]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L87-R101) [[6]](diffhunk://#diff-bd7fa318461c9688645471560d964e09bd48da7a29ba0d939a811401dfa6ab03L98-R119)