### PR TITLE
fix(api): move JSONPath modifier to query parameter with improved error handling

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4675,6 +4675,9 @@ async def list_tools(
         HTTPException: If JSONPath modifier fails to process the tools list
     """
 
+    # Validate apijsonpath early — fail fast before the database query
+    parsed_apijsonpath = _parse_apijsonpath(apijsonpath)
+
     # Parse tags parameter if provided
     tags_list = None
     if tags:
@@ -4727,10 +4730,6 @@ async def list_tools(
     # Release transaction before response serialization
     db.commit()
     db.close()
-
-    # Allow apijsonpath to be supplied either as a model (direct call/tests) or
-    # as a JSON-encoded string via query (HTTP GET). Body() is not allowed on GET.
-    parsed_apijsonpath = _parse_apijsonpath(apijsonpath)
 
     if parsed_apijsonpath is None:
         if include_pagination:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1300,6 +1300,8 @@ def _apply_runtime_mode_headers(response: Response) -> None:
     response.headers["x-contextforge-mcp-live-stream-core-mode"] = _current_mcp_live_stream_core_mode()
     response.headers["x-contextforge-mcp-affinity-core-mode"] = _current_mcp_affinity_core_mode()
     response.headers["x-contextforge-mcp-session-auth-reuse-mode"] = _current_mcp_session_auth_reuse_mode()
+
+
 # Type aliases for improved readability
 ToolsResponse: TypeAlias = Union[List[ToolRead], CursorPaginatedToolsResponse, List[Dict[Any, Any]], Dict[Any, Any], ORJSONResponse]
 ToolResponse: TypeAlias = Union[ToolRead, Dict[Any, Any], ORJSONResponse]

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4633,7 +4633,10 @@ async def list_tools(
         visibility: Optional visibility filter (private, team, public)
         gateway_id: Optional gateway ID to filter tools by specific gateway
         db: Database session
-        apijsonpath: JSON path modifier to filter or transform the response
+        apijsonpath: Optional JSON-Path modifier supplied as URL-encoded query parameter.
+                     Example: ?apijsonpath=%7B%22jsonpath%22%3A%22%24.name%22%7D
+                     (decoded: {"jsonpath":"$.name"})
+                     Use to filter or transform the response via JSONPath expressions.
         user: Authenticated user with permissions
 
     Returns:
@@ -4830,7 +4833,10 @@ async def get_tool(
         request: The incoming HTTP request.
         db:     Active SQLAlchemy session (dependency).
         user:   Authenticated username (dependency).
-        apijsonpath: Optional JSON-Path modifier supplied as query parameter
+        apijsonpath: Optional JSON-Path modifier supplied as URL-encoded query parameter.
+                     Example: ?apijsonpath=%7B%22jsonpath%22%3A%22%24.name%22%7D
+                     (decoded: {"jsonpath":"$.name","mapping":null})
+                     Use to filter or transform the response via JSONPath expressions.
 
     Returns:
         The raw ``ToolRead`` model **or** a JSON-transformed ``dict`` if

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -35,6 +35,7 @@ from functools import lru_cache
 import hashlib
 import hmac
 import html
+import json
 import re
 import sys
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
@@ -1316,6 +1317,34 @@ def _parse_jsonpath(jsonpath: str) -> JSONPath:
     return parse(jsonpath)
 
 
+def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[JsonPathModifier]:
+    """
+    Parse apijsonpath parameter from either a JSON string or a JsonPathModifier model.
+
+    Args:
+        raw: Either a JSON-encoded string or a JsonPathModifier instance
+
+    Returns:
+        Parsed JsonPathModifier or None if raw is None
+
+    Raises:
+        HTTPException: If the JSON string is invalid or unexpected type provided (400 Bad Request)
+    """
+    if raw is None:
+        return None
+
+    if isinstance(raw, str):
+        try:
+            return JsonPathModifier.model_validate(json.loads(raw))
+        except Exception as ex:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid apijsonpath JSON: {ex}")
+    elif isinstance(raw, JsonPathModifier):
+        return raw
+
+    # Unexpected type - fail fast with clear error message
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid apijsonpath type: expected string or JsonPathModifier, got {type(raw).__name__}")
+
+
 def jsonpath_modifier(data: Any, jsonpath: str = "$[*]", mappings: Optional[Dict[str, str]] = None) -> Union[List, Dict]:
     """
     Applies the given JSONPath expression and mappings to the data.
@@ -1345,6 +1374,10 @@ def jsonpath_modifier(data: Any, jsonpath: str = "$[*]", mappings: Optional[Dict
     """
     if not jsonpath:
         jsonpath = "$[*]"
+
+    # Log jsonpath_modifier invocation with structured data
+    data_length = len(data) if isinstance(data, list) else None
+    logger.debug(f"jsonpath_modifier: path='{jsonpath}', has_mappings={mappings is not None}, " f"data_type={type(data).__name__}, data_length={data_length}")
 
     try:
         main_expr: JSONPath = _parse_jsonpath(jsonpath)
@@ -4569,9 +4602,9 @@ async def list_tools(
     visibility: Optional[str] = Query(None, description="Filter by visibility: private, team, public"),
     gateway_id: Optional[str] = Query(None, description="Filter by gateway ID"),
     db: Session = Depends(get_db),
-    apijsonpath: JsonPathModifier = Body(None),
+    apijsonpath: Optional[str] = Query(None, description="Optional JSONPath modifier as JSON string"),
     user=Depends(get_current_user_with_permissions),
-) -> Union[List[ToolRead], List[Dict], Dict]:
+) -> Union[List[ToolRead], List[Dict], Dict, ORJSONResponse]:
     """List all registered tools with team-based filtering and pagination support.
 
     Args:
@@ -4591,6 +4624,9 @@ async def list_tools(
 
     Returns:
         List of tools or modified result based on jsonpath
+
+    Raises:
+        HTTPException: If JSONPath modifier fails to process the tools list
     """
 
     # Parse tags parameter if provided
@@ -4646,14 +4682,26 @@ async def list_tools(
     db.commit()
     db.close()
 
-    if apijsonpath is None:
+    # Allow apijsonpath to be supplied either as a model (direct call/tests) or
+    # as a JSON-encoded string via query (HTTP GET). Body() is not allowed on GET.
+    parsed_apijsonpath = _parse_apijsonpath(apijsonpath)
+
+    if parsed_apijsonpath is None:
         if include_pagination:
             return CursorPaginatedToolsResponse.model_construct(tools=data, next_cursor=next_cursor)
         return data
 
     tools_dict_list = [tool.to_dict(use_alias=True) for tool in data]
-
-    return jsonpath_modifier(tools_dict_list, apijsonpath.jsonpath, apijsonpath.mapping)
+    try:
+        result = jsonpath_modifier(tools_dict_list, parsed_apijsonpath.jsonpath, parsed_apijsonpath.mapping)
+        # Return ORJSONResponse to bypass FastAPI's response_model validation
+        return ORJSONResponse(content=result)
+    except HTTPException:
+        # Re-raise HTTPException as-is (preserves 400 from apijsonpath parsing)
+        raise
+    except Exception:
+        logger.exception("JSONPath modifier failed while processing tools list")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="JSONPath modifier error")
 
 
 @tool_router.post("", response_model=ToolRead)
@@ -4758,8 +4806,8 @@ async def get_tool(
     request: Request,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
-    apijsonpath: JsonPathModifier = Body(None),
-) -> Union[ToolRead, Dict]:
+    apijsonpath: Optional[str] = Query(None, description="Optional JSONPath modifier as JSON string"),
+) -> Union[ToolRead, Dict, ORJSONResponse]:
     """
     Retrieve a tool by ID, optionally applying a JSONPath post-filter.
 
@@ -4768,11 +4816,12 @@ async def get_tool(
         request: The incoming HTTP request.
         db:     Active SQLAlchemy session (dependency).
         user:   Authenticated username (dependency).
-        apijsonpath: Optional JSON-Path modifier supplied in the body.
+        apijsonpath: Optional JSON-Path modifier supplied as query parameter
 
     Returns:
         The raw ``ToolRead`` model **or** a JSON-transformed ``dict`` if
-        a JSONPath filter/mapping was supplied.
+        a JSONPath filter/mapping was supplied, **or** an ``ORJSONResponse``
+        when JSONPath modifiers are applied.
 
     Raises:
         HTTPException: If the tool does not exist or the transformation fails.
@@ -4783,12 +4832,23 @@ async def get_tool(
         _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
         data = await tool_service.get_tool(db, tool_id, requesting_user_email=_req_email, requesting_user_is_admin=_req_is_admin, requesting_user_team_roles=_req_team_roles)
         _enforce_scoped_resource_access(request, db, user, f"/tools/{tool_id}")
-        if apijsonpath is None:
+
+        # Parse apijsonpath parameter (handles both string and JsonPathModifier inputs)
+        parsed_apijsonpath = _parse_apijsonpath(apijsonpath)
+        if parsed_apijsonpath is None:
             return data
 
         data_dict = data.to_dict(use_alias=True)
-
-        return jsonpath_modifier(data_dict, apijsonpath.jsonpath, apijsonpath.mapping)
+        try:
+            result = jsonpath_modifier(data_dict, parsed_apijsonpath.jsonpath, parsed_apijsonpath.mapping)
+            # Return ORJSONResponse to bypass FastAPI's response_model validation
+            return ORJSONResponse(content=result)
+        except HTTPException:
+            # Re-raise HTTPException as-is (preserves 400 from apijsonpath parsing)
+            raise
+        except Exception:
+            logger.exception("JSONPath modifier failed while processing single tool")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="JSONPath modifier error")
     except HTTPException:
         raise
     except Exception as e:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -39,7 +39,7 @@ import json
 import logging
 import re
 import sys
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, TypeAlias, Union
 from urllib.parse import urlparse, urlunparse
 import uuid
 import warnings
@@ -1161,6 +1161,7 @@ async def _authorize_run_cancellation(request: Request, user, request_id: str, *
 resource_cache = ResourceCache(max_size=settings.resource_cache_size, ttl=settings.resource_cache_ttl)
 
 
+<<<<<<< HEAD
 def _rust_build_included() -> bool:
     """Return whether the current image includes Rust MCP artifacts.
 
@@ -1300,6 +1301,11 @@ def _apply_runtime_mode_headers(response: Response) -> None:
     response.headers["x-contextforge-mcp-live-stream-core-mode"] = _current_mcp_live_stream_core_mode()
     response.headers["x-contextforge-mcp-affinity-core-mode"] = _current_mcp_affinity_core_mode()
     response.headers["x-contextforge-mcp-session-auth-reuse-mode"] = _current_mcp_session_auth_reuse_mode()
+=======
+# Type aliases for improved readability
+ToolsResponse: TypeAlias = Union[List[ToolRead], CursorPaginatedToolsResponse, List[Dict[Any, Any]], Dict[Any, Any], ORJSONResponse]
+ToolResponse: TypeAlias = Union[ToolRead, Dict[Any, Any], ORJSONResponse]
+>>>>>>> e859a84ab (review)
 
 
 @lru_cache(maxsize=512)
@@ -1322,6 +1328,8 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
     """
     Parse apijsonpath parameter from either a JSON string or a JsonPathModifier model.
 
+    Performs early validation of JSONPath syntax to fail fast and provide clear error messages.
+
     Args:
         raw: Either a JSON-encoded string or a JsonPathModifier instance
 
@@ -1330,7 +1338,7 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
 
     Raises:
         HTTPException: If the JSON string is invalid, unexpected type provided,
-                      or jsonpath expression is empty (400 Bad Request)
+                      jsonpath expression is empty, or JSONPath syntax is invalid (400 Bad Request)
     """
     if raw is None:
         return None
@@ -1339,14 +1347,21 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
         try:
             parsed = JsonPathModifier.model_validate(json.loads(raw))
             # Validate jsonpath is not empty if provided
-            if parsed.jsonpath is not None and not parsed.jsonpath.strip():
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="JSONPath expression cannot be empty")
+            if parsed.jsonpath is not None:
+                if not parsed.jsonpath.strip():
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="JSONPath expression cannot be empty")
+                # Early validation: ensure JSONPath syntax is valid
+                try:
+                    _parse_jsonpath(parsed.jsonpath)
+                except Exception as parse_ex:
+                    detail = f"Invalid JSONPath syntax: {parse_ex}" if settings.log_level == "DEBUG" else "Invalid JSONPath expression"
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
             return parsed
         except HTTPException:
-            # Re-raise HTTPException as-is (includes empty jsonpath validation)
+            # Re-raise HTTPException as-is (includes empty jsonpath and syntax validation)
             raise
-        except (json.JSONDecodeError, ValueError) as ex:
-            # User error: malformed JSON or validation failure
+        except json.JSONDecodeError as ex:
+            # User error: malformed JSON (JSONDecodeError is subclass of ValueError, so catch it specifically)
             detail = f"Invalid apijsonpath JSON: {ex}" if settings.log_level == "DEBUG" else "Invalid apijsonpath format"
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
         except ValidationError as ex:
@@ -1359,8 +1374,15 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to parse apijsonpath")
     elif isinstance(raw, JsonPathModifier):
         # Validate jsonpath is not empty if provided
-        if raw.jsonpath is not None and not raw.jsonpath.strip():
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="JSONPath expression cannot be empty")
+        if raw.jsonpath is not None:
+            if not raw.jsonpath.strip():
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="JSONPath expression cannot be empty")
+            # Early validation: ensure JSONPath syntax is valid
+            try:
+                _parse_jsonpath(raw.jsonpath)
+            except Exception as parse_ex:
+                detail = f"Invalid JSONPath syntax: {parse_ex}" if settings.log_level == "DEBUG" else "Invalid JSONPath expression"
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
         return raw
 
     # Unexpected type - fail fast with clear error message
@@ -4626,7 +4648,7 @@ async def list_tools(
     db: Session = Depends(get_db),
     apijsonpath: Optional[str] = Query(None, description="Optional JSONPath modifier as JSON string"),
     user=Depends(get_current_user_with_permissions),
-) -> Union[List[ToolRead], List[Dict], Dict, ORJSONResponse]:
+) -> ToolsResponse:
     """List all registered tools with team-based filtering and pagination support.
 
     Args:
@@ -4722,10 +4744,7 @@ async def list_tools(
 
         # If pagination is requested, wrap the result with cursor metadata
         if include_pagination:
-            paginated_result = {
-                "tools": result,
-                "next_cursor": next_cursor
-            }
+            paginated_result = {"tools": result, "next_cursor": next_cursor}
             return ORJSONResponse(content=paginated_result)
 
         # Return ORJSONResponse to bypass FastAPI's response_model validation
@@ -4841,7 +4860,7 @@ async def get_tool(
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
     apijsonpath: Optional[str] = Query(None, description="Optional JSONPath modifier as JSON string"),
-) -> Union[ToolRead, Dict, ORJSONResponse]:
+) -> ToolResponse:
     """
     Retrieve a tool by ID, optionally applying a JSONPath post-filter.
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1740,9 +1740,6 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # For plugin errors, exit cleanly without stack trace spam
         if "Plugin initialization failed" in str(e):
             # Suppress uvicorn error logging for clean exit
-            # Standard
-            import logging  # pylint: disable=import-outside-toplevel
-
             logging.getLogger("uvicorn.error").setLevel(logging.CRITICAL)
             raise SystemExit(1)
         raise
@@ -4722,6 +4719,15 @@ async def list_tools(
     tools_dict_list = [tool.to_dict(use_alias=True) for tool in data]
     try:
         result = jsonpath_modifier(tools_dict_list, parsed_apijsonpath.jsonpath, parsed_apijsonpath.mapping)
+
+        # If pagination is requested, wrap the result with cursor metadata
+        if include_pagination:
+            paginated_result = {
+                "tools": result,
+                "next_cursor": next_cursor
+            }
+            return ORJSONResponse(content=paginated_result)
+
         # Return ORJSONResponse to bypass FastAPI's response_model validation
         return ORJSONResponse(content=result)
     except HTTPException:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -36,6 +36,7 @@ import hashlib
 import hmac
 import html
 import json
+import logging
 import re
 import sys
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
@@ -1336,13 +1337,25 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
     if isinstance(raw, str):
         try:
             return JsonPathModifier.model_validate(json.loads(raw))
+        except (json.JSONDecodeError, ValueError) as ex:
+            # User error: malformed JSON or validation failure
+            detail = f"Invalid apijsonpath JSON: {ex}" if settings.log_level == "DEBUG" else "Invalid apijsonpath format"
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+        except ValidationError as ex:
+            # Pydantic validation error
+            detail = f"Invalid apijsonpath structure: {ex}" if settings.log_level == "DEBUG" else "Invalid apijsonpath structure"
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
         except Exception as ex:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid apijsonpath JSON: {ex}")
+            # Unexpected error - log it and return generic message
+            logger.error(f"Unexpected error parsing apijsonpath: {ex}", exc_info=True)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to parse apijsonpath")
     elif isinstance(raw, JsonPathModifier):
         return raw
 
     # Unexpected type - fail fast with clear error message
-    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid apijsonpath type: expected string or JsonPathModifier, got {type(raw).__name__}")
+    # Only show type name in debug mode to avoid information disclosure
+    type_info = f": got {type(raw).__name__}" if settings.log_level == "DEBUG" else ""
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid apijsonpath type{type_info}")
 
 
 def jsonpath_modifier(data: Any, jsonpath: str = "$[*]", mappings: Optional[Dict[str, str]] = None) -> Union[List, Dict]:
@@ -1375,9 +1388,10 @@ def jsonpath_modifier(data: Any, jsonpath: str = "$[*]", mappings: Optional[Dict
     if not jsonpath:
         jsonpath = "$[*]"
 
-    # Log jsonpath_modifier invocation with structured data
-    data_length = len(data) if isinstance(data, list) else None
-    logger.debug(f"jsonpath_modifier: path='{jsonpath}', has_mappings={mappings is not None}, " f"data_type={type(data).__name__}, data_length={data_length}")
+    # Log jsonpath_modifier invocation with structured data (only if debug enabled)
+    if logger.isEnabledFor(logging.DEBUG):
+        data_length = len(data) if isinstance(data, list) else None
+        logger.debug(f"jsonpath_modifier: path='{jsonpath}', has_mappings={mappings is not None}, " f"data_type={type(data).__name__}, data_length={data_length}")
 
     try:
         main_expr: JSONPath = _parse_jsonpath(jsonpath)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1329,14 +1329,22 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
         Parsed JsonPathModifier or None if raw is None
 
     Raises:
-        HTTPException: If the JSON string is invalid or unexpected type provided (400 Bad Request)
+        HTTPException: If the JSON string is invalid, unexpected type provided,
+                      or jsonpath expression is empty (400 Bad Request)
     """
     if raw is None:
         return None
 
     if isinstance(raw, str):
         try:
-            return JsonPathModifier.model_validate(json.loads(raw))
+            parsed = JsonPathModifier.model_validate(json.loads(raw))
+            # Validate jsonpath is not empty if provided
+            if parsed.jsonpath is not None and not parsed.jsonpath.strip():
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="JSONPath expression cannot be empty")
+            return parsed
+        except HTTPException:
+            # Re-raise HTTPException as-is (includes empty jsonpath validation)
+            raise
         except (json.JSONDecodeError, ValueError) as ex:
             # User error: malformed JSON or validation failure
             detail = f"Invalid apijsonpath JSON: {ex}" if settings.log_level == "DEBUG" else "Invalid apijsonpath format"
@@ -1350,6 +1358,9 @@ def _parse_apijsonpath(raw: Optional[Union[str, JsonPathModifier]]) -> Optional[
             logger.error(f"Unexpected error parsing apijsonpath: {ex}", exc_info=True)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to parse apijsonpath")
     elif isinstance(raw, JsonPathModifier):
+        # Validate jsonpath is not empty if provided
+        if raw.jsonpath is not None and not raw.jsonpath.strip():
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="JSONPath expression cannot be empty")
         return raw
 
     # Unexpected type - fail fast with clear error message

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1423,7 +1423,9 @@ def jsonpath_modifier(data: Any, jsonpath: str = "$[*]", mappings: Optional[Dict
     # Log jsonpath_modifier invocation with structured data (only if debug enabled)
     if logger.isEnabledFor(logging.DEBUG):
         data_length = len(data) if isinstance(data, list) else None
-        logger.debug(f"jsonpath_modifier: path='{jsonpath}', has_mappings={mappings is not None}, " f"data_type={type(data).__name__}, data_length={data_length}")
+        logger.debug(
+            f"jsonpath_modifier: path='{SecurityValidator.sanitize_log_message(jsonpath)}', has_mappings={mappings is not None}, " f"data_type={type(data).__name__}, data_length={data_length}"
+        )
 
     try:
         main_expr: JSONPath = _parse_jsonpath(jsonpath)
@@ -4740,9 +4742,10 @@ async def list_tools(
     try:
         result = jsonpath_modifier(tools_dict_list, parsed_apijsonpath.jsonpath, parsed_apijsonpath.mapping)
 
-        # If pagination is requested, wrap the result with cursor metadata
+        # If pagination is requested, wrap the result with cursor metadata.
+        # Use "nextCursor" to match the CursorPaginatedToolsResponse alias contract.
         if include_pagination:
-            paginated_result = {"tools": result, "next_cursor": next_cursor}
+            paginated_result = {"tools": result, "nextCursor": next_cursor}
             return ORJSONResponse(content=paginated_result)
 
         # Return ORJSONResponse to bypass FastAPI's response_model validation

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1161,7 +1161,6 @@ async def _authorize_run_cancellation(request: Request, user, request_id: str, *
 resource_cache = ResourceCache(max_size=settings.resource_cache_size, ttl=settings.resource_cache_ttl)
 
 
-<<<<<<< HEAD
 def _rust_build_included() -> bool:
     """Return whether the current image includes Rust MCP artifacts.
 
@@ -1301,11 +1300,9 @@ def _apply_runtime_mode_headers(response: Response) -> None:
     response.headers["x-contextforge-mcp-live-stream-core-mode"] = _current_mcp_live_stream_core_mode()
     response.headers["x-contextforge-mcp-affinity-core-mode"] = _current_mcp_affinity_core_mode()
     response.headers["x-contextforge-mcp-session-auth-reuse-mode"] = _current_mcp_session_auth_reuse_mode()
-=======
 # Type aliases for improved readability
 ToolsResponse: TypeAlias = Union[List[ToolRead], CursorPaginatedToolsResponse, List[Dict[Any, Any]], Dict[Any, Any], ORJSONResponse]
 ToolResponse: TypeAlias = Union[ToolRead, Dict[Any, Any], ORJSONResponse]
->>>>>>> e859a84ab (review)
 
 
 @lru_cache(maxsize=512)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -319,6 +319,7 @@ class JsonPathModifier(BaseModelWithConfigDict):
     Provides the structure for parsing JSONPath queries and optional mapping.
     """
 
+    model_config = ConfigDict(extra="forbid")  # ← rejects unknown fields
     jsonpath: Optional[str] = Field(None, description="JSONPath expression for querying JSON data.")
     mapping: Optional[Dict[str, str]] = Field(None, description="Mapping of fields from original data to output.")
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -50,6 +50,7 @@ from mcpgateway.main import (
     _run_internal_mcp_authentication,
     _serialize_mcp_tool_definition,
     _serialize_legacy_tool_payloads,
+    _parse_apijsonpath,
     app,
     create_prompt,
     create_resource,
@@ -1226,6 +1227,159 @@ class TestJsonPathHelpers:
             with pytest.raises(HTTPException) as excinfo:
                 transform_data_with_mappings([{"a": 1}], {"x": "$.a"})
         assert "Invalid mapping JSONPath" in excinfo.value.detail
+
+    def test_jsonpath_modifier_debug_logging_with_list(self, monkeypatch):
+        """Test jsonpath_modifier debug logging with list data (lines 789-790)."""
+        import logging
+
+        # Mock logger to ensure debug is enabled
+        mock_logger = MagicMock()
+        mock_logger.isEnabledFor.return_value = True
+        monkeypatch.setattr("mcpgateway.main.logger", mock_logger)
+
+        # Call jsonpath_modifier with list data to trigger the debug logging
+        data = [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]
+        result = jsonpath_modifier(data, "$.*.id", None)
+
+        # Verify debug logging was called
+        mock_logger.isEnabledFor.assert_called_with(logging.DEBUG)
+        mock_logger.debug.assert_called()
+        # Verify the debug message contains expected parts
+        debug_call_args = str(mock_logger.debug.call_args)
+        assert "jsonpath_modifier" in debug_call_args
+        assert "data_length=2" in debug_call_args or "data_type=list" in debug_call_args
+
+
+class TestParseApijsonpath:
+    """Test _parse_apijsonpath function for complete coverage."""
+
+    def test_parse_apijsonpath_none_input(self):
+        """Test that None input returns None (line 721)."""
+        result = _parse_apijsonpath(None)
+        assert result is None
+
+    def test_parse_apijsonpath_with_valid_string(self):
+        """Test successful parsing of valid JSON string (line 729)."""
+        from mcpgateway.schemas import JsonPathModifier
+
+        json_string = '{"jsonpath": "$.name", "mapping": null}'
+        result = _parse_apijsonpath(json_string)
+
+        assert result is not None
+        assert isinstance(result, JsonPathModifier)
+        assert result.jsonpath == "$.name"
+        assert result.mapping is None
+
+    def test_parse_apijsonpath_with_valid_string_and_mapping(self):
+        """Test successful parsing with mapping to ensure line 729 coverage."""
+        from mcpgateway.schemas import JsonPathModifier
+
+        json_string = '{"jsonpath": "$.items[*]", "mapping": {"id": "$.id", "name": "$.name"}}'
+        result = _parse_apijsonpath(json_string)
+
+        assert result is not None
+        assert isinstance(result, JsonPathModifier)
+        assert result.jsonpath == "$.items[*]"
+        assert result.mapping == {"id": "$.id", "name": "$.name"}
+
+    def test_parse_apijsonpath_empty_jsonpath_string(self):
+        """Test empty jsonpath in string raises error (lines 728, 732)."""
+        json_string = '{"jsonpath": "   ", "mapping": null}'
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(json_string)
+
+        assert excinfo.value.status_code == 400
+        assert "JSONPath expression cannot be empty" in excinfo.value.detail
+
+    def test_parse_apijsonpath_invalid_json_debug_mode(self, monkeypatch):
+        """Test invalid JSON in DEBUG mode (lines 733-736)."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "DEBUG")
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath('{"invalid json}')
+
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath JSON:" in excinfo.value.detail
+
+    def test_parse_apijsonpath_invalid_json_non_debug_mode(self, monkeypatch):
+        """Test invalid JSON in non-DEBUG mode (lines 733-736)."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "INFO")
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath('{"invalid json}')
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "Invalid apijsonpath format"
+
+    def test_parse_apijsonpath_jsonpathmodifier_valid(self):
+        """Test valid JsonPathModifier instance (lines 745-749)."""
+        from mcpgateway.schemas import JsonPathModifier
+
+        modifier = JsonPathModifier(jsonpath="$.test", mapping=None)
+        result = _parse_apijsonpath(modifier)
+
+        assert result is modifier
+        assert result.jsonpath == "$.test"
+
+    def test_parse_apijsonpath_jsonpathmodifier_empty_jsonpath(self):
+        """Test JsonPathModifier with empty jsonpath (lines 747-748)."""
+        from mcpgateway.schemas import JsonPathModifier
+
+        modifier = JsonPathModifier(jsonpath="  ", mapping=None)
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(modifier)
+
+        assert excinfo.value.status_code == 400
+        assert "JSONPath expression cannot be empty" in excinfo.value.detail
+
+    def test_parse_apijsonpath_invalid_type_debug_mode(self, monkeypatch):
+        """Test invalid type in DEBUG mode (lines 753-754)."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "DEBUG")
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(12345)  # Invalid type (int)
+
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath type: got int" in excinfo.value.detail
+
+    def test_parse_apijsonpath_invalid_type_non_debug_mode(self, monkeypatch):
+        """Test invalid type in non-DEBUG mode (lines 753-754)."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "INFO")
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(["list", "input"])  # Invalid type (list)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "Invalid apijsonpath type"
+
+    def test_parse_apijsonpath_unexpected_exception_logging(self, monkeypatch):
+        """Test unexpected exception handling with logging (lines 741-744)."""
+        import logging
+
+        # Mock json.loads to raise an unexpected exception (not ValueError/ValidationError/HTTPException)
+        def mock_json_loads(s):
+            raise RuntimeError("Unexpected error during parsing")
+
+        # Capture log calls
+        log_calls = []
+
+        def mock_logger_error(msg, *args, **kwargs):
+            log_calls.append((msg, kwargs))
+
+        monkeypatch.setattr("mcpgateway.main.json.loads", mock_json_loads)
+        monkeypatch.setattr("mcpgateway.main.logger.error", mock_logger_error)
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath('{"jsonpath": "$.test"}')
+
+        assert excinfo.value.status_code == 500
+        assert excinfo.value.detail == "Failed to parse apijsonpath"
+        # Verify logging was called
+        assert len(log_calls) > 0
+        assert "Unexpected error parsing apijsonpath" in log_calls[0][0]
+        assert log_calls[0][1].get("exc_info") is True
 
 
 class TestDocsAuthMiddleware:

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -9864,6 +9864,112 @@ class TestRemainingCoverageGaps:
         result = await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=apijsonpath)
         assert isinstance(result, ORJSONResponse)
         assert orjson.loads(result.body) == {"filtered": True}
+
+    async def test_list_tools_apijsonpath_with_pagination(self, monkeypatch):
+        """Test list_tools with apijsonpath and pagination returns cursor (lines 4100-4109)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+        from mcpgateway.utils.orjson_response import ORJSONResponse
+        import orjson
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool1 = MagicMock()
+        tool1.to_dict.return_value = {"id": "t1", "name": "Tool 1"}
+        tool2 = MagicMock()
+        tool2.to_dict.return_value = {"id": "t2", "name": "Tool 2"}
+
+        # Mock list_tools to return tools with a next_cursor
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool1, tool2], "cursor123")))
+
+        # Mock jsonpath_modifier to return transformed data
+        def mock_jsonpath_modifier(data, jsonpath, mapping):
+            # Simulate transformation: extract just id and name
+            return [{"toolId": d["id"], "toolName": d["name"]} for d in data]
+
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", mock_jsonpath_modifier)
+
+        apijsonpath = JsonPathModifier(jsonpath="$[*]", mapping={"toolId": "$.id", "toolName": "$.name"})
+
+        # Test with pagination enabled
+        result = await main_mod.list_tools.__wrapped__(
+            request,
+            cursor=None,
+            include_pagination=True,
+            limit=2,
+            include_inactive=False,
+            tags=None,
+            team_id=None,
+            visibility=None,
+            gateway_id=None,
+            db=MagicMock(),
+            apijsonpath=apijsonpath,
+            user={"email": "user@example.com"},
+        )
+
+        assert isinstance(result, ORJSONResponse)
+        response_data = orjson.loads(result.body)
+
+        # Should have both tools and next_cursor
+        assert "tools" in response_data
+        assert "next_cursor" in response_data
+        assert response_data["next_cursor"] == "cursor123"
+        assert len(response_data["tools"]) == 2
+        assert response_data["tools"][0] == {"toolId": "t1", "toolName": "Tool 1"}
+        assert response_data["tools"][1] == {"toolId": "t2", "toolName": "Tool 2"}
+
+    async def test_list_tools_apijsonpath_pagination_last_page(self, monkeypatch):
+        """Test list_tools with apijsonpath on last page returns null cursor (lines 4100-4109)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+        from mcpgateway.utils.orjson_response import ORJSONResponse
+        import orjson
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool1 = MagicMock()
+        tool1.to_dict.return_value = {"id": "t1", "name": "Tool 1"}
+
+        # Mock list_tools to return tools with None as next_cursor (last page)
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool1], None)))
+
+        def mock_jsonpath_modifier(data, jsonpath, mapping):
+            return [{"toolId": d["id"], "toolName": d["name"]} for d in data]
+
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", mock_jsonpath_modifier)
+
+        apijsonpath = JsonPathModifier(jsonpath="$[*]", mapping={"toolId": "$.id", "toolName": "$.name"})
+
+        # Test with pagination enabled on last page
+        result = await main_mod.list_tools.__wrapped__(
+            request,
+            cursor="somecursor",
+            include_pagination=True,
+            limit=2,
+            include_inactive=False,
+            tags=None,
+            team_id=None,
+            visibility=None,
+            gateway_id=None,
+            db=MagicMock(),
+            apijsonpath=apijsonpath,
+            user={"email": "user@example.com"},
+        )
+
+        assert isinstance(result, ORJSONResponse)
+        response_data = orjson.loads(result.body)
+
+        # Should have tools and next_cursor as null (last page)
+        assert "tools" in response_data
+        assert "next_cursor" in response_data
+        assert response_data["next_cursor"] is None
+        assert len(response_data["tools"]) == 1
+        assert response_data["tools"][0] == {"toolId": "t1", "toolName": "Tool 1"}
+
     async def test_list_tools_apijsonpath_string_parsing_error(self, monkeypatch):
         """Test list_tools with invalid apijsonpath string (lines 3668-3671)."""
         import mcpgateway.main as main_mod

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -9673,6 +9673,9 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_and_get_tool_jsonpath_modifier(self, monkeypatch):
         import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+        from mcpgateway.utils.orjson_response import ORJSONResponse
+        import orjson
 
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
@@ -9683,7 +9686,7 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
         monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(return_value={"filtered": True}))
 
-        apijsonpath = SimpleNamespace(jsonpath="$", mapping={})
+        apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
         result = await main_mod.list_tools.__wrapped__(
             request,
             cursor=None,
@@ -9698,13 +9701,487 @@ class TestRemainingCoverageGaps:
             apijsonpath=apijsonpath,
             user={"email": "user@example.com"},
         )
-        assert result == {"filtered": True}
+        assert isinstance(result, ORJSONResponse)
+        assert orjson.loads(result.body) == {"filtered": True}
 
         data = MagicMock()
         data.to_dict.return_value = {"id": "t1"}
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
         result = await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=apijsonpath)
-        assert result == {"filtered": True}
+        assert isinstance(result, ORJSONResponse)
+        assert orjson.loads(result.body) == {"filtered": True}
+    async def test_list_tools_apijsonpath_string_parsing_error(self, monkeypatch):
+        """Test list_tools with invalid apijsonpath string (lines 3668-3671)."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.to_dict.return_value = {"id": "t1"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
+
+        # Invalid JSON string for apijsonpath
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.list_tools.__wrapped__(
+                request,
+                cursor=None,
+                include_pagination=False,
+                limit=None,
+                include_inactive=False,
+                tags=None,
+                team_id=None,
+                visibility=None,
+                gateway_id=None,
+                db=MagicMock(),
+                apijsonpath="{invalid json",
+                user={"email": "user@example.com"},
+            )
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath JSON" in str(excinfo.value.detail)
+
+    async def test_list_tools_apijsonpath_none_with_pagination(self, monkeypatch):
+        """Test list_tools with parsed_apijsonpath=None and include_pagination=True (lines 3674-3681)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.model_dump.return_value = {"id": "t1", "name": "test"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], "next_cursor_123")))
+
+        # Pass JsonPathModifier instance but with None jsonpath to trigger parsed_apijsonpath=None path
+        result = await main_mod.list_tools.__wrapped__(
+            request,
+            cursor=None,
+            include_pagination=True,
+            limit=None,
+            include_inactive=False,
+            tags=None,
+            team_id=None,
+            visibility=None,
+            gateway_id=None,
+            db=MagicMock(),
+            apijsonpath=None,  # This will trigger the None path
+            user={"email": "user@example.com"},
+        )
+        # Result can be either a dict or Pydantic model depending on environment
+        if isinstance(result, dict):
+            assert "tools" in result
+            assert "nextCursor" in result
+            assert result["nextCursor"] == "next_cursor_123"
+        else:
+            assert hasattr(result, 'tools')
+            assert hasattr(result, 'next_cursor')
+            assert result.next_cursor == "next_cursor_123"
+
+    async def test_list_tools_apijsonpath_exception_handling(self, monkeypatch):
+        """Test list_tools jsonpath_modifier exception (lines 3684-3685, 3690-3692)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.to_dict.return_value = {"id": "t1"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
+
+        # Make jsonpath_modifier raise an exception
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(side_effect=RuntimeError("jsonpath error")))
+
+        apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.list_tools.__wrapped__(
+                request,
+                cursor=None,
+                include_pagination=False,
+                limit=None,
+                include_inactive=False,
+                tags=None,
+                team_id=None,
+                visibility=None,
+                gateway_id=None,
+                db=MagicMock(),
+                apijsonpath=apijsonpath,
+                user={"email": "user@example.com"},
+            )
+        assert excinfo.value.status_code == 500
+        assert "JSONPath modifier error" in str(excinfo.value.detail)
+
+    async def test_list_tools_apijsonpath_with_empty_tools_list(self, monkeypatch):
+        """Test list_tools with empty tools list and jsonpath (line 3684-3685 branch)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+        from mcpgateway.utils.orjson_response import ORJSONResponse
+        import orjson
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        # Empty tools list
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([], None)))
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(return_value={"filtered": []}))
+
+        apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
+        result = await main_mod.list_tools.__wrapped__(
+            request,
+            cursor=None,
+            include_pagination=False,
+            limit=None,
+            include_inactive=False,
+            tags=None,
+            team_id=None,
+            visibility=None,
+            gateway_id=None,
+            db=MagicMock(),
+            apijsonpath=apijsonpath,
+            user={"email": "user@example.com"},
+        )
+        assert isinstance(result, ORJSONResponse)
+        assert orjson.loads(result.body) == {"filtered": []}
+
+    async def test_get_tool_apijsonpath_none(self, monkeypatch):
+        """Test get_tool with parsed_apijsonpath=None (lines 3833-3834)."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        data = MagicMock()
+        data.to_dict.return_value = {"id": "t1", "name": "test"}
+
+        async def mock_get_tool(*args, **kwargs):
+            return data
+
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
+        monkeypatch.setattr(main_mod.tool_service, "get_tool", mock_get_tool)
+
+        result = await main_mod.get_tool.__wrapped__(
+            "tool-1",
+            request=request,
+            db=MagicMock(),
+            user={"email": "u"},
+            apijsonpath=None
+        )
+        assert result == data
+
+    async def test_get_tool_apijsonpath_string_parsing_error(self, monkeypatch):
+        """Test get_tool with invalid apijsonpath string (lines 3827-3830)."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        data = MagicMock()
+        data.to_dict.return_value = {"id": "t1"}
+
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
+        monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
+
+        # Invalid JSON string for apijsonpath - should raise 400 Bad Request
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.get_tool.__wrapped__(
+                "tool-1",
+                request=request,
+                db=MagicMock(),
+                user={"email": "u"},
+                apijsonpath="{invalid json"
+            )
+        # Should be 400 (not 404) for invalid apijsonpath JSON
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath JSON" in str(excinfo.value.detail)
+
+    async def test_get_tool_jsonpath_modifier_exception(self, monkeypatch):
+        """Test get_tool jsonpath_modifier exception (lines 3841-3843)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        data = MagicMock()
+        data.to_dict.return_value = {"id": "t1"}
+
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
+        monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
+
+        # Make jsonpath_modifier raise an exception
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(side_effect=RuntimeError("jsonpath error")))
+
+        apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.get_tool.__wrapped__(
+                "tool-1",
+                request=request,
+                db=MagicMock(),
+                user={"email": "u"},
+                apijsonpath=apijsonpath
+            )
+        # Should be 500 (not 404) for JSONPath modifier errors
+        assert excinfo.value.status_code == 500
+        assert "JSONPath modifier error" in str(excinfo.value.detail)
+
+    async def test_list_tools_apijsonpath_httpexception_reraise(self, monkeypatch):
+        """Test list_tools re-raises HTTPException from jsonpath_modifier (line 3695)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.to_dict.return_value = {"id": "t1"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
+
+        # Make jsonpath_modifier raise HTTPException (e.g., from invalid JSONPath)
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(side_effect=HTTPException(status_code=400, detail="Invalid JSONPath")))
+
+        apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.list_tools.__wrapped__(
+                request,
+                cursor=None,
+                include_pagination=False,
+                limit=None,
+                include_inactive=False,
+                tags=None,
+                team_id=None,
+                visibility=None,
+                gateway_id=None,
+                db=MagicMock(),
+                apijsonpath=apijsonpath,
+                user={"email": "user@example.com"},
+            )
+        # Should preserve the original HTTPException status and detail
+        assert excinfo.value.status_code == 400
+        assert "Invalid JSONPath" in str(excinfo.value.detail)
+
+    async def test_get_tool_apijsonpath_httpexception_reraise(self, monkeypatch):
+        """Test get_tool re-raises HTTPException from jsonpath_modifier (line 3844)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        data = MagicMock()
+        data.to_dict.return_value = {"id": "t1"}
+
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
+        monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
+
+        # Make jsonpath_modifier raise HTTPException (e.g., from invalid JSONPath)
+        monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(side_effect=HTTPException(status_code=400, detail="Invalid JSONPath expression")))
+
+        apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.get_tool.__wrapped__(
+                "tool-1",
+                request=request,
+                db=MagicMock(),
+                user={"email": "u"},
+                apijsonpath=apijsonpath
+            )
+        # Should preserve the original HTTPException status and detail
+        assert excinfo.value.status_code == 400
+        assert "Invalid JSONPath expression" in str(excinfo.value.detail)
+
+    async def test_list_tools_jsonpath_none_returns_pagination(self, monkeypatch):
+        """Test list_tools returns paginated response when jsonpath is None."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.model_dump.return_value = {"id": "t1", "name": "test"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], "cursor_abc")))
+
+        # Pass apijsonpath=None to trigger pagination path
+        result = await main_mod.list_tools.__wrapped__(
+            request,
+            cursor=None,
+            include_pagination=True,
+            limit=None,
+            include_inactive=False,
+            tags=None,
+            team_id=None,
+            visibility=None,
+            gateway_id=None,
+            db=MagicMock(),
+            apijsonpath=None,  # Explicitly None to trigger pagination path
+            user={"email": "user@example.com"},
+        )
+
+        # Should return pagination format when parsed_apijsonpath is None and include_pagination is True
+        # Result can be either a dict or Pydantic model depending on environment
+        if isinstance(result, dict):
+            assert "tools" in result
+            assert "nextCursor" in result
+            assert result["nextCursor"] == "cursor_abc"
+        else:
+            assert hasattr(result, 'tools')
+            assert hasattr(result, 'next_cursor')
+            assert result.next_cursor == "cursor_abc"
+
+    async def test_list_tools_apijsonpath_invalid_type(self, monkeypatch):
+        """Test list_tools with invalid apijsonpath type raises clear error."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.to_dict.return_value = {"id": "t1"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
+
+        # Pass invalid type (integer) - should raise 400 with clear message
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.list_tools.__wrapped__(
+                request,
+                cursor=None,
+                include_pagination=False,
+                limit=None,
+                include_inactive=False,
+                tags=None,
+                team_id=None,
+                visibility=None,
+                gateway_id=None,
+                db=MagicMock(),
+                apijsonpath=123,  # Invalid type
+                user={"email": "user@example.com"},
+            )
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath type" in str(excinfo.value.detail)
+        assert "int" in str(excinfo.value.detail)
+
+    async def test_get_tool_apijsonpath_invalid_type(self, monkeypatch):
+        """Test get_tool with invalid apijsonpath type raises clear error."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        data = MagicMock()
+        data.to_dict.return_value = {"id": "t1"}
+
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
+        monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
+
+        # Pass invalid type (list) - should raise 400 with clear message
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.get_tool.__wrapped__(
+                "tool-1",
+                request=request,
+                db=MagicMock(),
+                user={"email": "u"},
+                apijsonpath=["invalid", "type"]  # Invalid type
+            )
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath type" in str(excinfo.value.detail)
+        assert "list" in str(excinfo.value.detail)
+
+    async def test_create_tool_endpoint_coverage(self, monkeypatch):
+        """Test create_tool endpoint (lines 3695-3698)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import ToolCreate
+        from mcpgateway.utils.metadata_capture import MetadataCapture
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None, token_teams=None)
+
+        tool_data = ToolCreate(
+            name="test_tool",
+            url="http://example.com",
+            description="Test",
+            integration_type="REST",
+            request_type="GET"
+        )
+
+        created_tool = MagicMock()
+        created_tool.id = "tool-123"
+
+        # Mock all the dependencies
+        monkeypatch.setattr(MetadataCapture, "extract_creation_metadata", lambda *args: {
+            "created_by": "user@example.com",
+            "created_from_ip": "127.0.0.1",
+            "created_via": "api",
+            "created_user_agent": "test",
+            "import_batch_id": None,
+            "federation_source": None
+        })
+        monkeypatch.setattr(main_mod, "get_user_email", lambda user: "user@example.com")
+        monkeypatch.setattr(main_mod.tool_service, "register_tool", AsyncMock(return_value=created_tool))
+
+        mock_db = MagicMock()
+        mock_db.commit = MagicMock()
+        mock_db.close = MagicMock()
+
+        result = await main_mod.create_tool.__wrapped__(
+            tool=tool_data,
+            request=request,
+            team_id=None,
+            db=mock_db,
+            user={"email": "user@example.com"}
+        )
+        assert result == created_tool
+
+    async def test_update_tool_endpoint_coverage(self, monkeypatch):
+        """Test update_tool endpoint (lines 3848-3851)."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import ToolUpdate
+        from mcpgateway.utils.metadata_capture import MetadataCapture
+        from mcpgateway.db import Tool as DbTool
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool_update = ToolUpdate(description="Updated description")
+
+        updated_tool = MagicMock()
+        updated_tool.id = "tool-123"
+
+        current_tool = MagicMock()
+        current_tool.version = 1
+
+        mock_db = MagicMock()
+        mock_db.get = MagicMock(return_value=current_tool)
+        mock_db.commit = MagicMock()
+        mock_db.close = MagicMock()
+
+        # Mock dependencies
+        monkeypatch.setattr(MetadataCapture, "extract_modification_metadata", lambda *args: {
+            "modified_by": "user@example.com",
+            "modified_from_ip": "127.0.0.1",
+            "modified_via": "api",
+            "modified_user_agent": "test"
+        })
+        monkeypatch.setattr(main_mod.tool_service, "update_tool", AsyncMock(return_value=updated_tool))
+
+        result = await main_mod.update_tool.__wrapped__(
+            tool_id="tool-123",
+            tool=tool_update,
+            request=request,
+            db=mock_db,
+            user={"email": "user@example.com"}
+        )
+        assert result == updated_tool
+
 
     async def test_deprecated_toggle_endpoints(self, monkeypatch):
         import mcpgateway.main as main_mod

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -9739,7 +9739,8 @@ class TestRemainingCoverageGaps:
                 user={"email": "user@example.com"},
             )
         assert excinfo.value.status_code == 400
