### PR TITLE
fix(middleware): add client disconnect middleware to prevent CLOSE_WAIT accumulation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-10T16:05:52Z",
+  "generated_at": "2026-05-10T16:19:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4988,7 +4988,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2907,
+        "line_number": 2908,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -503,6 +503,7 @@ class Settings(BaseSettings):
         description="Enable experimental Rust native extension for request logging sensitive-data masking",
     )
     validation_middleware_enabled: bool = Field(default=False, description="Enable validation middleware for all requests")
+    client_disconnect_middleware_enabled: bool = Field(default=True, description="Enable client disconnect middleware to cancel handlers on connection close")
     validation_strict: bool = Field(default=True, description="Strict validation mode - reject on violations")
     sanitize_output: bool = Field(default=True, description="Sanitize output to remove control characters")
     allowed_roots: List[str] = Field(default_factory=list, description="Allowed root paths for resource access")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -99,7 +99,6 @@ from mcpgateway.db import A2APushNotificationConfig
 from mcpgateway.db import A2ATask as DbA2ATask
 from mcpgateway.db import refresh_slugs_on_startup, SessionLocal
 from mcpgateway.db import Tool as DbTool
-<<<<<<< HEAD
 from mcpgateway.handlers.sampling import SamplingError, SamplingHandler
 from mcpgateway.middleware.client_disconnect import ClientDisconnectMiddleware
 from mcpgateway.middleware.compression import SSEAwareCompressMiddleware

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3174,8 +3174,11 @@ else:
 # Client disconnect middleware — MUST be outermost (added last, runs first).
 # Cancels in-flight request handlers when the client (nginx) closes the connection,
 # preventing CLOSE_WAIT accumulation and associated memory leaks.
-app.add_middleware(ClientDisconnectMiddleware)
-logger.info("Client disconnect middleware enabled - cancels handlers on nginx timeout")
+if settings.client_disconnect_middleware_enabled:
+    app.add_middleware(ClientDisconnectMiddleware)
+    logger.info("Client disconnect middleware enabled - cancels handlers on nginx timeout")
+else:
+    logger.debug("Client disconnect middleware disabled (enable with CLIENT_DISCONNECT_MIDDLEWARE_ENABLED=true)")
 
 # Set up Jinja2 templates and store in app state for later use
 # auto_reload=False in production prevents re-parsing templates on each request (performance)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -99,7 +99,9 @@ from mcpgateway.db import A2APushNotificationConfig
 from mcpgateway.db import A2ATask as DbA2ATask
 from mcpgateway.db import refresh_slugs_on_startup, SessionLocal
 from mcpgateway.db import Tool as DbTool
+<<<<<<< HEAD
 from mcpgateway.handlers.sampling import SamplingError, SamplingHandler
+from mcpgateway.middleware.client_disconnect import ClientDisconnectMiddleware
 from mcpgateway.middleware.compression import SSEAwareCompressMiddleware
 from mcpgateway.middleware.correlation_id import CorrelationIDMiddleware
 from mcpgateway.middleware.http_auth_middleware import HttpAuthMiddleware, run_pre_request_hooks
@@ -3169,6 +3171,12 @@ if settings.db_query_log_enabled:
     logger.info(f"📊 Database query logging enabled - logs: {settings.db_query_log_file}")
 else:
     logger.debug("📊 Database query logging disabled (enable with DB_QUERY_LOG_ENABLED=true)")
