### PR TITLE
feat(api): add PATCH endpoint for user updates

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-10T16:19:24Z",
+  "generated_at": "2026-05-10T16:42:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5970,7 +5970,7 @@
         "hashed_secret": "0378e32875a5f7f922d2cce11b0741096d61c5f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 483,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5978,7 +5978,7 @@
         "hashed_secret": "8b5f2dff4edd3be66dd04ef8f9b6da4f6a4d0463",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 506,
+        "line_number": 517,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5986,7 +5986,7 @@
         "hashed_secret": "1c5d7338a53cbdce0a6d26c4572e9725eb94ffc0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 519,
+        "line_number": 530,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5994,7 +5994,7 @@
         "hashed_secret": "673563640ec0c172e8d6f1316ae097269e3986c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 527,
+        "line_number": 538,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6002,7 +6002,7 @@
         "hashed_secret": "0269ac00d06201bd7bcf234fed607b713469d2d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 562,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6010,7 +6010,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 742,
+        "line_number": 753,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7106,7 +7106,7 @@
         "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 701,
+        "line_number": 724,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7114,7 +7114,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1465,
+        "line_number": 1488,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7122,7 +7122,7 @@
         "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1534,
+        "line_number": 1557,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7130,7 +7130,7 @@
         "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1638,
+        "line_number": 1661,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7138,7 +7138,7 @@
         "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1669,
+        "line_number": 1692,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7146,7 +7146,7 @@
         "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1686,
+        "line_number": 1709,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7154,7 +7154,7 @@
         "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1720,