-        assert "Invalid apijsonpath JSON" in str(excinfo.value.detail)
+        # Generic error message in non-DEBUG mode (security improvement)
+        assert "Invalid apijsonpath" in str(excinfo.value.detail)
 
     async def test_list_tools_apijsonpath_none_with_pagination(self, monkeypatch):
         """Test list_tools with parsed_apijsonpath=None and include_pagination=True (lines 3674-3681)."""
@@ -9898,7 +9899,8 @@ class TestRemainingCoverageGaps:
             )
         # Should be 400 (not 404) for invalid apijsonpath JSON
         assert excinfo.value.status_code == 400
-        assert "Invalid apijsonpath JSON" in str(excinfo.value.detail)
+        # Generic error message in non-DEBUG mode (security improvement)
+        assert "Invalid apijsonpath" in str(excinfo.value.detail)
 
     async def test_get_tool_jsonpath_modifier_exception(self, monkeypatch):
         """Test get_tool jsonpath_modifier exception (lines 3841-3843)."""
@@ -10066,8 +10068,9 @@ class TestRemainingCoverageGaps:
                 user={"email": "user@example.com"},
             )
         assert excinfo.value.status_code == 400
+        # Generic error message in non-DEBUG mode (security improvement)
         assert "Invalid apijsonpath type" in str(excinfo.value.detail)