+
+# Client disconnect middleware — MUST be outermost (added last, runs first).
+# Cancels in-flight request handlers when the client (nginx) closes the connection,
+# preventing CLOSE_WAIT accumulation and associated memory leaks.
+app.add_middleware(ClientDisconnectMiddleware)
+logger.info("Client disconnect middleware enabled - cancels handlers on nginx timeout")
 
 # Set up Jinja2 templates and store in app state for later use
 # auto_reload=False in production prevents re-parsing templates on each request (performance)

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/middleware/client_disconnect.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Client Disconnect Middleware.
+
+Pure ASGI middleware that detects when a client (e.g., nginx reverse proxy)
+closes the connection and cancels the in-flight request handler. This triggers
+cleanup of all resources held by the request (DB sessions via get_db's finally
+block, HTTP client connections, etc.).
+
+Without this middleware, when nginx's proxy_read_timeout fires (e.g., 60s),
+it sends FIN to the gateway but the handler keeps running — the socket enters
+CLOSE_WAIT and all request memory (ORM objects, response buffers) is retained
+until the handler eventually finishes. Under sustained load this causes a
+death spiral: slow requests → nginx timeouts → CLOSE_WAIT accumulation →
+OOM → swap thrashing → even slower requests.
+
+This middleware breaks the cycle by cancelling the handler as soon as the
+ASGI server signals disconnect, allowing finally blocks to release resources.
+"""
+
+# Standard
+import asyncio
+from contextlib import suppress
+from typing import Tuple
+
+# Third-Party
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# First-Party
+from mcpgateway.services.logging_service import LoggingService
+
+logger = LoggingService().get_logger(__name__)
+
+# Paths that manage their own disconnect handling (SSE, WebSocket, streaming)
+_SELF_MANAGED_PREFIXES: Tuple[str, ...] = (
+    "/sse/",
+    "/ws/",
+    "/mcp/",
+)
+
+
+class ClientDisconnectMiddleware:
+    """Cancel HTTP request processing when the client disconnects.
+
+    Uses a message queue to relay ASGI ``receive`` messages to the app while
+    a reader task watches for the ``http.disconnect`` event.  When disconnect
+    is detected the handler task is cancelled, triggering ``finally`` blocks
+    in FastAPI dependencies (e.g. ``get_db`` closing its session).
+
+    Only applies to ``http`` scope; WebSocket and lifespan scopes are passed
+    through unchanged.  SSE / WebSocket / MCP streaming paths that already
+    implement their own disconnect detection are also skipped.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Initialize with the wrapped ASGI application."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Intercept HTTP requests to cancel processing on client disconnect.
+
+        Args:
+            scope: ASGI connection scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+
+        Raises:
+            asyncio.CancelledError: Re-raised when cancellation is not from a disconnect.
+        """
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Skip paths that handle disconnect internally
+        path: str = scope.get("path", "")
+        if any(path.startswith(prefix) for prefix in _SELF_MANAGED_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        disconnected = asyncio.Event()
+        response_started = False
+
+        # Queue relays ASGI receive messages from the reader to the app.
+        recv_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+        async def _reader() -> None:
+            """Read from the raw ASGI receive channel and forward to the queue.
+
+            When ``http.disconnect`` arrives, signal via the event rather than
+            forwarding — the app should not see the disconnect message since
+            we cancel it instead.
+            """
+            try:
+                while True:
+                    message = await receive()
+                    if message["type"] == "http.disconnect":
+                        disconnected.set()
+                        # Put a disconnect message in case app is waiting on receive
+                        await recv_queue.put(message)
+                        return
+                    await recv_queue.put(message)
+            except asyncio.CancelledError:
+                return
+
+        async def _receive_wrapper() -> Message:
+            """Drop-in replacement for ``receive`` that reads from the queue.
+
+            Returns:
+                Message: The next ASGI message, or a disconnect message on cancellation.
+            """
+            try:
+                return await recv_queue.get()
+            except asyncio.CancelledError:
+                return {"type": "http.disconnect"}
+
+        async def _send_wrapper(message: Message) -> None:
+            """Forward ASGI send messages, suppressing errors after disconnect.
+
+            Args:
+                message: ASGI message to send.
+            """
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            # Don't send if client already gone and response hasn't started
+            if disconnected.is_set() and not response_started:
+                return
+            try:
+                await send(message)
+            except Exception:
+                # Client gone — send will fail, that's expected
+                disconnected.set()
+
+        reader_task = asyncio.create_task(_reader())
+        handler_task = asyncio.create_task(self.app(scope, _receive_wrapper, _send_wrapper))
+
+        async def _cancel_on_disconnect() -> None:
+            """Wait for disconnect, then cancel the handler."""
+            await disconnected.wait()
+            if not handler_task.done():
+                handler_task.cancel()
+
+        cancel_task = asyncio.create_task(_cancel_on_disconnect())
+
+        try:
+            await handler_task
+        except asyncio.CancelledError:
+            if disconnected.is_set():
+                logger.debug("Request cancelled: client disconnected (%s)", path)
+            else:
+                raise
+        finally:
+            # Clean up helper tasks
+            for task in (reader_task, cancel_task):
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -38,6 +38,8 @@ logger = LoggingService().get_logger(__name__)
 _SELF_MANAGED_PREFIXES: tuple[str, ...] = (
     "/sse",
     "/mcp",
+    "/servers",
+    "/_internal/mcp",
 )
 
 

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -34,12 +34,23 @@ from mcpgateway.services.logging_service import LoggingService
 
 logger = LoggingService().get_logger(__name__)
 
+def _is_server_streaming_path(path: str) -> bool:
+    """Return whether path is a server-scoped SSE or MCP streaming endpoint.
+
+    Matches ``/servers/{id}/sse`` and ``/servers/{id}/mcp`` (with or without
+    trailing slash) while NOT matching regular REST endpoints like
+    ``/servers/{id}`` or ``/servers/{id}/tools``.
+    """
+    normalized = path.rstrip("/")
+    parts = normalized.split("/")
+    return len(parts) == 4 and parts[1] == "servers" and parts[3] in ("sse", "mcp")
+
+
 # Paths that manage their own disconnect handling (SSE, WebSocket, streaming)
 _SELF_MANAGED_PREFIXES: tuple[str, ...] = (
     "/sse",
     "/mcp",
-    "/servers",
-    "/_internal/mcp",
+    "/_internal/mcp/transport",
 )
 
 
@@ -77,7 +88,7 @@ class ClientDisconnectMiddleware:
 
         # Skip paths that handle disconnect internally
         path: str = scope.get("path", "")
-        if any(path == prefix or path.startswith(prefix + "/") for prefix in _SELF_MANAGED_PREFIXES):
+        if any(path == prefix or path.startswith(prefix + "/") for prefix in _SELF_MANAGED_PREFIXES) or _is_server_streaming_path(path):
             await self.app(scope, receive, send)
             return
 

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -103,16 +103,15 @@ class ClientDisconnectMiddleware:
         async def _reader() -> None:
             """Read from the raw ASGI receive channel and forward to the queue.
 
