### PR TITLE
feat(ui): add roots to global search

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-11T14:31:54Z",
+  "generated_at": "2026-04-11T18:47:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5110,7 +5110,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15018,
+        "line_number": 15084,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9870,7 +9870,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1604,
+        "line_number": 1605,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9878,7 +9878,7 @@
         "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1776,
+        "line_number": 1777,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9886,7 +9886,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2781,
+        "line_number": 2782,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9894,7 +9894,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5215,
+        "line_number": 5216,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9902,7 +9902,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5868,
+        "line_number": 5869,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9910,7 +9910,7 @@
         "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5932,
+        "line_number": 5933,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9918,7 +9918,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6184,
+        "line_number": 6185,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9926,7 +9926,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9167,
+        "line_number": 9168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9934,7 +9934,7 @@
         "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9216,
+        "line_number": 9217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9942,7 +9942,7 @@
         "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9255,
+        "line_number": 9256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9950,7 +9950,7 @@
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9312,
+        "line_number": 9313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9958,7 +9958,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14088,
+        "line_number": 14402,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9966,7 +9966,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16845,
+        "line_number": 17159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9974,7 +9974,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16864,
+        "line_number": 17178,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9982,7 +9982,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20522,
+        "line_number": 20836,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11214,8 +11214,10 @@ async def admin_unified_search(
     async def _safe_entity_search(search_callable, empty_key: str, **kwargs: Any) -> dict[str, Any]:
         """Execute entity search and return empty results on auth denials.
 
-        This keeps unified search resilient when one entity type is not visible
-        to the caller due to authorization boundaries.
+        Intentional silent 401/403 suppression: unified search spans entity types
+        with heterogeneous permission gates (e.g. roots require admin.system_config
+        with no admin bypass), and a single denial must not fail the whole search
+        or leak existence of restricted entities to unprivileged callers.
 
         Args:
             search_callable: Async entity search function to execute.
@@ -13273,9 +13275,9 @@ async def admin_search_roots(
     """Search roots by name or URI.
 
     Roots are held in-memory by :class:`~mcpgateway.services.root_service.RootService`,
-    so this function fetches the full list before filtering.  In typical deployments the
-    number of registered roots is small (< 100), making the in-memory scan negligible.
-    If root counts grow substantially, consider adding filtering support directly to
+    so this function fetches the full list before filtering. Registered roots are
+    typically a small set, making the in-memory scan negligible. If root counts grow
+    substantially, consider adding filtering support directly to
     :meth:`~mcpgateway.services.root_service.RootService.list_roots`.
 
     Args:
@@ -13298,7 +13300,6 @@ async def admin_search_roots(
     limit = max(1, min(limit, settings.pagination_max_page_size))
     all_roots = await root_service.list_roots()
 
-    # Single pass: convert URI once, filter and transform together, stop at limit.
     results: list[dict[str, Any]] = []
     for r in all_roots:
         if len(results) >= limit:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11123,7 +11123,7 @@ async def admin_unified_search(
     tags: Optional[str] = Query(None, description="Tag filter expression (comma=OR, plus=AND)"),
     entity_types: Optional[str] = Query(
         None,
-        description="Comma-separated entity types to include (servers,gateways,tools,resources,prompts,agents,teams,users)",
+        description="Comma-separated entity types to include (servers,gateways,tools,resources,prompts,agents,teams,users,roots)",
     ),
     include_inactive: bool = False,
     limit: int = Query(8, ge=1, le=settings.pagination_max_page_size, description="Per-entity result limit"),
@@ -11140,10 +11140,15 @@ async def admin_unified_search(
 ):
     """Unified search across primary admin entities.
 
+    Searches servers, gateways, tools, resources, prompts, agents, teams, roots,
+    and optionally users (when the caller has ``admin.user_management`` permission).
+
     Args:
         q (str): Free-text search query.
         tags (Optional[str]): Tag filter expression (comma=OR, plus=AND).
         entity_types (Optional[str]): Optional comma-separated entity type list.
+            Supported values: servers, gateways, tools, resources, prompts,
+            agents, teams, users, roots.
         include_inactive (bool): Whether to include inactive entities.
         limit (int): Default per-entity limit for returned items.
         limit_per_type (Optional[int]): Optional alias overriding ``limit``.
@@ -11163,8 +11168,8 @@ async def admin_unified_search(
     normalized_entity_types = _normalize_tags_query(entity_types)
     tag_groups = _parse_tag_filter_groups(normalized_tags)
 
-    supported_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams", "users"]
-    default_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams"]
+    supported_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams", "users", "roots"]
+    default_entity_types = ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams", "roots"]
     selected_entity_types: list[str] = []
     if normalized_entity_types:
         for raw_entity_type in normalized_entity_types.split(","):
@@ -11352,6 +11357,17 @@ async def admin_unified_search(
             user=user,
         )
         grouped_results["users"] = typing_cast(list[dict[str, Any]], users_result.get("users", users_result.get("items", [])))
+
+    # Roots do not support tag filtering; only include when a text query exists.
+    if "roots" in selected_entity_types and search_query:
+        roots_result = await _safe_entity_search(
+            admin_search_roots,
+            "roots",
+            q=search_query,
+            limit=effective_limit,
+            user=user,
+        )
+        grouped_results["roots"] = typing_cast(list[dict[str, Any]], roots_result.get("roots", roots_result.get("items", [])))
 
     groups = []
     flat_items: list[dict[str, Any]] = []
@@ -13245,6 +13261,55 @@ async def admin_set_prompt_state(
     team_id = str(form.get("team_id", "") or "")
     redirect_url = _build_admin_redirect(root_path, "prompts", error=error_message, include_inactive=is_inactive_checked.lower() == "true", team_id=team_id)
     return RedirectResponse(redirect_url, status_code=303)
+
+
+@admin_router.get("/roots/search", response_class=JSONResponse)
+@require_permission("admin.system_config", allow_admin_bypass=False)
+async def admin_search_roots(
+    q: str = Query("", description="Search query"),
+    limit: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Maximum number of results to return"),
+    user=Depends(get_current_user_with_permissions),
+) -> dict:
+    """Search roots by name or URI.
+
+    Roots are held in-memory by :class:`~mcpgateway.services.root_service.RootService`,
+    so this function fetches the full list before filtering.  In typical deployments the
+    number of registered roots is small (< 100), making the in-memory scan negligible.
+    If root counts grow substantially, consider adding filtering support directly to
+    :meth:`~mcpgateway.services.root_service.RootService.list_roots`.
+
+    Args:
+        q (str): Free-text search query matched against root name and URI.
+        limit (int): Maximum number of results to return.
+        user: Authenticated user context.
+
+    Returns:
+        dict: Unified search payload containing matching roots.
+
+    Examples:
+        >>> callable(admin_search_roots)
+        True
+        >>> admin_search_roots.__name__
+        'admin_search_roots'
+    """
+    search_query = _normalize_search_query(q)
+    # Defense-in-depth clamp: FastAPI validates ge/le at the HTTP layer, but direct
+    # Python calls (e.g. from admin_unified_search) bypass that validation.
+    limit = max(1, min(limit, settings.pagination_max_page_size))
+    all_roots = await root_service.list_roots()
+
+    # Single pass: convert URI once, filter and transform together, stop at limit.
+    results: list[dict[str, Any]] = []
+    for r in all_roots:
+        if len(results) >= limit:
+            break
+        uri_str = str(r.uri)
+        name_str = r.name or uri_str
+        if not search_query or search_query in uri_str.lower() or search_query in name_str.lower():
+            results.append({"id": uri_str, "name": name_str, "uri": uri_str})
+
+    LOGGER.debug(f"User {get_user_email(user)} searched roots with query '{search_query}': {len(results)} results")
+    return _build_search_response(entity_key="roots", entity_type="roots", items=results, query=search_query, tags="", tag_groups=[])
 
 
 @admin_router.get("/roots/export")

--- a/mcpgateway/admin_ui/constants.js
+++ b/mcpgateway/admin_ui/constants.js
@@ -119,6 +119,7 @@ export const GLOBAL_SEARCH_ENTITY_CONFIG = {
   },
   teams: { label: "Teams", tab: "teams", viewFunction: "showTeamEditModal" },
   users: { label: "Users", tab: "users", viewFunction: "showUserEditModal" },
+  roots: { label: "Roots", tab: "roots", viewFunction: "viewRoot" },
 };
 
 // Configuration objects for each search type

--- a/mcpgateway/admin_ui/initialization.js
+++ b/mcpgateway/admin_ui/initialization.js
@@ -61,6 +61,7 @@ import {
   navigateToGlobalSearchResult,
   openGlobalSearchModal,
   queueSearchablePanelReload,
+  renderGlobalSearchMessage,
   runGlobalSearch,
   serverSideEditPromptsSearch,
   serverSideEditResourcesSearch,
@@ -767,6 +768,12 @@ export const initializeGlobalSearch = function () {
         return;
       }
       if (event.key === "Enter") {
+        const currentValue = (input.value || "").trim();
+        if (!currentValue) {
+          renderGlobalSearchMessage("Please enter a search term.");
+          event.preventDefault();
+          return;
+        }
         const firstResult = document.querySelector(
           "#global-search-results .global-search-result-item"
         );

--- a/mcpgateway/admin_ui/search.js
+++ b/mcpgateway/admin_ui/search.js
@@ -270,6 +270,7 @@ export const runGlobalSearch = async function (query) {
     "agents",
     "teams",
     "users",
+    "roots",
   ];
   const visibleEntityTypes = searchableEntityTypes.filter((entityType) => {
     if (entityType === "users" && !isAdminUser()) {

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -804,7 +804,7 @@
                 id="global-search-trigger"
                 onclick="Admin.openGlobalSearchModal()"
                 class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                title="Search across tools, prompts, resources, servers, gateways, and agents (Ctrl/Cmd+K)"
+                title="Search across tools, prompts, resources, servers, gateways, agents, and roots (Ctrl/Cmd+K)"
               >
                 <span>Search</span>
                 <span class="hidden sm:inline text-xs text-gray-500 dark:text-gray-400">Ctrl/Cmd+K</span>
@@ -970,7 +970,7 @@
                 <input
                   type="text"
                   id="global-search-input"
-                  placeholder="Search across servers, gateways, tools, resources, prompts, and agents..."
+                  placeholder="Search across servers, gateways, tools, resources, prompts, agents, and roots..."
                   class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   autocomplete="off"
                 />

--- a/tests/js/admin-tabs.test.js
+++ b/tests/js/admin-tabs.test.js
@@ -383,7 +383,7 @@ describe("runGlobalSearch visible entity filtering", () => {
       "http://localhost",
     );
     expect(requestUrl.searchParams.get("entity_types")).toBe(
-      "servers,gateways,resources,agents,users",
+      "servers,gateways,resources,agents,users,roots",
     );
   });
 
@@ -402,6 +402,7 @@ describe("runGlobalSearch visible entity filtering", () => {
       "agents",
       "teams",
       "users",
+      "roots",
     ];
 
     await runGlobalSearch("anything");

--- a/tests/js/admin-tabs.test.js
+++ b/tests/js/admin-tabs.test.js
@@ -383,7 +383,7 @@ describe("runGlobalSearch visible entity filtering", () => {
       "http://localhost",
     );
     expect(requestUrl.searchParams.get("entity_types")).toBe(
-      "servers,gateways,resources,agents,users,roots",
+      "servers,gateways,resources,agents,users",
     );
   });
 
@@ -402,7 +402,6 @@ describe("runGlobalSearch visible entity filtering", () => {
       "agents",
       "teams",
       "users",
-      "roots",
     ];
 
     await runGlobalSearch("anything");

--- a/tests/unit/js/initialization.test.js
+++ b/tests/unit/js/initialization.test.js
@@ -186,6 +186,12 @@ vi.mock("../../../mcpgateway/admin_ui/search.js", () => ({
   navigateToGlobalSearchResult: vi.fn(),
   openGlobalSearchModal: vi.fn(),
   queueSearchablePanelReload: vi.fn(),
+  renderGlobalSearchMessage: vi.fn((message) => {
+    const container = document.getElementById("global-search-results");
+    if (container) {
+      container.textContent = message;
+    }
+  }),
   runGlobalSearch: vi.fn(),
   serverSideEditPromptsSearch: vi.fn(),
   serverSideEditResourcesSearch: vi.fn(),
@@ -717,6 +723,7 @@ describe("initializeGlobalSearch", () => {
   test("Enter keydown with first result calls navigateToGlobalSearchResult", () => {
     const input = document.createElement("input");
     input.id = "global-search-input";
+    input.value = "query";
     document.body.appendChild(input);
 
     const resultsContainer = document.createElement("div");
@@ -738,6 +745,7 @@ describe("initializeGlobalSearch", () => {
   test("Enter keydown with no result does nothing", () => {
     const input = document.createElement("input");
     input.id = "global-search-input";
+    input.value = "query";
     document.body.appendChild(input);
 
     initializeGlobalSearch();
@@ -746,6 +754,38 @@ describe("initializeGlobalSearch", () => {
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
     );
 
+    expect(navigateToGlobalSearchResult).not.toHaveBeenCalled();
+  });
+
+  test("Enter keydown with empty/whitespace query prompts for a term and prevents default", async () => {
+    const { renderGlobalSearchMessage } = await import(
+      "../../../mcpgateway/admin_ui/search.js"
+    );
+    const input = document.createElement("input");
+    input.id = "global-search-input";
+    input.value = "   ";
+    document.body.appendChild(input);
+
+    const resultsContainer = document.createElement("div");
+    resultsContainer.id = "global-search-results";
+    const resultItem = document.createElement("div");
+    resultItem.className = "global-search-result-item";
+    resultsContainer.appendChild(resultItem);
+    document.body.appendChild(resultsContainer);
+
+    initializeGlobalSearch();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(renderGlobalSearchMessage).toHaveBeenCalledWith(
+      "Please enter a search term.",
+    );
     expect(navigateToGlobalSearchResult).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/js/search.test.js
+++ b/tests/unit/js/search.test.js
@@ -648,6 +648,45 @@ describe("runGlobalSearch", () => {
     expect(container.innerHTML).toContain("Server 2");
     expect(container.innerHTML).not.toContain("Server 1");
   });
+
+  test("includes roots in entity_types for admin users", async () => {
+    const { fetchWithAuth } = await import("../../../mcpgateway/admin_ui/tokens.js");
+    const { isAdminUser } = await import("../../../mcpgateway/admin_ui/utils.js");
+    const { getUiHiddenSections } = await import("../../../mcpgateway/admin_ui/tabs.js");
+    isAdminUser.mockReturnValue(true);
+    getUiHiddenSections.mockReturnValue(new Set());
+    fetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ groups: [] }) });
+
+    const container = document.createElement("div");
+    container.id = "global-search-results";
+    document.body.appendChild(container);
+
+    await runGlobalSearch("tmp");
+
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+    const requestUrl = new URL(fetchWithAuth.mock.calls[0][0], "http://localhost");
+    const entityTypes = requestUrl.searchParams.get("entity_types").split(",");
+    expect(entityTypes).toContain("roots");
+  });
+
+  test("omits roots when the roots section is hidden", async () => {
+    const { fetchWithAuth } = await import("../../../mcpgateway/admin_ui/tokens.js");
+    const { isAdminUser } = await import("../../../mcpgateway/admin_ui/utils.js");
+    const { getUiHiddenSections } = await import("../../../mcpgateway/admin_ui/tabs.js");
+    isAdminUser.mockReturnValue(true);
+    getUiHiddenSections.mockReturnValue(new Set(["roots"]));
+    fetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ groups: [] }) });
+
+    const container = document.createElement("div");
+    container.id = "global-search-results";
+    document.body.appendChild(container);
+
+    await runGlobalSearch("tmp");
+
+    const requestUrl = new URL(fetchWithAuth.mock.calls[0][0], "http://localhost");
+    const entityTypes = requestUrl.searchParams.get("entity_types").split(",");
+    expect(entityTypes).not.toContain("roots");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -12144,7 +12144,7 @@ async def test_admin_search_roots_null_name_falls_back_to_uri(allow_permission, 
     """admin_search_roots returns the URI as name when root.name is None."""
     from mcpgateway.common.models import Root
 
-    root = Root(uri="file:///tmp")  # name defaults to None or basename
+    root = Root(uri="file:///tmp")
     monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=[root])))
 
     result = await admin_search_roots(q="tmp", limit=10, user={"email": "admin@example.com"})
@@ -12213,8 +12213,13 @@ async def test_admin_unified_search_roots_only(monkeypatch, mock_db, allow_permi
 
 
 @pytest.mark.asyncio
-async def test_admin_unified_search_roots_permission_denied_returns_empty(monkeypatch, mock_db, allow_permission):
-    """Unified search gracefully returns empty roots when the endpoint returns 403."""
+async def test_admin_unified_search_roots_swallows_http_exception(monkeypatch, mock_db, allow_permission):
+    """Unified search falls back to empty roots when admin_search_roots raises 401/403.
+
+    This is the intentional silent-suppression contract in _safe_entity_search:
+    unified search must not fail or leak existence of restricted entities when a
+    single entity type is gated by a stricter permission than the caller holds.
+    """
     tools_search = AsyncMock(return_value={"tools": [{"id": "tool-1", "name": "Tool 1"}], "count": 1})
     roots_search = AsyncMock(side_effect=HTTPException(status_code=403, detail="forbidden"))
     monkeypatch.setattr("mcpgateway.admin.admin_search_tools", tools_search)
@@ -12240,6 +12245,121 @@ async def test_admin_unified_search_roots_permission_denied_returns_empty(monkey
 
     assert result["results"]["roots"] == []
     assert result["results"]["tools"][0]["id"] == "tool-1"
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_denies_without_system_config_permission(monkeypatch, mock_db):
+    from mcpgateway.common.models import Root
+
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=[Root(uri="file:///tmp", name="tmp")])))
+    deny_service = MagicMock()
+    deny_service.check_permission = AsyncMock(return_value=False)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: deny_service)
+    monkeypatch.setattr("mcpgateway.admin.PermissionService", lambda db: deny_service)
+    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", AsyncMock(return_value=None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await admin_search_roots(q="tmp", limit=10, user={"email": "dev@example.com", "db": mock_db})
+
+    assert exc_info.value.status_code == 403
+
+
+def test_admin_search_roots_disables_admin_bypass():
+    """The decorator must enforce admin.system_config even for platform admins.
+
+    The roots catalog is a system-wide resource and must not be readable via the
+    generic admin bypass; this regression guard fires if the decorator argument
+    is ever changed.
+    """
+    assert getattr(admin_search_roots, "_allow_admin_bypass", True) is False
+
+
+@pytest.mark.asyncio
+async def test_admin_unified_search_roots_empty_for_non_admin(monkeypatch, mock_db):
+    """Non-admin user without admin.system_config sees roots=[] while other entity types populate.
+
+    Exercises the real permission decorator path through _safe_entity_search rather
+    than a mocked HTTPException, proving the silent-suppression contract end-to-end.
+    """
+    tools_search = AsyncMock(return_value={"tools": [{"id": "tool-1", "name": "Tool 1"}], "count": 1})
+    monkeypatch.setattr("mcpgateway.admin.admin_search_tools", tools_search)
+    monkeypatch.setattr("mcpgateway.admin.admin_search_servers", AsyncMock(return_value={"servers": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_gateways", AsyncMock(return_value={"gateways": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_resources", AsyncMock(return_value={"resources": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_prompts", AsyncMock(return_value={"prompts": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_a2a_agents", AsyncMock(return_value={"agents": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_teams", AsyncMock(return_value={"teams": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_users", AsyncMock(return_value={"users": [], "count": 0}))
+
+    async def _check_permission(**kwargs):
+        return kwargs.get("permission") != "admin.system_config"
+
+    perm_service = MagicMock()
+    perm_service.check_permission = AsyncMock(side_effect=_check_permission)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: perm_service)
+    monkeypatch.setattr("mcpgateway.admin.PermissionService", lambda db: perm_service)
+    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", AsyncMock(return_value=None))
+
+    result = await admin_unified_search(
+        q="tmp",
+        tags=None,
+        entity_types="tools,roots",
+        include_inactive=False,
+        limit=5,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user={"email": "dev@example.com", "db": mock_db},
+    )
+
+    assert result["results"]["roots"] == []
+    assert result["results"]["tools"][0]["id"] == "tool-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_limit", [0, -5, 1_000_000])
+async def test_admin_search_roots_clamps_out_of_range_limit(raw_limit, allow_permission, monkeypatch):
+    """Defense-in-depth clamp: direct Python callers bypass FastAPI ge/le validation."""
+    from mcpgateway.common.models import Root
+    from mcpgateway.config import settings
+
+    roots = [Root(uri=f"file:///r{i}", name=f"root{i}") for i in range(3)]
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=roots)))
+
+    result = await admin_search_roots(q="", limit=raw_limit, user={"email": "admin@example.com"})
+
+    assert 1 <= result["count"] <= settings.pagination_max_page_size
+    assert result["count"] <= len(roots)
+
+
+@pytest.mark.asyncio
+async def test_admin_unified_search_roots_ignores_tag_filter(monkeypatch, mock_db, allow_permission):
+    """Roots lack tag metadata; a tag filter must not suppress the roots branch."""
+    roots_search = AsyncMock(return_value={"roots": [{"id": "file:///tmp", "name": "tmp", "uri": "file:///tmp"}], "count": 1})
+    monkeypatch.setattr("mcpgateway.admin.admin_search_roots", roots_search)
+    monkeypatch.setattr("mcpgateway.admin.admin_search_servers", AsyncMock(return_value={"servers": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_gateways", AsyncMock(return_value={"gateways": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_tools", AsyncMock(return_value={"tools": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_resources", AsyncMock(return_value={"resources": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_prompts", AsyncMock(return_value={"prompts": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_a2a_agents", AsyncMock(return_value={"agents": [], "count": 0}))
+
+    result = await admin_unified_search(
+        q="tmp",
+        tags="nonexistent",
+        entity_types="roots",
+        include_inactive=False,
+        limit=5,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user={"email": "admin@example.com", "db": mock_db},
+    )
+
+    roots_search.assert_called_once()
+    call_kwargs = roots_search.call_args.kwargs
+    assert "tags" not in call_kwargs
+    assert result["results"]["roots"][0]["id"] == "file:///tmp"
 
 
 class TestAdminAdditionalCoverage:

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -150,6 +150,7 @@ from mcpgateway.admin import (  # admin_get_metrics,
     admin_search_gateways,
     admin_search_prompts,
     admin_search_resources,
+    admin_search_roots,
     admin_search_servers,
     admin_search_teams,
     admin_search_tokens,
@@ -12046,6 +12047,199 @@ async def test_admin_unified_search_empty_query_and_tags_returns_empty(mock_db, 
     assert result["count"] == 0
     assert result["items"] == []
     assert result["results"]["tools"] == []
+
+
+# ---------------------------------------------------------------------------
+# admin_search_roots tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_returns_matching_by_name(allow_permission, monkeypatch):
+    """admin_search_roots returns roots whose name contains the query."""
+    from mcpgateway.common.models import Root
+
+    root_tmp = Root(uri="file:///tmp", name="tmp")
+    root_home = Root(uri="file:///home", name="home")
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=[root_tmp, root_home])))
+
+    result = await admin_search_roots(q="tmp", limit=10, user={"email": "admin@example.com"})
+
+    assert result["count"] == 1
+    assert result["items"][0]["id"] == "file:///tmp"
+    assert result["items"][0]["name"] == "tmp"
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_matches_by_uri(allow_permission, monkeypatch):
+    """admin_search_roots returns roots whose URI contains the query."""
+    from mcpgateway.common.models import Root
+
+    root = Root(uri="file:///project/data", name="data")
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=[root])))
+
+    result = await admin_search_roots(q="project", limit=10, user={"email": "admin@example.com"})
+
+    assert result["count"] == 1
+    assert result["items"][0]["uri"] == "file:///project/data"
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_empty_query_returns_all(allow_permission, monkeypatch):
+    """admin_search_roots with empty query returns all roots."""
+    from mcpgateway.common.models import Root
+
+    roots = [Root(uri="file:///tmp", name="tmp"), Root(uri="file:///home", name="home")]
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=roots)))
+
+    result = await admin_search_roots(q="", limit=10, user={"email": "admin@example.com"})
+
+    assert result["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_no_match_returns_empty(allow_permission, monkeypatch):
+    """admin_search_roots returns empty list when no roots match the query."""
+    from mcpgateway.common.models import Root
+
+    roots = [Root(uri="file:///tmp", name="tmp")]
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=roots)))
+
+    result = await admin_search_roots(q="xyz12345", limit=10, user={"email": "admin@example.com"})
+
+    assert result["count"] == 0
+    assert result["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_respects_limit(allow_permission, monkeypatch):
+    """admin_search_roots respects the limit parameter."""
+    from mcpgateway.common.models import Root
+
+    roots = [Root(uri=f"file:///dir{i}", name=f"dir{i}") for i in range(10)]
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=roots)))
+
+    result = await admin_search_roots(q="dir", limit=3, user={"email": "admin@example.com"})
+
+    assert result["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_case_insensitive(allow_permission, monkeypatch):
+    """admin_search_roots performs case-insensitive matching on both name and URI."""
+    from mcpgateway.common.models import Root
+
+    root = Root(uri="file:///TMP", name="MyRoot")
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=[root])))
+
+    result = await admin_search_roots(q="tmp", limit=10, user={"email": "admin@example.com"})
+    assert result["count"] == 1
+
+    result2 = await admin_search_roots(q="myroot", limit=10, user={"email": "admin@example.com"})
+    assert result2["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_search_roots_null_name_falls_back_to_uri(allow_permission, monkeypatch):
+    """admin_search_roots returns the URI as name when root.name is None."""
+    from mcpgateway.common.models import Root
+
+    root = Root(uri="file:///tmp")  # name defaults to None or basename
+    monkeypatch.setattr("mcpgateway.admin.root_service", MagicMock(list_roots=AsyncMock(return_value=[root])))
+
+    result = await admin_search_roots(q="tmp", limit=10, user={"email": "admin@example.com"})
+
+    assert result["count"] == 1
+    item = result["items"][0]
+    # name must never be None or empty – falls back to the URI string
+    assert item["name"]
+    assert item["uri"] == item["id"]
+
+
+# ---------------------------------------------------------------------------
+# admin_unified_search — roots integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_unified_search_includes_roots_by_default(monkeypatch, mock_db, allow_permission):
+    """Roots are included in the default entity_types for unified search."""
+    monkeypatch.setattr("mcpgateway.admin.admin_search_servers", AsyncMock(return_value={"servers": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_gateways", AsyncMock(return_value={"gateways": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_tools", AsyncMock(return_value={"tools": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_resources", AsyncMock(return_value={"resources": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_prompts", AsyncMock(return_value={"prompts": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_a2a_agents", AsyncMock(return_value={"agents": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_teams", AsyncMock(return_value={"teams": [], "count": 0}))
+    roots_search = AsyncMock(return_value={"roots": [{"id": "file:///tmp", "name": "tmp", "uri": "file:///tmp"}], "count": 1})
+    monkeypatch.setattr("mcpgateway.admin.admin_search_roots", roots_search)
+
+    result = await admin_unified_search(
+        q="tmp",
+        tags=None,
+        include_inactive=False,
+        limit=5,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user={"email": "admin@example.com", "db": mock_db},
+    )
+
+    assert "roots" in result["entity_types"]
+    assert result["results"]["roots"][0]["id"] == "file:///tmp"
+    roots_search.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_admin_unified_search_roots_only(monkeypatch, mock_db, allow_permission):
+    """Unified search with entity_types=roots returns only root results."""
+    roots_search = AsyncMock(return_value={"roots": [{"id": "file:///tmp", "name": "tmp", "uri": "file:///tmp"}], "count": 1})
+    monkeypatch.setattr("mcpgateway.admin.admin_search_roots", roots_search)
+
+    result = await admin_unified_search(
+        q="tmp",
+        tags=None,
+        entity_types="roots",
+        include_inactive=False,
+        limit=5,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user={"email": "admin@example.com", "db": mock_db},
+    )
+
+    assert result["entity_types"] == ["roots"]
+    assert result["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_unified_search_roots_permission_denied_returns_empty(monkeypatch, mock_db, allow_permission):
+    """Unified search gracefully returns empty roots when the endpoint returns 403."""
+    tools_search = AsyncMock(return_value={"tools": [{"id": "tool-1", "name": "Tool 1"}], "count": 1})
+    roots_search = AsyncMock(side_effect=HTTPException(status_code=403, detail="forbidden"))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_tools", tools_search)
+    monkeypatch.setattr("mcpgateway.admin.admin_search_servers", AsyncMock(return_value={"servers": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_gateways", AsyncMock(return_value={"gateways": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_resources", AsyncMock(return_value={"resources": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_prompts", AsyncMock(return_value={"prompts": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_a2a_agents", AsyncMock(return_value={"agents": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_teams", AsyncMock(return_value={"teams": [], "count": 0}))
+    monkeypatch.setattr("mcpgateway.admin.admin_search_roots", roots_search)
+
+    result = await admin_unified_search(
+        q="tmp",
+        tags=None,
+        entity_types="tools,roots",
+        include_inactive=False,
+        limit=5,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user={"email": "admin@example.com", "db": mock_db},
+    )
+
+    assert result["results"]["roots"] == []
+    assert result["results"]["tools"][0]["id"] == "tool-1"
 
 
 class TestAdminAdditionalCoverage:


### PR DESCRIPTION
> **Note:** This PR was re-created from #3064 due to repository maintenance. Your code and branch are intact. @gcgoncalves please verify everything looks good.

# 🐛 Bug-fix PR

## 📌 Summary

Roots are not show on global search.

closes #2998 

## 🔁 Reproduction Steps
1. Open the Admin UI
2. Start the open search (either clicking the button or using the shortcut)
3. Search for a root name.

## 🐞 Root Cause
The backend didn't support root searching, and neither did the frontend.

## 💡 Fix Description
Added endpoints to root search and the JS/HTML code to support it.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
