### PR TITLE
feat(transport): complete direct_proxy gateway mode for streamable HTTP

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -850,6 +850,48 @@ async def _proxy_list_resources_to_gateway(gateway: Any, request_headers: dict, 
         return []
 
 
+async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, user_context: dict, meta: Optional[Any] = None) -> List[types.Prompt]:  # pylint: disable=unused-argument
+    """Proxy prompts/list request directly to remote MCP gateway using MCP SDK.
+
+    Args:
+        gateway: Gateway ORM instance
+        request_headers: Request headers from client
+        user_context: User context (not used - _meta comes from MCP SDK)
+        meta: Request metadata (_meta) from the original request
+
+    Returns:
+        List of Prompt objects from remote server
+    """
+    try:
+        headers = build_gateway_auth_headers(gateway)
+
+        if gateway.passthrough_headers and request_headers:
+            for header_name in gateway.passthrough_headers:
+                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
+                if header_value:
+                    headers[header_name] = header_value
+
+        logger.info(f"Proxying prompts/list to gateway {gateway.id} at {gateway.url}")
+        if meta:
+            logger.debug(f"Forwarding _meta to remote gateway: {meta}")
+
+        async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                params = None
+                if meta:
+                    params = PaginatedRequestParams(_meta=meta)
+
+                result = await session.list_prompts(params=params)
+                logger.info(f"Received {len(result.prompts)} prompts from gateway {gateway.id}")
+                return result.prompts
+
+    except Exception as e:
+        logger.exception(f"Error proxying prompts/list to gateway {gateway.id}: {e}")
+        return []
+
+
 async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_context: dict, meta: Optional[Any] = None) -> List[Any]:  # pylint: disable=unused-argument
     """Proxy resources/read request directly to remote MCP gateway using MCP SDK.
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1773,7 +1773,7 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
         >>> sig.return_annotation.__name__
         'GetPromptResult'
     """
-    server_id, _, user_context = await _get_request_context_or_default()
+    server_id, request_headers, user_context = await _get_request_context_or_default()
 
     # Token scope cap: deny early if scoped permissions exclude prompts.read
     if _should_enforce_streamable_rbac(user_context):
@@ -1813,6 +1813,33 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
 
     try:
         async with get_db() as db:
