### PR TITLE
chore(ci): add additional local-first CI quality gates

### DIFF
--- a/.github/workflows/linting-security-extra.yml
+++ b/.github/workflows/linting-security-extra.yml
@@ -1,0 +1,47 @@
+name: linting-security-extra
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  linting-security-extra:
+    name: linting-security-extra
+    runs-on: ubuntu-latest
+    env:
+      VENV_DIR: .venv
+      VENVS_DIR: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6.0.0
+
+      - name: Install project dev dependencies
+        run: make --no-print-directory venv install-dev
+
+      - name: Install hadolint
+        run: |
+          HADOLINT_VERSION="v2.12.0"
+          HADOLINT_BIN="$RUNNER_TEMP/hadolint"
+          curl -sSL "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" -o "$HADOLINT_BIN"
+          chmod +x "$HADOLINT_BIN"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Run extra pass-only security gates
+        run: make --no-print-directory linting-security-extra

--- a/.github/workflows/linting-security-pip-audit.yml
+++ b/.github/workflows/linting-security-pip-audit.yml
@@ -1,0 +1,75 @@
+name: linting-security-pip-audit
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      enforce_strict:
+        description: "Run strict blocking mode"
+        required: false
+        default: false
+        type: boolean
+      ignore_ids:
+        description: "Optional comma-separated vulnerability IDs to ignore"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  linting-security-pip-audit-advisory:
+    name: linting-security-pip-audit-advisory
+    runs-on: ubuntu-latest
+    env:
+      VENV_DIR: .venv
+      VENVS_DIR: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6.0.0
+
+      - name: Run advisory dependency audit
+        run: make --no-print-directory linting-security-pip-audit-advisory
+
+  linting-security-pip-audit-enforce:
+    name: linting-security-pip-audit-enforce
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.enforce_strict }}
+    runs-on: ubuntu-latest
+    env:
+      VENV_DIR: .venv
+      VENVS_DIR: .
+      PIP_AUDIT_IGNORE_IDS: ${{ inputs.ignore_ids }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6.0.0
+
+      - name: Run strict dependency audit
+        run: make --no-print-directory linting-security-pip-audit-enforce

--- a/.github/workflows/linting-security-secrets-diff.yml
+++ b/.github/workflows/linting-security-secrets-diff.yml
@@ -1,0 +1,43 @@
+name: linting-security-secrets-diff
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  linting-security-secrets-diff:
+    name: linting-security-secrets-diff
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine diff range
+        id: range
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "base=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${{ github.event.before }}" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
+            echo "base=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=HEAD~1" >> "$GITHUB_OUTPUT"
+            echo "head=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run diff-only secret scan
+        env:
+          LINT_SECRETS_BASE: ${{ steps.range.outputs.base }}
+          LINT_SECRETS_HEAD: ${{ steps.range.outputs.head }}
+        run: make --no-print-directory linting-security-secrets-diff

--- a/.github/workflows/linting-typing-telemetry.yml
+++ b/.github/workflows/linting-typing-telemetry.yml
@@ -1,0 +1,46 @@
+name: linting-typing-telemetry
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  linting-typing-telemetry:
+    name: linting-typing-telemetry
+    runs-on: ubuntu-latest
+    env:
+      VENV_DIR: .venv
+      VENVS_DIR: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6.0.0
+
+      - name: Install project dev dependencies
+        run: make --no-print-directory venv install-dev
+
+      - name: Run typing telemetry
+        run: make --no-print-directory linting-typing-telemetry
+
+      - name: Upload typing telemetry reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: typing-telemetry-reports
+          path: /tmp/mcp-context-forge-lint/typing
+          if-no-files-found: error

--- a/.github/workflows/linting-workflow-zizmor-changed.yml
+++ b/.github/workflows/linting-workflow-zizmor-changed.yml
@@ -1,0 +1,48 @@
+name: linting-workflow-zizmor-changed
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  linting-workflow-zizmor-changed:
+    name: linting-workflow-zizmor-changed
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Determine workflow diff range
+        id: range
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "base=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${{ github.event.before }}" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
+            echo "base=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=HEAD~1" >> "$GITHUB_OUTPUT"
+            echo "head=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run zizmor on changed workflows
+        env:
+          LINT_ZIZMOR_CHANGED_BASE: ${{ steps.range.outputs.base }}
+          LINT_ZIZMOR_CHANGED_HEAD: ${{ steps.range.outputs.head }}
+        run: make --no-print-directory linting-workflow-zizmor-changed

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c5996e0193a3df57d695c1b8a1dec2a4c62e8730" # v2.3.3
     with:
       # CLI flags (line-split)
       scan-args: |-
@@ -69,7 +69,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c5996e0193a3df57d695c1b8a1dec2a4c62e8730" # v2.3.3
     with:
       scan-args: |-
         -r

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -38,8 +38,6 @@ on:
 # -----------------------------------------------------------------
 permissions:
   contents: read # checkout / version diff
-  security-events: write # upload SARIF results
-  actions: read # needed by upload-sarif for private repos
 
 jobs:
   # =============================================================
@@ -47,6 +45,10 @@ jobs:
   # =============================================================
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
     with:
       # CLI flags (line-split)
@@ -54,6 +56,8 @@ jobs:
         -r              # recurse into sub-dirs
         --skip-git      # ignore .git dir
         ./              # repo root
+      # Keep mainline scans advisory; PR diff scan below remains blocking for new vulns.
+      fail-on-vuln: false
 
   # =============================================================
   # 2️⃣  Diff scan on PR / merge-queue
@@ -61,6 +65,10 @@ jobs:
   # =============================================================
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
     with:
       scan-args: |-

--- a/Makefile
+++ b/Makefile
@@ -2605,6 +2605,16 @@ images:
 # help: linting-security-checkov     - Run Checkov IaC security scan
 # help: linting-security-kube-linter - Run kube-linter against Kubernetes/Helm manifests
 # help: linting-security-trufflehog  - Run TruffleHog filesystem secret scan
+# help: linting-security-secrets-diff - Scan only git diff for newly introduced secrets (gitleaks)
+# help: linting-security-extra       - Run additional pass-only quality/security gates
+# help: linting-security-extra-hadolint - Run strict hadolint checks (error threshold)
+# help: linting-security-extra-pip-check - Validate Python environment dependencies
+# help: linting-security-pip-audit-advisory - Dependency CVE scan (non-blocking/advisory)
+# help: linting-security-pip-audit-enforce  - Dependency CVE scan (blocking/strict)
+# help: linting-workflow-zizmor-changed - Security lint only changed GitHub workflow files
+# help: linting-typing-mypy-report   - Run mypy telemetry and record error counts (non-blocking)
+# help: linting-typing-pyrefly-report - Run pyrefly telemetry and record error counts (non-blocking)
+# help: linting-typing-telemetry     - Run both typing telemetry checks (non-blocking)
 # help: linting-coverage-diff-cover  - Run diff-cover against changed lines
 # help: linting-full                 - Run passing linting gates used by CI
 
@@ -2643,7 +2653,11 @@ FILE_AWARE_LINTERS := isort black flake8 pylint mypy bandit pydocstyle \
 	linting-docs-codespell linting-docs-markdown-links linting-web-depcheck \
 	linting-helm-lint linting-helm-chart-testing linting-helm-unittest \
 	linting-go-gosec linting-go-govulncheck \
-	linting-security-checkov linting-security-kube-linter linting-security-trufflehog \
+	linting-security-checkov linting-security-kube-linter linting-security-trufflehog linting-security-secrets-diff \
+	linting-security-pip-audit-advisory linting-security-pip-audit-enforce \
+	linting-security-extra linting-security-extra-hadolint linting-security-extra-pip-check \
+	linting-workflow-zizmor-changed \
+	linting-typing-mypy-report linting-typing-pyrefly-report linting-typing-telemetry \
 	linting-coverage-diff-cover linting-full
 
 
@@ -2806,9 +2820,21 @@ LINT_KUBE_LINTER_TARGET ?= charts/mcp-stack
 LINT_TRUFFLEHOG_TARGET ?= mcpgateway tests docs charts deployment mcp-servers a2a-agents
 LINT_TRUFFLEHOG_VERSION ?= v3.93.3
 LINT_GO_MODULE_SEARCH_DIRS ?= mcp-servers a2a-agents
+LINT_HADOLINT_TARGETS ?= Containerfile Containerfile.lite Containerfile.scratch
+LINT_GITLEAKS_VERSION ?= v8.24.2
+LINT_GITLEAKS_BIN ?= $(LINT_GO_ROOT)/bin/gitleaks
+LINT_SECRETS_BASE ?= HEAD
+LINT_SECRETS_HEAD ?= WORKTREE
+LINT_ZIZMOR_CHANGED_BASE ?= HEAD
+LINT_ZIZMOR_CHANGED_HEAD ?= WORKTREE
+LINT_TYPING_REPORT_DIR ?= $(LINT_TMP_ROOT)/typing
+PIP_AUDIT_CACHE_DIR ?= $(CURDIR)/.cache/pip-audit
+PIP_AUDIT_IGNORE_IDS ?=
 
 # Passing gates only (used by CI workflow linting-full)
 LINTING_FULL_TARGETS := linting-workflow-actionlint linting-workflow-reviewdog linting-workflow-commitlint linting-helm-lint linting-helm-chart-testing linting-helm-unittest linting-go-gosec linting-go-govulncheck
+# Additional pass-only security gates (used by CI workflow linting-security-extra)
+LINTING_SECURITY_EXTRA_TARGETS := linting-security-extra-hadolint linting-security-extra-pip-check
 
 # Tools requiring auth/login (e.g. safety, OSSF scorecard) are intentionally excluded.
 
@@ -3044,8 +3070,156 @@ linting-security-trufflehog:         ## 🔑  Secret scanning with TruffleHog
 			'^z_.*,cover$$' > "$$exclude_file"; \
 		'$(LINT_GO_ROOT)/bin/trufflehog' filesystem --fail --exclude-paths "$$exclude_file" $(LINT_TRUFFLEHOG_TARGET)
 
+linting-security-secrets-diff:       ## 🔐  Scan git diff only for newly introduced secrets (gitleaks)
+	@echo "🔐 gitleaks diff scan ($(LINT_SECRETS_BASE)..$(LINT_SECRETS_HEAD))..."
+	@command -v curl >/dev/null 2>&1 || { echo "❌ curl not found"; exit 1; }
+	@command -v tar >/dev/null 2>&1 || { echo "❌ tar not found"; exit 1; }
+	@command -v git >/dev/null 2>&1 || { echo "❌ git not found"; exit 1; }
+	@version='$(LINT_GITLEAKS_VERSION)'; \
+	version_no_v="$${version#v}"; \
+	os="$$(uname -s | tr '[:upper:]' '[:lower:]')"; \
+	arch="$$(uname -m)"; \
+	case "$$arch" in \
+		x86_64) arch='x64' ;; \
+		aarch64|arm64) arch='arm64' ;; \
+		*) echo "❌ Unsupported architecture: $$arch"; exit 1 ;; \
+	esac; \
+	asset="gitleaks_$${version_no_v}_$${os}_$${arch}.tar.gz"; \
+	url="https://github.com/gitleaks/gitleaks/releases/download/$${version}/$${asset}"; \
+	mkdir -p '$(LINT_GO_ROOT)/bin' '$(LINT_TMP_ROOT)'; \
+	if [ ! -x '$(LINT_GITLEAKS_BIN)' ]; then \
+		curl -fsSL "$$url" -o '$(LINT_TMP_ROOT)/gitleaks.tar.gz'; \
+		tar -xzf '$(LINT_TMP_ROOT)/gitleaks.tar.gz' -C '$(LINT_GO_ROOT)/bin' gitleaks; \
+		chmod +x '$(LINT_GITLEAKS_BIN)'; \
+	fi; \
+	base_ref='$(LINT_SECRETS_BASE)'; \
+	head_ref='$(LINT_SECRETS_HEAD)'; \
+	if [ "$$head_ref" = 'WORKTREE' ]; then \
+		if git diff --quiet "$$base_ref"; then \
+			echo 'ℹ️  No local changes to scan'; \
+			exit 0; \
+		fi; \
+		git diff --no-color --unified=0 "$$base_ref" | '$(LINT_GITLEAKS_BIN)' detect --pipe --no-banner --redact=100; \
+	else \
+		if git diff --quiet "$$base_ref" "$$head_ref"; then \
+			echo 'ℹ️  No diff to scan'; \
+			exit 0; \
+		fi; \
+		git diff --no-color --unified=0 "$$base_ref" "$$head_ref" | '$(LINT_GITLEAKS_BIN)' detect --pipe --no-banner --redact=100; \
+	fi
+
+linting-security-pip-audit-advisory: ## 🔎  Dependency CVE scan (advisory / non-blocking)
+	@echo "🔎 pip-audit advisory scan..."
+	@test -d "$(VENV_DIR)" || $(MAKE) venv install-dev
+	@mkdir -p "$(PIP_AUDIT_CACHE_DIR)"
+	@source '$(VENV_DIR)/bin/activate'; \
+	uv pip install -q pip-audit; \
+	PIP_AUDIT_CACHE_DIR='$(PIP_AUDIT_CACHE_DIR)' \
+	XDG_CACHE_HOME='$(PIP_AUDIT_CACHE_DIR)' \
+		pip-audit || true
+
+linting-security-pip-audit-enforce:  ## 🚨  Dependency CVE scan (strict / blocking)
+	@echo "🚨 pip-audit strict scan..."
+	@test -d "$(VENV_DIR)" || $(MAKE) venv install-dev
+	@mkdir -p "$(PIP_AUDIT_CACHE_DIR)"
+	@source '$(VENV_DIR)/bin/activate'; \
+	uv pip install -q pip-audit; \
+	ignore_flags=(); \
+	if [ -n '$(PIP_AUDIT_IGNORE_IDS)' ]; then \
+		while IFS= read -r vuln; do \
+			[ -n "$$vuln" ] || continue; \
+			ignore_flags+=("--ignore-vuln" "$$vuln"); \
+		done < <(printf '%s\n' '$(PIP_AUDIT_IGNORE_IDS)' | tr ',' '\n'); \
+	fi; \
+	PIP_AUDIT_CACHE_DIR='$(PIP_AUDIT_CACHE_DIR)' \
+	XDG_CACHE_HOME='$(PIP_AUDIT_CACHE_DIR)' \
+		pip-audit --strict "$${ignore_flags[@]}"
+
+linting-workflow-zizmor-changed:     ## 🔐  Zizmor only on changed workflow files
+	@echo "🔐 zizmor scan of changed workflow files ($(LINT_ZIZMOR_CHANGED_BASE)..$(LINT_ZIZMOR_CHANGED_HEAD))..."
+	@$(MAKE) --no-print-directory linting-python-env
+	@"$(LINT_PY_VENV)/bin/python" -m pip install -q --disable-pip-version-check zizmor
+	@base_ref='$(LINT_ZIZMOR_CHANGED_BASE)'; \
+	head_ref='$(LINT_ZIZMOR_CHANGED_HEAD)'; \
+	if [ "$$head_ref" = 'WORKTREE' ]; then \
+		tracked_files="$$(git diff --name-only "$$base_ref" -- .github/workflows | rg '^\.github/workflows/.*\.yml$$' || true)"; \
+		untracked_files="$$(git ls-files --others --exclude-standard -- .github/workflows | rg '^\.github/workflows/.*\.yml$$' || true)"; \
+		files="$$(printf '%s\n%s\n' "$$tracked_files" "$$untracked_files" | awk 'NF' | sort -u)"; \
+	else \
+		files="$$(git diff --name-only "$$base_ref" "$$head_ref" -- .github/workflows | rg '^\.github/workflows/.*\.yml$$' || true)"; \
+	fi; \
+	if [ -z "$$files" ]; then \
+		echo 'ℹ️  No changed workflow files to scan'; \
+		exit 0; \
+	fi; \
+	echo "$$files"; \
+	'$(LINT_PY_VENV)/bin/zizmor' $$files
+
+linting-typing-mypy-report:          ## 🏷️  Mypy telemetry (non-blocking, writes report)
+	@echo "🏷️ mypy telemetry..."
+	@test -d "$(VENV_DIR)" || $(MAKE) venv install-dev
+	@mkdir -p "$(LINT_TYPING_REPORT_DIR)"
+	@out='$(LINT_TYPING_REPORT_DIR)/mypy-report.txt'; \
+	set +e; \
+	'$(VENV_DIR)/bin/mypy' mcpgateway >"$$out" 2>&1; \
+	status=$$?; \
+	set -e; \
+	if [ $$status -eq 0 ]; then \
+		count=0; \
+	else \
+		count="$$(grep -Eo '^Found [0-9]+ errors' "$$out" | awk '{print $$2}' | tail -1)"; \
+		if [ -z "$$count" ]; then count="$$(grep -c ': error:' "$$out" || true)"; fi; \
+	fi; \
+	printf 'mypy_errors=%s\n' "$$count" | tee '$(LINT_TYPING_REPORT_DIR)/mypy.count'; \
+	echo "📄 mypy report: $$out"
+
+linting-typing-pyrefly-report:       ## 🧠  Pyrefly telemetry (non-blocking, writes report)
+	@echo "🧠 pyrefly telemetry..."
+	@test -d "$(VENV_DIR)" || $(MAKE) venv install-dev
+	@mkdir -p "$(LINT_TYPING_REPORT_DIR)"
+	@out='$(LINT_TYPING_REPORT_DIR)/pyrefly-report.txt'; \
+	set +e; \
+	'$(VENV_DIR)/bin/pyrefly' check mcpgateway >"$$out" 2>&1; \
+	status=$$?; \
+	set -e; \
+	if [ $$status -eq 0 ]; then \
+		count=0; \
+	else \
+		count="$$(grep -Eo 'INFO [0-9]+ errors' "$$out" | awk '{print $$2}' | tail -1)"; \
+		if [ -z "$$count" ]; then count="$$(grep -c '^ERROR ' "$$out" || true)"; fi; \
+	fi; \
+	printf 'pyrefly_errors=%s\n' "$$count" | tee '$(LINT_TYPING_REPORT_DIR)/pyrefly.count'; \
+	echo "📄 pyrefly report: $$out"
+
+linting-typing-telemetry: linting-typing-mypy-report linting-typing-pyrefly-report ## 📊 Typing telemetry (non-blocking)
+	@echo "📊 typing telemetry summary:"
+	@cat "$(LINT_TYPING_REPORT_DIR)/mypy.count" "$(LINT_TYPING_REPORT_DIR)/pyrefly.count"
+
 linting-coverage-diff-cover:         ## 📊  Changed-lines coverage gate
 	@$(MAKE) --no-print-directory diff-cover