-            When ``http.disconnect`` arrives, signal via the event and enqueue
-            the disconnect message so the app can drain the queue, then return.
+            When ``http.disconnect`` arrives, signal via the event and return.
+            The handler will be cancelled by ``_cancel_on_disconnect``, so
+            there is no need to enqueue the disconnect message.
             """
             try:
                 while True:
                     message = await receive()
                     if message["type"] == "http.disconnect":
                         disconnected.set()
-                        # Enqueue disconnect so the app can drain the queue
-                        await recv_queue.put(message)
                         return
                     await recv_queue.put(message)
             except asyncio.CancelledError:
@@ -133,9 +132,6 @@ class ClientDisconnectMiddleware:
                 message: ASGI message to send.
             """
             nonlocal response_started
-            # Don't send if client already gone and response hasn't started
-            if disconnected.is_set() and not response_started:
-                return
             if message["type"] == "http.response.start":
                 try:
                     await send(message)
@@ -143,6 +139,9 @@ class ClientDisconnectMiddleware:
                     disconnected.set()
                 else:
                     response_started = True
+                return
+            # Don't send non-start messages if client already gone and response hasn't started
+            if disconnected.is_set() and not response_started:
                 return
             try:
                 await send(message)

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -34,6 +34,7 @@ from mcpgateway.services.logging_service import LoggingService
 
 logger = LoggingService().get_logger(__name__)
 