-        assert "int" in str(excinfo.value.detail)
+        # Type name not disclosed in production (non-DEBUG) mode
 
     async def test_get_tool_apijsonpath_invalid_type(self, monkeypatch):
         """Test get_tool with invalid apijsonpath type raises clear error."""
@@ -10093,8 +10096,9 @@ class TestRemainingCoverageGaps:
                 apijsonpath=["invalid", "type"]  # Invalid type
             )
         assert excinfo.value.status_code == 400
+        # Generic error message in non-DEBUG mode (security improvement)
         assert "Invalid apijsonpath type" in str(excinfo.value.detail)
-        assert "list" in str(excinfo.value.detail)
+        # Type name not disclosed in production (non-DEBUG) mode
 
     async def test_create_tool_endpoint_coverage(self, monkeypatch):
         """Test create_tool endpoint (lines 3695-3698)."""

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10100,6 +10100,64 @@ class TestRemainingCoverageGaps:
         assert "Invalid apijsonpath type" in str(excinfo.value.detail)
         # Type name not disclosed in production (non-DEBUG) mode
 
+    async def test_list_tools_empty_jsonpath_string(self, monkeypatch):
+        """Test list_tools rejects empty jsonpath string."""
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        tool = MagicMock()
+        tool.to_dict.return_value = {"id": "t1"}
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
+
+        # Empty jsonpath string - should raise 400
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.list_tools.__wrapped__(
+                request,
+                cursor=None,
+                include_pagination=False,
+                limit=None,
+                include_inactive=False,
+                tags=None,
+                team_id=None,
+                visibility=None,
+                gateway_id=None,
+                db=MagicMock(),
+                apijsonpath='{"jsonpath":"  ","mapping":null}',  # Empty/whitespace jsonpath
+                user={"email": "user@example.com"},
+            )
+        assert excinfo.value.status_code == 400
+        assert "JSONPath expression cannot be empty" in str(excinfo.value.detail)
+
+    async def test_get_tool_empty_jsonpath_model(self, monkeypatch):
+        """Test get_tool rejects JsonPathModifier with empty jsonpath."""
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import JsonPathModifier
+
+        request = MagicMock(spec=Request)
+        request.state = SimpleNamespace(team_id=None)
+
+        data = MagicMock()
+        data.to_dict.return_value = {"id": "t1"}
+
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
+        monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
+
+        # JsonPathModifier with empty jsonpath
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.get_tool.__wrapped__(
+                "tool-1",
+                request=request,
+                db=MagicMock(),
+                user={"email": "u"},
+                apijsonpath=JsonPathModifier(jsonpath="", mapping=None)
+            )
+        assert excinfo.value.status_code == 400
+        assert "JSONPath expression cannot be empty" in str(excinfo.value.detail)
+
     async def test_create_tool_endpoint_coverage(self, monkeypatch):
         """Test create_tool endpoint (lines 3695-3698)."""
         import mcpgateway.main as main_mod

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -1381,6 +1381,63 @@ class TestParseApijsonpath:
         assert "Unexpected error parsing apijsonpath" in log_calls[0][0]
         assert log_calls[0][1].get("exc_info") is True
 
