### PR TITLE
feat(mcp): add GraphQL to MCP translation support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2811,6 +2811,25 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # MCPGATEWAY_GRPC_TLS_ENABLED=false
 
 # =============================================================================
+# GraphQL Support Settings (EXPERIMENTAL)
+# =============================================================================
+
+# Enable GraphQL to MCP translation support (disabled by default)
+# MCPGATEWAY_GRAPHQL_ENABLED=false
+
+# Enable GraphQL schema introspection by default
+# MCPGATEWAY_GRAPHQL_INTROSPECTION_ENABLED=true
+
+# Maximum GraphQL field selection depth for auto-discovered tools
+# MCPGATEWAY_GRAPHQL_MAX_DEPTH=3
+
+# Default GraphQL operation timeout in seconds
+# MCPGATEWAY_GRAPHQL_TIMEOUT=30
+
+# Include GraphQL mutations when discovering tools
+# MCPGATEWAY_GRAPHQL_INCLUDE_MUTATIONS=true
+
+# =============================================================================
 # Audit Trail Logging
 # =============================================================================
 

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -737,6 +737,13 @@ mcpContextForge:
     MCPGATEWAY_GRPC_REFLECTION_ENABLED: "true" # enable gRPC reflection
     MCPGATEWAY_GRPC_TLS_ENABLED: "false" # enable gRPC TLS
 
+    # GraphQL support (experimental)
+    MCPGATEWAY_GRAPHQL_ENABLED: "false" # enable GraphQL
+    MCPGATEWAY_GRAPHQL_TIMEOUT: "30" # GraphQL timeout (seconds)
+    MCPGATEWAY_GRAPHQL_MAX_DEPTH: "3" # max field selection depth
+    MCPGATEWAY_GRAPHQL_INTROSPECTION_ENABLED: "true" # enable GraphQL introspection
+    MCPGATEWAY_GRAPHQL_INCLUDE_MUTATIONS: "true" # include mutations
+
     # Performance tracking (internal)
     PERFORMANCE_TRACKING_ENABLED: "true" # enable performance tracking
     PERFORMANCE_THRESHOLD_DATABASE_QUERY_MS: "100.0" # DB query threshold (ms)

--- a/docs/docs/architecture/adr/.pages
+++ b/docs/docs/architecture/adr/.pages
@@ -43,3 +43,4 @@ nav:
   - 38b Multi-Worker Session Affinity: 038-multi-worker-session-affinity.md
   - 39 Adopt Fully Independent Plugin Crates Architecture: 039-adopt-fully-independent-plugin-crates-architecture.md
   - 40 Flexible Admin UI Section Visibility: 040-flexible-admin-ui-sections.md
+  - 41 GraphQL to MCP Translation: 041-graphql-to-mcp-translation.md

--- a/docs/docs/architecture/adr/041-graphql-to-mcp-translation.md
+++ b/docs/docs/architecture/adr/041-graphql-to-mcp-translation.md
@@ -1,0 +1,103 @@
+# ADR-0041: GraphQL to MCP Translation
+
+- *Status:* Accepted
+- *Date:* 2026-02-17
+- *Deciders:* Mihai Criveti
+
+## Context
+
+MCP Gateway already supports REST passthrough and gRPC-to-MCP translation (ADR-0038-style experimental feature). Many organizations expose their APIs via GraphQL, which provides a self-describing schema through its introspection system. To allow MCP clients to interact with GraphQL services without manual tool definitions, the gateway needs a GraphQL translation layer analogous to the existing gRPC support.
+
+Key requirements:
+
+- **Auto-discovery**: Use GraphQL's built-in introspection to discover queries, mutations, and their argument/return types automatically.
+- **Dual-mode operation**: Support both a standalone CLI bridge (`translate_graphql.py`) and direct tool registration via `integration_type=GRAPHQL`.
+- **Feature-flagged**: Follow the gRPC pattern — disabled by default, opt-in via `MCPGATEWAY_GRAPHQL_ENABLED`.
+- **Depth control**: GraphQL schemas can be deeply nested; auto-generated field selections need a configurable depth limit.
+- **Authentication**: Support bearer tokens, basic auth, and custom headers for upstream GraphQL endpoints.
+
+## Decision
+
+### 1. GraphQL Introspection → MCP Tool Mapping
+
+The `GraphQLToMcpTranslator` class sends a standard introspection query to the GraphQL endpoint and:
+
+- Extracts all `Query` and `Mutation` fields (optionally `Subscription`)
+- Generates JSON Schema for each operation's input arguments using `GRAPHQL_SCALAR_TYPE_MAP`
+- Builds optimized field selections respecting `max_depth` via `QueryBuilder`
+- Exposes each operation as an MCP tool with name, description, and input schema
+
+### 2. Dual-Mode Architecture
+
+**CLI Bridge** (`python -m mcpgateway.translate_graphql`):
+
+- Standalone process that introspects a GraphQL endpoint and serves discovered tools via HTTP/SSE
+- Useful for quick integration without modifying gateway configuration
+- Can be registered as an MCP gateway via `POST /gateways`
+
+**Direct Registration** (`POST /tools` with `integration_type=GRAPHQL`):
+
+- Register individual GraphQL operations as MCP tools
+- Uses `graphql_operation`, `graphql_operation_type`, and `graphql_variables_mapping` fields
+- Validated by schema-level validators that enforce field constraints per integration type
+
+### 3. Database Schema Extension
+
+New nullable columns on the `tools` table:
+
+- `graphql_operation` (Text): The GraphQL query/mutation string
+- `graphql_variables_mapping` (JSON): Maps MCP argument names to GraphQL variable names
+- `graphql_field_selection` (Text): Auto-generated or custom field selection
+- `graphql_operation_type` (String): `query`, `mutation`, or `subscription`
+
+All columns are nullable and only populated for `integration_type=GRAPHQL`. An idempotent Alembic migration adds these columns.
+
+### 4. Feature Flags
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `MCPGATEWAY_GRAPHQL_ENABLED` | `false` | Master switch for GraphQL support |
+| `MCPGATEWAY_GRAPHQL_INTROSPECTION_ENABLED` | `true` | Enable schema introspection by default |
+| `MCPGATEWAY_GRAPHQL_MAX_DEPTH` | `3` | Maximum field selection depth |
+| `MCPGATEWAY_GRAPHQL_TIMEOUT` | `30` | Default operation timeout (seconds) |
+| `MCPGATEWAY_GRAPHQL_INCLUDE_MUTATIONS` | `true` | Include mutations in discovery |
+
+## Consequences
+
+### Positive
+
+- **Seamless integration**: GraphQL APIs can be exposed as MCP tools with zero manual schema work
+- **Consistent pattern**: Follows the established gRPC experimental feature pattern (feature flags, CLI bridge, direct registration)
+- **Low risk**: Disabled by default; no impact on existing functionality
+- **Self-describing**: Leverages GraphQL's introspection rather than requiring external schema files
+
+### Negative
+
+- **Introspection dependency**: Requires the upstream GraphQL server to have introspection enabled (many production servers disable it)
+- **Depth trade-off**: Auto-generated field selections may be too shallow or too deep for specific use cases
+- **No streaming**: GraphQL subscriptions (WebSocket-based) are not fully supported in this initial implementation
+- **httpx dependency**: Uses `httpx` for HTTP, which is already a project dependency but adds to the GraphQL code path
+
+## Alternatives Considered
+
+### Manual Schema Registration Only
+
+Register GraphQL tools manually via `POST /tools` with hand-written operations. Rejected because it eliminates the auto-discovery benefit and creates high friction for services with many operations.
+
+### GraphQL Relay / SDL Parsing
+
+Parse `.graphql` SDL files instead of using introspection. Rejected because it requires users to provide schema files separately, while introspection is always available at runtime and reflects the actual deployed schema.
+
+### Proxy to Existing GraphQL Client Libraries
+
+Use a full GraphQL client library (e.g., `gql`, `sgqlc`). Rejected because the translation layer needs only introspection and simple HTTP POST — `httpx` is sufficient and avoids heavy dependencies.
+
+## Files Changed
+
+- `mcpgateway/translate_graphql.py` — CLI bridge and translation logic
+- `mcpgateway/schemas.py` — `GRAPHQL` integration type, GraphQL-specific fields, validators
+- `mcpgateway/db.py` — GraphQL columns on `Tool` ORM model
+- `mcpgateway/services/tool_service.py` — GraphQL field persistence in tool CRUD
+- `mcpgateway/config.py` — Feature flag settings
+- `mcpgateway/alembic/versions/x7h8i9j0k1l2_add_graphql_fields_to_tools.py` — Migration
+- `tests/unit/mcpgateway/test_translate_graphql.py` — Unit tests

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -42,5 +42,7 @@ This page tracks all significant design decisions made for the MCP Gateway proje
 | 0037  | External Plugin STDIO Launch with Command/Env Overrides | Accepted | Extensibility | 2026-01-28 |
 | 0038  | Experimental Rust Transport Backend (Streamable HTTP) | Proposed | Performance | 2025-12-26 |
 | 0039  | Adopt Fully Independent Plugin Crates Architecture | Accepted | Architecture | 2026-02-13 |
+| 0040  | Flexible Admin UI Section Visibility               | Accepted | User Interface | 2026-02-16 |
+| 0041  | GraphQL to MCP Translation                         | Accepted | Protocol       | 2026-02-17 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.