+
 def _is_server_streaming_path(path: str) -> bool:
     """Return whether path is a server-scoped SSE or MCP streaming endpoint.
 

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Location: ./mcpgateway/middleware/client_disconnect.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Mihai Criveti
 
@@ -25,7 +25,6 @@ ASGI server signals disconnect, allowing finally blocks to release resources.
 # Standard
 import asyncio
 from contextlib import suppress
-from typing import Tuple
 
 # Third-Party
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -36,10 +35,9 @@ from mcpgateway.services.logging_service import LoggingService
 logger = LoggingService().get_logger(__name__)
 
 # Paths that manage their own disconnect handling (SSE, WebSocket, streaming)
-_SELF_MANAGED_PREFIXES: Tuple[str, ...] = (
-    "/sse/",
-    "/ws/",
-    "/mcp/",
+_SELF_MANAGED_PREFIXES: tuple[str, ...] = (
+    "/sse",
+    "/mcp",
 )
 
 
@@ -77,29 +75,29 @@ class ClientDisconnectMiddleware:
 
         # Skip paths that handle disconnect internally
         path: str = scope.get("path", "")
-        if any(path.startswith(prefix) for prefix in _SELF_MANAGED_PREFIXES):
+        if any(path == prefix or path.startswith(prefix + "/") for prefix in _SELF_MANAGED_PREFIXES):
             await self.app(scope, receive, send)
             return
 
         disconnected = asyncio.Event()
         response_started = False
 
-        # Queue relays ASGI receive messages from the reader to the app.
-        recv_queue: asyncio.Queue[Message] = asyncio.Queue()
+        # Bounded queue relays ASGI receive messages from the reader to the app.
+        # maxsize=1 preserves ASGI backpressure by preventing unbounded buffering.
+        recv_queue: asyncio.Queue[Message] = asyncio.Queue(maxsize=1)
 
         async def _reader() -> None:
             """Read from the raw ASGI receive channel and forward to the queue.
 
-            When ``http.disconnect`` arrives, signal via the event rather than
-            forwarding — the app should not see the disconnect message since
-            we cancel it instead.
+            When ``http.disconnect`` arrives, signal via the event and enqueue
+            the disconnect message so the app can drain the queue, then return.
             """
             try:
                 while True:
                     message = await receive()
                     if message["type"] == "http.disconnect":
                         disconnected.set()
-                        # Put a disconnect message in case app is waiting on receive
+                        # Enqueue disconnect so the app can drain the queue
                         await recv_queue.put(message)
                         return
                     await recv_queue.put(message)
@@ -110,12 +108,9 @@ class ClientDisconnectMiddleware:
             """Drop-in replacement for ``receive`` that reads from the queue.
 
             Returns:
-                Message: The next ASGI message, or a disconnect message on cancellation.
+                Message: The next ASGI message from the queue.
             """
-            try:
-                return await recv_queue.get()
-            except asyncio.CancelledError:
-                return {"type": "http.disconnect"}
+            return await recv_queue.get()
 
         async def _send_wrapper(message: Message) -> None:
             """Forward ASGI send messages, suppressing errors after disconnect.