+            # Check for direct_proxy mode (uses the same DB session as cache path)
+            if server_id:
+                gateway_id = extract_gateway_id_from_headers(request_headers)
+
+                if gateway_id:
+                    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+                    from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
+
+                    gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
+                    if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
+                        if not await check_gateway_access(db, gateway, user_email, token_teams):
+                            logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
+                            return []
+
+                        logger.info(f"[GET PROMPT] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
+                        result = await _proxy_get_prompt_to_gateway(gateway, request_headers, user_context, name=prompt_id, arguments=arguments, meta=meta_data)
+                        if not result or not result.messages:
+                            logger.warning(f"No content returned by upstream prompt: {prompt_id}")
+                            return []
+                        message_dicts = [message.model_dump() for message in result.messages]
+                        return types.GetPromptResult(messages=message_dicts, description=result.description)
+
+                    if gateway:
+                        logger.debug(f"Gateway {gateway_id} found but not in direct_proxy mode (mode: {getattr(gateway, 'gateway_mode', 'cache')}), using cache mode")
+                    else:
+                        logger.warning(f"Gateway {gateway_id} specified in {GATEWAY_ID_HEADER} header not found")
+
             try:
                 result = await prompt_service.get_prompt(
                     db=db,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -901,7 +901,9 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
         return []
 
 
-async def _proxy_get_prompt_to_gateway(gateway: Any, request_headers: dict, user_context: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None) -> Optional[types.GetPromptResult]:  # pylint: disable=unused-argument
+async def _proxy_get_prompt_to_gateway(
+    gateway: Any, request_headers: dict, user_context: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
+) -> Optional[types.GetPromptResult]:  # pylint: disable=unused-argument
     """Proxy prompts/get request directly to remote MCP gateway using MCP SDK.
 
     Uses session.send_request() when _meta is present (ClientSession.get_prompt()
@@ -1777,7 +1779,10 @@ async def list_prompts() -> List[types.Prompt]:
                 gateway_id = extract_gateway_id_from_headers(request_headers)
 
                 if gateway_id:
+                    # Third-Party
                     from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+
+                    # First-Party
                     from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
 
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
@@ -1887,7 +1892,10 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
                 gateway_id = extract_gateway_id_from_headers(request_headers)
 
                 if gateway_id:
+                    # Third-Party
                     from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+
+                    # First-Party
                     from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
 
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
@@ -2385,7 +2393,10 @@ async def complete(
                 gateway_id = extract_gateway_id_from_headers(request_headers)
 
                 if gateway_id:
+                    # Third-Party
                     from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+
+                    # First-Party
                     from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
 
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
@@ -2399,8 +2410,13 @@ async def complete(
 
                         logger.info(f"[COMPLETE] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
                         result = await _proxy_complete_to_gateway(
-                            gateway, request_headers, user_context,
-                            ref=ref, argument=argument, context=context, meta=meta_data,
+                            gateway,
+                            request_headers,
+                            user_context,
+                            ref=ref,
+                            argument=argument,
+                            context=context,
+                            meta=meta_data,
                         )
                         if result is None:
                             return types.Completion(values=[], total=0, hasMore=False)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -902,7 +902,7 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
 
 
 async def _proxy_get_prompt_to_gateway(
-    gateway: Any, request_headers: dict, user_context: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
+    gateway: Any, request_headers: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
 ) -> Optional[types.GetPromptResult]:  # pylint: disable=unused-argument
     """Proxy prompts/get request directly to remote MCP gateway using MCP SDK.
 
@@ -912,7 +912,6 @@ async def _proxy_get_prompt_to_gateway(
     Args:
         gateway: Gateway ORM instance
         request_headers: Request headers from client
-        user_context: User context (not used - auth comes from gateway config)
         name: Prompt name to retrieve
         arguments: Optional argument substitutions
         meta: Request metadata (_meta) from the original request

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1895,7 +1895,7 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
                             return types.GetPromptResult(messages=[], description=None)
 
                         logger.info(f"[GET PROMPT] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
-                        result = await _proxy_get_prompt_to_gateway(gateway, request_headers, user_context, name=prompt_id, arguments=arguments, meta=meta_data)
+                        result = await _proxy_get_prompt_to_gateway(gateway, request_headers, prompt_id, arguments, meta_data)
                         if not result or not result.messages:
                             logger.warning(f"No content returned by upstream prompt: {prompt_id}")
                             return types.GetPromptResult(messages=[], description=None)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -503,7 +503,6 @@ async def update_headers_with_passthrough_headers(gateway: Any, request_headers:
     return headers
 
 
-
 def _should_enforce_streamable_rbac(user_context: Optional[dict[str, Any]]) -> bool:
     """Return True when request originated from authenticated Streamable HTTP middleware.
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -954,6 +954,75 @@ async def _proxy_get_prompt_to_gateway(gateway: Any, request_headers: dict, user
         return None
 
 
+async def _proxy_complete_to_gateway(  # pylint: disable=unused-argument
+    gateway: Any,
+    request_headers: dict,
+    user_context: dict,
+    ref: Any,
+    argument: Any,
+    context: Optional[Any] = None,
+    meta: Optional[Any] = None,
+) -> Optional[types.CompleteResult]:
+    """Proxy completion/complete request directly to remote MCP gateway using MCP SDK.
+
+    Uses session.send_request() when _meta is present (ClientSession.complete()
+    has no params argument), matching the pattern in _proxy_read_resource_to_gateway.
+
+    Args:
+        gateway: Gateway ORM instance
+        request_headers: Request headers from client
+        user_context: User context (not used - auth comes from gateway config)
+        ref: PromptReference or ResourceTemplateReference
+        argument: CompletionArgument specifying name and partial value
+        context: Optional CompletionContext with previously resolved arguments
+        meta: Request metadata (_meta) from the original request
+
+    Returns:
+        CompleteResult from remote server, or None on failure
+    """
+    try:
+        headers = build_gateway_auth_headers(gateway)
+
+        if gateway.passthrough_headers and request_headers:
+            for header_name in gateway.passthrough_headers:
+                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
+                if header_value:
+                    headers[header_name] = header_value
+
+        logger.info(f"Proxying completion/complete to gateway {gateway.id} at {gateway.url}")
+        if meta:
+            logger.debug(f"Forwarding _meta to remote gateway: {meta}")
+
+        async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                if meta:
+                    # ClientSession.complete() has no params arg, use send_request to forward _meta
+                    params_dict = CompleteRequestParams(ref=ref, argument=argument, context=context).model_dump()
+                    params_dict["_meta"] = meta
+                    result = await session.send_request(
+                        types.ClientRequest(CompleteRequest(params=CompleteRequestParams.model_validate(params_dict))),
+                        types.CompleteResult,
+                    )
+                else:
+                    ref_dict = ref.model_dump() if hasattr(ref, "model_dump") else ref
+                    arg_dict = argument.model_dump() if hasattr(argument, "model_dump") else argument
+                    context_args = context.arguments if context and hasattr(context, "arguments") else None
+                    result = await session.complete(
+                        ref=ref_dict,
+                        argument=arg_dict,
+                        context_arguments=context_args,
+                    )
+
+                logger.info(f"Received completion result from gateway {gateway.id}")
+                return result
+
+    except Exception as e:
+        logger.exception(f"Error proxying completion/complete to gateway {gateway.id}: {e}")
+        return None
+
+
 async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_context: dict, meta: Optional[Any] = None) -> List[Any]:  # pylint: disable=unused-argument
     """Proxy resources/read request directly to remote MCP gateway using MCP SDK.
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2343,8 +2343,16 @@ async def complete(
         Exception: If completion handling fails internally. The method
             logs the exception and returns an empty completion structure.
     """
+    meta_data = None
+    try:
+        ctx = mcp_app.request_context
+        if ctx and ctx.meta is not None:
+            meta_data = ctx.meta.model_dump()
+    except LookupError:
+        logger.debug("No active request context found for _meta extraction in completion/complete")
+
     # Derive caller visibility scope from the current request context.
-    server_id, _, user_context = await _get_request_context_or_default()
+    server_id, request_headers, user_context = await _get_request_context_or_default()
 
     # Token scope cap: deny early if scoped permissions exclude tools.read
     if _should_enforce_streamable_rbac(user_context):
@@ -2372,10 +2380,47 @@ async def complete(
             token_teams = []  # Non-admin without explicit teams -> public-only
 
         async with get_db() as db:
+            # Check for direct_proxy mode (uses the same DB session as cache path)
+            if server_id:
+                gateway_id = extract_gateway_id_from_headers(request_headers)
+
+                if gateway_id:
+                    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+                    from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
+
+                    gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
+                    if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
+                        user_email = user_context.get("email") if user_context else None
+                        token_teams = user_context.get("teams") if user_context else None
+
+                        if not await check_gateway_access(db, gateway, user_email, token_teams):
+                            logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
+                            return types.Completion(values=[], total=0, hasMore=False)
+
+                        logger.info(f"[COMPLETE] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
+                        result = await _proxy_complete_to_gateway(
+                            gateway, request_headers, user_context,
+                            ref=ref, argument=argument, context=context, meta=meta_data,
+                        )
+                        if result is None:
+                            return types.Completion(values=[], total=0, hasMore=False)
+                        if isinstance(result, dict):
+                            return types.Completion(**result.get("completion", result))
+                        if hasattr(result, "completion"):
+                            comp = result.completion
+                            return comp if isinstance(comp, types.Completion) else types.Completion(**comp.model_dump())
+                        return result
+
+                    if gateway:
+                        logger.debug(f"Gateway {gateway_id} not in direct_proxy mode, using cache")
+                    else:
+                        logger.warning(f"Gateway {gateway_id} not found")
+
             params = {
                 "ref": ref.model_dump() if hasattr(ref, "model_dump") else ref,
                 "argument": argument.model_dump() if hasattr(argument, "model_dump") else argument,
                 "context": context.model_dump() if hasattr(context, "model_dump") else context,
+                "_meta": meta_data,
             }
 
             result = await completion_service.handle_completion(

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -902,7 +902,7 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
 
 
 async def _proxy_get_prompt_to_gateway(
-    gateway: Any, request_headers: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
+    gateway: Any, request_headers: dict, user_context: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
 ) -> Optional[types.GetPromptResult]:  # pylint: disable=unused-argument
     """Proxy prompts/get request directly to remote MCP gateway using MCP SDK.
 
@@ -912,6 +912,7 @@ async def _proxy_get_prompt_to_gateway(
     Args:
         gateway: Gateway ORM instance
         request_headers: Request headers from client
+        user_context: User context (not used - auth comes from gateway config)
         name: Prompt name to retrieve
         arguments: Optional argument substitutions
         meta: Request metadata (_meta) from the original request

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -478,6 +478,30 @@ def get_user_email_from_context() -> str:
         return user.get("email") or user.get("sub") or "unknown"
     return str(user) if user else "unknown"
 
+async def update_headers_with_passthrough_headers(gateway: Any, request_headers: dict) -> dict:
+    """
+    Build headers for forwarding to remote gateway, including auth headers and passthrough headers.
+
+    Args:
+        gateway: Gateway ORM instance containing auth config and passthrough header list
+        request_headers: Original request headers from the client
+
+    Returns:
+        Dictionary of headers to include in the proxied request to the remote gateway    
+    """
+
+    headers = build_gateway_auth_headers(gateway)
+
+    # Forward passthrough headers if configured
+    if gateway.passthrough_headers and request_headers:
+        for header_name in gateway.passthrough_headers:
+            header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
+            if header_value:
+                headers[header_name] = header_value
+
+    return headers
+
+
 
 def _should_enforce_streamable_rbac(user_context: Optional[dict[str, Any]]) -> bool:
     """Return True when request originated from authenticated Streamable HTTP middleware.
@@ -781,14 +805,7 @@ async def _proxy_list_tools_to_gateway(gateway: Any, request_headers: dict, user
     """
     try:
         # Prepare headers with gateway auth
-        headers = build_gateway_auth_headers(gateway)
-
-        # Forward passthrough headers if configured
-        if gateway.passthrough_headers and request_headers:
-            for header_name in gateway.passthrough_headers:
-                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
-                if header_value:
-                    headers[header_name] = header_value
+        headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
         # Use MCP SDK to connect and list tools
         async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
@@ -824,14 +841,7 @@ async def _proxy_list_resources_to_gateway(gateway: Any, request_headers: dict, 
     """
     try:
         # Prepare headers with gateway auth
-        headers = build_gateway_auth_headers(gateway)
-
-        # Forward passthrough headers if configured
-        if gateway.passthrough_headers and request_headers:
-            for header_name in gateway.passthrough_headers:
-                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
-                if header_value:
-                    headers[header_name] = header_value
+        headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
         logger.info("Proxying resources/list to gateway %s at %s", gateway.id, gateway.url)
         if meta:
@@ -872,13 +882,7 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
         List of Prompt objects from remote server
     """
     try:
-        headers = build_gateway_auth_headers(gateway)
-
-        if gateway.passthrough_headers and request_headers:
-            for header_name in gateway.passthrough_headers:
-                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
-                if header_value:
-                    headers[header_name] = header_value
+        headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
         logger.info(f"Proxying prompts/list to gateway {gateway.id} at {gateway.url}")
         if meta:
@@ -921,13 +925,7 @@ async def _proxy_get_prompt_to_gateway(
         GetPromptResult from remote server, or None on failure
     """
     try:
-        headers = build_gateway_auth_headers(gateway)
-
-        if gateway.passthrough_headers and request_headers:
-            for header_name in gateway.passthrough_headers:
-                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
-                if header_value:
-                    headers[header_name] = header_value
+        headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
         logger.info(f"Proxying prompts/get '{name}' to gateway {gateway.id} at {gateway.url}")
         if meta:
@@ -983,13 +981,7 @@ async def _proxy_complete_to_gateway(  # pylint: disable=unused-argument
         CompleteResult from remote server, or None on failure
     """
     try:
-        headers = build_gateway_auth_headers(gateway)
-
-        if gateway.passthrough_headers and request_headers:
-            for header_name in gateway.passthrough_headers:
-                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
-                if header_value:
-                    headers[header_name] = header_value
+        headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
         logger.info(f"Proxying completion/complete to gateway {gateway.id} at {gateway.url}")
         if meta:
@@ -1038,11 +1030,10 @@ async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_
         List of content objects (TextResourceContents or BlobResourceContents) from remote server
     """
     try:
-        # Prepare headers with gateway auth
-        headers = build_gateway_auth_headers(gateway)
-
         # Get request headers
         request_headers = request_headers_var.get()
+
+        headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
         # Forward X-Context-Forge-Gateway-Id header
         gw_id = extract_gateway_id_from_headers(request_headers)
@@ -1832,7 +1823,6 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
 
     Returns:
         GetPromptResult: Object containing the prompt messages and description.
-        Returns an empty list on failure or if no prompt content is found.
 
     Raises:
         PermissionError: If the user context indicates insufficient permissions (e.g., missing "prompts.read" scope).
@@ -1902,13 +1892,13 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
                     if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                         if not await check_gateway_access(db, gateway, user_email, token_teams):
                             logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
-                            return []
+                            return types.GetPromptResult(messages=[], description=None)
 
                         logger.info(f"[GET PROMPT] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
                         result = await _proxy_get_prompt_to_gateway(gateway, request_headers, user_context, name=prompt_id, arguments=arguments, meta=meta_data)
                         if not result or not result.messages:
                             logger.warning(f"No content returned by upstream prompt: {prompt_id}")
-                            return []
+                            return types.GetPromptResult(messages=[], description=None)
                         message_dicts = [message.model_dump() for message in result.messages]
                         return types.GetPromptResult(messages=message_dicts, description=result.description)
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1610,7 +1610,7 @@ async def list_prompts() -> List[types.Prompt]:
         >>> sig.return_annotation
         typing.List[mcp.types.Prompt]
     """
-    server_id, _, user_context = await _get_request_context_or_default()
+    server_id, request_headers, user_context = await _get_request_context_or_default()
 
     # Token scope cap: deny early if scoped permissions exclude prompts.read
     if _should_enforce_streamable_rbac(user_context):
@@ -1643,6 +1643,33 @@ async def list_prompts() -> List[types.Prompt]:
     if server_id:
         try:
             async with get_db() as db:
+                gateway_id = extract_gateway_id_from_headers(request_headers)
+
+                if gateway_id:
+                    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+                    from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
+
+                    gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
+                    if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
+                        if not await check_gateway_access(db, gateway, user_email, token_teams):
+                            logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
+                            return []
+
+                        meta = None
+                        try:
+                            request_ctx = mcp_app.request_context
+                            meta = request_ctx.meta
+                            logger.info(f"[LIST PROMPTS] Using direct_proxy mode for server {server_id}, gateway {gateway.id}. Meta Attached: {meta is not None}")
+                        except (LookupError, AttributeError) as e:
+                            logger.debug(f"No request context available for _meta extraction: {e}")
+
+                        return await _proxy_list_prompts_to_gateway(gateway, request_headers, user_context, meta)
+
+                    if gateway:
+                        logger.debug(f"Gateway {gateway_id} found but not in direct_proxy mode (mode: {getattr(gateway, 'gateway_mode', 'cache')}), using cache mode")
+                    else:
+                        logger.warning(f"Gateway {gateway_id} specified in {GATEWAY_ID_HEADER} header not found")
+
                 prompts = await prompt_service.list_server_prompts(db, server_id, user_email=user_email, token_teams=token_teams)
                 return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
         except Exception as e:

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -50,7 +50,16 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.server.lowlevel import Server
 from mcp.server.streamable_http import EventCallback, EventId, EventMessage, EventStore, StreamId
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.types import JSONRPCMessage, PaginatedRequestParams, ReadResourceRequest, ReadResourceRequestParams
+from mcp.types import (
+    CompleteRequest,
+    CompleteRequestParams,
+    GetPromptRequest,
+    GetPromptRequestParams,
+    JSONRPCMessage,
+    PaginatedRequestParams,
+    ReadResourceRequest,
+    ReadResourceRequestParams,
+)
 import orjson
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -890,6 +899,59 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
     except Exception as e:
         logger.exception(f"Error proxying prompts/list to gateway {gateway.id}: {e}")
         return []
+
+
+async def _proxy_get_prompt_to_gateway(gateway: Any, request_headers: dict, user_context: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None) -> Optional[types.GetPromptResult]:  # pylint: disable=unused-argument
+    """Proxy prompts/get request directly to remote MCP gateway using MCP SDK.
+
+    Uses session.send_request() when _meta is present (ClientSession.get_prompt()
+    has no params argument), matching the pattern in _proxy_read_resource_to_gateway.
+
+    Args:
+        gateway: Gateway ORM instance
+        request_headers: Request headers from client
+        user_context: User context (not used - auth comes from gateway config)
+        name: Prompt name to retrieve
+        arguments: Optional argument substitutions
+        meta: Request metadata (_meta) from the original request
+
+    Returns:
+        GetPromptResult from remote server, or None on failure
+    """
+    try:
+        headers = build_gateway_auth_headers(gateway)
+
+        if gateway.passthrough_headers and request_headers:
+            for header_name in gateway.passthrough_headers:
+                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
+                if header_value:
+                    headers[header_name] = header_value
+
+        logger.info(f"Proxying prompts/get '{name}' to gateway {gateway.id} at {gateway.url}")
+        if meta:
+            logger.debug(f"Forwarding _meta to remote gateway: {meta}")
+
+        async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                if meta:
+                    # ClientSession.get_prompt() has no params arg, use send_request to forward _meta
+                    params_dict = GetPromptRequestParams(name=name, arguments=arguments).model_dump()
+                    params_dict["_meta"] = meta
+                    result = await session.send_request(
+                        types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(params_dict))),
+                        types.GetPromptResult,
+                    )
+                else:
+                    result = await session.get_prompt(name, arguments=arguments)
+
+                logger.info(f"Received prompt '{name}' from gateway {gateway.id}")
+                return result
+
+    except Exception as e:
+        logger.exception(f"Error proxying prompts/get '{name}' to gateway {gateway.id}: {e}")
+        return None
 
 
 async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_context: dict, meta: Optional[Any] = None) -> List[Any]:  # pylint: disable=unused-argument

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -478,6 +478,7 @@ def get_user_email_from_context() -> str:
         return user.get("email") or user.get("sub") or "unknown"
     return str(user) if user else "unknown"
 
+
 async def update_headers_with_passthrough_headers(gateway: Any, request_headers: dict) -> dict:
     """
     Build headers for forwarding to remote gateway, including auth headers and passthrough headers.
@@ -487,7 +488,7 @@ async def update_headers_with_passthrough_headers(gateway: Any, request_headers:
         request_headers: Original request headers from the client
 
     Returns:
-        Dictionary of headers to include in the proxied request to the remote gateway    
+        Dictionary of headers to include in the proxied request to the remote gateway
     """
 
     headers = build_gateway_auth_headers(gateway)
@@ -906,7 +907,7 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
 
 
 async def _proxy_get_prompt_to_gateway(
-    gateway: Any, request_headers: dict, user_context: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
+    gateway: Any, request_headers: dict, name: str, arguments: dict[str, str] | None = None, meta: Optional[Any] = None
 ) -> Optional[types.GetPromptResult]:  # pylint: disable=unused-argument
     """Proxy prompts/get request directly to remote MCP gateway using MCP SDK.
 
@@ -916,7 +917,6 @@ async def _proxy_get_prompt_to_gateway(
     Args:
         gateway: Gateway ORM instance
         request_headers: Request headers from client
-        user_context: User context (not used - auth comes from gateway config)
         name: Prompt name to retrieve
         arguments: Optional argument substitutions
         meta: Request metadata (_meta) from the original request

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -884,9 +884,9 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
     try:
         headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
-        logger.info(f"Proxying prompts/list to gateway {gateway.id} at {gateway.url}")
+        logger.info("Proxying prompts/list to gateway %s at %s", gateway.id, gateway.url)
         if meta:
-            logger.debug(f"Forwarding _meta to remote gateway: {meta}")
+            logger.debug("Forwarding _meta to remote gateway: %s", meta)
 
         async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
             async with ClientSession(read_stream, write_stream) as session:
@@ -897,11 +897,11 @@ async def _proxy_list_prompts_to_gateway(gateway: Any, request_headers: dict, us
                     params = PaginatedRequestParams(_meta=meta)
 
                 result = await session.list_prompts(params=params)
-                logger.info(f"Received {len(result.prompts)} prompts from gateway {gateway.id}")
+                logger.info("Received %d prompts from gateway %s", len(result.prompts), gateway.id)
                 return result.prompts
 
     except Exception as e:
-        logger.exception(f"Error proxying prompts/list to gateway {gateway.id}: {e}")
+        logger.exception("Error proxying prompts/list to gateway %s: %s", gateway.id, e)
         return []
 
 
@@ -926,9 +926,9 @@ async def _proxy_get_prompt_to_gateway(
     try:
         headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
-        logger.info(f"Proxying prompts/get '{name}' to gateway {gateway.id} at {gateway.url}")
+        logger.info("Proxying prompts/get '%s' to gateway %s at %s", name, gateway.id, gateway.url)
         if meta:
-            logger.debug(f"Forwarding _meta to remote gateway: {meta}")
+            logger.debug("Forwarding _meta to remote gateway: %s", meta)
 
         async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
             async with ClientSession(read_stream, write_stream) as session:
@@ -945,11 +945,11 @@ async def _proxy_get_prompt_to_gateway(
                 else:
                     result = await session.get_prompt(name, arguments=arguments)
 
-                logger.info(f"Received prompt '{name}' from gateway {gateway.id}")
+                logger.info("Received prompt '%s' from gateway %s", name, gateway.id)
                 return result
 
     except Exception as e:
-        logger.exception(f"Error proxying prompts/get '{name}' to gateway {gateway.id}: {e}")
+        logger.exception("Error proxying prompts/get '%s' to gateway %s: %s", name, gateway.id, e)
         return None
 
 
@@ -982,9 +982,9 @@ async def _proxy_complete_to_gateway(  # pylint: disable=unused-argument
     try:
         headers = await update_headers_with_passthrough_headers(gateway=gateway, request_headers=request_headers)
 
-        logger.info(f"Proxying completion/complete to gateway {gateway.id} at {gateway.url}")
+        logger.info("Proxying completion/complete to gateway %s at %s", gateway.id, gateway.url)
         if meta:
-            logger.debug(f"Forwarding _meta to remote gateway: {meta}")
+            logger.debug("Forwarding _meta to remote gateway: %s", meta)
 
         async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
             async with ClientSession(read_stream, write_stream) as session:
@@ -1008,11 +1008,11 @@ async def _proxy_complete_to_gateway(  # pylint: disable=unused-argument
                         context_arguments=context_args,
                     )
 
-                logger.info(f"Received completion result from gateway {gateway.id}")
+                logger.info("Received completion result from gateway %s", gateway.id)
                 return result
 
     except Exception as e:
-        logger.exception(f"Error proxying completion/complete to gateway {gateway.id}: {e}")
+        logger.exception("Error proxying completion/complete to gateway %s: %s", gateway.id, e)
         return None
 
 
@@ -1038,13 +1038,6 @@ async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_
         gw_id = extract_gateway_id_from_headers(request_headers)
         if gw_id:
             headers[GATEWAY_ID_HEADER] = gw_id
-
-        # Forward passthrough headers if configured
-        if gateway.passthrough_headers and request_headers:
-            for header_name in gateway.passthrough_headers:
-                header_value = request_headers.get(header_name.lower()) or request_headers.get(header_name)
-                if header_value:
-                    headers[header_name] = header_value
 
         logger.info("Proxying resources/read for %s to gateway %s at %s", resource_uri, gateway.id, gateway.url)
         if meta:
@@ -1778,23 +1771,23 @@ async def list_prompts() -> List[types.Prompt]:
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
                     if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                         if not await check_gateway_access(db, gateway, user_email, token_teams):
-                            logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
+                            logger.warning("Access denied to gateway %s in direct_proxy mode for user %s", gateway_id, user_email)
                             return []
 
                         meta = None
                         try:
                             request_ctx = mcp_app.request_context
                             meta = request_ctx.meta
-                            logger.info(f"[LIST PROMPTS] Using direct_proxy mode for server {server_id}, gateway {gateway.id}. Meta Attached: {meta is not None}")
+                            logger.info("[LIST PROMPTS] Using direct_proxy mode for server %s, gateway %s. Meta Attached: %s", server_id, gateway.id, meta is not None)
                         except (LookupError, AttributeError) as e:
-                            logger.debug(f"No request context available for _meta extraction: {e}")
+                            logger.debug("No request context available for _meta extraction: %s", e)
 
                         return await _proxy_list_prompts_to_gateway(gateway, request_headers, user_context, meta)
 
                     if gateway:
-                        logger.debug(f"Gateway {gateway_id} found but not in direct_proxy mode (mode: {getattr(gateway, 'gateway_mode', 'cache')}), using cache mode")
+                        logger.debug("Gateway %s found but not in direct_proxy mode (mode: %s), using cache mode", gateway_id, getattr(gateway, "gateway_mode", "cache"))
                     else:
-                        logger.warning(f"Gateway {gateway_id} specified in {GATEWAY_ID_HEADER} header not found")
+                        logger.warning("Gateway %s specified in %s header not found", gateway_id, GATEWAY_ID_HEADER)
 
                 prompts = await prompt_service.list_server_prompts(db, server_id, user_email=user_email, token_teams=token_teams)
                 return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
@@ -1890,21 +1883,21 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
                     if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                         if not await check_gateway_access(db, gateway, user_email, token_teams):
-                            logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
+                            logger.warning("Access denied to gateway %s in direct_proxy mode for user %s", gateway_id, user_email)
                             return types.GetPromptResult(messages=[], description=None)
 
-                        logger.info(f"[GET PROMPT] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
+                        logger.info("[GET PROMPT] Using direct_proxy mode for server %s, gateway %s", server_id, gateway.id)
                         result = await _proxy_get_prompt_to_gateway(gateway, request_headers, prompt_id, arguments, meta_data)
                         if not result or not result.messages:
-                            logger.warning(f"No content returned by upstream prompt: {prompt_id}")
+                            logger.warning("No content returned by upstream prompt: %s", prompt_id)
                             return types.GetPromptResult(messages=[], description=None)
                         message_dicts = [message.model_dump() for message in result.messages]
                         return types.GetPromptResult(messages=message_dicts, description=result.description)
 
                     if gateway:
-                        logger.debug(f"Gateway {gateway_id} found but not in direct_proxy mode (mode: {getattr(gateway, 'gateway_mode', 'cache')}), using cache mode")
+                        logger.debug("Gateway %s found but not in direct_proxy mode (mode: %s), using cache mode", gateway_id, getattr(gateway, "gateway_mode", "cache"))
                     else:
-                        logger.warning(f"Gateway {gateway_id} specified in {GATEWAY_ID_HEADER} header not found")
+                        logger.warning("Gateway %s specified in %s header not found", gateway_id, GATEWAY_ID_HEADER)
 
             try:
                 result = await prompt_service.get_prompt(
@@ -1918,15 +1911,15 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
                 )
             except Exception as e:
                 logger.exception("Error getting prompt '%s': %s", prompt_id, e)
-                return []
+                return types.GetPromptResult(messages=[], description=None)
             if not result or not result.messages:
                 logger.warning("No content returned by prompt: %s", prompt_id)
-                return []
+                return types.GetPromptResult(messages=[], description=None)
             message_dicts = [message.model_dump() for message in result.messages]
             return types.GetPromptResult(messages=message_dicts, description=result.description)
     except Exception as e:
         logger.exception("Error getting prompt '%s': %s", prompt_id, e)
-        return []
+        return types.GetPromptResult(messages=[], description=None)
 
 
 @mcp_app.list_resources()
@@ -2390,14 +2383,11 @@ async def complete(
 
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
                     if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
-                        user_email = user_context.get("email") if user_context else None
-                        token_teams = user_context.get("teams") if user_context else None
-
                         if not await check_gateway_access(db, gateway, user_email, token_teams):
-                            logger.warning(f"Access denied to gateway {gateway_id} in direct_proxy mode for user {user_email}")
+                            logger.warning("Access denied to gateway %s in direct_proxy mode for user %s", gateway_id, user_email)
                             return types.Completion(values=[], total=0, hasMore=False)
 
-                        logger.info(f"[COMPLETE] Using direct_proxy mode for server {server_id}, gateway {gateway.id}")
+                        logger.info("[COMPLETE] Using direct_proxy mode for server %s, gateway %s", server_id, gateway.id)
                         result = await _proxy_complete_to_gateway(
                             gateway,
                             request_headers,
@@ -2417,9 +2407,9 @@ async def complete(
                         return result
 
                     if gateway:
-                        logger.debug(f"Gateway {gateway_id} not in direct_proxy mode, using cache")
+                        logger.debug("Gateway %s not in direct_proxy mode, using cache", gateway_id)
                     else:
-                        logger.warning(f"Gateway {gateway_id} not found")
+                        logger.warning("Gateway %s not found", gateway_id)
 
             params = {
                 "ref": ref.model_dump() if hasattr(ref, "model_dump") else ref,

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -4257,6 +4257,95 @@ async def test_complete_exception(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# complete direct_proxy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_direct_proxy_delegates_to_helper(monkeypatch):
+    """complete() delegates to _proxy_complete_to_gateway in direct_proxy mode."""
+    from mcpgateway.transports.streamablehttp_transport import complete, mcp_app
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    mock_completion = types.Completion(values=["python"], total=1, hasMore=False)
+    mock_proxy_result = types.CompleteResult(completion=mock_completion)
+
+    proxy_mock = AsyncMock(return_value=mock_proxy_result)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_complete_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                        AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False})))
+
+    mock_meta = MagicMock()
+    mock_meta.model_dump.return_value = {"progressToken": "tok-1"}
+    mock_ctx = MagicMock()
+    mock_ctx.meta = mock_meta
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    ref = types.PromptReference(type="ref/prompt", name="my-prompt")
+    argument = types.CompleteRequest(params=types.CompleteRequestParams(ref=ref, argument=types.CompletionArgument(name="language", value="py")))
+
+    result = await complete(ref, argument, context=None)
+
+    assert result is not None
+    proxy_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_complete_direct_proxy_access_denied(monkeypatch):
+    """complete() returns empty Completion when direct_proxy RBAC check fails."""
+    from mcpgateway.transports.streamablehttp_transport import complete, mcp_app
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-deny"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-deny")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                        AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": [], "is_admin": False})))
+    type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    ref = types.PromptReference(type="ref/prompt", name="p")
+    argument = types.CompleteRequest(params=types.CompleteRequestParams(ref=ref, argument=types.CompletionArgument(name="a", value="v")))
+
+    result = await complete(ref, argument, context=None)
+    assert result.values == []
+
+
+# ---------------------------------------------------------------------------
 # _proxy_complete_to_gateway tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -776,6 +776,118 @@ async def test_list_prompts_direct_proxy_access_denied(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _proxy_get_prompt_to_gateway tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_prompt_returns_result(monkeypatch):
+    """_proxy_get_prompt_to_gateway fetches prompt from upstream."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_get_prompt_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_message = types.PromptMessage(role="user", content=types.TextContent(type="text", text="Hello"))
+    mock_result = types.GetPromptResult(description="A prompt", messages=[mock_message])
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.get_prompt = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-gp"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self): return mock_session
+        async def __aexit__(self, *a): pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, {}, name="my-prompt", arguments={"lang": "en"}, meta=None)
+
+    assert result is not None
+    assert result.description == "A prompt"
+    mock_session.get_prompt.assert_called_once_with("my-prompt", arguments={"lang": "en"})
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_prompt_forwards_meta_via_send_request(monkeypatch):
+    """_proxy_get_prompt_to_gateway uses send_request when _meta is present."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_get_prompt_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_message = types.PromptMessage(role="user", content=types.TextContent(type="text", text="Hi"))
+    mock_result = types.GetPromptResult(description="d", messages=[mock_message])
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.get_prompt = AsyncMock()
+    mock_session.send_request = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-gp-meta"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self): return mock_session
+        async def __aexit__(self, *a): pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    meta = {"progressToken": "tok-42"}
+    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, {}, name="meta-prompt", arguments=None, meta=meta)
+
+    assert result is not None
+    mock_session.send_request.assert_called_once()
+    mock_session.get_prompt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_prompt_exception_returns_none(monkeypatch):
+    """_proxy_get_prompt_to_gateway returns None on exception."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_get_prompt_to_gateway
+    from contextlib import asynccontextmanager
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-err"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        raise RuntimeError("upstream down")
+        yield
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+
+    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, {}, name="p", arguments=None)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # get_prompt tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -698,6 +698,84 @@ async def test_list_prompts_exception_no_server_id(monkeypatch, caplog):
 
 
 # ---------------------------------------------------------------------------
+# list_prompts direct_proxy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_direct_proxy_delegates_to_helper(monkeypatch):
+    """list_prompts calls _proxy_list_prompts_to_gateway in direct_proxy mode."""
+    from mcpgateway.transports.streamablehttp_transport import list_prompts, mcp_app
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    mock_meta = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.meta = mock_meta
+
+    mock_prompt = types.Prompt(name="upstream-p", description="d", arguments=[])
+    proxy_mock = AsyncMock(return_value=[mock_prompt])
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_list_prompts_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                        AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False})))
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    result = await list_prompts()
+    assert len(result) == 1
+    assert result[0].name == "upstream-p"
+    proxy_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_direct_proxy_access_denied(monkeypatch):
+    """list_prompts returns [] when direct_proxy RBAC check fails."""
+    from mcpgateway.transports.streamablehttp_transport import list_prompts
+    from contextlib import asynccontextmanager
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-deny"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-deny")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                        AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": [], "is_admin": False})))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    result = await list_prompts()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
 # get_prompt tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -813,7 +813,7 @@ async def test_proxy_get_prompt_returns_result(monkeypatch):
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
 