+
+linting-security-extra-hadolint:     ## 🐳  Strict hadolint checks (error threshold)
+	@echo "🐳 hadolint (error threshold) on $(LINT_HADOLINT_TARGETS)..."
+	@command -v hadolint >/dev/null 2>&1 || { echo "❌ hadolint not found"; exit 1; }
+	@found=0; \
+	for f in $(LINT_HADOLINT_TARGETS); do \
+		if [ -f "$$f" ]; then \
+			echo "-> hadolint $$f"; \
+			hadolint --failure-threshold error "$$f"; \
+			found=1; \
+		fi; \
+	done; \
+	if [ "$$found" -eq 0 ]; then \
+		echo "ℹ️  No hadolint targets found"; \
+	fi
+
+linting-security-extra-pip-check:    ## 📦  Validate Python dependency resolution
+	@echo "📦 pip check in $(VENV_DIR)..."
+	@test -d "$(VENV_DIR)" || $(MAKE) venv install-dev
+	@"$(VENV_DIR)/bin/pip" check
+
+linting-security-extra: $(LINTING_SECURITY_EXTRA_TARGETS) ## ✅ Additional pass-only security gates
+	@echo "✅ linting-security-extra passed"
 
 linting-full: $(LINTING_FULL_TARGETS) ## ✅ Passing lint gates for CI
 	@echo "✅ linting-full passed"


