### PR TITLE
fix(auth): cache full team objects in get_user_teams (fixes #3005)

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5888,6 +5888,64 @@ class TeamUpdateRequest(BaseModel):
         return v if v else None
 
 
+class CachedTeamData(BaseModel):
+    """Schema for cached team data (read-only).
+
+    This model represents team data stored in cache and returned from cache lookups.
+    It is intentionally a Pydantic model (not a SQLAlchemy ORM object) to avoid
+    DetachedInstanceError when accessing relationships or attempting session operations.
+
+    IMPORTANT: Objects of this type should be treated as read-only data. They are not
+    attached to any database session and cannot be used for:
+    - Accessing relationships (e.g., team.members)
+    - Database operations (db.add(), db.merge(), db.commit())
+    - Modifying and persisting changes
+
+    Use this model when returning cached team data to avoid creating transient
+    SQLAlchemy objects that could cause session-related errors.
+
+    Attributes:
+        id: Team UUID
+        name: Team display name
+        slug: URL-friendly team identifier
+        description: Team description
+        created_by: Email of team creator
+        is_personal: Whether this is a personal team
+        visibility: Team visibility level
+        max_members: Maximum number of members allowed
+        is_active: Whether the team is active
+        created_at: Team creation timestamp
+        updated_at: Last update timestamp
+
+    Examples:
+        >>> team = CachedTeamData(
+        ...     id="team-123",
+        ...     name="Engineering Team",
+        ...     slug="engineering-team",
+        ...     created_by="admin@example.com",
+        ...     is_personal=False,
+        ...     visibility="private",
+        ...     is_active=True,
+        ...     created_at=datetime.now(timezone.utc),
+        ...     updated_at=datetime.now(timezone.utc)
+        ... )
+        >>> team.name
+        'Engineering Team'
+    """
+
+    id: str = Field(..., description="Team UUID")
+    name: str = Field(..., description="Team display name")
+    slug: Optional[str] = Field(None, description="URL-friendly team identifier")
+    description: Optional[str] = Field(None, description="Team description")
+    created_by: Optional[str] = Field(None, description="Email of team creator")
+    is_personal: bool = Field(False, description="Whether this is a personal team")
+    visibility: Optional[str] = Field("public", description="Team visibility level")
+    max_members: Optional[int] = Field(None, description="Maximum number of members allowed")
+    is_active: bool = Field(True, description="Whether the team is active")
+    created_at: Optional[datetime] = Field(None, description="Team creation timestamp")
+    updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
+
+
 class TeamResponse(BaseModel):
     """Schema for team response data.
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5904,6 +5904,11 @@ class CachedTeamData(BaseModel):
     Use this model when returning cached team data to avoid creating transient
     SQLAlchemy objects that could cause session-related errors.
 
+    Schema Versioning:
+        When adding new required fields to this model, increment the cache version
+        in TeamManagementService.get_user_teams() (e.g., v1: -> v2:) to auto-invalidate
+        stale cache entries and prevent schema drift errors.
+
     Attributes:
         id: Team UUID
         name: Team display name

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -905,6 +905,11 @@ class TeamManagementService:
 
         If you need full ORM functionality, disable caching or refetch from database.
 
+        Cache Versioning:
+            The cache key includes a version prefix (v1:) to handle schema changes.
+            If CachedTeamData schema changes (new required fields, etc.), increment
+            the version to auto-invalidate stale cache entries.
+
         Args:
             user_email: Email of the user
             include_personal: Whether to include personal teams
@@ -917,8 +922,10 @@ class TeamManagementService:
             User dashboard showing team memberships.
         """
         # Check cache first
+        # Cache key includes version prefix to handle schema changes
+        # Increment version (v1 -> v2) when CachedTeamData schema changes
         cache = self._get_auth_cache()
-        cache_key = f"{user_email}:{include_personal}"
+        cache_key = f"v1:{user_email}:{include_personal}"
 
         if cache:
             cached_teams = await cache.get_user_teams(cache_key)

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -940,7 +940,13 @@ class TeamManagementService:
                         team_data = team.copy()
                         for key, value in team_data.items():
                             if key in ("created_at", "updated_at") and isinstance(value, str):
-                                team_data[key] = datetime.fromisoformat(value)
+                                # Parse ISO format datetime (includes timezone info from isoformat())
+                                dt = datetime.fromisoformat(value)
+                                # Ensure timezone-aware (UTC) to match DB model
+                                if dt.tzinfo is None:
+                                    from datetime import timezone
+                                    dt = dt.replace(tzinfo=timezone.utc)
+                                team_data[key] = dt
                         teams.append(CachedTeamData(**team_data))
                     return teams
                 except Exception as e:

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -20,7 +20,7 @@ Examples:
 # Standard
 import asyncio
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 # Third-Party
@@ -952,9 +952,6 @@ class TeamManagementService:
                                 dt = datetime.fromisoformat(value)
                                 # Ensure timezone-aware (UTC) to match DB model
                                 if dt.tzinfo is None:
-                                    # Standard
-                                    from datetime import timezone
-
                                     dt = dt.replace(tzinfo=timezone.utc)
                                 team_data[key] = dt
                         teams.append(CachedTeamData(**team_data))

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -1789,7 +1789,10 @@ class TestTeamManagementService:
     # ---- get_user_teams cache paths ---- #
     @pytest.mark.asyncio
     async def test_get_user_teams_cache_hit_with_objects(self, service, mock_db):
-        """get_user_teams returns teams from cache when cache hit with team objects."""
+        """get_user_teams returns CachedTeamData from cache when cache hit with team objects."""
+        # Third-Party
+        from mcpgateway.schemas import CachedTeamData
+
         now = datetime.now(timezone.utc)
         cached_teams = [
             {
@@ -1813,6 +1816,8 @@ class TestTeamManagementService:
 
         result = await service.get_user_teams("user@test.com")
         assert len(result) == 1
+        # Verify it returns CachedTeamData (Pydantic model), not EmailTeam (SQLAlchemy ORM)
+        assert isinstance(result[0], CachedTeamData)
         assert result[0].id == "team-1"
         assert result[0].name == "Team One"
 


### PR DESCRIPTION
> **Note:** This PR was re-created from #3013 due to repository maintenance. Your code and branch are intact. @msureshkumar88 please verify everything looks good.

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3005

---

## 📝 Summary
_What does this PR do and why?_
This PR optimizes the authentication hot-path by extending the get_user_teams cache to store full Team objects (serialized) instead of only team IDs. On cache hits, downstream request handlers can now consume full team data without performing additional DB lookups, significantly reducing DB round-trips under high concurrency.

Key changes:

- Store serialised Team objects in auth_cache for get_user_teams.
- Prime cache using the request's existing DB session (avoid repeated fresh_db_session() calls).
- Update callers to read Team objects from cache and fall back to DB only on miss/partial data.
- Update unit tests to reflect the new changes in teams objects  


Performance Impact:

- Before: Cache hit → Returns IDs → Query DB for team details
- After: Cache hit → Returns full team objects → No DB query needed
- Cache hit: Reconstruct EmailTeam objects from cached dictionaries

Cache miss: Serialize team objects to dictionaries before caching

Handles datetime serialization using isoformat()

Code Changes: 

1. mcpgateway/cache/auth_cache.py

- get_user_teams(): Return type changed from Optional[List[str]] → Optional[List[Dict[str, Any]]]
- set_user_teams(): Parameter changed from team_ids: List[str] → teams: List[Dict[str, Any]]

2. mcpgateway/services/team_management_service.py

- Cache hit: Reconstruct EmailTeam objects from cached dictionaries
- Cache miss: Serialize team objects to dictionaries before caching
- Handles datetime serialization using isoformat()


3. Updated Existing Tests
- test_team_management_service.py: Updated test_get_user_teams_cache_hit_with_objects
- test_team_management_service_coverage.py: Updated test_cache_hit_with_objects


---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   PASS     |
| Unit tests                | `make test`     |      PASS       |
| Coverage ≥ 80%            | `make coverage` |    99%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