+    def test_parse_apijsonpath_invalid_jsonpath_syntax_string(self, monkeypatch):
+        """Test invalid JSONPath syntax in string input triggers early validation."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "DEBUG")
+
+        # Invalid JSONPath syntax
+        json_string = '{"jsonpath": "$..[**]", "mapping": null}'
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(json_string)
+
+        assert excinfo.value.status_code == 400
+        assert "Invalid JSONPath syntax:" in excinfo.value.detail
+
+    def test_parse_apijsonpath_invalid_jsonpath_syntax_string_non_debug(self, monkeypatch):
+        """Test invalid JSONPath syntax in string input (non-DEBUG mode)."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "INFO")
+
+        # Invalid JSONPath syntax
+        json_string = '{"jsonpath": "$..[**]", "mapping": null}'
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(json_string)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "Invalid JSONPath expression"
+
+    def test_parse_apijsonpath_invalid_jsonpath_syntax_modifier(self, monkeypatch):
+        """Test invalid JSONPath syntax in JsonPathModifier instance."""
+        from mcpgateway.schemas import JsonPathModifier
+
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "DEBUG")
+
+        # Invalid JSONPath syntax
+        modifier = JsonPathModifier(jsonpath="$..[**]", mapping=None)
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath(modifier)
+
+        assert excinfo.value.status_code == 400
+        assert "Invalid JSONPath syntax:" in excinfo.value.detail
+
+    def test_parse_apijsonpath_valid_jsonpath_syntax_validation(self):
+        """Test that valid JSONPath expressions pass early syntax validation."""
+        from mcpgateway.schemas import JsonPathModifier
+
+        # Valid JSONPath expressions that should pass validation
+        valid_paths = [
+            '{"jsonpath": "$.name", "mapping": null}',
+            '{"jsonpath": "$[*]", "mapping": null}',
+            '{"jsonpath": "$.items[0].id", "mapping": null}',
+        ]
+
+        for json_string in valid_paths:
+            result = _parse_apijsonpath(json_string)
+            assert result is not None
+            assert isinstance(result, JsonPathModifier)
+
 
 class TestDocsAuthMiddleware:
     """Cover DocsAuthMiddleware branches."""

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -1471,6 +1471,36 @@ class TestParseApijsonpath:
             assert isinstance(result, JsonPathModifier)
 
 