-    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, {}, name="my-prompt", arguments={"lang": "en"}, meta=None)
+    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, "my-prompt", {"lang": "en"}, None)
 
     assert result is not None
     assert result.description == "A prompt"
@@ -855,7 +855,7 @@ async def test_proxy_get_prompt_forwards_meta_via_send_request(monkeypatch):
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
 
     meta = {"progressToken": "tok-42"}
-    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, {}, name="meta-prompt", arguments=None, meta=meta)
+    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, "meta-prompt", None, meta)
 
     assert result is not None
     mock_session.send_request.assert_called_once()
@@ -883,7 +883,7 @@ async def test_proxy_get_prompt_exception_returns_none(monkeypatch):
 
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
 
-    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, {}, name="p", arguments=None)
+    result = await _proxy_get_prompt_to_gateway(mock_gateway, {}, "p", None, None)
     assert result is None
 
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -1011,6 +1011,87 @@ async def test_get_prompt_outer_exception(monkeypatch, caplog):
 
 
 # ---------------------------------------------------------------------------
+# get_prompt direct_proxy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_direct_proxy_delegates_to_helper(monkeypatch):
+    """get_prompt calls _proxy_get_prompt_to_gateway in direct_proxy mode."""
+    from mcpgateway.transports.streamablehttp_transport import get_prompt, mcp_app
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    mock_message = types.PromptMessage(role="user", content=types.TextContent(type="text", text="hi"))
+    mock_proxy_result = types.GetPromptResult(description="d", messages=[mock_message])
+
+    proxy_mock = AsyncMock(return_value=mock_proxy_result)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_get_prompt_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                        AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False})))
+    type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    result = await get_prompt("my-prompt", {"lang": "en"})
+
+    assert result is not None
+    assert len(result.messages) == 1
+    proxy_mock.assert_called_once()
+    call_kwargs = proxy_mock.call_args[1]
+    assert call_kwargs["name"] == "my-prompt"
+    assert call_kwargs["arguments"] == {"lang": "en"}
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_direct_proxy_access_denied(monkeypatch):
+    """get_prompt returns [] when direct_proxy RBAC check fails."""
+    from mcpgateway.transports.streamablehttp_transport import get_prompt, mcp_app
+    from contextlib import asynccontextmanager
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-deny"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-deny")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                        AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": [], "is_admin": False})))
+    type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    result = await get_prompt("denied-prompt", None)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
 # list_resources tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -940,8 +940,11 @@ async def test_get_prompt_no_content(monkeypatch, caplog):
     monkeypatch.setattr(prompt_service, "get_prompt", AsyncMock(return_value=mock_result))
 
     with caplog.at_level("WARNING"):