### PR DESCRIPTION
> **Note:** This PR was re-created from #3067 due to repository maintenance. Your code and branch are intact. @crivetimihai please verify everything looks good.

## Summary
- add new local-first Make targets for diff-only secret scanning (`gitleaks`), dependency CVE scanning (`pip-audit` advisory and strict), changed-workflow security linting (`zizmor`), and typing telemetry (`mypy` + `pyrefly`)
- add dedicated GitHub workflows for each new grouped section so review is isolated and easy (`linting-security-extra`, `linting-security-secrets-diff`, `linting-security-pip-audit`, `linting-workflow-zizmor-changed`, `linting-typing-telemetry`)
- reactivate `osv-scanner.yml` from inactive, keep PR diff scanning blocking for new vulnerabilities, and keep scheduled/push full scan advisory
- pin action SHAs and set `persist-credentials: false` on checkouts for workflow security hygiene

## Local verification
- `make linting-security-extra`
- `make linting-security-secrets-diff`
- `make linting-security-pip-audit-advisory`
- `make linting-security-pip-audit-enforce` (expected fail with current vulns)
- `make linting-security-pip-audit-enforce PIP_AUDIT_IGNORE_IDS=CVE-2026-1703,PYSEC-2022-42969,CVE-2026-24486` (pass path)
- `make linting-workflow-zizmor-changed`
- `make linting-workflow-actionlint`
- `make linting-typing-telemetry`

Refs #2383
