### PR TITLE
[FIX][UI]: Display CRUD changes on Users and Teams pages without full reload

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4956,10 +4956,6 @@ async def admin_teams_partial_html(
             "query_params": query_params_dict,
         },
     )
-    # Prevent nginx caching for real-time team updates
-    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "0"
     return response
 
 
@@ -5113,6 +5109,7 @@ async def admin_create_team(
         await team_service.create_team(name=team_data.name, description=team_data.description, created_by=user_email, visibility=team_data.visibility)
 
         response = HTMLResponse(content="", status_code=201)
+        response.headers["HX-Trigger"] = orjson.dumps({"adminTeamAction": {"refreshUnifiedTeamsList": True, "delayMs": 1000}}).decode()
         return response
 
     except (ValidationError, CoreValidationError) as e:
@@ -5522,7 +5519,12 @@ async def admin_get_team_edit(
             </form>
         </div>
         """
-        return HTMLResponse(content=edit_form)
+        response = HTMLResponse(content=edit_form)
+        # Prevent nginx caching for real-time team member updates
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["Expires"] = "0"
+        return response
 
     except Exception as e:
         LOGGER.error(f"Error getting team edit form for {team_id}: {e}")
@@ -5687,10 +5689,6 @@ async def admin_delete_team(
         </div>
         """
         response = HTMLResponse(content=success_html)
-        # Prevent nginx caching for real-time updates
-        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-        response.headers["Pragma"] = "no-cache"
-        response.headers["Expires"] = "0"
         response.headers["HX-Trigger"] = orjson.dumps({"adminTeamAction": {"refreshUnifiedTeamsList": True, "delayMs": 1000}}).decode()
         return response
 
@@ -5897,11 +5895,6 @@ async def admin_add_team_members(
         </script>
         """
         response = HTMLResponse(content=success_html)
-
-        # Prevent nginx caching for real-time updates
-        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-        response.headers["Pragma"] = "no-cache"
-        response.headers["Expires"] = "0"
 
         # Trigger refresh of teams list (but don't reopen modal)
         response.headers["HX-Trigger"] = orjson.dumps(
@@ -7503,7 +7496,9 @@ async def admin_delete_user(
         await auth_service.delete_user(decoded_email)
 
         # Return empty content to remove the user from the list
-        return HTMLResponse(content="", status_code=200)
+        response = HTMLResponse(content="", status_code=200)
+        response.headers["HX-Trigger"] = orjson.dumps({"adminUserAction": {"refreshUsersList": True, "delayMs": 1000}}).decode()
+        return response
 
     except Exception as e:
         LOGGER.error(f"Error deleting user {user_email}: {e}")

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -22351,7 +22351,7 @@ async function showTeamEditModal(teamId) {
     }
 
     // Construct the full URL - ensure it starts with /
-    const url = (rootPath || "") + "/admin/teams/" + teamId + "/edit";
+    const url = `${rootPath || ""}/admin/teams/${teamId}/edit`;
 
     // Load the team edit form via HTMX
     fetch(url, {
@@ -23012,6 +23012,8 @@ function handleAdminTeamAction(event) {
                 ) {
                     params.set("relationship", currentTeamRelationshipFilter);
                 }
+                // Cache-bust to bypass nginx proxy cache after mutation
+                params.set("_t", Date.now());
                 const url = `${window.ROOT_PATH || ""}/admin/teams/partial?${params.toString()}`;
                 window.htmx.ajax("GET", url, {
                     target: "#unified-teams-list",
@@ -23069,7 +23071,14 @@ function handleAdminUserAction(event) {
         if (detail.refreshUsersList) {
             const usersList = document.getElementById("users-list-container");
             if (usersList && window.htmx) {
-                window.htmx.trigger(usersList, "refreshUsers");
+                // Cache-bust with timestamp to bypass nginx proxy cache after mutation
+                const hxGet = usersList.getAttribute("hx-get") || "";
+                const separator = hxGet.includes("?") ? "&" : "?";
+                const url = `${hxGet}${separator}_t=${Date.now()}`;
+                window.htmx.ajax("GET", url, {
+                    target: "#users-list-container",
+                    swap: "outerHTML",
+                });
             }
         }
     }, delayMs);
@@ -32314,7 +32323,7 @@ async function serverSideUserSearch(teamId, searchTerm) {
         if (Object.keys(memberDataFromDom).length === 0) {
             try {
                 const membersResp = await fetchWithAuth(
-                    `${window.ROOT_PATH}/admin/teams/${teamId}/members/partial?page=1&per_page=100`,
+                    `${window.ROOT_PATH}/admin/teams/${teamId}/members/partial?page=1&per_page=100&_t=${Date.now()}`,
                 );
                 if (membersResp.ok) {
                     const tempDiv = document.createElement("div");

--- a/mcpgateway/templates/users_partial.html
+++ b/mcpgateway/templates/users_partial.html
@@ -49,6 +49,7 @@
           <button
             class="px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 border border-blue-300 dark:border-blue-600 hover:border-blue-500 dark:hover:border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             hx-get="{{ root_path }}/admin/users/{{ user.email | urlencode }}/edit"
+            hx-on::config-request="event.detail.path += (event.detail.path.includes('?') ? '&' : '?') + '_t=' + Date.now()"
             hx-target="#user-edit-modal-content"
             hx-swap="innerHTML show:top"
             hx-on::before-request="const modal = document.getElementById('user-edit-modal'); if (modal) { modal.style.display = 'block'; modal.classList.remove('hidden'); void modal.offsetHeight; }"

--- a/tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py
+++ b/tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py
@@ -187,10 +187,10 @@ class TestCacheInvalidationSubscriber:
                 self.unsubscribed = False
                 self.closed = False
 
-            async def subscribe(self, _channel):
+            async def subscribe(self, *channels):
                 self.subscribed = True
 
-            async def unsubscribe(self, _channel):
+            async def unsubscribe(self, *channels):
                 self.unsubscribed = True
 
             async def aclose(self):
@@ -229,7 +229,7 @@ class TestCacheInvalidationSubscriber:
     @pytest.mark.asyncio
     async def test_start_cleanup_on_exception(self, cache_subscriber, monkeypatch):
         class FakePubSub:
-            async def subscribe(self, _channel):
+            async def subscribe(self, *channels):
                 raise RuntimeError("subscribe failed")
 
             async def aclose(self):
@@ -250,7 +250,7 @@ class TestCacheInvalidationSubscriber:
     @pytest.mark.asyncio
     async def test_start_cleanup_on_exception_handles_cleanup_error(self, cache_subscriber, monkeypatch):
         class FakePubSub:
-            async def subscribe(self, _channel):
+            async def subscribe(self, *channels):
                 raise RuntimeError("subscribe failed")
 
             async def aclose(self):
@@ -419,7 +419,7 @@ class TestCacheInvalidationSubscriber:
         cache_subscriber._task = None
 
         class FakePubSub:
-            async def unsubscribe(self, _channel):
+            async def unsubscribe(self, *channels):
                 raise asyncio.TimeoutError()
 
             async def close(self):
@@ -437,7 +437,7 @@ class TestCacheInvalidationSubscriber:
         cache_subscriber._task = None
 
         class FakePubSub:
-            async def unsubscribe(self, _channel):
+            async def unsubscribe(self, *channels):
                 raise RuntimeError("unsubscribe boom")
 
             async def close(self):


### PR DESCRIPTION
> **Note:** This PR was re-created from #3011 due to repository maintenance. Your code and branch are intact. @marekdano please verify everything looks good.

# 🐛 Bug-fix PR

---

## 📌 Summary
Fixes stale UI data on Teams and Users admin pages when running multiple gateway replicas behind nginx. The root cause was three layers of caching preventing CRUD changes from being reflected:

1. Cross-replica cache invalidation gap — `auth_cache` published invalidation messages to `mcpgw:auth:invalidate` but `CacheInvalidationSubscriber` only listened on `mcpgw:cache:invalidate`, so other replicas never cleared their in-memory auth caches.
2. Missing HTMX refresh triggers — Create team and delete user endpoints returned responses without `HX-Trigger` headers, so the frontend never knew to refresh the lists
3. Nginx/browser caching — Nginx's `proxy_cache_valid 200 5s` and add_header `Cache-Control "private, max-age=5"` always caused stale responses for all /admin GET requests. Since nginx overrides backend Cache-Control headers, this was solved client-side with `_t=Date.now()` cache-busting query parameters.
4. Removed all 6 Cache-Control/Pragma/Expires header additions from partial endpoints — these are unnecessary since the `_t=Date.now()` timestamp cache-busting in admin.js already bypasses both nginx proxy cache and browser cache

## 🔁 Reproduction Steps
Users Page
1. Go to http://localhost:8080/admin
2. Navigate to the Users page
3. Create, Edit, Delete User(s)
4. Observe that a new / updated / deleted user is not updated on the page. The page has to be reloaded to see the change.

Teams Page
1. Go to http://localhost:8080/admin
2. Navigate to the Teams page
3. Create, Edit, Activate / Deactivate, Delete Team(s)
4. Add / Remove members to / from Teams
5. Observe that a new / updated / deleted teams or updated members are not updated on the page. The page has to be reloaded to see the change.


## 🐞 Root Cause
CRUD operations on Users and Teams are cached behind the nginx 5s cache time. So when the operations are executed on the admin UI, the changes are not reflected on the UI. The whole page must be reloaded to see them. 

## 💡 Fix Description
 Changes by file

`mcpgateway/cache/registry_cache.py`

- Subscribe `CacheInvalidationSubscriber` to both `mcpgw:cache:invalidate` and `mcpgw:auth:invalidate` channels
- Route messages by channel in `_listen_loop`
- Add `_process_auth_invalidation()` to clear L1 in-memory auth caches (_user_cache, _team_cache, _role_cache, _teams_list_cache, _revocation_cache, _context_cache, _revoked_jtis) across replicas

`mcpgateway/admin.py`

- Add `HX-Trigger` header to `admin_create_team` to refresh teams list
- Add `HX-Trigger` header to `admin_delete_user` to refresh users list
- Add `_t` cache-busting timestamp to server-rendered `hx-get` URLs for members/non-members partials and their infinite scroll `next_page_url`

`mcpgateway/static/admin.js`

  - Add `_t=Date.now()` cache-busting to teams partial, users partial, members partial, non-members partial, team edit, user edit, and team members refresh fetches

`mcpgateway/templates/admin.html`

  - Add `_t` cache-busting to `loadTeamMembersView()`, `loadAddMembersView()`, and `editTeamSafe()` HTMX ajax calls

`mcpgateway/templates/users_partial.html`

- Add `hx-on::config-request` to dynamically append `_t` on the user edit button's `hx-get` request

`tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py`

- Update `FakePubSub` subscribe/unsubscribe signatures to accept `*channels` (matching the new two-channel subscription)

`tests/js/admin-search.test.js`

- Update user edit modal test assertions to use `expect.stringContaining()` to accommodate the `_t` query parameter

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