+        import mcp.types as mcp_types
+
         result = await get_prompt("empty_prompt")
-        assert result == []
+        assert isinstance(result, mcp_types.GetPromptResult)
+        assert result.messages == []
         assert "No content returned by prompt: empty_prompt" in caplog.text
 
 
@@ -961,16 +964,20 @@ async def test_get_prompt_no_result(monkeypatch, caplog):
     monkeypatch.setattr(prompt_service, "get_prompt", AsyncMock(return_value=None))
 
     with caplog.at_level("WARNING"):
+        import mcp.types as mcp_types
+
         result = await get_prompt("missing_prompt")
-        assert result == []
+        assert isinstance(result, mcp_types.GetPromptResult)
+        assert result.messages == []
         assert "No content returned by prompt: missing_prompt" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_get_prompt_service_exception(monkeypatch, caplog):
-    """Test get_prompt returns [] and logs exception from service."""
+    """Test get_prompt returns GetPromptResult with empty messages and logs exception from service."""
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import get_prompt, prompt_service
+    import mcp.types as mcp_types
 
     mock_db = MagicMock()
 
@@ -983,18 +990,20 @@ async def test_get_prompt_service_exception(monkeypatch, caplog):
 
     with caplog.at_level("ERROR"):
         result = await get_prompt("error_prompt")
