### PR TITLE
feat(metrics): add Redis-backed metrics cache for multi-instance deployments

### DIFF
--- a/docs/docs/architecture/performance-architecture.md
+++ b/docs/docs/architecture/performance-architecture.md
@@ -96,6 +96,11 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 │  │  │  │  TTL: 30s      │ │  TTL: 60s      │ │  TTL: 15-20s   │ │   TTL: 30-60s  │ │   TTL: 60s  │ │   ││
 │  │  │  │  <1ms auth     │ │  0-1 queries   │ │  95%+ hit rate │ │  Dashboard opt │ │  42K→0 qry  │ │   ││
 │  │  │  └────────────────┘ └────────────────┘ └────────────────┘ └────────────────┘ └─────────────┘ │   ││
+│  │  │  ┌────────────────────────────────────────────────────────────────────────────────────────┐   │   ││
+│  │  │  │                         Metrics Aggregation Cache (Redis-backed)                       │   │   ││
+│  │  │  │  TTL: 60s  │  Shared across instances  │  Solves #2643 metric fluctuation             │   │   ││
+│  │  │  │  Caches PostgreSQL aggregates (func.sum/count)  │  Auto-invalidates on buffer flush   │   │   ││
+│  │  │  └────────────────────────────────────────────────────────────────────────────────────────┘   │   ││
 │  │  └──────────────────────────────────────────────────────────────────────────────────────────────┘   ││
 │  │                                                                                                     ││
 │  │  ┌───────────────────────────────────────────────────────────────────────────────────────────────┐  ││
@@ -198,6 +203,7 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 | **Auth Cache** | >90% | 8-15ms → 1-3ms | 3-4 → 0-1 queries/request |
 | **Registry Cache** | 95%+ | Variable | 50-200 → 0-1 queries |
 | **GlobalConfig Cache** | 99%+ | 1ms → 0.00001ms | 42K+ queries eliminated |
+| **Metrics Aggregation Cache** | 80%+ | 50-200ms → <1ms | PostgreSQL aggregate queries |
 
 ### Compression & Bandwidth
 
@@ -233,6 +239,7 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 | #1828, #1837 | SSE/logging micro-optimizations | Reduced allocation overhead |
 | #1844 | Monitoring profile | Production observability |
 | #2025 | Startup resilience (exponential backoff) | Prevents crash-loop CPU storms |
+| #2643 | Redis-backed metrics cache | Consistent metrics in multi-instance deployments |
 
 ## Startup Resilience
 

--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -201,6 +201,110 @@ You can load your `.env` as a ConfigMap:
 
 ---
 