--- a/docs/docs/config.schema.json
+++ b/docs/docs/config.schema.json
@@ -1,1099 +1,42 @@
 {
   "description": "MCP Gateway configuration settings.\n\nExamples:\n    >>> from mcpgateway.config import Settings\n    >>> s = Settings(basic_auth_user='admin', basic_auth_password='secret')\n    >>> s.api_key\n    'admin:secret'\n    >>> s2 = Settings(transport_type='http')\n    >>> s2.validate_transport()  # no error\n    >>> s3 = Settings(transport_type='invalid')\n    >>> try:\n    ...     s3.validate_transport()\n    ... except ValueError as e:\n    ...     print('error')\n    error\n    >>> s4 = Settings(database_url='sqlite:///./test.db')\n    >>> isinstance(s4.database_settings, dict)\n    True\n    >>> s5 = Settings()\n    >>> s5.app_name\n    'MCP_Gateway'\n    >>> s5.host in ('0.0.0.0', '127.0.0.1')  # Default can be either\n    True\n    >>> s5.port\n    4444\n    >>> s5.auth_required\n    True\n    >>> isinstance(s5.allowed_origins, set)\n    True\n    >>> s6 = Settings(log_detailed_skip_endpoints=[\"/metrics\", \"/health\"])\n    >>> s6.log_detailed_skip_endpoints\n    ['/metrics', '/health']\n    >>> s7 = Settings(log_detailed_sample_rate=0.5)\n    >>> s7.log_detailed_sample_rate\n    0.5\n    >>> s8 = Settings(log_resolve_user_identity=True)\n    >>> s8.log_resolve_user_identity\n    True\n    >>> s9 = Settings()\n    >>> s9.log_detailed_skip_endpoints\n    []\n    >>> s9.log_detailed_sample_rate\n    1.0\n    >>> s9.log_resolve_user_identity\n    False",
   "properties": {
-    "app_name": {
-      "default": "MCP_Gateway",
-      "title": "App Name",
-      "type": "string"
-    },
-    "host": {
-      "default": "127.0.0.1",
-      "title": "Host",
-      "type": "string"
-    },
-    "port": {
-      "default": 4444,
-      "exclusiveMinimum": 0,
-      "maximum": 65535,
-      "minimum": 1,
-      "title": "Port",
-      "type": "integer"
-    },
-    "client_mode": {
-      "default": false,
-      "title": "Client Mode",
+    "ENABLE_METRICS": {
+      "default": true,
+      "description": "Enable Prometheus metrics instrumentation",
+      "title": "Enable Metrics",
       "type": "boolean"
     },
-    "docs_allow_basic_auth": {
-      "default": false,
-      "title": "Docs Allow Basic Auth",
-      "type": "boolean"
-    },
-    "api_allow_basic_auth": {
-      "default": false,
-      "description": "Allow Basic authentication for API endpoints. Disabled by default for security. Use JWT or API tokens instead.",
-      "title": "Api Allow Basic Auth",
-      "type": "boolean"
-    },
-    "database_url": {
-      "default": "sqlite:///./mcp.db",
-      "description": "Database connection URL. Supports SQLite, PostgreSQL, MySQL/MariaDB. For PostgreSQL with custom schema, use the 'options' query parameter: postgresql://user:pass@host:5432/db?options=-c%20search_path=schema_name (See Issue #1535 for details)",
-      "title": "Database Url",
-      "type": "string"
-    },
-    "templates_dir": {
-      "format": "path",
-      "title": "Templates Dir",
-      "type": "string"
-    },
-    "static_dir": {
-      "format": "path",
-      "title": "Static Dir",
-      "type": "string"
-    },
-    "templates_auto_reload": {
-      "default": false,
-      "description": "Auto-reload Jinja2 templates on change (enable for development)",
-      "title": "Templates Auto Reload",
-      "type": "boolean"
-    },
-    "app_root_path": {
+    "METRICS_CUSTOM_LABELS": {
       "default": "",
-      "title": "App Root Path",
+      "description": "Comma-separated \"key=value\" pairs for static custom labels",
+      "title": "Metrics Custom Labels",
       "type": "string"
     },
-    "protocol_version": {
-      "default": "2025-06-18",
-      "title": "Protocol Version",
-      "type": "string"
-    },
-    "basic_auth_user": {
-      "default": "admin",
-      "title": "Basic Auth User",
-      "type": "string"
-    },
-    "basic_auth_password": {
-      "default": "**********",
-      "format": "password",
-      "title": "Basic Auth Password",
-      "type": "string",
-      "writeOnly": true
-    },
-    "jwt_algorithm": {
-      "default": "HS256",
-      "title": "Jwt Algorithm",
-      "type": "string"
-    },
-    "jwt_secret_key": {
-      "default": "**********",
-      "format": "password",
-      "title": "Jwt Secret Key",
-      "type": "string",
-      "writeOnly": true
-    },
-    "jwt_public_key_path": {
+    "METRICS_EXCLUDED_HANDLERS": {
       "default": "",
-      "title": "Jwt Public Key Path",
+      "description": "Comma-separated regex patterns for paths to exclude from metrics",
+      "title": "Metrics Excluded Handlers",
       "type": "string"
     },
-    "jwt_private_key_path": {
+    "METRICS_NAMESPACE": {
+      "default": "default",
+      "description": "Prometheus metrics namespace",
+      "title": "Metrics Namespace",
+      "type": "string"
+    },
+    "METRICS_SUBSYSTEM": {
       "default": "",
-      "title": "Jwt Private Key Path",
+      "description": "Prometheus metrics subsystem",
+      "title": "Metrics Subsystem",
       "type": "string"
     },
-    "jwt_audience": {
-      "default": "mcpgateway-api",
-      "title": "Jwt Audience",
-      "type": "string"
-    },
-    "jwt_issuer": {
-      "default": "mcpgateway",
-      "title": "Jwt Issuer",
-      "type": "string"
-    },
-    "jwt_audience_verification": {
-      "default": true,
-      "title": "Jwt Audience Verification",
-      "type": "boolean"
-    },
-    "jwt_issuer_verification": {
-      "default": true,
-      "title": "Jwt Issuer Verification",
-      "type": "boolean"
-    },
-    "auth_required": {
-      "default": true,
-      "title": "Auth Required",
-      "type": "boolean"
-    },
-    "token_expiry": {
-      "default": 10080,
-      "title": "Token Expiry",
-      "type": "integer"
-    },
-    "require_token_expiration": {
-      "default": true,
-      "description": "Require all JWT tokens to have expiration claims (secure default)",
-      "title": "Require Token Expiration",
-      "type": "boolean"
-    },
-    "require_jti": {
-      "default": true,
-      "description": "Require JTI (JWT ID) claim in all tokens for revocation support (secure default)",
-      "title": "Require Jti",
-      "type": "boolean"
-    },
-    "require_user_in_db": {
-      "default": false,
-      "description": "Require all authenticated users to exist in the database. When true, disables the platform admin bootstrap mechanism. WARNING: Enabling this on a fresh deployment will lock you out.",
-      "title": "Require User In Db",
-      "type": "boolean"
-    },
-    "embed_environment_in_tokens": {
-      "default": false,
-      "description": "Embed environment claim in gateway-issued JWTs for environment isolation",
-      "title": "Embed Environment In Tokens",
-      "type": "boolean"
-    },
-    "validate_token_environment": {
-      "default": false,
-      "description": "Reject tokens with mismatched environment claim (tokens without env claim are allowed)",
-      "title": "Validate Token Environment",
-      "type": "boolean"
-    },
-    "json_schema_validation_strict": {
-      "default": true,
-      "description": "Strict schema validation mode - reject invalid JSON schemas",
-      "title": "Json Schema Validation Strict",
-      "type": "boolean"
-    },
-    "sso_enabled": {
-      "default": false,
-      "description": "Enable Single Sign-On authentication",
-      "title": "Sso Enabled",
-      "type": "boolean"
-    },
-    "sso_github_enabled": {
-      "default": false,
-      "description": "Enable GitHub OAuth authentication",
-      "title": "Sso Github Enabled",
-      "type": "boolean"
-    },
-    "sso_github_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "GitHub OAuth client ID",
-      "title": "Sso Github Client Id"
-    },
-    "sso_github_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "GitHub OAuth client secret",
-      "title": "Sso Github Client Secret"
-    },
-    "sso_google_enabled": {
-      "default": false,
-      "description": "Enable Google OAuth authentication",
-      "title": "Sso Google Enabled",
-      "type": "boolean"
-    },
-    "sso_google_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Google OAuth client ID",
-      "title": "Sso Google Client Id"
-    },
-    "sso_google_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Google OAuth client secret",
-      "title": "Sso Google Client Secret"
-    },
-    "sso_ibm_verify_enabled": {
-      "default": false,
-      "description": "Enable IBM Security Verify OIDC authentication",
-      "title": "Sso Ibm Verify Enabled",
-      "type": "boolean"
-    },
-    "sso_ibm_verify_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "IBM Security Verify client ID",
-      "title": "Sso Ibm Verify Client Id"
-    },
-    "sso_ibm_verify_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "IBM Security Verify client secret",
-      "title": "Sso Ibm Verify Client Secret"
-    },
-    "sso_ibm_verify_issuer": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "IBM Security Verify OIDC issuer URL",
-      "title": "Sso Ibm Verify Issuer"
-    },
-    "sso_okta_enabled": {
-      "default": false,
-      "description": "Enable Okta OIDC authentication",
-      "title": "Sso Okta Enabled",
-      "type": "boolean"
-    },
-    "sso_okta_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Okta client ID",
-      "title": "Sso Okta Client Id"
-    },
-    "sso_okta_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Okta client secret",
-      "title": "Sso Okta Client Secret"
-    },
-    "sso_okta_issuer": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Okta issuer URL",
-      "title": "Sso Okta Issuer"
-    },
-    "sso_keycloak_enabled": {
-      "default": false,
-      "description": "Enable Keycloak OIDC authentication",
-      "title": "Sso Keycloak Enabled",
-      "type": "boolean"
-    },
-    "sso_keycloak_base_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Keycloak base URL (e.g., https://keycloak.example.com)",
-      "title": "Sso Keycloak Base Url"
-    },
-    "sso_keycloak_public_base_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Browser-facing Keycloak base URL for authorization redirects (e.g., http://localhost:8180)",
-      "title": "Sso Keycloak Public Base Url"
-    },
-    "sso_keycloak_realm": {
-      "default": "master",
-      "description": "Keycloak realm name",
-      "title": "Sso Keycloak Realm",
-      "type": "string"
-    },
-    "sso_keycloak_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Keycloak client ID",
-      "title": "Sso Keycloak Client Id"
-    },
-    "sso_keycloak_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Keycloak client secret",
-      "title": "Sso Keycloak Client Secret"
-    },
-    "sso_keycloak_map_realm_roles": {
-      "default": true,
-      "description": "Map Keycloak realm roles to gateway teams",
-      "title": "Sso Keycloak Map Realm Roles",
-      "type": "boolean"
-    },
-    "sso_keycloak_map_client_roles": {
-      "default": false,
-      "description": "Map Keycloak client roles to gateway RBAC",
-      "title": "Sso Keycloak Map Client Roles",
-      "type": "boolean"
-    },
-    "sso_keycloak_role_mappings": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "description": "Map Keycloak groups/roles to Context Forge roles (JSON: {group_or_role: role_name})",
-      "title": "Sso Keycloak Role Mappings",
-      "type": "object"
-    },
-    "sso_keycloak_default_role": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Default Context Forge role for Keycloak users without role mapping",
-      "title": "Sso Keycloak Default Role"
-    },
-    "sso_keycloak_resolve_team_scope_to_personal_team": {
-      "default": false,
-      "description": "Resolve team-scoped Keycloak role mappings to the user's personal team",
-      "title": "Sso Keycloak Resolve Team Scope To Personal Team",
-      "type": "boolean"
-    },
-    "sso_keycloak_username_claim": {
-      "default": "preferred_username",
-      "description": "JWT claim for username",
-      "title": "Sso Keycloak Username Claim",
-      "type": "string"
-    },
-    "experimental_validate_io": {
-      "default": false,
-      "description": "Enable experimental input validation and output sanitization",
-      "title": "Experimental Validate Io",
-      "type": "boolean"
-    },
-    "validation_middleware_enabled": {
-      "default": false,
-      "description": "Enable validation middleware for all requests",
-      "title": "Validation Middleware Enabled",
-      "type": "boolean"
-    },
-    "validation_strict": {
-      "default": true,
-      "description": "Strict validation mode - reject on violations",
-      "title": "Validation Strict",
-      "type": "boolean"
-    },
-    "sanitize_output": {
-      "default": true,
-      "description": "Sanitize output to remove control characters",
-      "title": "Sanitize Output",
-      "type": "boolean"
-    },
-    "allowed_roots": {
-      "description": "Allowed root paths for resource access",
-      "items": {
-        "type": "string"
-      },
-      "title": "Allowed Roots",
-      "type": "array"
-    },
-    "max_path_depth": {
-      "default": 10,
-      "description": "Maximum allowed path depth",
-      "title": "Max Path Depth",
-      "type": "integer"
-    },
-    "max_param_length": {
-      "default": 10000,
-      "description": "Maximum parameter length",
-      "title": "Max Param Length",
-      "type": "integer"
-    },
-    "dangerous_patterns": {
-      "description": "Regex patterns for dangerous input",
-      "items": {
-        "type": "string"
-      },
-      "title": "Dangerous Patterns",
-      "type": "array"
-    },
-    "sso_keycloak_email_claim": {
-      "default": "email",
-      "description": "JWT claim for email",
-      "title": "Sso Keycloak Email Claim",
-      "type": "string"
-    },
-    "sso_keycloak_groups_claim": {
-      "default": "groups",
-      "description": "JWT claim for groups/roles",
-      "title": "Sso Keycloak Groups Claim",
-      "type": "string"
-    },
-    "sso_entra_enabled": {
-      "default": false,
-      "description": "Enable Microsoft Entra ID OIDC authentication",
-      "title": "Sso Entra Enabled",
-      "type": "boolean"
-    },
-    "sso_entra_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Microsoft Entra ID client ID",
-      "title": "Sso Entra Client Id"
-    },
-    "sso_entra_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Microsoft Entra ID client secret",
-      "title": "Sso Entra Client Secret"
-    },
-    "sso_entra_tenant_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Microsoft Entra ID tenant ID",
-      "title": "Sso Entra Tenant Id"
-    },
-    "sso_entra_groups_claim": {
-      "default": "groups",
-      "description": "JWT claim for EntraID groups (groups/roles)",
-      "title": "Sso Entra Groups Claim",
-      "type": "string"
-    },
-    "sso_entra_admin_groups": {
-      "description": "EntraID groups granting platform_admin role (CSV/JSON)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Sso Entra Admin Groups",
-      "type": "array"
-    },
-    "sso_entra_role_mappings": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "description": "Map EntraID groups to Context Forge roles (JSON: {group_id: role_name})",
-      "title": "Sso Entra Role Mappings",
-      "type": "object"
-    },
-    "sso_entra_default_role": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Default role for EntraID users without group mapping (None = no role assigned)",
-      "title": "Sso Entra Default Role"
-    },
-    "sso_entra_sync_roles_on_login": {
-      "default": true,
-      "description": "Synchronize role assignments on each login",
-      "title": "Sso Entra Sync Roles On Login",
-      "type": "boolean"
-    },
-    "sso_generic_enabled": {
-      "default": false,
-      "description": "Enable generic OIDC provider (Keycloak, Auth0, etc.)",
-      "title": "Sso Generic Enabled",
-      "type": "boolean"
-    },
-    "sso_generic_provider_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Provider ID (e.g., 'keycloak', 'auth0', 'authentik')",
-      "title": "Sso Generic Provider Id"
-    },
-    "sso_generic_display_name": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Display name shown on login page",
-      "title": "Sso Generic Display Name"
-    },
-    "sso_generic_client_id": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Generic OIDC client ID",
-      "title": "Sso Generic Client Id"
-    },
-    "sso_generic_client_secret": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Generic OIDC client secret",
-      "title": "Sso Generic Client Secret"
-    },
-    "sso_generic_authorization_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Authorization endpoint URL",
-      "title": "Sso Generic Authorization Url"
-    },
-    "sso_generic_token_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Token endpoint URL",
-      "title": "Sso Generic Token Url"
-    },
-    "sso_generic_userinfo_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Userinfo endpoint URL",
-      "title": "Sso Generic Userinfo Url"
-    },
-    "sso_generic_issuer": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "OIDC issuer URL",
-      "title": "Sso Generic Issuer"
-    },
-    "sso_generic_scope": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": "openid profile email",
-      "description": "OAuth scopes (space-separated)",
-      "title": "Sso Generic Scope"
-    },
-    "sso_auto_create_users": {
-      "default": true,
-      "description": "Automatically create users from SSO providers",
-      "title": "Sso Auto Create Users",
-      "type": "boolean"
-    },
-    "sso_trusted_domains": {
-      "description": "Trusted email domains (CSV or JSON list)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Sso Trusted Domains",
-      "type": "array"
-    },
-    "sso_preserve_admin_auth": {
-      "default": true,
-      "description": "Preserve local admin authentication when SSO is enabled",
-      "title": "Sso Preserve Admin Auth",
-      "type": "boolean"
-    },
-    "sso_auto_admin_domains": {
-      "description": "Admin domains (CSV or JSON list)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Sso Auto Admin Domains",
-      "type": "array"
-    },
-    "sso_github_admin_orgs": {
-      "description": "GitHub orgs granting admin (CSV/JSON)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Sso Github Admin Orgs",
-      "type": "array"
-    },
-    "sso_google_admin_domains": {
-      "description": "Google admin domains (CSV/JSON)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Sso Google Admin Domains",
-      "type": "array"
-    },
-    "sso_require_admin_approval": {
-      "default": false,
-      "description": "Require admin approval for new SSO registrations",
-      "title": "Sso Require Admin Approval",
-      "type": "boolean"
-    },
-    "mcp_client_auth_enabled": {
-      "default": true,
-      "description": "Enable JWT authentication for MCP client operations",
-      "title": "Mcp Client Auth Enabled",
-      "type": "boolean"
-    },
-    "mcp_require_auth": {
-      "default": false,
-      "description": "Require authentication for /mcp endpoints. If false, unauthenticated requests can access public items only. If true, all /mcp requests must include a valid Bearer token.",
-      "title": "Mcp Require Auth",
-      "type": "boolean"
-    },
-    "trust_proxy_auth": {
-      "default": false,
-      "description": "Trust proxy authentication headers (required when mcp_client_auth_enabled=false)",
-      "title": "Trust Proxy Auth",
-      "type": "boolean"
-    },
-    "proxy_user_header": {
-      "default": "X-Authenticated-User",
-      "description": "Header containing authenticated username from proxy",
-      "title": "Proxy User Header",
-      "type": "string"
-    },
-    "auth_encryption_secret": {
-      "default": "**********",
-      "format": "password",
-      "title": "Auth Encryption Secret",
-      "type": "string",
-      "writeOnly": true
-    },
-    "insecure_allow_queryparam_auth": {
-      "default": false,
-      "description": "Enable query parameter authentication for gateway peers. WARNING: API keys may appear in proxy logs. See CWE-598.",
-      "title": "Insecure Allow Queryparam Auth",
-      "type": "boolean"
-    },
-    "insecure_queryparam_auth_allowed_hosts": {
-      "description": "Allowlist of hosts permitted to use query parameter auth. Empty list allows any host when feature is enabled. Format: ['mcp.tavily.com', 'api.example.com']",
-      "items": {
-        "type": "string"
-      },
-      "title": "Insecure Queryparam Auth Allowed Hosts",
-      "type": "array"
-    },
-    "ssrf_protection_enabled": {
-      "default": true,
-      "description": "Enable SSRF protection for gateway/tool URLs. Blocks access to dangerous endpoints.",
-      "title": "Ssrf Protection Enabled",
-      "type": "boolean"
-    },
-    "ssrf_blocked_networks": {
-      "default": [
-        "169.254.169.254/32",
-        "169.254.169.123/32",
-        "fd00::1/128",
-        "169.254.0.0/16",
-        "fe80::/10"
-      ],
-      "description": "CIDR ranges to block for SSRF protection. These are ALWAYS blocked regardless of other settings. Default blocks cloud metadata endpoints. Add private ranges for stricter security.",
-      "items": {
-        "type": "string"
-      },
-      "title": "Ssrf Blocked Networks",
-      "type": "array"
-    },
-    "ssrf_blocked_hosts": {
-      "default": [
-        "metadata.google.internal",
-        "metadata.internal"
-      ],
-      "description": "Hostnames to block for SSRF protection. Matched case-insensitively.",
-      "items": {
-        "type": "string"
-      },
-      "title": "Ssrf Blocked Hosts",
-      "type": "array"
-    },
-    "ssrf_allow_localhost": {
-      "default": true,
-      "description": "Allow localhost/loopback addresses (127.0.0.0/8, ::1). Set to false to block localhost access for stricter security. Default true for development compatibility.",
-      "title": "Ssrf Allow Localhost",
-      "type": "boolean"
-    },
-    "ssrf_allow_private_networks": {
-      "default": true,
-      "description": "Allow RFC 1918 private network addresses (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16). Set to false if the gateway should only access public internet endpoints. Default true for internal deployment compatibility.",
-      "title": "Ssrf Allow Private Networks",
-      "type": "boolean"
-    },
-    "ssrf_dns_fail_closed": {
-      "default": false,
-      "description": "Fail closed on DNS resolution errors. When true, URLs that cannot be resolved are rejected. When false (default), unresolvable hostnames are allowed through (hostname blocklist still applies). Set to true for stricter security.",
-      "title": "Ssrf Dns Fail Closed",
-      "type": "boolean"
-    },
-    "oauth_request_timeout": {
+    "a2a_stats_cache_ttl": {
       "default": 30,
-      "description": "OAuth request timeout in seconds",
-      "title": "Oauth Request Timeout",
-      "type": "integer"
-    },
-    "oauth_max_retries": {
-      "default": 3,
-      "description": "Maximum retries for OAuth token requests",
-      "title": "Oauth Max Retries",
-      "type": "integer"
-    },
-    "oauth_default_timeout": {
-      "default": 3600,
-      "description": "Default OAuth token timeout in seconds",
-      "title": "Oauth Default Timeout",
-      "type": "integer"
-    },
-    "dcr_enabled": {
-      "default": true,
-      "description": "Enable Dynamic Client Registration (RFC 7591) - gateway acts as DCR client",
-      "title": "Dcr Enabled",
-      "type": "boolean"
-    },
-    "dcr_auto_register_on_missing_credentials": {
-      "default": true,
-      "description": "Automatically register with AS when gateway has issuer but no client_id",
-      "title": "Dcr Auto Register On Missing Credentials",
-      "type": "boolean"
-    },
-    "dcr_default_scopes": {
-      "default": [
-        "mcp:read"
-      ],
-      "description": "Default MCP scopes to request during DCR",
-      "items": {
-        "type": "string"
-      },
-      "title": "Dcr Default Scopes",
-      "type": "array"
-    },
-    "dcr_allowed_issuers": {
-      "description": "Optional allowlist of issuer URLs for DCR (empty = allow any)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Dcr Allowed Issuers",
-      "type": "array"
-    },
-    "dcr_token_endpoint_auth_method": {
-      "default": "client_secret_basic",
-      "description": "Token endpoint auth method for DCR (client_secret_basic or client_secret_post)",
-      "title": "Dcr Token Endpoint Auth Method",
-      "type": "string"
-    },
-    "dcr_metadata_cache_ttl": {
-      "default": 3600,
-      "description": "AS metadata cache TTL in seconds (RFC 8414 discovery)",
-      "title": "Dcr Metadata Cache Ttl",
-      "type": "integer"
-    },
-    "dcr_client_name_template": {
-      "default": "MCP Gateway ({gateway_name})",
-      "description": "Template for client_name in DCR requests",
-      "title": "Dcr Client Name Template",
-      "type": "string"
-    },
-    "dcr_request_refresh_token_when_unsupported": {
-      "default": false,
-      "description": "Request refresh_token even when AS metadata omits grant_types_supported. Enable for AS servers that support refresh tokens but don't advertise it.",
-      "title": "Dcr Request Refresh Token When Unsupported",
-      "type": "boolean"
-    },
-    "oauth_discovery_enabled": {
-      "default": true,
-      "description": "Enable OAuth AS metadata discovery (RFC 8414)",
-      "title": "Oauth Discovery Enabled",
-      "type": "boolean"
-    },
-    "oauth_preferred_code_challenge_method": {
-      "default": "S256",
-      "description": "Preferred PKCE code challenge method (S256 or plain)",
-      "title": "Oauth Preferred Code Challenge Method",
-      "type": "string"
-    },
-    "email_auth_enabled": {
-      "default": true,
-      "description": "Enable email-based authentication",
-      "title": "Email Auth Enabled",
-      "type": "boolean"
-    },
-    "public_registration_enabled": {
-      "default": false,
-      "description": "Allow unauthenticated users to self-register accounts. When false, only admins can create users via /admin/users endpoint.",
-      "title": "Public Registration Enabled",
-      "type": "boolean"
-    },
-    "protect_all_admins": {
-      "default": true,
-      "description": "When true (default), prevent any admin from being demoted, deactivated, or locked out via API/UI. When false, only the last active admin is protected.",
-      "title": "Protect All Admins",
-      "type": "boolean"
-    },
-    "platform_admin_email": {
-      "default": "admin@example.com",
-      "description": "Platform administrator email address",
-      "title": "Platform Admin Email",
-      "type": "string"
-    },
-    "platform_admin_password": {
-      "default": "**********",
-      "description": "Platform administrator password",
-      "format": "password",
-      "title": "Platform Admin Password",
-      "type": "string",
-      "writeOnly": true
-    },
-    "default_user_password": {
-      "default": "**********",
-      "description": "Default password for new users",
-      "format": "password",
-      "title": "Default User Password",
-      "type": "string",
-      "writeOnly": true
-    },
-    "platform_admin_full_name": {
-      "default": "Platform Administrator",
-      "description": "Platform administrator full name",
-      "title": "Platform Admin Full Name",
-      "type": "string"
-    },
-    "argon2id_time_cost": {
-      "default": 3,
-      "description": "Argon2id time cost (number of iterations)",
-      "title": "Argon2Id Time Cost",
-      "type": "integer"
-    },
-    "argon2id_memory_cost": {
-      "default": 65536,
-      "description": "Argon2id memory cost in KiB",
-      "title": "Argon2Id Memory Cost",
-      "type": "integer"
-    },
-    "argon2id_parallelism": {
-      "default": 1,
-      "description": "Argon2id parallelism (number of threads)",
-      "title": "Argon2Id Parallelism",
-      "type": "integer"
-    },
-    "password_min_length": {
-      "default": 8,
-      "description": "Minimum password length",
-      "title": "Password Min Length",
-      "type": "integer"
-    },
-    "password_require_uppercase": {
-      "default": true,
-      "description": "Require uppercase letters in passwords",
-      "title": "Password Require Uppercase",
-      "type": "boolean"
-    },
-    "password_require_lowercase": {
-      "default": true,
-      "description": "Require lowercase letters in passwords",
-      "title": "Password Require Lowercase",
-      "type": "boolean"
-    },
-    "password_require_numbers": {
-      "default": false,
-      "description": "Require numbers in passwords",
-      "title": "Password Require Numbers",
-      "type": "boolean"
-    },
-    "password_require_special": {
-      "default": true,
-      "description": "Require special characters in passwords",
-      "title": "Password Require Special",
-      "type": "boolean"
-    },
-    "password_change_enforcement_enabled": {
-      "default": true,
-      "description": "Master switch for password change enforcement checks",
-      "title": "Password Change Enforcement Enabled",
-      "type": "boolean"
-    },
-    "admin_require_password_change_on_bootstrap": {
-      "default": true,
-      "description": "Force admin to change password after bootstrap",
-      "title": "Admin Require Password Change On Bootstrap",
-      "type": "boolean"
-    },
-    "detect_default_password_on_login": {
-      "default": true,
-      "description": "Detect default password during login and mark user for change",
-      "title": "Detect Default Password On Login",
-      "type": "boolean"
-    },
-    "require_password_change_for_default_password": {
-      "default": true,
-      "description": "Require password change when user is created with the default password",
-      "title": "Require Password Change For Default Password",
-      "type": "boolean"
-    },
-    "password_policy_enabled": {
-      "default": true,
-      "description": "Enable password complexity validation for new/changed passwords",
-      "title": "Password Policy Enabled",
-      "type": "boolean"
-    },
-    "password_prevent_reuse": {
-      "default": true,
-      "description": "Prevent reusing the current password when changing",
-      "title": "Password Prevent Reuse",
-      "type": "boolean"
-    },
-    "password_max_age_days": {
-      "default": 90,
-      "description": "Password maximum age in days before expiry forces a change",
-      "title": "Password Max Age Days",
-      "type": "integer"
-    },
-    "max_failed_login_attempts": {
-      "default": 10,
-      "description": "Maximum failed login attempts before account lockout",
-      "title": "Max Failed Login Attempts",
+      "description": "TTL in seconds for A2A stats in-memory cache (default: 30)",
+      "maximum": 3600,
+      "minimum": 5,
+      "title": "A2A Stats Cache Ttl",
       "type": "integer"
     },
     "account_lockout_duration_minutes": {
@@ -1108,574 +51,75 @@
       "title": "Account Lockout Notification Enabled",
       "type": "boolean"
     },
-    "password_reset_enabled": {
+    "admin_require_password_change_on_bootstrap": {
       "default": true,
-      "description": "Enable self-service password reset workflow (set false to disable public forgot/reset endpoints)",
-      "title": "Password Reset Enabled",
+      "description": "Force admin to change password after bootstrap",
+      "title": "Admin Require Password Change On Bootstrap",
       "type": "boolean"
     },
-    "password_reset_token_expiry_minutes": {
+    "admin_stats_cache_enabled": {
+      "default": true,
+      "description": "Enable caching for admin dashboard statistics",
+      "title": "Admin Stats Cache Enabled",
+      "type": "boolean"
+    },
+    "admin_stats_cache_observability_ttl": {
+      "default": 30,
+      "description": "TTL in seconds for observability stats cache",
+      "maximum": 120,
+      "minimum": 10,
+      "title": "Admin Stats Cache Observability Ttl",
+      "type": "integer"
+    },
+    "admin_stats_cache_performance_ttl": {
       "default": 60,
-      "description": "Password reset token expiration time in minutes",
-      "title": "Password Reset Token Expiry Minutes",
+      "description": "TTL in seconds for performance aggregates cache",
+      "maximum": 300,
+      "minimum": 15,
+      "title": "Admin Stats Cache Performance Ttl",
       "type": "integer"
     },
-    "password_reset_rate_limit": {
-      "default": 5,
-      "description": "Maximum password reset requests allowed per email in each rate-limit window",
-      "title": "Password Reset Rate Limit",
+    "admin_stats_cache_plugins_ttl": {
+      "default": 120,
+      "description": "TTL in seconds for plugin stats cache",
+      "maximum": 600,
+      "minimum": 30,
+      "title": "Admin Stats Cache Plugins Ttl",
       "type": "integer"
     },
-    "password_reset_rate_window_minutes": {
-      "default": 15,
-      "description": "Password reset request rate-limit window in minutes",
-      "title": "Password Reset Rate Window Minutes",
+    "admin_stats_cache_system_ttl": {
+      "default": 60,
+      "description": "TTL in seconds for system stats cache",
+      "maximum": 300,
+      "minimum": 10,
+      "title": "Admin Stats Cache System Ttl",
       "type": "integer"
     },
-    "password_reset_invalidate_sessions": {
-      "default": true,
-      "description": "Invalidate active sessions after password reset",
-      "title": "Password Reset Invalidate Sessions",
-      "type": "boolean"
-    },
-    "password_reset_min_response_ms": {
-      "default": 250,
-      "description": "Minimum response duration for forgot-password requests to reduce timing side channels",
-      "title": "Password Reset Min Response Ms",
+    "admin_stats_cache_tags_ttl": {
+      "default": 120,
+      "description": "TTL in seconds for tags listing cache",
+      "maximum": 600,
+      "minimum": 30,
+      "title": "Admin Stats Cache Tags Ttl",
       "type": "integer"
     },
-    "smtp_enabled": {
-      "default": false,
-      "description": "Enable SMTP email delivery for password reset and account lockout notifications (when false, reset requests are accepted but no email is sent)",
-      "title": "Smtp Enabled",
-      "type": "boolean"
-    },
-    "smtp_host": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
+    "allowed_mime_types": {
+      "default": [
+        "text/plain",
+        "application/xml",
+        "image/gif",
+        "image/jpeg",
+        "text/html",
+        "image/png",
+        "application/json",
+        "text/markdown"
       ],
-      "default": null,
-      "description": "SMTP server host",
-      "title": "Smtp Host"
-    },
-    "smtp_port": {
-      "default": 587,
-      "description": "SMTP server port",
-      "title": "Smtp Port",
-      "type": "integer"
-    },
-    "smtp_user": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "SMTP username",
-      "title": "Smtp User"
-    },
-    "smtp_password": {
-      "anyOf": [
-        {
-          "format": "password",
-          "type": "string",
-          "writeOnly": true
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "SMTP password",
-      "title": "Smtp Password"
-    },
-    "smtp_from_email": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "From email address used for auth notifications",
-      "title": "Smtp From Email"
-    },
-    "smtp_from_name": {
-      "default": "MCP Gateway",
-      "description": "From display name used for auth notifications",
-      "title": "Smtp From Name",
-      "type": "string"
-    },
-    "smtp_use_tls": {
-      "default": true,
-      "description": "Use STARTTLS for SMTP connections",
-      "title": "Smtp Use Tls",
-      "type": "boolean"
-    },
-    "smtp_use_ssl": {
-      "default": false,
-      "description": "Use implicit SSL/TLS for SMTP connections",
-      "title": "Smtp Use Ssl",
-      "type": "boolean"
-    },
-    "smtp_timeout_seconds": {
-      "default": 15,
-      "description": "SMTP connection timeout in seconds",
-      "title": "Smtp Timeout Seconds",
-      "type": "integer"
-    },
-    "auto_create_personal_teams": {
-      "default": true,
-      "description": "Enable automatic personal team creation for new users",
-      "title": "Auto Create Personal Teams",
-      "type": "boolean"
-    },
-    "personal_team_prefix": {
-      "default": "personal",
-      "description": "Personal team naming prefix",
-      "title": "Personal Team Prefix",
-      "type": "string"
-    },
-    "max_teams_per_user": {
-      "default": 50,
-      "description": "Maximum number of teams a user can belong to",
-      "title": "Max Teams Per User",
-      "type": "integer"
-    },
-    "max_members_per_team": {
-      "default": 100,
-      "description": "Maximum number of members per team",
-      "title": "Max Members Per Team",
-      "type": "integer"
-    },
-    "invitation_expiry_days": {
-      "default": 7,
-      "description": "Number of days before team invitations expire",
-      "title": "Invitation Expiry Days",
-      "type": "integer"
-    },
-    "require_email_verification_for_invites": {
-      "default": true,
-      "description": "Require email verification for team invitations",
-      "title": "Require Email Verification For Invites",
-      "type": "boolean"
-    },
-    "default_admin_role": {
-      "default": "platform_admin",
-      "description": "Global role assigned to admin users",
-      "title": "Default Admin Role",
-      "type": "string"
-    },
-    "default_user_role": {
-      "default": "platform_viewer",
-      "description": "Global role assigned to non-admin users",
-      "title": "Default User Role",
-      "type": "string"
-    },
-    "default_team_owner_role": {
-      "default": "team_admin",
-      "description": "Team-scoped role assigned to team owners (e.g. personal team creator)",
-      "title": "Default Team Owner Role",
-      "type": "string"
-    },
-    "default_team_member_role": {
-      "default": "viewer",
-      "description": "Team-scoped role assigned to team members",
-      "title": "Default Team Member Role",
-      "type": "string"
-    },
-    "mcpgateway_ui_enabled": {
-      "default": false,
-      "title": "Mcpgateway Ui Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_admin_api_enabled": {
-      "default": false,
-      "title": "Mcpgateway Admin Api Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_ui_airgapped": {
-      "default": false,
-      "description": "Use local CDN assets instead of external CDNs for airgapped deployments",
-      "title": "Mcpgateway Ui Airgapped",
-      "type": "boolean"
-    },
-    "mcpgateway_ui_embedded": {
-      "default": false,
-      "description": "Enable embedded UI mode (hides select header controls by default)",
-      "title": "Mcpgateway Ui Embedded",
-      "type": "boolean"
-    },
-    "mcpgateway_ui_hide_sections": {
-      "description": "CSV/JSON list of UI sections to hide. Valid values: overview, servers, gateways, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings",
       "items": {
         "type": "string"
       },
-      "title": "Mcpgateway Ui Hide Sections",
-      "type": "array"
-    },
-    "mcpgateway_ui_hide_header_items": {
-      "description": "CSV/JSON list of header items to hide. Valid values: logout, team_selector, user_identity, theme_toggle",
-      "items": {
-        "type": "string"
-      },
-      "title": "Mcpgateway Ui Hide Header Items",
-      "type": "array"
-    },
-    "mcpgateway_bulk_import_enabled": {
-      "default": true,
-      "title": "Mcpgateway Bulk Import Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_bulk_import_max_tools": {
-      "default": 200,
-      "title": "Mcpgateway Bulk Import Max Tools",
-      "type": "integer"
-    },
-    "mcpgateway_bulk_import_rate_limit": {
-      "default": 10,
-      "title": "Mcpgateway Bulk Import Rate Limit",
-      "type": "integer"
-    },
-    "mcpgateway_ui_tool_test_timeout": {
-      "default": 60000,
-      "description": "Tool test timeout in milliseconds for the admin UI",
-      "title": "Mcpgateway Ui Tool Test Timeout",
-      "type": "integer"
-    },
-    "mcpgateway_tool_cancellation_enabled": {
-      "default": true,
-      "description": "Enable gateway-authoritative tool execution cancellation with REST API endpoints",
-      "title": "Mcpgateway Tool Cancellation Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_a2a_enabled": {
-      "default": true,
-      "title": "Mcpgateway A2A Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_a2a_max_agents": {
-      "default": 100,
-      "title": "Mcpgateway A2A Max Agents",
-      "type": "integer"
-    },
-    "mcpgateway_a2a_default_timeout": {
-      "default": 30,
-      "title": "Mcpgateway A2A Default Timeout",
-      "type": "integer"
-    },
-    "mcpgateway_a2a_max_retries": {
-      "default": 3,
-      "title": "Mcpgateway A2A Max Retries",
-      "type": "integer"
-    },
-    "mcpgateway_a2a_metrics_enabled": {
-      "default": true,
-      "title": "Mcpgateway A2A Metrics Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_grpc_enabled": {
-      "default": false,
-      "description": "Enable gRPC to MCP translation support (experimental feature)",
-      "title": "Mcpgateway Grpc Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_grpc_reflection_enabled": {
-      "default": true,
-      "description": "Enable gRPC server reflection by default",
-      "title": "Mcpgateway Grpc Reflection Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_grpc_max_message_size": {
-      "default": 4194304,
-      "description": "Maximum gRPC message size in bytes (4MB)",
-      "title": "Mcpgateway Grpc Max Message Size",
-      "type": "integer"
-    },
-    "mcpgateway_grpc_timeout": {
-      "default": 30,
-      "description": "Default gRPC call timeout in seconds",
-      "title": "Mcpgateway Grpc Timeout",
-      "type": "integer"
-    },
-    "mcpgateway_grpc_tls_enabled": {
-      "default": false,
-      "description": "Enable TLS for gRPC connections by default",
-      "title": "Mcpgateway Grpc Tls Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_direct_proxy_enabled": {
-      "default": false,
-      "description": "Enable direct_proxy gateway mode for pass-through MCP operations",
-      "title": "Mcpgateway Direct Proxy Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_direct_proxy_timeout": {
-      "default": 30,
-      "description": "Default timeout in seconds for direct proxy MCP operations",
-      "title": "Mcpgateway Direct Proxy Timeout",
-      "type": "integer"
-    },
-    "mcpgateway_performance_tracking": {
-      "default": false,
-      "description": "Enable performance tracking tab in admin UI",
-      "title": "Mcpgateway Performance Tracking",
-      "type": "boolean"
-    },
-    "mcpgateway_performance_collection_interval": {
-      "default": 10,
-      "description": "Metric collection interval in seconds",
-      "maximum": 300,
-      "minimum": 1,
-      "title": "Mcpgateway Performance Collection Interval",
-      "type": "integer"
-    },
-    "mcpgateway_performance_retention_hours": {
-      "default": 24,
-      "description": "Snapshot retention period in hours",
-      "maximum": 168,
-      "minimum": 1,
-      "title": "Mcpgateway Performance Retention Hours",
-      "type": "integer"
-    },
-    "mcpgateway_performance_retention_days": {
-      "default": 90,
-      "description": "Aggregate retention period in days",
-      "maximum": 365,
-      "minimum": 1,
-      "title": "Mcpgateway Performance Retention Days",
-      "type": "integer"
-    },
-    "mcpgateway_performance_max_snapshots": {
-      "default": 10000,
-      "description": "Maximum performance snapshots to retain",
-      "maximum": 1000000,
-      "minimum": 100,
-      "title": "Mcpgateway Performance Max Snapshots",
-      "type": "integer"
-    },
-    "mcpgateway_performance_distributed": {
-      "default": false,
-      "description": "Enable distributed mode metrics aggregation via Redis",
-      "title": "Mcpgateway Performance Distributed",
-      "type": "boolean"
-    },
-    "mcpgateway_performance_net_connections_enabled": {
-      "default": true,
-      "description": "Enable network connections counting (can be CPU intensive)",
-      "title": "Mcpgateway Performance Net Connections Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_performance_net_connections_cache_ttl": {
-      "default": 15,
-      "description": "Cache TTL for net_connections in seconds",
-      "maximum": 300,
-      "minimum": 1,
-      "title": "Mcpgateway Performance Net Connections Cache Ttl",
-      "type": "integer"
-    },
-    "mcpgateway_catalog_enabled": {
-      "default": true,
-      "description": "Enable MCP server catalog feature",
-      "title": "Mcpgateway Catalog Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_catalog_file": {
-      "default": "mcp-catalog.yml",
-      "description": "Path to catalog configuration file",
-      "title": "Mcpgateway Catalog File",
-      "type": "string"
-    },
-    "mcpgateway_catalog_auto_health_check": {
-      "default": true,
-      "description": "Automatically health check catalog servers",
-      "title": "Mcpgateway Catalog Auto Health Check",
-      "type": "boolean"
-    },
-    "mcpgateway_catalog_cache_ttl": {
-      "default": 3600,
-      "description": "Catalog cache TTL in seconds",
-      "title": "Mcpgateway Catalog Cache Ttl",
-      "type": "integer"
-    },
-    "mcpgateway_catalog_page_size": {
-      "default": 100,
-      "description": "Number of catalog servers per page",
-      "title": "Mcpgateway Catalog Page Size",
-      "type": "integer"
-    },
-    "mcpgateway_bootstrap_roles_in_db_enabled": {
-      "default": false,
-      "description": "Enable MCP Gateway add additional roles in db",
-      "title": "Mcpgateway Bootstrap Roles In Db Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_bootstrap_roles_in_db_file": {
-      "default": "additional_roles_in_db.json",
-      "description": "Path to add additional roles in db",
-      "title": "Mcpgateway Bootstrap Roles In Db File",
-      "type": "string"
-    },
-    "mcpgateway_elicitation_enabled": {
-      "default": true,
-      "description": "Enable elicitation passthrough support (MCP 2025-06-18)",
-      "title": "Mcpgateway Elicitation Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_elicitation_timeout": {
-      "default": 60,
-      "description": "Default timeout for elicitation requests in seconds",
-      "title": "Mcpgateway Elicitation Timeout",
-      "type": "integer"
-    },
-    "mcpgateway_elicitation_max_concurrent": {
-      "default": 100,
-      "description": "Maximum concurrent elicitation requests",
-      "title": "Mcpgateway Elicitation Max Concurrent",
-      "type": "integer"
-    },
-    "skip_ssl_verify": {
-      "default": false,
-      "description": "Skip SSL certificate verification for ALL outbound HTTPS requests (federation, MCP servers, LLM providers, A2A agents). WARNING: Only enable in dev environments with self-signed certificates.",
-      "title": "Skip Ssl Verify",
-      "type": "boolean"
-    },
-    "cors_enabled": {
-      "default": true,
-      "title": "Cors Enabled",
-      "type": "boolean"
-    },
-    "environment": {
-      "default": "development",
-      "enum": [
-        "development",
-        "staging",
-        "production"
-      ],
-      "title": "Environment",
-      "type": "string"
-    },
-    "app_domain": {
-      "default": "http://localhost:4444/",
-      "format": "uri",
-      "maxLength": 2083,
-      "minLength": 1,
-      "title": "App Domain",
-      "type": "string"
-    },
-    "secure_cookies": {
-      "default": true,
-      "title": "Secure Cookies",
-      "type": "boolean"
-    },
-    "cookie_samesite": {
-      "default": "lax",
-      "title": "Cookie Samesite",
-      "type": "string"
-    },
-    "cors_allow_credentials": {
-      "default": true,
-      "title": "Cors Allow Credentials",
-      "type": "boolean"
-    },
-    "security_headers_enabled": {
-      "default": true,
-      "title": "Security Headers Enabled",
-      "type": "boolean"
-    },
-    "x_frame_options": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": "DENY",
-      "title": "X Frame Options"
-    },
-    "x_content_type_options_enabled": {
-      "default": true,
-      "title": "X Content Type Options Enabled",
-      "type": "boolean"
-    },
-    "x_xss_protection_enabled": {
-      "default": true,
-      "title": "X Xss Protection Enabled",
-      "type": "boolean"
-    },
-    "x_download_options_enabled": {
-      "default": true,
-      "title": "X Download Options Enabled",
-      "type": "boolean"
-    },
-    "hsts_enabled": {
-      "default": true,
-      "title": "Hsts Enabled",
-      "type": "boolean"
-    },
-    "hsts_max_age": {
-      "default": 31536000,
-      "title": "Hsts Max Age",
-      "type": "integer"
-    },
-    "hsts_include_subdomains": {
-      "default": true,
-      "title": "Hsts Include Subdomains",
-      "type": "boolean"
-    },
-    "remove_server_headers": {
-      "default": true,
-      "title": "Remove Server Headers",
-      "type": "boolean"
-    },
-    "compression_enabled": {
-      "default": true,
-      "description": "Enable response compression (Brotli, Zstd, GZip)",
-      "title": "Compression Enabled",
-      "type": "boolean"
-    },
-    "compression_minimum_size": {
-      "default": 500,
-      "description": "Minimum response size in bytes to compress (0 = compress all)",
-      "minimum": 0,
-      "title": "Compression Minimum Size",
-      "type": "integer"
-    },
-    "compression_gzip_level": {
-      "default": 6,
-      "description": "GZip compression level (1=fastest, 9=best compression)",
-      "maximum": 9,
-      "minimum": 1,
-      "title": "Compression Gzip Level",
-      "type": "integer"
-    },
-    "compression_brotli_quality": {
-      "default": 4,
-      "description": "Brotli compression quality (0-3=fast, 4-9=balanced, 10-11=max)",
-      "maximum": 11,
-      "minimum": 0,
-      "title": "Compression Brotli Quality",
-      "type": "integer"
-    },
-    "compression_zstd_level": {
-      "default": 3,
-      "description": "Zstd compression level (1-3=fast, 4-9=balanced, 10+=slow)",
-      "maximum": 22,
-      "minimum": 1,
-      "title": "Compression Zstd Level",
-      "type": "integer"
+      "title": "Allowed Mime Types",
+      "type": "array",
+      "uniqueItems": true
     },
     "allowed_origins": {
       "default": [
@@ -1689,44 +133,153 @@
       "type": "array",
       "uniqueItems": true
     },
-    "min_secret_length": {
-      "default": 32,
-      "title": "Min Secret Length",
+    "allowed_roots": {
+      "description": "Allowed root paths for resource access",
+      "items": {
+        "type": "string"
+      },
+      "title": "Allowed Roots",
+      "type": "array"
+    },
+    "anyio_cancel_delivery_max_iterations": {
+      "default": 100,
+      "title": "Anyio Cancel Delivery Max Iterations",
       "type": "integer"
     },
-    "min_password_length": {
-      "default": 12,
-      "title": "Min Password Length",
+    "anyio_cancel_delivery_patch_enabled": {
+      "default": false,
+      "title": "Anyio Cancel Delivery Patch Enabled",
+      "type": "boolean"
+    },
+    "api_allow_basic_auth": {
+      "default": false,
+      "description": "Allow Basic authentication for API endpoints. Disabled by default for security. Use JWT or API tokens instead.",
+      "title": "Api Allow Basic Auth",
+      "type": "boolean"
+    },
+    "app_domain": {
+      "default": "http://localhost:4444/",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "title": "App Domain",
+      "type": "string"
+    },
+    "app_name": {
+      "default": "MCP_Gateway",
+      "title": "App Name",
+      "type": "string"
+    },
+    "app_root_path": {
+      "default": "",
+      "title": "App Root Path",
+      "type": "string"
+    },
+    "argon2id_memory_cost": {
+      "default": 65536,
+      "description": "Argon2id memory cost in KiB",
+      "title": "Argon2Id Memory Cost",
       "type": "integer"
     },
-    "require_strong_secrets": {
+    "argon2id_parallelism": {
+      "default": 1,
+      "description": "Argon2id parallelism (number of threads)",
+      "title": "Argon2Id Parallelism",
+      "type": "integer"
+    },
+    "argon2id_time_cost": {
+      "default": 3,
+      "description": "Argon2id time cost (number of iterations)",
+      "title": "Argon2Id Time Cost",
+      "type": "integer"
+    },
+    "audit_trail_enabled": {
       "default": false,
-      "title": "Require Strong Secrets",
+      "description": "Enable audit trail logging to database for compliance",
+      "title": "Audit Trail Enabled",
       "type": "boolean"
     },
-    "llmchat_enabled": {
-      "default": false,
-      "description": "Enable LLM Chat feature",
-      "title": "Llmchat Enabled",
+    "auth_cache_batch_queries": {
+      "default": true,
+      "description": "Batch auth DB queries into single call (reduces 3 queries to 1)",
+      "title": "Auth Cache Batch Queries",
       "type": "boolean"
     },
-    "toolops_enabled": {
-      "default": false,
-      "description": "Enable ToolOps feature",
-      "title": "Toolops Enabled",
+    "auth_cache_enabled": {
+      "default": true,
+      "description": "Enable Redis/in-memory caching for authentication data (user, team, revocation)",
+      "title": "Auth Cache Enabled",
       "type": "boolean"
     },
-    "poll_interval": {
-      "default": 1.0,
-      "description": "Initial polling interval in seconds for checking new session messages",
-      "title": "Poll Interval",
-      "type": "number"
+    "auth_cache_revocation_ttl": {
+      "default": 30,
+      "description": "TTL in seconds for token revocation cache (security-critical, keep short)",
+      "maximum": 120,
+      "minimum": 5,
+      "title": "Auth Cache Revocation Ttl",
+      "type": "integer"
     },
-    "max_interval": {
-      "default": 5.0,
-      "description": "Maximum polling interval in seconds when the session is idle",
-      "title": "Max Interval",
-      "type": "number"
+    "auth_cache_role_ttl": {
+      "default": 60,
+      "description": "TTL in seconds for user role in team cache",
+      "maximum": 300,
+      "minimum": 10,
+      "title": "Auth Cache Role Ttl",
+      "type": "integer"
+    },
+    "auth_cache_team_ttl": {
+      "default": 60,
+      "description": "TTL in seconds for team membership cache",
+      "maximum": 300,
+      "minimum": 10,
+      "title": "Auth Cache Team Ttl",
+      "type": "integer"
+    },
+    "auth_cache_teams_enabled": {
+      "default": true,
+      "description": "Enable caching for get_user_teams() (default: true)",
+      "title": "Auth Cache Teams Enabled",
+      "type": "boolean"
+    },
+    "auth_cache_teams_ttl": {
+      "default": 60,
+      "description": "TTL in seconds for user teams list cache",
+      "maximum": 300,
+      "minimum": 10,
+      "title": "Auth Cache Teams Ttl",
+      "type": "integer"
+    },
+    "auth_cache_user_ttl": {
+      "default": 60,
+      "description": "TTL in seconds for cached user data",
+      "maximum": 300,
+      "minimum": 10,
+      "title": "Auth Cache User Ttl",
+      "type": "integer"
+    },
+    "auth_encryption_secret": {
+      "default": "**********",
+      "format": "password",
+      "title": "Auth Encryption Secret",
+      "type": "string",
+      "writeOnly": true
+    },
+    "auth_required": {
+      "default": true,
+      "title": "Auth Required",
+      "type": "boolean"
+    },
+    "auto_create_personal_teams": {
+      "default": true,
+      "description": "Enable automatic personal team creation for new users",
+      "title": "Auto Create Personal Teams",
+      "type": "boolean"
+    },
+    "auto_refresh_servers": {
+      "default": false,
+      "description": "Enable automatic tool/resource/prompt refresh during gateway health checks",
+      "title": "Auto Refresh Servers",
+      "type": "boolean"
     },
     "backoff_factor": {
       "default": 1.5,
@@ -1734,328 +287,80 @@
       "title": "Backoff Factor",
       "type": "number"
     },
-    "llmchat_session_ttl": {
-      "default": 300,
-      "description": "Seconds for active_session key TTL",
-      "title": "Llmchat Session Ttl",
-      "type": "integer"
+    "basic_auth_password": {
+      "default": "**********",
+      "format": "password",
+      "title": "Basic Auth Password",
+      "type": "string",
+      "writeOnly": true
     },
-    "llmchat_session_lock_ttl": {
-      "default": 30,
-      "description": "Seconds for lock expiry",
-      "title": "Llmchat Session Lock Ttl",
-      "type": "integer"
-    },
-    "llmchat_session_lock_retries": {
-      "default": 10,
-      "description": "How many times to poll while waiting",
-      "title": "Llmchat Session Lock Retries",
-      "type": "integer"
-    },
-    "llmchat_session_lock_wait": {
-      "default": 0.2,
-      "description": "Seconds between polls",
-      "title": "Llmchat Session Lock Wait",
-      "type": "number"
-    },
-    "llmchat_chat_history_ttl": {
-      "default": 3600,
-      "description": "Seconds for chat history expiry",
-      "title": "Llmchat Chat History Ttl",
-      "type": "integer"
-    },
-    "llmchat_chat_history_max_messages": {
-      "default": 50,
-      "description": "Maximum message history to store per user",
-      "title": "Llmchat Chat History Max Messages",
-      "type": "integer"
-    },
-    "llm_api_prefix": {
-      "default": "/v1",
-      "description": "API prefix for internal LLM endpoints",
-      "title": "Llm Api Prefix",
+    "basic_auth_user": {
+      "default": "admin",
+      "title": "Basic Auth User",
       "type": "string"
     },
-    "llm_request_timeout": {
-      "default": 120,
-      "description": "Request timeout in seconds for LLM API calls",
-      "title": "Llm Request Timeout",
-      "type": "integer"
+    "cache_prefix": {
+      "default": "mcpgw:",
+      "title": "Cache Prefix",
+      "type": "string"
     },
-    "llm_streaming_enabled": {
-      "default": true,
-      "description": "Enable streaming responses for LLM Chat",
-      "title": "Llm Streaming Enabled",
+    "cache_type": {
+      "default": "database",
+      "enum": [
+        "redis",
+        "memory",
+        "none",
+        "database"
+      ],
+      "title": "Cache Type",
+      "type": "string"
+    },
+    "client_mode": {
+      "default": false,
+      "title": "Client Mode",
       "type": "boolean"
     },
-    "llm_health_check_interval": {
-      "default": 300,
-      "description": "Provider health check interval in seconds",
-      "title": "Llm Health Check Interval",
+    "compression_brotli_quality": {
+      "default": 4,
+      "description": "Brotli compression quality (0-3=fast, 4-9=balanced, 10-11=max)",
+      "maximum": 11,
+      "minimum": 0,
+      "title": "Compression Brotli Quality",
       "type": "integer"
     },
-    "retry_max_attempts": {
+    "compression_enabled": {
+      "default": true,
+      "description": "Enable response compression (Brotli, Zstd, GZip)",
+      "title": "Compression Enabled",
+      "type": "boolean"
+    },
+    "compression_gzip_level": {
+      "default": 6,
+      "description": "GZip compression level (1=fastest, 9=best compression)",
+      "maximum": 9,
+      "minimum": 1,
+      "title": "Compression Gzip Level",
+      "type": "integer"
+    },
+    "compression_minimum_size": {
+      "default": 500,
+      "description": "Minimum response size in bytes to compress (0 = compress all)",
+      "minimum": 0,
+      "title": "Compression Minimum Size",
+      "type": "integer"
+    },
+    "compression_zstd_level": {
       "default": 3,
-      "title": "Retry Max Attempts",
-      "type": "integer"
-    },
-    "retry_base_delay": {
-      "default": 1.0,
-      "title": "Retry Base Delay",
-      "type": "number"
-    },
-    "retry_max_delay": {
-      "default": 60,
-      "title": "Retry Max Delay",
-      "type": "integer"
-    },
-    "retry_jitter_max": {
-      "default": 0.5,
-      "title": "Retry Jitter Max",
-      "type": "number"
-    },
-    "httpx_max_connections": {
-      "default": 200,
-      "description": "Maximum total concurrent HTTP connections (global, not per-host). Increase for high-traffic deployments with many outbound calls.",
-      "maximum": 1000,
-      "minimum": 10,
-      "title": "Httpx Max Connections",
-      "type": "integer"
-    },
-    "httpx_max_keepalive_connections": {
-      "default": 100,
-      "description": "Maximum idle keepalive connections to retain (typically 50% of max_connections)",
-      "maximum": 500,
+      "description": "Zstd compression level (1-3=fast, 4-9=balanced, 10+=slow)",
+      "maximum": 22,
       "minimum": 1,
-      "title": "Httpx Max Keepalive Connections",
+      "title": "Compression Zstd Level",
       "type": "integer"
     },
-    "httpx_keepalive_expiry": {
-      "default": 30.0,
-      "description": "Seconds before idle keepalive connections are closed",
-      "maximum": 300.0,
-      "minimum": 5.0,
-      "title": "Httpx Keepalive Expiry",
-      "type": "number"
-    },
-    "httpx_connect_timeout": {
-      "default": 5.0,
-      "description": "Timeout in seconds for establishing new connections (5s for LAN, increase for WAN)",
-      "maximum": 60.0,
-      "minimum": 1.0,
-      "title": "Httpx Connect Timeout",
-      "type": "number"
-    },
-    "httpx_read_timeout": {
-      "default": 120.0,
-      "description": "Timeout in seconds for reading response data (set high for slow MCP tool calls)",
-      "maximum": 600.0,
-      "minimum": 1.0,
-      "title": "Httpx Read Timeout",
-      "type": "number"
-    },
-    "httpx_write_timeout": {
-      "default": 30.0,
-      "description": "Timeout in seconds for writing request data",
-      "maximum": 600.0,
-      "minimum": 1.0,
-      "title": "Httpx Write Timeout",
-      "type": "number"
-    },
-    "httpx_pool_timeout": {
-      "default": 10.0,
-      "description": "Timeout in seconds waiting for a connection from the pool (fail fast on exhaustion)",
-      "maximum": 120.0,
-      "minimum": 1.0,
-      "title": "Httpx Pool Timeout",
-      "type": "number"
-    },
-    "httpx_http2_enabled": {
-      "default": false,
-      "description": "Enable HTTP/2 (requires h2 package; enable only if upstreams support HTTP/2)",
-      "title": "Httpx Http2 Enabled",
-      "type": "boolean"
-    },
-    "httpx_admin_read_timeout": {
-      "default": 30.0,
-      "description": "Read timeout for admin UI operations (model fetching, health checks). Shorter than httpx_read_timeout to fail fast on admin pages.",
-      "maximum": 120.0,
-      "minimum": 1.0,
-      "title": "Httpx Admin Read Timeout",
-      "type": "number"
-    },
-    "log_level": {
-      "default": "ERROR",
-      "enum": [
-        "DEBUG",
-        "INFO",
-        "WARNING",
-        "ERROR",
-        "CRITICAL"
-      ],
-      "title": "Log Level",
+    "cookie_samesite": {
+      "default": "lax",
+      "title": "Cookie Samesite",
       "type": "string"
-    },
-    "log_requests": {
-      "default": false,
-      "description": "Enable request payload logging with sensitive data masking",
-      "title": "Log Requests",
-      "type": "boolean"
-    },
-    "log_format": {
-      "default": "json",
-      "enum": [
-        "json",
-        "text"
-      ],
-      "title": "Log Format",
-      "type": "string"
-    },
-    "log_to_file": {
-      "default": false,
-      "title": "Log To File",
-      "type": "boolean"
-    },
-    "log_filemode": {
-      "default": "a+",
-      "title": "Log Filemode",
-      "type": "string"
-    },
-    "log_file": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Log File"
-    },
-    "log_folder": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Log Folder"
-    },
-    "log_rotation_enabled": {
-      "default": false,
-      "title": "Log Rotation Enabled",
-      "type": "boolean"
-    },
-    "log_max_size_mb": {
-      "default": 1,
-      "title": "Log Max Size Mb",
-      "type": "integer"
-    },
-    "log_backup_count": {
-      "default": 5,
-      "title": "Log Backup Count",
-      "type": "integer"
-    },
-    "log_detailed_max_body_size": {
-      "default": 16384,
-      "description": "Maximum request body size to log in detailed mode (bytes). Separate from log_max_size_mb which is for file rotation.",
-      "maximum": 1048576,
-      "minimum": 1024,
-      "title": "Log Detailed Max Body Size",
-      "type": "integer"
-    },
-    "log_detailed_skip_endpoints": {
-      "description": "List of path prefixes to skip when log_detailed_requests is enabled",
-      "items": {
-        "type": "string"
-      },
-      "title": "Log Detailed Skip Endpoints",
-      "type": "array"
-    },
-    "log_resolve_user_identity": {
-      "default": false,
-      "description": "If true, RequestLoggingMiddleware will attempt DB fallback to resolve user identity when needed",
-      "title": "Log Resolve User Identity",
-      "type": "boolean"
-    },
-    "log_detailed_sample_rate": {
-      "default": 1.0,
-      "description": "Fraction of requests to sample for detailed logging (0.0-1.0)",
-      "maximum": 1.0,
-      "minimum": 0.0,
-      "title": "Log Detailed Sample Rate",
-      "type": "number"
-    },
-    "log_buffer_size_mb": {
-      "default": 1.0,
-      "title": "Log Buffer Size Mb",
-      "type": "number"
-    },
-    "observability_enabled": {
-      "default": false,
-      "description": "Enable observability tracing and metrics collection",
-      "title": "Observability Enabled",
-      "type": "boolean"
-    },
-    "observability_trace_http_requests": {
-      "default": true,
-      "description": "Automatically trace HTTP requests",
-      "title": "Observability Trace Http Requests",
-      "type": "boolean"
-    },
-    "observability_trace_retention_days": {
-      "default": 7,
-      "description": "Number of days to retain trace data",
-      "minimum": 1,
-      "title": "Observability Trace Retention Days",
-      "type": "integer"
-    },
-    "observability_max_traces": {
-      "default": 100000,
-      "description": "Maximum number of traces to retain",
-      "minimum": 1000,
-      "title": "Observability Max Traces",
-      "type": "integer"
-    },
-    "observability_sample_rate": {
-      "default": 1.0,
-      "description": "Trace sampling rate (0.0-1.0)",
-      "maximum": 1.0,
-      "minimum": 0.0,
-      "title": "Observability Sample Rate",
-      "type": "number"
-    },
-    "observability_include_paths": {
-      "description": "Regex patterns to include for tracing (when empty, all paths are eligible before excludes)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Observability Include Paths",
-      "type": "array"
-    },
-    "observability_exclude_paths": {
-      "description": "Regex patterns to exclude from tracing (applies after include patterns)",
-      "items": {
-        "type": "string"
-      },
-      "title": "Observability Exclude Paths",
-      "type": "array"
-    },
-    "observability_metrics_enabled": {
-      "default": true,
-      "description": "Enable metrics collection",
-      "title": "Observability Metrics Enabled",
-      "type": "boolean"
-    },
-    "observability_events_enabled": {
-      "default": true,
-      "description": "Enable event logging within spans",
-      "title": "Observability Events Enabled",
-      "type": "boolean"
     },
     "correlation_id_enabled": {
       "default": true,
@@ -2081,6 +386,107 @@
       "title": "Correlation Id Response Header",
       "type": "boolean"
     },
+    "cors_allow_credentials": {
+      "default": true,
+      "title": "Cors Allow Credentials",
+      "type": "boolean"
+    },
+    "cors_enabled": {
+      "default": true,
+      "title": "Cors Enabled",
+      "type": "boolean"
+    },
+    "dangerous_patterns": {
+      "description": "Regex patterns for dangerous input",
+      "items": {
+        "type": "string"
+      },
+      "title": "Dangerous Patterns",
+      "type": "array"
+    },
+    "database_url": {
+      "default": "sqlite:///./mcp.db",
+      "description": "Database connection URL. Supports SQLite, PostgreSQL, MySQL/MariaDB. For PostgreSQL with custom schema, use the 'options' query parameter: postgresql://user:pass@host:5432/db?options=-c%20search_path=schema_name (See Issue #1535 for details)",
+      "title": "Database Url",
+      "type": "string"
+    },
+    "db_driver": {
+      "default": "mariadb+mariadbconnector",
+      "title": "Db Driver",
+      "type": "string"
+    },
+    "db_max_backoff_seconds": {
+      "default": 30,
+      "title": "Db Max Backoff Seconds",
+      "type": "integer"
+    },
+    "db_max_overflow": {
+      "default": 10,
+      "title": "Db Max Overflow",
+      "type": "integer"
+    },
+    "db_max_retries": {
+      "default": 30,
+      "title": "Db Max Retries",
+      "type": "integer"
+    },
+    "db_metrics_recording_enabled": {
+      "default": true,
+      "description": "Enable recording of execution metrics (tool/resource/prompt/server/A2A) to database. Disable if using external observability.",
+      "title": "Db Metrics Recording Enabled",
+      "type": "boolean"
+    },
+    "db_pool_class": {
+      "default": "auto",
+      "description": "Connection pool class: auto (NullPool with PgBouncer), null, or queue",
+      "enum": [
+        "auto",
+        "null",
+        "queue"
+      ],
+      "title": "Db Pool Class",
+      "type": "string"
+    },
+    "db_pool_pre_ping": {
+      "default": "auto",
+      "description": "Pre-ping connections: auto, true, or false",
+      "enum": [
+        "auto",
+        "true",
+        "false"
+      ],
+      "title": "Db Pool Pre Ping",
+      "type": "string"
+    },
+    "db_pool_recycle": {
+      "default": 3600,
+      "title": "Db Pool Recycle",
+      "type": "integer"
+    },
+    "db_pool_size": {
+      "default": 200,
+      "title": "Db Pool Size",
+      "type": "integer"
+    },
+    "db_pool_timeout": {
+      "default": 30,
+      "title": "Db Pool Timeout",
+      "type": "integer"
+    },
+    "db_prepare_threshold": {
+      "default": 5,
+      "description": "psycopg3 prepare_threshold for auto-prepared statements",
+      "maximum": 100,
+      "minimum": 0,
+      "title": "Db Prepare Threshold",
+      "type": "integer"
+    },
+    "db_query_log_detect_n1": {
+      "default": true,
+      "description": "Automatically detect and flag N+1 query patterns",
+      "title": "Db Query Log Detect N1",
+      "type": "boolean"
+    },
     "db_query_log_enabled": {
       "default": false,
       "description": "Enable database query logging to file (for N+1 detection)",
@@ -2093,16 +499,22 @@
       "title": "Db Query Log File",
       "type": "string"
     },
-    "db_query_log_json_file": {
-      "default": "logs/db-queries.jsonl",
-      "description": "Path to JSON Lines query log file",
-      "title": "Db Query Log Json File",
-      "type": "string"
-    },
     "db_query_log_format": {
       "default": "both",
       "description": "Log format: 'json', 'text', or 'both'",
       "title": "Db Query Log Format",
+      "type": "string"
+    },
+    "db_query_log_include_params": {
+      "default": false,
+      "description": "Include query parameters (may expose sensitive data)",
+      "title": "Db Query Log Include Params",
+      "type": "boolean"
+    },
+    "db_query_log_json_file": {
+      "default": "logs/db-queries.jsonl",
+      "description": "Path to JSON Lines query log file",
+      "title": "Db Query Log Json File",
       "type": "string"
     },
     "db_query_log_min_queries": {
@@ -2112,18 +524,6 @@
       "title": "Db Query Log Min Queries",
       "type": "integer"
     },
-    "db_query_log_include_params": {
-      "default": false,
-      "description": "Include query parameters (may expose sensitive data)",
-      "title": "Db Query Log Include Params",
-      "type": "boolean"
-    },
-    "db_query_log_detect_n1": {
-      "default": true,
-      "description": "Automatically detect and flag N+1 query patterns",
-      "title": "Db Query Log Detect N1",
-      "type": "boolean"
-    },
     "db_query_log_n1_threshold": {
       "default": 3,
       "description": "Number of similar queries to flag as potential N+1",
@@ -2131,111 +531,1114 @@
       "title": "Db Query Log N1 Threshold",
       "type": "integer"
     },
-    "structured_logging_enabled": {
+    "db_retry_interval_ms": {
+      "default": 2000,
+      "title": "Db Retry Interval Ms",
+      "type": "integer"
+    },
+    "db_sqlite_busy_timeout": {
+      "default": 5000,
+      "description": "SQLite busy timeout in milliseconds (default: 5000ms)",
+      "maximum": 60000,
+      "minimum": 1000,
+      "title": "Db Sqlite Busy Timeout",
+      "type": "integer"
+    },
+    "dcr_allowed_issuers": {
+      "description": "Optional allowlist of issuer URLs for DCR (empty = allow any)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Dcr Allowed Issuers",
+      "type": "array"
+    },
+    "dcr_auto_register_on_missing_credentials": {
       "default": true,
-      "description": "Enable structured JSON logging with database persistence",
-      "title": "Structured Logging Enabled",
+      "description": "Automatically register with AS when gateway has issuer but no client_id",
+      "title": "Dcr Auto Register On Missing Credentials",
       "type": "boolean"
     },
-    "structured_logging_database_enabled": {
-      "default": false,
-      "description": "Persist structured logs to database (enables /api/logs/* endpoints, impacts performance)",
-      "title": "Structured Logging Database Enabled",
-      "type": "boolean"
-    },
-    "structured_logging_external_enabled": {
-      "default": false,
-      "description": "Send logs to external systems",
-      "title": "Structured Logging External Enabled",
-      "type": "boolean"
-    },
-    "performance_tracking_enabled": {
-      "default": true,
-      "description": "Enable performance tracking and metrics",
-      "title": "Performance Tracking Enabled",
-      "type": "boolean"
-    },
-    "performance_threshold_database_query_ms": {
-      "default": 100.0,
-      "description": "Alert threshold for database queries (ms)",
-      "title": "Performance Threshold Database Query Ms",
-      "type": "number"
-    },
-    "performance_threshold_tool_invocation_ms": {
-      "default": 2000.0,
-      "description": "Alert threshold for tool invocations (ms)",
-      "title": "Performance Threshold Tool Invocation Ms",
-      "type": "number"
-    },
-    "performance_threshold_resource_read_ms": {
-      "default": 1000.0,
-      "description": "Alert threshold for resource reads (ms)",
-      "title": "Performance Threshold Resource Read Ms",
-      "type": "number"
-    },
-    "performance_threshold_http_request_ms": {
-      "default": 500.0,
-      "description": "Alert threshold for HTTP requests (ms)",
-      "title": "Performance Threshold Http Request Ms",
-      "type": "number"
-    },
-    "performance_degradation_multiplier": {
-      "default": 1.5,
-      "description": "Alert if performance degrades by this multiplier vs baseline",
-      "title": "Performance Degradation Multiplier",
-      "type": "number"
-    },
-    "audit_trail_enabled": {
-      "default": false,
-      "description": "Enable audit trail logging to database for compliance",
-      "title": "Audit Trail Enabled",
-      "type": "boolean"
-    },
-    "permission_audit_enabled": {
-      "default": false,
-      "description": "Enable permission audit logging for RBAC checks (writes a row per permission check)",
-      "title": "Permission Audit Enabled",
-      "type": "boolean"
-    },
-    "security_logging_enabled": {
-      "default": false,
-      "description": "Enable security event logging to database",
-      "title": "Security Logging Enabled",
-      "type": "boolean"
-    },
-    "security_logging_level": {
-      "default": "failures_only",
-      "description": "Security logging level: 'all' = log all events including successful auth (high DB load), 'failures_only' = log only authentication/authorization failures, 'high_severity' = log only high/critical severity events",
-      "enum": [
-        "all",
-        "failures_only",
-        "high_severity"
-      ],
-      "title": "Security Logging Level",
+    "dcr_client_name_template": {
+      "default": "MCP Gateway ({gateway_name})",
+      "description": "Template for client_name in DCR requests",
+      "title": "Dcr Client Name Template",
       "type": "string"
     },
-    "security_failed_auth_threshold": {
-      "default": 5,
-      "description": "Failed auth attempts before high severity alert",
-      "title": "Security Failed Auth Threshold",
+    "dcr_default_scopes": {
+      "default": [
+        "mcp:read"
+      ],
+      "description": "Default MCP scopes to request during DCR",
+      "items": {
+        "type": "string"
+      },
+      "title": "Dcr Default Scopes",
+      "type": "array"
+    },
+    "dcr_enabled": {
+      "default": true,
+      "description": "Enable Dynamic Client Registration (RFC 7591) - gateway acts as DCR client",
+      "title": "Dcr Enabled",
+      "type": "boolean"
+    },
+    "dcr_metadata_cache_ttl": {
+      "default": 3600,
+      "description": "AS metadata cache TTL in seconds (RFC 8414 discovery)",
+      "title": "Dcr Metadata Cache Ttl",
       "type": "integer"
     },
-    "security_threat_score_alert": {
-      "default": 0.7,
-      "description": "Threat score threshold for alerts (0.0-1.0)",
-      "title": "Security Threat Score Alert",
+    "dcr_request_refresh_token_when_unsupported": {
+      "default": false,
+      "description": "Request refresh_token even when AS metadata omits grant_types_supported. Enable for AS servers that support refresh tokens but don't advertise it.",
+      "title": "Dcr Request Refresh Token When Unsupported",
+      "type": "boolean"
+    },
+    "dcr_token_endpoint_auth_method": {
+      "default": "client_secret_basic",
+      "description": "Token endpoint auth method for DCR (client_secret_basic or client_secret_post)",
+      "title": "Dcr Token Endpoint Auth Method",
+      "type": "string"
+    },
+    "debug": {
+      "default": false,
+      "title": "Debug",
+      "type": "boolean"
+    },
+    "default_admin_role": {
+      "default": "platform_admin",
+      "description": "Global role assigned to admin users",
+      "title": "Default Admin Role",
+      "type": "string"
+    },
+    "default_passthrough_headers": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Default Passthrough Headers",
+      "type": "array"
+    },
+    "default_roots": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Default Roots",
+      "type": "array"
+    },
+    "default_team_member_role": {
+      "default": "viewer",
+      "description": "Team-scoped role assigned to team members",
+      "title": "Default Team Member Role",
+      "type": "string"
+    },
+    "default_team_owner_role": {
+      "default": "team_admin",
+      "description": "Team-scoped role assigned to team owners (e.g. personal team creator)",
+      "title": "Default Team Owner Role",
+      "type": "string"
+    },
+    "default_user_password": {
+      "default": "**********",
+      "description": "Default password for new users",
+      "format": "password",
+      "title": "Default User Password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "default_user_role": {
+      "default": "platform_viewer",
+      "description": "Global role assigned to non-admin users",
+      "title": "Default User Role",
+      "type": "string"
+    },
+    "detect_default_password_on_login": {
+      "default": true,
+      "description": "Detect default password during login and mark user for change",
+      "title": "Detect Default Password On Login",
+      "type": "boolean"
+    },
+    "dev_mode": {
+      "default": false,
+      "title": "Dev Mode",
+      "type": "boolean"
+    },
+    "docs_allow_basic_auth": {
+      "default": false,
+      "title": "Docs Allow Basic Auth",
+      "type": "boolean"
+    },
+    "ed25519_private_key": {
+      "default": "",
+      "description": "Ed25519 private key for signing",
+      "format": "password",
+      "title": "Ed25519 Private Key",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ed25519_public_key": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Derived Ed25519 public key",
+      "title": "Ed25519 Public Key"
+    },
+    "elasticsearch_enabled": {
+      "default": false,
+      "description": "Send logs to Elasticsearch",
+      "title": "Elasticsearch Enabled",
+      "type": "boolean"
+    },
+    "elasticsearch_index_prefix": {
+      "default": "mcpgateway-logs",
+      "description": "Elasticsearch index prefix",
+      "title": "Elasticsearch Index Prefix",
+      "type": "string"
+    },
+    "elasticsearch_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Elasticsearch cluster URL",
+      "title": "Elasticsearch Url"
+    },
+    "email_auth_enabled": {
+      "default": true,
+      "description": "Enable email-based authentication",
+      "title": "Email Auth Enabled",
+      "type": "boolean"
+    },
+    "embed_environment_in_tokens": {
+      "default": false,
+      "description": "Embed environment claim in gateway-issued JWTs for environment isolation",
+      "title": "Embed Environment In Tokens",
+      "type": "boolean"
+    },
+    "enable_ed25519_signing": {
+      "default": false,
+      "description": "Enable Ed25519 signing for certificates",
+      "title": "Enable Ed25519 Signing",
+      "type": "boolean"
+    },
+    "enable_header_passthrough": {
+      "default": false,
+      "description": "Enable HTTP header passthrough feature (WARNING: Security implications - only enable if needed)",
+      "title": "Enable Header Passthrough",
+      "type": "boolean"
+    },
+    "enable_overwrite_base_headers": {
+      "default": false,
+      "description": "Enable overwriting of base headers",
+      "title": "Enable Overwrite Base Headers",
+      "type": "boolean"
+    },
+    "environment": {
+      "default": "development",
+      "enum": [
+        "development",
+        "staging",
+        "production"
+      ],
+      "title": "Environment",
+      "type": "string"
+    },
+    "experimental_validate_io": {
+      "default": false,
+      "description": "Enable experimental input validation and output sanitization",
+      "title": "Experimental Validate Io",
+      "type": "boolean"
+    },
+    "federation_timeout": {
+      "default": 120,
+      "title": "Federation Timeout",
+      "type": "integer"
+    },
+    "filelock_name": {
+      "default": "gateway_service_leader.lock",
+      "title": "Filelock Name",
+      "type": "string"
+    },
+    "gateway_auto_refresh_interval": {
+      "default": 300,
+      "description": "Default refresh interval in seconds for gateway tools/resources/prompts sync (minimum 60 seconds)",
+      "minimum": 60,
+      "title": "Gateway Auto Refresh Interval",
+      "type": "integer"
+    },
+    "gateway_health_check_timeout": {
+      "default": 5.0,
+      "title": "Gateway Health Check Timeout",
       "type": "number"
     },
-    "security_rate_limit_window_minutes": {
+    "gateway_max_redirects": {
       "default": 5,
-      "description": "Time window for rate limit checks (minutes)",
-      "title": "Security Rate Limit Window Minutes",
+      "title": "Gateway Max Redirects",
       "type": "integer"
     },
-    "metrics_aggregation_enabled": {
+    "gateway_tool_name_separator": {
+      "default": "-",
+      "title": "Gateway Tool Name Separator",
+      "type": "string"
+    },
+    "gateway_validation_timeout": {
+      "default": 5,
+      "title": "Gateway Validation Timeout",
+      "type": "integer"
+    },
+    "global_config_cache_ttl": {
+      "default": 60,
+      "description": "TTL in seconds for GlobalConfig in-memory cache (default: 60)",
+      "maximum": 3600,
+      "minimum": 5,
+      "title": "Global Config Cache Ttl",
+      "type": "integer"
+    },
+    "health_check_interval": {
+      "default": 60,
+      "title": "Health Check Interval",
+      "type": "integer"
+    },
+    "health_check_timeout": {
+      "default": 5,
+      "title": "Health Check Timeout",
+      "type": "integer"
+    },
+    "host": {
+      "default": "127.0.0.1",
+      "title": "Host",
+      "type": "string"
+    },
+    "hsts_enabled": {
       "default": true,
-      "description": "Enable automatic log aggregation into performance metrics",
-      "title": "Metrics Aggregation Enabled",
+      "title": "Hsts Enabled",
+      "type": "boolean"
+    },
+    "hsts_include_subdomains": {
+      "default": true,
+      "title": "Hsts Include Subdomains",
+      "type": "boolean"
+    },
+    "hsts_max_age": {
+      "default": 31536000,
+      "title": "Hsts Max Age",
+      "type": "integer"
+    },
+    "httpx_admin_read_timeout": {
+      "default": 30.0,
+      "description": "Read timeout for admin UI operations (model fetching, health checks). Shorter than httpx_read_timeout to fail fast on admin pages.",
+      "maximum": 120.0,
+      "minimum": 1.0,
+      "title": "Httpx Admin Read Timeout",
+      "type": "number"
+    },
+    "httpx_connect_timeout": {
+      "default": 5.0,
+      "description": "Timeout in seconds for establishing new connections (5s for LAN, increase for WAN)",
+      "maximum": 60.0,
+      "minimum": 1.0,
+      "title": "Httpx Connect Timeout",
+      "type": "number"
+    },
+    "httpx_http2_enabled": {
+      "default": false,
+      "description": "Enable HTTP/2 (requires h2 package; enable only if upstreams support HTTP/2)",
+      "title": "Httpx Http2 Enabled",
+      "type": "boolean"
+    },
+    "httpx_keepalive_expiry": {
+      "default": 30.0,
+      "description": "Seconds before idle keepalive connections are closed",
+      "maximum": 300.0,
+      "minimum": 5.0,
+      "title": "Httpx Keepalive Expiry",
+      "type": "number"
+    },
+    "httpx_max_connections": {
+      "default": 200,
+      "description": "Maximum total concurrent HTTP connections (global, not per-host). Increase for high-traffic deployments with many outbound calls.",
+      "maximum": 1000,
+      "minimum": 10,
+      "title": "Httpx Max Connections",
+      "type": "integer"
+    },
+    "httpx_max_keepalive_connections": {
+      "default": 100,
+      "description": "Maximum idle keepalive connections to retain (typically 50% of max_connections)",
+      "maximum": 500,
+      "minimum": 1,
+      "title": "Httpx Max Keepalive Connections",
+      "type": "integer"
+    },
+    "httpx_pool_timeout": {
+      "default": 10.0,
+      "description": "Timeout in seconds waiting for a connection from the pool (fail fast on exhaustion)",
+      "maximum": 120.0,
+      "minimum": 1.0,
+      "title": "Httpx Pool Timeout",
+      "type": "number"
+    },
+    "httpx_read_timeout": {
+      "default": 120.0,
+      "description": "Timeout in seconds for reading response data (set high for slow MCP tool calls)",
+      "maximum": 600.0,
+      "minimum": 1.0,
+      "title": "Httpx Read Timeout",
+      "type": "number"
+    },
+    "httpx_write_timeout": {
+      "default": 30.0,
+      "description": "Timeout in seconds for writing request data",
+      "maximum": 600.0,
+      "minimum": 1.0,
+      "title": "Httpx Write Timeout",
+      "type": "number"
+    },
+    "insecure_allow_queryparam_auth": {
+      "default": false,
+      "description": "Enable query parameter authentication for gateway peers. WARNING: API keys may appear in proxy logs. See CWE-598.",
+      "title": "Insecure Allow Queryparam Auth",
+      "type": "boolean"
+    },
+    "insecure_queryparam_auth_allowed_hosts": {
+      "description": "Allowlist of hosts permitted to use query parameter auth. Empty list allows any host when feature is enabled. Format: ['mcp.tavily.com', 'api.example.com']",
+      "items": {
+        "type": "string"
+      },
+      "title": "Insecure Queryparam Auth Allowed Hosts",
+      "type": "array"
+    },
+    "invitation_expiry_days": {
+      "default": 7,
+      "description": "Number of days before team invitations expire",
+      "title": "Invitation Expiry Days",
+      "type": "integer"
+    },
+    "json_response_enabled": {
+      "default": true,
+      "title": "Json Response Enabled",
+      "type": "boolean"
+    },
+    "json_schema_validation_strict": {
+      "default": true,
+      "description": "Strict schema validation mode - reject invalid JSON schemas",
+      "title": "Json Schema Validation Strict",
+      "type": "boolean"
+    },
+    "jwt_algorithm": {
+      "default": "HS256",
+      "title": "Jwt Algorithm",
+      "type": "string"
+    },
+    "jwt_audience": {
+      "default": "mcpgateway-api",
+      "title": "Jwt Audience",
+      "type": "string"
+    },
+    "jwt_audience_verification": {
+      "default": true,
+      "title": "Jwt Audience Verification",
+      "type": "boolean"
+    },
+    "jwt_issuer": {
+      "default": "mcpgateway",
+      "title": "Jwt Issuer",
+      "type": "string"
+    },
+    "jwt_issuer_verification": {
+      "default": true,
+      "title": "Jwt Issuer Verification",
+      "type": "boolean"
+    },
+    "jwt_private_key_path": {
+      "default": "",
+      "title": "Jwt Private Key Path",
+      "type": "string"
+    },
+    "jwt_public_key_path": {
+      "default": "",
+      "title": "Jwt Public Key Path",
+      "type": "string"
+    },
+    "jwt_secret_key": {
+      "default": "**********",
+      "format": "password",
+      "title": "Jwt Secret Key",
+      "type": "string",
+      "writeOnly": true
+    },
+    "llm_api_prefix": {
+      "default": "/v1",
+      "description": "API prefix for internal LLM endpoints",
+      "title": "Llm Api Prefix",
+      "type": "string"
+    },
+    "llm_health_check_interval": {
+      "default": 300,
+      "description": "Provider health check interval in seconds",
+      "title": "Llm Health Check Interval",
+      "type": "integer"
+    },
+    "llm_request_timeout": {
+      "default": 120,
+      "description": "Request timeout in seconds for LLM API calls",
+      "title": "Llm Request Timeout",
+      "type": "integer"
+    },
+    "llm_streaming_enabled": {
+      "default": true,
+      "description": "Enable streaming responses for LLM Chat",
+      "title": "Llm Streaming Enabled",
+      "type": "boolean"
+    },
+    "llmchat_chat_history_max_messages": {
+      "default": 50,
+      "description": "Maximum message history to store per user",
+      "title": "Llmchat Chat History Max Messages",
+      "type": "integer"
+    },
+    "llmchat_chat_history_ttl": {
+      "default": 3600,
+      "description": "Seconds for chat history expiry",
+      "title": "Llmchat Chat History Ttl",
+      "type": "integer"
+    },
+    "llmchat_enabled": {
+      "default": false,
+      "description": "Enable LLM Chat feature",
+      "title": "Llmchat Enabled",
+      "type": "boolean"
+    },
+    "llmchat_session_lock_retries": {
+      "default": 10,
+      "description": "How many times to poll while waiting",
+      "title": "Llmchat Session Lock Retries",
+      "type": "integer"
+    },
+    "llmchat_session_lock_ttl": {
+      "default": 30,
+      "description": "Seconds for lock expiry",
+      "title": "Llmchat Session Lock Ttl",
+      "type": "integer"
+    },
+    "llmchat_session_lock_wait": {
+      "default": 0.2,
+      "description": "Seconds between polls",
+      "title": "Llmchat Session Lock Wait",
+      "type": "number"
+    },
+    "llmchat_session_ttl": {
+      "default": 300,
+      "description": "Seconds for active_session key TTL",
+      "title": "Llmchat Session Ttl",
+      "type": "integer"
+    },
+    "log_backup_count": {
+      "default": 5,
+      "title": "Log Backup Count",
+      "type": "integer"
+    },
+    "log_buffer_size_mb": {
+      "default": 1.0,
+      "title": "Log Buffer Size Mb",
+      "type": "number"
+    },
+    "log_detailed_max_body_size": {
+      "default": 16384,
+      "description": "Maximum request body size to log in detailed mode (bytes). Separate from log_max_size_mb which is for file rotation.",
+      "maximum": 1048576,
+      "minimum": 1024,
+      "title": "Log Detailed Max Body Size",
+      "type": "integer"
+    },
+    "log_detailed_sample_rate": {
+      "default": 1.0,
+      "description": "Fraction of requests to sample for detailed logging (0.0-1.0)",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Log Detailed Sample Rate",
+      "type": "number"
+    },
+    "log_detailed_skip_endpoints": {
+      "description": "List of path prefixes to skip when log_detailed_requests is enabled",
+      "items": {
+        "type": "string"
+      },
+      "title": "Log Detailed Skip Endpoints",
+      "type": "array"
+    },
+    "log_file": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Log File"
+    },
+    "log_filemode": {
+      "default": "a+",
+      "title": "Log Filemode",
+      "type": "string"
+    },
+    "log_folder": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Log Folder"
+    },
+    "log_format": {
+      "default": "json",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "title": "Log Format",
+      "type": "string"
+    },
+    "log_level": {
+      "default": "ERROR",
+      "enum": [
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
+      ],
+      "title": "Log Level",
+      "type": "string"
+    },
+    "log_max_size_mb": {
+      "default": 1,
+      "title": "Log Max Size Mb",
+      "type": "integer"
+    },
+    "log_requests": {
+      "default": false,
+      "description": "Enable request payload logging with sensitive data masking",
+      "title": "Log Requests",
+      "type": "boolean"
+    },
+    "log_resolve_user_identity": {
+      "default": false,
+      "description": "If true, RequestLoggingMiddleware will attempt DB fallback to resolve user identity when needed",
+      "title": "Log Resolve User Identity",
+      "type": "boolean"
+    },
+    "log_retention_days": {
+      "default": 30,
+      "description": "Number of days to retain logs in database",
+      "title": "Log Retention Days",
+      "type": "integer"
+    },
+    "log_rotation_enabled": {
+      "default": false,
+      "title": "Log Rotation Enabled",
+      "type": "boolean"
+    },
+    "log_search_max_results": {
+      "default": 1000,
+      "description": "Maximum results per log search query",
+      "title": "Log Search Max Results",
+      "type": "integer"
+    },
+    "log_to_file": {
+      "default": false,
+      "title": "Log To File",
+      "type": "boolean"
+    },
+    "masked_auth_value": {
+      "default": "*****",
+      "title": "Masked Auth Value",
+      "type": "string"
+    },
+    "max_concurrent_health_checks": {
+      "default": 10,
+      "title": "Max Concurrent Health Checks",
+      "type": "integer"
+    },
+    "max_failed_login_attempts": {
+      "default": 10,
+      "description": "Maximum failed login attempts before account lockout",
+      "title": "Max Failed Login Attempts",
+      "type": "integer"
+    },
+    "max_interval": {
+      "default": 5.0,
+      "description": "Maximum polling interval in seconds when the session is idle",
+      "title": "Max Interval",
+      "type": "number"
+    },
+    "max_members_per_team": {
+      "default": 100,
+      "description": "Maximum number of members per team",
+      "title": "Max Members Per Team",
+      "type": "integer"
+    },
+    "max_param_length": {
+      "default": 10000,
+      "description": "Maximum parameter length",
+      "title": "Max Param Length",
+      "type": "integer"
+    },
+    "max_path_depth": {
+      "default": 10,
+      "description": "Maximum allowed path depth",
+      "title": "Max Path Depth",
+      "type": "integer"
+    },
+    "max_prompt_size": {
+      "default": 102400,
+      "title": "Max Prompt Size",
+      "type": "integer"
+    },
+    "max_resource_size": {
+      "default": 10485760,
+      "title": "Max Resource Size",
+      "type": "integer"
+    },
+    "max_teams_per_user": {
+      "default": 50,
+      "description": "Maximum number of teams a user can belong to",
+      "title": "Max Teams Per User",
+      "type": "integer"
+    },
+    "max_tool_retries": {
+      "default": 3,
+      "title": "Max Tool Retries",
+      "type": "integer"
+    },
+    "mcp_client_auth_enabled": {
+      "default": true,
+      "description": "Enable JWT authentication for MCP client operations",
+      "title": "Mcp Client Auth Enabled",
+      "type": "boolean"
+    },
+    "mcp_require_auth": {
+      "default": false,
+      "description": "Require authentication for /mcp endpoints. If false, unauthenticated requests can access public items only. If true, all /mcp requests must include a valid Bearer token.",
+      "title": "Mcp Require Auth",
+      "type": "boolean"
+    },
+    "mcp_session_pool_acquire_timeout": {
+      "default": 30.0,
+      "title": "Mcp Session Pool Acquire Timeout",
+      "type": "number"
+    },
+    "mcp_session_pool_circuit_breaker_reset": {
+      "default": 60.0,
+      "title": "Mcp Session Pool Circuit Breaker Reset",
+      "type": "number"
+    },
+    "mcp_session_pool_circuit_breaker_threshold": {
+      "default": 5,
+      "title": "Mcp Session Pool Circuit Breaker Threshold",
+      "type": "integer"
+    },
+    "mcp_session_pool_cleanup_timeout": {
+      "default": 5.0,
+      "title": "Mcp Session Pool Cleanup Timeout",
+      "type": "number"
+    },
+    "mcp_session_pool_create_timeout": {
+      "default": 30.0,
+      "title": "Mcp Session Pool Create Timeout",
+      "type": "number"
+    },
+    "mcp_session_pool_enabled": {
+      "default": false,
+      "title": "Mcp Session Pool Enabled",
+      "type": "boolean"
+    },
+    "mcp_session_pool_explicit_health_rpc": {
+      "default": false,
+      "title": "Mcp Session Pool Explicit Health Rpc",
+      "type": "boolean"
+    },
+    "mcp_session_pool_health_check_interval": {
+      "default": 60.0,
+      "title": "Mcp Session Pool Health Check Interval",
+      "type": "number"
+    },
+    "mcp_session_pool_health_check_methods": {
+      "default": [
+        "ping",
+        "skip"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "title": "Mcp Session Pool Health Check Methods",
+      "type": "array"
+    },
+    "mcp_session_pool_health_check_timeout": {
+      "default": 5.0,
+      "title": "Mcp Session Pool Health Check Timeout",
+      "type": "number"
+    },
+    "mcp_session_pool_identity_headers": {
+      "default": [
+        "authorization",
+        "x-tenant-id",
+        "x-user-id",
+        "x-api-key",
+        "cookie",
+        "x-mcp-session-id"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "title": "Mcp Session Pool Identity Headers",
+      "type": "array"
+    },
+    "mcp_session_pool_idle_eviction": {
+      "default": 600.0,
+      "title": "Mcp Session Pool Idle Eviction",
+      "type": "number"
+    },
+    "mcp_session_pool_max_per_key": {
+      "default": 10,
+      "title": "Mcp Session Pool Max Per Key",
+      "type": "integer"
+    },
+    "mcp_session_pool_transport_timeout": {
+      "default": 30.0,
+      "title": "Mcp Session Pool Transport Timeout",
+      "type": "number"
+    },
+    "mcp_session_pool_ttl": {
+      "default": 300.0,
+      "title": "Mcp Session Pool Ttl",
+      "type": "number"
+    },
+    "mcpgateway_a2a_default_timeout": {
+      "default": 30,
+      "title": "Mcpgateway A2A Default Timeout",
+      "type": "integer"
+    },
+    "mcpgateway_a2a_enabled": {
+      "default": true,
+      "title": "Mcpgateway A2A Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_a2a_max_agents": {
+      "default": 100,
+      "title": "Mcpgateway A2A Max Agents",
+      "type": "integer"
+    },
+    "mcpgateway_a2a_max_retries": {
+      "default": 3,
+      "title": "Mcpgateway A2A Max Retries",
+      "type": "integer"
+    },
+    "mcpgateway_a2a_metrics_enabled": {
+      "default": true,
+      "title": "Mcpgateway A2A Metrics Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_admin_api_enabled": {
+      "default": false,
+      "title": "Mcpgateway Admin Api Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_bootstrap_roles_in_db_enabled": {
+      "default": false,
+      "description": "Enable MCP Gateway add additional roles in db",
+      "title": "Mcpgateway Bootstrap Roles In Db Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_bootstrap_roles_in_db_file": {
+      "default": "additional_roles_in_db.json",
+      "description": "Path to add additional roles in db",
+      "title": "Mcpgateway Bootstrap Roles In Db File",
+      "type": "string"
+    },
+    "mcpgateway_bulk_import_enabled": {
+      "default": true,
+      "title": "Mcpgateway Bulk Import Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_bulk_import_max_tools": {
+      "default": 200,
+      "title": "Mcpgateway Bulk Import Max Tools",
+      "type": "integer"
+    },
+    "mcpgateway_bulk_import_rate_limit": {
+      "default": 10,
+      "title": "Mcpgateway Bulk Import Rate Limit",
+      "type": "integer"
+    },
+    "mcpgateway_catalog_auto_health_check": {
+      "default": true,
+      "description": "Automatically health check catalog servers",
+      "title": "Mcpgateway Catalog Auto Health Check",
+      "type": "boolean"
+    },
+    "mcpgateway_catalog_cache_ttl": {
+      "default": 3600,
+      "description": "Catalog cache TTL in seconds",
+      "title": "Mcpgateway Catalog Cache Ttl",
+      "type": "integer"
+    },
+    "mcpgateway_catalog_enabled": {
+      "default": true,
+      "description": "Enable MCP server catalog feature",
+      "title": "Mcpgateway Catalog Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_catalog_file": {
+      "default": "mcp-catalog.yml",
+      "description": "Path to catalog configuration file",
+      "title": "Mcpgateway Catalog File",
+      "type": "string"
+    },
+    "mcpgateway_catalog_page_size": {
+      "default": 100,
+      "description": "Number of catalog servers per page",
+      "title": "Mcpgateway Catalog Page Size",
+      "type": "integer"
+    },
+    "mcpgateway_direct_proxy_enabled": {
+      "default": false,
+      "description": "Enable direct_proxy gateway mode for pass-through MCP operations",
+      "title": "Mcpgateway Direct Proxy Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_direct_proxy_timeout": {
+      "default": 30,
+      "description": "Default timeout in seconds for direct proxy MCP operations",
+      "title": "Mcpgateway Direct Proxy Timeout",
+      "type": "integer"
+    },
+    "mcpgateway_elicitation_enabled": {
+      "default": true,
+      "description": "Enable elicitation passthrough support (MCP 2025-06-18)",
+      "title": "Mcpgateway Elicitation Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_elicitation_max_concurrent": {
+      "default": 100,
+      "description": "Maximum concurrent elicitation requests",
+      "title": "Mcpgateway Elicitation Max Concurrent",
+      "type": "integer"
+    },
+    "mcpgateway_elicitation_timeout": {
+      "default": 60,
+      "description": "Default timeout for elicitation requests in seconds",
+      "title": "Mcpgateway Elicitation Timeout",
+      "type": "integer"
+    },
+    "mcpgateway_graphql_enabled": {
+      "default": false,
+      "description": "Enable GraphQL to MCP translation support (experimental feature)",
+      "title": "Mcpgateway Graphql Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_graphql_include_mutations": {
+      "default": true,
+      "description": "Include GraphQL mutations when discovering tools",
+      "title": "Mcpgateway Graphql Include Mutations",
+      "type": "boolean"
+    },
+    "mcpgateway_graphql_introspection_enabled": {
+      "default": true,
+      "description": "Enable GraphQL schema introspection by default",
+      "title": "Mcpgateway Graphql Introspection Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_graphql_max_depth": {
+      "default": 3,
+      "description": "Maximum GraphQL field selection depth for auto-discovered tools",
+      "title": "Mcpgateway Graphql Max Depth",
+      "type": "integer"
+    },
+    "mcpgateway_graphql_timeout": {
+      "default": 30,
+      "description": "Default GraphQL operation timeout in seconds",
+      "title": "Mcpgateway Graphql Timeout",
+      "type": "integer"
+    },
+    "mcpgateway_grpc_enabled": {
+      "default": false,
+      "description": "Enable gRPC to MCP translation support (experimental feature)",
+      "title": "Mcpgateway Grpc Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_grpc_max_message_size": {
+      "default": 4194304,
+      "description": "Maximum gRPC message size in bytes (4MB)",
+      "title": "Mcpgateway Grpc Max Message Size",
+      "type": "integer"
+    },
+    "mcpgateway_grpc_reflection_enabled": {
+      "default": true,
+      "description": "Enable gRPC server reflection by default",
+      "title": "Mcpgateway Grpc Reflection Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_grpc_timeout": {
+      "default": 30,
+      "description": "Default gRPC call timeout in seconds",
+      "title": "Mcpgateway Grpc Timeout",
+      "type": "integer"
+    },
+    "mcpgateway_grpc_tls_enabled": {
+      "default": false,
+      "description": "Enable TLS for gRPC connections by default",
+      "title": "Mcpgateway Grpc Tls Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_performance_collection_interval": {
+      "default": 10,
+      "description": "Metric collection interval in seconds",
+      "maximum": 300,
+      "minimum": 1,
+      "title": "Mcpgateway Performance Collection Interval",
+      "type": "integer"
+    },
+    "mcpgateway_performance_distributed": {
+      "default": false,
+      "description": "Enable distributed mode metrics aggregation via Redis",
+      "title": "Mcpgateway Performance Distributed",
+      "type": "boolean"
+    },
+    "mcpgateway_performance_max_snapshots": {
+      "default": 10000,
+      "description": "Maximum performance snapshots to retain",
+      "maximum": 1000000,
+      "minimum": 100,
+      "title": "Mcpgateway Performance Max Snapshots",
+      "type": "integer"
+    },
+    "mcpgateway_performance_net_connections_cache_ttl": {
+      "default": 15,
+      "description": "Cache TTL for net_connections in seconds",
+      "maximum": 300,
+      "minimum": 1,
+      "title": "Mcpgateway Performance Net Connections Cache Ttl",
+      "type": "integer"
+    },
+    "mcpgateway_performance_net_connections_enabled": {
+      "default": true,
+      "description": "Enable network connections counting (can be CPU intensive)",
+      "title": "Mcpgateway Performance Net Connections Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_performance_retention_days": {
+      "default": 90,
+      "description": "Aggregate retention period in days",
+      "maximum": 365,
+      "minimum": 1,
+      "title": "Mcpgateway Performance Retention Days",
+      "type": "integer"
+    },
+    "mcpgateway_performance_retention_hours": {
+      "default": 24,
+      "description": "Snapshot retention period in hours",
+      "maximum": 168,
+      "minimum": 1,
+      "title": "Mcpgateway Performance Retention Hours",
+      "type": "integer"
+    },
+    "mcpgateway_performance_tracking": {
+      "default": false,
+      "description": "Enable performance tracking tab in admin UI",
+      "title": "Mcpgateway Performance Tracking",
+      "type": "boolean"
+    },
+    "mcpgateway_pool_rpc_forward_timeout": {
+      "default": 30,
+      "title": "Mcpgateway Pool Rpc Forward Timeout",
+      "type": "integer"
+    },
+    "mcpgateway_session_affinity_enabled": {
+      "default": false,
+      "title": "Mcpgateway Session Affinity Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_session_affinity_max_sessions": {
+      "default": 1,
+      "title": "Mcpgateway Session Affinity Max Sessions",
+      "type": "integer"
+    },
+    "mcpgateway_session_affinity_ttl": {
+      "default": 300,
+      "title": "Mcpgateway Session Affinity Ttl",
+      "type": "integer"
+    },
+    "mcpgateway_tool_cancellation_enabled": {
+      "default": true,
+      "description": "Enable gateway-authoritative tool execution cancellation with REST API endpoints",
+      "title": "Mcpgateway Tool Cancellation Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_ui_airgapped": {
+      "default": false,
+      "description": "Use local CDN assets instead of external CDNs for airgapped deployments",
+      "title": "Mcpgateway Ui Airgapped",
+      "type": "boolean"
+    },
+    "mcpgateway_ui_embedded": {
+      "default": false,
+      "description": "Enable embedded UI mode (hides select header controls by default)",
+      "title": "Mcpgateway Ui Embedded",
+      "type": "boolean"
+    },
+    "mcpgateway_ui_enabled": {
+      "default": false,
+      "title": "Mcpgateway Ui Enabled",
+      "type": "boolean"
+    },
+    "mcpgateway_ui_hide_header_items": {
+      "description": "CSV/JSON list of header items to hide. Valid values: logout, team_selector, user_identity, theme_toggle",
+      "items": {
+        "type": "string"
+      },
+      "title": "Mcpgateway Ui Hide Header Items",
+      "type": "array"
+    },
+    "mcpgateway_ui_hide_sections": {
+      "description": "CSV/JSON list of UI sections to hide. Valid values: overview, servers, gateways, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings",
+      "items": {
+        "type": "string"
+      },
+      "title": "Mcpgateway Ui Hide Sections",
+      "type": "array"
+    },
+    "mcpgateway_ui_tool_test_timeout": {
+      "default": 60000,
+      "description": "Tool test timeout in milliseconds for the admin UI",
+      "title": "Mcpgateway Ui Tool Test Timeout",
+      "type": "integer"
+    },
+    "message_ttl": {
+      "default": 600,
+      "title": "Message Ttl",
+      "type": "integer"
+    },
+    "metrics_aggregation_auto_start": {
+      "default": false,
+      "description": "Automatically run the log aggregation loop on application startup",
+      "title": "Metrics Aggregation Auto Start",
       "type": "boolean"
     },
     "metrics_aggregation_backfill_hours": {
@@ -2246,31 +1649,17 @@
       "title": "Metrics Aggregation Backfill Hours",
       "type": "integer"
     },
+    "metrics_aggregation_enabled": {
+      "default": true,
+      "description": "Enable automatic log aggregation into performance metrics",
+      "title": "Metrics Aggregation Enabled",
+      "type": "boolean"
+    },
     "metrics_aggregation_window_minutes": {
       "default": 5,
       "description": "Time window for metrics aggregation (minutes)",
       "title": "Metrics Aggregation Window Minutes",
       "type": "integer"
-    },
-    "metrics_aggregation_auto_start": {
-      "default": false,
-      "description": "Automatically run the log aggregation loop on application startup",
-      "title": "Metrics Aggregation Auto Start",
-      "type": "boolean"
-    },
-    "yield_batch_size": {
-      "default": 1000,
-      "description": "Number of rows fetched per batch when streaming hourly metric data from the database. Used to limit memory usage during aggregation and percentile calculations. Smaller values reduce memory footprint but increase DB round-trips; larger values improve throughput at the cost of higher memory usage.",
-      "maximum": 100000,
-      "minimum": 100,
-      "title": "Yield Batch Size",
-      "type": "integer"
-    },
-    "db_metrics_recording_enabled": {
-      "default": true,
-      "description": "Enable recording of execution metrics (tool/resource/prompt/server/A2A) to database. Disable if using external observability.",
-      "title": "Db Metrics Recording Enabled",
-      "type": "boolean"
     },
     "metrics_buffer_enabled": {
       "default": true,
@@ -2308,28 +1697,6 @@
       "title": "Metrics Cache Ttl Seconds",
       "type": "integer"
     },
-    "metrics_cleanup_enabled": {
-      "default": true,
-      "description": "Enable automatic cleanup of old metrics data",
-      "title": "Metrics Cleanup Enabled",
-      "type": "boolean"
-    },
-    "metrics_retention_days": {
-      "default": 7,
-      "description": "Days to retain raw metrics before cleanup (fallback when rollup disabled)",
-      "maximum": 365,
-      "minimum": 1,
-      "title": "Metrics Retention Days",
-      "type": "integer"
-    },
-    "metrics_cleanup_interval_hours": {
-      "default": 1,
-      "description": "Hours between automatic cleanup runs",
-      "maximum": 168,
-      "minimum": 1,
-      "title": "Metrics Cleanup Interval Hours",
-      "type": "integer"
-    },
     "metrics_cleanup_batch_size": {
       "default": 10000,
       "description": "Batch size for metrics deletion (prevents long locks)",
@@ -2338,34 +1705,18 @@
       "title": "Metrics Cleanup Batch Size",
       "type": "integer"
     },
-    "metrics_rollup_enabled": {
+    "metrics_cleanup_enabled": {
       "default": true,
-      "description": "Enable hourly metrics rollup for efficient historical queries",
-      "title": "Metrics Rollup Enabled",
+      "description": "Enable automatic cleanup of old metrics data",
+      "title": "Metrics Cleanup Enabled",
       "type": "boolean"
     },
-    "metrics_rollup_interval_hours": {
+    "metrics_cleanup_interval_hours": {
       "default": 1,
-      "description": "Hours between rollup runs",
-      "maximum": 24,
+      "description": "Hours between automatic cleanup runs",
+      "maximum": 168,
       "minimum": 1,
-      "title": "Metrics Rollup Interval Hours",
-      "type": "integer"
-    },
-    "metrics_rollup_retention_days": {
-      "default": 365,
-      "description": "Days to retain hourly rollup data",
-      "maximum": 3650,
-      "minimum": 30,
-      "title": "Metrics Rollup Retention Days",
-      "type": "integer"
-    },
-    "metrics_rollup_late_data_hours": {
-      "default": 1,
-      "description": "Hours to re-process on each run to catch late-arriving data (smaller = less CPU, larger = more tolerance for delayed metrics)",
-      "maximum": 48,
-      "minimum": 1,
-      "title": "Metrics Rollup Late Data Hours",
+      "title": "Metrics Cleanup Interval Hours",
       "type": "integer"
     },
     "metrics_delete_raw_after_rollup": {
@@ -2382,712 +1733,171 @@
       "title": "Metrics Delete Raw After Rollup Hours",
       "type": "integer"
     },
-    "auth_cache_enabled": {
-      "default": true,
-      "description": "Enable Redis/in-memory caching for authentication data (user, team, revocation)",
-      "title": "Auth Cache Enabled",
-      "type": "boolean"
-    },
-    "auth_cache_user_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for cached user data",
-      "maximum": 300,
-      "minimum": 10,
-      "title": "Auth Cache User Ttl",
-      "type": "integer"
-    },
-    "auth_cache_revocation_ttl": {
-      "default": 30,
-      "description": "TTL in seconds for token revocation cache (security-critical, keep short)",
-      "maximum": 120,
-      "minimum": 5,
-      "title": "Auth Cache Revocation Ttl",
-      "type": "integer"
-    },
-    "auth_cache_team_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for team membership cache",
-      "maximum": 300,
-      "minimum": 10,
-      "title": "Auth Cache Team Ttl",
-      "type": "integer"
-    },
-    "auth_cache_role_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for user role in team cache",
-      "maximum": 300,
-      "minimum": 10,
-      "title": "Auth Cache Role Ttl",
-      "type": "integer"
-    },
-    "auth_cache_teams_enabled": {
-      "default": true,
-      "description": "Enable caching for get_user_teams() (default: true)",
-      "title": "Auth Cache Teams Enabled",
-      "type": "boolean"
-    },
-    "auth_cache_teams_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for user teams list cache",
-      "maximum": 300,
-      "minimum": 10,
-      "title": "Auth Cache Teams Ttl",
-      "type": "integer"
-    },
-    "auth_cache_batch_queries": {
-      "default": true,
-      "description": "Batch auth DB queries into single call (reduces 3 queries to 1)",
-      "title": "Auth Cache Batch Queries",
-      "type": "boolean"
-    },
-    "registry_cache_enabled": {
-      "default": true,
-      "description": "Enable caching for registry list endpoints (tools, prompts, resources, etc.)",
-      "title": "Registry Cache Enabled",
-      "type": "boolean"
-    },
-    "registry_cache_tools_ttl": {
-      "default": 20,
-      "description": "TTL in seconds for tools list cache",
-      "maximum": 300,
-      "minimum": 5,
-      "title": "Registry Cache Tools Ttl",
-      "type": "integer"
-    },
-    "registry_cache_prompts_ttl": {
-      "default": 15,
-      "description": "TTL in seconds for prompts list cache",
-      "maximum": 300,
-      "minimum": 5,
-      "title": "Registry Cache Prompts Ttl",
-      "type": "integer"
-    },
-    "registry_cache_resources_ttl": {
-      "default": 15,
-      "description": "TTL in seconds for resources list cache",
-      "maximum": 300,
-      "minimum": 5,
-      "title": "Registry Cache Resources Ttl",
-      "type": "integer"
-    },
-    "registry_cache_agents_ttl": {
-      "default": 20,
-      "description": "TTL in seconds for agents list cache",
-      "maximum": 300,
-      "minimum": 5,
-      "title": "Registry Cache Agents Ttl",
-      "type": "integer"
-    },
-    "registry_cache_servers_ttl": {
-      "default": 20,
-      "description": "TTL in seconds for servers list cache",
-      "maximum": 300,
-      "minimum": 5,
-      "title": "Registry Cache Servers Ttl",
-      "type": "integer"
-    },
-    "registry_cache_gateways_ttl": {
-      "default": 20,
-      "description": "TTL in seconds for gateways list cache",
-      "maximum": 300,
-      "minimum": 5,
-      "title": "Registry Cache Gateways Ttl",
-      "type": "integer"
-    },
-    "registry_cache_catalog_ttl": {
-      "default": 300,
-      "description": "TTL in seconds for catalog servers list cache (external catalog, changes infrequently)",
-      "maximum": 600,
-      "minimum": 60,
-      "title": "Registry Cache Catalog Ttl",
-      "type": "integer"
-    },
-    "tool_lookup_cache_enabled": {
-      "default": true,
-      "description": "Enable tool lookup cache (tool name -> tool config)",
-      "title": "Tool Lookup Cache Enabled",
-      "type": "boolean"
-    },
-    "tool_lookup_cache_ttl_seconds": {
-      "default": 60,
-      "description": "TTL in seconds for tool lookup cache entries",
-      "maximum": 600,
-      "minimum": 5,
-      "title": "Tool Lookup Cache Ttl Seconds",
-      "type": "integer"
-    },
-    "tool_lookup_cache_negative_ttl_seconds": {
-      "default": 10,
-      "description": "TTL in seconds for negative tool lookup cache entries",
-      "maximum": 60,
+    "metrics_retention_days": {
+      "default": 7,
+      "description": "Days to retain raw metrics before cleanup (fallback when rollup disabled)",
+      "maximum": 365,
       "minimum": 1,
-      "title": "Tool Lookup Cache Negative Ttl Seconds",
+      "title": "Metrics Retention Days",
       "type": "integer"
     },
-    "tool_lookup_cache_l1_maxsize": {
-      "default": 10000,
-      "description": "Max entries for in-memory tool lookup cache (L1)",
-      "maximum": 1000000,
-      "minimum": 100,
-      "title": "Tool Lookup Cache L1 Maxsize",
-      "type": "integer"
-    },
-    "tool_lookup_cache_l2_enabled": {
+    "metrics_rollup_enabled": {
       "default": true,
-      "description": "Enable Redis-backed tool lookup cache (L2) when cache_type=redis",
-      "title": "Tool Lookup Cache L2 Enabled",
+      "description": "Enable hourly metrics rollup for efficient historical queries",
+      "title": "Metrics Rollup Enabled",
       "type": "boolean"
     },
-    "admin_stats_cache_enabled": {
-      "default": true,
-      "description": "Enable caching for admin dashboard statistics",
-      "title": "Admin Stats Cache Enabled",
-      "type": "boolean"
-    },
-    "admin_stats_cache_system_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for system stats cache",
-      "maximum": 300,
-      "minimum": 10,
-      "title": "Admin Stats Cache System Ttl",
-      "type": "integer"
-    },
-    "admin_stats_cache_observability_ttl": {
-      "default": 30,
-      "description": "TTL in seconds for observability stats cache",
-      "maximum": 120,
-      "minimum": 10,
-      "title": "Admin Stats Cache Observability Ttl",
-      "type": "integer"
-    },
-    "admin_stats_cache_tags_ttl": {
-      "default": 120,
-      "description": "TTL in seconds for tags listing cache",
-      "maximum": 600,
-      "minimum": 30,
-      "title": "Admin Stats Cache Tags Ttl",
-      "type": "integer"
-    },
-    "admin_stats_cache_plugins_ttl": {
-      "default": 120,
-      "description": "TTL in seconds for plugin stats cache",
-      "maximum": 600,
-      "minimum": 30,
-      "title": "Admin Stats Cache Plugins Ttl",
-      "type": "integer"
-    },
-    "admin_stats_cache_performance_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for performance aggregates cache",
-      "maximum": 300,
-      "minimum": 15,
-      "title": "Admin Stats Cache Performance Ttl",
-      "type": "integer"
-    },
-    "team_member_count_cache_enabled": {
-      "default": true,
-      "description": "Enable Redis caching for team member counts",
-      "title": "Team Member Count Cache Enabled",
-      "type": "boolean"
-    },
-    "team_member_count_cache_ttl": {
-      "default": 300,
-      "description": "TTL in seconds for team member count cache (default: 5 minutes)",
-      "maximum": 3600,
-      "minimum": 30,
-      "title": "Team Member Count Cache Ttl",
-      "type": "integer"
-    },
-    "log_search_max_results": {
-      "default": 1000,
-      "description": "Maximum results per log search query",
-      "title": "Log Search Max Results",
-      "type": "integer"
-    },
-    "log_retention_days": {
-      "default": 30,
-      "description": "Number of days to retain logs in database",
-      "title": "Log Retention Days",
-      "type": "integer"
-    },
-    "elasticsearch_enabled": {
-      "default": false,
-      "description": "Send logs to Elasticsearch",
-      "title": "Elasticsearch Enabled",
-      "type": "boolean"
-    },
-    "elasticsearch_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Elasticsearch cluster URL",
-      "title": "Elasticsearch Url"
-    },
-    "elasticsearch_index_prefix": {
-      "default": "mcpgateway-logs",
-      "description": "Elasticsearch index prefix",
-      "title": "Elasticsearch Index Prefix",
-      "type": "string"
-    },
-    "syslog_enabled": {
-      "default": false,
-      "description": "Send logs to syslog",
-      "title": "Syslog Enabled",
-      "type": "boolean"
-    },
-    "syslog_host": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Syslog server host",
-      "title": "Syslog Host"
-    },
-    "syslog_port": {
-      "default": 514,
-      "description": "Syslog server port",
-      "title": "Syslog Port",
-      "type": "integer"
-    },
-    "webhook_logging_enabled": {
-      "default": false,
-      "description": "Send logs to webhook endpoints",
-      "title": "Webhook Logging Enabled",
-      "type": "boolean"
-    },
-    "webhook_logging_urls": {
-      "description": "Webhook URLs for log delivery",
-      "items": {
-        "type": "string"
-      },
-      "title": "Webhook Logging Urls",
-      "type": "array"
-    },
-    "transport_type": {
-      "default": "all",
-      "title": "Transport Type",
-      "type": "string"
-    },
-    "websocket_ping_interval": {
-      "default": 30,
-      "title": "Websocket Ping Interval",
-      "type": "integer"
-    },
-    "sse_retry_timeout": {
-      "default": 5000,
-      "title": "Sse Retry Timeout",
-      "type": "integer"
-    },
-    "sse_keepalive_enabled": {
-      "default": true,
-      "title": "Sse Keepalive Enabled",
-      "type": "boolean"
-    },
-    "sse_keepalive_interval": {
-      "default": 30,
-      "title": "Sse Keepalive Interval",
-      "type": "integer"
-    },
-    "sse_send_timeout": {
-      "default": 30.0,
-      "title": "Sse Send Timeout",
-      "type": "number"
-    },
-    "sse_rapid_yield_window_ms": {
-      "default": 1000,
-      "title": "Sse Rapid Yield Window Ms",
-      "type": "integer"
-    },
-    "sse_rapid_yield_max": {
-      "default": 50,
-      "title": "Sse Rapid Yield Max",
-      "type": "integer"
-    },
-    "federation_timeout": {
-      "default": 120,
-      "title": "Federation Timeout",
-      "type": "integer"
-    },
-    "sso_issuers": {
-      "anyOf": [
-        {
-          "items": {
-            "format": "uri",
-            "maxLength": 2083,
-            "minLength": 1,
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Sso Issuers"
-    },
-    "resource_cache_size": {
-      "default": 1000,
-      "title": "Resource Cache Size",
-      "type": "integer"
-    },
-    "resource_cache_ttl": {
-      "default": 3600,
-      "title": "Resource Cache Ttl",
-      "type": "integer"
-    },
-    "max_resource_size": {
-      "default": 10485760,
-      "title": "Max Resource Size",
-      "type": "integer"
-    },
-    "allowed_mime_types": {
-      "default": [
-        "image/gif",
-        "text/plain",
-        "image/jpeg",
-        "image/png",
-        "text/markdown",
-        "text/html",
-        "application/json",
-        "application/xml"
-      ],
-      "items": {
-        "type": "string"
-      },
-      "title": "Allowed Mime Types",
-      "type": "array",
-      "uniqueItems": true
-    },
-    "tool_timeout": {
-      "default": 60,
-      "title": "Tool Timeout",
-      "type": "integer"
-    },
-    "max_tool_retries": {
-      "default": 3,
-      "title": "Max Tool Retries",
-      "type": "integer"
-    },
-    "tool_rate_limit": {
-      "default": 100,
-      "title": "Tool Rate Limit",
-      "type": "integer"
-    },
-    "tool_concurrent_limit": {
-      "default": 10,
-      "title": "Tool Concurrent Limit",
-      "type": "integer"
-    },
-    "mcp_session_pool_enabled": {
-      "default": false,
-      "title": "Mcp Session Pool Enabled",
-      "type": "boolean"
-    },
-    "mcp_session_pool_max_per_key": {
-      "default": 10,
-      "title": "Mcp Session Pool Max Per Key",
-      "type": "integer"
-    },
-    "mcp_session_pool_ttl": {
-      "default": 300.0,
-      "title": "Mcp Session Pool Ttl",
-      "type": "number"
-    },
-    "mcp_session_pool_health_check_interval": {
-      "default": 60.0,
-      "title": "Mcp Session Pool Health Check Interval",
-      "type": "number"
-    },
-    "mcp_session_pool_acquire_timeout": {
-      "default": 30.0,
-      "title": "Mcp Session Pool Acquire Timeout",
-      "type": "number"
-    },
-    "mcp_session_pool_create_timeout": {
-      "default": 30.0,
-      "title": "Mcp Session Pool Create Timeout",
-      "type": "number"
-    },
-    "mcp_session_pool_circuit_breaker_threshold": {
-      "default": 5,
-      "title": "Mcp Session Pool Circuit Breaker Threshold",
-      "type": "integer"
-    },
-    "mcp_session_pool_circuit_breaker_reset": {
-      "default": 60.0,
-      "title": "Mcp Session Pool Circuit Breaker Reset",
-      "type": "number"
-    },
-    "mcp_session_pool_idle_eviction": {
-      "default": 600.0,
-      "title": "Mcp Session Pool Idle Eviction",
-      "type": "number"
-    },
-    "mcp_session_pool_transport_timeout": {
-      "default": 30.0,
-      "title": "Mcp Session Pool Transport Timeout",
-      "type": "number"
-    },
-    "mcp_session_pool_explicit_health_rpc": {
-      "default": false,
-      "title": "Mcp Session Pool Explicit Health Rpc",
-      "type": "boolean"
-    },
-    "mcp_session_pool_health_check_methods": {
-      "default": [
-        "ping",
-        "skip"
-      ],
-      "items": {
-        "type": "string"
-      },
-      "title": "Mcp Session Pool Health Check Methods",
-      "type": "array"
-    },
-    "mcp_session_pool_health_check_timeout": {
-      "default": 5.0,
-      "title": "Mcp Session Pool Health Check Timeout",
-      "type": "number"
-    },
-    "mcp_session_pool_identity_headers": {
-      "default": [
-        "authorization",
-        "x-tenant-id",
-        "x-user-id",
-        "x-api-key",
-        "cookie",
-        "x-mcp-session-id"
-      ],
-      "items": {
-        "type": "string"
-      },
-      "title": "Mcp Session Pool Identity Headers",
-      "type": "array"
-    },
-    "mcp_session_pool_cleanup_timeout": {
-      "default": 5.0,
-      "title": "Mcp Session Pool Cleanup Timeout",
-      "type": "number"
-    },
-    "sse_task_group_cleanup_timeout": {
-      "default": 5.0,
-      "title": "Sse Task Group Cleanup Timeout",
-      "type": "number"
-    },
-    "anyio_cancel_delivery_patch_enabled": {
-      "default": false,
-      "title": "Anyio Cancel Delivery Patch Enabled",
-      "type": "boolean"
-    },
-    "anyio_cancel_delivery_max_iterations": {
-      "default": 100,
-      "title": "Anyio Cancel Delivery Max Iterations",
-      "type": "integer"
-    },
-    "mcpgateway_session_affinity_enabled": {
-      "default": false,
-      "title": "Mcpgateway Session Affinity Enabled",
-      "type": "boolean"
-    },
-    "mcpgateway_session_affinity_ttl": {
-      "default": 300,
-      "title": "Mcpgateway Session Affinity Ttl",
-      "type": "integer"
-    },
-    "mcpgateway_session_affinity_max_sessions": {
+    "metrics_rollup_interval_hours": {
       "default": 1,
-      "title": "Mcpgateway Session Affinity Max Sessions",
+      "description": "Hours between rollup runs",
+      "maximum": 24,
+      "minimum": 1,
+      "title": "Metrics Rollup Interval Hours",
       "type": "integer"
     },
-    "mcpgateway_pool_rpc_forward_timeout": {
-      "default": 30,
-      "title": "Mcpgateway Pool Rpc Forward Timeout",
+    "metrics_rollup_late_data_hours": {
+      "default": 1,
+      "description": "Hours to re-process on each run to catch late-arriving data (smaller = less CPU, larger = more tolerance for delayed metrics)",
+      "maximum": 48,
+      "minimum": 1,
+      "title": "Metrics Rollup Late Data Hours",
       "type": "integer"
     },
-    "prompt_cache_size": {
-      "default": 100,
-      "title": "Prompt Cache Size",
+    "metrics_rollup_retention_days": {
+      "default": 365,
+      "description": "Days to retain hourly rollup data",
+      "maximum": 3650,
+      "minimum": 30,
+      "title": "Metrics Rollup Retention Days",
       "type": "integer"
     },
-    "max_prompt_size": {
-      "default": 102400,
-      "title": "Max Prompt Size",
+    "min_password_length": {
+      "default": 12,
+      "title": "Min Password Length",
       "type": "integer"
     },
-    "prompt_render_timeout": {
-      "default": 10,
-      "title": "Prompt Render Timeout",
+    "min_secret_length": {
+      "default": 32,
+      "title": "Min Secret Length",
       "type": "integer"
     },
-    "health_check_interval": {
-      "default": 60,
-      "title": "Health Check Interval",
+    "oauth_default_timeout": {
+      "default": 3600,
+      "description": "Default OAuth token timeout in seconds",
+      "title": "Oauth Default Timeout",
       "type": "integer"
     },
-    "health_check_timeout": {
-      "default": 5,
-      "title": "Health Check Timeout",
-      "type": "integer"
-    },
-    "gateway_health_check_timeout": {
-      "default": 5.0,
-      "title": "Gateway Health Check Timeout",
-      "type": "number"
-    },
-    "unhealthy_threshold": {
-      "default": 3,
-      "title": "Unhealthy Threshold",
-      "type": "integer"
-    },
-    "max_concurrent_health_checks": {
-      "default": 10,
-      "title": "Max Concurrent Health Checks",
-      "type": "integer"
-    },
-    "auto_refresh_servers": {
-      "default": false,
-      "description": "Enable automatic tool/resource/prompt refresh during gateway health checks",
-      "title": "Auto Refresh Servers",
+    "oauth_discovery_enabled": {
+      "default": true,
+      "description": "Enable OAuth AS metadata discovery (RFC 8414)",
+      "title": "Oauth Discovery Enabled",
       "type": "boolean"
     },
-    "gateway_auto_refresh_interval": {
-      "default": 300,
-      "description": "Default refresh interval in seconds for gateway tools/resources/prompts sync (minimum 60 seconds)",
-      "minimum": 60,
-      "title": "Gateway Auto Refresh Interval",
+    "oauth_max_retries": {
+      "default": 3,
+      "description": "Maximum retries for OAuth token requests",
+      "title": "Oauth Max Retries",
       "type": "integer"
     },
-    "gateway_validation_timeout": {
-      "default": 5,
-      "title": "Gateway Validation Timeout",
-      "type": "integer"
-    },
-    "gateway_max_redirects": {
-      "default": 5,
-      "title": "Gateway Max Redirects",
-      "type": "integer"
-    },
-    "filelock_name": {
-      "default": "gateway_service_leader.lock",
-      "title": "Filelock Name",
+    "oauth_preferred_code_challenge_method": {
+      "default": "S256",
+      "description": "Preferred PKCE code challenge method (S256 or plain)",
+      "title": "Oauth Preferred Code Challenge Method",
       "type": "string"
     },
-    "default_roots": {
-      "default": [],
+    "oauth_request_timeout": {
+      "default": 30,
+      "description": "OAuth request timeout in seconds",
+      "title": "Oauth Request Timeout",
+      "type": "integer"
+    },
+    "observability_enabled": {
+      "default": false,
+      "description": "Enable observability tracing and metrics collection",
+      "title": "Observability Enabled",
+      "type": "boolean"
+    },
+    "observability_events_enabled": {
+      "default": true,
+      "description": "Enable event logging within spans",
+      "title": "Observability Events Enabled",
+      "type": "boolean"
+    },
+    "observability_exclude_paths": {
+      "description": "Regex patterns to exclude from tracing (applies after include patterns)",
       "items": {
         "type": "string"
       },
-      "title": "Default Roots",
+      "title": "Observability Exclude Paths",
       "type": "array"
     },
-    "db_driver": {
-      "default": "mariadb+mariadbconnector",
-      "title": "Db Driver",
-      "type": "string"
+    "observability_include_paths": {
+      "description": "Regex patterns to include for tracing (when empty, all paths are eligible before excludes)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Observability Include Paths",
+      "type": "array"
     },
-    "db_pool_size": {
-      "default": 200,
-      "title": "Db Pool Size",
+    "observability_max_traces": {
+      "default": 100000,
+      "description": "Maximum number of traces to retain",
+      "minimum": 1000,
+      "title": "Observability Max Traces",
       "type": "integer"
     },
-    "db_max_overflow": {
-      "default": 10,
-      "title": "Db Max Overflow",
-      "type": "integer"
-    },
-    "db_pool_timeout": {
-      "default": 30,
-      "title": "Db Pool Timeout",
-      "type": "integer"
-    },
-    "db_pool_recycle": {
-      "default": 3600,
-      "title": "Db Pool Recycle",
-      "type": "integer"
-    },
-    "db_max_retries": {
-      "default": 30,
-      "title": "Db Max Retries",
-      "type": "integer"
-    },
-    "db_retry_interval_ms": {
-      "default": 2000,
-      "title": "Db Retry Interval Ms",
-      "type": "integer"
-    },
-    "db_max_backoff_seconds": {
-      "default": 30,
-      "title": "Db Max Backoff Seconds",
-      "type": "integer"
-    },
-    "use_postgresdb_percentiles": {
+    "observability_metrics_enabled": {
       "default": true,
-      "description": "Use database-native percentile functions (percentile_cont) for performance metrics. When enabled, PostgreSQL uses native SQL percentile calculations (5-10x faster). When disabled or using SQLite, falls back to Python-based percentile calculations. Recommended: true for PostgreSQL, auto-detected for SQLite.",
-      "title": "Use Postgresdb Percentiles",
+      "description": "Enable metrics collection",
+      "title": "Observability Metrics Enabled",
       "type": "boolean"
     },
-    "db_prepare_threshold": {
-      "default": 5,
-      "description": "psycopg3 prepare_threshold for auto-prepared statements",
-      "maximum": 100,
-      "minimum": 0,
-      "title": "Db Prepare Threshold",
+    "observability_sample_rate": {
+      "default": 1.0,
+      "description": "Trace sampling rate (0.0-1.0)",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Observability Sample Rate",
+      "type": "number"
+    },
+    "observability_trace_http_requests": {
+      "default": true,
+      "description": "Automatically trace HTTP requests",
+      "title": "Observability Trace Http Requests",
+      "type": "boolean"
+    },
+    "observability_trace_retention_days": {
+      "default": 7,
+      "description": "Number of days to retain trace data",
+      "minimum": 1,
+      "title": "Observability Trace Retention Days",
       "type": "integer"
     },
-    "db_pool_class": {
-      "default": "auto",
-      "description": "Connection pool class: auto (NullPool with PgBouncer), null, or queue",
-      "enum": [
-        "auto",
-        "null",
-        "queue"
-      ],
-      "title": "Db Pool Class",
-      "type": "string"
+    "otel_bsp_max_export_batch_size": {
+      "default": 512,
+      "description": "Max export batch size",
+      "title": "Otel Bsp Max Export Batch Size",
+      "type": "integer"
     },
-    "db_pool_pre_ping": {
-      "default": "auto",
-      "description": "Pre-ping connections: auto, true, or false",
-      "enum": [
-        "auto",
-        "true",
-        "false"
-      ],
-      "title": "Db Pool Pre Ping",
-      "type": "string"
+    "otel_bsp_max_queue_size": {
+      "default": 2048,
+      "description": "Max queue size for batch span processor",
+      "title": "Otel Bsp Max Queue Size",
+      "type": "integer"
     },
-    "db_sqlite_busy_timeout": {
+    "otel_bsp_schedule_delay": {
       "default": 5000,
-      "description": "SQLite busy timeout in milliseconds (default: 5000ms)",
-      "maximum": 60000,
-      "minimum": 1000,
-      "title": "Db Sqlite Busy Timeout",
+      "description": "Schedule delay in milliseconds",
+      "title": "Otel Bsp Schedule Delay",
       "type": "integer"
     },
-    "cache_type": {
-      "default": "database",
-      "enum": [
-        "redis",
-        "memory",
-        "none",
-        "database"
-      ],
-      "title": "Cache Type",
-      "type": "string"
+    "otel_enable_observability": {
+      "default": false,
+      "description": "Enable OpenTelemetry observability",
+      "title": "Otel Enable Observability",
+      "type": "boolean"
     },
-    "redis_url": {
+    "otel_exporter_jaeger_endpoint": {
       "anyOf": [
         {
           "type": "string"
@@ -3096,145 +1906,336 @@
           "type": "null"
         }
       ],
-      "default": "redis://localhost:6379/0",
-      "title": "Redis Url"
+      "default": null,
+      "description": "Jaeger endpoint",
+      "title": "Otel Exporter Jaeger Endpoint"
     },
-    "cache_prefix": {
-      "default": "mcpgw:",
-      "title": "Cache Prefix",
-      "type": "string"
-    },
-    "session_ttl": {
-      "default": 3600,
-      "title": "Session Ttl",
-      "type": "integer"
-    },
-    "message_ttl": {
-      "default": 600,
-      "title": "Message Ttl",
-      "type": "integer"
-    },
-    "redis_max_retries": {
-      "default": 30,
-      "title": "Redis Max Retries",
-      "type": "integer"
-    },
-    "redis_retry_interval_ms": {
-      "default": 2000,
-      "title": "Redis Retry Interval Ms",
-      "type": "integer"
-    },
-    "redis_max_backoff_seconds": {
-      "default": 30,
-      "title": "Redis Max Backoff Seconds",
-      "type": "integer"
-    },
-    "global_config_cache_ttl": {
-      "default": 60,
-      "description": "TTL in seconds for GlobalConfig in-memory cache (default: 60)",
-      "maximum": 3600,
-      "minimum": 5,
-      "title": "Global Config Cache Ttl",
-      "type": "integer"
-    },
-    "a2a_stats_cache_ttl": {
-      "default": 30,
-      "description": "TTL in seconds for A2A stats in-memory cache (default: 30)",
-      "maximum": 3600,
-      "minimum": 5,
-      "title": "A2A Stats Cache Ttl",
-      "type": "integer"
-    },
-    "redis_parser": {
-      "default": "auto",
-      "description": "Redis protocol parser: auto (use hiredis if available), hiredis (require hiredis), python (pure-Python)",
-      "enum": [
-        "auto",
-        "hiredis",
-        "python"
+    "otel_exporter_otlp_endpoint": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
       ],
-      "title": "Redis Parser",
-      "type": "string"
+      "default": null,
+      "description": "OTLP endpoint (e.g., http://localhost:4317)",
+      "title": "Otel Exporter Otlp Endpoint"
     },
-    "redis_decode_responses": {
+    "otel_exporter_otlp_headers": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "OTLP headers (comma-separated key=value)",
+      "title": "Otel Exporter Otlp Headers"
+    },
+    "otel_exporter_otlp_insecure": {
       "default": true,
-      "description": "Return strings instead of bytes",
-      "title": "Redis Decode Responses",
+      "description": "Use insecure connection for OTLP",
+      "title": "Otel Exporter Otlp Insecure",
       "type": "boolean"
     },
-    "redis_max_connections": {
+    "otel_exporter_otlp_protocol": {
+      "default": "grpc",
+      "description": "OTLP protocol: grpc or http",
+      "title": "Otel Exporter Otlp Protocol",
+      "type": "string"
+    },
+    "otel_exporter_zipkin_endpoint": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Zipkin endpoint",
+      "title": "Otel Exporter Zipkin Endpoint"
+    },
+    "otel_resource_attributes": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Resource attributes (comma-separated key=value)",
+      "title": "Otel Resource Attributes"
+    },
+    "otel_service_name": {
+      "default": "mcp-gateway",
+      "description": "Service name for traces",
+      "title": "Otel Service Name",
+      "type": "string"
+    },
+    "otel_traces_exporter": {
+      "default": "otlp",
+      "description": "Traces exporter: otlp, jaeger, zipkin, console, none",
+      "title": "Otel Traces Exporter",
+      "type": "string"
+    },
+    "pagination_base_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Base URL for pagination links",
+      "title": "Pagination Base Url"
+    },
+    "pagination_count_cache_ttl": {
+      "default": 300,
+      "description": "Cache TTL for pagination counts",
+      "minimum": 0,
+      "title": "Pagination Count Cache Ttl",
+      "type": "integer"
+    },
+    "pagination_cursor_enabled": {
+      "default": true,
+      "description": "Enable cursor-based pagination",
+      "title": "Pagination Cursor Enabled",
+      "type": "boolean"
+    },
+    "pagination_cursor_threshold": {
+      "default": 10000,
+      "description": "Threshold for cursor-based pagination",
+      "minimum": 1,
+      "title": "Pagination Cursor Threshold",
+      "type": "integer"
+    },
+    "pagination_default_page_size": {
       "default": 50,
-      "description": "Connection pool size per worker",
-      "title": "Redis Max Connections",
+      "description": "Default number of items per page",
+      "maximum": 1000,
+      "minimum": 1,
+      "title": "Pagination Default Page Size",
       "type": "integer"
     },
-    "redis_socket_timeout": {
-      "default": 2.0,
-      "description": "Socket read/write timeout in seconds",
-      "title": "Redis Socket Timeout",
-      "type": "number"
-    },
-    "redis_socket_connect_timeout": {
-      "default": 2.0,
-      "description": "Connection timeout in seconds",
-      "title": "Redis Socket Connect Timeout",
-      "type": "number"
-    },
-    "redis_retry_on_timeout": {
-      "default": true,
-      "description": "Retry commands on timeout",
-      "title": "Redis Retry On Timeout",
-      "type": "boolean"
-    },
-    "redis_health_check_interval": {
-      "default": 30,
-      "description": "Seconds between connection health checks (0=disabled)",
-      "title": "Redis Health Check Interval",
-      "type": "integer"
-    },
-    "redis_leader_ttl": {
-      "default": 15,
-      "description": "Leader election TTL in seconds",
-      "title": "Redis Leader Ttl",
-      "type": "integer"
-    },
-    "redis_leader_key": {
-      "default": "gateway_service_leader",
-      "description": "Leader key name",
-      "title": "Redis Leader Key",
+    "pagination_default_sort_field": {
+      "default": "created_at",
+      "description": "Default sort field",
+      "title": "Pagination Default Sort Field",
       "type": "string"
     },
-    "redis_leader_heartbeat_interval": {
-      "default": 5,
-      "description": "Seconds between leader heartbeats",
-      "title": "Redis Leader Heartbeat Interval",
-      "type": "integer"
+    "pagination_default_sort_order": {
+      "default": "desc",
+      "description": "Default sort order",
+      "pattern": "^(asc|desc)$",
+      "title": "Pagination Default Sort Order",
+      "type": "string"
     },
-    "use_stateful_sessions": {
-      "default": false,
-      "title": "Use Stateful Sessions",
-      "type": "boolean"
-    },
-    "json_response_enabled": {
+    "pagination_include_links": {
       "default": true,
-      "title": "Json Response Enabled",
+      "description": "Include pagination links",
+      "title": "Pagination Include Links",
       "type": "boolean"
     },
-    "streamable_http_max_events_per_stream": {
-      "default": 100,
-      "title": "Streamable Http Max Events Per Stream",
+    "pagination_max_offset": {
+      "default": 100000,
+      "description": "Maximum offset for pagination",
+      "minimum": 0,
+      "title": "Pagination Max Offset",
       "type": "integer"
     },
-    "streamable_http_event_ttl": {
-      "default": 3600,
-      "title": "Streamable Http Event Ttl",
+    "pagination_max_page_size": {
+      "default": 500,
+      "description": "Maximum allowed items per page",
+      "maximum": 10000,
+      "minimum": 1,
+      "title": "Pagination Max Page Size",
       "type": "integer"
     },
-    "plugins_enabled": {
+    "pagination_min_page_size": {
+      "default": 1,
+      "description": "Minimum items per page",
+      "minimum": 1,
+      "title": "Pagination Min Page Size",
+      "type": "integer"
+    },
+    "passthrough_headers_source": {
+      "default": "db",
+      "description": "Source priority for passthrough headers: env (environment always wins), db (database wins, default), merge (combine both)",
+      "enum": [
+        "env",
+        "db",
+        "merge"
+      ],
+      "title": "Passthrough Headers Source",
+      "type": "string"
+    },
+    "password_change_enforcement_enabled": {
+      "default": true,
+      "description": "Master switch for password change enforcement checks",
+      "title": "Password Change Enforcement Enabled",
+      "type": "boolean"
+    },
+    "password_max_age_days": {
+      "default": 90,
+      "description": "Password maximum age in days before expiry forces a change",
+      "title": "Password Max Age Days",
+      "type": "integer"
+    },
+    "password_min_length": {
+      "default": 8,
+      "description": "Minimum password length",
+      "title": "Password Min Length",
+      "type": "integer"
+    },
+    "password_policy_enabled": {
+      "default": true,
+      "description": "Enable password complexity validation for new/changed passwords",
+      "title": "Password Policy Enabled",
+      "type": "boolean"
+    },
+    "password_prevent_reuse": {
+      "default": true,
+      "description": "Prevent reusing the current password when changing",
+      "title": "Password Prevent Reuse",
+      "type": "boolean"
+    },
+    "password_require_lowercase": {
+      "default": true,
+      "description": "Require lowercase letters in passwords",
+      "title": "Password Require Lowercase",
+      "type": "boolean"
+    },
+    "password_require_numbers": {
       "default": false,
-      "description": "Enable the plugin framework",
-      "title": "Plugins Enabled",
+      "description": "Require numbers in passwords",
+      "title": "Password Require Numbers",
       "type": "boolean"
+    },
+    "password_require_special": {
+      "default": true,
+      "description": "Require special characters in passwords",
+      "title": "Password Require Special",
+      "type": "boolean"
+    },
+    "password_require_uppercase": {
+      "default": true,
+      "description": "Require uppercase letters in passwords",
+      "title": "Password Require Uppercase",
+      "type": "boolean"
+    },
+    "password_reset_enabled": {
+      "default": true,
+      "description": "Enable self-service password reset workflow (set false to disable public forgot/reset endpoints)",
+      "title": "Password Reset Enabled",
+      "type": "boolean"
+    },
+    "password_reset_invalidate_sessions": {
+      "default": true,
+      "description": "Invalidate active sessions after password reset",
+      "title": "Password Reset Invalidate Sessions",
+      "type": "boolean"
+    },
+    "password_reset_min_response_ms": {
+      "default": 250,
+      "description": "Minimum response duration for forgot-password requests to reduce timing side channels",
+      "title": "Password Reset Min Response Ms",
+      "type": "integer"
+    },
+    "password_reset_rate_limit": {
+      "default": 5,
+      "description": "Maximum password reset requests allowed per email in each rate-limit window",
+      "title": "Password Reset Rate Limit",
+      "type": "integer"
+    },
+    "password_reset_rate_window_minutes": {
+      "default": 15,
+      "description": "Password reset request rate-limit window in minutes",
+      "title": "Password Reset Rate Window Minutes",
+      "type": "integer"
+    },
+    "password_reset_token_expiry_minutes": {
+      "default": 60,
+      "description": "Password reset token expiration time in minutes",
+      "title": "Password Reset Token Expiry Minutes",
+      "type": "integer"
+    },
+    "performance_degradation_multiplier": {
+      "default": 1.5,
+      "description": "Alert if performance degrades by this multiplier vs baseline",
+      "title": "Performance Degradation Multiplier",
+      "type": "number"
+    },
+    "performance_threshold_database_query_ms": {
+      "default": 100.0,
+      "description": "Alert threshold for database queries (ms)",
+      "title": "Performance Threshold Database Query Ms",
+      "type": "number"
+    },
+    "performance_threshold_http_request_ms": {
+      "default": 500.0,
+      "description": "Alert threshold for HTTP requests (ms)",
+      "title": "Performance Threshold Http Request Ms",
+      "type": "number"
+    },
+    "performance_threshold_resource_read_ms": {
+      "default": 1000.0,
+      "description": "Alert threshold for resource reads (ms)",
+      "title": "Performance Threshold Resource Read Ms",
+      "type": "number"
+    },
+    "performance_threshold_tool_invocation_ms": {
+      "default": 2000.0,
+      "description": "Alert threshold for tool invocations (ms)",
+      "title": "Performance Threshold Tool Invocation Ms",
+      "type": "number"
+    },
+    "performance_tracking_enabled": {
+      "default": true,
+      "description": "Enable performance tracking and metrics",
+      "title": "Performance Tracking Enabled",
+      "type": "boolean"
+    },
+    "permission_audit_enabled": {
+      "default": false,
+      "description": "Enable permission audit logging for RBAC checks (writes a row per permission check)",
+      "title": "Permission Audit Enabled",
+      "type": "boolean"
+    },
+    "personal_team_prefix": {
+      "default": "personal",
+      "description": "Personal team naming prefix",
+      "title": "Personal Team Prefix",
+      "type": "string"
+    },
+    "platform_admin_email": {
+      "default": "admin@example.com",
+      "description": "Platform administrator email address",
+      "title": "Platform Admin Email",
+      "type": "string"
+    },
+    "platform_admin_full_name": {
+      "default": "Platform Administrator",
+      "description": "Platform administrator full name",
+      "title": "Platform Admin Full Name",
+      "type": "string"
+    },
+    "platform_admin_password": {
+      "default": "**********",
+      "description": "Platform administrator password",
+      "format": "password",
+      "title": "Platform Admin Password",
+      "type": "string",
+      "writeOnly": true
     },
     "plugin_config_file": {
       "default": "plugins/config.yaml",
@@ -3266,163 +2267,370 @@
       "description": "Set markup mode for plugins CLI",
       "title": "Plugins Cli Markup Mode"
     },
-    "dev_mode": {
+    "plugins_enabled": {
       "default": false,
-      "title": "Dev Mode",
+      "description": "Enable the plugin framework",
+      "title": "Plugins Enabled",
       "type": "boolean"
+    },
+    "poll_interval": {
+      "default": 1.0,
+      "description": "Initial polling interval in seconds for checking new session messages",
+      "title": "Poll Interval",
+      "type": "number"
+    },
+    "port": {
+      "default": 4444,
+      "exclusiveMinimum": 0,
+      "maximum": 65535,
+      "minimum": 1,
+      "title": "Port",
+      "type": "integer"
+    },
+    "prev_ed25519_private_key": {
+      "default": "",
+      "description": "Previous Ed25519 private key for signing",
+      "format": "password",
+      "title": "Prev Ed25519 Private Key",
+      "type": "string",
+      "writeOnly": true
+    },
+    "prev_ed25519_public_key": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Derived previous Ed25519 public key",
+      "title": "Prev Ed25519 Public Key"
+    },
+    "prompt_cache_size": {
+      "default": 100,
+      "title": "Prompt Cache Size",
+      "type": "integer"
+    },
+    "prompt_render_timeout": {
+      "default": 10,
+      "title": "Prompt Render Timeout",
+      "type": "integer"
+    },
+    "protect_all_admins": {
+      "default": true,
+      "description": "When true (default), prevent any admin from being demoted, deactivated, or locked out via API/UI. When false, only the last active admin is protected.",
+      "title": "Protect All Admins",
+      "type": "boolean"
+    },
+    "protocol_version": {
+      "default": "2025-11-25",
+      "title": "Protocol Version",
+      "type": "string"
+    },
+    "proxy_user_header": {
+      "default": "X-Authenticated-User",
+      "description": "Header containing authenticated username from proxy",
+      "title": "Proxy User Header",
+      "type": "string"
+    },
+    "public_registration_enabled": {
+      "default": false,
+      "description": "Allow unauthenticated users to self-register accounts. When false, only admins can create users via /admin/users endpoint.",
+      "title": "Public Registration Enabled",
+      "type": "boolean"
+    },
+    "redis_decode_responses": {
+      "default": true,
+      "description": "Return strings instead of bytes",
+      "title": "Redis Decode Responses",
+      "type": "boolean"
+    },
+    "redis_health_check_interval": {
+      "default": 30,
+      "description": "Seconds between connection health checks (0=disabled)",
+      "title": "Redis Health Check Interval",
+      "type": "integer"
+    },
+    "redis_leader_heartbeat_interval": {
+      "default": 5,
+      "description": "Seconds between leader heartbeats",
+      "title": "Redis Leader Heartbeat Interval",
+      "type": "integer"
+    },
+    "redis_leader_key": {
+      "default": "gateway_service_leader",
+      "description": "Leader key name",
+      "title": "Redis Leader Key",
+      "type": "string"
+    },
+    "redis_leader_ttl": {
+      "default": 15,
+      "description": "Leader election TTL in seconds",
+      "title": "Redis Leader Ttl",
+      "type": "integer"
+    },
+    "redis_max_backoff_seconds": {
+      "default": 30,
+      "title": "Redis Max Backoff Seconds",
+      "type": "integer"
+    },
+    "redis_max_connections": {
+      "default": 50,
+      "description": "Connection pool size per worker",
+      "title": "Redis Max Connections",
+      "type": "integer"
+    },
+    "redis_max_retries": {
+      "default": 30,
+      "title": "Redis Max Retries",
+      "type": "integer"
+    },
+    "redis_parser": {
+      "default": "auto",
+      "description": "Redis protocol parser: auto (use hiredis if available), hiredis (require hiredis), python (pure-Python)",
+      "enum": [
+        "auto",
+        "hiredis",
+        "python"
+      ],
+      "title": "Redis Parser",
+      "type": "string"
+    },
+    "redis_retry_interval_ms": {
+      "default": 2000,
+      "title": "Redis Retry Interval Ms",
+      "type": "integer"
+    },
+    "redis_retry_on_timeout": {
+      "default": true,
+      "description": "Retry commands on timeout",
+      "title": "Redis Retry On Timeout",
+      "type": "boolean"
+    },
+    "redis_socket_connect_timeout": {
+      "default": 2.0,
+      "description": "Connection timeout in seconds",
+      "title": "Redis Socket Connect Timeout",
+      "type": "number"
+    },
+    "redis_socket_timeout": {
+      "default": 2.0,
+      "description": "Socket read/write timeout in seconds",
+      "title": "Redis Socket Timeout",
+      "type": "number"
+    },
+    "redis_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "redis://localhost:6379/0",
+      "title": "Redis Url"
+    },
+    "registry_cache_agents_ttl": {
+      "default": 20,
+      "description": "TTL in seconds for agents list cache",
+      "maximum": 300,
+      "minimum": 5,
+      "title": "Registry Cache Agents Ttl",
+      "type": "integer"
+    },
+    "registry_cache_catalog_ttl": {
+      "default": 300,
+      "description": "TTL in seconds for catalog servers list cache (external catalog, changes infrequently)",
+      "maximum": 600,
+      "minimum": 60,
+      "title": "Registry Cache Catalog Ttl",
+      "type": "integer"
+    },
+    "registry_cache_enabled": {
+      "default": true,
+      "description": "Enable caching for registry list endpoints (tools, prompts, resources, etc.)",
+      "title": "Registry Cache Enabled",
+      "type": "boolean"
+    },
+    "registry_cache_gateways_ttl": {
+      "default": 20,
+      "description": "TTL in seconds for gateways list cache",
+      "maximum": 300,
+      "minimum": 5,
+      "title": "Registry Cache Gateways Ttl",
+      "type": "integer"
+    },
+    "registry_cache_prompts_ttl": {
+      "default": 15,
+      "description": "TTL in seconds for prompts list cache",
+      "maximum": 300,
+      "minimum": 5,
+      "title": "Registry Cache Prompts Ttl",
+      "type": "integer"
+    },
+    "registry_cache_resources_ttl": {
+      "default": 15,
+      "description": "TTL in seconds for resources list cache",
+      "maximum": 300,
+      "minimum": 5,
+      "title": "Registry Cache Resources Ttl",
+      "type": "integer"
+    },
+    "registry_cache_servers_ttl": {
+      "default": 20,
+      "description": "TTL in seconds for servers list cache",
+      "maximum": 300,
+      "minimum": 5,
+      "title": "Registry Cache Servers Ttl",
+      "type": "integer"
+    },
+    "registry_cache_tools_ttl": {
+      "default": 20,
+      "description": "TTL in seconds for tools list cache",
+      "maximum": 300,
+      "minimum": 5,
+      "title": "Registry Cache Tools Ttl",
+      "type": "integer"
     },
     "reload": {
       "default": false,
       "title": "Reload",
       "type": "boolean"
     },
-    "debug": {
-      "default": false,
-      "title": "Debug",
-      "type": "boolean"
-    },
-    "otel_enable_observability": {
-      "default": false,
-      "description": "Enable OpenTelemetry observability",
-      "title": "Otel Enable Observability",
-      "type": "boolean"
-    },
-    "otel_traces_exporter": {
-      "default": "otlp",
-      "description": "Traces exporter: otlp, jaeger, zipkin, console, none",
-      "title": "Otel Traces Exporter",
-      "type": "string"
-    },
-    "otel_exporter_otlp_endpoint": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "OTLP endpoint (e.g., http://localhost:4317)",
-      "title": "Otel Exporter Otlp Endpoint"
-    },
-    "otel_exporter_otlp_protocol": {
-      "default": "grpc",
-      "description": "OTLP protocol: grpc or http",
-      "title": "Otel Exporter Otlp Protocol",
-      "type": "string"
-    },
-    "otel_exporter_otlp_insecure": {
+    "remove_server_headers": {
       "default": true,
-      "description": "Use insecure connection for OTLP",
-      "title": "Otel Exporter Otlp Insecure",
+      "title": "Remove Server Headers",
       "type": "boolean"
     },
-    "otel_exporter_otlp_headers": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "OTLP headers (comma-separated key=value)",
-      "title": "Otel Exporter Otlp Headers"
-    },
-    "otel_exporter_jaeger_endpoint": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Jaeger endpoint",
-      "title": "Otel Exporter Jaeger Endpoint"
-    },
-    "otel_exporter_zipkin_endpoint": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Zipkin endpoint",
-      "title": "Otel Exporter Zipkin Endpoint"
-    },
-    "otel_service_name": {
-      "default": "mcp-gateway",
-      "description": "Service name for traces",
-      "title": "Otel Service Name",
-      "type": "string"
-    },
-    "otel_resource_attributes": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Resource attributes (comma-separated key=value)",
-      "title": "Otel Resource Attributes"
-    },
-    "otel_bsp_max_queue_size": {
-      "default": 2048,
-      "description": "Max queue size for batch span processor",
-      "title": "Otel Bsp Max Queue Size",
-      "type": "integer"
-    },
-    "otel_bsp_max_export_batch_size": {
-      "default": 512,
-      "description": "Max export batch size",
-      "title": "Otel Bsp Max Export Batch Size",
-      "type": "integer"
-    },
-    "otel_bsp_schedule_delay": {
-      "default": 5000,
-      "description": "Schedule delay in milliseconds",
-      "title": "Otel Bsp Schedule Delay",
-      "type": "integer"
-    },
-    "well_known_enabled": {
+    "require_email_verification_for_invites": {
       "default": true,
-      "title": "Well Known Enabled",
+      "description": "Require email verification for team invitations",
+      "title": "Require Email Verification For Invites",
       "type": "boolean"
     },
-    "well_known_robots_txt": {
-      "default": "User-agent: *\nDisallow: /\n\n# MCP Gateway is a private API gateway\n# Public crawling is disabled by default",
-      "title": "Well Known Robots Txt",
-      "type": "string"
+    "require_jti": {
+      "default": true,
+      "description": "Require JTI (JWT ID) claim in all tokens for revocation support (secure default)",
+      "title": "Require Jti",
+      "type": "boolean"
     },
-    "well_known_security_txt": {
-      "default": "",
-      "title": "Well Known Security Txt",
-      "type": "string"
+    "require_password_change_for_default_password": {
+      "default": true,
+      "description": "Require password change when user is created with the default password",
+      "title": "Require Password Change For Default Password",
+      "type": "boolean"
     },
-    "well_known_security_txt_enabled": {
+    "require_strong_secrets": {
       "default": false,
-      "title": "Well Known Security Txt Enabled",
+      "title": "Require Strong Secrets",
       "type": "boolean"
     },
-    "well_known_custom_files": {
-      "default": "{}",
-      "title": "Well Known Custom Files",
-      "type": "string"
+    "require_token_expiration": {
+      "default": true,
+      "description": "Require all JWT tokens to have expiration claims (secure default)",
+      "title": "Require Token Expiration",
+      "type": "boolean"
     },
-    "well_known_cache_max_age": {
+    "require_user_in_db": {
+      "default": false,
+      "description": "Require all authenticated users to exist in the database. When true, disables the platform admin bootstrap mechanism. WARNING: Enabling this on a fresh deployment will lock you out.",
+      "title": "Require User In Db",
+      "type": "boolean"
+    },
+    "resource_cache_size": {
+      "default": 1000,
+      "title": "Resource Cache Size",
+      "type": "integer"
+    },
+    "resource_cache_ttl": {
       "default": 3600,
-      "title": "Well Known Cache Max Age",
+      "title": "Resource Cache Ttl",
       "type": "integer"
+    },
+    "retry_base_delay": {
+      "default": 1.0,
+      "title": "Retry Base Delay",
+      "type": "number"
+    },
+    "retry_jitter_max": {
+      "default": 0.5,
+      "title": "Retry Jitter Max",
+      "type": "number"
+    },
+    "retry_max_attempts": {
+      "default": 3,
+      "title": "Retry Max Attempts",
+      "type": "integer"
+    },
+    "retry_max_delay": {
+      "default": 60,
+      "title": "Retry Max Delay",
+      "type": "integer"
+    },
+    "sanitize_output": {
+      "default": true,
+      "description": "Sanitize output to remove control characters",
+      "title": "Sanitize Output",
+      "type": "boolean"
+    },
+    "secure_cookies": {
+      "default": true,
+      "title": "Secure Cookies",
+      "type": "boolean"
+    },
+    "security_failed_auth_threshold": {
+      "default": 5,
+      "description": "Failed auth attempts before high severity alert",
+      "title": "Security Failed Auth Threshold",
+      "type": "integer"
+    },
+    "security_headers_enabled": {
+      "default": true,
+      "title": "Security Headers Enabled",
+      "type": "boolean"
+    },
+    "security_logging_enabled": {
+      "default": false,
+      "description": "Enable security event logging to database",
+      "title": "Security Logging Enabled",
+      "type": "boolean"
+    },
+    "security_logging_level": {
+      "default": "failures_only",
+      "description": "Security logging level: 'all' = log all events including successful auth (high DB load), 'failures_only' = log only authentication/authorization failures, 'high_severity' = log only high/critical severity events",
+      "enum": [
+        "all",
+        "failures_only",
+        "high_severity"
+      ],
+      "title": "Security Logging Level",
+      "type": "string"
+    },
+    "security_rate_limit_window_minutes": {
+      "default": 5,
+      "description": "Time window for rate limit checks (minutes)",
+      "title": "Security Rate Limit Window Minutes",
+      "type": "integer"
+    },
+    "security_threat_score_alert": {
+      "default": 0.7,
+      "description": "Threat score threshold for alerts (0.0-1.0)",
+      "title": "Security Threat Score Alert",
+      "type": "number"
+    },
+    "session_ttl": {
+      "default": 3600,
+      "title": "Session Ttl",
+      "type": "integer"
+    },
+    "skip_ssl_verify": {
+      "default": false,
+      "description": "Skip SSL certificate verification for ALL outbound HTTPS requests (federation, MCP servers, LLM providers, A2A agents). WARNING: Only enable in dev environments with self-signed certificates.",
+      "title": "Skip Ssl Verify",
+      "type": "boolean"
     },
     "slug_refresh_batch_size": {
       "default": 1000,
@@ -3430,106 +2638,945 @@
       "title": "Slug Refresh Batch Size",
       "type": "integer"
     },
-    "gateway_tool_name_separator": {
-      "default": "-",
-      "title": "Gateway Tool Name Separator",
-      "type": "string"
+    "smtp_enabled": {
+      "default": false,
+      "description": "Enable SMTP email delivery for password reset and account lockout notifications (when false, reset requests are accepted but no email is sent)",
+      "title": "Smtp Enabled",
+      "type": "boolean"
     },
-    "validation_dangerous_html_pattern": {
-      "default": "<(script|iframe|object|embed|link|meta|base|form|img|svg|video|audio|source|track|area|map|canvas|applet|frame|frameset|html|head|body|style)\\b|</*(script|iframe|object|embed|link|meta|base|form|img|svg|video|audio|source|track|area|map|canvas|applet|frame|frameset|html|head|body|style)>",
-      "title": "Validation Dangerous Html Pattern",
-      "type": "string"
-    },
-    "validation_dangerous_js_pattern": {
-      "default": "(?i)(?:^|\\s|[\\\"'`<>=])(javascript:|vbscript:|data:\\s*[^,]*[;\\s]*(javascript|vbscript)|\\bon[a-z]+\\s*=|<\\s*script\\b)",
-      "title": "Validation Dangerous Js Pattern",
-      "type": "string"
-    },
-    "validation_allowed_url_schemes": {
-      "default": [
-        "http://",
-        "https://",
-        "ws://",
-        "wss://"
+    "smtp_from_email": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
       ],
+      "default": null,
+      "description": "From email address used for auth notifications",
+      "title": "Smtp From Email"
+    },
+    "smtp_from_name": {
+      "default": "MCP Gateway",
+      "description": "From display name used for auth notifications",
+      "title": "Smtp From Name",
+      "type": "string"
+    },
+    "smtp_host": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "SMTP server host",
+      "title": "Smtp Host"
+    },
+    "smtp_password": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "SMTP password",
+      "title": "Smtp Password"
+    },
+    "smtp_port": {
+      "default": 587,
+      "description": "SMTP server port",
+      "title": "Smtp Port",
+      "type": "integer"
+    },
+    "smtp_timeout_seconds": {
+      "default": 15,
+      "description": "SMTP connection timeout in seconds",
+      "title": "Smtp Timeout Seconds",
+      "type": "integer"
+    },
+    "smtp_use_ssl": {
+      "default": false,
+      "description": "Use implicit SSL/TLS for SMTP connections",
+      "title": "Smtp Use Ssl",
+      "type": "boolean"
+    },
+    "smtp_use_tls": {
+      "default": true,
+      "description": "Use STARTTLS for SMTP connections",
+      "title": "Smtp Use Tls",
+      "type": "boolean"
+    },
+    "smtp_user": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "SMTP username",
+      "title": "Smtp User"
+    },
+    "sse_keepalive_enabled": {
+      "default": true,
+      "title": "Sse Keepalive Enabled",
+      "type": "boolean"
+    },
+    "sse_keepalive_interval": {
+      "default": 30,
+      "title": "Sse Keepalive Interval",
+      "type": "integer"
+    },
+    "sse_rapid_yield_max": {
+      "default": 50,
+      "title": "Sse Rapid Yield Max",
+      "type": "integer"
+    },
+    "sse_rapid_yield_window_ms": {
+      "default": 1000,
+      "title": "Sse Rapid Yield Window Ms",
+      "type": "integer"
+    },
+    "sse_retry_timeout": {
+      "default": 5000,
+      "title": "Sse Retry Timeout",
+      "type": "integer"
+    },
+    "sse_send_timeout": {
+      "default": 30.0,
+      "title": "Sse Send Timeout",
+      "type": "number"
+    },
+    "sse_task_group_cleanup_timeout": {
+      "default": 5.0,
+      "title": "Sse Task Group Cleanup Timeout",
+      "type": "number"
+    },
+    "sso_auto_admin_domains": {
+      "description": "Admin domains (CSV or JSON list)",
       "items": {
         "type": "string"
       },
-      "title": "Validation Allowed Url Schemes",
+      "title": "Sso Auto Admin Domains",
       "type": "array"
     },
-    "validation_name_pattern": {
-      "default": "^[a-zA-Z0-9_.\\-\\s]+$",
-      "title": "Validation Name Pattern",
+    "sso_auto_create_users": {
+      "default": true,
+      "description": "Automatically create users from SSO providers",
+      "title": "Sso Auto Create Users",
+      "type": "boolean"
+    },
+    "sso_enabled": {
+      "default": false,
+      "description": "Enable Single Sign-On authentication",
+      "title": "Sso Enabled",
+      "type": "boolean"
+    },
+    "sso_entra_admin_groups": {
+      "description": "EntraID groups granting platform_admin role (CSV/JSON)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Sso Entra Admin Groups",
+      "type": "array"
+    },
+    "sso_entra_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Microsoft Entra ID client ID",
+      "title": "Sso Entra Client Id"
+    },
+    "sso_entra_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Microsoft Entra ID client secret",
+      "title": "Sso Entra Client Secret"
+    },
+    "sso_entra_default_role": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Default role for EntraID users without group mapping (None = no role assigned)",
+      "title": "Sso Entra Default Role"
+    },
+    "sso_entra_enabled": {
+      "default": false,
+      "description": "Enable Microsoft Entra ID OIDC authentication",
+      "title": "Sso Entra Enabled",
+      "type": "boolean"
+    },
+    "sso_entra_groups_claim": {
+      "default": "groups",
+      "description": "JWT claim for EntraID groups (groups/roles)",
+      "title": "Sso Entra Groups Claim",
       "type": "string"
     },
-    "validation_identifier_pattern": {
-      "default": "^[a-zA-Z0-9_\\-\\.]+$",
-      "title": "Validation Identifier Pattern",
+    "sso_entra_role_mappings": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Map EntraID groups to Context Forge roles (JSON: {group_id: role_name})",
+      "title": "Sso Entra Role Mappings",
+      "type": "object"
+    },
+    "sso_entra_sync_roles_on_login": {
+      "default": true,
+      "description": "Synchronize role assignments on each login",
+      "title": "Sso Entra Sync Roles On Login",
+      "type": "boolean"
+    },
+    "sso_entra_tenant_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Microsoft Entra ID tenant ID",
+      "title": "Sso Entra Tenant Id"
+    },
+    "sso_generic_authorization_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Authorization endpoint URL",
+      "title": "Sso Generic Authorization Url"
+    },
+    "sso_generic_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Generic OIDC client ID",
+      "title": "Sso Generic Client Id"
+    },
+    "sso_generic_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Generic OIDC client secret",
+      "title": "Sso Generic Client Secret"
+    },
+    "sso_generic_display_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Display name shown on login page",
+      "title": "Sso Generic Display Name"
+    },
+    "sso_generic_enabled": {
+      "default": false,
+      "description": "Enable generic OIDC provider (Keycloak, Auth0, etc.)",
+      "title": "Sso Generic Enabled",
+      "type": "boolean"
+    },
+    "sso_generic_issuer": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "OIDC issuer URL",
+      "title": "Sso Generic Issuer"
+    },
+    "sso_generic_provider_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Provider ID (e.g., 'keycloak', 'auth0', 'authentik')",
+      "title": "Sso Generic Provider Id"
+    },
+    "sso_generic_scope": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "openid profile email",
+      "description": "OAuth scopes (space-separated)",
+      "title": "Sso Generic Scope"
+    },
+    "sso_generic_token_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Token endpoint URL",
+      "title": "Sso Generic Token Url"
+    },
+    "sso_generic_userinfo_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Userinfo endpoint URL",
+      "title": "Sso Generic Userinfo Url"
+    },
+    "sso_github_admin_orgs": {
+      "description": "GitHub orgs granting admin (CSV/JSON)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Sso Github Admin Orgs",
+      "type": "array"
+    },
+    "sso_github_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "GitHub OAuth client ID",
+      "title": "Sso Github Client Id"
+    },
+    "sso_github_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "GitHub OAuth client secret",
+      "title": "Sso Github Client Secret"
+    },
+    "sso_github_enabled": {
+      "default": false,
+      "description": "Enable GitHub OAuth authentication",
+      "title": "Sso Github Enabled",
+      "type": "boolean"
+    },
+    "sso_google_admin_domains": {
+      "description": "Google admin domains (CSV/JSON)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Sso Google Admin Domains",
+      "type": "array"
+    },
+    "sso_google_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Google OAuth client ID",
+      "title": "Sso Google Client Id"
+    },
+    "sso_google_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Google OAuth client secret",
+      "title": "Sso Google Client Secret"
+    },
+    "sso_google_enabled": {
+      "default": false,
+      "description": "Enable Google OAuth authentication",
+      "title": "Sso Google Enabled",
+      "type": "boolean"
+    },
+    "sso_ibm_verify_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "IBM Security Verify client ID",
+      "title": "Sso Ibm Verify Client Id"
+    },
+    "sso_ibm_verify_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "IBM Security Verify client secret",
+      "title": "Sso Ibm Verify Client Secret"
+    },
+    "sso_ibm_verify_enabled": {
+      "default": false,
+      "description": "Enable IBM Security Verify OIDC authentication",
+      "title": "Sso Ibm Verify Enabled",
+      "type": "boolean"
+    },
+    "sso_ibm_verify_issuer": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "IBM Security Verify OIDC issuer URL",
+      "title": "Sso Ibm Verify Issuer"
+    },
+    "sso_issuers": {
+      "anyOf": [
+        {
+          "items": {
+            "format": "uri",
+            "maxLength": 2083,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Sso Issuers"
+    },
+    "sso_keycloak_base_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Keycloak base URL (e.g., https://keycloak.example.com)",
+      "title": "Sso Keycloak Base Url"
+    },
+    "sso_keycloak_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Keycloak client ID",
+      "title": "Sso Keycloak Client Id"
+    },
+    "sso_keycloak_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Keycloak client secret",
+      "title": "Sso Keycloak Client Secret"
+    },
+    "sso_keycloak_default_role": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Default Context Forge role for Keycloak users without role mapping",
+      "title": "Sso Keycloak Default Role"
+    },
+    "sso_keycloak_email_claim": {
+      "default": "email",
+      "description": "JWT claim for email",
+      "title": "Sso Keycloak Email Claim",
       "type": "string"
     },
-    "validation_safe_uri_pattern": {
-      "default": "^[a-zA-Z0-9_\\-.:/?=&%{}]+$",
-      "title": "Validation Safe Uri Pattern",
+    "sso_keycloak_enabled": {
+      "default": false,
+      "description": "Enable Keycloak OIDC authentication",
+      "title": "Sso Keycloak Enabled",
+      "type": "boolean"
+    },
+    "sso_keycloak_groups_claim": {
+      "default": "groups",
+      "description": "JWT claim for groups/roles",
+      "title": "Sso Keycloak Groups Claim",
       "type": "string"
     },
-    "validation_unsafe_uri_pattern": {
-      "default": "[<>\"\\'\\\\]",
-      "title": "Validation Unsafe Uri Pattern",
+    "sso_keycloak_map_client_roles": {
+      "default": false,
+      "description": "Map Keycloak client roles to gateway RBAC",
+      "title": "Sso Keycloak Map Client Roles",
+      "type": "boolean"
+    },
+    "sso_keycloak_map_realm_roles": {
+      "default": true,
+      "description": "Map Keycloak realm roles to gateway teams",
+      "title": "Sso Keycloak Map Realm Roles",
+      "type": "boolean"
+    },
+    "sso_keycloak_public_base_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Browser-facing Keycloak base URL for authorization redirects (e.g., http://localhost:8180)",
+      "title": "Sso Keycloak Public Base Url"
+    },
+    "sso_keycloak_realm": {
+      "default": "master",
+      "description": "Keycloak realm name",
+      "title": "Sso Keycloak Realm",
       "type": "string"
     },
-    "validation_tool_name_pattern": {
-      "default": "^[a-zA-Z0-9_][a-zA-Z0-9._/-]*$",
-      "title": "Validation Tool Name Pattern",
+    "sso_keycloak_resolve_team_scope_to_personal_team": {
+      "default": false,
+      "description": "Resolve team-scoped Keycloak role mappings to the user's personal team",
+      "title": "Sso Keycloak Resolve Team Scope To Personal Team",
+      "type": "boolean"
+    },
+    "sso_keycloak_role_mappings": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Map Keycloak groups/roles to Context Forge roles (JSON: {group_or_role: role_name})",
+      "title": "Sso Keycloak Role Mappings",
+      "type": "object"
+    },
+    "sso_keycloak_username_claim": {
+      "default": "preferred_username",
+      "description": "JWT claim for username",
+      "title": "Sso Keycloak Username Claim",
       "type": "string"
     },
-    "validation_tool_method_pattern": {
-      "default": "^[a-zA-Z][a-zA-Z0-9_\\./-]*$",
-      "title": "Validation Tool Method Pattern",
+    "sso_okta_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Okta client ID",
+      "title": "Sso Okta Client Id"
+    },
+    "sso_okta_client_secret": {
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Okta client secret",
+      "title": "Sso Okta Client Secret"
+    },
+    "sso_okta_enabled": {
+      "default": false,
+      "description": "Enable Okta OIDC authentication",
+      "title": "Sso Okta Enabled",
+      "type": "boolean"
+    },
+    "sso_okta_issuer": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Okta issuer URL",
+      "title": "Sso Okta Issuer"
+    },
+    "sso_preserve_admin_auth": {
+      "default": true,
+      "description": "Preserve local admin authentication when SSO is enabled",
+      "title": "Sso Preserve Admin Auth",
+      "type": "boolean"
+    },
+    "sso_require_admin_approval": {
+      "default": false,
+      "description": "Require admin approval for new SSO registrations",
+      "title": "Sso Require Admin Approval",
+      "type": "boolean"
+    },
+    "sso_trusted_domains": {
+      "description": "Trusted email domains (CSV or JSON list)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Sso Trusted Domains",
+      "type": "array"
+    },
+    "ssrf_allow_localhost": {
+      "default": true,
+      "description": "Allow localhost/loopback addresses (127.0.0.0/8, ::1). Set to false to block localhost access for stricter security. Default true for development compatibility.",
+      "title": "Ssrf Allow Localhost",
+      "type": "boolean"
+    },
+    "ssrf_allow_private_networks": {
+      "default": true,
+      "description": "Allow RFC 1918 private network addresses (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16). Set to false if the gateway should only access public internet endpoints. Default true for internal deployment compatibility.",
+      "title": "Ssrf Allow Private Networks",
+      "type": "boolean"
+    },
+    "ssrf_blocked_hosts": {
+      "default": [
+        "metadata.google.internal",
+        "metadata.internal"
+      ],
+      "description": "Hostnames to block for SSRF protection. Matched case-insensitively.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Ssrf Blocked Hosts",
+      "type": "array"
+    },
+    "ssrf_blocked_networks": {
+      "default": [
+        "169.254.169.254/32",
+        "169.254.169.123/32",
+        "fd00::1/128",
+        "169.254.0.0/16",
+        "fe80::/10"
+      ],
+      "description": "CIDR ranges to block for SSRF protection. These are ALWAYS blocked regardless of other settings. Default blocks cloud metadata endpoints. Add private ranges for stricter security.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Ssrf Blocked Networks",
+      "type": "array"
+    },
+    "ssrf_dns_fail_closed": {
+      "default": false,
+      "description": "Fail closed on DNS resolution errors. When true, URLs that cannot be resolved are rejected. When false (default), unresolvable hostnames are allowed through (hostname blocklist still applies). Set to true for stricter security.",
+      "title": "Ssrf Dns Fail Closed",
+      "type": "boolean"
+    },
+    "ssrf_protection_enabled": {
+      "default": true,
+      "description": "Enable SSRF protection for gateway/tool URLs. Blocks access to dangerous endpoints.",
+      "title": "Ssrf Protection Enabled",
+      "type": "boolean"
+    },
+    "static_dir": {
+      "format": "path",
+      "title": "Static Dir",
       "type": "string"
     },
-    "validation_max_name_length": {
-      "default": 255,
-      "title": "Validation Max Name Length",
+    "streamable_http_event_ttl": {
+      "default": 3600,
+      "title": "Streamable Http Event Ttl",
       "type": "integer"
     },
-    "validation_max_description_length": {
-      "default": 8192,
-      "title": "Validation Max Description Length",
+    "streamable_http_max_events_per_stream": {
+      "default": 100,
+      "title": "Streamable Http Max Events Per Stream",
       "type": "integer"
     },
-    "validation_max_template_length": {
-      "default": 65536,
-      "title": "Validation Max Template Length",
+    "structured_logging_database_enabled": {
+      "default": false,
+      "description": "Persist structured logs to database (enables /api/logs/* endpoints, impacts performance)",
+      "title": "Structured Logging Database Enabled",
+      "type": "boolean"
+    },
+    "structured_logging_enabled": {
+      "default": true,
+      "description": "Enable structured JSON logging with database persistence",
+      "title": "Structured Logging Enabled",
+      "type": "boolean"
+    },
+    "structured_logging_external_enabled": {
+      "default": false,
+      "description": "Send logs to external systems",
+      "title": "Structured Logging External Enabled",
+      "type": "boolean"
+    },
+    "syslog_enabled": {
+      "default": false,
+      "description": "Send logs to syslog",
+      "title": "Syslog Enabled",
+      "type": "boolean"
+    },
+    "syslog_host": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Syslog server host",
+      "title": "Syslog Host"
+    },
+    "syslog_port": {
+      "default": 514,
+      "description": "Syslog server port",
+      "title": "Syslog Port",
       "type": "integer"
     },
-    "validation_max_content_length": {
-      "default": 1048576,
-      "title": "Validation Max Content Length",
+    "team_member_count_cache_enabled": {
+      "default": true,
+      "description": "Enable Redis caching for team member counts",
+      "title": "Team Member Count Cache Enabled",
+      "type": "boolean"
+    },
+    "team_member_count_cache_ttl": {
+      "default": 300,
+      "description": "TTL in seconds for team member count cache (default: 5 minutes)",
+      "maximum": 3600,
+      "minimum": 30,
+      "title": "Team Member Count Cache Ttl",
       "type": "integer"
     },
-    "validation_max_json_depth": {
-      "default": 30,
-      "description": "Maximum allowed JSON nesting depth for tool/resource schemas. Increased from 10 to 30 for compatibility with deeply nested schemas like Notion MCP (issue #1542). Override with VALIDATION_MAX_JSON_DEPTH environment variable. Minimum: 1, Maximum: 100",
-      "maximum": 100,
+    "templates_auto_reload": {
+      "default": false,
+      "description": "Auto-reload Jinja2 templates on change (enable for development)",
+      "title": "Templates Auto Reload",
+      "type": "boolean"
+    },
+    "templates_dir": {
+      "format": "path",
+      "title": "Templates Dir",
+      "type": "string"
+    },
+    "token_expiry": {
+      "default": 10080,
+      "title": "Token Expiry",
+      "type": "integer"
+    },
+    "token_last_used_update_interval_minutes": {
+      "default": 5,
+      "description": "Minimum minutes between last_used timestamp updates (rate-limits DB writes)",
+      "maximum": 1440,
       "minimum": 1,
-      "title": "Validation Max Json Depth",
+      "title": "Token Last Used Update Interval Minutes",
       "type": "integer"
     },
-    "validation_max_url_length": {
-      "default": 2048,
-      "title": "Validation Max Url Length",
+    "token_usage_logging_enabled": {
+      "default": true,
+      "description": "Enable API token usage logging middleware",
+      "title": "Token Usage Logging Enabled",
+      "type": "boolean"
+    },
+    "tool_concurrent_limit": {
+      "default": 10,
+      "title": "Tool Concurrent Limit",
       "type": "integer"
     },
-    "validation_max_rpc_param_size": {
-      "default": 262144,
-      "title": "Validation Max Rpc Param Size",
+    "tool_lookup_cache_enabled": {
+      "default": true,
+      "description": "Enable tool lookup cache (tool name -> tool config)",
+      "title": "Tool Lookup Cache Enabled",
+      "type": "boolean"
+    },
+    "tool_lookup_cache_l1_maxsize": {
+      "default": 10000,
+      "description": "Max entries for in-memory tool lookup cache (L1)",
+      "maximum": 1000000,
+      "minimum": 100,
+      "title": "Tool Lookup Cache L1 Maxsize",
       "type": "integer"
     },
-    "validation_max_method_length": {
-      "default": 128,
-      "title": "Validation Max Method Length",
+    "tool_lookup_cache_l2_enabled": {
+      "default": true,
+      "description": "Enable Redis-backed tool lookup cache (L2) when cache_type=redis",
+      "title": "Tool Lookup Cache L2 Enabled",
+      "type": "boolean"
+    },
+    "tool_lookup_cache_negative_ttl_seconds": {
+      "default": 10,
+      "description": "TTL in seconds for negative tool lookup cache entries",
+      "maximum": 60,
+      "minimum": 1,
+      "title": "Tool Lookup Cache Negative Ttl Seconds",
       "type": "integer"
+    },
+    "tool_lookup_cache_ttl_seconds": {
+      "default": 60,
+      "description": "TTL in seconds for tool lookup cache entries",
+      "maximum": 600,
+      "minimum": 5,
+      "title": "Tool Lookup Cache Ttl Seconds",
+      "type": "integer"
+    },
+    "tool_rate_limit": {
+      "default": 100,
+      "title": "Tool Rate Limit",
+      "type": "integer"
+    },
+    "tool_timeout": {
+      "default": 60,
+      "title": "Tool Timeout",
+      "type": "integer"
+    },
+    "toolops_enabled": {
+      "default": false,
+      "description": "Enable ToolOps feature",
+      "title": "Toolops Enabled",
+      "type": "boolean"
+    },
+    "transport_type": {
+      "default": "all",
+      "title": "Transport Type",
+      "type": "string"
+    },
+    "trust_proxy_auth": {
+      "default": false,
+      "description": "Trust proxy authentication headers (required when mcp_client_auth_enabled=false)",
+      "title": "Trust Proxy Auth",
+      "type": "boolean"
+    },
+    "unhealthy_threshold": {
+      "default": 3,
+      "title": "Unhealthy Threshold",
+      "type": "integer"
+    },
+    "use_postgresdb_percentiles": {
+      "default": true,
+      "description": "Use database-native percentile functions (percentile_cont) for performance metrics. When enabled, PostgreSQL uses native SQL percentile calculations (5-10x faster). When disabled or using SQLite, falls back to Python-based percentile calculations. Recommended: true for PostgreSQL, auto-detected for SQLite.",
+      "title": "Use Postgresdb Percentiles",
+      "type": "boolean"
+    },
+    "use_stateful_sessions": {
+      "default": false,
+      "title": "Use Stateful Sessions",
+      "type": "boolean"
+    },
+    "validate_token_environment": {
+      "default": false,
+      "description": "Reject tokens with mismatched environment claim (tokens without env claim are allowed)",
+      "title": "Validate Token Environment",
+      "type": "boolean"
     },
     "validation_allowed_mime_types": {
       "default": [
@@ -3553,205 +3600,202 @@
       "title": "Validation Allowed Mime Types",
       "type": "array"
     },
+    "validation_allowed_url_schemes": {
+      "default": [
+        "http://",
+        "https://",
+        "ws://",
+        "wss://"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "title": "Validation Allowed Url Schemes",
+      "type": "array"
+    },
+    "validation_dangerous_html_pattern": {
+      "default": "<(script|iframe|object|embed|link|meta|base|form|img|svg|video|audio|source|track|area|map|canvas|applet|frame|frameset|html|head|body|style)\\b|</*(script|iframe|object|embed|link|meta|base|form|img|svg|video|audio|source|track|area|map|canvas|applet|frame|frameset|html|head|body|style)>",
+      "title": "Validation Dangerous Html Pattern",
+      "type": "string"
+    },
+    "validation_dangerous_js_pattern": {
+      "default": "(?i)(?:^|\\s|[\\\"'`<>=])(javascript:|vbscript:|data:\\s*[^,]*[;\\s]*(javascript|vbscript)|\\bon[a-z]+\\s*=|<\\s*script\\b)",
+      "title": "Validation Dangerous Js Pattern",
+      "type": "string"
+    },
+    "validation_identifier_pattern": {
+      "default": "^[a-zA-Z0-9_\\-\\.]+$",
+      "title": "Validation Identifier Pattern",
+      "type": "string"
+    },
+    "validation_max_content_length": {
+      "default": 1048576,
+      "title": "Validation Max Content Length",
+      "type": "integer"
+    },
+    "validation_max_description_length": {
+      "default": 8192,
+      "title": "Validation Max Description Length",
+      "type": "integer"
+    },
+    "validation_max_json_depth": {
+      "default": 30,
+      "description": "Maximum allowed JSON nesting depth for tool/resource schemas. Increased from 10 to 30 for compatibility with deeply nested schemas like Notion MCP (issue #1542). Override with VALIDATION_MAX_JSON_DEPTH environment variable. Minimum: 1, Maximum: 100",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Validation Max Json Depth",
+      "type": "integer"
+    },
+    "validation_max_method_length": {
+      "default": 128,
+      "title": "Validation Max Method Length",
+      "type": "integer"
+    },
+    "validation_max_name_length": {
+      "default": 255,
+      "title": "Validation Max Name Length",
+      "type": "integer"
+    },
     "validation_max_requests_per_minute": {
       "default": 60,
       "title": "Validation Max Requests Per Minute",
       "type": "integer"
     },
-    "enable_header_passthrough": {
+    "validation_max_rpc_param_size": {
+      "default": 262144,
+      "title": "Validation Max Rpc Param Size",
+      "type": "integer"
+    },
+    "validation_max_template_length": {
+      "default": 65536,
+      "title": "Validation Max Template Length",
+      "type": "integer"
+    },
+    "validation_max_url_length": {
+      "default": 2048,
+      "title": "Validation Max Url Length",
+      "type": "integer"
+    },
+    "validation_middleware_enabled": {
       "default": false,
-      "description": "Enable HTTP header passthrough feature (WARNING: Security implications - only enable if needed)",
-      "title": "Enable Header Passthrough",
+      "description": "Enable validation middleware for all requests",
+      "title": "Validation Middleware Enabled",
       "type": "boolean"
     },
-    "enable_overwrite_base_headers": {
-      "default": false,
-      "description": "Enable overwriting of base headers",
-      "title": "Enable Overwrite Base Headers",
+    "validation_name_pattern": {
+      "default": "^[a-zA-Z0-9_.\\-\\s]+$",
+      "title": "Validation Name Pattern",
+      "type": "string"
+    },
+    "validation_safe_uri_pattern": {
+      "default": "^[a-zA-Z0-9_\\-.:/?=&%{}]+$",
+      "title": "Validation Safe Uri Pattern",
+      "type": "string"
+    },
+    "validation_strict": {
+      "default": true,
+      "description": "Strict validation mode - reject on violations",
+      "title": "Validation Strict",
       "type": "boolean"
     },
-    "default_passthrough_headers": {
+    "validation_tool_method_pattern": {
+      "default": "^[a-zA-Z][a-zA-Z0-9_\\./-]*$",
+      "title": "Validation Tool Method Pattern",
+      "type": "string"
+    },
+    "validation_tool_name_pattern": {
+      "default": "^[a-zA-Z0-9_][a-zA-Z0-9._/-]*$",
+      "title": "Validation Tool Name Pattern",
+      "type": "string"
+    },
+    "validation_unsafe_uri_pattern": {
+      "default": "[<>\"\\'\\\\]",
+      "title": "Validation Unsafe Uri Pattern",
+      "type": "string"
+    },
+    "webhook_logging_enabled": {
+      "default": false,
+      "description": "Send logs to webhook endpoints",
+      "title": "Webhook Logging Enabled",
+      "type": "boolean"
+    },
+    "webhook_logging_urls": {
+      "description": "Webhook URLs for log delivery",
       "items": {
         "type": "string"
       },
-      "title": "Default Passthrough Headers",
+      "title": "Webhook Logging Urls",
       "type": "array"
     },
-    "passthrough_headers_source": {
-      "default": "db",
-      "description": "Source priority for passthrough headers: env (environment always wins), db (database wins, default), merge (combine both)",
-      "enum": [
-        "env",
-        "db",
-        "merge"
-      ],
-      "title": "Passthrough Headers Source",
+    "websocket_ping_interval": {
+      "default": 30,
+      "title": "Websocket Ping Interval",
+      "type": "integer"
+    },
+    "well_known_cache_max_age": {
+      "default": 3600,
+      "title": "Well Known Cache Max Age",
+      "type": "integer"
+    },
+    "well_known_custom_files": {
+      "default": "{}",
+      "title": "Well Known Custom Files",
       "type": "string"
     },
-    "pagination_default_page_size": {
-      "default": 50,
-      "description": "Default number of items per page",
-      "maximum": 1000,
-      "minimum": 1,
-      "title": "Pagination Default Page Size",
-      "type": "integer"
-    },
-    "pagination_max_page_size": {
-      "default": 500,
-      "description": "Maximum allowed items per page",
-      "maximum": 10000,
-      "minimum": 1,
-      "title": "Pagination Max Page Size",
-      "type": "integer"
-    },
-    "pagination_min_page_size": {
-      "default": 1,
-      "description": "Minimum items per page",
-      "minimum": 1,
-      "title": "Pagination Min Page Size",
-      "type": "integer"
-    },
-    "pagination_cursor_threshold": {
-      "default": 10000,
-      "description": "Threshold for cursor-based pagination",
-      "minimum": 1,
-      "title": "Pagination Cursor Threshold",
-      "type": "integer"
-    },
-    "pagination_cursor_enabled": {
+    "well_known_enabled": {
       "default": true,
-      "description": "Enable cursor-based pagination",
-      "title": "Pagination Cursor Enabled",
+      "title": "Well Known Enabled",
       "type": "boolean"
     },
-    "pagination_default_sort_field": {
-      "default": "created_at",
-      "description": "Default sort field",
-      "title": "Pagination Default Sort Field",
+    "well_known_robots_txt": {
+      "default": "User-agent: *\nDisallow: /\n\n# MCP Gateway is a private API gateway\n# Public crawling is disabled by default",
+      "title": "Well Known Robots Txt",
       "type": "string"
     },
-    "pagination_default_sort_order": {
-      "default": "desc",
-      "description": "Default sort order",
-      "pattern": "^(asc|desc)$",
-      "title": "Pagination Default Sort Order",
+    "well_known_security_txt": {
+      "default": "",
+      "title": "Well Known Security Txt",
       "type": "string"
     },
-    "pagination_max_offset": {
-      "default": 100000,
-      "description": "Maximum offset for pagination",
-      "minimum": 0,
-      "title": "Pagination Max Offset",
-      "type": "integer"
-    },
-    "pagination_count_cache_ttl": {
-      "default": 300,
-      "description": "Cache TTL for pagination counts",
-      "minimum": 0,
-      "title": "Pagination Count Cache Ttl",
-      "type": "integer"
-    },
-    "pagination_include_links": {
-      "default": true,
-      "description": "Include pagination links",
-      "title": "Pagination Include Links",
-      "type": "boolean"
-    },
-    "pagination_base_url": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Base URL for pagination links",
-      "title": "Pagination Base Url"
-    },
-    "enable_ed25519_signing": {
+    "well_known_security_txt_enabled": {
       "default": false,
-      "description": "Enable Ed25519 signing for certificates",
-      "title": "Enable Ed25519 Signing",
+      "title": "Well Known Security Txt Enabled",
       "type": "boolean"
     },
-    "prev_ed25519_private_key": {
-      "default": "",
-      "description": "Previous Ed25519 private key for signing",
-      "format": "password",
-      "title": "Prev Ed25519 Private Key",
-      "type": "string",
-      "writeOnly": true
-    },
-    "prev_ed25519_public_key": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Derived previous Ed25519 public key",
-      "title": "Prev Ed25519 Public Key"
-    },
-    "ed25519_private_key": {
-      "default": "",
-      "description": "Ed25519 private key for signing",
-      "format": "password",
-      "title": "Ed25519 Private Key",
-      "type": "string",
-      "writeOnly": true
-    },
-    "ed25519_public_key": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Derived Ed25519 public key",
-      "title": "Ed25519 Public Key"
-    },
-    "masked_auth_value": {
-      "default": "*****",
-      "title": "Masked Auth Value",
-      "type": "string"
-    },
-    "ENABLE_METRICS": {
+    "x_content_type_options_enabled": {
       "default": true,
-      "description": "Enable Prometheus metrics instrumentation",
-      "title": "Enable Metrics",
+      "title": "X Content Type Options Enabled",
       "type": "boolean"
     },
-    "METRICS_EXCLUDED_HANDLERS": {
-      "default": "",
-      "description": "Comma-separated regex patterns for paths to exclude from metrics",
-      "title": "Metrics Excluded Handlers",
-      "type": "string"
+    "x_download_options_enabled": {
+      "default": true,
+      "title": "X Download Options Enabled",
+      "type": "boolean"
     },
-    "METRICS_NAMESPACE": {
-      "default": "default",
-      "description": "Prometheus metrics namespace",
-      "title": "Metrics Namespace",
-      "type": "string"
+    "x_frame_options": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "DENY",
+      "title": "X Frame Options"
     },
-    "METRICS_SUBSYSTEM": {
-      "default": "",
-      "description": "Prometheus metrics subsystem",
-      "title": "Metrics Subsystem",
-      "type": "string"
+    "x_xss_protection_enabled": {
+      "default": true,
+      "title": "X Xss Protection Enabled",
+      "type": "boolean"
     },
-    "METRICS_CUSTOM_LABELS": {
-      "default": "",
-      "description": "Comma-separated \"key=value\" pairs for static custom labels",
-      "title": "Metrics Custom Labels",
-      "type": "string"
+    "yield_batch_size": {
+      "default": 1000,
+      "description": "Number of rows fetched per batch when streaming hourly metric data from the database. Used to limit memory usage during aggregation and percentile calculations. Smaller values reduce memory footprint but increase DB round-trips; larger values improve throughput at the cost of higher memory usage.",
+      "maximum": 100000,
+      "minimum": 100,
+      "title": "Yield Batch Size",
+      "type": "integer"
     }
   },
   "title": "Settings",

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -307,6 +307,37 @@ For detailed guidance on embedding and section customization, see [Admin UI Cust
 
 **Usage:** Register a gateway with `"gateway_mode": "direct_proxy"`, then send requests with the `X-Context-Forge-Gateway-Id` header set to the gateway's ID. All MCP operations (tools/list, tools/call, resources/list, resources/read) will be proxied directly to the remote server.
 
+### gRPC Support (EXPERIMENTAL)
+
+| Setting                              | Description                                    | Default     | Options |
+| ------------------------------------ | ---------------------------------------------- | ----------- | ------- |
+| `MCPGATEWAY_GRPC_ENABLED`           | Enable gRPC to MCP translation support         | `false`     | bool    |
+| `MCPGATEWAY_GRPC_REFLECTION_ENABLED`| Enable gRPC server reflection by default       | `true`      | bool    |
+| `MCPGATEWAY_GRPC_MAX_MESSAGE_SIZE`  | Maximum gRPC message size in bytes             | `4194304`   | int     |
+| `MCPGATEWAY_GRPC_TIMEOUT`           | Default gRPC call timeout in seconds           | `30`        | int     |
+| `MCPGATEWAY_GRPC_TLS_ENABLED`      | Enable TLS for gRPC connections by default     | `false`     | bool    |
+
+**Configuration Effects:**
+
+- `MCPGATEWAY_GRPC_ENABLED=false` (default): gRPC service registration is disabled; the Admin UI hides the gRPC Services tab and API endpoints return 404
+- `MCPGATEWAY_GRPC_ENABLED=true`: Enables gRPC service discovery via server reflection and exposes gRPC methods as MCP tools
+
+### GraphQL Support (EXPERIMENTAL)
+
+| Setting                                    | Description                                          | Default | Options |
+| ------------------------------------------ | ---------------------------------------------------- | ------- | ------- |
+| `MCPGATEWAY_GRAPHQL_ENABLED`               | Enable GraphQL to MCP translation support            | `false` | bool    |
+| `MCPGATEWAY_GRAPHQL_INTROSPECTION_ENABLED` | Enable GraphQL schema introspection by default       | `true`  | bool    |
+| `MCPGATEWAY_GRAPHQL_MAX_DEPTH`             | Maximum GraphQL field selection depth                | `3`     | int     |
+| `MCPGATEWAY_GRAPHQL_TIMEOUT`               | Default GraphQL operation timeout in seconds         | `30`    | int     |
+| `MCPGATEWAY_GRAPHQL_INCLUDE_MUTATIONS`     | Include GraphQL mutations when discovering tools     | `true`  | bool    |
+
+**Configuration Effects:**
+
+- `MCPGATEWAY_GRAPHQL_ENABLED=false` (default): GraphQL tool registration is disabled; tools with `integration_type=GRAPHQL` cannot be created
+- `MCPGATEWAY_GRAPHQL_ENABLED=true`: Enables GraphQL schema introspection and exposes GraphQL queries/mutations as MCP tools
+- `MCPGATEWAY_GRAPHQL_INCLUDE_MUTATIONS=false`: Only GraphQL queries are exposed as tools; mutations are excluded
+
 ### ToolOps
 
 ToolOps streamlines the entire workflow by enabling seamless tool enrichment, automated test case generation, and comprehensive tool validation.

--- a/docs/docs/using/.pages
+++ b/docs/docs/using/.pages
@@ -8,6 +8,7 @@ nav:
   - tool-annotations.md
   - rest-passthrough.md
   - "gRPC Services (Experimental)": grpc-services.md
+  - "GraphQL Services (Experimental)": graphql-services.md
   - Clients: clients
   - Agents: agents
   - Servers: servers

--- a/docs/docs/using/graphql-services.md
+++ b/docs/docs/using/graphql-services.md
@@ -1,0 +1,310 @@
+# GraphQL Services (Experimental)
+
+!!! warning "Experimental Feature"
+    GraphQL support is an **experimental opt-in feature** that is disabled by default. It requires `httpx` and explicit enablement via feature flag.
+
+MCP Gateway supports automatic translation of GraphQL APIs into MCP tools via GraphQL's built-in introspection system. This enables seamless integration of GraphQL services into your MCP ecosystem without manual schema definition.
+
+## Installation & Setup
+
+### 1. Install Dependencies
+
+GraphQL support uses `httpx` for HTTP communication. It is included in the default installation:
+
+```bash
+# httpx is included by default
+pip install mcp-contextforge-gateway
+
+# Or explicitly with uv
+uv pip install httpx
+```
+
+### 2. Enable the Feature
+
+Set the environment variable to enable GraphQL support:
+
+```bash
+# In .env file
+MCPGATEWAY_GRAPHQL_ENABLED=true
+
+# Or export in shell
+export MCPGATEWAY_GRAPHQL_ENABLED=true
+
+# Or set in docker-compose.yml
+environment:
+  - MCPGATEWAY_GRAPHQL_ENABLED=true
+```
+
+### 3. Restart the Gateway
+
+After enabling the feature, restart MCP Gateway:
+
+```bash
+# Development mode
+make dev
+
+# Production mode
+mcpgateway
+
+# Or with Docker
+docker restart mcpgateway
+```
+
+## Overview
+
+The GraphQL-to-MCP translation feature allows you to:
+
+- **Automatically discover** GraphQL queries and mutations via schema introspection
+- **Expose GraphQL operations** as MCP tools with zero configuration
+- **Translate protocols** between GraphQL and MCP/JSON
+- **Control field depth** to limit response size and complexity
+- **Support authentication** via bearer tokens, basic auth, or custom headers
+
+## Quick Start
+
+### 1. CLI: Expose a GraphQL API
+
+The simplest way to expose a GraphQL API is via the CLI bridge:
+
+```bash
+# Basic usage - expose GraphQL API as MCP tools via SSE at :9001
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql --port 9001
+
+# With bearer token authentication
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql \
+    --auth-type bearer --auth-value "your-token" --port 9001
+
+# With field depth control and no mutations
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql \
+    --max-depth 4 --no-include-mutations --port 9001
+```
+
+### 2. Direct Registration: POST /tools
+
+Register a GraphQL tool directly via the REST API:
+
+```bash
+curl -X POST http://localhost:4444/tools \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "name": "get-users",
+    "description": "Fetch users from the GraphQL API",
+    "integration_type": "GRAPHQL",
+    "url": "https://api.example.com/graphql",
+    "request_type": "POST",
+    "graphql_operation": "query GetUsers($limit: Int) { users(limit: $limit) { id name email } }",
+    "graphql_operation_type": "query",
+    "graphql_variables_mapping": {"limit": "limit"},
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "limit": {"type": "integer", "description": "Maximum number of users to return"}
+      }
+    }
+  }'
+```
+
+## How It Works
+
+### Schema Introspection
+
+When you use the CLI bridge, the translator:
+
+1. **Connects** to the GraphQL endpoint
+2. **Sends** a standard introspection query to discover the schema
+3. **Parses** query and mutation types, their arguments, and return types
+4. **Generates** JSON Schema for each operation's input parameters
+5. **Builds** optimized field selections respecting the configured max depth
+6. **Exposes** each operation as an MCP tool via HTTP/SSE
+
+### Protocol Translation
+
+```
+┌─────────────┐         ┌──────────────┐         ┌─────────────────┐
+│  MCP Client │────────▶│  MCP Gateway │────────▶│ GraphQL Server  │
+│  (JSON)     │  HTTP   │  (Translate) │  HTTP   │ (GraphQL)       │
+└─────────────┘         └──────────────┘         └─────────────────┘
+                              │
+                              ▼
+                        [Introspection]
+                        Discover queries,
+                        mutations, types
+```
+
+**Request Flow:**
+
+1. Client calls MCP tool: `query_users`
+2. Gateway looks up the GraphQL operation and field selections
+3. Gateway constructs the GraphQL query with variables from tool arguments
+4. Gateway sends HTTP POST to the GraphQL endpoint
+5. Gateway extracts the data from the GraphQL response
+6. Gateway returns JSON result to MCP client
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Enable/disable GraphQL support globally
+MCPGATEWAY_GRAPHQL_ENABLED=true
+
+# Enable schema introspection by default
+MCPGATEWAY_GRAPHQL_INTROSPECTION_ENABLED=true
+
+# Maximum field selection depth (controls query complexity)
+MCPGATEWAY_GRAPHQL_MAX_DEPTH=3
+
+# Default timeout for GraphQL operations (seconds)
+MCPGATEWAY_GRAPHQL_TIMEOUT=30
+
+# Include mutations when discovering tools
+MCPGATEWAY_GRAPHQL_INCLUDE_MUTATIONS=true
+```
+
+### Tool Registration Fields
+
+When registering GraphQL tools directly via `POST /tools`, the following fields are available:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `integration_type` | string | Yes | Must be `"GRAPHQL"` |
+| `url` | string | Yes | GraphQL endpoint URL |
+| `graphql_operation` | string | No | GraphQL operation string (query/mutation) |
+| `graphql_operation_type` | string | No | `"query"`, `"mutation"`, or `"subscription"` |
+| `graphql_variables_mapping` | object | No | Maps MCP argument names to GraphQL variable names |
+| `request_type` | string | Yes | Must be `"POST"` for GraphQL |
+
+### CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--endpoint` | (required) | GraphQL endpoint URL |
+| `--port` | `9001` | HTTP/SSE port to listen on |
+| `--host` | `127.0.0.1` | Bind address |
+| `--auth-type` | (none) | Authentication type: `bearer`, `basic`, or `header` |
+| `--auth-value` | (none) | Authentication credential value |
+| `--max-depth` | `3` | Max field selection depth |
+| `--include-mutations` | `true` | Include mutations as tools |
+| `--no-include-mutations` | - | Exclude mutations |
+| `--include-subscriptions` | `false` | Include subscriptions as tools |
+| `--cache-ttl` | `3600` | Introspection cache TTL in seconds |
+| `--log-level` | `INFO` | Log level |
+
+## Security Considerations
+
+### Authentication Headers
+
+Pass authentication credentials to the GraphQL endpoint:
+
+```bash
+# Bearer token
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql \
+    --auth-type bearer --auth-value "your-jwt-token"
+
+# Basic auth
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql \
+    --auth-type basic --auth-value "user:password"
+
+# Custom header
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql \
+    --auth-type header --auth-value "X-API-Key: secret"
+```
+
+### TLS
+
+GraphQL endpoints using HTTPS are supported natively via `httpx`. Ensure the server's TLS certificate is valid or configure custom CA certificates as needed.
+
+### Depth Limiting
+
+Use `--max-depth` (CLI) or `MCPGATEWAY_GRAPHQL_MAX_DEPTH` (env) to control how deep field selections go. Lower values reduce response size and prevent overly complex queries against the upstream GraphQL server.
+
+## Examples
+
+### Example 1: Expose a Public GraphQL API
+
+```bash
+# Expose the SpaceX GraphQL API as MCP tools
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://spacex-production.up.railway.app/graphql \
+    --port 9001
+
+# Now accessible at:
+# http://localhost:9001/sse
+```
+
+### Example 2: Register a Specific Query as a Tool
+
+```bash
+# Register a single GraphQL query as an MCP tool
+curl -X POST http://localhost:4444/tools \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "name": "search-repositories",
+    "description": "Search GitHub repositories via GraphQL",
+    "integration_type": "GRAPHQL",
+    "url": "https://api.github.com/graphql",
+    "request_type": "POST",
+    "graphql_operation": "query SearchRepos($query: String!) { search(query: $query, type: REPOSITORY, first: 10) { nodes { ... on Repository { name description stargazerCount } } } }",
+    "graphql_operation_type": "query",
+    "graphql_variables_mapping": {"query": "query"},
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {"type": "string", "description": "Search query string"}
+      },
+      "required": ["query"]
+    }
+  }'
+```
+
+### Example 3: Auto-Discover and Register via Gateway
+
+```bash
+# 1. Start the GraphQL bridge
+python3 -m mcpgateway.translate_graphql \
+    --endpoint https://api.example.com/graphql \
+    --auth-type bearer --auth-value "token" \
+    --port 9001
+
+# 2. Register the bridge as a gateway
+curl -X POST http://localhost:4444/gateways \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "name": "graphql-service",
+    "url": "http://localhost:9001/sse",
+    "description": "GraphQL API exposed as MCP tools"
+  }'
+```
+
+## Limitations
+
+### Current Limitations
+
+1. **Subscriptions**: GraphQL subscriptions are not fully supported (WebSocket transport)
+2. **File Uploads**: GraphQL multipart uploads are not supported
+3. **Fragments**: Complex fragment spreads may have limited support in auto-discovery
+4. **Unions/Interfaces**: Inline fragments on union/interface types use simplified field selection
+
+### Planned Enhancements
+
+- Admin UI tab for GraphQL service management
+- WebSocket subscription support
+- Advanced type mapping for unions and interfaces
+- Batch query support
+- Schema change detection and auto-reload
+
+## Related Documentation
+
+- [mcpgateway.translate CLI](mcpgateway-translate.md)
+- [gRPC Services (Experimental)](grpc-services.md)
+- [Configuration Reference](../manage/configuration.md)
+- [REST API Reference](../manage/api-usage.md)

--- a/mcpgateway/alembic/versions/x7h8i9j0k1l2_add_graphql_fields_to_tools.py
+++ b/mcpgateway/alembic/versions/x7h8i9j0k1l2_add_graphql_fields_to_tools.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Add GraphQL fields to tools table
+
+Revision ID: x7h8i9j0k1l2
+Revises: w6g7h8i9j0k1
+Create Date: 2026-02-17 12:00:00.000000
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "x7h8i9j0k1l2"
+down_revision: Union[str, Sequence[str], None] = "w6g7h8i9j0k1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add GraphQL-specific columns to the tools table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Skip if tools table doesn't exist (fresh DB uses db.py models directly)
+    if "tools" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("tools")]
+
+    if "graphql_operation" not in columns:
+        op.add_column("tools", sa.Column("graphql_operation", sa.Text(), nullable=True))
+
+    if "graphql_variables_mapping" not in columns:
+        op.add_column("tools", sa.Column("graphql_variables_mapping", sa.JSON(), nullable=True))
+
+    if "graphql_field_selection" not in columns:
+        op.add_column("tools", sa.Column("graphql_field_selection", sa.Text(), nullable=True))
+
+    if "graphql_operation_type" not in columns:
+        op.add_column("tools", sa.Column("graphql_operation_type", sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove GraphQL-specific columns from the tools table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "tools" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("tools")]
+
+    if "graphql_operation_type" in columns:
+        op.drop_column("tools", "graphql_operation_type")
+
+    if "graphql_field_selection" in columns:
+        op.drop_column("tools", "graphql_field_selection")
+
+    if "graphql_variables_mapping" in columns:
+        op.drop_column("tools", "graphql_variables_mapping")
+
+    if "graphql_operation" in columns:
+        op.drop_column("tools", "graphql_operation")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -594,6 +594,13 @@ class Settings(BaseSettings):
     mcpgateway_grpc_timeout: int = Field(default=30, description="Default gRPC call timeout in seconds")
     mcpgateway_grpc_tls_enabled: bool = Field(default=False, description="Enable TLS for gRPC connections by default")
 
+    # GraphQL Support Configuration (EXPERIMENTAL - disabled by default)
+    mcpgateway_graphql_enabled: bool = Field(default=False, description="Enable GraphQL to MCP translation support (experimental feature)")
+    mcpgateway_graphql_introspection_enabled: bool = Field(default=True, description="Enable GraphQL schema introspection by default")
+    mcpgateway_graphql_max_depth: int = Field(default=3, description="Maximum GraphQL field selection depth for auto-discovered tools")
+    mcpgateway_graphql_timeout: int = Field(default=30, description="Default GraphQL operation timeout in seconds")
+    mcpgateway_graphql_include_mutations: bool = Field(default=True, description="Include GraphQL mutations when discovering tools")
+
     # Direct Proxy Configuration (disabled by default)
     mcpgateway_direct_proxy_enabled: bool = Field(default=False, description="Enable direct_proxy gateway mode for pass-through MCP operations")
     mcpgateway_direct_proxy_timeout: int = Field(default=30, description="Default timeout in seconds for direct proxy MCP operations")

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -2872,6 +2872,12 @@ class Tool(Base):
     plugin_chain_pre: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True)
     plugin_chain_post: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True)
 
+    # GraphQL-specific fields
+    graphql_operation: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    graphql_variables_mapping: Mapped[Optional[Dict[str, str]]] = mapped_column(JSON, nullable=True)
+    graphql_field_selection: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    graphql_operation_type: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+
     # Federation relationship with a local gateway
     gateway_id: Mapped[Optional[str]] = mapped_column(ForeignKey("gateways.id", ondelete="CASCADE"))
     # gateway_slug: Mapped[Optional[str]] = mapped_column(ForeignKey("gateways.slug"))

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1149,6 +1149,11 @@ class ToolService:
                 allowlist=tool.allowlist if tool.integration_type == "REST" else None,
                 plugin_chain_pre=tool.plugin_chain_pre if tool.integration_type == "REST" else None,
                 plugin_chain_post=tool.plugin_chain_post if tool.integration_type == "REST" else None,
+                # GraphQL-specific fields
+                graphql_operation=tool.graphql_operation if tool.integration_type == "GRAPHQL" else None,
+                graphql_variables_mapping=tool.graphql_variables_mapping if tool.integration_type == "GRAPHQL" else None,
+                graphql_field_selection=tool.graphql_field_selection if tool.integration_type == "GRAPHQL" else None,
+                graphql_operation_type=tool.graphql_operation_type if tool.integration_type == "GRAPHQL" else None,
             )
             db.add(db_tool)
             db.commit()
@@ -1589,6 +1594,13 @@ class ToolService:
                         existing_tool.plugin_chain_pre = tool.plugin_chain_pre
                         existing_tool.plugin_chain_post = tool.plugin_chain_post
 
+                    # Update GraphQL-specific fields if applicable
+                    if tool.integration_type == "GRAPHQL":
+                        existing_tool.graphql_operation = tool.graphql_operation
+                        existing_tool.graphql_variables_mapping = tool.graphql_variables_mapping
+                        existing_tool.graphql_field_selection = tool.graphql_field_selection
+                        existing_tool.graphql_operation_type = tool.graphql_operation_type
+
                     return {"status": "update", "tool": existing_tool}
 
                 if conflict_strategy == "rename":
@@ -1710,6 +1722,10 @@ class ToolService:
             allowlist=tool.allowlist if tool.integration_type == "REST" else None,
             plugin_chain_pre=tool.plugin_chain_pre if tool.integration_type == "REST" else None,
             plugin_chain_post=tool.plugin_chain_post if tool.integration_type == "REST" else None,
+            graphql_operation=tool.graphql_operation if tool.integration_type == "GRAPHQL" else None,
+            graphql_variables_mapping=tool.graphql_variables_mapping if tool.integration_type == "GRAPHQL" else None,
+            graphql_field_selection=tool.graphql_field_selection if tool.integration_type == "GRAPHQL" else None,
+            graphql_operation_type=tool.graphql_operation_type if tool.integration_type == "GRAPHQL" else None,
         )
 
     async def list_tools(
@@ -2991,6 +3007,19 @@ class ToolService:
         # ═══════════════════════════════════════════════════════════════════════════
         # CRITICAL: Release DB connection back to pool BEFORE making HTTP calls
         # This prevents connection pool exhaustion during slow upstream requests.
+        # ═══════════════════════════════════════════════════════════════════════════
+        # GraphQL Data Extraction (must happen before db.close())
+        # ═══════════════════════════════════════════════════════════════════════════
+        graphql_operation: Optional[str] = None
+        graphql_variables_mapping: Optional[Dict[str, str]] = None
+        graphql_field_selection: Optional[str] = None
+        graphql_operation_type_field: Optional[str] = None
+        if tool_integration_type == "GRAPHQL" and tool is not None:
+            graphql_operation = getattr(tool, "graphql_operation", None)
+            graphql_variables_mapping = getattr(tool, "graphql_variables_mapping", None)
+            getattr(tool, "graphql_field_selection", None)
+            getattr(tool, "graphql_operation_type", None)
+
         # All needed data has been extracted to local variables above.
         # The session will be closed again by FastAPI's get_db() finally block (safe no-op).
         # ═══════════════════════════════════════════════════════════════════════════
@@ -3827,6 +3856,77 @@ class ToolService:
                         error_message = f"HTTP {http_response.status_code}: {http_response.text}"
                         content = [TextContent(type="text", text=f"A2A agent error: {error_message}")]
                         tool_result = ToolResult(content=content, is_error=True)
+                elif tool_integration_type == "GRAPHQL":
+                    # GraphQL tool invocation
+                    headers = tool_headers.copy()
+                    # Handle authentication
+                    if tool_auth_type and tool_auth_value:
+                        credentials = decode_auth(tool_auth_value)
+                        filtered_credentials = {k: v for k, v in credentials.items() if k and v}
+                        headers.update(filtered_credentials)
+                    headers["Content-Type"] = "application/json"
+
+                    # Plugin hook: tool pre-invoke for GraphQL
+                    if self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE):
+                        if tool_metadata:
+                            global_context.metadata[TOOL_METADATA] = tool_metadata
+                        pre_result, context_table = await self._plugin_manager.invoke_hook(
+                            ToolHookType.TOOL_PRE_INVOKE,
+                            payload=ToolPreInvokePayload(name=name, args=arguments, headers=HttpHeaderPayload(root=headers)),
+                            global_context=global_context,
+                            local_contexts=context_table,
+                            violations_as_exceptions=True,
+                        )
+                        if pre_result.modified_payload:
+                            payload = pre_result.modified_payload
+                            name = payload.name
+                            arguments = payload.args
+                            if payload.headers is not None:
+                                headers = payload.headers.model_dump()
+
+                    # Build GraphQL request using pre-extracted local variables
+                    if graphql_operation:
+                        # Direct tool registration mode: use stored operation and variables mapping
+                        variables = {}
+                        if graphql_variables_mapping and arguments:
+                            for mcp_arg, gql_var in graphql_variables_mapping.items():
+                                if mcp_arg in arguments:
+                                    variables[gql_var] = arguments[mcp_arg]
+                        elif arguments:
+                            variables = arguments.copy()
+                        graphql_payload = {"query": graphql_operation, "variables": variables}
+                    else:
+                        # Auto-discovered tool: build query from arguments
+                        graphql_payload = {"query": f"query {{ {name}  }}", "variables": arguments or {}}
+
+                    time.time()
+                    try:
+                        response = await asyncio.wait_for(self._http_client.post(tool_url, json=graphql_payload, headers=headers), timeout=effective_timeout)
+                    except (asyncio.TimeoutError, httpx.TimeoutException):
+                        raise ToolTimeoutError(f"GraphQL tool invocation timed out after {effective_timeout}s")
+
+                    response.raise_for_status()
+
+                    try:
+                        result = response.json()
+                    except Exception:
+                        result = {"response_text": response.text} if response.text else {}
+
+                    # Handle GraphQL errors
+                    if "errors" in result and result["errors"]:
+                        error_msgs = "; ".join(e.get("message", str(e)) for e in result["errors"])
+                        tool_result = ToolResult(content=[TextContent(type="text", text=f"GraphQL error: {error_msgs}")], is_error=True)
+                    else:
+                        data = result.get("data", result)
+                        filtered_response = extract_using_jq(data, tool_jsonpath_filter)
+                        if isinstance(filtered_response, list) and len(filtered_response) > 0 and isinstance(filtered_response[0], TextContent):
+                            tool_result = ToolResult(content=filtered_response, is_error=True)
+                            success = False
+                        else:
+                            serialized = orjson.dumps(filtered_response, option=orjson.OPT_INDENT_2)
+                            tool_result = ToolResult(content=[TextContent(type="text", text=serialized.decode())])
+                            success = True
+
                 else:
                     tool_result = ToolResult(content=[TextContent(type="text", text="Invalid tool type")], is_error=True)
 

--- a/mcpgateway/translate_graphql.py
+++ b/mcpgateway/translate_graphql.py
@@ -1,0 +1,926 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/translate_graphql.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: MCP Gateway Contributors
+
+GraphQL to MCP Translation Module
+
+This module provides GraphQL to MCP protocol translation capabilities.
+It enables exposing GraphQL APIs as MCP tools via HTTP/SSE endpoints
+using automatic schema discovery through GraphQL's built-in introspection system.
+
+Examples:
+    Programmatic usage:
+
+    >>> import asyncio
+    >>> from mcpgateway.translate_graphql import GraphQLEndpoint, GraphQLToMcpTranslator
+    >>> isinstance(GraphQLEndpoint, type)
+    True
+    >>> isinstance(GraphQLToMcpTranslator, type)
+    True
+    >>> isinstance(QueryBuilder, type)
+    True
+
+    Test constants:
+
+    >>> from mcpgateway.translate_graphql import GRAPHQL_AVAILABLE
+    >>> isinstance(GRAPHQL_AVAILABLE, bool)
+    True
+    >>> from mcpgateway.translate_graphql import GRAPHQL_SCALAR_TYPE_MAP
+    >>> GRAPHQL_SCALAR_TYPE_MAP["String"]
+    'string'
+    >>> GRAPHQL_SCALAR_TYPE_MAP["Int"]
+    'integer'
+    >>> GRAPHQL_SCALAR_TYPE_MAP["Float"]
+    'number'
+    >>> GRAPHQL_SCALAR_TYPE_MAP["Boolean"]
+    'boolean'
+    >>> GRAPHQL_SCALAR_TYPE_MAP["ID"]
+    'string'
+
+Usage:
+    Command line usage::
+
+        # 1. Expose a GraphQL API as MCP tools via SSE at :9001
+        python3 -m mcpgateway.translate_graphql \\
+            --endpoint https://api.example.com/graphql --port 9001
+
+        # 2. With bearer token auth
+        python3 -m mcpgateway.translate_graphql \\
+            --endpoint https://api.example.com/graphql \\
+            --auth-type bearer --auth-value "your-token" --port 9001
+
+        # 3. With field depth control
+        python3 -m mcpgateway.translate_graphql \\
+            --endpoint https://api.example.com/graphql \\
+            --max-depth 4 --include-mutations --port 9001
+"""
+
+# Standard
+import argparse
+import asyncio
+import json
+import time
+from typing import Any, Dict, List, Optional, Set
+
+try:
+    # Third-Party
+    import httpx
+
+    GRAPHQL_AVAILABLE = True
+except ImportError:
+    GRAPHQL_AVAILABLE = False
+    httpx = None  # type: ignore
+
+# First-Party
+from mcpgateway.services.logging_service import LoggingService
+
+# Initialize logging
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+
+GRAPHQL_SCALAR_TYPE_MAP: Dict[str, str] = {
+    "String": "string",
+    "Int": "integer",
+    "Float": "number",
+    "Boolean": "boolean",
+    "ID": "string",
+}
+
+INTROSPECTION_QUERY = """
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      kind
+      name
+      description
+      fields(includeDeprecated: false) {
+        name
+        description
+        args {
+          name
+          description
+          type {
+            ...TypeRef
+          }
+          defaultValue
+        }
+        type {
+          ...TypeRef
+        }
+      }
+      inputFields {
+        name
+        description
+        type {
+          ...TypeRef
+        }
+        defaultValue
+      }
+      enumValues(includeDeprecated: false) {
+        name
+        description
+      }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class GraphQLEndpoint:
+    """Wrapper around a GraphQL HTTP endpoint with introspection-based discovery.
+
+    Examples:
+        >>> ep = GraphQLEndpoint("https://example.com/graphql")
+        >>> ep._url
+        'https://example.com/graphql'
+        >>> ep._schema is None
+        True
+    """
+
+    def __init__(
+        self,
+        url: str,
+        auth_type: Optional[str] = None,
+        auth_value: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        max_depth: int = 3,
+        include_mutations: bool = True,
+        include_subscriptions: bool = False,
+        cache_ttl: int = 3600,
+        timeout: int = 30,
+    ):
+        """Initialize GraphQL endpoint.
+
+        Args:
+            url: GraphQL endpoint URL.
+            auth_type: Authentication type ('bearer', 'basic', 'header').
+            auth_value: Authentication credential value.
+            headers: Additional HTTP headers.
+            max_depth: Maximum field selection depth for auto-generated queries.
+            include_mutations: Whether to expose mutations as tools.
+            include_subscriptions: Whether to expose subscriptions as tools.
+            cache_ttl: Introspection cache TTL in seconds.
+            timeout: HTTP request timeout in seconds.
+        """
+        self._url = url
+        self._auth_type = auth_type
+        self._auth_value = auth_value
+        self._extra_headers = headers or {}
+        self._max_depth = max_depth
+        self._include_mutations = include_mutations
+        self._include_subscriptions = include_subscriptions
+        self._cache_ttl = cache_ttl
+        self._timeout = timeout
+        self._schema: Optional[Dict[str, Any]] = None
+        self._types: Dict[str, Dict[str, Any]] = {}
+        self._query_type_name: Optional[str] = None
+        self._mutation_type_name: Optional[str] = None
+        self._subscription_type_name: Optional[str] = None
+        self._client: Optional[httpx.AsyncClient] = None
+        self._introspected_at: float = 0.0
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Build HTTP headers including authentication.
+
+        Returns:
+            Dict of HTTP headers.
+
+        Examples:
+            >>> ep = GraphQLEndpoint("https://example.com/graphql")
+            >>> h = ep._build_headers()
+            >>> h["Content-Type"]
+            'application/json'
+            >>> ep2 = GraphQLEndpoint("https://x.com/gql", auth_type="bearer", auth_value="tok123")
+            >>> h2 = ep2._build_headers()
+            >>> h2["Authorization"]
+            'Bearer tok123'
+        """
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        headers.update(self._extra_headers)
+        if self._auth_type and self._auth_value:
+            if self._auth_type == "bearer":
+                headers["Authorization"] = f"Bearer {self._auth_value}"
+            elif self._auth_type == "basic":
+                headers["Authorization"] = f"Basic {self._auth_value}"
+            elif self._auth_type == "header":
+                # auth_value is expected to be "HeaderName: HeaderValue"
+                if ":" in self._auth_value:
+                    key, _, val = self._auth_value.partition(":")
+                    headers[key.strip()] = val.strip()
+        return headers
+
+    async def start(self) -> None:
+        """Initialize HTTP client and perform introspection.
+
+        Raises:
+            RuntimeError: If httpx is not installed or introspection fails.
+        """
+        if not GRAPHQL_AVAILABLE:
+            raise RuntimeError("httpx is required for GraphQL translation. Install with: pip install httpx")
+
+        self._client = httpx.AsyncClient(timeout=self._timeout, follow_redirects=True)
+        await self._introspect_schema()
+
+    async def _introspect_schema(self) -> None:
+        """Execute GraphQL introspection query and parse the schema.
+
+        Raises:
+            RuntimeError: If introspection query fails or returns errors.
+        """
+        logger.info(f"Introspecting GraphQL schema at {self._url}")
+        start = time.time()
+
+        response = await self._client.post(  # type: ignore[union-attr]
+            self._url,
+            json={"query": INTROSPECTION_QUERY},
+            headers=self._build_headers(),
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "errors" in result and result["errors"]:
+            errors = result["errors"]
+            msg = "; ".join(e.get("message", str(e)) for e in errors)
+            raise RuntimeError(f"GraphQL introspection failed: {msg}")
+
+        schema_data = result.get("data", {}).get("__schema")
+        if not schema_data:
+            raise RuntimeError("GraphQL introspection returned no schema data")
+
+        self._schema = schema_data
+        self._query_type_name = (schema_data.get("queryType") or {}).get("name")
+        self._mutation_type_name = (schema_data.get("mutationType") or {}).get("name")
+        self._subscription_type_name = (schema_data.get("subscriptionType") or {}).get("name")
+
+        # Build type lookup
+        self._types = {}
+        for t in schema_data.get("types", []):
+            name = t.get("name", "")
+            if not name.startswith("__"):
+                self._types[name] = t
+
+        self._introspected_at = time.time()
+        elapsed_ms = (self._introspected_at - start) * 1000
+        logger.info(f"Introspection complete in {elapsed_ms:.1f}ms. Types: {len(self._types)}")
+
+    async def invoke(
+        self,
+        operation_type: str,
+        field_name: str,
+        arguments: Dict[str, Any],
+        field_selection: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Execute a GraphQL operation and return the result.
+
+        Args:
+            operation_type: 'query' or 'mutation'.
+            field_name: The root field name to invoke.
+            arguments: Arguments for the operation.
+            field_selection: Optional explicit field selection string.
+
+        Returns:
+            The data from the GraphQL response for the given field.
+
+        Raises:
+            RuntimeError: If the operation fails or returns errors.
+            ValueError: If the operation type is invalid.
+        """
+        builder = QueryBuilder(self._types, self._max_depth)
+        type_name = self._query_type_name if operation_type == "query" else self._mutation_type_name
+        if not type_name:
+            raise ValueError(f"Schema has no {operation_type} type")
+
+        query_str, variables = builder.build(operation_type, type_name, field_name, arguments, field_selection)
+
+        logger.debug(f"Executing GraphQL {operation_type}: {field_name}")
+        response = await self._client.post(  # type: ignore[union-attr]
+            self._url,
+            json={"query": query_str, "variables": variables},
+            headers=self._build_headers(),
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "errors" in result and result["errors"]:
+            errors = result["errors"]
+            msg = "; ".join(e.get("message", str(e)) for e in errors)
+            raise RuntimeError(f"GraphQL error: {msg}")
+
+        data: Dict[str, Any] = result.get("data", {})
+        field_data: Any = data.get(field_name, data)
+        if isinstance(field_data, dict):
+            return field_data
+        return {"result": field_data}
+
+    async def invoke_raw(self, query: str, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Execute a raw GraphQL query string.
+
+        Args:
+            query: GraphQL query string.
+            variables: Optional variables dict.
+
+        Returns:
+            The full data dict from the GraphQL response.
+
+        Raises:
+            RuntimeError: If the query returns errors.
+        """
+        payload: Dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = variables
+
+        response = await self._client.post(  # type: ignore[union-attr]
+            self._url,
+            json=payload,
+            headers=self._build_headers(),
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "errors" in result and result["errors"]:
+            errors = result["errors"]
+            msg = "; ".join(e.get("message", str(e)) for e in errors)
+            raise RuntimeError(f"GraphQL error: {msg}")
+
+        data: Dict[str, Any] = result.get("data", {})
+        return data
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            logger.info(f"Closed GraphQL connection to {self._url}")
+
+    @property
+    def url(self) -> str:
+        """Return the GraphQL endpoint URL."""
+        return self._url
+
+    @property
+    def types(self) -> Dict[str, Dict[str, Any]]:
+        """Return the introspected type map."""
+        return self._types
+
+    @property
+    def query_type_name(self) -> Optional[str]:
+        """Return the name of the root Query type."""
+        return self._query_type_name
+
+    @property
+    def mutation_type_name(self) -> Optional[str]:
+        """Return the name of the root Mutation type."""
+        return self._mutation_type_name
+
+    @property
+    def subscription_type_name(self) -> Optional[str]:
+        """Return the name of the root Subscription type."""
+        return self._subscription_type_name
+
+    @property
+    def include_mutations(self) -> bool:
+        """Return whether mutations are included."""
+        return self._include_mutations
+
+    @property
+    def include_subscriptions(self) -> bool:
+        """Return whether subscriptions are included."""
+        return self._include_subscriptions
+
+    def get_queries(self) -> List[str]:
+        """Get list of discovered query field names.
+
+        Returns:
+            List of query field names.
+        """
+        if not self._query_type_name or self._query_type_name not in self._types:
+            return []
+        return [f["name"] for f in self._types[self._query_type_name].get("fields", [])]
+
+    def get_mutations(self) -> List[str]:
+        """Get list of discovered mutation field names.
+
+        Returns:
+            List of mutation field names.
+        """
+        if not self._include_mutations:
+            return []
+        if not self._mutation_type_name or self._mutation_type_name not in self._types:
+            return []
+        return [f["name"] for f in self._types[self._mutation_type_name].get("fields", [])]
+
+    def get_subscriptions(self) -> List[str]:
+        """Get list of discovered subscription field names.
+
+        Returns:
+            List of subscription field names.
+        """
+        if not self._include_subscriptions:
+            return []
+        if not self._subscription_type_name or self._subscription_type_name not in self._types:
+            return []
+        return [f["name"] for f in self._types[self._subscription_type_name].get("fields", [])]
+
+
+class QueryBuilder:
+    """Builds GraphQL query strings from MCP tool arguments.
+
+    Examples:
+        >>> types = {"Query": {"kind": "OBJECT", "name": "Query", "fields": []}}
+        >>> qb = QueryBuilder(types, max_depth=3)
+        >>> qb._max_depth
+        3
+    """
+
+    def __init__(self, types: Dict[str, Dict[str, Any]], max_depth: int = 3):
+        """Initialize query builder.
+
+        Args:
+            types: Parsed GraphQL type map from introspection.
+            max_depth: Maximum depth for automatic field selection.
+        """
+        self._types = types
+        self._max_depth = max_depth
+
+    def build(
+        self,
+        operation_type: str,
+        root_type_name: str,
+        field_name: str,
+        arguments: Dict[str, Any],
+        field_selection: Optional[str] = None,
+    ) -> tuple[str, Dict[str, Any]]:
+        """Build a GraphQL operation string with parameterized variables.
+
+        Args:
+            operation_type: 'query' or 'mutation'.
+            root_type_name: Name of the root type (e.g. 'Query', 'Mutation').
+            field_name: The field to query.
+            arguments: Dict of argument values.
+            field_selection: Optional explicit field selection.
+
+        Returns:
+            Tuple of (query_string, variables_dict).
+        """
+        root_type = self._types.get(root_type_name, {})
+        field_def = None
+        for f in root_type.get("fields", []):
+            if f["name"] == field_name:
+                field_def = f
+                break
+
+        if not field_def:
+            # Fallback: simple query without variable typing
+            args_str = self._format_inline_args(arguments) if arguments else ""
+            selection = field_selection or "{ __typename }"
+            return f"{operation_type} {{ {field_name}{args_str} {selection} }}", {}
+
+        # Build variable declarations and argument references
+        var_decls = []
+        arg_refs = []
+        variables: Dict[str, Any] = {}
+        reserved_keys = {"_fields"}
+
+        for arg_def in field_def.get("args", []):
+            arg_name = arg_def["name"]
+            if arg_name in arguments and arg_name not in reserved_keys:
+                gql_type_str = self._type_ref_to_string(arg_def["type"])
+                var_name = arg_name
+                var_decls.append(f"${var_name}: {gql_type_str}")
+                arg_refs.append(f"{arg_name}: ${var_name}")
+                variables[var_name] = arguments[arg_name]
+
+        # Build field selection
+        if field_selection:
+            selection = field_selection
+        else:
+            return_type = self._unwrap_type(field_def["type"])
+            selection = self._build_field_selection(return_type, depth=0, visited=set())
+
+        var_decl_str = f"({', '.join(var_decls)})" if var_decls else ""
+        arg_ref_str = f"({', '.join(arg_refs)})" if arg_refs else ""
+
+        query = f"{operation_type}{var_decl_str} {{ {field_name}{arg_ref_str} {selection} }}"
+        return query, variables
+
+    def _type_ref_to_string(self, type_ref: Dict[str, Any]) -> str:
+        """Convert a GraphQL type reference to its string representation.
+
+        Args:
+            type_ref: Type reference dict from introspection.
+
+        Returns:
+            GraphQL type string (e.g. 'String!', '[Int]', '[User!]!').
+
+        Examples:
+            >>> qb = QueryBuilder({}, 3)
+            >>> qb._type_ref_to_string({"kind": "SCALAR", "name": "String", "ofType": None})
+            'String'
+            >>> qb._type_ref_to_string({"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "Int", "ofType": None}})
+            'Int!'
+        """
+        kind = type_ref.get("kind")
+        if kind == "NON_NULL":
+            inner = type_ref.get("ofType", {})
+            return f"{self._type_ref_to_string(inner)}!"
+        if kind == "LIST":
+            inner = type_ref.get("ofType", {})
+            return f"[{self._type_ref_to_string(inner)}]"
+        name: str = type_ref.get("name", "String")
+        return name
+
+    def _unwrap_type(self, type_ref: Dict[str, Any]) -> str:
+        """Unwrap NON_NULL and LIST wrappers to get the base type name.
+
+        Args:
+            type_ref: Type reference dict from introspection.
+
+        Returns:
+            The base type name string.
+
+        Examples:
+            >>> qb = QueryBuilder({}, 3)
+            >>> qb._unwrap_type({"kind": "NON_NULL", "name": None, "ofType": {"kind": "LIST", "name": None, "ofType": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "OBJECT", "name": "User", "ofType": None}}}})
+            'User'
+        """
+        while type_ref and type_ref.get("kind") in ("NON_NULL", "LIST"):
+            type_ref = type_ref.get("ofType", {})
+        result: str = type_ref.get("name", "")
+        return result
+
+    def _build_field_selection(self, type_name: str, depth: int, visited: Set[str]) -> str:
+        """Build a field selection string for a given type.
+
+        Automatically selects scalar fields and recurses into object fields
+        up to the configured max_depth.
+
+        Args:
+            type_name: The GraphQL type name.
+            depth: Current recursion depth.
+            visited: Set of type names already visited (cycle detection).
+
+        Returns:
+            A field selection string (e.g. '{ id name email }').
+        """
+        if depth >= self._max_depth:
+            return ""
+        if type_name in visited:
+            return ""
+        type_def = self._types.get(type_name, {})
+        kind = type_def.get("kind")
+        if kind not in ("OBJECT", "INTERFACE"):
+            return ""
+
+        visited_copy = visited | {type_name}
+        fields = []
+        for field in type_def.get("fields", []):
+            field_type_name = self._unwrap_type(field["type"])
+            field_kind = self._types.get(field_type_name, {}).get("kind", "SCALAR")
+
+            if field_kind in ("SCALAR", "ENUM"):
+                fields.append(field["name"])
+            elif field_kind in ("OBJECT", "INTERFACE") and depth + 1 < self._max_depth:
+                nested = self._build_field_selection(field_type_name, depth + 1, visited_copy)
+                if nested:
+                    fields.append(f"{field['name']} {nested}")
+
+        if not fields:
+            fields = ["__typename"]
+        return "{ " + " ".join(fields) + " }"
+
+    def _format_inline_args(self, arguments: Dict[str, Any]) -> str:
+        """Format arguments as inline GraphQL arguments (fallback).
+
+        Args:
+            arguments: Argument key-value pairs.
+
+        Returns:
+            Formatted argument string.
+        """
+        parts = []
+        for key, value in arguments.items():
+            if key.startswith("_"):
+                continue
+            parts.append(f"{key}: {json.dumps(value)}")
+        return f"({', '.join(parts)})" if parts else ""
+
+
+class GraphQLToMcpTranslator:
+    """Translates between GraphQL schemas and MCP tool definitions.
+
+    Examples:
+        >>> ep = GraphQLEndpoint("https://example.com/graphql")
+        >>> tr = GraphQLToMcpTranslator(ep)
+        >>> tr._endpoint is ep
+        True
+    """
+
+    def __init__(self, endpoint: GraphQLEndpoint):
+        """Initialize translator.
+
+        Args:
+            endpoint: GraphQL endpoint with introspected schema.
+        """
+        self._endpoint = endpoint
+
+    def graphql_schema_to_mcp_server(self) -> Dict[str, Any]:
+        """Convert the full GraphQL schema to an MCP virtual server definition.
+
+        Returns:
+            MCP server definition dict.
+        """
+        return {
+            "name": f"graphql-{self._endpoint.url}",
+            "description": f"GraphQL API: {self._endpoint.url}",
+            "transport": ["sse", "http"],
+            "tools": self.graphql_fields_to_mcp_tools(),
+        }
+
+    def graphql_fields_to_mcp_tools(self) -> List[Dict[str, Any]]:
+        """Convert GraphQL query/mutation/subscription fields to MCP tool definitions.
+
+        Returns:
+            List of MCP tool definition dicts.
+        """
+        tools = []
+
+        # Convert queries
+        if self._endpoint.query_type_name:
+            query_type = self._endpoint.types.get(self._endpoint.query_type_name, {})
+            for field in query_type.get("fields", []):
+                tools.append(self._field_to_mcp_tool(field, "query"))
+
+        # Convert mutations
+        if self._endpoint.include_mutations and self._endpoint.mutation_type_name:
+            mutation_type = self._endpoint.types.get(self._endpoint.mutation_type_name, {})
+            for field in mutation_type.get("fields", []):
+                tools.append(self._field_to_mcp_tool(field, "mutation"))
+
+        # Convert subscriptions
+        if self._endpoint.include_subscriptions and self._endpoint.subscription_type_name:
+            sub_type = self._endpoint.types.get(self._endpoint.subscription_type_name, {})
+            for field in sub_type.get("fields", []):
+                tools.append(self._field_to_mcp_tool(field, "subscription"))
+
+        return tools
+
+    def _field_to_mcp_tool(self, field: Dict[str, Any], operation_type: str) -> Dict[str, Any]:
+        """Convert a single GraphQL field to an MCP tool definition.
+
+        Args:
+            field: GraphQL field definition from introspection.
+            operation_type: 'query', 'mutation', or 'subscription'.
+
+        Returns:
+            MCP tool definition dict.
+        """
+        field_name = field["name"]
+        description = field.get("description") or f"GraphQL {operation_type}: {field_name}"
+        input_schema = self._args_to_json_schema(field.get("args", []))
+
+        return {
+            "name": f"{operation_type}_{field_name}",
+            "description": description,
+            "inputSchema": input_schema,
+        }
+
+    def _args_to_json_schema(self, args: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Convert GraphQL argument definitions to JSON Schema.
+
+        Args:
+            args: List of argument definitions from introspection.
+
+        Returns:
+            JSON Schema dict.
+        """
+        schema: Dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+
+        for arg in args:
+            arg_name = arg["name"]
+            arg_type = arg["type"]
+            is_required = arg_type.get("kind") == "NON_NULL"
+            prop_schema = self._graphql_type_to_json_schema(arg_type, visited=set())
+            if arg.get("description"):
+                prop_schema["description"] = arg["description"]
+            if arg.get("defaultValue") is not None:
+                try:
+                    prop_schema["default"] = json.loads(arg["defaultValue"])
+                except (json.JSONDecodeError, TypeError):
+                    prop_schema["default"] = arg["defaultValue"]
+            schema["properties"][arg_name] = prop_schema
+            if is_required:
+                schema["required"].append(arg_name)
+
+        if not schema["required"]:
+            del schema["required"]
+        return schema
+
+    def _graphql_type_to_json_schema(self, type_ref: Dict[str, Any], visited: Set[str]) -> Dict[str, Any]:
+        """Convert a GraphQL type reference to JSON Schema.
+
+        Handles NON_NULL, LIST, SCALAR, ENUM, and INPUT_OBJECT types recursively.
+
+        Args:
+            type_ref: GraphQL type reference dict.
+            visited: Set of visited type names for cycle detection.
+
+        Returns:
+            JSON Schema dict.
+
+        Examples:
+            >>> ep = GraphQLEndpoint("https://example.com/graphql")
+            >>> tr = GraphQLToMcpTranslator(ep)
+            >>> tr._graphql_type_to_json_schema({"kind": "SCALAR", "name": "String", "ofType": None}, set())
+            {'type': 'string'}
+            >>> tr._graphql_type_to_json_schema({"kind": "SCALAR", "name": "Int", "ofType": None}, set())
+            {'type': 'integer'}
+            >>> tr._graphql_type_to_json_schema({"kind": "SCALAR", "name": "Boolean", "ofType": None}, set())
+            {'type': 'boolean'}
+        """
+        kind = type_ref.get("kind")
+        name = type_ref.get("name")
+
+        if kind == "NON_NULL":
+            inner = type_ref.get("ofType", {})
+            return self._graphql_type_to_json_schema(inner, visited)
+
+        if kind == "LIST":
+            inner = type_ref.get("ofType", {})
+            return {"type": "array", "items": self._graphql_type_to_json_schema(inner, visited)}
+
+        if kind == "SCALAR":
+            json_type = GRAPHQL_SCALAR_TYPE_MAP.get(name or "", "string")
+            return {"type": json_type}
+
+        if kind == "ENUM":
+            type_def = self._endpoint.types.get(name or "", {})
+            values = [ev["name"] for ev in type_def.get("enumValues", [])]
+            if values:
+                return {"type": "string", "enum": values}
+            return {"type": "string"}
+
+        if kind == "INPUT_OBJECT":
+            if name in visited:
+                return {"type": "object"}
+            visited_copy = visited | {name or ""}
+            type_def = self._endpoint.types.get(name or "", {})
+            schema: Dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+            for input_field in type_def.get("inputFields", []):
+                field_name = input_field["name"]
+                is_required = input_field["type"].get("kind") == "NON_NULL"
+                prop_schema = self._graphql_type_to_json_schema(input_field["type"], visited_copy)
+                if input_field.get("description"):
+                    prop_schema["description"] = input_field["description"]
+                schema["properties"][field_name] = prop_schema
+                if is_required:
+                    schema["required"].append(field_name)
+            if not schema["required"]:
+                del schema["required"]
+            return schema
+
+        # OBJECT / INTERFACE types used as input — fallback
+        return {"type": "object"}
+
+
+# Utility functions for CLI usage
+
+
+async def expose_graphql_via_sse(
+    endpoint_url: str,
+    port: int = 9001,
+    host: str = "127.0.0.1",
+    auth_type: Optional[str] = None,
+    auth_value: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    max_depth: int = 3,
+    include_mutations: bool = True,
+    include_subscriptions: bool = False,
+    cache_ttl: int = 3600,
+) -> None:
+    """Expose a GraphQL API as MCP tools via SSE/HTTP endpoints.
+
+    Args:
+        endpoint_url: GraphQL API endpoint URL.
+        port: HTTP port to listen on.
+        host: Bind address.
+        auth_type: Authentication type ('bearer', 'basic', 'header').
+        auth_value: Authentication credential value.
+        headers: Additional HTTP headers for the GraphQL endpoint.
+        max_depth: Maximum field selection depth.
+        include_mutations: Include mutations as tools.
+        include_subscriptions: Include subscriptions as tools.
+        cache_ttl: Introspection cache TTL in seconds.
+    """
+    logger.info(f"Exposing GraphQL API {endpoint_url} via SSE on {host}:{port}")
+
+    endpoint = GraphQLEndpoint(
+        url=endpoint_url,
+        auth_type=auth_type,
+        auth_value=auth_value,
+        headers=headers,
+        max_depth=max_depth,
+        include_mutations=include_mutations,
+        include_subscriptions=include_subscriptions,
+        cache_ttl=cache_ttl,
+    )
+
+    try:
+        await endpoint.start()
+
+        translator = GraphQLToMcpTranslator(endpoint)
+        tools = translator.graphql_fields_to_mcp_tools()
+
+        logger.info(f"GraphQL API exposed. Discovered {len(tools)} MCP tools:")
+        for tool in tools:
+            logger.info(f"  - {tool['name']}: {tool['description'][:80]}")
+        logger.info("To expose via HTTP/SSE, register this service in the gateway admin UI")
+        logger.info(f"  Endpoint: {endpoint_url}")
+        logger.info(f"  Queries: {len(endpoint.get_queries())}")
+        logger.info(f"  Mutations: {len(endpoint.get_mutations())}")
+        logger.info(f"  Subscriptions: {len(endpoint.get_subscriptions())}")
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+    finally:
+        await endpoint.close()
+
+
+def main() -> None:
+    """CLI entry point for GraphQL-to-MCP translation."""
+    parser = argparse.ArgumentParser(
+        description="Expose a GraphQL API as MCP tools via SSE/HTTP",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python -m mcpgateway.translate_graphql --endpoint https://api.example.com/graphql --port 9001
+  python -m mcpgateway.translate_graphql --endpoint https://api.example.com/graphql --auth-type bearer --auth-value TOKEN
+        """,
+    )
+    parser.add_argument("--endpoint", required=True, help="GraphQL endpoint URL")
+    parser.add_argument("--port", type=int, default=9001, help="HTTP/SSE port to listen on (default: 9001)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--auth-type", choices=["bearer", "basic", "header"], help="Authentication type")
+    parser.add_argument("--auth-value", help="Authentication credential value")
+    parser.add_argument("--max-depth", type=int, default=3, help="Max field selection depth (default: 3)")
+    parser.add_argument("--include-mutations", action="store_true", default=True, help="Include mutations as tools (default: true)")
+    parser.add_argument("--no-include-mutations", action="store_false", dest="include_mutations", help="Exclude mutations")
+    parser.add_argument("--include-subscriptions", action="store_true", default=False, help="Include subscriptions as tools")
+    parser.add_argument("--cache-ttl", type=int, default=3600, help="Introspection cache TTL in seconds (default: 3600)")
+    parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"], help="Log level")
+
+    args = parser.parse_args()
+
+    asyncio.run(
+        expose_graphql_via_sse(
+            endpoint_url=args.endpoint,
+            port=args.port,
+            host=args.host,
+            auth_type=args.auth_type,
+            auth_value=args.auth_value,
+            max_depth=args.max_depth,
+            include_mutations=args.include_mutations,
+            include_subscriptions=args.include_subscriptions,
+            cache_ttl=args.cache_ttl,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/mcpgateway/test_translate_graphql.py
+++ b/tests/unit/mcpgateway/test_translate_graphql.py
@@ -1,0 +1,814 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_translate_graphql.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: MCP Gateway Contributors
+
+Tests for GraphQL to MCP translation module.
+"""
+
+# Standard
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.translate_graphql import (
+    expose_graphql_via_sse,
+    GRAPHQL_AVAILABLE,
+    GRAPHQL_SCALAR_TYPE_MAP,
+    GraphQLEndpoint,
+    GraphQLToMcpTranslator,
+    QueryBuilder,
+)
+
+# ── Sample introspection data ──────────────────────────────────────────────
+
+SAMPLE_SCHEMA = {
+    "queryType": {"name": "Query"},
+    "mutationType": {"name": "Mutation"},
+    "subscriptionType": None,
+    "types": [
+        {
+            "kind": "OBJECT",
+            "name": "Query",
+            "description": None,
+            "fields": [
+                {
+                    "name": "users",
+                    "description": "Fetch all users",
+                    "args": [
+                        {
+                            "name": "limit",
+                            "description": "Max results",
+                            "type": {"kind": "SCALAR", "name": "Int", "ofType": None},
+                            "defaultValue": "10",
+                        },
+                        {
+                            "name": "role",
+                            "description": None,
+                            "type": {"kind": "ENUM", "name": "Role", "ofType": None},
+                            "defaultValue": None,
+                        },
+                    ],
+                    "type": {
+                        "kind": "NON_NULL",
+                        "name": None,
+                        "ofType": {
+                            "kind": "LIST",
+                            "name": None,
+                            "ofType": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "OBJECT", "name": "User", "ofType": None}},
+                        },
+                    },
+                },
+                {
+                    "name": "user",
+                    "description": "Fetch a single user",
+                    "args": [
+                        {
+                            "name": "id",
+                            "description": None,
+                            "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "ID", "ofType": None}},
+                            "defaultValue": None,
+                        },
+                    ],
+                    "type": {"kind": "OBJECT", "name": "User", "ofType": None},
+                },
+            ],
+            "inputFields": None,
+            "enumValues": None,
+        },
+        {
+            "kind": "OBJECT",
+            "name": "Mutation",
+            "description": None,
+            "fields": [
+                {
+                    "name": "createUser",
+                    "description": "Create a new user",
+                    "args": [
+                        {
+                            "name": "input",
+                            "description": None,
+                            "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "INPUT_OBJECT", "name": "CreateUserInput", "ofType": None}},
+                            "defaultValue": None,
+                        },
+                    ],
+                    "type": {"kind": "OBJECT", "name": "User", "ofType": None},
+                },
+                {
+                    "name": "deleteUser",
+                    "description": "Delete a user",
+                    "args": [
+                        {
+                            "name": "id",
+                            "description": None,
+                            "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "ID", "ofType": None}},
+                            "defaultValue": None,
+                        },
+                    ],
+                    "type": {"kind": "SCALAR", "name": "Boolean", "ofType": None},
+                },
+            ],
+            "inputFields": None,
+            "enumValues": None,
+        },
+        {
+            "kind": "OBJECT",
+            "name": "User",
+            "description": "A user entity",
+            "fields": [
+                {"name": "id", "description": None, "args": [], "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "ID", "ofType": None}}},
+                {"name": "name", "description": None, "args": [], "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "String", "ofType": None}}},
+                {"name": "email", "description": None, "args": [], "type": {"kind": "SCALAR", "name": "String", "ofType": None}},
+                {"name": "role", "description": None, "args": [], "type": {"kind": "ENUM", "name": "Role", "ofType": None}},
+                {"name": "posts", "description": None, "args": [], "type": {"kind": "LIST", "name": None, "ofType": {"kind": "OBJECT", "name": "Post", "ofType": None}}},
+            ],
+            "inputFields": None,
+            "enumValues": None,
+        },
+        {
+            "kind": "OBJECT",
+            "name": "Post",
+            "description": None,
+            "fields": [
+                {"name": "id", "description": None, "args": [], "type": {"kind": "SCALAR", "name": "ID", "ofType": None}},
+                {"name": "title", "description": None, "args": [], "type": {"kind": "SCALAR", "name": "String", "ofType": None}},
+                {"name": "body", "description": None, "args": [], "type": {"kind": "SCALAR", "name": "String", "ofType": None}},
+                {"name": "author", "description": None, "args": [], "type": {"kind": "OBJECT", "name": "User", "ofType": None}},
+            ],
+            "inputFields": None,
+            "enumValues": None,
+        },
+        {
+            "kind": "ENUM",
+            "name": "Role",
+            "description": "User roles",
+            "fields": None,
+            "inputFields": None,
+            "enumValues": [{"name": "ADMIN", "description": None}, {"name": "USER", "description": None}, {"name": "VIEWER", "description": None}],
+        },
+        {
+            "kind": "INPUT_OBJECT",
+            "name": "CreateUserInput",
+            "description": None,
+            "fields": None,
+            "inputFields": [
+                {
+                    "name": "name",
+                    "description": "User name",
+                    "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "String", "ofType": None}},
+                    "defaultValue": None,
+                },
+                {
+                    "name": "email",
+                    "description": "User email",
+                    "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "String", "ofType": None}},
+                    "defaultValue": None,
+                },
+                {
+                    "name": "role",
+                    "description": None,
+                    "type": {"kind": "ENUM", "name": "Role", "ofType": None},
+                    "defaultValue": '"USER"',
+                },
+            ],
+            "enumValues": None,
+        },
+        {"kind": "SCALAR", "name": "String", "description": None, "fields": None, "inputFields": None, "enumValues": None},
+        {"kind": "SCALAR", "name": "Int", "description": None, "fields": None, "inputFields": None, "enumValues": None},
+        {"kind": "SCALAR", "name": "Float", "description": None, "fields": None, "inputFields": None, "enumValues": None},
+        {"kind": "SCALAR", "name": "Boolean", "description": None, "fields": None, "inputFields": None, "enumValues": None},
+        {"kind": "SCALAR", "name": "ID", "description": None, "fields": None, "inputFields": None, "enumValues": None},
+    ],
+}
+
+
+def _make_endpoint_with_schema(include_mutations=True, include_subscriptions=False, max_depth=3):
+    """Create a GraphQLEndpoint pre-loaded with sample schema data."""
+    ep = GraphQLEndpoint(
+        url="https://api.example.com/graphql",
+        include_mutations=include_mutations,
+        include_subscriptions=include_subscriptions,
+        max_depth=max_depth,
+    )
+    ep._schema = SAMPLE_SCHEMA
+    ep._query_type_name = "Query"
+    ep._mutation_type_name = "Mutation"
+    ep._subscription_type_name = None
+    ep._types = {t["name"]: t for t in SAMPLE_SCHEMA["types"] if not t["name"].startswith("__")}
+    return ep
+
+
+# ── GraphQLEndpoint tests ──────────────────────────────────────────────────
+
+
+class TestGraphQLEndpoint:
+    """Test suite for GraphQLEndpoint."""
+
+    def test_initialization_defaults(self):
+        """Test basic endpoint initialization with defaults."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        assert ep._url == "https://api.example.com/graphql"
+        assert ep._auth_type is None
+        assert ep._auth_value is None
+        assert ep._max_depth == 3
+        assert ep._include_mutations is True
+        assert ep._include_subscriptions is False
+        assert ep._schema is None
+
+    def test_initialization_with_auth(self):
+        """Test endpoint initialization with authentication."""
+        ep = GraphQLEndpoint(
+            "https://api.example.com/graphql",
+            auth_type="bearer",
+            auth_value="my-token",
+            max_depth=5,
+            include_subscriptions=True,
+        )
+        assert ep._auth_type == "bearer"
+        assert ep._auth_value == "my-token"
+        assert ep._max_depth == 5
+        assert ep._include_subscriptions is True
+
+    def test_build_headers_no_auth(self):
+        """Test header building without authentication."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        headers = ep._build_headers()
+        assert headers["Content-Type"] == "application/json"
+        assert "Authorization" not in headers
+
+    def test_build_headers_bearer_auth(self):
+        """Test header building with bearer token."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql", auth_type="bearer", auth_value="tok123")
+        headers = ep._build_headers()
+        assert headers["Authorization"] == "Bearer tok123"
+
+    def test_build_headers_basic_auth(self):
+        """Test header building with basic authentication."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql", auth_type="basic", auth_value="dXNlcjpwYXNz")
+        headers = ep._build_headers()
+        assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+    def test_build_headers_header_auth(self):
+        """Test header building with custom header authentication."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql", auth_type="header", auth_value="X-API-Key: secret123")
+        headers = ep._build_headers()
+        assert headers["X-API-Key"] == "secret123"
+
+    def test_build_headers_extra_headers(self):
+        """Test header building with extra headers."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql", headers={"X-Custom": "value"})
+        headers = ep._build_headers()
+        assert headers["X-Custom"] == "value"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_get_queries(self):
+        """Test query field discovery."""
+        ep = _make_endpoint_with_schema()
+        queries = ep.get_queries()
+        assert "users" in queries
+        assert "user" in queries
+        assert len(queries) == 2
+
+    def test_get_mutations(self):
+        """Test mutation field discovery."""
+        ep = _make_endpoint_with_schema()
+        mutations = ep.get_mutations()
+        assert "createUser" in mutations
+        assert "deleteUser" in mutations
+        assert len(mutations) == 2
+
+    def test_get_mutations_disabled(self):
+        """Test mutations are excluded when disabled."""
+        ep = _make_endpoint_with_schema(include_mutations=False)
+        assert ep.get_mutations() == []
+
+    def test_get_subscriptions_empty(self):
+        """Test subscriptions when none exist."""
+        ep = _make_endpoint_with_schema()
+        assert ep.get_subscriptions() == []
+
+    def test_get_queries_no_schema(self):
+        """Test queries return empty when no schema loaded."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        assert ep.get_queries() == []
+
+    @pytest.mark.asyncio
+    async def test_start_without_httpx(self):
+        """Test start raises error when httpx not available."""
+        with patch("mcpgateway.translate_graphql.GRAPHQL_AVAILABLE", False):
+            ep = GraphQLEndpoint("https://api.example.com/graphql")
+            with pytest.raises(RuntimeError, match="httpx is required"):
+                await ep.start()
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        """Test closing the HTTP client."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        mock_client = AsyncMock()
+        ep._client = mock_client
+        await ep.close()
+        mock_client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_no_client(self):
+        """Test closing when no client exists."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        await ep.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_introspect_schema_success(self):
+        """Test successful schema introspection."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"__schema": SAMPLE_SCHEMA}}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        await ep._introspect_schema()
+        assert ep._query_type_name == "Query"
+        assert ep._mutation_type_name == "Mutation"
+        assert "User" in ep._types
+        assert "Role" in ep._types
+
+    @pytest.mark.asyncio
+    async def test_introspect_schema_with_errors(self):
+        """Test introspection failure on GraphQL errors."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"errors": [{"message": "Introspection not allowed"}]}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        with pytest.raises(RuntimeError, match="Introspection not allowed"):
+            await ep._introspect_schema()
+
+    @pytest.mark.asyncio
+    async def test_introspect_schema_no_data(self):
+        """Test introspection failure when no schema data returned."""
+        ep = GraphQLEndpoint("https://api.example.com/graphql")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {}}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        with pytest.raises(RuntimeError, match="no schema data"):
+            await ep._introspect_schema()
+
+    @pytest.mark.asyncio
+    async def test_invoke_query(self):
+        """Test invoking a GraphQL query."""
+        ep = _make_endpoint_with_schema()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"users": [{"id": "1", "name": "Alice"}]}}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        result = await ep.invoke("query", "users", {"limit": 10})
+        assert result == {"result": [{"id": "1", "name": "Alice"}]}
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert "query" in payload["query"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_graphql_errors(self):
+        """Test invoke raises on GraphQL errors."""
+        ep = _make_endpoint_with_schema()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"errors": [{"message": "Field not found"}]}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        with pytest.raises(RuntimeError, match="Field not found"):
+            await ep.invoke("query", "users", {})
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_query_type(self):
+        """Test invoke raises for missing query type."""
+        ep = _make_endpoint_with_schema()
+        ep._mutation_type_name = None
+        with pytest.raises(ValueError, match="no mutation type"):
+            await ep.invoke("mutation", "createUser", {})
+
+    @pytest.mark.asyncio
+    async def test_invoke_raw(self):
+        """Test raw query execution."""
+        ep = _make_endpoint_with_schema()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"users": []}}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        result = await ep.invoke_raw("query { users { id } }")
+        assert result == {"users": []}
+
+    @pytest.mark.asyncio
+    async def test_invoke_raw_with_variables(self):
+        """Test raw query with variables."""
+        ep = _make_endpoint_with_schema()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"user": {"id": "1", "name": "Alice"}}}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        ep._client = mock_client
+
+        result = await ep.invoke_raw("query($id: ID!) { user(id: $id) { id name } }", {"id": "1"})
+        assert result["user"]["id"] == "1"
+        call_payload = mock_client.post.call_args.kwargs.get("json") or mock_client.post.call_args[1].get("json")
+        assert call_payload["variables"] == {"id": "1"}
+
+
+# ── QueryBuilder tests ─────────────────────────────────────────────────────
+
+
+class TestQueryBuilder:
+    """Test suite for QueryBuilder."""
+
+    @pytest.fixture
+    def types(self):
+        """Return parsed types from sample schema."""
+        return {t["name"]: t for t in SAMPLE_SCHEMA["types"] if not t["name"].startswith("__")}
+
+    def test_type_ref_to_string_scalar(self):
+        """Test scalar type reference to string."""
+        qb = QueryBuilder({}, 3)
+        assert qb._type_ref_to_string({"kind": "SCALAR", "name": "String", "ofType": None}) == "String"
+        assert qb._type_ref_to_string({"kind": "SCALAR", "name": "Int", "ofType": None}) == "Int"
+
+    def test_type_ref_to_string_non_null(self):
+        """Test NON_NULL wrapper type reference."""
+        qb = QueryBuilder({}, 3)
+        result = qb._type_ref_to_string({"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "String", "ofType": None}})
+        assert result == "String!"
+
+    def test_type_ref_to_string_list(self):
+        """Test LIST wrapper type reference."""
+        qb = QueryBuilder({}, 3)
+        result = qb._type_ref_to_string({"kind": "LIST", "name": None, "ofType": {"kind": "SCALAR", "name": "Int", "ofType": None}})
+        assert result == "[Int]"
+
+    def test_type_ref_to_string_nested(self):
+        """Test nested NON_NULL + LIST type reference."""
+        qb = QueryBuilder({}, 3)
+        result = qb._type_ref_to_string(
+            {
+                "kind": "NON_NULL",
+                "name": None,
+                "ofType": {
+                    "kind": "LIST",
+                    "name": None,
+                    "ofType": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "OBJECT", "name": "User", "ofType": None}},
+                },
+            }
+        )
+        assert result == "[User!]!"
+
+    def test_unwrap_type(self):
+        """Test type unwrapping."""
+        qb = QueryBuilder({}, 3)
+        assert qb._unwrap_type({"kind": "SCALAR", "name": "String", "ofType": None}) == "String"
+        assert qb._unwrap_type({"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "Int", "ofType": None}}) == "Int"
+        assert (
+            qb._unwrap_type(
+                {
+                    "kind": "NON_NULL",
+                    "name": None,
+                    "ofType": {
+                        "kind": "LIST",
+                        "name": None,
+                        "ofType": {"kind": "OBJECT", "name": "User", "ofType": None},
+                    },
+                }
+            )
+            == "User"
+        )
+
+    def test_build_field_selection_scalar_type(self, types):
+        """Test field selection returns empty for scalar types."""
+        qb = QueryBuilder(types, 3)
+        assert qb._build_field_selection("String", 0, set()) == ""
+
+    def test_build_field_selection_simple_object(self, types):
+        """Test field selection for a simple object."""
+        qb = QueryBuilder(types, 1)
+        selection = qb._build_field_selection("User", 0, set())
+        assert "id" in selection
+        assert "name" in selection
+        assert "email" in selection
+        assert "role" in selection
+        # At depth 1, nested objects should not be included
+        assert "posts" not in selection
+
+    def test_build_field_selection_with_nesting(self, types):
+        """Test field selection with nested objects."""
+        qb = QueryBuilder(types, 2)
+        selection = qb._build_field_selection("User", 0, set())
+        assert "id" in selection
+        assert "name" in selection
+        assert "posts" in selection
+
+    def test_build_field_selection_cycle_detection(self, types):
+        """Test cycle detection in recursive types (User -> posts -> Post -> author -> User)."""
+        qb = QueryBuilder(types, 10)
+        selection = qb._build_field_selection("User", 0, set())
+        # Should include posts but not infinite recursion
+        assert "posts" in selection
+        # The author field within Post references User, which should be detected as a cycle
+        assert selection.count("User") == 0  # No actual "User" text in selection
+
+    def test_build_field_selection_max_depth(self, types):
+        """Test field selection respects max depth."""
+        qb = QueryBuilder(types, 0)
+        selection = qb._build_field_selection("User", 0, set())
+        assert selection == ""
+
+    def test_build_query_with_variables(self, types):
+        """Test building a query with typed variables."""
+        qb = QueryBuilder(types, 2)
+        query, variables = qb.build("query", "Query", "users", {"limit": 10, "role": "ADMIN"})
+        assert "query(" in query
+        assert "$limit: Int" in query
+        assert "$role: Role" in query
+        assert "users(limit: $limit, role: $role)" in query
+        assert variables == {"limit": 10, "role": "ADMIN"}
+
+    def test_build_query_with_explicit_field_selection(self, types):
+        """Test building a query with explicit field selection."""
+        qb = QueryBuilder(types, 2)
+        query, variables = qb.build("query", "Query", "users", {"limit": 5}, field_selection="{ id name }")
+        assert "{ id name }" in query
+        assert variables == {"limit": 5}
+
+    def test_build_query_no_arguments(self, types):
+        """Test building a query with no arguments."""
+        qb = QueryBuilder(types, 2)
+        query, variables = qb.build("query", "Query", "users", {})
+        assert "users" in query
+        assert variables == {}
+
+    def test_build_query_unknown_field(self, types):
+        """Test building a query for an unknown field (fallback)."""
+        qb = QueryBuilder(types, 2)
+        query, variables = qb.build("query", "Query", "nonexistent", {"foo": "bar"})
+        assert "nonexistent" in query
+        assert variables == {}
+
+    def test_build_mutation(self, types):
+        """Test building a mutation query."""
+        qb = QueryBuilder(types, 2)
+        query, variables = qb.build("mutation", "Mutation", "deleteUser", {"id": "123"})
+        assert "mutation(" in query
+        assert "$id: ID!" in query
+        assert "deleteUser(id: $id)" in query
+        assert variables == {"id": "123"}
+
+    def test_format_inline_args(self):
+        """Test inline argument formatting."""
+        qb = QueryBuilder({}, 3)
+        result = qb._format_inline_args({"limit": 10, "name": "Alice"})
+        assert "limit: 10" in result
+        assert 'name: "Alice"' in result
+
+    def test_format_inline_args_skips_underscore_keys(self):
+        """Test inline args skip keys starting with underscore."""
+        qb = QueryBuilder({}, 3)
+        result = qb._format_inline_args({"limit": 10, "_fields": "id name"})
+        assert "limit: 10" in result
+        assert "_fields" not in result
+
+    def test_format_inline_args_empty(self):
+        """Test inline args with empty dict."""
+        qb = QueryBuilder({}, 3)
+        assert qb._format_inline_args({}) == ""
+
+
+# ── GraphQLToMcpTranslator tests ───────────────────────────────────────────
+
+
+class TestGraphQLToMcpTranslator:
+    """Test suite for GraphQLToMcpTranslator."""
+
+    @pytest.fixture
+    def translator(self):
+        """Create a translator with sample schema."""
+        ep = _make_endpoint_with_schema()
+        return GraphQLToMcpTranslator(ep)
+
+    def test_graphql_fields_to_mcp_tools(self, translator):
+        """Test converting GraphQL fields to MCP tools."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        tool_names = [t["name"] for t in tools]
+        assert "query_users" in tool_names
+        assert "query_user" in tool_names
+        assert "mutation_createUser" in tool_names
+        assert "mutation_deleteUser" in tool_names
+        assert len(tools) == 4
+
+    def test_graphql_fields_mutations_disabled(self):
+        """Test mutations excluded when disabled."""
+        ep = _make_endpoint_with_schema(include_mutations=False)
+        tr = GraphQLToMcpTranslator(ep)
+        tools = tr.graphql_fields_to_mcp_tools()
+        tool_names = [t["name"] for t in tools]
+        assert "mutation_createUser" not in tool_names
+        assert len(tools) == 2
+
+    def test_tool_has_input_schema(self, translator):
+        """Test generated tools have correct input schema."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        users_tool = next(t for t in tools if t["name"] == "query_users")
+        schema = users_tool["inputSchema"]
+        assert schema["type"] == "object"
+        assert "limit" in schema["properties"]
+        assert schema["properties"]["limit"]["type"] == "integer"
+        assert "role" in schema["properties"]
+        assert "enum" in schema["properties"]["role"]
+
+    def test_tool_has_description(self, translator):
+        """Test generated tools have descriptions."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        users_tool = next(t for t in tools if t["name"] == "query_users")
+        assert users_tool["description"] == "Fetch all users"
+
+    def test_tool_default_description(self, translator):
+        """Test tool gets default description when none in schema."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        delete_tool = next(t for t in tools if t["name"] == "mutation_deleteUser")
+        assert "Delete a user" in delete_tool["description"]
+
+    def test_required_fields_in_schema(self, translator):
+        """Test NON_NULL args become required in JSON Schema."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        user_tool = next(t for t in tools if t["name"] == "query_user")
+        schema = user_tool["inputSchema"]
+        assert "id" in schema.get("required", [])
+
+    def test_input_object_type_conversion(self, translator):
+        """Test INPUT_OBJECT types are converted to nested JSON Schema."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        create_tool = next(t for t in tools if t["name"] == "mutation_createUser")
+        schema = create_tool["inputSchema"]
+        assert "input" in schema.get("required", [])
+        input_prop = schema["properties"]["input"]
+        assert input_prop["type"] == "object"
+        assert "name" in input_prop["properties"]
+        assert "email" in input_prop["properties"]
+        assert "role" in input_prop["properties"]
+        assert input_prop["properties"]["name"]["type"] == "string"
+
+    def test_enum_type_conversion(self, translator):
+        """Test ENUM types are converted to JSON Schema enum."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        users_tool = next(t for t in tools if t["name"] == "query_users")
+        role_schema = users_tool["inputSchema"]["properties"]["role"]
+        assert role_schema["type"] == "string"
+        assert "enum" in role_schema
+        assert set(role_schema["enum"]) == {"ADMIN", "USER", "VIEWER"}
+
+    def test_list_type_conversion(self, translator):
+        """Test LIST types are converted to JSON Schema array."""
+        schema = translator._graphql_type_to_json_schema(
+            {"kind": "LIST", "name": None, "ofType": {"kind": "SCALAR", "name": "String", "ofType": None}},
+            set(),
+        )
+        assert schema == {"type": "array", "items": {"type": "string"}}
+
+    def test_scalar_type_mappings(self, translator):
+        """Test all scalar type mappings."""
+        for gql_name, json_type in GRAPHQL_SCALAR_TYPE_MAP.items():
+            schema = translator._graphql_type_to_json_schema({"kind": "SCALAR", "name": gql_name, "ofType": None}, set())
+            assert schema == {"type": json_type}, f"Failed for {gql_name}"
+
+    def test_custom_scalar_fallback(self, translator):
+        """Test custom scalars fall back to string."""
+        schema = translator._graphql_type_to_json_schema({"kind": "SCALAR", "name": "DateTime", "ofType": None}, set())
+        assert schema == {"type": "string"}
+
+    def test_cycle_detection_in_input_object(self):
+        """Test cycle detection for recursive input objects."""
+        ep = _make_endpoint_with_schema()
+        # Add a recursive input type
+        ep._types["RecursiveInput"] = {
+            "kind": "INPUT_OBJECT",
+            "name": "RecursiveInput",
+            "inputFields": [
+                {"name": "value", "description": None, "type": {"kind": "SCALAR", "name": "String", "ofType": None}, "defaultValue": None},
+                {"name": "children", "description": None, "type": {"kind": "LIST", "name": None, "ofType": {"kind": "INPUT_OBJECT", "name": "RecursiveInput", "ofType": None}}, "defaultValue": None},
+            ],
+        }
+        tr = GraphQLToMcpTranslator(ep)
+        schema = tr._graphql_type_to_json_schema({"kind": "INPUT_OBJECT", "name": "RecursiveInput", "ofType": None}, set())
+        assert schema["type"] == "object"
+        assert "value" in schema["properties"]
+        # The recursive reference should be a simple object (cycle detected)
+        children_schema = schema["properties"]["children"]
+        assert children_schema["type"] == "array"
+        assert children_schema["items"]["type"] == "object"
+
+    def test_default_value_parsing(self, translator):
+        """Test default values are parsed into JSON Schema."""
+        tools = translator.graphql_fields_to_mcp_tools()
+        users_tool = next(t for t in tools if t["name"] == "query_users")
+        limit_prop = users_tool["inputSchema"]["properties"]["limit"]
+        assert limit_prop.get("default") == 10
+        assert limit_prop.get("description") == "Max results"
+
+    def test_graphql_schema_to_mcp_server(self, translator):
+        """Test full schema to MCP server definition."""
+        server = translator.graphql_schema_to_mcp_server()
+        assert "graphql-" in server["name"]
+        assert "sse" in server["transport"]
+        assert len(server["tools"]) == 4
+
+    def test_object_type_fallback(self, translator):
+        """Test OBJECT types used as input fall back to object."""
+        schema = translator._graphql_type_to_json_schema({"kind": "OBJECT", "name": "User", "ofType": None}, set())
+        assert schema == {"type": "object"}
+
+    def test_non_null_unwrapping(self, translator):
+        """Test NON_NULL wrapper is properly unwrapped."""
+        schema = translator._graphql_type_to_json_schema(
+            {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "Boolean", "ofType": None}},
+            set(),
+        )
+        assert schema == {"type": "boolean"}
+
+
+# ── Constant and module-level tests ────────────────────────────────────────
+
+
+class TestModuleConstants:
+    """Test module-level constants and availability."""
+
+    def test_graphql_available(self):
+        """Test GRAPHQL_AVAILABLE is a boolean."""
+        assert isinstance(GRAPHQL_AVAILABLE, bool)
+
+    def test_scalar_type_map_completeness(self):
+        """Test all standard GraphQL scalars are mapped."""
+        assert "String" in GRAPHQL_SCALAR_TYPE_MAP
+        assert "Int" in GRAPHQL_SCALAR_TYPE_MAP
+        assert "Float" in GRAPHQL_SCALAR_TYPE_MAP
+        assert "Boolean" in GRAPHQL_SCALAR_TYPE_MAP
+        assert "ID" in GRAPHQL_SCALAR_TYPE_MAP
+
+    def test_scalar_type_map_values(self):
+        """Test scalar type map values are valid JSON Schema types."""
+        valid_types = {"string", "integer", "number", "boolean"}
+        for value in GRAPHQL_SCALAR_TYPE_MAP.values():
+            assert value in valid_types
+
+
+# ── expose_graphql_via_sse tests ───────────────────────────────────────────
+
+
+class TestExposeGraphqlViaSse:
+    """Test the CLI utility function."""
+
+    @pytest.mark.asyncio
+    async def test_expose_graphql_basic(self):
+        """Test expose function performs introspection and logs tools."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"__schema": SAMPLE_SCHEMA}}
+
+        with patch("mcpgateway.translate_graphql.httpx") as mock_httpx:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_httpx.AsyncClient.return_value = mock_client
+
+            task = asyncio.create_task(
+                expose_graphql_via_sse(
+                    endpoint_url="https://api.example.com/graphql",
+                    port=9001,
+                )
+            )
+            # Let the task start and perform introspection
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task


### PR DESCRIPTION
> **Note:** This PR was re-created from #2989 due to repository maintenance. Your code and branch are intact. @crivetimihai please verify everything looks good.

## Summary

- Add experimental GraphQL-to-MCP translation with automatic schema introspection, dual-mode operation (CLI bridge + direct registration), feature flags, configuration, documentation, and ADR-0041
- Extend the tool model with `GRAPHQL` integration type and GraphQL-specific fields (`graphql_operation`, `graphql_variables_mapping`, `graphql_field_selection`, `graphql_operation_type`)
- Add `translate_graphql.py` CLI bridge that introspects GraphQL endpoints and exposes discovered queries/mutations as MCP tools via HTTP/SSE

## Test plan

- [x] Config loads with correct defaults: `mcpgateway_graphql_enabled=False`
- [x] Config schema JSON contains all 5 new GraphQL fields
- [x] `config.py` passes flake8
- [x] All existing unit tests pass
- [x] Unit tests for `translate_graphql` module included