-        assert result == []
+        assert isinstance(result, mcp_types.GetPromptResult)
+        assert result.messages == []
         assert "Error getting prompt 'error_prompt': service error!" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_get_prompt_outer_exception(monkeypatch, caplog):
-    """Test get_prompt returns [] and logs exception from outer try-catch."""
+    """Test get_prompt returns GetPromptResult with empty messages and logs exception from outer try-catch."""
     # Standard
     from contextlib import asynccontextmanager
 
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import get_prompt
+    import mcp.types as mcp_types
 
     # Cause an exception during get_db context management
     @asynccontextmanager
@@ -1006,7 +1015,8 @@ async def test_get_prompt_outer_exception(monkeypatch, caplog):
 
     with caplog.at_level("ERROR"):
         result = await get_prompt("db_error_prompt")
-        assert result == []
+        assert isinstance(result, mcp_types.GetPromptResult)
+        assert result.messages == []
         assert "Error getting prompt 'db_error_prompt': db error!" in caplog.text
 
 
@@ -11961,6 +11971,8 @@ async def test_list_prompts_gateway_not_direct_proxy_mode(monkeypatch):
     result = await list_prompts()
     assert len(result) == 1
     assert result[0].name == "cached-prompt"
+
+
 @pytest.mark.asyncio
 async def test_get_prompt_gateway_not_direct_proxy_mode(monkeypatch):
     """get_prompt falls through to cache mode when gateway exists but not in direct_proxy mode."""