+        "line_number": 1743,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7162,7 +7162,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2179,
+        "line_number": 2202,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -829,14 +829,14 @@ async def update_user_deprecated(
         HTTPException: If user not found or update fails
     """
     result = await update_user_delegate(user_email, user_request, current_user_ctx, db)
-    deprecation_date = "@" + str(int(datetime(2026, 2, 24, 23, 59, 59).timestamp()))
+    deprecation_date = "@" + str(int(datetime(2026, 2, 24, 23, 59, 59, tzinfo=UTC).timestamp()))
     response.headers["Deprecation"] = deprecation_date
     response.headers["Sunset"] = "Sun, 16 Aug 2026 23:59:59 UTC"
     return result
 
 
 async def update_user_delegate(user_email: str, user_request: AdminUserUpdateRequest, current_user_ctx: dict, db: Session):
-    """Update user information. Common function for both update_user and update_user_depreciated.
+    """Update user information. Common function for both update_user and update_user_deprecated.
     Helps in reducing duplicate code and consistent behaviour. Move this entire code back to update_user after
     Sun, 16 Aug 2026 23:59:59 UTC.
 

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -829,7 +829,7 @@ async def update_user_deprecated(
         HTTPException: If user not found or update fails
     """
     result = await update_user_delegate(user_email, user_request, current_user_ctx, db)
-    deprecation_date = "@" + str(int(datetime(2026, 2, 24, 23, 59, 59, tzinfo=UTC).timestamp()))
+    deprecation_date = "@" + str(int(datetime(2026, 3, 31, 23, 59, 59, tzinfo=UTC).timestamp()))
     response.headers["Deprecation"] = deprecation_date
     response.headers["Sunset"] = "Sun, 16 Aug 2026 23:59:59 UTC"
     return result

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta, UTC
 from typing import List, Optional, Union
 
 # Third-Party
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.security import HTTPBearer
 from sqlalchemy.orm import Session
 
@@ -787,10 +787,58 @@ async def get_user(user_email: str, current_user_ctx: dict = Depends(get_current
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve user")
 
 
-@email_auth_router.put("/admin/users/{user_email}", response_model=EmailUserResponse)
+@email_auth_router.patch("/admin/users/{user_email}", response_model=EmailUserResponse)
 @require_permission("admin.user_management")
 async def update_user(user_email: str, user_request: AdminUserUpdateRequest, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
     """Update user information (admin only).
+
+    Args:
+        user_email: Email of user to update
+        user_request: Updated user information
+        current_user_ctx: Currently authenticated user context with permissions
+        db: Database session
+
+    Returns:
+        EmailUserResponse: Updated user information
+
+    Raises:
+        HTTPException: If user not found or update fails
+    """
+    return await update_user_delegate(user_email, user_request, current_user_ctx, db)
+
+
+# ----------------------> [#2754] remove after Sun, 16 Aug 2026 23:59:59 UTC and replace update_user as dirrected in the docstring of update_user_delegate
+@email_auth_router.put("/admin/users/{user_email}", response_model=EmailUserResponse, deprecated=True)
+@require_permission("admin.user_management")
+async def update_user_depreciated(
+    user_email: str, user_request: AdminUserUpdateRequest, response: Response, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)
+):
+    """Update user information (admin only). Deprecated: use PATCH instead.
+
+    Args:
+        user_email: Email of user to update
+        user_request: Updated user information
+        current_user_ctx: Currently authenticated user context with permissions
+        db: Database session
+        response: FastAPI Response object to manipulate the headers
+
+    Returns:
+        EmailUserResponse: Updated user information
+
+    Raises:
+        HTTPException: If user not found or update fails
+    """
+    result = await update_user_delegate(user_email, user_request, current_user_ctx, db)
+    deprecation_date = "@" + str(int(datetime(2026, 2, 24, 23, 59, 59).timestamp()))
+    response.headers["Deprecation"] = deprecation_date
+    response.headers["Sunset"] = "Sun, 16 Aug 2026 23:59:59 UTC"
+    return result
+
+
+async def update_user_delegate(user_email: str, user_request: AdminUserUpdateRequest, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Update user information. Common function for both update_user and update_user_depreciated.
+    Helps in reducing duplicate code and consistent behaviour. Move this entire code back to update_user after
+    Sun, 16 Aug 2026 23:59:59 UTC.
 
     Args:
         user_email: Email of user to update
@@ -833,6 +881,7 @@ async def update_user(user_email: str, user_request: AdminUserUpdateRequest, cur
     except Exception as e:
         logger.error(f"Error updating user {SecurityValidator.sanitize_log_message(user_email)}: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
+# -------------------------->
 
 
 @email_auth_router.delete("/admin/users/{user_email}", response_model=SuccessResponse)

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -807,7 +807,7 @@ async def update_user(user_email: str, user_request: AdminUserUpdateRequest, cur
     return await update_user_delegate(user_email, user_request, current_user_ctx, db)
 
 
-# ----------------------> [#2754] remove after Sun, 16 Aug 2026 23:59:59 UTC and replace update_user as dirrected in the docstring of update_user_delegate
+# ----------------------> [#2754] remove after Sun, 16 Aug 2026 23:59:59 UTC and replace update_user as directed in the docstring of update_user_delegate
 @email_auth_router.put("/admin/users/{user_email}", response_model=EmailUserResponse, deprecated=True)
 @require_permission("admin.user_management")
 async def update_user_deprecated(

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -810,7 +810,7 @@ async def update_user(user_email: str, user_request: AdminUserUpdateRequest, cur
 # ----------------------> [#2754] remove after Sun, 16 Aug 2026 23:59:59 UTC and replace update_user as dirrected in the docstring of update_user_delegate
 @email_auth_router.put("/admin/users/{user_email}", response_model=EmailUserResponse, deprecated=True)
 @require_permission("admin.user_management")
-async def update_user_depreciated(
+async def update_user_deprecated(
     user_email: str, user_request: AdminUserUpdateRequest, response: Response, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)
 ):
     """Update user information (admin only). Deprecated: use PATCH instead.
@@ -835,7 +835,7 @@ async def update_user_depreciated(
     return result
 
 
-async def update_user_delegate(user_email: str, user_request: AdminUserUpdateRequest, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+async def update_user_delegate(user_email: str, user_request: AdminUserUpdateRequest, current_user_ctx: dict, db: Session):
     """Update user information. Common function for both update_user and update_user_depreciated.
     Helps in reducing duplicate code and consistent behaviour. Move this entire code back to update_user after
     Sun, 16 Aug 2026 23:59:59 UTC.

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -881,6 +881,8 @@ async def update_user_delegate(user_email: str, user_request: AdminUserUpdateReq
     except Exception as e:
         logger.error(f"Error updating user {SecurityValidator.sanitize_log_message(user_email)}: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
+
+
 # -------------------------->
 
 

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -831,7 +831,7 @@ async def update_user_deprecated(
     result = await update_user_delegate(user_email, user_request, current_user_ctx, db)
     deprecation_date = "@" + str(int(datetime(2026, 3, 31, 23, 59, 59, tzinfo=UTC).timestamp()))
     response.headers["Deprecation"] = deprecation_date
-    response.headers["Sunset"] = "Sun, 16 Aug 2026 23:59:59 UTC"
+    response.headers["Sunset"] = "Sun, 16 Aug 2026 23:59:59 GMT"
     return result
 
 

--- a/scripts/test_email_auth_api.py
+++ b/scripts/test_email_auth_api.py
@@ -469,9 +469,9 @@ def test_admin_update_partial(ctx: TestContext):
     test("Name-only update with PUT returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("Name updated", resp.body.get("full_name") == "Updated Name2")
-        test("is_admin preserved (False)", resp.body.get("is_admin") is True)
-        test("is_active preserved (True)", resp.body.get("is_active") is False)
-        test("pcr preserved (False)", resp.body.get("password_change_required") is True)
+        test("is_admin preserved (True)", resp.body.get("is_admin") is True)
+        test("is_active preserved (False)", resp.body.get("is_active") is False)
+        test("pcr preserved (True)", resp.body.get("password_change_required") is True)
     #---------->
 
     # Update non-existent user

--- a/scripts/test_email_auth_api.py
+++ b/scripts/test_email_auth_api.py
@@ -389,7 +389,7 @@ def test_admin_update_partial(ctx: TestContext):
     ctx.create_user(email, full_name="Original Name")
 
     # Update name only — other fields must be preserved
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"full_name": "Updated Name"})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"full_name": "Updated Name"})
     test("Name-only update returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("Name updated", resp.body.get("full_name") == "Updated Name")
@@ -402,43 +402,43 @@ def test_admin_update_partial(ctx: TestContext):
     test("Login after partial update works", resp.status in (200, 403), f"status={resp.status}")
 
     # Update is_active only
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"is_active": False})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"is_active": False})
     test("is_active-only update returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("is_active changed to False", resp.body.get("is_active") is False)
         test("Name preserved", resp.body.get("full_name") == "Updated Name")
 
     # Reactivate
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"is_active": True})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"is_active": True})
     test("Reactivate returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("is_active back to True", resp.body.get("is_active") is True)
 
     # Update is_admin only
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"is_admin": True})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"is_admin": True})
     test("is_admin-only update returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("is_admin changed to True", resp.body.get("is_admin") is True)
 
     # Demote
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"is_admin": False})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"is_admin": False})
     test("Demote returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("is_admin back to False", resp.body.get("is_admin") is False)
 
     # Update pcr only
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"password_change_required": True})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"password_change_required": True})
     test("pcr-only update returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("pcr changed to True", resp.body.get("password_change_required") is True)
 
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"password_change_required": False})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"password_change_required": False})
     test("Clear pcr returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("pcr back to False", resp.body.get("password_change_required") is False)
 
     # Empty body (no-op)
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {})
     test("Empty body update returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("No-op preserves name", resp.body.get("full_name") == "Updated Name")
@@ -447,7 +447,7 @@ def test_admin_update_partial(ctx: TestContext):
 
     # Multi-field update
     resp = ctx.api(
-        "PUT",
+        "PATCH",
         f"/auth/email/admin/users/{email}",
         {
             "full_name": "Multi Updated",
@@ -463,8 +463,19 @@ def test_admin_update_partial(ctx: TestContext):
         test("Multi: is_active updated", resp.body.get("is_active") is False)
         test("Multi: pcr updated", resp.body.get("password_change_required") is True)
 
+    #----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
+    # Update name only — other fields must be preserved
+    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"full_name": "Updated Name2"})
+    test("Name-only update with PUT returns 200", resp.status == 200, f"status={resp.status}")
+    if resp.status == 200:
+        test("Name updated", resp.body.get("full_name") == "Updated Name2")
+        test("is_admin preserved (False)", resp.body.get("is_admin") is True)
+        test("is_active preserved (True)", resp.body.get("is_active") is False)
+        test("pcr preserved (False)", resp.body.get("password_change_required") is True)
+    #---------->
+
     # Update non-existent user
-    resp = ctx.api("PUT", "/auth/email/admin/users/nonexistent-xyz@example.com", {"full_name": "Ghost"})
+    resp = ctx.api("PATCH", "/auth/email/admin/users/nonexistent-xyz@example.com", {"full_name": "Ghost"})
     test("Update non-existent user returns 404", resp.status == 404, f"status={resp.status}")
 
 
@@ -477,7 +488,7 @@ def test_password_management(ctx: TestContext):
 
     # Admin sets temp password + forces password change
     resp = ctx.api(
-        "PUT",
+        "PATCH",
         f"/auth/email/admin/users/{email}",
         {
             "password": "TempPass999!",
@@ -489,7 +500,7 @@ def test_password_management(ctx: TestContext):
         test("pcr=True honored despite password change", resp.body.get("password_change_required") is True)
 
     # Admin resets password without explicit pcr (should auto-clear)
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"password": "FinalPass999!"})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"password": "FinalPass999!"})
     test("Password reset without pcr returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("pcr auto-cleared to False", resp.body.get("password_change_required") is False)
@@ -503,7 +514,7 @@ def test_password_management(ctx: TestContext):
     test("Old password rejected after reset", resp.status == 401, f"status={resp.status}")
 
     # Password update with short password
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"password": "Short!"})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email}", {"password": "Short!"})
     test("Short password in update returns 400/422", resp.status in (400, 422), f"status={resp.status}")
 
     # Change password via user endpoint (self-service)