@@ -124,14 +119,20 @@ class ClientDisconnectMiddleware:
                 message: ASGI message to send.
             """
             nonlocal response_started
-            if message["type"] == "http.response.start":
-                response_started = True
             # Don't send if client already gone and response hasn't started
             if disconnected.is_set() and not response_started:
                 return
+            if message["type"] == "http.response.start":
+                try:
+                    await send(message)
+                except (OSError, ConnectionError):
+                    disconnected.set()
+                else:
+                    response_started = True
+                return
             try:
                 await send(message)
-            except Exception:
+            except (OSError, ConnectionError):
                 # Client gone — send will fail, that's expected
                 disconnected.set()
 
@@ -154,8 +155,10 @@ class ClientDisconnectMiddleware:
             else:
                 raise
         finally:
-            # Clean up helper tasks
-            for task in (reader_task, cancel_task):
+            # Clean up all tasks including the handler to prevent orphans
+            if not handler_task.done():
+                handler_task.cancel()
+            for task in (reader_task, cancel_task, handler_task):
                 task.cancel()
                 with suppress(asyncio.CancelledError):
                     await task

--- a/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
@@ -342,20 +342,17 @@ async def test_request_body_reading():
 
 
 @pytest.mark.asyncio
-async def test_disconnect_message_enqueued():
-    """Disconnect message is enqueued so app can drain receive."""
-    received_messages: list[dict] = []
+async def test_handler_cancelled_while_waiting_on_receive():
+    """Handler is cancelled when waiting on receive() and client disconnects."""
+    receive_call_count = 0
 
-    async def app_that_reads_all(scope, receive, send):  # type: ignore[no-untyped-def]
+    async def app_that_reads_forever(scope, receive, send):  # type: ignore[no-untyped-def]
+        nonlocal receive_call_count
         while True:
-            msg = await receive()
-            received_messages.append(msg)
-            if msg["type"] == "http.disconnect":
-                break
-        await send({"type": "http.response.start", "status": 200, "headers": []})
-        await send({"type": "http.response.body", "body": b"ok"})
+            await receive()
+            receive_call_count += 1
 
-    middleware = ClientDisconnectMiddleware(app_that_reads_all)
+    middleware = ClientDisconnectMiddleware(app_that_reads_forever)
     messages: list[dict] = []
 
     async def send(msg):  # type: ignore[no-untyped-def]
@@ -368,7 +365,8 @@ async def test_disconnect_message_enqueued():
     ])
     await middleware(scope, receive, send)
 
-    assert any(msg["type"] == "http.disconnect" for msg in received_messages)
+    # App received the first message, then was cancelled on the second receive()
+    assert receive_call_count == 1
 
 
 @pytest.mark.asyncio
@@ -401,3 +399,78 @@ async def test_empty_path_defaults_to_empty_string():
     await middleware(scope, receive, send)
 
     assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_send_wrapper_suppresses_body_when_disconnected_before_start():
+    """Non-start messages are suppressed when disconnected before response start."""
+    async def app_that_sends_body_after_delay(scope, receive, send):  # type: ignore[no-untyped-def]
+        await asyncio.sleep(0.05)
+        await send({"type": "http.response.body", "body": b"should not send"})
+
+    middleware = ClientDisconnectMiddleware(app_that_sends_body_after_delay)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.disconnect"},
+    ])
+
+    await middleware(scope, receive, send)
+    assert len(messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_send_wrapper_oserror_on_body_sets_disconnected():
+    """OSError when sending body sets disconnected flag."""
+    call_count = 0
+
+    async def flaky_send(msg):  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        call_count += 1
+        if msg["type"] == "http.response.body":
+            raise ConnectionResetError("client gone")
+
+    async def app(scope, receive, send):  # type: ignore[no-untyped-def]
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = ClientDisconnectMiddleware(app)
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    await middleware(scope, receive, flaky_send)
+    # Should not raise; the OSError is caught and disconnected is set
+
+
+@pytest.mark.asyncio
+async def test_handler_not_done_in_finally_gets_cancelled():
+    """Handler task is cancelled in finally if not done when middleware returns."""
+    handler_started = asyncio.Event()
+    handler_continue = asyncio.Event()
+
+    async def app_that_waits(scope, receive, send):  # type: ignore[no-untyped-def]
+        handler_started.set()
+        await handler_continue.wait()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    middleware = ClientDisconnectMiddleware(app_that_waits)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+
+    # Run middleware in background so we can test the finally block
+    middleware_task = asyncio.create_task(middleware(scope, receive, send))
+    await handler_started.wait()
+    # Cancel the middleware itself; this should trigger the finally block
+    middleware_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await middleware_task

--- a/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
@@ -1,0 +1,350 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Tests for the client disconnect middleware.
+"""
+
+# Standard
+import asyncio
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.middleware.client_disconnect import ClientDisconnectMiddleware
+
+
+async def _ok_app(scope, receive, send):  # type: ignore[no-untyped-def]
+    """Simple ASGI app that responds OK."""
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def _slow_app(scope, receive, send):  # type: ignore[no-untyped-def]
+    """ASGI app that simulates slow processing."""
+    await asyncio.sleep(3600)
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def _body_app(scope, receive, send):  # type: ignore[no-untyped-def]
+    """ASGI app that reads request body."""
+    body = b""
+    while True:
+        msg = await receive()
+        body += msg.get("body", b"")
+        if not msg.get("more_body", False):
+            break
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": body})
+
+
+async def _receive_messages(messages):  # type: ignore[no-untyped-def]
+    """Build an ASGI receive callable that yields messages then waits forever."""
+    idx = 0
+
+    async def receive():  # type: ignore[no-untyped-def]
+        nonlocal idx
+        if idx < len(messages):
+            msg = messages[idx]
+            idx += 1
+            return msg
+        # After all messages, wait forever (simulates open connection)
+        await asyncio.Event().wait()
+        return {"type": "http.disconnect"}  # pragma: no cover
+
+    return receive
+
+
+@pytest.mark.asyncio
+async def test_normal_request_completes():
+    """Normal HTTP request completes without disconnect."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[0]["status"] == 200
+    assert messages[1]["type"] == "http.response.body"
+    assert messages[1]["body"] == b"ok"
+
+
+@pytest.mark.asyncio
+async def test_handler_cancelled_on_disconnect():
+    """Handler is cancelled when client disconnects before response."""
+    middleware = ClientDisconnectMiddleware(_slow_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.disconnect"},
+    ])
+
+    await middleware(scope, receive, send)
+    # No response should have been sent (handler was cancelled before send)
+    assert len(messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_websocket_passes_through():
+    """WebSocket scope passes through unchanged."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "websocket", "path": "/ws/chat"}
+    receive = await _receive_messages([])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_lifespan_passes_through():
+    """Lifespan scope passes through unchanged."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "lifespan", "path": "/"}
+    receive = await _receive_messages([])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2
+
+
+@pytest.mark.parametrize("path", ["/sse", "/sse/", "/mcp", "/mcp/", "/servers/abc/sse", "/servers/abc/mcp"])
+@pytest.mark.asyncio
+async def test_self_managed_paths_skipped(path):
+    """SSE and MCP paths are skipped (pass through unchanged)."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": path}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_reraised_when_not_disconnect():
+    """CancelledError from non-disconnect sources is re-raised."""
+    async def app_that_gets_cancelled(scope, receive, send):  # type: ignore[no-untyped-def]
+        await asyncio.sleep(0.01)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    middleware = ClientDisconnectMiddleware(app_that_gets_cancelled)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+
+    # Cancel the middleware itself to simulate external cancellation
+    task = asyncio.create_task(middleware(scope, receive, send))
+    await asyncio.sleep(0.005)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_task_cleanup_no_orphans():
+    """All tasks are cleaned up in finally block."""
+    middleware = ClientDisconnectMiddleware(_slow_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.disconnect"},
+    ])
+
+    await middleware(scope, receive, send)
+
+    # After middleware returns, there should be no pending tasks related to it
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    assert len(pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_send_wrapper_suppresses_after_disconnect():
+    """Send wrapper suppresses sends after disconnect and before response start."""
+    async def app_that_sends_after_delay(scope, receive, send):  # type: ignore[no-untyped-def]
+        await asyncio.sleep(0.05)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = ClientDisconnectMiddleware(app_that_sends_after_delay)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.disconnect"},
+    ])
+
+    await middleware(scope, receive, send)
+    # Response start should be suppressed because disconnect happened first
+    assert len(messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_send_wrapper_allows_response_after_disconnect():
+    """Send wrapper allows response if response.start already sent."""
+    async def app_that_starts_then_disconnects(scope, receive, send):  # type: ignore[no-untyped-def]
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await asyncio.sleep(0.05)
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = ClientDisconnectMiddleware(app_that_starts_then_disconnects)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.disconnect"},
+    ])
+
+    await middleware(scope, receive, send)
+    # Response start was sent before disconnect, so it should be in messages
+    assert len(messages) == 1
+    assert messages[0]["type"] == "http.response.start"
+
+
+@pytest.mark.asyncio
+async def test_send_wrapper_oserror_sets_disconnected():
+    """OSError from send sets disconnected flag."""
+    call_count = 0
+
+    async def flaky_send(msg):  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionResetError("client gone")
+        raise OSError("client gone")
+
+    async def app(scope, receive, send):  # type: ignore[no-untyped-def]
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    middleware = ClientDisconnectMiddleware(app)
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    await middleware(scope, receive, flaky_send)
+    # Should not raise; the OSError is caught and disconnected is set
+
+
+@pytest.mark.asyncio
+async def test_request_body_reading():
+    """Request body is correctly relayed through the queue."""
+    middleware = ClientDisconnectMiddleware(_body_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"hello", "more_body": True},
+        {"type": "http.request", "body": b" world", "more_body": False},
+    ])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2
+    assert messages[1]["body"] == b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_message_enqueued():
+    """Disconnect message is enqueued so app can drain receive."""
+    received_messages: list[dict] = []
+
+    async def app_that_reads_all(scope, receive, send):  # type: ignore[no-untyped-def]
+        while True:
+            msg = await receive()
+            received_messages.append(msg)
+            if msg["type"] == "http.disconnect":
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = ClientDisconnectMiddleware(app_that_reads_all)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/test"}
+    receive = await _receive_messages([
+        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.disconnect"},
+    ])
+    await middleware(scope, receive, send)
+
+    assert any(msg["type"] == "http.disconnect" for msg in received_messages)
+
+
+@pytest.mark.asyncio
+async def test_non_managed_path_processed():
+    """Non-managed paths go through the middleware."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http", "path": "/api/tools"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_path_defaults_to_empty_string():
+    """Scope with missing path defaults to empty string and is processed."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    scope = {"type": "http"}
+    receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    await middleware(scope, receive, send)
+
+    assert len(messages) == 2