@@ -12154,8 +12166,6 @@ async def test_get_prompt_direct_proxy_empty_result(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 # Completion passthrough headers test
 # ---------------------------------------------------------------------------
-# Completion passthrough headers test
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -12336,3 +12346,87 @@ async def test_complete_direct_proxy_result_is_completion_type(monkeypatch):
     assert isinstance(result, types.Completion)
     assert result.values == ["m", "n"]
     assert result.hasMore is True
+
+
+# ---------------------------------------------------------------------------
+# Complete gateway-not-found and fallthrough-to-cache tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_gateway_not_found(monkeypatch, caplog):
+    """complete logs warning when gateway is not found."""
+    from mcpgateway.transports.streamablehttp_transport import complete
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "nonexistent-gw")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = None
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    completion_result = {"completion": {"values": [], "total": 0, "hasMore": False}}
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.completion_service.handle_completion", AsyncMock(return_value=completion_result))
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    mock_ref = MagicMock()
+    mock_arg = MagicMock()
+
+    with caplog.at_level("WARNING"):
+        result = await complete(mock_ref, mock_arg, None)
+        assert "not found" in caplog.text
+
+    assert isinstance(result, types.Completion)
+
+
+@pytest.mark.asyncio
+async def test_complete_gateway_not_direct_proxy_mode(monkeypatch):
+    """complete falls through to cache mode when gateway exists but not in direct_proxy mode."""
+    from mcpgateway.transports.streamablehttp_transport import complete
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-cache"
+    mock_gateway.gateway_mode = "cache"
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-cache")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    completion_result = {"completion": {"values": ["cached"], "total": 1, "hasMore": False}}
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.completion_service.handle_completion", AsyncMock(return_value=completion_result))
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    mock_ref = MagicMock()
+    mock_arg = MagicMock()
+
+    result = await complete(mock_ref, mock_arg, None)
+
+    assert isinstance(result, types.Completion)
+    assert result.values == ["cached"]

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -1054,9 +1054,9 @@ async def test_get_prompt_direct_proxy_delegates_to_helper(monkeypatch):
     assert result is not None
     assert len(result.messages) == 1
     proxy_mock.assert_called_once()