@@ -748,7 +759,7 @@ def test_edge_cases(ctx: TestContext):
     # Idempotent update (set same value)
     email_idem = test_email("idempotent")
     ctx.create_user(email_idem, full_name="Idempotent User", is_admin=False)
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email_idem}", {"is_admin": False})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email_idem}", {"is_admin": False})
     test("Idempotent update (same value) returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("Value unchanged after idempotent update", resp.body.get("is_admin") is False)
@@ -772,14 +783,14 @@ def test_last_admin_lockout_prevention(ctx: TestContext):
     ctx.create_user(email_b, is_admin=True, full_name="Guard Admin B")
 
     # Demoting A should succeed (B + platform admin still active)
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email_a}", {"is_admin": False})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email_a}", {"is_admin": False})
     test("Demote non-last admin returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("Non-last admin demoted", resp.body.get("is_admin") is False)
 
     # Re-promote A, then deactivate A (different path)
-    ctx.api("PUT", f"/auth/email/admin/users/{email_a}", {"is_admin": True})
-    resp = ctx.api("PUT", f"/auth/email/admin/users/{email_a}", {"is_active": False})
+    ctx.api("PATCH", f"/auth/email/admin/users/{email_a}", {"is_admin": True})
+    resp = ctx.api("PATCH", f"/auth/email/admin/users/{email_a}", {"is_active": False})
     test("Deactivate non-last admin returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:
         test("Non-last admin deactivated", resp.body.get("is_active") is False)
@@ -800,7 +811,7 @@ def test_last_admin_lockout_prevention(ctx: TestContext):
 
     # We'll make email_b the sole active admin.
     # Reactivate B in case it got touched, ensure admin+active.
-    ctx.api("PUT", f"/auth/email/admin/users/{email_b}", {"is_admin": True, "is_active": True})
+    ctx.api("PATCH", f"/auth/email/admin/users/{email_b}", {"is_admin": True, "is_active": True})
 
     # Demote every OTHER active admin (except email_b) temporarily.
     demoted: list[str] = []
@@ -808,19 +819,19 @@ def test_last_admin_lockout_prevention(ctx: TestContext):
         uemail = u["email"]
         if uemail == email_b:
             continue
-        r = ctx.api("PUT", f"/auth/email/admin/users/{uemail}", {"is_admin": False})
+        r = ctx.api("PATCH", f"/auth/email/admin/users/{uemail}", {"is_admin": False})
         if r.status == 200:
             demoted.append(uemail)
             vprint(f"Temporarily demoted {uemail}")
 
     try:
         # Now email_b should be the sole active admin. Verify the guard.
-        resp = ctx.api("PUT", f"/auth/email/admin/users/{email_b}", {"is_admin": False})
+        resp = ctx.api("PATCH", f"/auth/email/admin/users/{email_b}", {"is_admin": False})
         test("Demote last admin returns 400", resp.status == 400, f"status={resp.status}")
         if resp.status == 400:
             test("Demote error mentions last admin", "last" in resp.body.get("detail", "").lower())
 
-        resp = ctx.api("PUT", f"/auth/email/admin/users/{email_b}", {"is_active": False})
+        resp = ctx.api("PATCH", f"/auth/email/admin/users/{email_b}", {"is_active": False})
         test("Deactivate last admin returns 400", resp.status == 400, f"status={resp.status}")
         if resp.status == 400:
             test("Deactivate error mentions last admin", "last" in resp.body.get("detail", "").lower())
@@ -833,7 +844,7 @@ def test_last_admin_lockout_prevention(ctx: TestContext):
     finally:
         # Restore all temporarily demoted admins
         for uemail in demoted:
-            ctx.api("PUT", f"/auth/email/admin/users/{uemail}", {"is_admin": True})
+            ctx.api("PATCH", f"/auth/email/admin/users/{uemail}", {"is_admin": True})
             vprint(f"Restored admin: {uemail}")
 
 

--- a/scripts/test_email_auth_api.py
+++ b/scripts/test_email_auth_api.py
@@ -464,7 +464,7 @@ def test_admin_update_partial(ctx: TestContext):
         test("Multi: pcr updated", resp.body.get("password_change_required") is True)
 
     #----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
-    # Update name only — other fields must be preserved
+    # Tests to improve the coverage and maintain compatibility with PATCH endpoint
     resp = ctx.api("PUT", f"/auth/email/admin/users/{email}", {"full_name": "Updated Name2"})
     test("Name-only update with PUT returns 200", resp.status == 200, f"status={resp.status}")
     if resp.status == 200:

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -650,17 +650,14 @@ async def test_admin_get_update_delete_user():
             admin_origin_source="api",
         )
         assert response_input.headers["deprecation"] == "@1775001599"
-        assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 UTC"
+        assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 GMT"
         #----------->
 
         delete_response = await email_auth.delete_user("user@example.com", current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
         assert delete_response.success is True
 
         #----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
-        if datetime(2026, 8, 16, 23, 59, 59) < datetime.now():
-            pytest.xfail("Time to remove this code visit #2754")
-        else:
-            assert datetime(2026, 8, 16, 23, 59, 59) > datetime.now(), "Will soon deprecate"
+        assert datetime.now(timezone.utc) < datetime(2026, 8, 16, 23, 59, 59, tzinfo=timezone.utc), "Sunset reached: remove deprecated PUT endpoint. See #2754"
         #----------->
 
 

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -644,6 +644,7 @@ async def test_admin_get_update_delete_user():
             full_name="Updated2",
             is_admin=True,
             is_active=None,
+            email_verified=None,
             password_change_required=None,
             password="newPassword123!",
             admin_origin_source="api",

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -637,7 +637,7 @@ async def test_admin_get_update_delete_user():
         #----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
         response_input = Response()
         update_request = AdminUserUpdateRequest(password="newPassword123!", full_name="Updated2", is_admin=True)
-        response = await email_auth.update_user_depreciated("user@example.com", update_request, response_input, current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
+        response = await email_auth.update_user_deprecated("user@example.com", update_request, response_input, current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
         # Verify update_user was called with correct params
         auth_service.update_user.assert_called_with(
             email="user@example.com",
@@ -650,11 +650,17 @@ async def test_admin_get_update_delete_user():
         )
         assert response_input.headers["deprecation"] == "@1771977599"
         assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 UTC"
-        assert datetime(2026, 8, 16, 23, 59, 59) > datetime.now() , "Time to remove this code visit #2754"
         #----------->
 
         delete_response = await email_auth.delete_user("user@example.com", current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
         assert delete_response.success is True
+
+        #----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
+        if datetime(2026, 8, 16, 23, 59, 59) < datetime.now():
+            pytest.xfail("Time to remove this code visit #2754")
+        else:
+            assert datetime(2026, 8, 16, 23, 59, 59) > datetime.now(), "Will soon deprecate"
+        #----------->
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
-from fastapi import HTTPException, status
+from fastapi import HTTPException, status, Response
 import pytest
 
 # First-Party
@@ -633,6 +633,25 @@ async def test_admin_get_update_delete_user():
             password="newPassword123!",
             admin_origin_source="api",
         )
+
+        #----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
+        response_input = Response()
+        update_request = AdminUserUpdateRequest(password="newPassword123!", full_name="Updated2", is_admin=True)
+        response = await email_auth.update_user_depreciated("user@example.com", update_request, response_input, current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
+        # Verify update_user was called with correct params
+        auth_service.update_user.assert_called_with(
+            email="user@example.com",
+            full_name="Updated2",
+            is_admin=True,
+            is_active=None,
+            password_change_required=None,
+            password="newPassword123!",
+            admin_origin_source="api",
+        )
+        assert response_input.headers["deprecation"] == "@1771977599"
+        assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 UTC"
+        assert datetime(2026, 8, 16, 23, 59, 59) > datetime.now() , "Time to remove this code visit #2754"
+        #----------->
 
         delete_response = await email_auth.delete_user("user@example.com", current_user_ctx={"db": mock_db, "email": "admin@example.com"}, db=mock_db)
         assert delete_response.success is True

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -648,7 +648,7 @@ async def test_admin_get_update_delete_user():
             password="newPassword123!",
             admin_origin_source="api",
         )
-        assert response_input.headers["deprecation"] == "@1771977599"
+        assert response_input.headers["deprecation"] == "@1775001599"
         assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 UTC"
         #----------->
 


### PR DESCRIPTION
> **Note:** This PR was re-created from #2896 due to repository maintenance. Your code and branch are intact. @ja8zyjits please verify everything looks good.


<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #2754

---

## 📝 Summary
- Added Deprecation and Sunset headers for PUT route with reference to https://datatracker.ietf.org/doc/rfc9745/. 
- Both PATCH and PUT will exist till Sun, 16 Aug 2026 23:59:59 UTC; after which PUT will be removed completely
- Made both PUT and PATCH call same delegated function to maintain the behavior and cover all the test cases.
- Didn't make changes to Admin UI, since it uses POST and not PUT
- Appropriate comments are made in the code for removal guidance in future
- A condition is inserted to fail tests after sunset period to make sure PUT endpoint is removed.


---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    passes all linters    |
| Unit tests                | `make test`     |    all unit + integration tests green    |
| Coverage ≥ 80%            | `make coverage` |    98%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## Acceptance Criteria
- [x] PATCH /auth/email/admin/users/{email} works with partial payloads
- [x] PUT /auth/email/admin/users/{email} still works but returns Deprecation header
- [x] OpenAPI docs show PUT as deprecated with migration guidance
- [x] Integration tests (scripts/test_email_auth_api.py) updated to use PATCH
- [x] Unit tests cover both endpoints
 