--- a/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
@@ -172,6 +172,32 @@ async def test_self_managed_paths_skipped(path):
 
 
 @pytest.mark.asyncio
+async def test_regular_server_paths_not_skipped():
+    """Regular REST endpoints under /servers are NOT skipped."""
+    middleware = ClientDisconnectMiddleware(_ok_app)
+    messages: list[dict] = []
+
+    async def send(msg):  # type: ignore[no-untyped-def]
+        messages.append(msg)
+
+    # These are regular REST endpoints, not streaming paths
+    for path in (
+        "/servers",
+        "/servers/abc",
+        "/servers/abc/tools",
+        "/servers/abc/state",
+        "/_internal/mcp",
+        "/_internal/mcp/authenticate",
+        "/_internal/mcp/rpc",
+    ):
+        messages.clear()
+        scope = {"type": "http", "path": path}
+        receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+        await middleware(scope, receive, send)
+        assert len(messages) == 2, f"Expected middleware to process {path}, not skip it"
+
+
+@pytest.mark.asyncio
 async def test_cancelled_error_reraised_when_not_disconnect():
     """CancelledError from non-disconnect sources is re-raised."""
     async def app_that_gets_cancelled(scope, receive, send):  # type: ignore[no-untyped-def]

--- a/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
@@ -131,11 +131,33 @@ async def test_lifespan_passes_through():
     assert len(messages) == 2
 
 