+## 🔄 Multi-Instance Deployments with Redis
+
+When deploying multiple gateway replicas behind a load balancer, configure Redis for shared metrics caching to ensure consistent metrics display across all instances.
+
+### Why Redis is Required for Multi-Instance
+
+Without Redis, each gateway instance maintains its own in-memory metrics cache. This causes:
+- **Fluctuating metrics values** on page refresh (different instances return different cached values)
+- **Non-monotonic totals** (values appear to decrease when hitting different instances)
+- **Inconsistent dashboards** (metrics vary based on which instance serves the request)
+
+See [Issue #2643](https://github.com/IBM/mcp-context-forge/issues/2643) for technical details.
+
+### Redis Configuration
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcpgateway-env
+data:
+  HOST: "0.0.0.0"
+  PORT: "4444"
+  DATABASE_URL: "postgresql+psycopg://postgres:changeme@postgres-service:5432/mcp"
+  REDIS_URL: "redis://redis-service:6379"
+  METRICS_CACHE_USE_REDIS: "true"  # Required for multi-instance
+  METRICS_CACHE_TTL_SECONDS: "60"
+  JWT_SECRET_KEY: "your-secret-key"
+  PLATFORM_ADMIN_EMAIL: "admin@example.com"
+  PLATFORM_ADMIN_PASSWORD: "changeme"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcpgateway
+spec:
+  replicas: 3  # Multiple instances
+  selector:
+    matchLabels:
+      app: mcpgateway
+  template:
+    metadata:
+      labels:
+        app: mcpgateway
+    spec:
+      containers:
+        - name: gateway
+          image: ghcr.io/YOUR_ORG/mcpgateway:latest
+          ports:
+            - containerPort: 4444
+          envFrom:
+            - configMapRef:
+                name: mcpgateway-env
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+```
+
+### Verification
+
+After deployment, verify Redis cache is working:
+
+```bash
+# Check gateway logs for Redis initialization
+kubectl logs -l app=mcpgateway | grep "Redis backend"
+# Should show: "MetricsCache initialized with Redis backend"
+
+# Connect to Redis and check cache keys
+kubectl exec -it deploy/redis -- redis-cli
+> KEYS metrics:*
+> GET metrics:aggregate:total_executions
+> TTL metrics:aggregate:total_executions
+```
+
+---
+
 ## 🗄 Database Deployment Examples
 
 ### MySQL Deployment

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -1008,7 +1008,7 @@ The gateway includes built-in observability features for tracking HTTP requests,
 | --------------------------- | ------------------------------------- | ------- | ---------- |
 | `METRICS_CACHE_ENABLED`     | Enable metrics query caching          | `true`  | bool       |
 | `METRICS_CACHE_TTL_SECONDS` | Cache TTL (seconds)                   | `60`    | int (1-300)|
-| `METRICS_CACHE_USE_REDIS`   | Use Redis for shared cache (multi-instance) | `true`  | bool       |
+| `METRICS_CACHE_USE_REDIS`   | Use Redis for shared cache (multi-instance) | `false` | bool       |
 
 !!! info "Multi-Instance Deployments"
     When deploying multiple gateway instances behind a load balancer, `METRICS_CACHE_USE_REDIS=true` ensures consistent metrics display across all instances by using a shared Redis cache. Without Redis, each instance maintains its own cache, leading to fluctuating metrics values on page refresh. See [Issue #2643](https://github.com/IBM/mcp-context-forge/issues/2643) for details.

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -1008,6 +1008,10 @@ The gateway includes built-in observability features for tracking HTTP requests,
 | --------------------------- | ------------------------------------- | ------- | ---------- |
 | `METRICS_CACHE_ENABLED`     | Enable metrics query caching          | `true`  | bool       |
 | `METRICS_CACHE_TTL_SECONDS` | Cache TTL (seconds)                   | `60`    | int (1-300)|
+| `METRICS_CACHE_USE_REDIS`   | Use Redis for shared cache (multi-instance) | `true`  | bool       |
+
+!!! info "Multi-Instance Deployments"
+    When deploying multiple gateway instances behind a load balancer, `METRICS_CACHE_USE_REDIS=true` ensures consistent metrics display across all instances by using a shared Redis cache. Without Redis, each instance maintains its own cache, leading to fluctuating metrics values on page refresh. See [Issue #2643](https://github.com/IBM/mcp-context-forge/issues/2643) for details.
 
 ### MCP Session Pool
 

--- a/mcpgateway/cache/metrics_cache.py
+++ b/mcpgateway/cache/metrics_cache.py
@@ -7,23 +7,58 @@ with optional Redis support for distributed deployments.
 The cache uses double-checked locking for thread safety and supports
 configurable TTL with automatic expiration.
 
-See GitHub Issue #1734 for details.
+Redis support enables shared caching across multiple gateway instances,
+solving metric fluctuation issues in multi-instance deployments.
+
+See GitHub Issue #1734 and #2643 for details.
 """
 
 # Future
 from __future__ import annotations
 
 # Standard
+import json
 import logging
 import threading
 import time
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+try:
+    # Third-Party
+    from redis.asyncio import Redis
+    from redis.exceptions import RedisError
+
+    REDIS_AVAILABLE = True
+except ImportError:
+    REDIS_AVAILABLE = False
+    Redis = None  # type: ignore
+    RedisError = Exception  # type: ignore
+
+try:
+    # Third-Party
+    from prometheus_client import Counter
+
+    PROMETHEUS_AVAILABLE = True
+
+    # Prometheus metrics for cache performance
+    metrics_cache_hits_total = Counter("metrics_cache_hits_total", "Total number of metrics cache hits", ["backend"])
+
+    metrics_cache_misses_total = Counter("metrics_cache_misses_total", "Total number of metrics cache misses", ["backend"])
+except ImportError:
+    PROMETHEUS_AVAILABLE = False
+    metrics_cache_hits_total = None  # type: ignore  # pylint: disable=invalid-name
+    metrics_cache_misses_total = None  # type: ignore  # pylint: disable=invalid-name
+
 
 class MetricsCache:
-    """Thread-safe in-memory cache for metrics aggregation results.
+    """Thread-safe cache for metrics aggregation results with Redis support.
+
+    Supports both in-memory caching (single-instance) and Redis-based
+    distributed caching (multi-instance deployments). Automatically falls
+    back to local cache if Redis is unavailable.
 
     Uses double-checked locking to minimize lock contention while
     ensuring thread safety. Supports separate caches for different
@@ -31,45 +66,133 @@ class MetricsCache:
 
     Attributes:
         ttl_seconds: Time-to-live for cached entries in seconds.
+        redis_client: Optional Redis client for distributed caching.
+        use_redis: Whether Redis backend is enabled and available.
 
     Examples:
+        >>> # Local cache (single instance)
         >>> cache = MetricsCache(ttl_seconds=10)
         >>> cache.get("tools") is None
         True
         >>> cache.set("tools", {"total": 100, "successful": 90})
         >>> cache.get("tools")
         {'total': 100, 'successful': 90}
-        >>> cache.invalidate("tools")
-        >>> cache.get("tools") is None
+
+        >>> # Redis cache (multi-instance)
+        >>> from redis.asyncio import Redis
+        >>> redis_client = Redis.from_url("redis://localhost:6379")
+        >>> cache = MetricsCache(redis_client=redis_client, ttl_seconds=60)
+        >>> cache.use_redis
         True
     """
 
     _NOT_CACHED = object()  # Sentinel to distinguish "not cached" from "cached None"
 
-    def __init__(self, ttl_seconds: int = 10) -> None:
+    def __init__(self, redis_client: Optional[Redis] = None, ttl_seconds: int = 10) -> None:
         """Initialize the metrics cache.
 
         Args:
+            redis_client: Optional Redis client for distributed caching.
+                         If None, uses in-memory cache only.
             ttl_seconds: Time-to-live for cached entries. Defaults to 10 seconds.
         """
         self._caches: Dict[str, Any] = {}
         self._expiries: Dict[str, float] = {}
         self._lock = threading.Lock()
         self._ttl_seconds = ttl_seconds
-        self._hit_count = 0
-        self._miss_count = 0
+        self._total_hit_count = 0
+        self._total_miss_count = 0
+        self._redis_hit_count = 0
+        self._redis_miss_count = 0
+        self._local_hit_count = 0
+        self._local_miss_count = 0
+        self._sync_method_warned = False
 
-    def get(self, metric_type: str) -> Optional[Dict[str, Any]]:
-        """Get cached metrics for a specific type.
+        # Redis support
+        self.redis_client = redis_client
+        self.use_redis = redis_client is not None and REDIS_AVAILABLE
 
-        Uses double-checked locking for thread safety with minimal
-        lock contention on cache hits.
+        if self.use_redis:
+            logger.info("MetricsCache initialized with Redis backend for distributed caching")
+        else:
+            if redis_client is not None and not REDIS_AVAILABLE:
+                logger.warning("Redis client provided but redis library not available, falling back to local cache")
+            logger.info("MetricsCache initialized with local in-memory backend")
+
+    async def get_async(self, metric_type: str) -> Optional[Dict[str, Any]]:
+        """Get cached metrics for a specific type (async version for Redis).
+
+        Tries Redis first if enabled, falls back to local cache.
 
         Args:
             metric_type: Type of metrics (tools, resources, prompts, servers, a2a).
 
         Returns:
             Cached metrics dictionary if valid, None if expired or not cached.
+
+        Examples:
+            >>> import asyncio
+            >>> cache = MetricsCache()
+            >>> asyncio.run(cache.get_async("tools")) is None
+            True
+        """
+        # Try Redis first if enabled
+        if self.use_redis:
+            try:
+                cache_key = f"metrics:{metric_type}"
+                value = await self.redis_client.get(cache_key)
+                if value:
+                    self._total_hit_count += 1
+                    self._redis_hit_count += 1
+                    if PROMETHEUS_AVAILABLE:
+                        metrics_cache_hits_total.labels(backend="redis").inc()
+                    logger.debug("Metrics cache hit (Redis)", extra={"cache_key": metric_type, "cache_backend": "redis"})
+                    return json.loads(value)
+                self._total_miss_count += 1
+                self._redis_miss_count += 1
+                if PROMETHEUS_AVAILABLE:
+                    metrics_cache_misses_total.labels(backend="redis").inc()
+                logger.debug("Metrics cache miss (Redis)", extra={"cache_key": metric_type, "cache_backend": "redis"})
+                return None
+            except (RedisError, json.JSONDecodeError) as e:
+                logger.warning(f"Redis get failed for key '{metric_type}', falling back to local cache: {e}", extra={"cache_key": metric_type, "error": str(e)})
+                # Fall through to local cache
+
+        # Local cache fallback
+        now = time.time()
+        cached = self._caches.get(metric_type, self._NOT_CACHED)
+        expiry = self._expiries.get(metric_type, 0)
+
+        if cached is not self._NOT_CACHED and now < expiry:
+            self._total_hit_count += 1
+            self._local_hit_count += 1
+            if PROMETHEUS_AVAILABLE:
+                metrics_cache_hits_total.labels(backend="local").inc()
+            logger.debug("Metrics cache hit (local)", extra={"cache_key": metric_type, "cache_backend": "local"})
+            return cached
+
+        self._total_miss_count += 1
+        self._local_miss_count += 1
+        if PROMETHEUS_AVAILABLE:
+            metrics_cache_misses_total.labels(backend="local").inc()
+        logger.debug("Metrics cache miss (local)", extra={"cache_key": metric_type, "cache_backend": "local"})
+        return None
+
+    def get(self, metric_type: str) -> Optional[Dict[str, Any]]:
+        """Get cached metrics for a specific type (sync version).
+
+        For backward compatibility. Only uses local cache.
+        Use get_async() for Redis support.
+
+        Args:
+            metric_type: Type of metrics (tools, resources, prompts, servers, a2a).
+
+        Returns:
+            Cached metrics dictionary if valid, None if expired or not cached.
+
+        Warning:
+            When Redis backend is active, this method only accesses local cache.
+            Use get_async() for Redis-backed caching.
 
         Examples:
             >>> cache = MetricsCache()
@@ -79,26 +202,79 @@ class MetricsCache:
             >>> cache.get("tools")
             {'total': 50}
         """
-        now = time.time()
+        if self.use_redis and not self._sync_method_warned:
+            logger.warning(
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                "Only local cache will be used. Use async methods for Redis support. "
+                "This warning will only be shown once."
+            )
+            self._sync_method_warned = True
 
-        # Fast path: check without lock
+        now = time.time()
         cached = self._caches.get(metric_type, self._NOT_CACHED)
         expiry = self._expiries.get(metric_type, 0)
 
         if cached is not self._NOT_CACHED and now < expiry:
-            self._hit_count += 1
+            self._total_hit_count += 1
+            self._local_hit_count += 1
+            if PROMETHEUS_AVAILABLE:
+                metrics_cache_hits_total.labels(backend="local").inc()
             return cached
 
-        # Cache miss or expired
-        self._miss_count += 1
+        self._total_miss_count += 1
+        self._local_miss_count += 1
+        if PROMETHEUS_AVAILABLE:
+            metrics_cache_misses_total.labels(backend="local").inc()
         return None
 
-    def set(self, metric_type: str, value: Dict[str, Any]) -> None:
-        """Set cached metrics for a specific type.
+    async def set_async(self, metric_type: str, value: Dict[str, Any]) -> None:
+        """Set cached metrics for a specific type (async version for Redis).
+
+        Writes to both Redis (if enabled) and local cache.
 
         Args:
             metric_type: Type of metrics (tools, resources, prompts, servers, a2a).
             value: Metrics dictionary to cache.
+
+        Examples:
+            >>> import asyncio
+            >>> cache = MetricsCache(ttl_seconds=60)
+            >>> asyncio.run(cache.set_async("tools", {"total": 100}))
+        """
+        # Try Redis first if enabled
+        if self.use_redis:
+            try:
+                cache_key = f"metrics:{metric_type}"
+                await self.redis_client.setex(cache_key, self._ttl_seconds, json.dumps(value))
+                logger.debug("Metrics cache set (Redis)", extra={"cache_key": metric_type, "cache_backend": "redis", "ttl_seconds": self._ttl_seconds})
+                # Also set in local cache for faster subsequent access
+                with self._lock:
+                    self._caches[metric_type] = value
+                    self._expiries[metric_type] = time.time() + self._ttl_seconds
+                return
+            except (RedisError, TypeError, ValueError) as e:
+                logger.warning(f"Redis set failed for key '{metric_type}', falling back to local cache: {e}", extra={"cache_key": metric_type, "error": str(e)})
+                # Fall through to local cache
+
+        # Local cache (fallback or primary)
+        with self._lock:
+            self._caches[metric_type] = value
+            self._expiries[metric_type] = time.time() + self._ttl_seconds
+            logger.debug("Metrics cache set (local)", extra={"cache_key": metric_type, "cache_backend": "local", "ttl_seconds": self._ttl_seconds})
+
+    def set(self, metric_type: str, value: Dict[str, Any]) -> None:
+        """Set cached metrics for a specific type (sync version).
+
+        For backward compatibility. Only uses local cache.
+        Use set_async() for Redis support.
+
+        Args:
+            metric_type: Type of metrics (tools, resources, prompts, servers, a2a).
+            value: Metrics dictionary to cache.
+
+        Warning:
+            When Redis backend is active, this method only updates local cache.
+            Use set_async() for Redis-backed caching.
 
         Examples:
             >>> cache = MetricsCache(ttl_seconds=60)
@@ -106,15 +282,69 @@ class MetricsCache:
             >>> cache.get("tools")
             {'total': 100, 'successful': 95}
         """
+        if self.use_redis and not self._sync_method_warned:
+            logger.warning(
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                "Only local cache will be used. Use async methods for Redis support. "
+                "This warning will only be shown once."
+            )
+            self._sync_method_warned = True
+
         with self._lock:
             self._caches[metric_type] = value
             self._expiries[metric_type] = time.time() + self._ttl_seconds
 
-    def invalidate(self, metric_type: Optional[str] = None) -> None:
-        """Invalidate cached metrics.
+    async def invalidate_async(self, metric_type: Optional[str] = None) -> None:
+        """Invalidate cached metrics (async version for Redis).
 
         Args:
             metric_type: Specific type to invalidate, or None to invalidate all.
+
+        Examples:
+            >>> import asyncio
+            >>> cache = MetricsCache()
+            >>> cache.set("tools", {"total": 100})
+            >>> asyncio.run(cache.invalidate_async("tools"))
+        """
+        # Invalidate in Redis if enabled
+        if self.use_redis:
+            try:
+                if metric_type is None:
+                    # Delete all metrics:* keys using SCAN with batch delete
+                    keys = [key async for key in self.redis_client.scan_iter("metrics:*")]
+                    if keys:
+                        await self.redis_client.delete(*keys)
+                        logger.debug(f"Invalidated {len(keys)} metrics cache entries in Redis")
+                else:
+                    cache_key = f"metrics:{metric_type}"
+                    await self.redis_client.delete(cache_key)
+                    logger.debug(f"Invalidated metrics cache for '{metric_type}' in Redis")
+            except RedisError as e:
+                logger.warning(f"Redis invalidation failed: {e}", extra={"metric_type": metric_type, "error": str(e)})
+
+        # Also invalidate local cache
+        with self._lock:
+            if metric_type is None:
+                self._caches.clear()
+                self._expiries.clear()
+                logger.debug("Invalidated all metrics caches (local)")
+            else:
+                self._caches.pop(metric_type, None)
+                self._expiries.pop(metric_type, None)
+                logger.debug(f"Invalidated metrics cache for '{metric_type}' (local)")
+
+    def invalidate(self, metric_type: Optional[str] = None) -> None:
+        """Invalidate cached metrics (sync version).
+
+        For backward compatibility. Only invalidates local cache.
+        Use invalidate_async() for Redis support.
+
+        Args:
+            metric_type: Specific type to invalidate, or None to invalidate all.
+
+        Warning:
+            When Redis backend is active, this method only invalidates local cache.
+            Use invalidate_async() for Redis-backed invalidation.
 
         Examples:
             >>> cache = MetricsCache()
@@ -129,21 +359,33 @@ class MetricsCache:
             >>> cache.get("resources") is None
             True
         """
+        if self.use_redis and not self._sync_method_warned:
+            logger.warning(
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                "Only local cache will be used. Use async methods for Redis support. "
+                "This warning will only be shown once."
+            )
+            self._sync_method_warned = True
+
         with self._lock:
             if metric_type is None:
                 self._caches.clear()
                 self._expiries.clear()
-                logger.debug("Invalidated all metrics caches")
+                logger.debug("Invalidated all metrics caches (local)")
             else:
                 self._caches.pop(metric_type, None)
                 self._expiries.pop(metric_type, None)
-                logger.debug(f"Invalidated metrics cache for: {metric_type}")
+                logger.debug(f"Invalidated metrics cache for '{metric_type}' (local)")
 
     def invalidate_prefix(self, prefix: str) -> None:
         """Invalidate all cached metrics with keys starting with prefix.
 
         Args:
             prefix: Key prefix to match for invalidation.
+
+        Warning:
+            When Redis backend is active, this method only invalidates local cache.
+            Consider using invalidate_async() for Redis-backed invalidation.
 
         Examples:
             >>> cache = MetricsCache()
@@ -158,6 +400,14 @@ class MetricsCache:
             >>> cache.get("tools") is not None
             True
         """
+        if self.use_redis and not self._sync_method_warned:
+            logger.warning(
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                "Only local cache will be used. Use async methods for Redis support. "
+                "This warning will only be shown once."
+            )
+            self._sync_method_warned = True
+
         with self._lock:
             keys_to_remove = [k for k in self._caches if k.startswith(prefix)]
             for key in keys_to_remove:
@@ -171,7 +421,7 @@ class MetricsCache:
 
         Returns:
             Dictionary containing hit_count, miss_count, hit_rate,
-            cached_types, and ttl_seconds.
+            cached_types, backend info, and ttl_seconds.
 
         Examples:
             >>> cache = MetricsCache()
@@ -185,16 +435,41 @@ class MetricsCache:
             >>> stats["miss_count"]
             1
         """
-        total = self._hit_count + self._miss_count
+        total = self._total_hit_count + self._total_miss_count
         now = time.time()
         cached_types = [k for k, v in self._caches.items() if v is not self._NOT_CACHED and self._expiries.get(k, 0) > now]
-        return {
-            "hit_count": self._hit_count,
-            "miss_count": self._miss_count,
-            "hit_rate": self._hit_count / total if total > 0 else 0.0,
+
+        stats = {
+            "hit_count": self._total_hit_count,
+            "miss_count": self._total_miss_count,
+            "hit_rate": self._total_hit_count / total if total > 0 else 0.0,
             "cached_types": cached_types,
             "ttl_seconds": self._ttl_seconds,
+            "backend": "redis" if self.use_redis else "local",
         }
+
+        # Add Redis-specific stats if enabled
+        if self.use_redis:
+            redis_total = self._redis_hit_count + self._redis_miss_count
+            stats.update(
+                {
+                    "redis_hit_count": self._redis_hit_count,
+                    "redis_miss_count": self._redis_miss_count,
+                    "redis_hit_rate": self._redis_hit_count / redis_total if redis_total > 0 else 0.0,
+                }
+            )
+
+        # Add local cache stats
+        local_total = self._local_hit_count + self._local_miss_count
+        stats.update(
+            {
+                "local_hit_count": self._local_hit_count,
+                "local_miss_count": self._local_miss_count,
+                "local_hit_rate": self._local_hit_count / local_total if local_total > 0 else 0.0,
+            }
+        )
+
+        return stats
 
     def reset_stats(self) -> None:
         """Reset hit/miss counters.
@@ -209,24 +484,45 @@ class MetricsCache:
             >>> cache.stats()["hit_count"]
             0
         """
-        self._hit_count = 0
-        self._miss_count = 0
+        self._total_hit_count = 0
+        self._total_miss_count = 0
+        self._redis_hit_count = 0
+        self._redis_miss_count = 0
+        self._local_hit_count = 0
+        self._local_miss_count = 0
 
 
 def _create_metrics_cache() -> MetricsCache:
     """Create the metrics cache with settings from configuration.
 
+    Automatically configures Redis backend if enabled in settings.
+
     Returns:
-        MetricsCache instance configured with TTL from settings.
+        MetricsCache instance configured with TTL and optional Redis backend.
     """
     try:
         # First-Party
         from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
 
         ttl = getattr(settings, "metrics_cache_ttl_seconds", 10)
+        use_redis = getattr(settings, "metrics_cache_use_redis", False)
+        redis_url = getattr(settings, "redis_url", None)
+
+        # Initialize Redis client if enabled and URL provided
+        redis_client = None
+        if use_redis and redis_url and REDIS_AVAILABLE:
+            try:
+                redis_client = Redis.from_url(redis_url, decode_responses=True)
+                # Sanitize URL to avoid logging credentials
+                parsed = urlparse(redis_url)
+                safe_url = f"{parsed.scheme}://{parsed.hostname}:{parsed.port or 6379}"
+                logger.info(f"Metrics cache configured with Redis backend: {safe_url}")
+            except (RedisError, ConnectionError, OSError, ValueError) as e:
+                logger.warning(f"Failed to initialize Redis client for metrics cache: {e}")
+
+        return MetricsCache(redis_client=redis_client, ttl_seconds=ttl)
     except ImportError:
-        ttl = 10
-    return MetricsCache(ttl_seconds=ttl)
+        return MetricsCache(ttl_seconds=10)
 
 
 def is_cache_enabled() -> bool:

--- a/mcpgateway/cache/metrics_cache.py
+++ b/mcpgateway/cache/metrics_cache.py
@@ -204,9 +204,9 @@ class MetricsCache:
         """
         if self.use_redis and not self._sync_method_warned:
             logger.warning(
-                "Sync methods (get/set/invalidate) called with Redis backend active. " +
-                "Only local cache will be used. Use async methods for Redis support. " +
-                "This warning will only be shown once."
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                + "Only local cache will be used. Use async methods for Redis support. "
+                + "This warning will only be shown once."
             )
             self._sync_method_warned = True
 
@@ -284,9 +284,9 @@ class MetricsCache:
         """
         if self.use_redis and not self._sync_method_warned:
             logger.warning(
-                "Sync methods (get/set/invalidate) called with Redis backend active. " +
-                "Only local cache will be used. Use async methods for Redis support. " +
-                "This warning will only be shown once."
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                + "Only local cache will be used. Use async methods for Redis support. "
+                + "This warning will only be shown once."
             )
             self._sync_method_warned = True
 
@@ -428,9 +428,9 @@ class MetricsCache:
         """
         if self.use_redis and not self._sync_method_warned:
             logger.warning(
-                "Sync methods (get/set/invalidate) called with Redis backend active. " +
-                "Only local cache will be used. Use async methods for Redis support. " +
-                "This warning will only be shown once."
+                "Sync methods (get/set/invalidate) called with Redis backend active. "
+                + "Only local cache will be used. Use async methods for Redis support. "
+                + "This warning will only be shown once."
             )
             self._sync_method_warned = True
 

--- a/mcpgateway/cache/metrics_cache.py
+++ b/mcpgateway/cache/metrics_cache.py
@@ -362,8 +362,8 @@ class MetricsCache:
         if self.use_redis and not self._sync_method_warned:
             logger.warning(
                 "Sync methods (get/set/invalidate) called with Redis backend active. "
-                "Only local cache will be used. Use async methods for Redis support. "
-                "This warning will only be shown once."
+                + "Only local cache will be used. Use async methods for Redis support. "
+                + "This warning will only be shown once."
             )
             self._sync_method_warned = True
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1312,6 +1312,7 @@ class Settings(BaseSettings):
     # Metrics Cache Configuration (for caching aggregate metrics queries)
     metrics_cache_enabled: bool = Field(default=True, description="Enable in-memory caching for aggregate metrics queries")
     metrics_cache_ttl_seconds: int = Field(default=60, ge=1, le=300, description="TTL for cached aggregate metrics in seconds")
+    metrics_cache_use_redis: bool = Field(default=False, description="Use Redis for shared metrics cache (required for multi-instance deployments)")
 
     # Metrics Cleanup Configuration (automatic deletion of old metrics)
     metrics_cleanup_enabled: bool = Field(default=True, description="Enable automatic cleanup of old metrics data")

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -469,7 +469,7 @@ class A2AAgentService:
                 # First-Party
                 from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-                metrics_cache.invalidate("a2a")
+                await metrics_cache.invalidate_async("a2a")
             except Exception as cache_error:
                 logger.warning(f"Cache invalidation failed after agent commit: {cache_error}")
 
@@ -1587,7 +1587,7 @@ class A2AAgentService:
         from mcpgateway.cache.metrics_cache import is_cache_enabled, metrics_cache  # pylint: disable=import-outside-toplevel
 
         if is_cache_enabled():
-            cached = metrics_cache.get("a2a")
+            cached = await metrics_cache.get_async("a2a")
             if cached is not None:
                 return cached
 
@@ -1620,7 +1620,7 @@ class A2AAgentService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set("a2a", metrics)
+            await metrics_cache.set_async("a2a", metrics)
 
         return metrics
 
@@ -1643,7 +1643,7 @@ class A2AAgentService:
         # First-Party
         from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-        metrics_cache.invalidate("a2a")
+        await metrics_cache.invalidate_async("a2a")
 
         logger.info("Reset A2A agent metrics" + (f" for agent {agent_id}" if agent_id else ""))
 

--- a/mcpgateway/services/metrics_buffer_service.py
+++ b/mcpgateway/services/metrics_buffer_service.py
@@ -450,6 +450,16 @@ class MetricsBufferService:
             f"servers={len(server_metrics)}, a2a={len(a2a_agent_metrics)})"
         )
 
+        # Invalidate metrics cache after successful flush to ensure fresh aggregates
+        try:
+            # First-Party
+            from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
+
+            await metrics_cache.invalidate_async()
+            logger.debug("Invalidated metrics cache after buffer flush")
+        except Exception as e:
+            logger.warning(f"Failed to invalidate metrics cache after flush: {e}")
+
     def _flush_to_db(
         self,
         tool_metrics: list[BufferedToolMetric],

--- a/mcpgateway/services/metrics_query_service.py
+++ b/mcpgateway/services/metrics_query_service.py
@@ -51,10 +51,6 @@ class AggregatedMetrics:
     # Source breakdown for debugging
     raw_count: int = 0
     rollup_count: int = 0
-    # Current hour metrics (for real-time visibility)
-    current_hour_executions: int = 0
-    current_hour_successful: int = 0
-    current_hour_failed: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary format for API response.

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -254,7 +254,7 @@ class PromptService:
         cache_key = f"top_prompts:{effective_limit}:include_deleted={include_deleted}"
 
         if is_cache_enabled():
-            cached = metrics_cache.get(cache_key)
+            cached = await metrics_cache.get_async(cache_key)
             if cached is not None:
                 return cached
 
@@ -273,7 +273,7 @@ class PromptService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set(cache_key, top_performers)
+            await metrics_cache.set_async(cache_key, top_performers)
 
         return top_performers
 
@@ -588,8 +588,8 @@ class PromptService:
             # First-Party
             from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-            metrics_cache.invalidate_prefix("top_prompts:")
-            metrics_cache.invalidate("prompts")
+            await metrics_cache.invalidate_prefix_async("top_prompts:")
+            await metrics_cache.invalidate_async("prompts")
 
             return PromptRead.model_validate(prompt_dict)
 
@@ -2592,7 +2592,7 @@ class PromptService:
         from mcpgateway.cache.metrics_cache import is_cache_enabled, metrics_cache  # pylint: disable=import-outside-toplevel
 
         if is_cache_enabled():
-            cached = metrics_cache.get("prompts")
+            cached = await metrics_cache.get_async("prompts")
             if cached is not None:
                 return cached
 
@@ -2605,7 +2605,7 @@ class PromptService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set("prompts", metrics)
+            await metrics_cache.set_async("prompts", metrics)
 
         return metrics
 
@@ -2635,8 +2635,8 @@ class PromptService:
         # First-Party
         from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-        metrics_cache.invalidate("prompts")
-        metrics_cache.invalidate_prefix("top_prompts:")
+        await metrics_cache.invalidate_async("prompts")
+        await metrics_cache.invalidate_prefix_async("top_prompts:")
 
 
 # Lazy singleton - created on first access, not at module import time.

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -227,7 +227,7 @@ class ResourceService:
         cache_key = f"top_resources:{effective_limit}:include_deleted={include_deleted}"
 
         if is_cache_enabled():
-            cached = metrics_cache.get(cache_key)
+            cached = await metrics_cache.get_async(cache_key)
             if cached is not None:
                 return cached
 
@@ -248,7 +248,7 @@ class ResourceService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set(cache_key, top_performers)
+            await metrics_cache.set_async(cache_key, top_performers)
 
         return top_performers
 
@@ -2796,8 +2796,8 @@ class ResourceService:
             # First-Party
             from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-            metrics_cache.invalidate_prefix("top_resources:")
-            metrics_cache.invalidate("resources")
+            await metrics_cache.invalidate_prefix_async("top_resources:")
+            await metrics_cache.invalidate_async("resources")
 
             # Notify subscribers
             await self._notify_resource_updated(resource)
@@ -3623,7 +3623,7 @@ class ResourceService:
         from mcpgateway.cache.metrics_cache import is_cache_enabled, metrics_cache  # pylint: disable=import-outside-toplevel
 
         if is_cache_enabled():
-            cached = metrics_cache.get("resources")
+            cached = await metrics_cache.get_async("resources")
             if cached is not None:
                 return ResourceMetrics(**cached)
 
@@ -3646,7 +3646,7 @@ class ResourceService:
 
         # Cache the result as dict for serialization compatibility (if enabled)
         if is_cache_enabled():
-            metrics_cache.set("resources", metrics.model_dump())
+            await metrics_cache.set_async("resources", metrics.model_dump())
 
         return metrics
 
@@ -3675,8 +3675,8 @@ class ResourceService:
         # First-Party
         from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-        metrics_cache.invalidate("resources")
-        metrics_cache.invalidate_prefix("top_resources:")
+        await metrics_cache.invalidate_async("resources")
+        await metrics_cache.invalidate_prefix_async("top_resources:")
 
 
 # Lazy singleton - created on first access, not at module import time.

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -248,7 +248,7 @@ class ServerService:
         cache_key = f"top_servers:{effective_limit}:include_deleted={include_deleted}"
 
         if is_cache_enabled():
-            cached = metrics_cache.get(cache_key)
+            cached = await metrics_cache.get_async(cache_key)
             if cached is not None:
                 return cached
 
@@ -267,7 +267,7 @@ class ServerService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set(cache_key, top_performers)
+            await metrics_cache.set_async(cache_key, top_performers)
 
         return top_performers
 
@@ -1661,8 +1661,8 @@ class ServerService:
             # First-Party
             from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-            metrics_cache.invalidate_prefix("top_servers:")
-            metrics_cache.invalidate("servers")
+            await metrics_cache.invalidate_prefix_async("top_servers:")
+            await metrics_cache.invalidate_async("servers")
 
             await self._notify_server_deleted(server_info)
             logger.info(f"Deleted server: {server_info['name']}")
@@ -1873,7 +1873,7 @@ class ServerService:
         from mcpgateway.cache.metrics_cache import is_cache_enabled, metrics_cache  # pylint: disable=import-outside-toplevel
 
         if is_cache_enabled():
-            cached = metrics_cache.get("servers")
+            cached = await metrics_cache.get_async("servers")
             if cached is not None:
                 return ServerMetrics(**cached)
 
@@ -1896,7 +1896,7 @@ class ServerService:
 
         # Cache the result as dict for serialization compatibility (if enabled)
         if is_cache_enabled():
-            metrics_cache.set("servers", metrics.model_dump())
+            await metrics_cache.set_async("servers", metrics.model_dump())
 
         return metrics
 
@@ -1925,8 +1925,8 @@ class ServerService:
         # First-Party
         from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-        metrics_cache.invalidate("servers")
-        metrics_cache.invalidate_prefix("top_servers:")
+        await metrics_cache.invalidate_async("servers")
+        await metrics_cache.invalidate_prefix_async("top_servers:")
 
     def get_oauth_protected_resource_metadata(self, db: Session, server_id: str, resource_base_url: str) -> Dict[str, Any]:
         """

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -622,7 +622,7 @@ class ToolService:
         cache_key = f"top_tools:{effective_limit}:include_deleted={include_deleted}"
 
         if is_cache_enabled():
-            cached = metrics_cache.get(cache_key)
+            cached = await metrics_cache.get_async(cache_key)
             if cached is not None:
                 return cached
 
@@ -638,7 +638,7 @@ class ToolService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set(cache_key, top_performers)
+            await metrics_cache.set_async(cache_key, top_performers)
 
         return top_performers
 
@@ -2479,8 +2479,8 @@ class ToolService:
             # First-Party
             from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-            metrics_cache.invalidate_prefix("top_tools:")
-            metrics_cache.invalidate("tools")
+            await metrics_cache.invalidate_prefix_async("top_tools:")
+            await metrics_cache.invalidate_async("tools")
         except PermissionError as pe:
             db.rollback()
 
@@ -4640,7 +4640,7 @@ class ToolService:
         from mcpgateway.cache.metrics_cache import is_cache_enabled, metrics_cache  # pylint: disable=import-outside-toplevel
 
         if is_cache_enabled():
-            cached = metrics_cache.get("tools")
+            cached = await metrics_cache.get_async("tools")
             if cached is not None:
                 return cached
 
@@ -4653,7 +4653,7 @@ class ToolService:
 
         # Cache the result (if enabled)
         if is_cache_enabled():
-            metrics_cache.set("tools", metrics)
+            await metrics_cache.set_async("tools", metrics)
 
         return metrics
 
@@ -4688,8 +4688,8 @@ class ToolService:
         # First-Party
         from mcpgateway.cache.metrics_cache import metrics_cache  # pylint: disable=import-outside-toplevel
 
-        metrics_cache.invalidate("tools")
-        metrics_cache.invalidate_prefix("top_tools:")
+        await metrics_cache.invalidate_async("tools")
+        await metrics_cache.invalidate_prefix_async("top_tools:")
 
     async def create_tool_from_a2a_agent(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -608,7 +608,8 @@ env = [
     "MCPGATEWAY_ADMIN_API_ENABLED=true",
     "MCPGATEWAY_UI_ENABLED=true",
     "DATABASE_URL=sqlite:///:memory:",
-    "TEST_DATABASE_URL=sqlite:///:memory:"
+    "TEST_DATABASE_URL=sqlite:///:memory:",
+    "METRICS_CACHE_USE_REDIS=false"
 ]
 
 # ===== PLAYWRIGHT-SPECIFIC CONFIGURATIONS =====

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,10 @@ import tempfile
 import warnings
 from unittest.mock import AsyncMock
 
+# Set environment variable BEFORE any other imports to disable Redis in tests
+# This must happen at module level, before pytest collects tests
+os.environ["METRICS_CACHE_USE_REDIS"] = "false"
+
 # Third-Party
 from _pytest.monkeypatch import MonkeyPatch
 import pytest

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -62,6 +62,8 @@ from sqlalchemy.pool import StaticPool
 
 # Standard
 # Patch bootstrap_db to prevent it from running during tests
+# Disable Redis for metrics cache in tests (prevents event loop issues)
+os.environ["METRICS_CACHE_USE_REDIS"] = "false"
 
 with mock_patch("mcpgateway.bootstrap_db.main"):
     # First-Party
@@ -232,9 +234,18 @@ async def temp_db():
     sec_patcher = patch("mcpgateway.middleware.auth_middleware.security_logger", mock_sec_logger)
     sec_patcher.start()
 
+    # Replace metrics_cache singleton with local-only version to prevent Redis event loop issues
+    # First-Party
+    from mcpgateway.cache.metrics_cache import MetricsCache
+
+    local_metrics_cache = MetricsCache(redis_client=None, ttl_seconds=10)
+    cache_patcher = patch("mcpgateway.cache.metrics_cache.metrics_cache", local_metrics_cache)
+    cache_patcher.start()
+
     yield engine
 
     # Cleanup
+    cache_patcher.stop()
     sec_patcher.stop()
     test_user_context_db.close()
     app.dependency_overrides.clear()

--- a/tests/e2e/test_session_pool_e2e.py
+++ b/tests/e2e/test_session_pool_e2e.py
@@ -1112,7 +1112,7 @@ class TestMultiWorkerSessionAffinityE2E:
             # Mock httpx.AsyncClient to simulate 401 response
             mock_response = MagicMock()
             mock_response.json.return_value = {"result": {}}
-            
+
             mock_client = AsyncMock()
             mock_client.__aenter__.return_value = mock_client
             mock_client.__aexit__.return_value = None
@@ -1197,7 +1197,7 @@ class TestMultiWorkerSessionAffinityE2E:
                     "message": "Method not found"
                 }
             }
-            
+
             mock_client = AsyncMock()
             mock_client.__aenter__.return_value = mock_client
             mock_client.__aexit__.return_value = None
@@ -1232,7 +1232,7 @@ class TestMultiWorkerSessionAffinityE2E:
             mock_response.status_code = 200
             mock_response.headers = {"content-type": "application/json"}
             mock_response.content = b'{"result": "success"}'
-            
+
             mock_client = AsyncMock()
             mock_client.__aenter__.return_value = mock_client
             mock_client.__aexit__.return_value = None
@@ -1256,7 +1256,7 @@ class TestMultiWorkerSessionAffinityE2E:
                 mock_redis.publish.assert_called_once()
                 call_args = mock_redis.publish.call_args
                 assert call_args[0][0] == "test-response-channel"
-                
+
                 # Verify response structure
                 response_data = orjson.loads(call_args[0][1])
                 assert response_data["status"] == 200
@@ -1346,7 +1346,7 @@ class TestMultiWorkerSessionAffinityE2E:
             mock_pubsub = AsyncMock()
             mock_pubsub.subscribe = AsyncMock()
             mock_pubsub.unsubscribe = AsyncMock()
-            
+
             # Simulate receiving one RPC message then stopping
             call_count = 0
             async def mock_get_message(*args, **kwargs):
@@ -1369,7 +1369,7 @@ class TestMultiWorkerSessionAffinityE2E:
                 # Stop the loop by closing pool
                 pool._closed = True
                 return None
-            
+
             mock_pubsub.get_message = mock_get_message
 
             mock_redis = AsyncMock()
@@ -1386,7 +1386,7 @@ class TestMultiWorkerSessionAffinityE2E:
                     # Mock _execute_forwarded_request
                     with patch.object(pool, '_execute_forwarded_request', new_callable=AsyncMock) as mock_execute:
                         mock_execute.return_value = {"result": []}
-                        
+
                         await pool.start_rpc_listener()
 
                         # Verify message was processed
@@ -1405,7 +1405,7 @@ class TestMultiWorkerSessionAffinityE2E:
             mock_pubsub = AsyncMock()
             mock_pubsub.subscribe = AsyncMock()
             mock_pubsub.unsubscribe = AsyncMock()
-            
+
             # Simulate receiving one HTTP message then stopping
             call_count = 0
             async def mock_get_message(*args, **kwargs):
@@ -1429,7 +1429,7 @@ class TestMultiWorkerSessionAffinityE2E:
                 # Stop the loop
                 pool._closed = True
                 return None
-            
+
             mock_pubsub.get_message = mock_get_message
 
             mock_redis = AsyncMock()
@@ -1461,7 +1461,7 @@ class TestMultiWorkerSessionAffinityE2E:
             mock_pubsub = AsyncMock()
             mock_pubsub.subscribe = AsyncMock()
             mock_pubsub.unsubscribe = AsyncMock()
-            
+
             # Simulate receiving unknown message type
             call_count = 0
             async def mock_get_message(*args, **kwargs):
@@ -1477,7 +1477,7 @@ class TestMultiWorkerSessionAffinityE2E:
                     }
                 pool._closed = True
                 return None
-            
+
             mock_pubsub.get_message = mock_get_message
 
             mock_redis = AsyncMock()
@@ -1505,7 +1505,7 @@ class TestMultiWorkerSessionAffinityE2E:
             mock_pubsub = AsyncMock()
             mock_pubsub.subscribe = AsyncMock()
             mock_pubsub.unsubscribe = AsyncMock()
-            
+
             # Simulate receiving message that causes processing error
             call_count = 0
             async def mock_get_message(*args, **kwargs):
@@ -1518,7 +1518,7 @@ class TestMultiWorkerSessionAffinityE2E:
                     }
                 pool._closed = True
                 return None
-            
+
             mock_pubsub.get_message = mock_get_message
 
             mock_redis = AsyncMock()
@@ -1691,7 +1691,7 @@ class TestMultiWorkerSessionAffinityE2E:
                 # Mock httpx.AsyncClient to simulate 401 response
                 mock_response = MagicMock()
                 mock_response.json.return_value = {"result": {}}
-                
+
                 mock_client = AsyncMock()
                 mock_client.__aenter__.return_value = mock_client
                 mock_client.__aexit__.return_value = None

--- a/tests/unit/mcpgateway/cache/test_metrics_cache.py
+++ b/tests/unit/mcpgateway/cache/test_metrics_cache.py
@@ -3,12 +3,23 @@
 
 # Standard
 import builtins
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
 
 # First-Party
 from mcpgateway.cache import metrics_cache as metrics_cache_module
+
+try:
+    from redis.exceptions import RedisError
+except ImportError:
+    RedisError = Exception  # type: ignore
+
+# First-Party
+from mcpgateway.cache.metrics_cache import MetricsCache
 
 
 def test_create_metrics_cache_import_error_falls_back_to_default_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -36,3 +47,430 @@ def test_is_cache_enabled_import_error_defaults_to_enabled(monkeypatch: pytest.M
     monkeypatch.setattr(builtins, "__import__", _fake_import)
 
     assert metrics_cache_module.is_cache_enabled() is True
+
+
+class TestMetricsCacheLocal:
+    """Tests for local (non-Redis) cache behavior."""
+
+    def test_init_local_cache(self):
+        """Test initialization without Redis."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        assert cache.use_redis is False
+        assert cache.redis_client is None
+        assert cache._ttl_seconds == 10
+
+    def test_set_and_get_local(self):
+        """Test basic set/get operations with local cache."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        test_data = {"total": 100, "successful": 95}
+        
+        cache.set("tools", test_data)
+        result = cache.get("tools")
+        
+        assert result == test_data
+
+    def test_get_nonexistent_local(self):
+        """Test getting non-existent key returns None."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        assert cache.get("nonexistent") is None
+
+    def test_expiration_local(self):
+        """Test cache expiration with local cache."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("tools", {"total": 100})
+        
+        # Should be cached
+        assert cache.get("tools") is not None
+        
+        # Simulate time passing beyond TTL
+        cache._expiries["tools"] = time.time() - 1
+        assert cache.get("tools") is None
+
+    def test_invalidate_specific_local(self):
+        """Test invalidating specific cache entry."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("tools", {"total": 100})
+        cache.set("resources", {"total": 50})
+        
+        cache.invalidate("tools")
+        
+        assert cache.get("tools") is None
+        assert cache.get("resources") is not None
+
+    def test_invalidate_all_local(self):
+        """Test invalidating all cache entries."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("tools", {"total": 100})
+        cache.set("resources", {"total": 50})
+        
+        cache.invalidate()
+        
+        assert cache.get("tools") is None
+        assert cache.get("resources") is None
+
+    def test_invalidate_prefix_local(self):
+        """Test prefix-based invalidation."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("top_tools:5", [{"id": "1"}])
+        cache.set("top_tools:10", [{"id": "2"}])
+        cache.set("tools", {"total": 100})
+        
+        cache.invalidate_prefix("top_tools:")
+        
+        assert cache.get("top_tools:5") is None
+        assert cache.get("top_tools:10") is None
+        assert cache.get("tools") is not None
+
+    def test_stats_local(self):
+        """Test cache statistics tracking."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("tools", {"total": 100})
+        
+        # Generate hits and misses
+        cache.get("tools")  # Hit
+        cache.get("tools")  # Hit
+        cache.get("missing")  # Miss
+        
+        stats = cache.stats()
+        assert stats["hit_count"] == 2
+        assert stats["miss_count"] == 1
+        assert stats["hit_rate"] == 2/3
+        assert stats["backend"] == "local"
+        assert "tools" in stats["cached_types"]
+
+    def test_reset_stats_local(self):
+        """Test resetting statistics."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("tools", {"total": 100})
+        cache.get("tools")
+        
+        assert cache.stats()["hit_count"] == 1
+        
+        cache.reset_stats()
+        
+        stats = cache.stats()
+        assert stats["hit_count"] == 0
+        assert stats["miss_count"] == 0
+        assert stats["local_hit_count"] == 0
+        assert stats["local_miss_count"] == 0
+
+
+class TestMetricsCacheRedis:
+    """Tests for Redis-backed cache behavior."""
+
+    def test_init_redis_cache(self):
+        """Test initialization with Redis client."""
+        mock_redis = MagicMock()
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        assert cache.use_redis is True
+        assert cache.redis_client is mock_redis
+        assert cache._ttl_seconds == 60
+
+    async def test_get_async_redis_hit(self):
+        """Test async get with Redis hit."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = json.dumps({"total": 100})
+        
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        result = await cache.get_async("tools")
+        
+        assert result == {"total": 100}
+        mock_redis.get.assert_called_once_with("metrics:tools")
+
+    async def test_get_async_redis_miss(self):
+        """Test async get with Redis miss."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        result = await cache.get_async("tools")
+        
+        assert result is None
+        mock_redis.get.assert_called_once_with("metrics:tools")
+
+    async def test_set_async_redis(self):
+        """Test async set with Redis."""
+        mock_redis = AsyncMock()
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        test_data = {"total": 100, "successful": 95}
+        await cache.set_async("tools", test_data)
+        
+        mock_redis.setex.assert_called_once()
+        call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == "metrics:tools"
+        assert call_args[0][1] == 60
+        assert json.loads(call_args[0][2]) == test_data
+
+    async def test_invalidate_async_specific_redis(self):
+        """Test async invalidation of specific key."""
+        mock_redis = AsyncMock()
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        await cache.invalidate_async("tools")
+        
+        mock_redis.delete.assert_called_once_with("metrics:tools")
+
+    async def test_invalidate_async_all_redis_with_scan(self):
+        """Test async invalidation of all keys using SCAN with batch delete."""
+        mock_redis = AsyncMock()
+        
+        # Mock scan_iter to return keys
+        async def mock_scan_iter(pattern):
+            for key in ["metrics:tools", "metrics:resources", "metrics:prompts"]:
+                yield key
+        
+        mock_redis.scan_iter = mock_scan_iter
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        await cache.invalidate_async(None)
+        
+        # Should have called delete once with all keys (batch delete)
+        mock_redis.delete.assert_called_once_with("metrics:tools", "metrics:resources", "metrics:prompts")
+
+    async def test_redis_fallback_on_error(self):
+        """Test fallback to local cache on Redis error."""
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = RedisError("Redis connection failed")
+        
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        # Should fall back to local cache (which is empty)
+        result = await cache.get_async("tools")
+        assert result is None
+
+    async def test_redis_stats_tracking(self):
+        """Test separate Redis and local stats tracking."""
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = [
+            json.dumps({"total": 100}),  # Redis hit
+            None,  # Redis miss
+        ]
+        
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        await cache.get_async("tools")  # Redis hit
+        await cache.get_async("missing")  # Redis miss
+        
+        stats = cache.stats()
+        assert stats["redis_hit_count"] == 1
+        assert stats["redis_miss_count"] == 1
+        assert stats["hit_count"] == 1
+        assert stats["miss_count"] == 1
+
+    async def test_set_async_also_populates_local_cache(self):
+        """Test that set_async writes to both Redis and local cache."""
+        mock_redis = AsyncMock()
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        test_data = {"total": 100, "successful": 95}
+        await cache.set_async("tools", test_data)
+        
+        # Local cache should also have the value
+        assert cache._caches.get("tools") == test_data
+        assert "tools" in cache._expiries
+
+    async def test_get_async_fallback_with_populated_local_cache(self):
+        """Test fallback to local cache when Redis errors but local has data."""
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = RedisError("Redis connection failed")
+        
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        # Populate local cache first
+        test_data = {"total": 100}
+        cache._caches["tools"] = test_data
+        cache._expiries["tools"] = time.time() + 60
+        
+        # Should fall back to local cache and return the data
+        result = await cache.get_async("tools")
+        assert result == test_data
+
+    async def test_invalidate_async_clears_local_cache_on_redis_error(self):
+        """Test that invalidate_async clears local cache even if Redis fails."""
+        mock_redis = AsyncMock()
+        mock_redis.delete.side_effect = RedisError("Redis connection failed")
+        
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        # Populate local cache
+        cache._caches["tools"] = {"total": 100}
+        cache._expiries["tools"] = time.time() + 60
+        
+        # Invalidate should clear local cache despite Redis error
+        await cache.invalidate_async("tools")
+        
+        assert "tools" not in cache._caches
+        assert "tools" not in cache._expiries
+
+
+class TestMetricsCacheSyncAsyncSeparation:
+    """Tests for sync/async method separation with Redis."""
+
+    def test_sync_methods_warn_once_with_redis(self, caplog):
+        """Test that sync methods log warning only once when Redis is active."""
+        mock_redis = MagicMock()
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        # Call multiple sync methods
+        cache.get("tools")
+        cache.set("tools", {"total": 100})
+        cache.invalidate("resources")
+        cache.invalidate_prefix("top_")
+        
+        # Should only have one warning
+        warnings = [r for r in caplog.records if "Sync methods" in r.message and "Redis backend active" in r.message]
+        assert len(warnings) == 1
+        assert "This warning will only be shown once" in warnings[0].message
+
+    def test_sync_methods_work_with_redis_local_fallback(self):
+        """Test that sync methods work with Redis active (local fallback)."""
+        mock_redis = MagicMock()
+        cache = MetricsCache(redis_client=mock_redis, ttl_seconds=60)
+        
+        # Should work using local cache
+        cache.set("tools", {"total": 100})
+        result = cache.get("tools")
+        assert result == {"total": 100}
+        
+        cache.invalidate("tools")
+        assert cache.get("tools") is None
+
+    def test_sync_methods_work_without_redis(self):
+        """Test that sync methods work normally without Redis."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        
+        # Should not raise or warn
+        cache.set("tools", {"total": 100})
+        result = cache.get("tools")
+        assert result == {"total": 100}
+        
+        cache.invalidate("tools")
+        assert cache.get("tools") is None
+
+
+class TestMetricsCacheFactory:
+    """Tests for cache factory function."""
+
+    @patch("mcpgateway.cache.metrics_cache.REDIS_AVAILABLE", True)
+    @patch("mcpgateway.cache.metrics_cache.Redis")
+    @patch("mcpgateway.config.settings")
+    def test_create_with_redis_enabled(self, mock_settings, mock_redis_class):
+        """Test factory creates Redis-backed cache when configured."""
+        mock_settings.metrics_cache_ttl_seconds = 30
+        mock_settings.metrics_cache_use_redis = True
+        mock_settings.redis_url = "redis://localhost:6379"
+        
+        mock_redis_instance = MagicMock()
+        mock_redis_class.from_url.return_value = mock_redis_instance
+        
+        from mcpgateway.cache.metrics_cache import _create_metrics_cache
+        cache = _create_metrics_cache()
+        
+        assert cache.use_redis is True
+        assert cache._ttl_seconds == 30
+        mock_redis_class.from_url.assert_called_once_with(
+            "redis://localhost:6379", 
+            decode_responses=True
+        )
+
+    @patch("mcpgateway.config.settings")
+    def test_create_without_redis(self, mock_settings):
+        """Test factory creates local cache when Redis disabled."""
+        mock_settings.metrics_cache_ttl_seconds = 15
+        mock_settings.metrics_cache_use_redis = False
+        mock_settings.redis_url = None
+        
+        from mcpgateway.cache.metrics_cache import _create_metrics_cache
+        cache = _create_metrics_cache()
+        
+        assert cache.use_redis is False
+        assert cache._ttl_seconds == 15
+
+    @patch("mcpgateway.cache.metrics_cache.REDIS_AVAILABLE", True)
+    @patch("mcpgateway.cache.metrics_cache.Redis")
+    @patch("mcpgateway.config.settings")
+    def test_create_redis_connection_failure(self, mock_settings, mock_redis_class):
+        """Test factory handles Redis connection failure gracefully."""
+        mock_settings.metrics_cache_ttl_seconds = 30
+        mock_settings.metrics_cache_use_redis = True
+        mock_settings.redis_url = "redis://localhost:6379"
+        
+        # Simulate connection failure
+        mock_redis_class.from_url.side_effect = ConnectionError("Connection refused")
+        
+        from mcpgateway.cache.metrics_cache import _create_metrics_cache
+        cache = _create_metrics_cache()
+        
+        # Should fall back to local cache
+        assert cache.use_redis is False
+
+
+class TestMetricsCacheSingleton:
+    """Tests for module-level singleton and is_cache_enabled()."""
+
+    @patch("mcpgateway.config.settings")
+    def test_is_cache_enabled_returns_true_when_enabled(self, mock_settings):
+        """Test is_cache_enabled() returns True when cache is enabled."""
+        mock_settings.metrics_cache_enabled = True
+        
+        from mcpgateway.cache.metrics_cache import is_cache_enabled
+        assert is_cache_enabled() is True
+
+    @patch("mcpgateway.config.settings")
+    def test_is_cache_enabled_returns_false_when_disabled(self, mock_settings):
+        """Test is_cache_enabled() returns False when cache is disabled."""
+        mock_settings.metrics_cache_enabled = False
+        
+        from mcpgateway.cache.metrics_cache import is_cache_enabled
+        assert is_cache_enabled() is False
+
+    def test_metrics_cache_singleton_exists(self):
+        """Test that metrics_cache singleton is accessible."""
+        from mcpgateway.cache.metrics_cache import metrics_cache
+        
+        assert metrics_cache is not None
+        assert isinstance(metrics_cache, MetricsCache)
+
+
+class TestMetricsCacheResetStats:
+    """Tests for reset_stats() completeness."""
+
+    def test_reset_stats_resets_all_counters(self):
+        """Test that reset_stats() resets all 6 counters."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        
+        # Manually set all counters
+        cache._total_hit_count = 10
+        cache._total_miss_count = 5
+        cache._redis_hit_count = 3
+        cache._redis_miss_count = 2
+        cache._local_hit_count = 7
+        cache._local_miss_count = 3
+        
+        cache.reset_stats()
+        
+        # All should be zero
+        assert cache._total_hit_count == 0
+        assert cache._total_miss_count == 0
+        assert cache._redis_hit_count == 0
+        assert cache._redis_miss_count == 0
+        assert cache._local_hit_count == 0
+        assert cache._local_miss_count == 0
+
+    def test_stats_consistency_after_reset(self):
+        """Test that stats remain consistent after reset."""
+        cache = MetricsCache(redis_client=None, ttl_seconds=10)
+        cache.set("tools", {"total": 100})
+        cache.get("tools")  # Hit
+        cache.get("missing")  # Miss
+        
+        cache.reset_stats()
+        
+        stats = cache.stats()
+        assert stats["hit_count"] == 0
+        assert stats["miss_count"] == 0
+        assert stats["local_hit_count"] == 0
+        assert stats["local_miss_count"] == 0
+        assert stats["hit_rate"] == 0.0

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -2351,7 +2351,7 @@ class TestAggregateMetricsEdgeCases:
 
         monkeypatch.setattr("mcpgateway.cache.metrics_cache.is_cache_enabled", lambda: True)
         monkeypatch.setattr("mcpgateway.cache.metrics_cache.metrics_cache", SimpleNamespace(
-            get=MagicMock(return_value=cached_metrics),
+            get_async=AsyncMock(return_value=cached_metrics),
         ))
 
         result = await service.aggregate_metrics(mock_db)
@@ -2368,8 +2368,8 @@ class TestAggregateMetricsEdgeCases:
         )
 
         mock_cache = MagicMock()
-        mock_cache.get.return_value = None  # cache miss
-        mock_cache.set = MagicMock()
+        mock_cache.get_async = AsyncMock(return_value=None)  # cache miss
+        mock_cache.set_async = AsyncMock()
 
         monkeypatch.setattr("mcpgateway.cache.metrics_cache.is_cache_enabled", lambda: True)
         monkeypatch.setattr("mcpgateway.cache.metrics_cache.metrics_cache", mock_cache)
@@ -2383,4 +2383,4 @@ class TestAggregateMetricsEdgeCases:
 
         result = await service.aggregate_metrics(mock_db)
         assert result["total_agents"] == 3
-        mock_cache.set.assert_called_once()
+        mock_cache.set_async.assert_called_once()

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -1850,6 +1850,200 @@ class TestUpdateAgentAdvanced:
                     await service.update_agent(mock_db, "a1", update)
 
 
+class TestUpdateAgentQueryParamAuth:
+    """Cover update_agent query_param auth handling (lines 1085-1127)."""
+
+    @pytest.fixture
+    def service(self):
+        return A2AAgentService()
+
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock(spec=Session)
+
+    def _make_agent(self, **overrides):
+        defaults = dict(
+            id="a1", name="ag", slug="ag", endpoint_url="https://safe.host.com",
+            auth_type=None, auth_value=None, auth_query_params=None,
+            enabled=True, version=1, visibility="public", team_id=None,
+            owner_email=None, passthrough_headers=None, oauth_config=None,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    async def test_switch_to_queryparam_with_new_key_value(self, service, mock_db, monkeypatch):
+        """Switching to query_param with new key+value encrypts and stores them."""
+        agent = self._make_agent(auth_type="bearer")
+        with patch("mcpgateway.services.a2a_service.get_for_update", return_value=agent):
+            with patch("mcpgateway.config.settings") as mock_settings:
+                mock_settings.insecure_allow_queryparam_auth = True
+                mock_settings.insecure_queryparam_auth_allowed_hosts = ["safe.host.com"]
+                mock_settings.masked_auth_value = "***MASKED***"
+
+                mock_db.commit = MagicMock()
+                mock_db.refresh = MagicMock()
+                service.convert_agent_to_read = MagicMock(return_value=MagicMock())
+
+                dummy_cache = SimpleNamespace(invalidate_agents=AsyncMock())
+                monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: dummy_cache)
+                monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", SimpleNamespace(invalidate_tags=AsyncMock()))
+
+                with patch("mcpgateway.services.tool_service.tool_service") as ts:
+                    ts.update_tool_from_a2a_agent = AsyncMock(return_value=None)
+                    update = A2AAgentUpdate.model_construct(
+                        auth_type="query_param",
+                        auth_query_param_key="api_key",
+                        auth_query_param_value="my-secret-value",
+                    )
+                    await service.update_agent(mock_db, "a1", update)
+
+        assert agent.auth_type == "query_param"
+        assert agent.auth_value is None
+        assert agent.auth_query_params is not None
+        assert "api_key" in agent.auth_query_params
+
+    async def test_update_queryparam_value_only_rotation(self, service, mock_db, monkeypatch):
+        """Updating only value reuses existing key (value-only rotation)."""
+        agent = self._make_agent(
+            auth_type="query_param",
+            auth_query_params={"existing_key": "old_encrypted"},
+        )
+        with patch("mcpgateway.services.a2a_service.get_for_update", return_value=agent):
+            with patch("mcpgateway.config.settings") as mock_settings:
+                mock_settings.insecure_allow_queryparam_auth = True
+                mock_settings.insecure_queryparam_auth_allowed_hosts = ["safe.host.com"]
+                mock_settings.masked_auth_value = "***MASKED***"
+
+                mock_db.commit = MagicMock()
+                mock_db.refresh = MagicMock()
+                service.convert_agent_to_read = MagicMock(return_value=MagicMock())
+
+                dummy_cache = SimpleNamespace(invalidate_agents=AsyncMock())
+                monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: dummy_cache)
+                monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", SimpleNamespace(invalidate_tags=AsyncMock()))
+
+                with patch("mcpgateway.services.tool_service.tool_service") as ts:
+                    ts.update_tool_from_a2a_agent = AsyncMock(return_value=None)
+                    update = A2AAgentUpdate.model_construct(
+                        auth_query_param_key=None,
+                        auth_query_param_value="new-secret-value",
+                    )
+                    await service.update_agent(mock_db, "a1", update)
+
+        assert agent.auth_query_params is not None
+        assert "existing_key" in agent.auth_query_params
+
+    async def test_update_queryparam_masked_value_preserves_existing(self, service, mock_db, monkeypatch):
+        """Masked placeholder value preserves existing encrypted value."""
+        agent = self._make_agent(
+            auth_type="query_param",
+            auth_query_params={"api_key": "old_encrypted_value"},
+        )
+        with patch("mcpgateway.services.a2a_service.get_for_update", return_value=agent):
+            with patch("mcpgateway.config.settings") as mock_settings:
+                mock_settings.insecure_allow_queryparam_auth = True
+                mock_settings.insecure_queryparam_auth_allowed_hosts = ["safe.host.com"]
+                mock_settings.masked_auth_value = "***MASKED***"
+
+                mock_db.commit = MagicMock()
+                mock_db.refresh = MagicMock()
+                service.convert_agent_to_read = MagicMock(return_value=MagicMock())
+
+                dummy_cache = SimpleNamespace(invalidate_agents=AsyncMock())
+                monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: dummy_cache)
+                monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", SimpleNamespace(invalidate_tags=AsyncMock()))
+
+                with patch("mcpgateway.services.tool_service.tool_service") as ts:
+                    ts.update_tool_from_a2a_agent = AsyncMock(return_value=None)
+
+                    # Simulate SecretStr with masked value
+                    mock_secret = MagicMock()
+                    mock_secret.get_secret_value.return_value = "***MASKED***"
+                    update = A2AAgentUpdate.model_construct(
+                        auth_query_param_key="api_key",
+                        auth_query_param_value=mock_secret,
+                    )
+                    await service.update_agent(mock_db, "a1", update)
+
+        # Should preserve existing encrypted value since value was masked
+        assert agent.auth_query_params == {"api_key": "old_encrypted_value"}
+
+    async def test_update_queryparam_key_change_with_masked_value(self, service, mock_db, monkeypatch):
+        """Changing key with masked value re-encrypts with new key."""
+        agent = self._make_agent(
+            auth_type="query_param",
+            auth_query_params={"old_key": "encrypted_data"},
+        )
+        with patch("mcpgateway.services.a2a_service.get_for_update", return_value=agent):
+            with patch("mcpgateway.config.settings") as mock_settings:
+                mock_settings.insecure_allow_queryparam_auth = True
+                mock_settings.insecure_queryparam_auth_allowed_hosts = ["safe.host.com"]
+                mock_settings.masked_auth_value = "***MASKED***"
+
+                mock_db.commit = MagicMock()
+                mock_db.refresh = MagicMock()
+                service.convert_agent_to_read = MagicMock(return_value=MagicMock())
+
+                dummy_cache = SimpleNamespace(invalidate_agents=AsyncMock())
+                monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: dummy_cache)
+                monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", SimpleNamespace(invalidate_tags=AsyncMock()))
+
+                with patch("mcpgateway.services.tool_service.tool_service") as ts:
+                    ts.update_tool_from_a2a_agent = AsyncMock(return_value=None)
+
+                    # Mock decode_auth to return decrypted value
+                    with patch("mcpgateway.services.a2a_service.decode_auth", return_value={"old_key": "decrypted_secret"}):
+                        mock_secret = MagicMock()
+                        mock_secret.get_secret_value.return_value = "***MASKED***"
+                        update = A2AAgentUpdate.model_construct(
+                            auth_query_param_key="new_key",
+                            auth_query_param_value=mock_secret,
+                        )
+                        await service.update_agent(mock_db, "a1", update)
+
+        # Should have re-encrypted with new key
+        assert agent.auth_query_params is not None
+        assert "new_key" in agent.auth_query_params
+
+
+class TestListAgentsCacheError:
+    """Cover list_agents cache write AttributeError path (lines 720-721)."""
+
+    @pytest.fixture
+    def service(self):
+        return A2AAgentService()
+
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock(spec=Session)
+
+    async def test_list_agents_cache_attribute_error_ignored(self, service, mock_db, monkeypatch):
+        """AttributeError during cache write is silently ignored."""
+        # Return an agent-like object that lacks model_dump
+        agent_without_model_dump = SimpleNamespace(
+            id="a1", name="ag", slug="ag", endpoint_url="https://example.com",
+            enabled=True, visibility="public",
+        )
+
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [agent_without_model_dump]
+        mock_db.execute.return_value.scalar.return_value = 1
+
+        # Mock convert_agent_to_read to return objects without model_dump
+        result_obj = SimpleNamespace(id="a1", name="ag")
+        service.convert_agent_to_read = MagicMock(return_value=result_obj)
+
+        # Mock cache to trigger the AttributeError path
+        mock_cache = MagicMock()
+        mock_cache.get = MagicMock(return_value=None)
+        mock_cache.set = MagicMock()
+        monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: mock_cache)
+
+        # This should not raise despite the objects not having model_dump
+        result, next_cursor = await service.list_agents(mock_db)
+
+        assert result is not None
+
+
 class TestInvokeAgentEdgeCases:
     """Cover invoke_agent branches: not-found, access denied, auth paths, exceptions."""
 

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -2018,30 +2018,39 @@ class TestListAgentsCacheError:
         return MagicMock(spec=Session)
 
     async def test_list_agents_cache_attribute_error_ignored(self, service, mock_db, monkeypatch):
-        """AttributeError during cache write is silently ignored."""
-        # Return an agent-like object that lacks model_dump
-        agent_without_model_dump = SimpleNamespace(
-            id="a1", name="ag", slug="ag", endpoint_url="https://example.com",
-            enabled=True, visibility="public",
-        )
+        """AttributeError during cache write is silently ignored.
 
-        mock_db.execute.return_value.scalars.return_value.all.return_value = [agent_without_model_dump]
+        Tests coverage of the try/except block (lines 720-721) that catches AttributeError
+        when result objects don't support model_dump() during cache serialization.
+        """
+        # Setup: DB returns minimal agent object with required attributes
+        agent_obj = SimpleNamespace(
+            id="a1", name="ag", slug="ag", endpoint_url="https://example.com",
+            enabled=True, visibility="public", team_id=None,
+        )
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [agent_obj]
         mock_db.execute.return_value.scalar.return_value = 1
 
-        # Mock convert_agent_to_read to return objects without model_dump
+        # Mock convert_agent_to_read to return objects WITHOUT model_dump method
+        # This triggers the AttributeError in the cache write block when trying to serialize
         result_obj = SimpleNamespace(id="a1", name="ag")
         service.convert_agent_to_read = MagicMock(return_value=result_obj)
 
-        # Mock cache to trigger the AttributeError path
+        # Mock async cache methods properly
         mock_cache = MagicMock()
-        mock_cache.get = MagicMock(return_value=None)
-        mock_cache.set = MagicMock()
+        mock_cache.hash_filters = MagicMock(return_value="hash")
+        mock_cache.get = AsyncMock(return_value=None)
+        mock_cache.set = AsyncMock()  # Must be AsyncMock for await expression
         monkeypatch.setattr("mcpgateway.services.a2a_service._get_registry_cache", lambda: mock_cache)
 
-        # This should not raise despite the objects not having model_dump
+        # Execute: Should NOT raise AttributeError despite objects lacking model_dump()
+        # The exception during cache_data creation is silently caught (except AttributeError: pass)
         result, next_cursor = await service.list_agents(mock_db)
 
+        # Verify: Method completed successfully and returned results
         assert result is not None
+        assert len(result) == 1
+        # cache.set is never called because AttributeError occurs during list comprehension
 
 
 class TestInvokeAgentEdgeCases:

--- a/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
+++ b/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
@@ -830,3 +830,117 @@ class TestImmediateWriteMethods:
         )
         service = MetricsBufferService(enabled=False)
         service._write_a2a_agent_metric_immediately("a1", time.monotonic(), False, "invoke", "err")
+
+
+class TestShutdownCancelledError:
+    """Tests for shutdown handling CancelledError from flush task."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_handles_cancelled_error(self):
+        """Shutdown should catch CancelledError from flush task (lines 164-165)."""
+        service = MetricsBufferService(enabled=True)
+
+        class CancelledTask:
+            def __init__(self):
+                self.cancel_called = False
+
+            def cancel(self):
+                self.cancel_called = True
+
+            def __await__(self):
+                async def _raise():
+                    raise asyncio.CancelledError()
+                return _raise().__await__()
+
+        task = CancelledTask()
+        service._flush_task = task
+        service._flush_all = AsyncMock()
+
+        await service.shutdown()
+
+        assert task.cancel_called is True
+        service._flush_all.assert_awaited()
+
+
+class TestFlushLoopCancelled:
+    """Tests for _flush_loop CancelledError path."""
+
+    @pytest.mark.asyncio
+    async def test_flush_loop_cancelled_error_reraises(self, monkeypatch):
+        """_flush_loop should re-raise CancelledError (lines 401-403)."""
+        service = MetricsBufferService(enabled=True, flush_interval=1)
+
+        async def fake_wait_for(awaitable, timeout=None):
+            if hasattr(awaitable, "close"):
+                awaitable.close()
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+
+        with pytest.raises(asyncio.CancelledError):
+            await service._flush_loop()
+
+
+class TestFlushAllEmpty:
+    """Tests for _flush_all early return on empty buffers."""
+
+    @pytest.mark.asyncio
+    async def test_flush_all_returns_early_when_empty(self):
+        """_flush_all should return early when all buffers are empty (line 426)."""
+        service = MetricsBufferService(enabled=True)
+
+        # Ensure buffers are empty
+        assert len(service._tool_metrics) == 0
+
+        await service._flush_all()
+
+        # No flush should have occurred
+        assert service._flush_count == 0
+        assert service._total_flushed == 0
+
+
+class TestFlushAllCacheInvalidation:
+    """Tests for _flush_all cache invalidation error handling."""
+
+    @pytest.mark.asyncio
+    async def test_flush_all_cache_invalidation_error_swallowed(self, monkeypatch):
+        """_flush_all should swallow cache invalidation errors (lines 460-461)."""
+        service = MetricsBufferService(enabled=True)
+
+        service.record_tool_metric("tool-1", start_time=time.monotonic() - 0.1, success=True)
+
+        async def _fake_to_thread(func, *args, **kwargs):
+            pass  # Simulate successful flush
+
+        monkeypatch.setattr(asyncio, "to_thread", _fake_to_thread)
+
+        # Mock metrics_cache to raise on invalidate_async
+        mock_cache = MagicMock()
+        mock_cache.invalidate_async = AsyncMock(side_effect=RuntimeError("cache error"))
+        monkeypatch.setattr("mcpgateway.cache.metrics_cache.metrics_cache", mock_cache)
+
+        # Should not raise
+        await service._flush_all()
+
+        assert service._flush_count == 1
+
+
+class TestFlushToDbError:
+    """Tests for _flush_to_db error handling."""
+
+    def test_flush_to_db_swallows_db_error(self, monkeypatch):
+        """_flush_to_db should swallow database errors (lines 565-566)."""
+        service = MetricsBufferService(enabled=True)
+
+        monkeypatch.setattr(
+            "mcpgateway.services.metrics_buffer_service.fresh_db_session",
+            MagicMock(side_effect=Exception("connection lost")),
+        )
+
+        tool_metric = SimpleNamespace(
+            tool_id="t1", timestamp=time.time(), response_time=0.1,
+            is_success=True, error_message=None,
+        )
+
+        # Should not raise
+        service._flush_to_db([tool_metric], [], [], [], [])

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -2195,14 +2195,15 @@ class TestResourceServiceMetricsExtended:
             patch("mcpgateway.cache.metrics_cache.metrics_cache") as mock_cache,
             patch("mcpgateway.services.metrics_query_service.get_top_performers_combined") as mock_combined,
         ):
-            mock_cache.get.return_value = cached
+            mock_cache.get_async = AsyncMock(return_value=cached)
+            mock_cache.set_async = AsyncMock()
 
             result = await resource_service.get_top_resources(db, limit=2)
 
         assert result is cached
         mock_combined.assert_not_called()
-        mock_cache.get.assert_called_once()
-        mock_cache.set.assert_not_called()
+        mock_cache.get_async.assert_called_once()
+        mock_cache.set_async.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_top_resources_skips_cache_when_disabled(self, resource_service, mock_db):
@@ -4261,8 +4262,8 @@ class TestResourceServiceCoverageEdges:
             patch("mcpgateway.services.resource_service.get_for_update", side_effect=_gfu_side_effect),
             patch("mcpgateway.services.resource_service._get_registry_cache", return_value=cache),
             patch("mcpgateway.cache.admin_stats_cache.admin_stats_cache.invalidate_tags", new_callable=AsyncMock),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate_prefix"),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate"),
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate_prefix_async", new_callable=AsyncMock),
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate_async", new_callable=AsyncMock),
             patch.object(svc, "_notify_resource_updated", new_callable=AsyncMock),
             patch.object(svc, "convert_resource_to_read", return_value="resource_read"),
         ):
@@ -4303,8 +4304,8 @@ class TestResourceServiceCoverageEdges:
             patch("mcpgateway.services.resource_service.get_for_update", side_effect=_gfu_side_effect),
             patch("mcpgateway.services.resource_service._get_registry_cache", return_value=cache),
             patch("mcpgateway.cache.admin_stats_cache.admin_stats_cache.invalidate_tags", new_callable=AsyncMock),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate_prefix"),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate"),
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate_prefix_async", new_callable=AsyncMock),
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.invalidate_async", new_callable=AsyncMock),
             patch.object(svc, "_notify_resource_updated", new_callable=AsyncMock),
             patch.object(svc, "convert_resource_to_read", return_value="resource_read"),
         ):
@@ -4456,7 +4457,7 @@ class TestResourceServiceCoverageEdges:
 
         with (
             patch("mcpgateway.cache.metrics_cache.is_cache_enabled", return_value=True),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.get", return_value=cached),
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.get_async", return_value=cached),
         ):
             out = await svc.aggregate_metrics(db)
         assert out.total_executions == 1
@@ -4483,8 +4484,8 @@ class TestResourceServiceCoverageEdges:
 
         with (
             patch("mcpgateway.cache.metrics_cache.is_cache_enabled", return_value=True),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.get", return_value=None),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.set") as mock_set,
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.get_async", return_value=None),
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.set_async") as mock_set,
             patch("mcpgateway.services.metrics_query_service.aggregate_metrics_combined", return_value=combined),
         ):
             out = await svc.aggregate_metrics(db)
@@ -4513,8 +4514,8 @@ class TestResourceServiceCoverageEdges:
 
         with (
             patch("mcpgateway.cache.metrics_cache.is_cache_enabled", return_value=False),
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.get") as mock_get,
-            patch("mcpgateway.cache.metrics_cache.metrics_cache.set") as mock_set,
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.get_async") as mock_get,
+            patch("mcpgateway.cache.metrics_cache.metrics_cache.set_async") as mock_set,
             patch("mcpgateway.services.metrics_query_service.aggregate_metrics_combined", return_value=combined),
         ):
             out = await svc.aggregate_metrics(db)

--- a/tests/unit/mcpgateway/services/test_row_level_locking.py
+++ b/tests/unit/mcpgateway/services/test_row_level_locking.py
@@ -167,12 +167,15 @@ class TestToolServiceLocking:
         mock_tool_lookup_cache.invalidate = AsyncMock()
         mock_admin_stats = MagicMock()
         mock_admin_stats.invalidate_tags = AsyncMock()
+        mock_metrics_cache = MagicMock()
+        mock_metrics_cache.invalidate_prefix_async = AsyncMock()
+        mock_metrics_cache.invalidate_async = AsyncMock()
 
         with patch.object(service, "_notify_tool_deleted", return_value=None):
             with patch("mcpgateway.services.tool_service._get_registry_cache", return_value=mock_registry_cache):
                 with patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=mock_tool_lookup_cache):
                     with patch("mcpgateway.cache.admin_stats_cache.admin_stats_cache", mock_admin_stats):
-                        with patch("mcpgateway.cache.metrics_cache.metrics_cache"):
+                        with patch("mcpgateway.cache.metrics_cache.metrics_cache", mock_metrics_cache):
                             await service.delete_tool(db, "tool-id")
 
         # Verify db.get was called for initial lookup (not get_for_update)

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -1840,7 +1840,7 @@ class TestServerService:
             patch("mcpgateway.cache.metrics_cache.is_cache_enabled", return_value=True),
             patch("mcpgateway.cache.metrics_cache.metrics_cache") as mock_cache,
         ):
-            mock_cache.get.return_value = cached
+            mock_cache.get_async = AsyncMock(return_value=cached)
             result = await server_service.get_top_servers(MagicMock(), limit=5)
         assert result == cached
 
@@ -1853,10 +1853,11 @@ class TestServerService:
             patch("mcpgateway.services.metrics_query_service.get_top_performers_combined", return_value=[]),
             patch("mcpgateway.services.server_service.build_top_performers", return_value=[]),
         ):
-            mock_cache.get.return_value = None
+            mock_cache.get_async = AsyncMock(return_value=None)
+            mock_cache.set_async = AsyncMock()
             result = await server_service.get_top_servers(MagicMock(), limit=3)
         assert result == []
-        mock_cache.set.assert_called_once()
+        mock_cache.set_async.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_top_servers_cache_disabled(self, server_service):
@@ -1887,7 +1888,7 @@ class TestServerService:
             patch("mcpgateway.cache.metrics_cache.is_cache_enabled", return_value=True),
             patch("mcpgateway.cache.metrics_cache.metrics_cache") as mock_cache,
         ):
-            mock_cache.get.return_value = cached
+            mock_cache.get_async = AsyncMock(return_value=cached)
             result = await server_service.aggregate_metrics(MagicMock())
         assert result.total_executions == 10
         assert result.failed_executions == 2
@@ -1909,10 +1910,11 @@ class TestServerService:
             patch("mcpgateway.cache.metrics_cache.metrics_cache") as mock_cache,
             patch("mcpgateway.services.metrics_query_service.aggregate_metrics_combined", return_value=mock_result),
         ):
-            mock_cache.get.return_value = None
+            mock_cache.get_async = AsyncMock(return_value=None)
+            mock_cache.set_async = AsyncMock()
             result = await server_service.aggregate_metrics(MagicMock())
         assert result.total_executions == 5
-        mock_cache.set.assert_called_once()
+        mock_cache.set_async.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_aggregate_metrics_cache_disabled(self, server_service):
@@ -2748,6 +2750,8 @@ class TestDeleteServerPermission:
             mock_cache = AsyncMock()
             mock_cache_fn.return_value = mock_cache
             mock_admin_cache.invalidate_tags = AsyncMock()
+            mock_metrics_cache.invalidate_prefix_async = AsyncMock()
+            mock_metrics_cache.invalidate_async = AsyncMock()
 
             await server_service.delete_server(test_db, "srv-1", user_email="owner@test.com")
 

--- a/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
@@ -834,6 +834,14 @@ class TestMemberCountsCachedEdge:
         mock_redis = AsyncMock()
         mock_redis.mget = AsyncMock(return_value=[b"5"])
 
+        # Mock DB query to return empty (no cache misses)
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        mock_filter.group_by = MagicMock(return_value=mock_filter)
+        mock_filter.all = MagicMock(return_value=[])  # No DB results since cache hit
+        mock_query.filter = MagicMock(return_value=mock_filter)
+        db.query = MagicMock(return_value=mock_query)
+
         with patch("mcpgateway.services.team_management_service.settings") as mock_settings, \
              patch("mcpgateway.services.team_management_service.get_redis_client", AsyncMock(return_value=mock_redis)):
             mock_settings.team_member_count_cache_enabled = True

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -125,7 +125,6 @@ def setup_db_execute_mock(test_db, mock_tool, mock_global_config):
     mock_scalar_tool.scalars.return_value = mock_scalar_tool
     mock_scalar_tool.all.return_value = [mock_tool] if mock_tool else []
 
-
     test_db.execute = Mock(return_value=mock_scalar_tool)
 
     # Mock db.query() for GlobalConfig cache (Issue #1715)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -241,7 +241,7 @@ class TestToolServiceHelpersExtended:
         cached = [SimpleNamespace(id="tool-1")]
 
         monkeypatch.setattr(cache_module, "is_cache_enabled", lambda: True)
-        cache_module.metrics_cache.get = MagicMock(return_value=cached)
+        cache_module.metrics_cache.get_async = AsyncMock(return_value=cached)
 
         mock_combined = MagicMock()
         monkeypatch.setattr("mcpgateway.services.tool_service.get_top_performers_combined", mock_combined)

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -203,8 +203,10 @@ def test_supports_transport_properties():
 # --------------------------------------------------------------------------- #
 #                          Response Compression                               #
 # --------------------------------------------------------------------------- #
-def test_compression_default_values():
+def test_compression_default_values(monkeypatch):
     """Test that compression settings have correct defaults."""
+    # Clear any environment variable that might override the default
+    monkeypatch.delenv("COMPRESSION_ENABLED", raising=False)
     s = Settings(_env_file=None)
     assert s.compression_enabled is True
     assert s.compression_minimum_size == 500


### PR DESCRIPTION
> **Note:** This PR was re-created from #2857 due to repository maintenance. Your code and branch are intact. @gcgoncalves please verify everything looks good.

# 🐛 Bug-fix PR

## 📌 Summary
Implements centralized metrics aggregation cache using Redis to solve metric fluctuation issue in multi-instance deployments behind load balancers. This change is behind the `METRICS_CACHE_USE_REDIS` feature flag.

The downside of this approach is that the metrics are updated on the UI only after the cache TTL is expired. The cache TTL is defined using the `METRICS_CACHE_TTL_SECONDS` environment setting.

Closes #2643

## 🔁 Reproduction Steps
1. Navigate to `http://localhost:8080/admin/#metrics`
2. Note the "Total Executions" value
3. Refresh the page (F5 or Ctrl+R)
4. Observe the value changes significantly (up or down)
5. Repeat several times - values appear random

https://github.com/IBM/mcp-context-forge/issues/2643

## 🐞 Root Cause
- Each gateway instance had its own in-memory cache of PostgreSQL aggregates
- Load balancer routing to different instances showed different cached values
- Metrics fluctuated non-monotonically on page refresh (e.g., 32075 → 21858)

## 💡 Fix Description
- Shared Redis cache for aggregated query results across all instances
- Cache invalidation after buffer flush ensures consistency
- Automatic fallback to local cache if Redis unavailable
- Default enabled (`METRICS_CACHE_USE_REDIS=true`)

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