+class TestApijsonpathHTTP:
+    """End-to-end HTTP tests for the apijsonpath query parameter via TestClient."""
+
+    def test_list_tools_apijsonpath_via_http(self, test_client, auth_headers):
+        """GET /tools?apijsonpath=... should return 200 with JSONPath applied."""
+        resp = test_client.get("/tools/", headers=auth_headers, params={"apijsonpath": '{"jsonpath":"$[*].name"}'})
+        assert resp.status_code == 200
+        data = resp.json()
+        # jsonpath_modifier returns a list of matched values (may be empty)
+        assert isinstance(data, list)
+
+    def test_list_tools_apijsonpath_invalid_json_via_http(self, test_client, auth_headers):
+        """GET /tools?apijsonpath={bad should return 400."""
+        resp = test_client.get("/tools/", headers=auth_headers, params={"apijsonpath": "{bad json"})
+        assert resp.status_code == 400
+
+    def test_list_tools_apijsonpath_pagination_via_http(self, test_client, auth_headers):
+        """GET /tools?apijsonpath=...&include_pagination=true should use nextCursor key."""
+        resp = test_client.get(
+            "/tools/",
+            headers=auth_headers,
+            params={"apijsonpath": '{"jsonpath":"$[*].name"}', "include_pagination": "true"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "tools" in data
+        # Must be camelCase to match CursorPaginatedToolsResponse alias contract
+        assert "nextCursor" in data
+
+
 class TestDocsAuthMiddleware:
     """Cover DocsAuthMiddleware branches."""
 
@@ -10117,10 +10147,10 @@ class TestRemainingCoverageGaps:
         assert isinstance(result, ORJSONResponse)
         response_data = orjson.loads(result.body)
 
-        # Should have both tools and next_cursor
+        # Should have both tools and nextCursor (camelCase matches CursorPaginatedToolsResponse alias)
         assert "tools" in response_data
-        assert "next_cursor" in response_data
-        assert response_data["next_cursor"] == "cursor123"
+        assert "nextCursor" in response_data
+        assert response_data["nextCursor"] == "cursor123"
         assert len(response_data["tools"]) == 2
         assert response_data["tools"][0] == {"toolId": "t1", "toolName": "Tool 1"}
         assert response_data["tools"][1] == {"toolId": "t2", "toolName": "Tool 2"}
@@ -10171,10 +10201,10 @@ class TestRemainingCoverageGaps:
         assert isinstance(result, ORJSONResponse)
         response_data = orjson.loads(result.body)
 
-        # Should have tools and next_cursor as null (last page)
+        # Should have tools and nextCursor as null (last page, camelCase matches alias)
         assert "tools" in response_data
-        assert "next_cursor" in response_data
-        assert response_data["next_cursor"] is None
+        assert "nextCursor" in response_data
+        assert response_data["nextCursor"] is None
         assert len(response_data["tools"]) == 1
         assert response_data["tools"][0] == {"toolId": "t1", "toolName": "Tool 1"}
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -11,19 +11,20 @@ error handlers, and startup logic.
 """
 
 # Standard
-import builtins
 import asyncio
 import base64
+import builtins
 import importlib.util
 import json
 from pathlib import Path
-from types import SimpleNamespace
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 # Third-Party
-from fastapi import HTTPException, Request, Response as FastAPIResponse
+from fastapi import HTTPException, Request
+from fastapi import Response as FastAPIResponse
 from fastapi.testclient import TestClient
 import orjson
 import pytest
@@ -33,24 +34,21 @@ from starlette.responses import Response as StarletteResponse
 # First-Party
 from mcpgateway.common.models import LogLevel
 from mcpgateway.config import settings
+import mcpgateway.db as db_mod
 from mcpgateway.main import (
-    AdminAuthMiddleware,
-    DocsAuthMiddleware,
-    InternalTrustedMCPTransportBridge,
-    MCPRuntimeHeaderTransportWrapper,
-    MCPPathRewriteMiddleware,
-    _expected_internal_mcp_runtime_auth_header,
     _build_internal_mcp_auth_scope,
     _build_internal_mcp_forwarded_user,
     _decode_internal_mcp_auth_context,
     _enforce_internal_mcp_server_scope,
     _ensure_rpc_permission,
+    _expected_internal_mcp_runtime_auth_header,
     _extract_scoped_permissions,
     _is_permission_admin_user,
-    _run_internal_mcp_authentication,
-    _serialize_mcp_tool_definition,
-    _serialize_legacy_tool_payloads,
     _parse_apijsonpath,
+    _run_internal_mcp_authentication,
+    _serialize_legacy_tool_payloads,
+    _serialize_mcp_tool_definition,
+    AdminAuthMiddleware,
     app,
     create_prompt,
     create_resource,
@@ -58,42 +56,46 @@ from mcpgateway.main import (
     delete_prompt,
     delete_resource,
     delete_tool,
+    DocsAuthMiddleware,
     export_configuration,
     export_selective_configuration,
     get_a2a_agent,
-    handle_internal_mcp_initialize,
-    handle_internal_mcp_completion_complete,
     handle_internal_mcp_authenticate,
+    handle_internal_mcp_completion_complete,
+    handle_internal_mcp_initialize,
     handle_internal_mcp_logging_set_level,
     handle_internal_mcp_notifications_cancelled,
     handle_internal_mcp_notifications_initialized,
     handle_internal_mcp_notifications_message,
-    handle_internal_mcp_session_delete,
+    handle_internal_mcp_prompts_get,
+    handle_internal_mcp_prompts_get_authz,
+    handle_internal_mcp_prompts_list,
+    handle_internal_mcp_prompts_list_authz,
+    handle_internal_mcp_resource_templates_list,
+    handle_internal_mcp_resource_templates_list_authz,
     handle_internal_mcp_resources_list,
+    handle_internal_mcp_resources_list_authz,
     handle_internal_mcp_resources_read,
+    handle_internal_mcp_resources_read_authz,
     handle_internal_mcp_resources_subscribe,
     handle_internal_mcp_resources_unsubscribe,
-    handle_internal_mcp_resource_templates_list,
     handle_internal_mcp_roots_list,
-    handle_internal_mcp_prompts_get,
-    handle_internal_mcp_prompts_list,
-    handle_internal_mcp_prompts_get_authz,
-    handle_internal_mcp_prompts_list_authz,
-    handle_internal_mcp_resource_templates_list_authz,
-    handle_internal_mcp_resources_list_authz,
-    handle_internal_mcp_resources_read_authz,
+    handle_internal_mcp_rpc,
     handle_internal_mcp_sampling_create_message,
+    handle_internal_mcp_session_delete,
     handle_internal_mcp_tools_call,
     handle_internal_mcp_tools_call_metric,
     handle_internal_mcp_tools_call_resolve,
-    handle_internal_mcp_tools_list_authz,
     handle_internal_mcp_tools_list,
-    handle_internal_mcp_rpc,
+    handle_internal_mcp_tools_list_authz,
     handle_rpc,
     import_configuration,
+    InternalTrustedMCPTransportBridge,
     jsonpath_modifier,
     list_a2a_agents,
     list_resources,
+    MCPPathRewriteMiddleware,
+    MCPRuntimeHeaderTransportWrapper,
     message_endpoint,
     server_get_prompts,
     server_get_resources,
@@ -109,7 +111,6 @@ from mcpgateway.main import (
     update_tool,
     validate_security_configuration,
 )
-import mcpgateway.db as db_mod
 from mcpgateway.plugins.framework import PluginError
 from mcpgateway.schemas import PromptCreate, PromptUpdate, ResourceCreate, ResourceUpdate, ToolCreate, ToolUpdate
 from mcpgateway.services.tool_service import ToolError, ToolNotFoundError
@@ -690,7 +691,7 @@ class TestInternalTrustedMcpTransportBridge:
                     "headers": [(b"content-type", b"application/json"), (b"www-authenticate", b"Bearer")],
                 }
             )
-            await send({"type": "http.response.body", "body": b'{\"detail\":\"bad token\"}'})
+            await send({"type": "http.response.body", "body": b'{"detail":"bad token"}'})
             return False
 
         async def _passthrough_middleware(request, call_next):
@@ -1124,8 +1125,10 @@ class TestApplicationStartupPaths:
         # NOTE: This test previously used a single giant parenthesized `with (...)` statement
         # with many context managers. On Python 3.12.3 that reliably triggered a compiler
         # segfault when compiling this file. Keep patches explicit via ExitStack instead.
+        # Standard
         from contextlib import ExitStack
 
+        # First-Party
         import mcpgateway.main as main_mod
 
         mock_logging_service = MagicMock()
@@ -1230,6 +1233,7 @@ class TestJsonPathHelpers:
 
     def test_jsonpath_modifier_debug_logging_with_list(self, monkeypatch):
         """Test jsonpath_modifier debug logging with list data (lines 789-790)."""
+        # Standard
         import logging
 
         # Mock logger to ensure debug is enabled
@@ -1260,6 +1264,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_with_valid_string(self):
         """Test successful parsing of valid JSON string (line 729)."""
+        # First-Party
         from mcpgateway.schemas import JsonPathModifier
 
         json_string = '{"jsonpath": "$.name", "mapping": null}'
@@ -1272,6 +1277,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_with_valid_string_and_mapping(self):
         """Test successful parsing with mapping to ensure line 729 coverage."""
+        # First-Party
         from mcpgateway.schemas import JsonPathModifier
 
         json_string = '{"jsonpath": "$.items[*]", "mapping": {"id": "$.id", "name": "$.name"}}'
@@ -1314,6 +1320,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_jsonpathmodifier_valid(self):
         """Test valid JsonPathModifier instance (lines 745-749)."""
+        # First-Party
         from mcpgateway.schemas import JsonPathModifier
 
         modifier = JsonPathModifier(jsonpath="$.test", mapping=None)
@@ -1324,6 +1331,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_jsonpathmodifier_empty_jsonpath(self):
         """Test JsonPathModifier with empty jsonpath (lines 747-748)."""
+        # First-Party
         from mcpgateway.schemas import JsonPathModifier
 
         modifier = JsonPathModifier(jsonpath="  ", mapping=None)
@@ -1333,6 +1341,27 @@ class TestParseApijsonpath:
 
         assert excinfo.value.status_code == 400
         assert "JSONPath expression cannot be empty" in excinfo.value.detail
+
+    def test_parse_apijsonpath_validation_error_extra_fields(self, monkeypatch):
+        """Test that extra fields in JSON string trigger ValidationError path."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "INFO")
+
+        # Valid JSON but with extra field rejected by extra="forbid"
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath('{"jsonpath": "$.name", "unexpected_field": "value"}')
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "Invalid apijsonpath structure"
+
+    def test_parse_apijsonpath_validation_error_debug_mode(self, monkeypatch):
+        """Test ValidationError path shows details in DEBUG mode."""
+        monkeypatch.setattr("mcpgateway.main.settings.log_level", "DEBUG")
+
+        with pytest.raises(HTTPException) as excinfo:
+            _parse_apijsonpath('{"jsonpath": "$.name", "unknown": 123}')
+
+        assert excinfo.value.status_code == 400
+        assert "Invalid apijsonpath structure:" in excinfo.value.detail
 
     def test_parse_apijsonpath_invalid_type_debug_mode(self, monkeypatch):
         """Test invalid type in DEBUG mode (lines 753-754)."""
@@ -1356,6 +1385,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_unexpected_exception_logging(self, monkeypatch):
         """Test unexpected exception handling with logging (lines 741-744)."""
+        # Standard
         import logging
 
         # Mock json.loads to raise an unexpected exception (not ValueError/ValidationError/HTTPException)
@@ -1409,6 +1439,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_invalid_jsonpath_syntax_modifier(self, monkeypatch):
         """Test invalid JSONPath syntax in JsonPathModifier instance."""
+        # First-Party
         from mcpgateway.schemas import JsonPathModifier
 
         monkeypatch.setattr("mcpgateway.main.settings.log_level", "DEBUG")
@@ -1424,6 +1455,7 @@ class TestParseApijsonpath:
 
     def test_parse_apijsonpath_valid_jsonpath_syntax_validation(self):
         """Test that valid JSONPath expressions pass early syntax validation."""
+        # First-Party
         from mcpgateway.schemas import JsonPathModifier
 
         # Valid JSONPath expressions that should pass validation
@@ -2374,6 +2406,7 @@ class TestAdminAuthMiddleware:
     @pytest.mark.asyncio
     async def test_admin_auth_repeated_team_id_uses_last_value(self, monkeypatch):
         """Repeated team_id query keys: .get() returns last value; validate against token_teams."""
+        # Third-Party
         from starlette.datastructures import QueryParams
 
         middleware = AdminAuthMiddleware(None)
@@ -2514,6 +2547,7 @@ class TestServerEndpointCoverage:
         request.scope = {"root_path": ""}
         db = MagicMock()
 
+        # First-Party
         from mcpgateway.services.permission_service import PermissionService
 
         monkeypatch.setattr(PermissionService, "check_permission", AsyncMock(return_value=True))
@@ -2543,6 +2577,7 @@ class TestServerEndpointCoverage:
         request.scope = {"root_path": ""}
         db = MagicMock()
 
+        # First-Party
         from mcpgateway.services.server_service import ServerNotFoundError
 
         monkeypatch.setattr("mcpgateway.main.server_service.get_server", AsyncMock(side_effect=ServerNotFoundError("missing")))
@@ -2573,6 +2608,7 @@ class TestServerEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_get_server_denies_when_scope_enforcement_fails(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -2592,6 +2628,7 @@ class TestServerEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_get_tool_denies_when_scope_enforcement_fails(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -2614,6 +2651,7 @@ class TestServerEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_get_gateway_denies_when_scope_enforcement_fails(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -2633,6 +2671,7 @@ class TestServerEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_read_resource_denies_when_scope_enforcement_fails(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3018,6 +3057,7 @@ class TestCrudEndpoints:
             },
         )
 
+        # First-Party
         from mcpgateway.services.tool_service import ToolNameConflictError
 
         monkeypatch.setattr("mcpgateway.main.tool_service.register_tool", AsyncMock(side_effect=ToolNameConflictError("tool-a", enabled=False, tool_id=123)))
@@ -3045,6 +3085,7 @@ class TestCrudEndpoints:
             },
         )
 
+        # First-Party
         from mcpgateway.services.tool_service import ToolError
 
         monkeypatch.setattr("mcpgateway.main.tool_service.register_tool", AsyncMock(side_effect=ToolError("bad")))
@@ -3074,6 +3115,7 @@ class TestCrudEndpoints:
             },
         )
 
+        # First-Party
         from mcpgateway.services.tool_service import ToolError
 
         monkeypatch.setattr("mcpgateway.main.tool_service.update_tool", AsyncMock(side_effect=ToolError("bad")))
@@ -3089,6 +3131,7 @@ class TestCrudEndpoints:
 
     @pytest.mark.asyncio
     async def test_set_tool_state_lock_conflict_and_generic_error(self, monkeypatch, allow_permission):
+        # First-Party
         from mcpgateway.services.tool_service import ToolLockConflictError
 
         monkeypatch.setattr("mcpgateway.main.tool_service.set_tool_state", AsyncMock(side_effect=ToolLockConflictError("locked")))
@@ -3161,6 +3204,7 @@ class TestCrudEndpoints:
         )
 
         # Build a real pydantic ValidationError instance
+        # Third-Party
         from pydantic import BaseModel, ValidationError
 
         class _DummyModel(BaseModel):
@@ -3179,6 +3223,7 @@ class TestCrudEndpoints:
             await create_resource(resource_input, request, db=MagicMock(), user={"email": "user@example.com"})
         assert excinfo.value.status_code == 422
 
+        # Third-Party
         from sqlalchemy.exc import IntegrityError
 
         monkeypatch.setattr("mcpgateway.main.ErrorFormatter.format_database_error", lambda _e: "db-error")
@@ -3199,6 +3244,7 @@ class TestCrudEndpoints:
                 "modified_user_agent": "test",
             },
         )
+        # First-Party
         from mcpgateway.services.resource_service import ResourceURIConflictError
 
         monkeypatch.setattr("mcpgateway.main.resource_service.update_resource", AsyncMock(side_effect=ResourceURIConflictError("conflict")))
@@ -3208,6 +3254,7 @@ class TestCrudEndpoints:
 
     @pytest.mark.asyncio
     async def test_delete_resource_permission_not_found_and_error(self, monkeypatch, allow_permission):
+        # First-Party
         from mcpgateway.services.resource_service import ResourceError, ResourceNotFoundError
 
         monkeypatch.setattr("mcpgateway.main.resource_service.delete_resource", AsyncMock(side_effect=PermissionError("nope")))
@@ -3257,6 +3304,7 @@ class TestCrudEndpoints:
         await create_prompt(prompt_input, request3, team_id="team-1", visibility="public", db=MagicMock(), user={"email": "user@example.com"})
         assert register_prompt.await_args.kwargs["team_id"] is None
 
+        # First-Party
         from mcpgateway.services.prompt_service import PromptError, PromptNameConflictError
 
         monkeypatch.setattr("mcpgateway.main.prompt_service.register_prompt", AsyncMock(side_effect=PromptNameConflictError("dup")))
@@ -3269,6 +3317,7 @@ class TestCrudEndpoints:
             await create_prompt(prompt_input, request3, visibility="public", db=MagicMock(), user={"email": "user@example.com"})
         assert excinfo.value.status_code == 400
 
+        # Third-Party
         from pydantic import BaseModel, ValidationError
 
         class _DummyModel(BaseModel):
@@ -3304,6 +3353,7 @@ class TestCrudEndpoints:
         )
         prompt_update = PromptUpdate(name="Prompt Updated")
 
+        # First-Party
         from mcpgateway.services.prompt_service import PromptError, PromptNameConflictError
 
         monkeypatch.setattr("mcpgateway.main.prompt_service.update_prompt", AsyncMock(side_effect=PromptNameConflictError("dup")))
@@ -3323,6 +3373,7 @@ class TestCrudEndpoints:
 
     @pytest.mark.asyncio
     async def test_delete_prompt_permission_prompt_error_and_unexpected(self, monkeypatch, allow_permission):
+        # First-Party
         from mcpgateway.services.prompt_service import PromptError
 
         monkeypatch.setattr("mcpgateway.main.prompt_service.delete_prompt", AsyncMock(side_effect=PermissionError("nope")))
@@ -3385,6 +3436,7 @@ class TestSecurityConfiguration:
     def test_log_critical_issues_exits_when_enforced(self, monkeypatch):
         monkeypatch.setattr(settings, "require_strong_secrets", True)
         with patch("mcpgateway.main.sys.exit") as mock_exit:
+            # First-Party
             from mcpgateway.main import log_critical_issues
 
             log_critical_issues(["bad"])