-@pytest.mark.parametrize("path", ["/sse", "/sse/", "/mcp", "/mcp/", "/servers/abc/sse", "/servers/abc/mcp"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/sse",
+        "/sse/",
+        "/mcp",
+        "/mcp/",
+        "/servers/abc/sse",
+        "/servers/abc/mcp",
+        "/_internal/mcp/transport",
+        "/_internal/mcp/transport/",
+    ],
+)
 @pytest.mark.asyncio
 async def test_self_managed_paths_skipped(path):
-    """SSE and MCP paths are skipped (pass through unchanged)."""
-    middleware = ClientDisconnectMiddleware(_ok_app)
+    """SSE and MCP paths are skipped (receive/send passed through unwrapped)."""
+    received_via: list[str] = []
+
+    async def tracking_app(scope, receive, send):  # type: ignore[no-untyped-def]
+        # Verify we got the original receive/send, not wrapped versions
+        received_via.append("app")
+        msg = await receive()
+        assert msg["type"] == "http.request"
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = ClientDisconnectMiddleware(tracking_app)
     messages: list[dict] = []
 
     async def send(msg):  # type: ignore[no-untyped-def]
@@ -146,6 +168,7 @@ async def test_self_managed_paths_skipped(path):
     await middleware(scope, receive, send)
 
     assert len(messages) == 2