-    call_kwargs = proxy_mock.call_args[1]
-    assert call_kwargs["name"] == "my-prompt"
-    assert call_kwargs["arguments"] == {"lang": "en"}
+    call_args = proxy_mock.call_args.args
+    assert call_args[2] == "my-prompt"
+    assert call_args[3] == {"lang": "en"}
 
 
 @pytest.mark.asyncio
@@ -1088,7 +1088,7 @@ async def test_get_prompt_direct_proxy_access_denied(monkeypatch):
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
 
     result = await get_prompt("denied-prompt", None)
-    assert result == []
+    assert result.messages == []
 
 
 # ---------------------------------------------------------------------------
@@ -11921,3 +11921,418 @@ async def test_session_manager_wrapper_rbac_gate_denies_missing_servers_use(monk
     assert sent[0]["status"] == 403
     body = json.loads(sent[1]["body"])
     assert body["detail"] == "Access denied"
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_gateway_not_direct_proxy_mode(monkeypatch):
+    """list_prompts falls through to cache mode when gateway exists but not in direct_proxy mode."""
+    from mcpgateway.transports.streamablehttp_transport import list_prompts
+    from contextlib import asynccontextmanager
+    from mcpgateway.transports.streamablehttp_transport import prompt_service
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-cache"
+    mock_gateway.gateway_mode = "cache"
+
+    mock_prompt = MagicMock()
+    mock_prompt.name = "cached-prompt"
+    mock_prompt.description = "desc"
+    mock_prompt.arguments = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-cache")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.prompt_service.list_server_prompts", AsyncMock(return_value=[mock_prompt]))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    result = await list_prompts()
+    assert len(result) == 1
+    assert result[0].name == "cached-prompt"
+@pytest.mark.asyncio
+async def test_get_prompt_gateway_not_direct_proxy_mode(monkeypatch):
+    """get_prompt falls through to cache mode when gateway exists but not in direct_proxy mode."""
+    from mcpgateway.transports.streamablehttp_transport import get_prompt
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-cache"
+    mock_gateway.gateway_mode = "cache"
+
+    mock_message = types.PromptMessage(role="user", content=types.TextContent(type="text", text="Hello"))
+    mock_result = types.GetPromptResult(description="A prompt", messages=[mock_message])
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-cache")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.prompt_service.get_prompt", AsyncMock(return_value=mock_result))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    result = await get_prompt("test-prompt", None)
+    assert result is not None
+    assert result.description == "A prompt"
+
+
+# ---------------------------------------------------------------------------
+# Gateway not found tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_gateway_not_found(monkeypatch, caplog):
+    """list_prompts logs warning when gateway is not found."""
+    from mcpgateway.transports.streamablehttp_transport import list_prompts
+    from contextlib import asynccontextmanager
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "nonexistent-gw")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = None
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    with caplog.at_level("WARNING"):
+        result = await list_prompts()
+        assert "not found" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_gateway_not_found(monkeypatch, caplog):
+    """get_prompt logs warning when gateway is not found."""
+    from mcpgateway.transports.streamablehttp_transport import get_prompt
+    from contextlib import asynccontextmanager
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "nonexistent-gw")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = None
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    with caplog.at_level("WARNING"):
+        result = await get_prompt("test-prompt", None)
+        assert "not found" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Request context lookup error tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_no_request_context_for_meta(monkeypatch, caplog):
+    """list_prompts handles LookupError when extracting _meta from request context."""
+    from mcpgateway.transports.streamablehttp_transport import list_prompts, mcp_app
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    mock_prompt = types.Prompt(name="upstream-p", description="d", arguments=[])
+    proxy_mock = AsyncMock(return_value=[mock_prompt])
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_list_prompts_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+    type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError("no context")))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    with caplog.at_level("DEBUG"):
+        result = await list_prompts()
+        assert len(result) == 1
+        assert result[0].name == "upstream-p"
+        proxy_mock.assert_called_once()
+        call_kwargs = proxy_mock.call_args[1]
+        assert call_kwargs.get("meta") is None
+
+
+# ---------------------------------------------------------------------------
+# Upstream prompt empty result tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_direct_proxy_empty_result(monkeypatch, caplog):
+    """get_prompt returns [] when proxy returns empty result."""
+    from mcpgateway.transports.streamablehttp_transport import get_prompt, mcp_app
+    from contextlib import asynccontextmanager
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    proxy_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_get_prompt_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+    type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    with caplog.at_level("WARNING"):
+        result = await get_prompt("empty-prompt", None)
+        assert result.messages == []
+        assert "No content returned by upstream prompt" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Completion passthrough headers test
+# ---------------------------------------------------------------------------
+# Completion passthrough headers test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_complete_passthrough_headers(monkeypatch):
+    """_proxy_complete_to_gateway passes through headers from request_headers."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_complete_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_result = types.Completion(values=["opt1", "opt2"], total=2, hasMore=False)
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.complete = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-comp"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = ["x-forwarded-for", "x-request-id"]
+
+    captured_headers = {}
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self):
+            return mock_session
+
+        async def __aexit__(self, *a):
+            pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        captured_headers.update(headers)
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    request_headers = {"x-forwarded-for": "192.168.1.1", "x-request-id": "req-123"}
+    mock_ref = MagicMock()
+    mock_arg = MagicMock()
+
+    result = await _proxy_complete_to_gateway(mock_gateway, request_headers, {}, ref=mock_ref, argument=mock_arg, context=None, meta=None)
+
+    assert result is not None
+    assert captured_headers.get("x-forwarded-for") == "192.168.1.1"
+    assert captured_headers.get("x-request-id") == "req-123"
+
+
+# ---------------------------------------------------------------------------
+# Completion result type handling tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_direct_proxy_result_is_dict(monkeypatch):
+    """complete returns normalized result when proxy returns a dict."""
+    from mcpgateway.transports.streamablehttp_transport import complete
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    mock_result = {"values": ["a", "b"], "total": 2, "hasMore": False}
+    proxy_mock = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_complete_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    mock_ref = MagicMock()
+    mock_arg = MagicMock()
+
+    result = await complete(mock_ref, mock_arg, None)
+
+    assert isinstance(result, types.Completion)
+    assert result.values == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_complete_direct_proxy_result_has_completion_attr(monkeypatch):
+    """complete returns normalized result when proxy returns object with completion attr."""
+    from mcpgateway.transports.streamablehttp_transport import complete
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    inner_completion = types.Completion(values=["x", "y"], total=2, hasMore=False)
+    mock_result = MagicMock()
+    mock_result.completion = inner_completion
+    proxy_mock = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_complete_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    mock_ref = MagicMock()
+    mock_arg = MagicMock()
+
+    result = await complete(mock_ref, mock_arg, None)
+
+    assert isinstance(result, types.Completion)
+    assert result.values == ["x", "y"]
+
+
+@pytest.mark.asyncio
+async def test_complete_direct_proxy_result_is_completion_type(monkeypatch):
+    """complete returns result directly when proxy returns types.Completion."""
+    from mcpgateway.transports.streamablehttp_transport import complete
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-dp"
+    mock_gateway.gateway_mode = "direct_proxy"
+
+    mock_result = types.Completion(values=["m", "n"], total=2, hasMore=True)
+    proxy_mock = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._proxy_complete_to_gateway", proxy_mock)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_enabled=True))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers", lambda h: "gw-dp")
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default", AsyncMock(return_value=("srv-1", {}, {"email": "u@x.com", "teams": ["t1"], "is_admin": False}))
+    )
+
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = mock_gateway
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=mock_db_result)
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+
+    mock_ref = MagicMock()
+    mock_arg = MagicMock()
+
+    result = await complete(mock_ref, mock_arg, None)
+
+    assert isinstance(result, types.Completion)
+    assert result.values == ["m", "n"]
+    assert result.hasMore is True

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -4257,6 +4257,127 @@ async def test_complete_exception(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _proxy_complete_to_gateway tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_complete_returns_result(monkeypatch):
+    """_proxy_complete_to_gateway fetches completions from upstream."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_complete_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_completion = types.Completion(values=["python", "pytorch"], total=2, hasMore=False)
+    mock_result = types.CompleteResult(completion=mock_completion)
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.complete = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-cmp"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self): return mock_session
+        async def __aexit__(self, *a): pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    ref = types.PromptReference(type="ref/prompt", name="my-prompt")
+    argument = types.CompletionArgument(name="language", value="py")
+
+    result = await _proxy_complete_to_gateway(mock_gateway, {}, {}, ref=ref, argument=argument, context=None, meta=None)
+
+    assert result is not None
+    mock_session.complete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_proxy_complete_forwards_meta_via_send_request(monkeypatch):
+    """_proxy_complete_to_gateway uses send_request when _meta is present."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_complete_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_completion = types.Completion(values=["x"], total=1, hasMore=False)
+    mock_result = types.CompleteResult(completion=mock_completion)
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.complete = AsyncMock()
+    mock_session.send_request = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-cmp-meta"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self): return mock_session
+        async def __aexit__(self, *a): pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    ref = types.PromptReference(type="ref/prompt", name="my-prompt")
+    argument = types.CompletionArgument(name="language", value="py")
+    meta = {"progressToken": "tok-99"}
+
+    result = await _proxy_complete_to_gateway(mock_gateway, {}, {}, ref=ref, argument=argument, context=None, meta=meta)
+
+    assert result is not None
+    mock_session.send_request.assert_called_once()
+    mock_session.complete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_proxy_complete_exception_returns_none(monkeypatch):
+    """_proxy_complete_to_gateway returns None on exception."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_complete_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-err"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        raise RuntimeError("upstream down")
+        yield
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+
+    ref = types.PromptReference(type="ref/prompt", name="p")
+    argument = types.CompletionArgument(name="a", value="v")
+
+    result = await _proxy_complete_to_gateway(mock_gateway, {}, {}, ref=ref, argument=argument, context=None)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # _get_oauth_experimental_config (Lines 1740-1750)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -474,6 +474,116 @@ async def test_list_tools_exception_with_server_id(monkeypatch, caplog):
 
 
 # ---------------------------------------------------------------------------