@@ -3400,6 +3452,7 @@ class TestSecurityHealthEndpoint:
 
     @pytest.mark.asyncio
     async def test_security_health_returns_healthy_for_admin(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3425,6 +3478,7 @@ class TestSecurityHealthEndpoint:
 
     @pytest.mark.asyncio
     async def test_security_health_includes_warnings_when_present(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3449,6 +3503,7 @@ class TestSecurityHealthEndpoint:
 
     @pytest.mark.asyncio
     async def test_security_health_unhealthy_low_score(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3475,8 +3530,10 @@ class TestSecurityHealthEndpoint:
         """Unauthenticated HTTP requests to /health/security must be rejected."""
         # The test_client fixture overrides require_auth but NOT require_admin_auth,
         # so this exercises the real admin auth dependency rejection path.
+        # Third-Party
         from fastapi.testclient import TestClient
 
+        # First-Party
         from mcpgateway.main import app
 
         # Create a client with NO auth overrides for admin auth
@@ -3490,6 +3547,7 @@ class TestRootEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_export_root_success_and_username_extraction(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         root = SimpleNamespace(uri="root://example", name="Root Name")
@@ -3502,6 +3560,7 @@ class TestRootEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_export_root_not_found_and_generic_error(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.root_service, "get_root_by_uri", AsyncMock(side_effect=main_mod.RootServiceNotFoundError("nope")))
@@ -3516,6 +3575,7 @@ class TestRootEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_get_root_by_uri_success_and_errors(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         root = SimpleNamespace(uri="root://example", name="Root Name")
@@ -3533,6 +3593,7 @@ class TestRootEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_update_root_success_and_errors(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         updated = SimpleNamespace(uri="root://example", name="Updated")
@@ -3555,6 +3616,7 @@ class TestToolListEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_list_tools_parses_tags_and_paginates(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3587,6 +3649,7 @@ class TestToolListEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_list_tools_admin_bypass_and_public_only_default(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3633,6 +3696,7 @@ class TestToolListEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_list_tools_team_mismatch_returns_403(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3662,6 +3726,7 @@ class TestPromptListEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_list_prompts_parses_tags_and_paginates(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3692,6 +3757,7 @@ class TestPromptListEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_list_prompts_team_mismatch_returns_403(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3719,6 +3785,7 @@ class TestReadResourceEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_read_resource_serializes_text_bytes_and_str(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3729,6 +3796,7 @@ class TestReadResourceEndpointCoverage:
         monkeypatch.setattr(db, "commit", MagicMock())
         monkeypatch.setattr(db, "close", MagicMock())
 
+        # First-Party
         from mcpgateway.common.models import TextContent
 
         class TextWithUri(TextContent):
@@ -3775,6 +3843,7 @@ class TestGetPromptEndpointCoverage:
 
     @pytest.mark.asyncio
     async def test_get_prompt_maps_common_errors_to_422(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3782,6 +3851,7 @@ class TestGetPromptEndpointCoverage:
         request.state = SimpleNamespace(plugin_context_table=None, plugin_global_context=None)
 
         # PluginViolationError -> 422 with plugin message.
+        # First-Party
         from mcpgateway.plugins.framework.errors import PluginViolationError
 
         monkeypatch.setattr(main_mod.prompt_service, "get_prompt", AsyncMock(side_effect=PluginViolationError("blocked", violation=SimpleNamespace(code="c"))))
@@ -3794,6 +3864,7 @@ class TestGetPromptEndpointCoverage:
         assert response.status_code == 422
 
         # PromptError -> 422 with message.
+        # First-Party
         from mcpgateway.services.prompt_service import PromptError
 
         monkeypatch.setattr(main_mod.prompt_service, "get_prompt", AsyncMock(side_effect=PromptError("bad prompt")))
@@ -3806,6 +3877,7 @@ class TestGatewayEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_delete_gateway_error_mappings(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         db = MagicMock()
@@ -3817,7 +3889,8 @@ class TestGatewayEndpointsCoverage:
             await main_mod.delete_gateway("gw-1", db=db, user={"email": "user@example.com"})
         assert excinfo.value.status_code == 403
 
-        from mcpgateway.services.gateway_service import GatewayNotFoundError, GatewayError
+        # First-Party
+        from mcpgateway.services.gateway_service import GatewayError, GatewayNotFoundError
 
         monkeypatch.setattr(main_mod.gateway_service, "get_gateway", AsyncMock(side_effect=GatewayNotFoundError("missing")))
         with pytest.raises(HTTPException) as excinfo:
@@ -3831,6 +3904,7 @@ class TestGatewayEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_delete_gateway_success_invalidates_resource_cache_when_needed(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         db = MagicMock()
@@ -3849,9 +3923,11 @@ class TestGatewayEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_refresh_gateway_tools_success_and_errors(self, monkeypatch):
-        import mcpgateway.main as main_mod
-
+        # Standard
         from datetime import datetime, timezone
+
+        # First-Party
+        import mcpgateway.main as main_mod
         from mcpgateway.services.gateway_service import GatewayError, GatewayNotFoundError
 
         request = MagicMock(spec=Request)
@@ -3903,6 +3979,7 @@ class TestGatewayEndpointsCoverage:
 
     @pytest.mark.asyncio
     async def test_refresh_gateway_tools_denies_cross_scope_access(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -3929,6 +4006,7 @@ class TestLifespanAdvanced:
 
     @pytest.mark.asyncio
     async def test_lifespan_with_feature_flags(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeEvent:
@@ -4049,6 +4127,7 @@ class TestLifespanAdvanced:
         subscriber.stop = AsyncMock(side_effect=Exception("stop fail"))
         # `mcpgateway.cache` uses lazy `__getattr__` which returns a `registry_cache`
         # instance, so string-based patching can resolve to the wrong object under xdist.
+        # First-Party
         import mcpgateway.cache.registry_cache as registry_cache_mod
 
         monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
@@ -4082,6 +4161,7 @@ class TestLifespanAdvanced:
     @pytest.mark.asyncio
     async def test_lifespan_exits_on_plugin_initialization_failed(self, monkeypatch):
         """Cover lifespan startup exception branch that raises SystemExit on plugin init failure."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         def make_service():  # noqa: ANN001 - local test helper
@@ -4138,6 +4218,7 @@ class TestLifespanAdvanced:
         subscriber = MagicMock()
         subscriber.start = AsyncMock()
         subscriber.stop = AsyncMock()
+        # First-Party
         import mcpgateway.cache.registry_cache as registry_cache_mod
 
         monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
@@ -4158,6 +4239,7 @@ class TestLifespanAdvanced:
     @pytest.mark.asyncio
     async def test_shutdown_services_continues_on_exception(self):
         """Cover shutdown_services exception logging branch."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         bad = MagicMock()
@@ -4280,6 +4362,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_websocket_feature_disabled_closes(self, monkeypatch):
         """WebSocket relay should reject connections when feature flag is disabled."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcpgateway_ws_relay_enabled", False)
@@ -4294,6 +4377,7 @@ class TestUtilityFunctions:
 
     def test_get_websocket_bearer_token_accepts_lowercase_scheme(self):
         """Bearer scheme parsing should be case-insensitive for WebSocket auth headers."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         websocket = MagicMock()
@@ -4304,6 +4388,7 @@ class TestUtilityFunctions:
 
     def test_get_websocket_bearer_token_ignores_query_param(self):
         """Query-string tokens should not be accepted for WebSocket auth."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         websocket = MagicMock()
@@ -4315,6 +4400,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_authenticate_websocket_user_wraps_unexpected_auth_errors(self, monkeypatch):
         """Unexpected auth backend errors should be normalized to HTTP 401."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", True)
@@ -4337,6 +4423,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_authenticate_websocket_user_propagates_http_exception(self, monkeypatch):
         """HTTPException from auth backend should pass through unchanged."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", True)
@@ -4359,6 +4446,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_authenticate_websocket_user_success_with_bearer_token(self, monkeypatch):
         """Successful bearer auth should return token and no proxy user."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", True)
@@ -4382,6 +4470,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_authenticate_websocket_user_proxy_auth_missing_header_requires_auth(self, monkeypatch):
         """Proxy-auth mode should reject requests without trusted user header when auth is required."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", False)
@@ -4405,6 +4494,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_authenticate_websocket_user_denies_when_permissions_missing(self, monkeypatch):
         """Authenticated websocket users must have at least one allowed permission."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", True)
@@ -4429,6 +4519,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_websocket_bearer_auth_invalid_token_closes(self, monkeypatch):
         """Cover Bearer token extraction + invalid token close path."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", True)
@@ -4451,6 +4542,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_websocket_proxy_auth_required_closes(self, monkeypatch):
         """Cover proxy-auth required branch when trust_proxy_auth is enabled."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", False)
@@ -4474,6 +4566,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_websocket_jsonrpc_error_sends_error_text(self, monkeypatch):
         """Cover JSONRPCError branch inside the websocket relay loop."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", False)
@@ -4514,6 +4607,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_websocket_invalid_json_sends_parse_error(self, monkeypatch):
         """Cover orjson.JSONDecodeError -> JSON-RPC parse error response."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", False)
@@ -4538,6 +4632,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_websocket_outer_exception_close_failure_is_caught(self, monkeypatch):
         """Cover outer exception handler when websocket.close itself fails."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "mcp_client_auth_enabled", False)
@@ -4571,6 +4666,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_utility_sse_bearer_token_and_disconnect_cleanup(self, monkeypatch, allow_permission):
         """Cover /sse auth token extraction + defensive disconnect cleanup callback."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -4614,6 +4710,7 @@ class TestUtilityFunctions:
     @pytest.mark.asyncio
     async def test_utility_sse_cookie_token_and_cleanup_warning(self, monkeypatch, allow_permission):
         """Cover cookie token extraction + cleanup exception branch."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -4809,6 +4906,7 @@ def test_client(app_with_temp_db):
 @pytest.fixture
 def allow_permission(monkeypatch):
     """Force permission checks to pass for direct endpoint calls."""
+    # First-Party
     from mcpgateway.services.permission_service import PermissionService
 
     monkeypatch.setattr(PermissionService, "check_permission", AsyncMock(return_value=True))
@@ -4898,6 +4996,7 @@ class TestA2ABranchCoverage:
 
     @pytest.mark.asyncio
     async def test_create_a2a_agent_rejects_public_only_token_for_team_visibility(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import A2AAgentCreate
 
@@ -4922,6 +5021,7 @@ class TestA2ABranchCoverage:
 
     @pytest.mark.asyncio
     async def test_create_a2a_agent_team_mismatch_and_service_unavailable(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import A2AAgentCreate
 
@@ -4951,10 +5051,13 @@ class TestA2ABranchCoverage:
 
     @pytest.mark.asyncio
     async def test_create_a2a_agent_validation_and_integrity_errors(self, monkeypatch):
-        import mcpgateway.main as main_mod
-        from mcpgateway.schemas import A2AAgentCreate
+        # Third-Party
         from pydantic import BaseModel, ValidationError
         from sqlalchemy.exc import IntegrityError
+
+        # First-Party
+        import mcpgateway.main as main_mod
+        from mcpgateway.schemas import A2AAgentCreate
 
         class _Tmp(BaseModel):
             value: int
@@ -4997,6 +5100,7 @@ class TestA2ABranchCoverage:
 
     @pytest.mark.asyncio
     async def test_delete_a2a_agent_error_mappings(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNotFoundError
 
@@ -5024,6 +5128,7 @@ class TestA2ABranchCoverage:
 
     @pytest.mark.asyncio
     async def test_invoke_a2a_agent_branches_and_errors(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNotFoundError
 
@@ -5062,6 +5167,7 @@ class TestA2ABranchCoverage:
 
     @pytest.mark.asyncio
     async def test_list_and_get_a2a_agents_branches(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.a2a_service import A2AAgentNotFoundError
 
@@ -5125,8 +5231,7 @@ class TestRpcHandling:
         """
         monkeypatch.setattr(
             "mcpgateway.main._is_trusted_internal_mcp_runtime_request",
-            lambda request: request.headers.get("x-contextforge-mcp-runtime") == "rust"
-            and getattr(getattr(request, "client", None), "host", None) in ("127.0.0.1", "::1"),
+            lambda request: request.headers.get("x-contextforge-mcp-runtime") == "rust" and getattr(getattr(request, "client", None), "host", None) in ("127.0.0.1", "::1"),
         )
 
     @staticmethod
@@ -5757,6 +5862,7 @@ class TestRpcHandling:
         }
 
     async def test_handle_internal_mcp_resources_read_normalizes_legacy_resource_content(self):
+        # First-Party
         from mcpgateway.common.models import ResourceContent
 
         request = self._make_request({"jsonrpc": "2.0", "id": "resources-read-legacy", "method": "resources/read", "params": {"uri": "resource://legacy"}})
@@ -5953,6 +6059,7 @@ class TestRpcHandling:
         assert subscription.subscriber_id == "user@example.com"
 
     async def test_handle_internal_mcp_resources_subscribe_and_unsubscribe_extra_error_paths(self):
+        # First-Party
         from mcpgateway.services.resource_service import ResourceNotFoundError
 
         subscribe_request = self._make_request({"jsonrpc": "2.0", "id": "resources-sub-2", "method": "resources/subscribe", "params": []})
@@ -7034,6 +7141,7 @@ class TestRpcHandling:
         mock_db.close.assert_called()
 
     async def test_handle_internal_mcp_initialize_non_dict_params_returns_internal_error(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = self._make_request({"jsonrpc": "2.0", "id": "init-err", "method": "initialize", "params": []})
@@ -7273,6 +7381,7 @@ class TestRpcHandling:
         assert json.loads(response.body.decode()) == {"contents": [{"uri": "resource://one"}]}
 
     async def test_handle_internal_mcp_resources_read_returns_not_found_payload(self):
+        # First-Party
         from mcpgateway.services.resource_service import ResourceNotFoundError
 
         request = self._make_request({"jsonrpc": "2.0", "id": "res-read", "method": "resources/read", "params": {"uri": "resource://missing"}})
@@ -7319,6 +7428,7 @@ class TestRpcHandling:
         mock_db.invalidate.assert_called_once()
 
     async def test_handle_internal_mcp_resources_read_returns_resource_error_payload(self):
+        # First-Party
         from mcpgateway.services.resource_service import ResourceError
 
         request = self._make_request({"jsonrpc": "2.0", "id": "res-read-ambiguous", "method": "resources/read", "params": {"uri": "resource://dup"}})
@@ -7407,6 +7517,7 @@ class TestRpcHandling:
         error_db.invalidate.assert_called_once()
 
     async def test_handle_internal_mcp_prompts_get_missing_name_and_not_found(self):
+        # First-Party
         from mcpgateway.services.prompt_service import PromptError, PromptNotFoundError
 
         request_missing = self._make_request({"jsonrpc": "2.0", "id": "prompt-get", "method": "prompts/get", "params": []})
@@ -8573,6 +8684,7 @@ class TestRpcHandling:
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["ok"] is True
 
+        # First-Party
         from mcpgateway.plugins.framework.models import PluginErrorModel
 
         with (
@@ -8647,6 +8759,7 @@ class TestRpcHandling:
         assert result["result"] == {}
 
     async def test_maybe_forward_affinitized_rpc_request_internally_forwarded_branch(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", True)
@@ -8937,6 +9050,7 @@ class TestExportImportEndpoints:
             assert result["tools"] == []
 
     async def test_export_configuration_parsing_and_error_mappings(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.export_service import ExportError
 
@@ -8987,6 +9101,7 @@ class TestExportImportEndpoints:
             assert kwargs["token_teams"] == []
 
     async def test_export_selective_configuration_error_mappings(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.export_service import ExportError
 
@@ -9016,6 +9131,7 @@ class TestExportImportEndpoints:
         assert excinfo.value.status_code == 500
 
     async def test_import_configuration_invalid_strategy(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         with pytest.raises(HTTPException) as excinfo:
@@ -9036,8 +9152,11 @@ class TestExportImportEndpoints:
             assert result["status"] == "ok"
 
     async def test_import_configuration_error_mappings(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
-        from mcpgateway.services.import_service import ImportConflictError, ImportError as ImportServiceError, ImportValidationError
+        from mcpgateway.services.import_service import ImportConflictError
+        from mcpgateway.services.import_service import ImportError as ImportServiceError
+        from mcpgateway.services.import_service import ImportValidationError
 
         request_import_status = MagicMock()
         request_import_status.to_dict.return_value = {"status": "ok"}
@@ -9080,6 +9199,7 @@ class TestMessageEndpointElicitation:
         request.body = AsyncMock(return_value=json.dumps({"id": "req-1", "result": {"action": "accept", "content": {"foo": "bar"}}}).encode())
 
         # Allow permission checks to pass for direct invocation
+        # First-Party
         from mcpgateway.services.permission_service import PermissionService
 
         monkeypatch.setattr(PermissionService, "check_permission", AsyncMock(return_value=True))
@@ -9177,6 +9297,7 @@ class TestRemainingCoverageGaps:
     """Targeted unit tests for remaining uncovered main.py branches (per HTML coverage report)."""
 
     def test_get_db_invalidates_when_rollback_fails(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeSession:  # noqa: D401 - test helper
@@ -9214,6 +9335,7 @@ class TestRemainingCoverageGaps:
         assert sess.closed is True
 
     def test_healthcheck_invalidate_failure_is_best_effort(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeSession:  # noqa: D401 - test helper
@@ -9244,6 +9366,7 @@ class TestRemainingCoverageGaps:
         assert sess.closed is True
 
     def test_healthcheck_reports_runtime_mode_and_headers(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeSession:  # noqa: D401 - test helper
@@ -9283,6 +9406,7 @@ class TestRemainingCoverageGaps:
         assert response.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "python"
 
     async def test_readiness_check_invalidate_failure_is_best_effort(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeSession:  # noqa: D401 - test helper
@@ -9314,6 +9438,7 @@ class TestRemainingCoverageGaps:
         assert payload["status"] == "not ready"
 
     async def test_readiness_check_reports_runtime_mode_headers(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeSession:  # noqa: D401 - test helper
@@ -9365,6 +9490,7 @@ class TestRemainingCoverageGaps:
         assert response.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "rust"
 
     def test_runtime_status_payload_reports_http_transport_and_rust_affinity_core(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setenv("CONTEXTFORGE_ENABLE_RUST_BUILD", "true")
@@ -9384,6 +9510,7 @@ class TestRemainingCoverageGaps:
         assert payload["session_auth_reuse_mode"] == "rust"
 
     def test_runtime_status_payload_reports_python_mount_without_session_auth_reuse(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setenv("CONTEXTFORGE_ENABLE_RUST_BUILD", "true")
@@ -9414,6 +9541,7 @@ class TestRemainingCoverageGaps:
         assert payload["session_auth_reuse_mode"] == "python"
 
     def test_healthcheck_unhealthy_applies_runtime_headers(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeSession:  # noqa: D401 - test helper
@@ -9436,6 +9564,7 @@ class TestRemainingCoverageGaps:
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "rust-managed"
 
     async def test_sse_endpoint_cookie_auth_and_disconnect_cleanup(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9472,6 +9601,7 @@ class TestRemainingCoverageGaps:
         remove_session.assert_awaited_once()
 
     async def test_sse_endpoint_disconnect_cleanup_warns_on_failure(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9505,6 +9635,7 @@ class TestRemainingCoverageGaps:
         assert response.status_code == 200
 
     async def test_list_servers_tags_team_mismatch_and_pagination(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9549,6 +9680,7 @@ class TestRemainingCoverageGaps:
         assert list_servers.call_args.kwargs["tags"] == ["a", "b"]
 
     async def test_list_gateways_team_mismatch_and_pagination(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9591,6 +9723,7 @@ class TestRemainingCoverageGaps:
         db.close.assert_called()
 
     async def test_read_resource_fallback_serialization_branches(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9628,6 +9761,7 @@ class TestRemainingCoverageGaps:
         assert result["text"] == "dummy"
 
     async def test_get_resource_info_success_and_not_found(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.resource_service import ResourceNotFoundError
 
@@ -9658,6 +9792,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 404
 
     async def test_get_resource_info_denies_when_scope_enforcement_fails(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9679,6 +9814,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 403
 
     async def test_get_import_status_found_and_not_found(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         status_obj = MagicMock()
@@ -9693,6 +9829,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 404
 
     async def test_list_and_cleanup_import_statuses(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         s1 = MagicMock()
@@ -9708,6 +9845,7 @@ class TestRemainingCoverageGaps:
         assert result["removed_count"] == 2
 
     async def test_create_server_public_only_restrictions_and_team_id(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = _make_request("/servers")
@@ -9762,6 +9900,7 @@ class TestRemainingCoverageGaps:
         assert register.call_args.kwargs["team_id"] is None
 
     async def test_register_gateway_public_only_restrictions_and_validation_error(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = _make_request("/gateways")
@@ -9799,6 +9938,7 @@ class TestRemainingCoverageGaps:
         assert json.loads(response.body.decode()) == {"detail": "bad"}
 
     async def test_state_endpoints_error_branches(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.gateway_service import GatewayNotFoundError
         from mcpgateway.services.prompt_service import PromptLockConflictError
@@ -9846,6 +9986,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 400
 
     async def test_delete_server_error_mappings(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.server_service import ServerError
 
@@ -9861,6 +10002,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 400
 
     async def test_message_endpoints_generic_exception_mapping(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -9883,10 +10025,13 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 500
 
     async def test_list_tools_and_get_tool_jsonpath_modifier(self, monkeypatch):
+        # Third-Party
+        import orjson
+
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
         from mcpgateway.utils.orjson_response import ORJSONResponse
-        import orjson
 
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
@@ -9924,10 +10069,13 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_apijsonpath_with_pagination(self, monkeypatch):
         """Test list_tools with apijsonpath and pagination returns cursor (lines 4100-4109)."""
+        # Third-Party
+        import orjson
+
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
         from mcpgateway.utils.orjson_response import ORJSONResponse
-        import orjson
 
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
@@ -9979,10 +10127,13 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_apijsonpath_pagination_last_page(self, monkeypatch):
         """Test list_tools with apijsonpath on last page returns null cursor (lines 4100-4109)."""
+        # Third-Party
+        import orjson
+
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
         from mcpgateway.utils.orjson_response import ORJSONResponse
-        import orjson
 
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
@@ -10029,6 +10180,7 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_apijsonpath_string_parsing_error(self, monkeypatch):
         """Test list_tools with invalid apijsonpath string (lines 3668-3671)."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10061,6 +10213,7 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_apijsonpath_none_with_pagination(self, monkeypatch):
         """Test list_tools with parsed_apijsonpath=None and include_pagination=True (lines 3674-3681)."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
 
@@ -10093,12 +10246,13 @@ class TestRemainingCoverageGaps:
             assert "nextCursor" in result
             assert result["nextCursor"] == "next_cursor_123"
         else:
-            assert hasattr(result, 'tools')
-            assert hasattr(result, 'next_cursor')
+            assert hasattr(result, "tools")
+            assert hasattr(result, "next_cursor")
             assert result.next_cursor == "next_cursor_123"
 
     async def test_list_tools_apijsonpath_exception_handling(self, monkeypatch):
         """Test list_tools jsonpath_modifier exception (lines 3684-3685, 3690-3692)."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
 
@@ -10134,10 +10288,13 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_apijsonpath_with_empty_tools_list(self, monkeypatch):
         """Test list_tools with empty tools list and jsonpath (line 3684-3685 branch)."""
+        # Third-Party
+        import orjson
+
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
         from mcpgateway.utils.orjson_response import ORJSONResponse
-        import orjson
 
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
@@ -10167,6 +10324,7 @@ class TestRemainingCoverageGaps:
 
     async def test_get_tool_apijsonpath_none(self, monkeypatch):
         """Test get_tool with parsed_apijsonpath=None (lines 3833-3834)."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10182,17 +10340,12 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", mock_get_tool)
 
-        result = await main_mod.get_tool.__wrapped__(
-            "tool-1",
-            request=request,
-            db=MagicMock(),
-            user={"email": "u"},
-            apijsonpath=None
-        )
+        result = await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=None)
         assert result == data
 
     async def test_get_tool_apijsonpath_string_parsing_error(self, monkeypatch):
         """Test get_tool with invalid apijsonpath string (lines 3827-3830)."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10207,13 +10360,7 @@ class TestRemainingCoverageGaps:
 
         # Invalid JSON string for apijsonpath - should raise 400 Bad Request
         with pytest.raises(HTTPException) as excinfo:
-            await main_mod.get_tool.__wrapped__(
-                "tool-1",
-                request=request,
-                db=MagicMock(),
-                user={"email": "u"},
-                apijsonpath="{invalid json"
-            )
+            await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath="{invalid json")
         # Should be 400 (not 404) for invalid apijsonpath JSON
         assert excinfo.value.status_code == 400
         # Generic error message in non-DEBUG mode (security improvement)
@@ -10221,6 +10368,7 @@ class TestRemainingCoverageGaps:
 
     async def test_get_tool_jsonpath_modifier_exception(self, monkeypatch):
         """Test get_tool jsonpath_modifier exception (lines 3841-3843)."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
 
@@ -10239,19 +10387,14 @@ class TestRemainingCoverageGaps:
 
         apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
         with pytest.raises(HTTPException) as excinfo:
-            await main_mod.get_tool.__wrapped__(
-                "tool-1",
-                request=request,
-                db=MagicMock(),
-                user={"email": "u"},
-                apijsonpath=apijsonpath
-            )
+            await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=apijsonpath)
         # Should be 500 (not 404) for JSONPath modifier errors
         assert excinfo.value.status_code == 500
         assert "JSONPath modifier error" in str(excinfo.value.detail)
 
     async def test_list_tools_apijsonpath_httpexception_reraise(self, monkeypatch):
         """Test list_tools re-raises HTTPException from jsonpath_modifier (line 3695)."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
 
@@ -10288,6 +10431,7 @@ class TestRemainingCoverageGaps:
 
     async def test_get_tool_apijsonpath_httpexception_reraise(self, monkeypatch):
         """Test get_tool re-raises HTTPException from jsonpath_modifier (line 3844)."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
 
@@ -10306,19 +10450,14 @@ class TestRemainingCoverageGaps:
 
         apijsonpath = JsonPathModifier(jsonpath="$", mapping={})
         with pytest.raises(HTTPException) as excinfo:
-            await main_mod.get_tool.__wrapped__(
-                "tool-1",
-                request=request,
-                db=MagicMock(),
-                user={"email": "u"},
-                apijsonpath=apijsonpath
-            )
+            await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=apijsonpath)
         # Should preserve the original HTTPException status and detail
         assert excinfo.value.status_code == 400
         assert "Invalid JSONPath expression" in str(excinfo.value.detail)
 
     async def test_list_tools_jsonpath_none_returns_pagination(self, monkeypatch):
         """Test list_tools returns paginated response when jsonpath is None."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10352,12 +10491,13 @@ class TestRemainingCoverageGaps:
             assert "nextCursor" in result
             assert result["nextCursor"] == "cursor_abc"
         else:
-            assert hasattr(result, 'tools')
-            assert hasattr(result, 'next_cursor')
+            assert hasattr(result, "tools")
+            assert hasattr(result, "next_cursor")
             assert result.next_cursor == "cursor_abc"
 
     async def test_list_tools_apijsonpath_invalid_type(self, monkeypatch):
         """Test list_tools with invalid apijsonpath type raises clear error."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10391,6 +10531,7 @@ class TestRemainingCoverageGaps:
 
     async def test_get_tool_apijsonpath_invalid_type(self, monkeypatch):
         """Test get_tool with invalid apijsonpath type raises clear error."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10405,13 +10546,7 @@ class TestRemainingCoverageGaps:
 
         # Pass invalid type (list) - should raise 400 with clear message
         with pytest.raises(HTTPException) as excinfo:
-            await main_mod.get_tool.__wrapped__(
-                "tool-1",
-                request=request,
-                db=MagicMock(),
-                user={"email": "u"},
-                apijsonpath=["invalid", "type"]  # Invalid type
-            )
+            await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=["invalid", "type"])  # Invalid type
         assert excinfo.value.status_code == 400
         # Generic error message in non-DEBUG mode (security improvement)
         assert "Invalid apijsonpath type" in str(excinfo.value.detail)
@@ -10419,6 +10554,7 @@ class TestRemainingCoverageGaps:
 
     async def test_list_tools_empty_jsonpath_string(self, monkeypatch):
         """Test list_tools rejects empty jsonpath string."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10450,6 +10586,7 @@ class TestRemainingCoverageGaps:
 
     async def test_get_tool_empty_jsonpath_model(self, monkeypatch):
         """Test get_tool rejects JsonPathModifier with empty jsonpath."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import JsonPathModifier
 
@@ -10465,18 +10602,13 @@ class TestRemainingCoverageGaps:
 
         # JsonPathModifier with empty jsonpath
         with pytest.raises(HTTPException) as excinfo:
-            await main_mod.get_tool.__wrapped__(
-                "tool-1",
-                request=request,
-                db=MagicMock(),
-                user={"email": "u"},
-                apijsonpath=JsonPathModifier(jsonpath="", mapping=None)
-            )
+            await main_mod.get_tool.__wrapped__("tool-1", request=request, db=MagicMock(), user={"email": "u"}, apijsonpath=JsonPathModifier(jsonpath="", mapping=None))
         assert excinfo.value.status_code == 400
         assert "JSONPath expression cannot be empty" in str(excinfo.value.detail)
 
     async def test_create_tool_endpoint_coverage(self, monkeypatch):
         """Test create_tool endpoint (lines 3695-3698)."""
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import ToolCreate
         from mcpgateway.utils.metadata_capture import MetadataCapture
@@ -10484,26 +10616,17 @@ class TestRemainingCoverageGaps:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None, token_teams=None)
 
-        tool_data = ToolCreate(
-            name="test_tool",
-            url="http://example.com",
-            description="Test",
-            integration_type="REST",
-            request_type="GET"
-        )
+        tool_data = ToolCreate(name="test_tool", url="http://example.com", description="Test", integration_type="REST", request_type="GET")
 
         created_tool = MagicMock()
         created_tool.id = "tool-123"
 
         # Mock all the dependencies
-        monkeypatch.setattr(MetadataCapture, "extract_creation_metadata", lambda *args: {
-            "created_by": "user@example.com",
-            "created_from_ip": "127.0.0.1",
-            "created_via": "api",
-            "created_user_agent": "test",
-            "import_batch_id": None,
-            "federation_source": None
-        })
+        monkeypatch.setattr(
+            MetadataCapture,
+            "extract_creation_metadata",
+            lambda *args: {"created_by": "user@example.com", "created_from_ip": "127.0.0.1", "created_via": "api", "created_user_agent": "test", "import_batch_id": None, "federation_source": None},
+        )
         monkeypatch.setattr(main_mod, "get_user_email", lambda user: "user@example.com")
         monkeypatch.setattr(main_mod.tool_service, "register_tool", AsyncMock(return_value=created_tool))
 
@@ -10511,21 +10634,16 @@ class TestRemainingCoverageGaps:
         mock_db.commit = MagicMock()
         mock_db.close = MagicMock()
 
-        result = await main_mod.create_tool.__wrapped__(
-            tool=tool_data,
-            request=request,
-            team_id=None,
-            db=mock_db,
-            user={"email": "user@example.com"}
-        )
+        result = await main_mod.create_tool.__wrapped__(tool=tool_data, request=request, team_id=None, db=mock_db, user={"email": "user@example.com"})
         assert result == created_tool
 
     async def test_update_tool_endpoint_coverage(self, monkeypatch):
         """Test update_tool endpoint (lines 3848-3851)."""
+        # First-Party
+        from mcpgateway.db import Tool as DbTool
         import mcpgateway.main as main_mod
         from mcpgateway.schemas import ToolUpdate
         from mcpgateway.utils.metadata_capture import MetadataCapture
-        from mcpgateway.db import Tool as DbTool
 
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
@@ -10544,25 +10662,16 @@ class TestRemainingCoverageGaps:
         mock_db.close = MagicMock()
 
         # Mock dependencies
-        monkeypatch.setattr(MetadataCapture, "extract_modification_metadata", lambda *args: {
-            "modified_by": "user@example.com",
-            "modified_from_ip": "127.0.0.1",
-            "modified_via": "api",
-            "modified_user_agent": "test"
-        })
+        monkeypatch.setattr(
+            MetadataCapture, "extract_modification_metadata", lambda *args: {"modified_by": "user@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "api", "modified_user_agent": "test"}
+        )
         monkeypatch.setattr(main_mod.tool_service, "update_tool", AsyncMock(return_value=updated_tool))
 
-        result = await main_mod.update_tool.__wrapped__(
-            tool_id="tool-123",
-            tool=tool_update,
-            request=request,
-            db=mock_db,
-            user={"email": "user@example.com"}
-        )
+        result = await main_mod.update_tool.__wrapped__(tool_id="tool-123", tool=tool_update, request=request, db=mock_db, user={"email": "user@example.com"})
         assert result == updated_tool
 
-
     async def test_deprecated_toggle_endpoints(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod, "set_server_state", AsyncMock(return_value={"ok": True}))
@@ -10590,6 +10699,7 @@ class TestRemainingCoverageGaps:
             assert await main_mod.toggle_a2a_agent_status.__wrapped__("a1", True, MagicMock(), {"email": "u"}) == {"ok": True}
 
     async def test_reset_metrics_a2a_agent_enabled_and_disabled(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         a2a = MagicMock()
@@ -10606,6 +10716,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 400
 
     async def test_get_prompt_no_args_not_found_and_permission(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.prompt_service import PromptNotFoundError
 
@@ -10624,6 +10735,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 403
 
     async def test_list_resource_templates_token_teams_normalization(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10640,6 +10752,7 @@ class TestRemainingCoverageGaps:
         assert result.resource_templates == []
 
     async def test_list_prompts_token_teams_normalization(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10680,6 +10793,7 @@ class TestRemainingCoverageGaps:
         assert list_prompts.call_args.kwargs["token_teams"] == []
 
     async def test_server_get_resources_and_prompts_admin_bypass(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10701,8 +10815,11 @@ class TestRemainingCoverageGaps:
         assert result == [{"id": "p1"}]
 
     async def test_update_a2a_agent_service_unavailable_and_validation(self, monkeypatch):
-        import mcpgateway.main as main_mod
+        # Third-Party
         from pydantic import ValidationError
+
+        # First-Party
+        import mcpgateway.main as main_mod
 
         request = _make_request("/a2a/a1")
         monkeypatch.setattr(
@@ -10727,8 +10844,10 @@ class TestRemainingCoverageGaps:
 
     async def test_module_level_router_registration_branches(self, monkeypatch):
         """Import main.py under unique name to cover module-level wiring branches."""
+        # Standard
         from types import ModuleType
 
+        # Third-Party
         from fastapi import APIRouter
 
         # Provide lightweight router modules to avoid importing heavy optional dependencies.
@@ -10782,6 +10901,7 @@ class TestRemainingCoverageGaps:
         assert jsonpath_modifier([{"a": 1}], jsonpath="") == {"a": 1}
 
     async def test_import_configuration_uses_user_email_attribute(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         status_obj = MagicMock()
@@ -10804,6 +10924,7 @@ class TestRemainingCoverageGaps:
         assert svc.import_configuration.call_args.kwargs["imported_by"] == "obj@example.com"
 
     async def test_initialize_maps_orjson_decode_error(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10814,6 +10935,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 400
 
     async def test_update_server_name_conflict_maps_to_409(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.server_service import ServerNameConflictError
 
@@ -10829,6 +10951,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 409
 
     async def test_server_get_tools_public_only_default(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10844,6 +10967,7 @@ class TestRemainingCoverageGaps:
         assert result == [{"id": "t1"}]
 
     async def test_tag_endpoints_parse_entity_types(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = _make_request("/tags")
@@ -10856,6 +10980,7 @@ class TestRemainingCoverageGaps:
         _ = await main_mod.get_entities_by_tag.__wrapped__(request, "tag-1", entity_types="Tools", db=MagicMock(), user={"email": "u"})
 
     async def test_get_a2a_agent_service_unavailable(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = _make_request("/a2a/a1")
@@ -10866,6 +10991,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 503
 
     async def test_create_a2a_agent_public_only_sets_team_id_none(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = _make_request("/a2a")
@@ -10898,6 +11024,7 @@ class TestRemainingCoverageGaps:
         assert svc.register_agent.call_args.kwargs["team_id"] is None
 
     async def test_set_a2a_agent_state_service_unavailable(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod, "a2a_service", None)
@@ -10906,6 +11033,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 503
 
     async def test_delete_tool_not_found_maps_to_404(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.tool_service import ToolNotFoundError
 
@@ -10915,6 +11043,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 404
 
     async def test_create_resource_resource_error_maps_to_400(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
         from mcpgateway.services.resource_service import ResourceError
 
@@ -10939,6 +11068,7 @@ class TestRemainingCoverageGaps:
         assert excinfo.value.status_code == 400
 
     async def test_get_prompt_reraises_unhandled_exception(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10950,12 +11080,14 @@ class TestRemainingCoverageGaps:
             await main_mod.get_prompt.__wrapped__(request, "p1", args={}, db=MagicMock(), user={"email": "u"})
 
     def test_log_security_recommendations_skip_ssl_verify_line(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         monkeypatch.setattr(main_mod.settings, "skip_ssl_verify", True, raising=False)
         main_mod.log_security_recommendations({"secure_secrets": False, "auth_enabled": False})
 
     async def test_request_validation_exception_handler_ctx_non_dict(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -10968,6 +11100,7 @@ class TestRemainingCoverageGaps:
         assert response.status_code == 422
 
     async def test_update_gateway_validation_error_branch(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         class FakeValidationError(Exception):
@@ -10988,6 +11121,7 @@ class TestRemainingCoverageGaps:
         assert json.loads(response.body.decode()) == {"detail": "bad"}
 
     async def test_lifespan_log_aggregation_timeout_and_cancellation(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         def make_service():  # noqa: ANN001 - local test helper
@@ -11046,6 +11180,7 @@ class TestRemainingCoverageGaps:
         subscriber = MagicMock()
         subscriber.start = AsyncMock()
         subscriber.stop = AsyncMock()
+        # First-Party
         import mcpgateway.cache.registry_cache as registry_cache_mod
 
         monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
@@ -11076,6 +11211,7 @@ class TestRemainingCoverageGaps:
 
     async def test_lifespan_log_aggregation_timeout_branch(self, monkeypatch):
         """Specifically hit the TimeoutError -> continue branch in run_log_aggregation_loop."""
+        # First-Party
         import mcpgateway.main as main_mod
 
         def make_service():  # noqa: ANN001 - local test helper
@@ -11130,6 +11266,7 @@ class TestRemainingCoverageGaps:
         subscriber = MagicMock()
         subscriber.start = AsyncMock()
         subscriber.stop = AsyncMock()
+        # First-Party
         import mcpgateway.cache.registry_cache as registry_cache_mod
 
         monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
@@ -11160,6 +11297,7 @@ class TestRemainingCoverageGaps:
             await asyncio.sleep(0.05)
 
     async def test_lifespan_reraises_unexpected_startup_error(self, monkeypatch):
+        # First-Party
         import mcpgateway.main as main_mod
 
         # Keep startup/shutdown lightweight.
@@ -11174,6 +11312,7 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr("mcpgateway.services.http_client_service.SharedHttpClient.get_instance", AsyncMock())
         monkeypatch.setattr("mcpgateway.services.http_client_service.SharedHttpClient.shutdown", AsyncMock())
 
+        # First-Party
         import mcpgateway.cache.registry_cache as registry_cache_mod
 
         subscriber = MagicMock()
@@ -11188,8 +11327,10 @@ class TestRemainingCoverageGaps:
                 pass
 
     async def test_module_level_structured_logging_and_static_mount_errors(self, monkeypatch):
+        # Standard
         from types import ModuleType
 
+        # Third-Party
         from fastapi import APIRouter
 
         # Keep router imports light.
@@ -11215,8 +11356,10 @@ class TestRemainingCoverageGaps:
         assert resp.status_code == 301
 
     async def test_module_level_llm_and_toolops_router_success_paths(self, monkeypatch):
+        # Standard
         from types import ModuleType
 
+        # Third-Party
         from fastapi import APIRouter
 
         # Stub router modules so include_router executes without importing heavy deps.
@@ -11248,8 +11391,10 @@ class TestRemainingCoverageGaps:
         _ = _import_fresh_main_module(monkeypatch, overrides=overrides)
 
     async def test_module_level_email_auth_and_sso_success(self, monkeypatch):
+        # Standard
         from types import ModuleType
 
+        # Third-Party
         from fastapi import APIRouter
 
         auth_mod = ModuleType("mcpgateway.routers.auth")
@@ -11268,8 +11413,10 @@ class TestRemainingCoverageGaps:
         _ = _import_fresh_main_module(monkeypatch, overrides=overrides)
 
     async def test_module_level_email_auth_and_sso_import_error(self, monkeypatch):
+        # Standard
         from types import ModuleType
 
+        # Third-Party
         from fastapi import APIRouter
 
         auth_mod = ModuleType("mcpgateway.routers.auth")
@@ -11299,8 +11446,10 @@ class TestRemainingCoverageGaps:
         _ = _import_fresh_main_module(monkeypatch, overrides=overrides, force_import_error=force_error)
 
     async def test_module_level_reverse_proxy_router_success(self, monkeypatch):
+        # Standard
         from types import ModuleType
 
+        # Third-Party
         from fastapi import APIRouter
 
         reverse_proxy_mod = ModuleType("mcpgateway.routers.reverse_proxy")
@@ -11328,6 +11477,7 @@ class TestRemainingCoverageGaps:
         assert mod.plugin_manager is None
 
     async def test_module_level_uses_settings_backed_plugin_enablement(self, monkeypatch):
+        # First-Party
         import mcpgateway.plugins.framework.settings as plugin_settings_mod
 
         monkeypatch.delenv("PLUGINS_ENABLED", raising=False)
@@ -11351,6 +11501,7 @@ class TestHardeningHelperCoverage:
     """Target helper branches added for hardening paths."""
 
     def test_get_request_identity_prefers_verified_payload_context(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -11363,6 +11514,7 @@ class TestHardeningHelperCoverage:
         assert is_admin is True
 
     def test_get_request_identity_uses_user_attribute_admin_fallback(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -11379,6 +11531,7 @@ class TestHardeningHelperCoverage:
         assert is_admin is True
 
     def test_get_scoped_resource_access_context_admin_and_public_only(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -11392,6 +11545,7 @@ class TestHardeningHelperCoverage:
 
     @pytest.mark.asyncio
     async def test_assert_session_owner_or_admin_returns_404_for_missing_session(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -11407,6 +11561,7 @@ class TestHardeningHelperCoverage:
         assert excinfo.value.status_code == 404
 
     def test_enforce_scoped_resource_access_denies_on_failed_ownership_check(self):
+        # First-Party
         import mcpgateway.main as main_mod
 
         request = MagicMock(spec=Request)
@@ -11425,6 +11580,7 @@ class TestHardeningHelperCoverage:
 @pytest.mark.asyncio
 async def test_protocol_completion_endpoint_direct_admin_null_teams_preserves_bypass(monkeypatch):
     """Direct call should preserve admin bypass semantics for completion endpoint."""
+    # First-Party
     import mcpgateway.main as main_mod
 
     request = MagicMock(spec=Request)
@@ -11447,6 +11603,7 @@ async def test_protocol_completion_endpoint_direct_admin_null_teams_preserves_by
 @pytest.mark.asyncio
 async def test_protocol_completion_endpoint_direct_non_admin_none_teams_becomes_public_only(monkeypatch):
     """Direct call should normalize non-admin teams=None to public-only scope."""
+    # First-Party
     import mcpgateway.main as main_mod
 
     request = MagicMock(spec=Request)
@@ -11469,6 +11626,7 @@ async def test_protocol_completion_endpoint_direct_non_admin_none_teams_becomes_
 @pytest.mark.asyncio
 async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(monkeypatch):
     """RPC completion direct path should preserve admin bypass context."""
+    # First-Party
     import mcpgateway.main as main_mod
 
     request = MagicMock(spec=Request)
@@ -11493,6 +11651,7 @@ async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(mo
 @pytest.mark.asyncio
 async def test_handle_rpc_completion_direct_non_admin_none_teams_becomes_public_only(monkeypatch):
     """RPC completion direct path should normalize teams=None for non-admin callers."""
+    # First-Party
     import mcpgateway.main as main_mod
 
     request = MagicMock(spec=Request)


### PR DESCRIPTION
> **Note:** This PR was re-created from #3023 due to repository maintenance. Your code and branch are intact. @rakdutta please verify everything looks good.

closes #2848 
This PR enhances the tools API endpoints (`/tools` and `/tools/{tool_id}`) by refactoring JSONPath modifier support from request body to query parameters, improving error handling, and adding comprehensive logging for better debugging.

### Changes

**API Parameter Changes**
- Moved `apijsonpath` parameter from request body to optional query parameter in both `list_tools` and `get_tool` endpoints
- Enables JSONPath modifiers to be passed as JSON strings in GET requests, improving API usability
- Added unified parsing logic to handle `apijsonpath` as either a string (HTTP requests) or model instance (internal calls/tests)

**Response Handling**
- Changed endpoints to return `ORJSONResponse` when JSONPath modifiers are applied, bypassing FastAPI's response model validation
- Ensures correct response format and prevents validation errors on modified responses

**Error Handling**
- Improved error reporting for invalid JSONPath modifier input with appropriate HTTP exceptions
- Added detailed error messages for parsing and processing failures

**Test Updates**
- Updated unit tests to use new query parameter format for `apijsonpath`
- Switched tests to use `JsonPathModifier` model instances
- Validated that endpoints return `ORJSONResponse` objects when modifiers are applied

**Documentation**
- Added docstring notes about raised exceptions
- Clarified parameter descriptions in endpoint documentation

### Impact

These changes improve API flexibility by allowing JSONPath modifiers in GET requests, enhance reliability through better error handling, and improve maintainability with comprehensive logging and updated tests.

### Testing

All existing unit tests have been updated and pass successfully. The changes maintain backward compatibility for internal calls while adding new query parameter support for HTTP requests.