### PR TITLE
feat(vfs): Virtual Tool Filesystem for browsable tool metadata

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2282,6 +2282,11 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
                 oauth_enabled = False
                 oauth_config = None
 
+        # VFS configuration
+        server_type = str(form.get("server_type", "standard")).strip() or "standard"
+        stub_format_raw = str(form.get("stub_format", "")).strip()
+        stub_format = stub_format_raw if stub_format_raw in ("python", "typescript", "json") else None
+
         server = ServerCreate(
             id=form.get("id") or None,
             name=form.get("name"),
@@ -2294,6 +2299,8 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
             visibility=visibility,
             oauth_enabled=oauth_enabled,
             oauth_config=oauth_config,
+            server_type=server_type,
+            stub_format=stub_format,
         )
     except KeyError as e:
         # Convert KeyError to ValidationError-like response
@@ -2456,6 +2463,11 @@ async def admin_edit_server(
                 oauth_enabled = False
                 oauth_config = None
 
+        # VFS configuration
+        edit_server_type = str(form.get("server_type", "")).strip() or None
+        edit_stub_format_raw = str(form.get("stub_format", "")).strip()
+        edit_stub_format = edit_stub_format_raw if edit_stub_format_raw in ("python", "typescript", "json") else None
+
         server = ServerUpdate(
             id=form.get("id"),
             name=form.get("name"),
@@ -2470,6 +2482,8 @@ async def admin_edit_server(
             owner_email=user_email,
             oauth_enabled=oauth_enabled,
             oauth_config=oauth_config,
+            server_type=edit_server_type,
+            stub_format=edit_stub_format,
         )
 
         await server_service.update_server(

--- a/mcpgateway/alembic/versions/a1b2c3d4e5f6_add_vfs_server_type.py
+++ b/mcpgateway/alembic/versions/a1b2c3d4e5f6_add_vfs_server_type.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Add VFS server type columns to servers table.
+
+Revision ID: a1b2c3d4e5f6
+Revises: x7h8i9j0k1l2
+Create Date: 2026-02-19
+
+Adds server_type, stub_format, and mount_rules columns to the servers table
+for Virtual Tool Filesystem (VFS) support.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "x7h8i9j0k1l2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add server_type, stub_format, and mount_rules columns."""
+    inspector = sa.inspect(op.get_bind())
+
+    if "servers" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("servers")]
+
+    if "server_type" not in columns:
+        op.add_column("servers", sa.Column("server_type", sa.String(length=32), nullable=False, server_default="standard"))
+        op.create_index("ix_servers_server_type", "servers", ["server_type"])
+
+    if "stub_format" not in columns:
+        op.add_column("servers", sa.Column("stub_format", sa.String(length=32), nullable=True))
+
+    if "mount_rules" not in columns:
+        op.add_column("servers", sa.Column("mount_rules", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove VFS columns from servers table."""
+    inspector = sa.inspect(op.get_bind())
+
+    if "servers" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("servers")]
+
+    if "mount_rules" in columns:
+        op.drop_column("servers", "mount_rules")
+    if "stub_format" in columns:
+        op.drop_column("servers", "stub_format")
+    if "server_type" in columns:
+        op.drop_index("ix_servers_server_type", table_name="servers")
+        op.drop_column("servers", "server_type")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1729,6 +1729,20 @@ Disallow: /
     well_known_cache_max_age: int = 3600  # 1 hour default
 
     # ===================================
+    # Virtual Tool Filesystem (VFS)
+    # ===================================
+    vfs_enabled: bool = Field(default=False, description="Enable VFS virtual servers (server_type='vfs') with fs_browse/fs_read/fs_write meta-tools")
+    vfs_base_dir: str = Field(default="", description="Base directory for VFS session files. Empty uses system temp dir.")
+    vfs_session_ttl_seconds: int = Field(default=900, ge=60, le=86400, description="TTL for VFS sessions (seconds)")
+    vfs_fs_browse_enabled: bool = Field(default=True, description="Enable fs_browse meta-tool for VFS servers")
+    vfs_fs_read_enabled: bool = Field(default=True, description="Enable fs_read meta-tool for VFS servers")
+    vfs_fs_write_enabled: bool = Field(default=True, description="Enable fs_write meta-tool for VFS servers")
+    vfs_fs_read_max_size_bytes: int = Field(default=1048576, ge=1024, le=10485760, description="Maximum file size in bytes for fs_read (default 1MB)")
+    vfs_fs_browse_default_max_entries: int = Field(default=200, ge=1, le=5000, description="Default max_entries for fs_browse")
+    vfs_fs_browse_max_entries: int = Field(default=1000, ge=1, le=10000, description="Hard maximum max_entries for fs_browse")
+    vfs_default_stub_format: Literal["python", "typescript", "json"] = Field(default="json", description="Default stub format for VFS tool metadata")
+
+    # ===================================
     # Performance / Startup Tuning
     # ===================================
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -4050,6 +4050,13 @@ class Server(Base):
     federation_source: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
 
+    # Virtual filesystem (VFS) support
+    # standard: normal server exposing attached tools/resources/prompts
+    # vfs: exposes fs_browse/fs_read/fs_write meta-tools for tool metadata browsing
+    server_type: Mapped[str] = mapped_column(String(32), default="standard", nullable=False, index=True)
+    stub_format: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)  # python | typescript | json
+    mount_rules: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True)
+
     metrics: Mapped[List["ServerMetric"]] = relationship("ServerMetric", back_populates="server", cascade="all, delete-orphan")
 
     # Many-to-many relationships for associated items

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5628,7 +5628,7 @@ _vfs_service_singleton: Optional[Any] = None
 
 def _get_vfs_service():
     """Lazily initialise the VFS service singleton."""
-    global _vfs_service_singleton  # noqa: PLW0603
+    global _vfs_service_singleton  # noqa: PLW0603  # pylint: disable=global-statement
     if _vfs_service_singleton is None:
         # First-Party
         from mcpgateway.services.vfs_service import VfsService  # pylint: disable=import-outside-toplevel

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5627,7 +5627,11 @@ _vfs_service_singleton: Optional[Any] = None
 
 
 def _get_vfs_service():
-    """Lazily initialise the VFS service singleton."""
+    """Lazily initialise the VFS service singleton.
+
+    Returns:
+        VfsService: The shared VFS service instance.
+    """
     global _vfs_service_singleton  # noqa: PLW0603  # pylint: disable=global-statement
     if _vfs_service_singleton is None:
         # First-Party
@@ -5638,7 +5642,15 @@ def _get_vfs_service():
 
 
 def _lookup_vfs_server(db: Session, server_id: str):
-    """Return the DbServer if *server_id* refers to a VFS server, else None."""
+    """Return the DbServer if *server_id* refers to a VFS server, else None.
+
+    Args:
+        db: Active database session.
+        server_id: Unique identifier of the server to look up.
+
+    Returns:
+        Optional[DbServer]: The matching VFS server record, or None.
+    """
     # First-Party
     from mcpgateway.db import Server as DbServer  # pylint: disable=import-outside-toplevel
 
@@ -5649,7 +5661,19 @@ def _lookup_vfs_server(db: Session, server_id: str):
 
 
 async def _invoke_vfs_meta_tool(db: Session, server, name: str, arguments: Dict[str, Any], user_email: Optional[str], token_teams: Optional[List[str]]) -> Dict[str, Any]:
-    """Dispatch a VFS meta-tool call and return an MCP-compliant ToolResult dict."""
+    """Dispatch a VFS meta-tool call and return an MCP-compliant ToolResult dict.
+
+    Args:
+        db: Active database session.
+        server: The VFS server record to operate against.
+        name: Name of the meta-tool to invoke (e.g. fs_browse, fs_read, fs_write).
+        arguments: Tool-specific arguments forwarded to the VFS service.
+        user_email: Email of the calling user, used for access control.
+        token_teams: Team scopes from the caller's JWT token.
+
+    Returns:
+        Dict[str, Any]: MCP-compliant ToolResult with ``content`` and ``isError`` keys.
+    """
     # First-Party
     from mcpgateway.services.vfs_service import META_TOOL_FS_BROWSE, META_TOOL_FS_READ, META_TOOL_FS_WRITE, VfsError, VfsSecurityError  # pylint: disable=import-outside-toplevel
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -54,7 +54,7 @@ from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import JSONPath
 import orjson
 from pydantic import ValidationError
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -5621,6 +5621,75 @@ async def remove_root(
 
 
 ##################
+# VFS Helpers    #
+##################
+_vfs_service_singleton: Optional[Any] = None
+
+
+def _get_vfs_service():
+    """Lazily initialise the VFS service singleton."""
+    global _vfs_service_singleton  # noqa: PLW0603
+    if _vfs_service_singleton is None:
+        # First-Party
+        from mcpgateway.services.vfs_service import VfsService  # pylint: disable=import-outside-toplevel
+
+        _vfs_service_singleton = VfsService()
+    return _vfs_service_singleton
+
+
+def _lookup_vfs_server(db: Session, server_id: str):
+    """Return the DbServer if *server_id* refers to a VFS server, else None."""
+    # First-Party
+    from mcpgateway.db import Server as DbServer  # pylint: disable=import-outside-toplevel
+
+    server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
+    if server and getattr(server, "server_type", "standard") == "vfs":
+        return server
+    return None
+
+
+async def _invoke_vfs_meta_tool(db: Session, server, name: str, arguments: Dict[str, Any], user_email: Optional[str], token_teams: Optional[List[str]]) -> Dict[str, Any]:
+    """Dispatch a VFS meta-tool call and return an MCP-compliant ToolResult dict."""
+    # First-Party
+    from mcpgateway.services.vfs_service import META_TOOL_FS_BROWSE, META_TOOL_FS_READ, META_TOOL_FS_WRITE, VfsError, VfsSecurityError  # pylint: disable=import-outside-toplevel
+
+    vfs = _get_vfs_service()
+    try:
+        if name == META_TOOL_FS_BROWSE:
+            data = await vfs.fs_browse(
+                db=db,
+                server=server,
+                path=arguments.get("path", "/"),
+                include_hidden=arguments.get("include_hidden", False),
+                max_entries=arguments.get("max_entries"),
+                user_email=user_email,
+                token_teams=token_teams,
+            )
+        elif name == META_TOOL_FS_READ:
+            data = await vfs.fs_read(db=db, server=server, path=arguments.get("path", ""), user_email=user_email, token_teams=token_teams)
+        elif name == META_TOOL_FS_WRITE:
+            data = await vfs.fs_write(
+                db=db,
+                server=server,
+                path=arguments.get("path", ""),
+                content=arguments.get("content", ""),
+                user_email=user_email,
+                token_teams=token_teams,
+            )
+        else:
+            return {"content": [{"type": "text", "text": f"Unknown VFS meta-tool: {name}"}], "isError": True}
+        # Success — return structured text content
+        # Standard
+        import json as _json  # pylint: disable=import-outside-toplevel
+
+        return {"content": [{"type": "text", "text": _json.dumps(data, indent=2, default=str)}], "isError": False}
+    except VfsSecurityError as exc:
+        return {"content": [{"type": "text", "text": f"VFS security error: {exc}"}], "isError": True}
+    except VfsError as exc:
+        return {"content": [{"type": "text", "text": f"VFS error: {exc}"}], "isError": True}
+
+
+##################
 # Utility Routes #
 ##################
 @utility_router.post("/rpc/")
@@ -5753,20 +5822,27 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
             if server_id:
-                tools = await tool_service.list_server_tools(
-                    db,
-                    server_id,
-                    cursor=cursor,
-                    user_email=user_email,
-                    token_teams=token_teams,
-                    requesting_user_email=_req_email,
-                    requesting_user_is_admin=_req_is_admin,
-                    requesting_user_team_roles=_req_team_roles,
-                )
-                # Release DB connection early to prevent idle-in-transaction under load
-                db.commit()
-                db.close()
-                result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
+                # VFS servers expose only meta-tools (fs_browse, fs_read, fs_write)
+                _vfs_srv = _lookup_vfs_server(db, server_id) if settings.vfs_enabled else None
+                if _vfs_srv is not None:
+                    result = {"tools": _get_vfs_service().get_meta_tools(_vfs_srv)}
+                    db.commit()
+                    db.close()
+                else:
+                    tools = await tool_service.list_server_tools(
+                        db,
+                        server_id,
+                        cursor=cursor,
+                        user_email=user_email,
+                        token_teams=token_teams,
+                        requesting_user_email=_req_email,
+                        requesting_user_is_admin=_req_is_admin,
+                        requesting_user_team_roles=_req_team_roles,
+                    )
+                    # Release DB connection early to prevent idle-in-transaction under load
+                    db.commit()
+                    db.close()
+                    result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
             else:
                 tools, next_cursor = await tool_service.list_tools(
                     db,
@@ -5796,19 +5872,26 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
             if server_id:
-                tools = await tool_service.list_server_tools(
-                    db,
-                    server_id,
-                    cursor=cursor,
-                    user_email=user_email,
-                    token_teams=token_teams,
-                    requesting_user_email=_req_email,
-                    requesting_user_is_admin=_req_is_admin,
-                    requesting_user_team_roles=_req_team_roles,
-                )
-                db.commit()
-                db.close()
-                result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
+                # VFS servers expose only meta-tools (fs_browse, fs_read, fs_write)
+                _vfs_srv = _lookup_vfs_server(db, server_id) if settings.vfs_enabled else None
+                if _vfs_srv is not None:
+                    result = {"tools": _get_vfs_service().get_meta_tools(_vfs_srv)}
+                    db.commit()
+                    db.close()
+                else:
+                    tools = await tool_service.list_server_tools(
+                        db,
+                        server_id,
+                        cursor=cursor,
+                        user_email=user_email,
+                        token_teams=token_teams,
+                        requesting_user_email=_req_email,
+                        requesting_user_is_admin=_req_is_admin,
+                        requesting_user_team_roles=_req_team_roles,
+                    )
+                    db.commit()
+                    db.close()
+                    result = {"tools": [t.model_dump(by_alias=True, exclude_none=True) for t in tools]}
             else:
                 tools, next_cursor = await tool_service.list_tools(
                     db,
@@ -6002,6 +6085,21 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
                 # auth_token_teams stays None (unrestricted)
             elif auth_token_teams is None:
                 auth_token_teams = []  # Non-admin without teams = public-only
+
+            # VFS meta-tool routing — bypass normal tool dispatch for VFS servers
+            if settings.vfs_enabled and server_id:
+                # First-Party
+                from mcpgateway.services.vfs_service import VFS_META_TOOLS as _VFS_META_TOOLS  # pylint: disable=import-outside-toplevel
+
+                if name in _VFS_META_TOOLS:
+                    _vfs_srv = _lookup_vfs_server(db, server_id)
+                    if _vfs_srv is not None:
+                        vfs_user = get_user_email(user)
+                        result = await _invoke_vfs_meta_tool(db, _vfs_srv, name, arguments, user_email=vfs_user, token_teams=auth_token_teams)
+                        db.commit()
+                        db.close()
+                        # Skip normal tool dispatch — jump to return
+                        return {"jsonrpc": "2.0", "result": result, "id": req_id}
 
             # Get user email for OAuth token selection
             oauth_user_email = get_user_email(user)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -3796,6 +3796,11 @@ class ServerCreate(BaseModel):
     oauth_enabled: bool = Field(False, description="Enable OAuth 2.0 for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
 
+    # Virtual Tool Filesystem (VFS) configuration
+    server_type: Literal["standard", "vfs"] = Field(default="standard", description="Server type: standard (normal proxy) or vfs (virtual tool filesystem)")
+    stub_format: Optional[Literal["python", "typescript", "json"]] = Field(None, description="Stub format for VFS tool metadata (python/typescript/json)")
+    mount_rules: Optional[Dict[str, Any]] = Field(None, description="VFS mount rules controlling which tools to expose")
+
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:
@@ -3929,6 +3934,11 @@ class ServerUpdate(BaseModelWithConfigDict):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: Optional[bool] = Field(None, description="Enable OAuth 2.0 for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+
+    # Virtual Tool Filesystem (VFS) configuration
+    server_type: Optional[Literal["standard", "vfs"]] = Field(None, description="Server type: standard (normal proxy) or vfs (virtual tool filesystem)")
+    stub_format: Optional[Literal["python", "typescript", "json"]] = Field(None, description="Stub format for VFS tool metadata")
+    mount_rules: Optional[Dict[str, Any]] = Field(None, description="VFS mount rules controlling which tools to expose")
 
     @field_validator("tags")
     @classmethod
@@ -4105,6 +4115,11 @@ class ServerRead(BaseModelWithConfigDict):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: bool = Field(False, description="Whether OAuth 2.0 is enabled for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+
+    # Virtual Tool Filesystem (VFS)
+    server_type: str = Field(default="standard", description="Server type: standard or vfs")
+    stub_format: Optional[str] = Field(None, description="Stub format for VFS tool metadata")
+    mount_rules: Optional[Dict[str, Any]] = Field(None, description="VFS mount rules")
 
     @model_validator(mode="before")
     @classmethod

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -299,6 +299,10 @@ class ServerService:
             # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
             "oauth_enabled": getattr(server, "oauth_enabled", False),
             "oauth_config": getattr(server, "oauth_config", None),
+            # Virtual Tool Filesystem (VFS) fields
+            "server_type": getattr(server, "server_type", "standard") or "standard",
+            "stub_format": getattr(server, "stub_format", None),
+            "mount_rules": getattr(server, "mount_rules", None),
         }
 
         # Compute aggregated metrics only if requested (avoids N+1 queries in list operations)
@@ -492,6 +496,10 @@ class ServerService:
                 # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
                 oauth_enabled=getattr(server_in, "oauth_enabled", False) or False,
                 oauth_config=getattr(server_in, "oauth_config", None),
+                # Virtual Tool Filesystem (VFS) fields
+                server_type=getattr(server_in, "server_type", "standard") or "standard",
+                stub_format=getattr(server_in, "stub_format", None),
+                mount_rules=getattr(server_in, "mount_rules", None),
                 # Metadata fields
                 created_by=created_by,
                 created_from_ip=created_from_ip,
@@ -1284,6 +1292,14 @@ class ServerService:
                     server.oauth_config = server_update.oauth_config
                 elif server_update.oauth_config is not None:
                     server.oauth_config = server_update.oauth_config
+
+            # Update VFS fields if provided
+            if getattr(server_update, "server_type", None) is not None:
+                server.server_type = server_update.server_type
+            if getattr(server_update, "stub_format", None) is not None:
+                server.stub_format = server_update.stub_format
+            if hasattr(server_update, "model_fields_set") and "mount_rules" in server_update.model_fields_set:
+                server.mount_rules = server_update.mount_rules
 
             # Update metadata fields
             server.updated_at = datetime.now(timezone.utc)

--- a/mcpgateway/services/vfs_service.py
+++ b/mcpgateway/services/vfs_service.py
@@ -1,0 +1,816 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/vfs_service.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Virtual Tool Filesystem (VFS) service.
+
+Provides a browsable, read/write virtual filesystem that exposes mounted MCP tools
+as generated stubs in configurable formats (Python, TypeScript, or MCP JSON).
+
+Meta-tools:
+- fs_browse: list virtual directory contents
+- fs_read:   read a file from the virtual filesystem
+- fs_write:  write a file to writable directories (/scratch, /results)
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import contextlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import fnmatch
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# Third-Party
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload, Session
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import Server as DbServer
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.db import utc_now
+from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.utils.create_slug import slugify
+
+try:
+    # First-Party
+    from plugins_rust import catalog_builder as rust_catalog_builder
+    from plugins_rust import json_schema_to_stubs as rust_json_schema_to_stubs
+
+    _RUST_VFS_AVAILABLE = True
+except ImportError:
+    rust_catalog_builder = None
+    rust_json_schema_to_stubs = None
+    _RUST_VFS_AVAILABLE = False
+
+
+logger = LoggingService().get_logger(__name__)
+
+VFS_SERVER_TYPE = "vfs"
+META_TOOL_FS_BROWSE = "fs_browse"
+META_TOOL_FS_READ = "fs_read"
+META_TOOL_FS_WRITE = "fs_write"
+VFS_META_TOOLS = (META_TOOL_FS_BROWSE, META_TOOL_FS_READ, META_TOOL_FS_WRITE)
+VFS_SCHEMA_VERSION = "2026-02-19"
+
+_DEFAULT_VFS_BASE_DIR = str(Path(tempfile.gettempdir()) / "mcpgateway_vfs")
+_DEFAULT_FS_READ = ("/tools/**", "/scratch/**", "/results/**")
+_DEFAULT_FS_WRITE = ("/scratch/**", "/results/**")
+_DEFAULT_FS_DENY = ("/etc/**", "/proc/**", "/sys/**")
+
+
+class VfsError(Exception):
+    """General VFS operation error."""
+
+
+class VfsSecurityError(VfsError):
+    """VFS security violation (path traversal, permission denied)."""
+
+
+def _is_path_within(child: Path, parent: Path) -> bool:
+    """Return True if *child* is equal to or inside *parent* (symlink-safe)."""
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+@dataclass
+class VfsSession:
+    """In-memory VFS session state."""
+
+    session_id: str
+    server_id: str
+    user_email: str
+    stub_format: str  # "python", "typescript", or "json"
+    root_dir: Path
+    tools_dir: Path
+    scratch_dir: Path
+    results_dir: Path
+    mounted_tools: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    content_hash: Optional[str] = None
+    generated_at: Optional[datetime] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    last_used_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    @property
+    def all_dirs(self) -> Tuple[Path, Path, Path]:
+        """Return primary virtual directories."""
+        return (self.tools_dir, self.scratch_dir, self.results_dir)
+
+
+class VfsService:
+    """Service implementing the Virtual Tool Filesystem.
+
+    Exposes mounted MCP tools as browsable files in Python, TypeScript, or
+    JSON format. Provides fs_browse, fs_read, and fs_write meta-tools.
+    """
+
+    def __init__(self) -> None:
+        """Initialize VFS service from gateway settings."""
+        configured_base_dir = str(getattr(settings, "vfs_base_dir", "") or "").strip()
+        self._base_dir = Path(configured_base_dir or _DEFAULT_VFS_BASE_DIR)
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+
+        self._default_ttl = int(getattr(settings, "vfs_session_ttl_seconds", 900))
+        self._fs_browse_enabled = bool(getattr(settings, "vfs_fs_browse_enabled", True))
+        self._fs_read_enabled = bool(getattr(settings, "vfs_fs_read_enabled", True))
+        self._fs_write_enabled = bool(getattr(settings, "vfs_fs_write_enabled", True))
+        self._fs_read_max_size_bytes = int(getattr(settings, "vfs_fs_read_max_size_bytes", 1048576))
+        self._fs_browse_default_max_entries = int(getattr(settings, "vfs_fs_browse_default_max_entries", 200))
+        self._fs_browse_max_entries = int(getattr(settings, "vfs_fs_browse_max_entries", 1000))
+        self._default_stub_format = str(getattr(settings, "vfs_default_stub_format", "json"))
+        self._rust_acceleration_enabled = _RUST_VFS_AVAILABLE
+
+        self._sessions: Dict[Tuple[str, str], VfsSession] = {}
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def _deterministic_session_id(self, server_id: str, user_email: str) -> str:
+        """Generate a deterministic session ID from server + user."""
+        raw = f"{server_id}:{user_email}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+    async def get_or_create_session(
+        self,
+        db: Session,
+        server: DbServer,
+        user_email: str,
+        token_teams: Optional[List[str]] = None,
+    ) -> VfsSession:
+        """Get an existing VFS session or create a new one."""
+        stub_format = getattr(server, "stub_format", None) or self._default_stub_format
+        if stub_format not in {"python", "typescript", "json"}:
+            stub_format = self._default_stub_format
+
+        key = (server.id, user_email)
+        session = self._sessions.get(key)
+        if session is not None:
+            session.last_used_at = datetime.now(tz=timezone.utc)
+            await self._refresh_virtual_filesystem_if_needed(db=db, session=session, server=server, token_teams=token_teams)
+            return session
+
+        session_id = self._deterministic_session_id(server.id, user_email)
+        root_dir = self._base_dir / session_id
+        root_dir.mkdir(parents=True, exist_ok=True)
+
+        session = VfsSession(
+            session_id=session_id,
+            server_id=server.id,
+            user_email=user_email,
+            stub_format=stub_format,
+            root_dir=root_dir,
+            tools_dir=root_dir / "tools",
+            scratch_dir=root_dir / "scratch",
+            results_dir=root_dir / "results",
+        )
+
+        for d in session.all_dirs:
+            d.mkdir(parents=True, exist_ok=True)
+
+        await self._refresh_virtual_filesystem_if_needed(db=db, session=session, server=server, token_teams=token_teams)
+        self._sessions[key] = session
+        return session
+
+    # ------------------------------------------------------------------
+    # Meta-tools
+    # ------------------------------------------------------------------
+
+    def get_meta_tools(self, server: DbServer) -> List[Dict[str, Any]]:
+        """Return the list of VFS meta-tool definitions for a server."""
+        browse_tool = {
+            "name": META_TOOL_FS_BROWSE,
+            "description": "Browse the virtual tool filesystem. Lists files and directories under /tools (read-only tool stubs), /scratch (read-write workspace), and /results (outputs).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Virtual path to browse (e.g. '/', '/tools', '/scratch'). Defaults to '/'."},
+                    "include_hidden": {"type": "boolean", "description": "Include hidden (dot) files", "default": False},
+                    "max_entries": {
+                        "type": "integer",
+                        "description": f"Max entries (default {self._fs_browse_default_max_entries}, max {self._fs_browse_max_entries})",
+                        "default": self._fs_browse_default_max_entries,
+                    },
+                },
+            },
+        }
+        read_tool = {
+            "name": META_TOOL_FS_READ,
+            "description": "Read a file from the virtual filesystem. Returns file content as text with metadata.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Virtual path to read (e.g. '/tools/server_name/tool_name.py')"},
+                },
+                "required": ["path"],
+            },
+        }
+        write_tool = {
+            "name": META_TOOL_FS_WRITE,
+            "description": "Write a file to a writable virtual directory (/scratch or /results).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Virtual path to write (must be under /scratch or /results)"},
+                    "content": {"type": "string", "description": "File content to write"},
+                },
+                "required": ["path", "content"],
+            },
+        }
+
+        tools = []
+        if self._fs_browse_enabled:
+            tools.append(browse_tool)
+        if self._fs_read_enabled:
+            tools.append(read_tool)
+        if self._fs_write_enabled:
+            tools.append(write_tool)
+        return tools
+
+    async def fs_browse(
+        self,
+        db: Session,
+        server: DbServer,
+        path: str,
+        include_hidden: bool,
+        max_entries: Any,
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        """Browse virtual filesystem for a VFS server."""
+        if not self._fs_browse_enabled:
+            raise VfsError("fs_browse meta-tool is disabled by configuration")
+
+        if max_entries is None:
+            max_entries_value = self._fs_browse_default_max_entries
+        elif isinstance(max_entries, bool):
+            max_entries_value = self._fs_browse_default_max_entries
+        else:
+            try:
+                max_entries_value = int(max_entries)
+            except (TypeError, ValueError):
+                max_entries_value = self._fs_browse_default_max_entries
+        max_entries_value = max(1, min(max_entries_value, self._fs_browse_max_entries))
+
+        session = await self.get_or_create_session(db=db, server=server, user_email=user_email or "anonymous", token_teams=token_teams)
+        virtual_path = path or "/"
+
+        normalized_vpath = "/" + virtual_path.strip().lstrip("/")
+        if normalized_vpath == "/":
+            vfs_roots = [
+                ("/tools", "read-only tool stubs (browsable metadata)", session.tools_dir),
+                ("/scratch", "read-write temporary workspace", session.scratch_dir),
+                ("/results", "read-write outputs", session.results_dir),
+            ]
+            entries: List[Dict[str, Any]] = []
+            for vroot, description, real_root in vfs_roots:
+                entry: Dict[str, Any] = {
+                    "name": vroot.lstrip("/"),
+                    "path": vroot,
+                    "type": "directory",
+                    "description": description,
+                }
+                if real_root.exists():
+                    entry["size_bytes"] = sum(1 for _ in real_root.iterdir() if not _.name.startswith("."))
+                entries.append(entry)
+            return {"path": "/", "entries": entries, "truncated": False}
+
+        real_path = self._virtual_to_real_path(session, virtual_path)
+        if real_path is None:
+            raise VfsSecurityError(f"Path '{virtual_path}' is outside the virtual filesystem")
+
+        self._enforce_fs_permission("read", virtual_path)
+
+        if not real_path.exists():
+            raise VfsError(f"Path not found: {virtual_path}")
+
+        entries = []
+        if real_path.is_file():
+            stat = real_path.stat()
+            entries.append(
+                {
+                    "name": real_path.name,
+                    "path": virtual_path,
+                    "type": "file",
+                    "size_bytes": stat.st_size,
+                    "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                }
+            )
+        else:
+            children = sorted(real_path.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+            for child in children:
+                if not include_hidden and child.name.startswith("."):
+                    continue
+                stat = child.stat()
+                entries.append(
+                    {
+                        "name": child.name,
+                        "path": self._real_to_virtual_path(session, child),
+                        "type": "directory" if child.is_dir() else "file",
+                        "size_bytes": stat.st_size,
+                        "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                    }
+                )
+                if len(entries) >= max_entries_value:
+                    break
+
+        return {"path": virtual_path, "entries": entries, "truncated": len(entries) >= max_entries_value}
+
+    async def fs_read(
+        self,
+        db: Session,
+        server: DbServer,
+        path: str,
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        """Read a file from the virtual filesystem."""
+        if not self._fs_read_enabled:
+            raise VfsError("fs_read meta-tool is disabled by configuration")
+        if not path or not path.strip():
+            raise VfsError("path is required")
+
+        session = await self.get_or_create_session(db=db, server=server, user_email=user_email or "anonymous", token_teams=token_teams)
+        virtual_path = path.strip()
+
+        self._enforce_fs_permission("read", virtual_path)
+
+        real_path = self._virtual_to_real_path(session, virtual_path)
+        if real_path is None:
+            raise VfsSecurityError(f"Path '{virtual_path}' is outside the virtual filesystem")
+        if not real_path.exists():
+            raise VfsError(f"Path not found: {virtual_path}")
+        if not real_path.is_file():
+            raise VfsError(f"Path is a directory, not a file: {virtual_path}. Use fs_browse to list directories.")
+
+        stat = real_path.stat()
+        if stat.st_size > self._fs_read_max_size_bytes:
+            raise VfsError(f"File too large ({stat.st_size} bytes, limit {self._fs_read_max_size_bytes}).")
+
+        content = real_path.read_text(encoding="utf-8")
+        return {
+            "path": virtual_path,
+            "content": content,
+            "size_bytes": stat.st_size,
+            "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+        }
+
+    async def fs_write(
+        self,
+        db: Session,
+        server: DbServer,
+        path: str,
+        content: str,
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        """Write a file to the virtual filesystem (only /scratch and /results)."""
+        if not self._fs_write_enabled:
+            raise VfsError("fs_write meta-tool is disabled by configuration")
+        if not path or not path.strip():
+            raise VfsError("path is required")
+        if content is None:
+            raise VfsError("content is required")
+
+        session = await self.get_or_create_session(db=db, server=server, user_email=user_email or "anonymous", token_teams=token_teams)
+        virtual_path = path.strip()
+
+        self._enforce_fs_permission("write", virtual_path)
+
+        real_path = self._virtual_to_real_path(session, virtual_path)
+        if real_path is None:
+            raise VfsSecurityError(f"Path '{virtual_path}' is outside the virtual filesystem")
+
+        allowed_roots = (session.scratch_dir.resolve(), session.results_dir.resolve())
+        resolved = real_path.resolve()
+        if not any(_is_path_within(resolved, root) for root in allowed_roots):
+            raise VfsSecurityError(f"EACCES: write denied for path: {virtual_path}. Only /scratch and /results are writable.")
+
+        real_path.parent.mkdir(parents=True, exist_ok=True)
+        real_path.write_text(content, encoding="utf-8")
+
+        stat = real_path.stat()
+        return {
+            "path": virtual_path,
+            "size_bytes": stat.st_size,
+            "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+        }
+
+    # ------------------------------------------------------------------
+    # Virtual filesystem refresh
+    # ------------------------------------------------------------------
+
+    async def _refresh_virtual_filesystem_if_needed(
+        self,
+        db: Session,
+        session: VfsSession,
+        server: DbServer,
+        token_teams: Optional[List[str]],
+    ) -> None:
+        """Regenerate mounted tool stubs if source content changed."""
+        mounted = self._resolve_mounted_tools(db=db, server=server, user_email=session.user_email, token_teams=token_teams)
+        digest_src = [f"{tool.id}:{tool.updated_at.isoformat() if getattr(tool, 'updated_at', None) else ''}:{tool.name}" for tool in mounted]
+        digest = hashlib.sha256("\n".join(sorted(digest_src)).encode("utf-8")).hexdigest()
+        if session.content_hash == digest and session.generated_at:
+            return
+
+        session.mounted_tools = {}
+        self._wipe_and_recreate_directory(session.tools_dir)
+        (session.tools_dir / "_schema.json").write_text(
+            json.dumps({"version": VFS_SCHEMA_VERSION, "roots": ["/tools", "/scratch", "/results"], "stub_format": session.stub_format}, indent=2),
+            encoding="utf-8",
+        )
+
+        grouped: Dict[str, List[DbTool]] = {}
+        catalog_tools: List[Dict[str, Any]] = []
+        for tool in mounted:
+            server_slug = self._tool_server_slug(tool)
+            stub_basename = self._tool_file_name(tool)
+
+            if server_slug not in grouped:
+                grouped[server_slug] = []
+            grouped[server_slug].append(tool)
+
+            session.mounted_tools[tool.name] = {
+                "tool_id": tool.id,
+                "tool_name": tool.name,
+                "server_slug": server_slug,
+                "stub_basename": stub_basename,
+                "original_name": getattr(tool, "original_name", None),
+                "description": tool.description,
+                "input_schema": tool.input_schema,
+                "tags": tool.tags or [],
+            }
+            catalog_tools.append(
+                {
+                    "id": tool.id,
+                    "name": tool.name,
+                    "original_name": tool.original_name,
+                    "server": server_slug,
+                    "description": tool.description,
+                    "tags": tool.tags or [],
+                    "input_schema": tool.input_schema or {"type": "object", "properties": {}},
+                }
+            )
+
+        for server_slug, tools in grouped.items():
+            server_dir = session.tools_dir / server_slug
+            server_dir.mkdir(parents=True, exist_ok=True)
+            meta_payload = {
+                "server": server_slug,
+                "tool_count": len(tools),
+                "generated_at": utc_now().isoformat(),
+            }
+            (server_dir / "_meta.json").write_text(json.dumps(meta_payload, indent=2), encoding="utf-8")
+            for tool in tools:
+                base_name = self._tool_file_name(tool)
+                if session.stub_format == "typescript":
+                    stub = self._generate_typescript_stub(tool=tool, server_slug=server_slug)
+                    (server_dir / f"{base_name}.ts").write_text(stub, encoding="utf-8")
+                elif session.stub_format == "python":
+                    stub = self._generate_python_stub(tool=tool, server_slug=server_slug)
+                    (server_dir / f"{base_name}.py").write_text(stub, encoding="utf-8")
+                else:
+                    schema = self._generate_json_schema(tool=tool, server_slug=server_slug)
+                    (server_dir / f"{base_name}.json").write_text(schema, encoding="utf-8")
+
+        if catalog_tools:
+            self._write_catalog_json(session.tools_dir, catalog_tools)
+
+        self._build_search_index(session.tools_dir)
+        session.content_hash = digest
+        session.generated_at = datetime.now(tz=timezone.utc)
+
+    # ------------------------------------------------------------------
+    # Stub generation
+    # ------------------------------------------------------------------
+
+    def _generate_python_stub(self, tool: DbTool, server_slug: str) -> str:
+        """Generate a Python type-annotated stub for a tool."""
+        function_name = self._python_identifier(self._tool_file_name(tool))
+        if self._rust_acceleration_enabled and rust_json_schema_to_stubs is not None:
+            with contextlib.suppress(Exception):
+                schema_json = json.dumps(tool.input_schema or {"type": "object"})
+                payload = rust_json_schema_to_stubs(schema_json, server_slug, function_name, tool.description or "")
+                parsed = json.loads(payload) if isinstance(payload, str) else payload
+                if isinstance(parsed, dict):
+                    stub = parsed.get("python")
+                    if isinstance(stub, str) and stub.strip():
+                        return stub
+
+        args_type = self._schema_to_python_type(tool.input_schema or {"type": "object"})
+        description = (tool.description or "").strip().replace('"""', r"\"\"\"")
+        return (
+            "# Auto-generated by MCP Gateway VFS. Do not edit.\n"
+            f"# Server: {server_slug}\n\n"
+            "from __future__ import annotations\n"
+            "from typing import Any, Dict, List, Literal\n\n"
+            f"async def {function_name}(args: {args_type}) -> Any:\n"
+            f'    """{description}"""\n'
+            "    ...\n"
+        )
+
+    def _generate_typescript_stub(self, tool: DbTool, server_slug: str) -> str:
+        """Generate a TypeScript interface stub for a tool."""
+        function_name = self._python_identifier(self._tool_file_name(tool))
+        if self._rust_acceleration_enabled and rust_json_schema_to_stubs is not None:
+            with contextlib.suppress(Exception):
+                schema_json = json.dumps(tool.input_schema or {"type": "object"})
+                payload = rust_json_schema_to_stubs(schema_json, server_slug, function_name, tool.description or "")
+                parsed = json.loads(payload) if isinstance(payload, str) else payload
+                if isinstance(parsed, dict):
+                    stub = parsed.get("typescript")
+                    if isinstance(stub, str) and stub.strip():
+                        return stub
+
+        args_type = self._schema_to_typescript_type(tool.input_schema or {"type": "object"})
+        description = (tool.description or "").strip().replace("*/", "* /")
+        return (
+            "// Auto-generated by MCP Gateway VFS. Do not edit.\n"
+            f"// Server: {server_slug}\n\n"
+            "/**\n"
+            f" * {description}\n"
+            f" * @server {server_slug}\n"
+            " */\n"
+            f"export async function {function_name}(args: {args_type}): Promise<any> {{\n"
+            "  // stub: invoke via MCP tool call\n"
+            "}\n"
+        )
+
+    def _generate_json_schema(self, tool: DbTool, server_slug: str) -> str:
+        """Generate raw MCP JSON tool schema."""
+        return json.dumps(
+            {
+                "name": tool.name,
+                "original_name": getattr(tool, "original_name", None),
+                "server": server_slug,
+                "description": tool.description or "",
+                "inputSchema": tool.input_schema or {"type": "object", "properties": {}},
+            },
+            indent=2,
+        )
+
+    # ------------------------------------------------------------------
+    # Type mapping helpers
+    # ------------------------------------------------------------------
+
+    def _schema_to_python_type(self, schema: Dict[str, Any]) -> str:
+        """Map JSON Schema fragments to Python typing annotations."""
+        schema_type = schema.get("type")
+        if schema.get("enum"):
+            values = [repr(v) for v in schema.get("enum", [])]
+            return "Literal[" + ", ".join(values) + "]" if values else "Any"
+        if schema_type == "string":
+            return "str"
+        if schema_type == "integer":
+            return "int"
+        if schema_type == "number":
+            return "float"
+        if schema_type == "boolean":
+            return "bool"
+        if schema_type == "array":
+            return f"List[{self._schema_to_python_type(schema.get('items') or {})}]"
+        if schema_type == "object":
+            return "Dict[str, Any]"
+        return "Any"
+
+    def _schema_to_typescript_type(self, schema: Dict[str, Any]) -> str:
+        """Map JSON Schema fragments to TypeScript type expressions."""
+        schema_type = schema.get("type")
+        if schema.get("enum"):
+            options = [json.dumps(v) for v in schema.get("enum", [])]
+            return " | ".join(options) if options else "any"
+        if schema_type == "string":
+            return "string"
+        if schema_type in {"integer", "number"}:
+            return "number"
+        if schema_type == "boolean":
+            return "boolean"
+        if schema_type == "array":
+            return f"{self._schema_to_typescript_type(schema.get('items') or {})}[]"
+        if schema_type == "object":
+            props = schema.get("properties") or {}
+            required = set(schema.get("required") or [])
+            if not props:
+                return "Record<string, any>"
+            fields = []
+            for key, prop in props.items():
+                ts_type = self._schema_to_typescript_type(prop or {})
+                optional = "" if key in required else "?"
+                fields.append(f"{key}{optional}: {ts_type};")
+            return "{ " + " ".join(fields) + " }"
+        return "any"
+
+    # ------------------------------------------------------------------
+    # Path mapping
+    # ------------------------------------------------------------------
+
+    def _virtual_to_real_path(self, session: VfsSession, virtual_path: str) -> Optional[Path]:
+        """Resolve a virtual path into a session-scoped real filesystem path."""
+        normalized = "/" + virtual_path.strip().lstrip("/")
+        mapping = {
+            "/tools": session.tools_dir,
+            "/scratch": session.scratch_dir,
+            "/results": session.results_dir,
+        }
+        for root, real_root in mapping.items():
+            if normalized == root:
+                return real_root
+            if normalized.startswith(root + "/"):
+                suffix = normalized[len(root) + 1 :]
+                resolved = (real_root / suffix).resolve()
+                real_root_resolved = real_root.resolve()
+                try:
+                    resolved.relative_to(real_root_resolved)
+                except ValueError:
+                    return None
+                return resolved
+        return None
+
+    def _real_to_virtual_path(self, session: VfsSession, real_path: Path) -> str:
+        """Convert a real path under session roots back into virtual notation."""
+        candidates = (
+            (session.tools_dir.resolve(), "/tools"),
+            (session.scratch_dir.resolve(), "/scratch"),
+            (session.results_dir.resolve(), "/results"),
+        )
+        resolved = real_path.resolve()
+        for root, virtual in candidates:
+            with contextlib.suppress(ValueError):
+                rel = resolved.relative_to(root)
+                return f"{virtual}/{rel.as_posix()}" if rel.as_posix() != "." else virtual
+        return resolved.as_posix()
+
+    # ------------------------------------------------------------------
+    # Tool resolution and mounting
+    # ------------------------------------------------------------------
+
+    def _resolve_mounted_tools(
+        self,
+        db: Session,
+        server: DbServer,
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+    ) -> List[DbTool]:
+        """Resolve all reachable tools visible to the current scope."""
+        query = select(DbTool).options(joinedload(DbTool.gateway)).where(DbTool.enabled.is_(True), DbTool.reachable.is_(True))
+        tools = db.execute(query).scalars().all()
+        mount_rules = self._server_mount_rules(server)
+
+        resolved: List[DbTool] = []
+        for tool in tools:
+            if not self._tool_visible_for_scope(tool, user_email=user_email, token_teams=token_teams):
+                continue
+            if not self._tool_matches_mount_rules(tool, mount_rules):
+                continue
+            resolved.append(tool)
+        return resolved
+
+    def _tool_visible_for_scope(self, tool: DbTool, user_email: Optional[str], token_teams: Optional[List[str]]) -> bool:
+        """Return whether a tool is visible under token-team scoping rules."""
+        if token_teams is None:
+            return True
+        if len(token_teams) == 0:
+            return tool.visibility == "public"
+        if tool.visibility == "public":
+            return True
+        if user_email and tool.owner_email == user_email:
+            return True
+        return tool.team_id in token_teams and tool.visibility in {"team", "public"}
+
+    def _tool_matches_mount_rules(self, tool: DbTool, mount_rules: Dict[str, Any]) -> bool:
+        """Evaluate include/exclude mount rules against a candidate tool."""
+        raw_tags = tool.tags or []
+        tags = set(t if isinstance(t, str) else t.get("name", str(t)) for t in raw_tags)
+        include_tags = set(mount_rules.get("include_tags") or [])
+        exclude_tags = set(mount_rules.get("exclude_tags") or [])
+        include_tools = set(mount_rules.get("include_tools") or [])
+        exclude_tools = set(mount_rules.get("exclude_tools") or [])
+        include_servers = set(mount_rules.get("include_servers") or [])
+        exclude_servers = set(mount_rules.get("exclude_servers") or [])
+        server_slug = self._tool_server_slug(tool)
+
+        if include_tags and not tags.intersection(include_tags):
+            return False
+        if exclude_tags and tags.intersection(exclude_tags):
+            return False
+        if include_tools and tool.name not in include_tools and tool.original_name not in include_tools:
+            return False
+        if tool.name in exclude_tools or tool.original_name in exclude_tools:
+            return False
+        if include_servers and server_slug not in include_servers:
+            return False
+        if server_slug in exclude_servers:
+            return False
+        return True
+
+    def _server_mount_rules(self, server: DbServer) -> Dict[str, Any]:
+        """Normalize server mount-rules payload to a plain dict."""
+        raw = getattr(server, "mount_rules", None) or {}
+        if hasattr(raw, "model_dump"):
+            raw = raw.model_dump()
+        if not isinstance(raw, dict):
+            return {}
+        return dict(raw)
+
+    # ------------------------------------------------------------------
+    # Filesystem permissions
+    # ------------------------------------------------------------------
+
+    def _enforce_fs_permission(self, operation: str, virtual_path: str) -> None:
+        """Enforce filesystem allow/deny rules for a virtual path."""
+        deny = list(_DEFAULT_FS_DENY)
+        read_allow = list(_DEFAULT_FS_READ)
+        write_allow = list(_DEFAULT_FS_WRITE)
+
+        normalized = "/" + virtual_path.strip().lstrip("/")
+
+        if self._matches_any_pattern(normalized, deny):
+            raise VfsSecurityError(f"EACCES: {operation} denied for path: {normalized}")
+
+        allowed = read_allow if operation == "read" else write_allow
+        if not self._matches_any_pattern(normalized, allowed):
+            raise VfsSecurityError(f"EACCES: {operation} denied for path: {normalized}")
+
+    def _matches_any_pattern(self, value: str, patterns: Sequence[str]) -> bool:
+        """Return True when a value matches any configured glob pattern."""
+        for pattern in patterns or []:
+            if fnmatch.fnmatch(value, pattern):
+                return True
+            if pattern.endswith("/**") and value == pattern[: -len("/**")]:
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Naming helpers
+    # ------------------------------------------------------------------
+
+    def _tool_server_slug(self, tool: DbTool) -> str:
+        """Return a stable server slug for a mounted tool."""
+        gateway = getattr(tool, "gateway", None)
+        if gateway:
+            slug = getattr(gateway, "slug", None) or slugify(getattr(gateway, "name", "gateway"))
+            return slugify(slug)
+        return "local"
+
+    def _tool_file_name(self, tool: DbTool) -> str:
+        """Return a deterministic filesystem-safe base filename for a tool."""
+        value = getattr(tool, "custom_name_slug", None) or getattr(tool, "original_name", None) or tool.name
+        return slugify(value).replace("-", "_")
+
+    def _python_identifier(self, value: str) -> str:
+        """Convert arbitrary strings into valid Python identifiers."""
+        normalized = re.sub(r"[^a-zA-Z0-9_]", "_", value)
+        if not normalized:
+            normalized = "x"
+        if normalized[0].isdigit():
+            normalized = f"_{normalized}"
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Filesystem utilities
+    # ------------------------------------------------------------------
+
+    def _wipe_and_recreate_directory(self, path: Path) -> None:
+        """Recreate a directory from scratch, discarding previous contents."""
+        shutil.rmtree(path, ignore_errors=True)
+        path.mkdir(parents=True, exist_ok=True)
+
+    def _write_catalog_json(self, tools_dir: Path, catalog_tools: List[Dict[str, Any]]) -> None:
+        """Write a _catalog.json index of all mounted tools."""
+        (tools_dir / "_catalog.json").write_text(
+            json.dumps({"version": VFS_SCHEMA_VERSION, "tool_count": len(catalog_tools), "tools": catalog_tools}, indent=2),
+            encoding="utf-8",
+        )
+
+    def _build_search_index(self, tools_dir: Path) -> None:
+        """Build a simple text index for fast tool-search operations."""
+        index_lines: List[str] = []
+        for file_path in tools_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+            if file_path.name.startswith("."):
+                continue
+            try:
+                content = file_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                content = ""
+            if not content:
+                continue
+            rel = file_path.relative_to(tools_dir)
+            index_lines.append(f"{rel}:{content.replace(os.linesep, ' ')}")
+        (tools_dir / ".search_index").write_text("\n".join(index_lines), encoding="utf-8")

--- a/mcpgateway/services/vfs_service.py
+++ b/mcpgateway/services/vfs_service.py
@@ -45,12 +45,10 @@ from mcpgateway.utils.create_slug import slugify
 
 try:
     # First-Party
-    from plugins_rust import catalog_builder as rust_catalog_builder
     from plugins_rust import json_schema_to_stubs as rust_json_schema_to_stubs
 
     _RUST_VFS_AVAILABLE = True
 except ImportError:
-    rust_catalog_builder = None
     rust_json_schema_to_stubs = None
     _RUST_VFS_AVAILABLE = False
 
@@ -190,7 +188,7 @@ class VfsService:
     # Meta-tools
     # ------------------------------------------------------------------
 
-    def get_meta_tools(self, server: DbServer) -> List[Dict[str, Any]]:
+    def get_meta_tools(self, server: DbServer) -> List[Dict[str, Any]]:  # noqa: ARG002  # pylint: disable=unused-argument
         """Return the list of VFS meta-tool definitions for a server."""
         browse_tool = {
             "name": META_TOOL_FS_BROWSE,

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3092,6 +3092,42 @@
               </div>
             </div>
 
+            <!-- Virtual Tool Filesystem (VFS) Configuration -->
+            <div class="mt-6 border-t border-gray-200 dark:border-gray-700 pt-4">
+              <div class="mb-4">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-400" for="server-type">Server Type</label>
+                <select
+                  name="server_type"
+                  id="server-type"
+                  class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300 px-1.5 py-1.5"
+                  onchange="document.getElementById('vfs-config-section').classList.toggle('hidden', this.value !== 'vfs')"
+                >
+                  <option value="standard">Standard (normal proxy)</option>
+                  <option value="vfs">VFS (virtual tool filesystem)</option>
+                </select>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  VFS servers expose fs_browse/fs_read/fs_write meta-tools for browsable tool metadata.
+                </p>
+              </div>
+              <div id="vfs-config-section" class="hidden space-y-4 pl-6 border-l-2 border-indigo-200 dark:border-indigo-800">
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-400" for="server-stub-format">Stub Format</label>
+                  <select
+                    name="stub_format"
+                    id="server-stub-format"
+                    class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300 px-1.5 py-1.5"
+                  >
+                    <option value="json">JSON (MCP raw schema)</option>
+                    <option value="python">Python (type-annotated stubs)</option>
+                    <option value="typescript">TypeScript (interface stubs)</option>
+                  </select>
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Format for generated tool stubs in the virtual filesystem.
+                  </p>
+                </div>
+              </div>
+            </div>
+
             <!-- OAuth 2.0 Configuration Section (RFC 9728) -->
             <div class="mt-6 border-t border-gray-200 dark:border-gray-700 pt-4">
               <div class="flex items-center mb-4">

--- a/mcpgateway/templates/servers_partial.html
+++ b/mcpgateway/templates/servers_partial.html
@@ -56,7 +56,12 @@
     </td>
     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300">{{ (pagination.page - 1) * pagination.per_page + loop.index }}</td>
     <td class="px-6 py-4 whitespace-normal break-all text-sm font-medium text-gray-900 dark:text-gray-300 max-w-32">{{ server.id }}</td>
-    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300">{{ server.name }}</td>
+    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300">
+      {{ server.name }}
+      {% if server.serverType == 'vfs' %}
+      <span class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">VFS</span>
+      {% endif %}
+    </td>
     <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300">{{ server.description | decode_html }}</td>
     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-300">
       {% if server.associatedTools %}

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -104,6 +104,11 @@ def mock_server(mock_tool, mock_resource, mock_prompt):
     server.oauth_enabled = False
     server.oauth_config = None
 
+    # Virtual Tool Filesystem (VFS) fields
+    server.server_type = "standard"
+    server.stub_format = None
+    server.mount_rules = None
+
     # Associated objects -------------------------------------------------- #
     server.tools = [mock_tool]
     server.resources = [mock_resource]

--- a/tests/unit/mcpgateway/services/test_vfs_service.py
+++ b/tests/unit/mcpgateway/services/test_vfs_service.py
@@ -1,0 +1,876 @@
+# -*- coding: utf-8 -*-
+"""Tests for mcpgateway.services.vfs_service."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcpgateway.services.vfs_service import (
+    META_TOOL_FS_BROWSE,
+    META_TOOL_FS_READ,
+    META_TOOL_FS_WRITE,
+    VFS_META_TOOLS,
+    VFS_SCHEMA_VERSION,
+    VFS_SERVER_TYPE,
+    VfsError,
+    VfsSecurityError,
+    VfsService,
+    VfsSession,
+    _is_path_within,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _make_tool(
+    tool_id: str = "t1",
+    name: str = "my_tool",
+    original_name: str = "my_tool",
+    description: str = "A test tool",
+    input_schema: Optional[Dict[str, Any]] = None,
+    tags: Optional[List] = None,
+    gateway_name: str = "demo_gw",
+    gateway_slug: str = "demo_gw",
+    visibility: str = "public",
+    owner_email: Optional[str] = None,
+    team_id: Optional[str] = None,
+    enabled: bool = True,
+    reachable: bool = True,
+    custom_name_slug: Optional[str] = None,
+) -> SimpleNamespace:
+    """Build a lightweight tool-like object accepted by VfsService internals."""
+    gw = SimpleNamespace(id="gw1", name=gateway_name, slug=gateway_slug)
+    return SimpleNamespace(
+        id=tool_id,
+        name=name,
+        original_name=original_name,
+        description=description,
+        input_schema=input_schema or {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]},
+        tags=tags or [],
+        gateway=gw,
+        visibility=visibility,
+        owner_email=owner_email,
+        team_id=team_id,
+        enabled=enabled,
+        reachable=reachable,
+        updated_at=datetime(2026, 2, 19, tzinfo=timezone.utc),
+        custom_name_slug=custom_name_slug,
+    )
+
+
+def _make_server(
+    server_id: str = "srv1",
+    server_type: str = "vfs",
+    stub_format: Optional[str] = None,
+    mount_rules: Optional[Dict[str, Any]] = None,
+) -> SimpleNamespace:
+    """Build a lightweight server-like object."""
+    return SimpleNamespace(
+        id=server_id,
+        server_type=server_type,
+        stub_format=stub_format,
+        mount_rules=mount_rules,
+    )
+
+
+def _stub_db(tools: Optional[List] = None):
+    """Return a mock DB session that yields the given tools from select()."""
+    db = MagicMock()
+    db.execute.return_value.scalars.return_value.all.return_value = tools or []
+    return db
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def vfs(tmp_path):
+    """Create a VfsService rooted in a temp dir."""
+    with patch("mcpgateway.services.vfs_service.settings") as mock_settings:
+        mock_settings.vfs_base_dir = str(tmp_path / "vfs")
+        mock_settings.vfs_session_ttl_seconds = 900
+        mock_settings.vfs_fs_browse_enabled = True
+        mock_settings.vfs_fs_read_enabled = True
+        mock_settings.vfs_fs_write_enabled = True
+        mock_settings.vfs_fs_read_max_size_bytes = 1048576
+        mock_settings.vfs_fs_browse_default_max_entries = 200
+        mock_settings.vfs_fs_browse_max_entries = 1000
+        mock_settings.vfs_default_stub_format = "json"
+        service = VfsService()
+    return service
+
+
+@pytest.fixture()
+def server():
+    return _make_server()
+
+
+@pytest.fixture()
+def tool():
+    return _make_tool()
+
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+class TestConstants:
+    def test_vfs_server_type(self):
+        assert VFS_SERVER_TYPE == "vfs"
+
+    def test_meta_tool_names(self):
+        assert META_TOOL_FS_BROWSE == "fs_browse"
+        assert META_TOOL_FS_READ == "fs_read"
+        assert META_TOOL_FS_WRITE == "fs_write"
+
+    def test_meta_tools_tuple(self):
+        assert VFS_META_TOOLS == ("fs_browse", "fs_read", "fs_write")
+
+    def test_schema_version(self):
+        assert VFS_SCHEMA_VERSION == "2026-02-19"
+
+
+# --------------------------------------------------------------------------- #
+# _is_path_within
+# --------------------------------------------------------------------------- #
+class TestIsPathWithin:
+    def test_same_dir(self, tmp_path):
+        assert _is_path_within(tmp_path, tmp_path) is True
+
+    def test_child(self, tmp_path):
+        child = tmp_path / "sub" / "file.txt"
+        child.parent.mkdir(parents=True)
+        child.touch()
+        assert _is_path_within(child, tmp_path) is True
+
+    def test_outside(self, tmp_path):
+        other = tmp_path.parent / "elsewhere"
+        assert _is_path_within(other, tmp_path) is False
+
+
+# --------------------------------------------------------------------------- #
+# VfsSession
+# --------------------------------------------------------------------------- #
+class TestVfsSession:
+    def test_all_dirs(self, tmp_path):
+        session = VfsSession(
+            session_id="s1",
+            server_id="srv1",
+            user_email="u@e.com",
+            stub_format="json",
+            root_dir=tmp_path,
+            tools_dir=tmp_path / "tools",
+            scratch_dir=tmp_path / "scratch",
+            results_dir=tmp_path / "results",
+        )
+        assert session.all_dirs == (tmp_path / "tools", tmp_path / "scratch", tmp_path / "results")
+
+    def test_default_fields(self, tmp_path):
+        session = VfsSession(
+            session_id="s1",
+            server_id="srv1",
+            user_email="u@e.com",
+            stub_format="json",
+            root_dir=tmp_path,
+            tools_dir=tmp_path / "tools",
+            scratch_dir=tmp_path / "scratch",
+            results_dir=tmp_path / "results",
+        )
+        assert session.mounted_tools == {}
+        assert session.content_hash is None
+        assert session.generated_at is None
+
+
+# --------------------------------------------------------------------------- #
+# get_meta_tools
+# --------------------------------------------------------------------------- #
+class TestGetMetaTools:
+    def test_all_enabled(self, vfs, server):
+        tools = vfs.get_meta_tools(server)
+        names = [t["name"] for t in tools]
+        assert names == ["fs_browse", "fs_read", "fs_write"]
+
+    def test_browse_disabled(self, vfs, server):
+        vfs._fs_browse_enabled = False
+        tools = vfs.get_meta_tools(server)
+        names = [t["name"] for t in tools]
+        assert "fs_browse" not in names
+        assert "fs_read" in names
+        assert "fs_write" in names
+
+    def test_read_disabled(self, vfs, server):
+        vfs._fs_read_enabled = False
+        tools = vfs.get_meta_tools(server)
+        names = [t["name"] for t in tools]
+        assert "fs_read" not in names
+
+    def test_write_disabled(self, vfs, server):
+        vfs._fs_write_enabled = False
+        tools = vfs.get_meta_tools(server)
+        names = [t["name"] for t in tools]
+        assert "fs_write" not in names
+
+    def test_all_disabled(self, vfs, server):
+        vfs._fs_browse_enabled = False
+        vfs._fs_read_enabled = False
+        vfs._fs_write_enabled = False
+        assert vfs.get_meta_tools(server) == []
+
+    def test_schema_shape(self, vfs, server):
+        tools = vfs.get_meta_tools(server)
+        for t in tools:
+            assert "name" in t
+            assert "description" in t
+            assert "inputSchema" in t
+            assert isinstance(t["inputSchema"], dict)
+
+
+# --------------------------------------------------------------------------- #
+# Session lifecycle
+# --------------------------------------------------------------------------- #
+class TestSessionLifecycle:
+    @pytest.mark.asyncio
+    async def test_deterministic_session_id(self, vfs):
+        sid1 = vfs._deterministic_session_id("srv1", "u@e.com")
+        sid2 = vfs._deterministic_session_id("srv1", "u@e.com")
+        assert sid1 == sid2
+        assert len(sid1) == 24
+
+    @pytest.mark.asyncio
+    async def test_different_users_different_ids(self, vfs):
+        sid1 = vfs._deterministic_session_id("srv1", "alice@e.com")
+        sid2 = vfs._deterministic_session_id("srv1", "bob@e.com")
+        assert sid1 != sid2
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_creates_dirs(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        assert session.tools_dir.exists()
+        assert session.scratch_dir.exists()
+        assert session.results_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_returns_same(self, vfs, server):
+        db = _stub_db()
+        s1 = await vfs.get_or_create_session(db, server, "u@e.com")
+        s2 = await vfs.get_or_create_session(db, server, "u@e.com")
+        assert s1 is s2
+
+    @pytest.mark.asyncio
+    async def test_session_respects_stub_format(self, vfs):
+        srv = _make_server(stub_format="typescript")
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, srv, "u@e.com")
+        assert session.stub_format == "typescript"
+
+    @pytest.mark.asyncio
+    async def test_session_falls_back_to_default_format(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        assert session.stub_format == "json"
+
+    @pytest.mark.asyncio
+    async def test_invalid_stub_format_falls_back(self, vfs):
+        srv = _make_server(stub_format="invalid_format")
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, srv, "u@e.com")
+        assert session.stub_format == "json"
+
+
+# --------------------------------------------------------------------------- #
+# fs_browse
+# --------------------------------------------------------------------------- #
+class TestFsBrowse:
+    @pytest.mark.asyncio
+    async def test_browse_root(self, vfs, server):
+        db = _stub_db()
+        result = await vfs.fs_browse(db, server, "/", False, None, "u@e.com", None)
+        assert result["path"] == "/"
+        entries = result["entries"]
+        names = {e["name"] for e in entries}
+        assert names == {"tools", "scratch", "results"}
+
+    @pytest.mark.asyncio
+    async def test_browse_tools_empty(self, vfs, server):
+        db = _stub_db()
+        result = await vfs.fs_browse(db, server, "/tools", False, None, "u@e.com", None)
+        # With no tools, /tools should have only meta files (_schema.json)
+        assert result["path"] == "/tools"
+        assert isinstance(result["entries"], list)
+
+    @pytest.mark.asyncio
+    async def test_browse_with_tool_generates_stubs(self, vfs, server):
+        db = _stub_db([_make_tool()])
+        result = await vfs.fs_browse(db, server, "/tools", False, None, "u@e.com", None)
+        # Should contain at least the gateway directory and/or meta files
+        assert len(result["entries"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_browse_nonexistent_path(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsError, match="Path not found"):
+            await vfs.fs_browse(db, server, "/tools/nonexistent", False, None, "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_browse_outside_vfs_denied(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsSecurityError):
+            await vfs.fs_browse(db, server, "/etc/passwd", False, None, "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_browse_disabled(self, vfs, server):
+        vfs._fs_browse_enabled = False
+        db = _stub_db()
+        with pytest.raises(VfsError, match="disabled"):
+            await vfs.fs_browse(db, server, "/", False, None, "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_browse_max_entries_limit(self, vfs, server):
+        db = _stub_db()
+        # Create a session with some files in scratch
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        for i in range(10):
+            (session.scratch_dir / f"file{i}.txt").write_text(f"content {i}")
+        result = await vfs.fs_browse(db, server, "/scratch", False, 3, "u@e.com", None)
+        assert len(result["entries"]) == 3
+        assert result["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_browse_hidden_files_excluded(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        (session.scratch_dir / ".hidden").write_text("secret")
+        (session.scratch_dir / "visible.txt").write_text("ok")
+        result = await vfs.fs_browse(db, server, "/scratch", False, None, "u@e.com", None)
+        names = {e["name"] for e in result["entries"]}
+        assert ".hidden" not in names
+        assert "visible.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_browse_hidden_files_included(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        (session.scratch_dir / ".hidden").write_text("secret")
+        (session.scratch_dir / "visible.txt").write_text("ok")
+        result = await vfs.fs_browse(db, server, "/scratch", True, None, "u@e.com", None)
+        names = {e["name"] for e in result["entries"]}
+        assert ".hidden" in names
+
+    @pytest.mark.asyncio
+    async def test_browse_file_path(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        (session.scratch_dir / "test.txt").write_text("hello")
+        result = await vfs.fs_browse(db, server, "/scratch/test.txt", False, None, "u@e.com", None)
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["type"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_browse_max_entries_bool_ignored(self, vfs, server):
+        """Bool max_entries should fall back to default."""
+        db = _stub_db()
+        result = await vfs.fs_browse(db, server, "/", False, True, "u@e.com", None)
+        assert isinstance(result["entries"], list)
+
+    @pytest.mark.asyncio
+    async def test_browse_max_entries_string_ignored(self, vfs, server):
+        """Non-numeric max_entries should fall back to default."""
+        db = _stub_db()
+        result = await vfs.fs_browse(db, server, "/", False, "invalid", "u@e.com", None)
+        assert isinstance(result["entries"], list)
+
+
+# --------------------------------------------------------------------------- #
+# fs_read
+# --------------------------------------------------------------------------- #
+class TestFsRead:
+    @pytest.mark.asyncio
+    async def test_read_scratch_file(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        (session.scratch_dir / "hello.txt").write_text("Hello, VFS!")
+        result = await vfs.fs_read(db, server, "/scratch/hello.txt", "u@e.com", None)
+        assert result["content"] == "Hello, VFS!"
+        assert result["path"] == "/scratch/hello.txt"
+        assert "size_bytes" in result
+        assert "modified_at" in result
+
+    @pytest.mark.asyncio
+    async def test_read_nonexistent(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsError, match="Path not found"):
+            await vfs.fs_read(db, server, "/scratch/nope.txt", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_read_directory(self, vfs, server):
+        db = _stub_db()
+        await vfs.get_or_create_session(db, server, "u@e.com")
+        with pytest.raises(VfsError, match="directory"):
+            await vfs.fs_read(db, server, "/scratch", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_read_empty_path(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsError, match="path is required"):
+            await vfs.fs_read(db, server, "", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_read_outside_vfs_denied(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsSecurityError):
+            await vfs.fs_read(db, server, "/etc/passwd", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_read_disabled(self, vfs, server):
+        vfs._fs_read_enabled = False
+        db = _stub_db()
+        with pytest.raises(VfsError, match="disabled"):
+            await vfs.fs_read(db, server, "/scratch/file.txt", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_read_tool_stub_json(self, vfs, server):
+        """After stub generation, we should be able to read a tool stub."""
+        tool = _make_tool(name="list_users", original_name="list_users")
+        db = _stub_db([tool])
+        await vfs.get_or_create_session(db, server, "u@e.com")
+        # Browse to find generated stubs
+        browse_result = await vfs.fs_browse(db, server, "/tools", False, None, "u@e.com", None)
+        # There should be a server directory
+        dirs = [e for e in browse_result["entries"] if e["type"] == "directory"]
+        assert len(dirs) > 0
+
+    @pytest.mark.asyncio
+    async def test_read_file_too_large(self, vfs, server):
+        vfs._fs_read_max_size_bytes = 10  # Very small limit
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        (session.scratch_dir / "big.txt").write_text("x" * 100)
+        with pytest.raises(VfsError, match="too large"):
+            await vfs.fs_read(db, server, "/scratch/big.txt", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_read_traversal_denied(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsSecurityError):
+            await vfs.fs_read(db, server, "/scratch/../../etc/passwd", "u@e.com", None)
+
+
+# --------------------------------------------------------------------------- #
+# fs_write
+# --------------------------------------------------------------------------- #
+class TestFsWrite:
+    @pytest.mark.asyncio
+    async def test_write_to_scratch(self, vfs, server):
+        db = _stub_db()
+        result = await vfs.fs_write(db, server, "/scratch/test.txt", "Hello!", "u@e.com", None)
+        assert result["path"] == "/scratch/test.txt"
+        assert result["size_bytes"] == 6
+
+    @pytest.mark.asyncio
+    async def test_write_to_results(self, vfs, server):
+        db = _stub_db()
+        result = await vfs.fs_write(db, server, "/results/output.json", '{"ok": true}', "u@e.com", None)
+        assert result["path"] == "/results/output.json"
+
+    @pytest.mark.asyncio
+    async def test_write_to_tools_denied(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsSecurityError, match="write denied"):
+            await vfs.fs_write(db, server, "/tools/evil.py", "bad", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_write_empty_path(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsError, match="path is required"):
+            await vfs.fs_write(db, server, "", "content", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_write_none_content(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsError, match="content is required"):
+            await vfs.fs_write(db, server, "/scratch/test.txt", None, "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_write_disabled(self, vfs, server):
+        vfs._fs_write_enabled = False
+        db = _stub_db()
+        with pytest.raises(VfsError, match="disabled"):
+            await vfs.fs_write(db, server, "/scratch/test.txt", "hi", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_write_outside_vfs_denied(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsSecurityError):
+            await vfs.fs_write(db, server, "/etc/hack.txt", "pwned", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_write_traversal_denied(self, vfs, server):
+        db = _stub_db()
+        with pytest.raises(VfsSecurityError):
+            await vfs.fs_write(db, server, "/scratch/../../etc/passwd", "pwned", "u@e.com", None)
+
+    @pytest.mark.asyncio
+    async def test_write_creates_subdirectories(self, vfs, server):
+        db = _stub_db()
+        result = await vfs.fs_write(db, server, "/scratch/a/b/c/file.txt", "nested", "u@e.com", None)
+        assert result["path"] == "/scratch/a/b/c/file.txt"
+        assert result["size_bytes"] == 6
+
+    @pytest.mark.asyncio
+    async def test_write_then_read(self, vfs, server):
+        db = _stub_db()
+        await vfs.fs_write(db, server, "/scratch/roundtrip.txt", "round trip!", "u@e.com", None)
+        read_result = await vfs.fs_read(db, server, "/scratch/roundtrip.txt", "u@e.com", None)
+        assert read_result["content"] == "round trip!"
+
+
+# --------------------------------------------------------------------------- #
+# Stub generation
+# --------------------------------------------------------------------------- #
+class TestStubGeneration:
+    @pytest.mark.asyncio
+    async def test_json_stub_format(self, vfs):
+        srv = _make_server(stub_format="json")
+        tool = _make_tool(name="test_tool", description="A test tool")
+        db = _stub_db([tool])
+        session = await vfs.get_or_create_session(db, srv, "u@e.com")
+        # Find the json stub file
+        json_files = list(session.tools_dir.rglob("*.json"))
+        # Filter out meta files
+        tool_stubs = [f for f in json_files if not f.name.startswith("_")]
+        assert len(tool_stubs) >= 1
+        content = json.loads(tool_stubs[0].read_text())
+        assert "name" in content
+        assert "inputSchema" in content
+
+    @pytest.mark.asyncio
+    async def test_python_stub_format(self, vfs):
+        srv = _make_server(stub_format="python")
+        tool = _make_tool(name="test_tool", description="A test tool")
+        db = _stub_db([tool])
+        session = await vfs.get_or_create_session(db, srv, "u@e.com")
+        py_files = list(session.tools_dir.rglob("*.py"))
+        assert len(py_files) >= 1
+        content = py_files[0].read_text()
+        assert "async def" in content
+        assert "Auto-generated" in content
+
+    @pytest.mark.asyncio
+    async def test_typescript_stub_format(self, vfs):
+        srv = _make_server(stub_format="typescript")
+        tool = _make_tool(name="test_tool", description="A test tool")
+        db = _stub_db([tool])
+        session = await vfs.get_or_create_session(db, srv, "u@e.com")
+        ts_files = list(session.tools_dir.rglob("*.ts"))
+        assert len(ts_files) >= 1
+        content = ts_files[0].read_text()
+        assert "export async function" in content
+        assert "Auto-generated" in content
+
+    @pytest.mark.asyncio
+    async def test_catalog_json_written(self, vfs, server):
+        tool = _make_tool()
+        db = _stub_db([tool])
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        catalog = session.tools_dir / "_catalog.json"
+        assert catalog.exists()
+        data = json.loads(catalog.read_text())
+        assert data["tool_count"] == 1
+        assert len(data["tools"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_schema_json_written(self, vfs, server):
+        db = _stub_db([_make_tool()])
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        schema = session.tools_dir / "_schema.json"
+        assert schema.exists()
+        data = json.loads(schema.read_text())
+        assert data["version"] == VFS_SCHEMA_VERSION
+        assert data["stub_format"] == "json"
+
+    @pytest.mark.asyncio
+    async def test_search_index_built(self, vfs, server):
+        db = _stub_db([_make_tool()])
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        index = session.tools_dir / ".search_index"
+        assert index.exists()
+
+    @pytest.mark.asyncio
+    async def test_content_hash_prevents_regeneration(self, vfs, server):
+        tool = _make_tool()
+        db = _stub_db([tool])
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        first_hash = session.content_hash
+        first_gen = session.generated_at
+        assert first_hash is not None
+        # Get session again — should reuse without regeneration
+        await vfs.get_or_create_session(db, server, "u@e.com")
+        assert session.content_hash == first_hash
+        assert session.generated_at == first_gen
+
+
+# --------------------------------------------------------------------------- #
+# Type mapping
+# --------------------------------------------------------------------------- #
+class TestTypeMapping:
+    def test_python_string(self, vfs):
+        assert vfs._schema_to_python_type({"type": "string"}) == "str"
+
+    def test_python_integer(self, vfs):
+        assert vfs._schema_to_python_type({"type": "integer"}) == "int"
+
+    def test_python_number(self, vfs):
+        assert vfs._schema_to_python_type({"type": "number"}) == "float"
+
+    def test_python_boolean(self, vfs):
+        assert vfs._schema_to_python_type({"type": "boolean"}) == "bool"
+
+    def test_python_array(self, vfs):
+        assert vfs._schema_to_python_type({"type": "array", "items": {"type": "string"}}) == "List[str]"
+
+    def test_python_object(self, vfs):
+        assert vfs._schema_to_python_type({"type": "object"}) == "Dict[str, Any]"
+
+    def test_python_enum(self, vfs):
+        result = vfs._schema_to_python_type({"enum": ["a", "b"]})
+        assert "Literal[" in result
+
+    def test_python_unknown(self, vfs):
+        assert vfs._schema_to_python_type({}) == "Any"
+
+    def test_typescript_string(self, vfs):
+        assert vfs._schema_to_typescript_type({"type": "string"}) == "string"
+
+    def test_typescript_number(self, vfs):
+        assert vfs._schema_to_typescript_type({"type": "number"}) == "number"
+
+    def test_typescript_integer(self, vfs):
+        assert vfs._schema_to_typescript_type({"type": "integer"}) == "number"
+
+    def test_typescript_boolean(self, vfs):
+        assert vfs._schema_to_typescript_type({"type": "boolean"}) == "boolean"
+
+    def test_typescript_array(self, vfs):
+        assert vfs._schema_to_typescript_type({"type": "array", "items": {"type": "string"}}) == "string[]"
+
+    def test_typescript_object_no_props(self, vfs):
+        assert vfs._schema_to_typescript_type({"type": "object"}) == "Record<string, any>"
+
+    def test_typescript_object_with_props(self, vfs):
+        result = vfs._schema_to_typescript_type(
+            {"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "integer"}}, "required": ["name"]}
+        )
+        assert "name: string" in result
+        assert "age?: number" in result
+
+    def test_typescript_enum(self, vfs):
+        result = vfs._schema_to_typescript_type({"enum": ["a", "b"]})
+        assert '"a"' in result
+        assert '"b"' in result
+
+    def test_typescript_unknown(self, vfs):
+        assert vfs._schema_to_typescript_type({}) == "any"
+
+
+# --------------------------------------------------------------------------- #
+# Path mapping
+# --------------------------------------------------------------------------- #
+class TestPathMapping:
+    @pytest.mark.asyncio
+    async def test_virtual_to_real_tools(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        real = vfs._virtual_to_real_path(session, "/tools")
+        assert real == session.tools_dir
+
+    @pytest.mark.asyncio
+    async def test_virtual_to_real_scratch_subpath(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        real = vfs._virtual_to_real_path(session, "/scratch/file.txt")
+        assert str(real).endswith("file.txt")
+
+    @pytest.mark.asyncio
+    async def test_virtual_to_real_outside_returns_none(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        assert vfs._virtual_to_real_path(session, "/unknown/path") is None
+
+    @pytest.mark.asyncio
+    async def test_virtual_to_real_traversal_returns_none(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        result = vfs._virtual_to_real_path(session, "/scratch/../../etc/passwd")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_real_to_virtual(self, vfs, server):
+        db = _stub_db()
+        session = await vfs.get_or_create_session(db, server, "u@e.com")
+        real = session.tools_dir / "gateway" / "tool.json"
+        virtual = vfs._real_to_virtual_path(session, real)
+        assert virtual == "/tools/gateway/tool.json"
+
+
+# --------------------------------------------------------------------------- #
+# Mount rules
+# --------------------------------------------------------------------------- #
+class TestMountRules:
+    def test_include_tags(self, vfs):
+        tool = _make_tool(tags=[{"name": "math"}])
+        assert vfs._tool_matches_mount_rules(tool, {"include_tags": ["math"]}) is True
+        assert vfs._tool_matches_mount_rules(tool, {"include_tags": ["science"]}) is False
+
+    def test_exclude_tags(self, vfs):
+        tool = _make_tool(tags=[{"name": "deprecated"}])
+        assert vfs._tool_matches_mount_rules(tool, {"exclude_tags": ["deprecated"]}) is False
+        assert vfs._tool_matches_mount_rules(tool, {"exclude_tags": ["other"]}) is True
+
+    def test_include_tools(self, vfs):
+        tool = _make_tool(name="my_tool")
+        assert vfs._tool_matches_mount_rules(tool, {"include_tools": ["my_tool"]}) is True
+        assert vfs._tool_matches_mount_rules(tool, {"include_tools": ["other"]}) is False
+
+    def test_exclude_tools(self, vfs):
+        tool = _make_tool(name="my_tool")
+        assert vfs._tool_matches_mount_rules(tool, {"exclude_tools": ["my_tool"]}) is False
+        assert vfs._tool_matches_mount_rules(tool, {"exclude_tools": ["other"]}) is True
+
+    def test_include_servers(self, vfs):
+        tool = _make_tool(gateway_slug="demo_gw")
+        # slugify converts underscores to dashes
+        assert vfs._tool_matches_mount_rules(tool, {"include_servers": ["demo-gw"]}) is True
+        assert vfs._tool_matches_mount_rules(tool, {"include_servers": ["other"]}) is False
+
+    def test_exclude_servers(self, vfs):
+        tool = _make_tool(gateway_slug="demo_gw")
+        assert vfs._tool_matches_mount_rules(tool, {"exclude_servers": ["demo-gw"]}) is False
+        assert vfs._tool_matches_mount_rules(tool, {"exclude_servers": ["other"]}) is True
+
+    def test_empty_rules_match_all(self, vfs):
+        tool = _make_tool()
+        assert vfs._tool_matches_mount_rules(tool, {}) is True
+
+    def test_server_mount_rules_normalizes(self, vfs):
+        srv = _make_server(mount_rules={"include_tags": ["math"]})
+        result = vfs._server_mount_rules(srv)
+        assert result == {"include_tags": ["math"]}
+
+    def test_server_mount_rules_none(self, vfs):
+        srv = _make_server(mount_rules=None)
+        result = vfs._server_mount_rules(srv)
+        assert result == {}
+
+
+# --------------------------------------------------------------------------- #
+# Visibility scoping
+# --------------------------------------------------------------------------- #
+class TestVisibilityScoping:
+    def test_no_teams_sees_all(self, vfs):
+        tool = _make_tool(visibility="team", team_id="t1")
+        assert vfs._tool_visible_for_scope(tool, None, None) is True
+
+    def test_empty_teams_sees_public_only(self, vfs):
+        public_tool = _make_tool(visibility="public")
+        team_tool = _make_tool(visibility="team", team_id="t1")
+        assert vfs._tool_visible_for_scope(public_tool, "u@e.com", []) is True
+        assert vfs._tool_visible_for_scope(team_tool, "u@e.com", []) is False
+
+    def test_team_member_sees_team_tools(self, vfs):
+        tool = _make_tool(visibility="team", team_id="t1")
+        assert vfs._tool_visible_for_scope(tool, "u@e.com", ["t1"]) is True
+        assert vfs._tool_visible_for_scope(tool, "u@e.com", ["t2"]) is False
+
+    def test_owner_sees_own_tools(self, vfs):
+        tool = _make_tool(visibility="private", owner_email="u@e.com", team_id="t1")
+        assert vfs._tool_visible_for_scope(tool, "u@e.com", ["t2"]) is True
+        assert vfs._tool_visible_for_scope(tool, "other@e.com", ["t2"]) is False
+
+
+# --------------------------------------------------------------------------- #
+# Naming helpers
+# --------------------------------------------------------------------------- #
+class TestNamingHelpers:
+    def test_tool_server_slug(self, vfs):
+        tool = _make_tool(gateway_slug="my-gateway")
+        result = vfs._tool_server_slug(tool)
+        assert result == "my-gateway"
+
+    def test_tool_server_slug_no_gateway(self, vfs):
+        tool = _make_tool()
+        tool.gateway = None
+        assert vfs._tool_server_slug(tool) == "local"
+
+    def test_tool_file_name(self, vfs):
+        tool = _make_tool(name="my-fancy-tool")
+        result = vfs._tool_file_name(tool)
+        # Should be filesystem-safe (slugified with underscores)
+        assert all(c.isalnum() or c == "_" for c in result)
+
+    def test_python_identifier(self, vfs):
+        assert vfs._python_identifier("my-tool") == "my_tool"
+        assert vfs._python_identifier("123start") == "_123start"
+        assert vfs._python_identifier("") == "x"
+
+    def test_python_identifier_special_chars(self, vfs):
+        result = vfs._python_identifier("tool@server#1")
+        assert result.isidentifier()
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem permissions
+# --------------------------------------------------------------------------- #
+class TestFsPermissions:
+    def test_read_tools_allowed(self, vfs):
+        vfs._enforce_fs_permission("read", "/tools/foo.py")
+
+    def test_read_scratch_allowed(self, vfs):
+        vfs._enforce_fs_permission("read", "/scratch/bar.txt")
+
+    def test_read_results_allowed(self, vfs):
+        vfs._enforce_fs_permission("read", "/results/output.json")
+
+    def test_read_etc_denied(self, vfs):
+        with pytest.raises(VfsSecurityError):
+            vfs._enforce_fs_permission("read", "/etc/passwd")
+
+    def test_write_scratch_allowed(self, vfs):
+        vfs._enforce_fs_permission("write", "/scratch/test.txt")
+
+    def test_write_results_allowed(self, vfs):
+        vfs._enforce_fs_permission("write", "/results/out.json")
+
+    def test_write_tools_denied(self, vfs):
+        with pytest.raises(VfsSecurityError):
+            vfs._enforce_fs_permission("write", "/tools/evil.py")
+
+    def test_write_etc_denied(self, vfs):
+        with pytest.raises(VfsSecurityError):
+            vfs._enforce_fs_permission("write", "/etc/hack")
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem utilities
+# --------------------------------------------------------------------------- #
+class TestFsUtilities:
+    def test_wipe_and_recreate(self, vfs, tmp_path):
+        d = tmp_path / "sub"
+        d.mkdir()
+        (d / "file.txt").write_text("old")
+        vfs._wipe_and_recreate_directory(d)
+        assert d.exists()
+        assert list(d.iterdir()) == []
+
+    def test_matches_any_pattern(self, vfs):
+        assert vfs._matches_any_pattern("/tools/foo.py", ["/tools/**"]) is True
+        assert vfs._matches_any_pattern("/etc/passwd", ["/tools/**"]) is False
+        # Direct root match
+        assert vfs._matches_any_pattern("/tools", ["/tools/**"]) is True


### PR DESCRIPTION
> **Note:** This PR was re-created from #3077 due to repository maintenance. Your code and branch are intact. @crivetimihai please verify everything looks good.

## Summary

- Adds a new **VFS (Virtual Tool Filesystem)** server type that exposes mounted MCP tools as a browsable filesystem with `fs_browse`, `fs_read`, and `fs_write` meta-tools
- Enables LLM agents to discover tools and generate typed stubs (Python, TypeScript, MCP JSON) for available tools
- Integrates VFS routing into the MCP JSON-RPC handler (`tools/list`, `tools/call`) with session-based filesystem and mount-rule scoping
- Adds admin UI support for creating/editing VFS servers with server-type selector and stub-format configuration
- All VFS behavior gated behind `vfs_enabled` config flag (default: `False`)

## Changes

| File | Change |
|------|--------|
| `mcpgateway/services/vfs_service.py` | New VfsService with session management, filesystem ops, stub generation, mount rules, visibility scoping |
| `mcpgateway/main.py` | VFS routing in `tools/list` and `tools/call` RPC handlers |
| `mcpgateway/db.py` | `server_type`, `stub_format`, `mount_rules` columns on Server model |
| `mcpgateway/schemas.py` | VFS fields on ServerCreate, ServerUpdate, ServerRead |
| `mcpgateway/config.py` | `vfs_enabled` and `vfs_session_ttl_seconds` settings |
| `mcpgateway/services/server_service.py` | VFS field persistence in register/update/convert |
| `mcpgateway/admin.py` | VFS form field parsing for create/edit |
| `mcpgateway/templates/admin.html` | VFS Configuration section in server form |
| `mcpgateway/templates/servers_partial.html` | VFS badge on server list |
| `mcpgateway/alembic/versions/a1b2c3d4e5f6_*.py` | Idempotent migration for VFS columns |
| `tests/unit/.../test_vfs_service.py` | 110 unit tests covering all VFS operations |
| `tests/unit/.../test_server_service.py` | Updated mock fixture for VFS fields |