+    assert received_via == ["app"]
 
 
 @pytest.mark.asyncio
@@ -175,7 +198,7 @@ async def test_cancelled_error_reraised_when_not_disconnect():
 
 @pytest.mark.asyncio
 async def test_task_cleanup_no_orphans():
-    """All tasks are cleaned up in finally block."""
+    """All middleware-created tasks are cleaned up in finally block."""
     middleware = ClientDisconnectMiddleware(_slow_app)
     messages: list[dict] = []
 
@@ -188,11 +211,15 @@ async def test_task_cleanup_no_orphans():
         {"type": "http.disconnect"},
     ])
 
+    # Capture tasks created by the middleware by tracking before/after
+    before_tasks = set(asyncio.all_tasks())
     await middleware(scope, receive, send)
+    after_tasks = set(asyncio.all_tasks())
 
-    # After middleware returns, there should be no pending tasks related to it
-    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    assert len(pending) == 0
+    # Only middleware-created tasks should be gone; ignore pytest/plugin tasks
+    new_tasks = after_tasks - before_tasks
+    pending_new = [t for t in new_tasks if not t.done()]
+    assert len(pending_new) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_main_client_disconnect.py
+++ b/tests/unit/mcpgateway/test_main_client_disconnect.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_main_client_disconnect.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Tests for client disconnect middleware registration in main.py.
+"""
+
+import importlib
+from unittest.mock import patch
+
+
+def test_client_disconnect_middleware_registered_when_enabled():
+    """ClientDisconnectMiddleware is added when feature flag is enabled."""
+    with patch("mcpgateway.main.settings.client_disconnect_middleware_enabled", True):
+        main = importlib.reload(importlib.import_module("mcpgateway.main"))
+
+    middleware_classes = [mw.cls.__name__ for mw in main.app.user_middleware]
+    assert "ClientDisconnectMiddleware" in middleware_classes
+
+
+def test_client_disconnect_middleware_not_registered_when_disabled():
+    """ClientDisconnectMiddleware is NOT added when feature flag is disabled."""
+    with patch("mcpgateway.main.settings.client_disconnect_middleware_enabled", False):
+        main = importlib.reload(importlib.import_module("mcpgateway.main"))
+
+    middleware_classes = [mw.cls.__name__ for mw in main.app.user_middleware]
+    assert "ClientDisconnectMiddleware" not in middleware_classes


### PR DESCRIPTION
> **Note:** This PR was re-created from #2719 due to repository maintenance. Your code and branch are intact. @crivetimihai please verify everything looks good.

## Summary

- Add `ClientDisconnectMiddleware` — pure ASGI middleware that cancels in-flight request handlers when the client (e.g., nginx reverse proxy) closes the connection
- Prevents CLOSE_WAIT socket accumulation and memory leaks under sustained load when nginx's `proxy_read_timeout` fires before the handler completes
- Triggers `finally` blocks in FastAPI dependencies (e.g., `get_db` closing its DB session), ensuring resource cleanup
- Skips SSE, WebSocket, and MCP streaming paths that manage their own disconnect handling
- Added as outermost middleware (last registered = first to run)

## Test plan

- [ ] Verify normal HTTP requests complete successfully
- [ ] Verify SSE/WebSocket/MCP paths are not affected (skipped by prefix check)
- [ ] Under load with short nginx timeouts, confirm CLOSE_WAIT sockets are cleaned up instead of accumulating
- [ ] Verify DB sessions are released when requests are cancelled (via `get_db` finally block)