+# _proxy_list_prompts_to_gateway tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_list_prompts_forwards_meta(monkeypatch):
+    """_proxy_list_prompts_to_gateway passes _meta via PaginatedRequestParams."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_list_prompts_to_gateway
+    from contextlib import asynccontextmanager
+    import mcp.types as types
+
+    mock_prompt = types.Prompt(name="p1", description="desc", arguments=[])
+    mock_result = MagicMock()
+    mock_result.prompts = [mock_prompt]
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.list_prompts = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-1"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self): return mock_session
+        async def __aexit__(self, *a): pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    from mcp.types import RequestParams
+    meta = RequestParams.Meta(progressToken="tok-1")
+    result = await _proxy_list_prompts_to_gateway(mock_gateway, {}, {}, meta=meta)
+
+    assert len(result) == 1
+    assert result[0].name == "p1"
+    call_kwargs = mock_session.list_prompts.call_args[1]
+    assert call_kwargs["params"] is not None
+
+
+@pytest.mark.asyncio
+async def test_proxy_list_prompts_no_meta(monkeypatch):
+    """_proxy_list_prompts_to_gateway passes params=None when no meta."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_list_prompts_to_gateway
+    from contextlib import asynccontextmanager
+
+    mock_result = MagicMock()
+    mock_result.prompts = []
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.list_prompts = AsyncMock(return_value=mock_result)
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-2"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    class FakeSession:
+        async def __aenter__(self): return mock_session
+        async def __aexit__(self, *a): pass
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        yield (MagicMock(), MagicMock(), MagicMock())
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.ClientSession", lambda r, w: FakeSession())
+
+    result = await _proxy_list_prompts_to_gateway(mock_gateway, {}, {}, meta=None)
+    assert result == []
+    mock_session.list_prompts.assert_called_once_with(params=None)
+
+
+@pytest.mark.asyncio
+async def test_proxy_list_prompts_exception_returns_empty(monkeypatch):
+    """_proxy_list_prompts_to_gateway returns [] on exception."""
+    from mcpgateway.transports.streamablehttp_transport import _proxy_list_prompts_to_gateway
+    from contextlib import asynccontextmanager
+
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-err"
+    mock_gateway.url = "http://upstream"
+    mock_gateway.passthrough_headers = []
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.build_gateway_auth_headers", lambda g: {})
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings", MagicMock(mcpgateway_direct_proxy_timeout=30))
+
+    @asynccontextmanager
+    async def fake_client(url, headers, timeout):
+        raise RuntimeError("upstream down")
+        yield
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.streamablehttp_client", fake_client)
+
+    result = await _proxy_list_prompts_to_gateway(mock_gateway, {}, {})
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
 # list_prompts tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> **Note:** This PR was re-created from #3041 due to repository maintenance. Your code and branch are intact. @madhav165 please verify everything looks good.

# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #2332

---

## 🚀 Summary (1-2 sentences)
Completes `direct_proxy` gateway mode support for `prompts/list`, `prompts/get`, and `completion/complete` in the streamable HTTP transport, closing the feature gap that existed relative to tools and resources. `_meta` (carrying `progressToken`) is forwarded to upstream MCP servers via `PaginatedRequestParams` where the SDK exposes a `params` arg, and via raw `session.send_request()` where it does not.

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes

---

## 📓 Notes (optional)

### What changed

Three new proxy helpers added to `mcpgateway/transports/streamablehttp_transport.py`, each following the same pattern already established for tools and resources:

| Helper | Method | `_meta` forwarding |
|--------|--------|--------------------|
| `_proxy_list_prompts_to_gateway` | `prompts/list` | `PaginatedRequestParams(_meta=meta)` |
| `_proxy_get_prompt_to_gateway` | `prompts/get` | `session.send_request(GetPromptRequest(...))` |
| `_proxy_complete_to_gateway` | `completion/complete` | `session.send_request(CompleteRequest(...))` |

The `list_prompts`, `get_prompt`, and `complete` handlers each received a direct_proxy path that: extracts `X-Context-Forge-Gateway-Id` from request headers → looks up the gateway → checks `gateway_mode == "direct_proxy"` → enforces RBAC via `check_gateway_access` → delegates to the proxy helper. Falls through to cache mode when no matching direct_proxy gateway is found.

`ClientSession.get_prompt()` and `ClientSession.complete()` have no `params` argument in the MCP Python SDK, so `_meta` is injected via `send_request()` — the same pattern already used by `_proxy_read_resource_to_gateway`.

**Out of scope:** SSE, WebSocket, and stdio transports have no direct_proxy infrastructure at all — that is a separate effort.

```mermaid
flowchart TD
    C[MCP Client] -->|prompts/list, prompts/get, completion/complete| G(MCPGateway\nStreamable HTTP)
    G -->|gateway_mode == cache| DB[(Database)]
    G -->|gateway_mode == direct_proxy| U[Upstream MCP Server]
    U -->|_meta forwarded| U
```
