### PR TITLE
fix(api): remove shared db session from audit trail calls to prevent inactive transaction errors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-26T15:26:45Z",
+  "generated_at": "2026-06-25T12:02:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -240,7 +240,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 218,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 220,
+        "line_number": 231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -256,7 +256,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 303,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -264,7 +264,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 293,
+        "line_number": 304,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1594,
+        "line_number": 1590,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1682,
+        "line_number": 1678,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2032,
+        "line_number": 2028,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3398,
+        "line_number": 3394,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3489,
+        "line_number": 3485,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3532,
+        "line_number": 3528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3537,
+        "line_number": 3533,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3542,
+        "line_number": 3538,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3363,20 +3363,20 @@
         "verified_result": null
       }
     ],
-    "docs/docs/using/agents/beeai.md": [
+    "docs/docs/using/agents/bee.md": [
       {
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 39,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "ec545cfb40ff2f1b4eb959dbd0e3177236c540fa",
+        "hashed_secret": "be0e0678e7132e8f991d463818e1befbaf3aad9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 203,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4215,6 +4215,24 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/alembic/versions/e28cd485ad3c_remove_global_unique_constraints_for_.py": [
+      {
+        "hashed_secret": "64589d1d5776faad3fc219e30c877e7ab8abb551",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5dbedebc3423bc4336c49a36bd75fe7d370c5176",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/common/validators.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
@@ -4256,7 +4274,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 739,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-25T12:02:36Z",
+  "generated_at": "2026-06-26T13:46:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -240,7 +240,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 230,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 231,
+        "line_number": 232,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -256,7 +256,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 303,
+        "line_number": 304,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -264,7 +264,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 304,
+        "line_number": 305,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-26T13:46:12Z",
+  "generated_at": "2026-06-26T16:10:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1590,
+        "line_number": 1594,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1678,
+        "line_number": 1682,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2028,
+        "line_number": 2032,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3394,
+        "line_number": 3398,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3485,
+        "line_number": 3489,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3528,
+        "line_number": 3532,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3533,
+        "line_number": 3537,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3538,
+        "line_number": 3542,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3363,24 +3363,6 @@
         "verified_result": null
       }
     ],
-    "docs/docs/using/agents/bee.md": [
-      {
-        "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 39,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "be0e0678e7132e8f991d463818e1befbaf3aad9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 61,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "docs/docs/using/clients/claude-desktop.md": [
       {
         "hashed_secret": "11c78bef19ce10e34aff236b1f8e37779a74cf24",
@@ -4215,24 +4197,6 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/alembic/versions/e28cd485ad3c_remove_global_unique_constraints_for_.py": [
-      {
-        "hashed_secret": "64589d1d5776faad3fc219e30c877e7ab8abb551",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 33,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5dbedebc3423bc4336c49a36bd75fe7d370c5176",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/common/validators.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
@@ -4274,7 +4238,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 738,
+        "line_number": 739,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,18 @@ Observability write operations use **independent database sessions** that commit
 
 **Pattern**: Follows existing SQL instrumentation approach in `instrumentation/sqlalchemy.py:58-87`
 
+## Audit Trail Transaction Behavior
+
+**Issue #2871 - Separate Session Pattern**
+
+`AuditTrailService.log_action()` (`mcpgateway/services/audit_trail_service.py`) always opens its own `SessionLocal()` when no `db` is supplied, and closes/rolls back that session itself. Callers in `tool_service.py`, `resource_service.py`, `gateway_service.py`, `prompt_service.py`, and `server_service.py` must **never** pass `db=db` (the caller's request-scoped session) to `log_action()`.
+
+Passing the shared session caused **"This transaction is inactive"** errors: the main CRUD operation already calls `db.commit()` before the audit call, and reusing that same session for a second commit after it has already committed leaves the session in a state that breaks rollback on subsequent errors.
+
+- `log_action()` swallows its own exceptions internally and returns `None` on failure — it does not propagate them to the caller in production.
+- The main resource (tool/gateway/resource/prompt/server) is committed **before** `log_action()` runs, so an audit-logging failure never rolls back already-persisted data — but callers' generic `except Exception` handlers still call `db.rollback()` and surface an error to the API caller even though the underlying row was already committed.
+- Do not add `db: Session` back to a `log_action()` call site. If a service needs the audit entry guaranteed within the same transaction as the main write, that is a deliberate design change requiring review, not a default.
+
 **Middleware**: `ObservabilityMiddleware` no longer creates `request.state.db`. Each observability operation creates its own short-lived session.
 
 **Security**: Query operations use request-scoped sessions for RBAC/token scoping. Write operations are not RBAC-protected (observability visibility is platform-wide).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ Observability write operations use **independent database sessions** that commit
 
 **Issue #2871 - Separate Session Pattern**
 
-`AuditTrailService.log_action()` (`mcpgateway/services/audit_trail_service.py`) always opens its own `SessionLocal()` when no `db` is supplied, and closes/rolls back that session itself. Callers in `tool_service.py`, `resource_service.py`, `gateway_service.py`, `prompt_service.py`, and `server_service.py` must **never** pass `db=db` (the caller's request-scoped session) to `log_action()`.
+`AuditTrailService.log_action()` (`mcpgateway/services/audit_trail_service.py`) always opens its own `SessionLocal()` when no `db` is supplied, and closes/rolls back that session itself. Callers in `tool_service.py`, `resource_service.py`, `gateway_service.py`, `prompt_service.py`, `server_service.py`, and `admin.py` must **never** pass `db=db` (the caller's request-scoped session) to `log_action()`. In `admin.py`, plugin-view audit logging goes through `log_audit()`, which is a thin wrapper over `log_action()` and inherits the same optional-session behavior.
 
 Passing the shared session caused **"This transaction is inactive"** errors: the main CRUD operation already calls `db.commit()` before the audit call, and reusing that same session for a second commit after it has already committed leaves the session in a state that breaks rollback on subsequent errors.
 

--- a/docs/docs/using/agents/beeai.md
+++ b/docs/docs/using/agents/beeai.md
@@ -32,7 +32,7 @@ Prepare the ContextForge connection values used in the examples:
 
 ```bash
 export MCPGATEWAY_BEARER_TOKEN="<gateway-token>"
-export MCP_AUTH="Bearer ${MCPGATEWAY_BEARER_TOKEN}"
+export MCP_AUTH="Bearer ${MCPGATEWAY_BEARER_TOKEN}" # pragma: allowlist secret
 
 # Virtual server endpoint used by mcpgateway-wrapper.
 export MCP_SERVER_URL="http://localhost:4444/servers/UUID_OF_SERVER_1/mcp"
@@ -200,7 +200,7 @@ await client.connect(
     args: ["-m", "mcpgateway.wrapper"],
     env: {
       MCP_SERVER_URL: process.env.MCP_SERVER_URL!,
-      MCP_AUTH: process.env.MCP_AUTH!,
+      MCP_AUTH: process.env.MCP_AUTH!, # pragma: allowlist secret
       MCP_WRAPPER_LOG_LEVEL: "OFF",
     },
   })

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -17759,7 +17759,7 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
 
         # Create audit trail for plugin access
         audit_service.log_audit(
-            user_id=get_user_id(user), user_email=get_user_email(user), resource_type="plugin", resource_id=name, action="view", description=f"Viewed plugin '{name}' details in marketplace", db=db
+            user_id=get_user_id(user), user_email=get_user_email(user), resource_type="plugin", resource_id=name, action="view", description=f"Viewed plugin '{name}' details in marketplace"
         )
 
         return PluginDetail(**plugin)

--- a/mcpgateway/services/audit_trail_service.py
+++ b/mcpgateway/services/audit_trail_service.py
@@ -169,7 +169,13 @@ class AuditTrailService:
         # Use provided session or create new one
         close_db = False
         if db is None:
-            db = SessionLocal()
+            try:
+                db = SessionLocal()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.error(
+                    "Failed to create audit trail session: %s", e, exc_info=True, extra={"correlation_id": correlation_id, "action": action, "resource_type": resource_type, "resource_id": resource_id}
+                )
+                return None
             close_db = True
 
         try:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1748,7 +1748,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 context={
                     "created_via": created_via,
                 },
-                db=db,
             )
 
             # Structured logging: Log successful gateway creation
@@ -2892,7 +2891,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     context={
                         "modified_via": modified_via,
                     },
-                    db=db,
                 )
 
                 # Structured logging: Log successful gateway update
@@ -3378,7 +3376,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         "action": "activate" if activate else "deactivate",
                         "only_update_reachable": only_update_reachable,
                     },
-                    db=db,
                 )
 
                 # Structured logging: Log successful gateway state change
@@ -3581,7 +3578,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             db.commit()
 
             await self._finalize_gateway_deletion(
-                db=db,
                 gateway_id=str(gateway_id),
                 gateway_info=gateway_info,
                 gateway_name=gateway_name,
@@ -3657,7 +3653,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
     async def _finalize_gateway_deletion(
         self,
-        db: Session,
         gateway_id: str,
         gateway_info: Dict[str, Any],
         gateway_name: str,
@@ -3700,7 +3695,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 "name": gateway_name,
                 "url": gateway_info["url"],
             },
-            db=db,
         )
 
         structured_logger.log(
@@ -3995,7 +3989,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         db.commit()
 
         await self._finalize_gateway_deletion(
-            db=db,
             gateway_id=str(gateway.id),
             gateway_info=gateway_info,
             gateway_name=gateway_name,

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -2122,7 +2122,6 @@ class PromptService(BaseService):
                         "arguments_provided": arguments_supplied,
                         "request_id": request_id,
                     },
-                    db=db,
                 )
 
                 structured_logger.log(

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -902,7 +902,6 @@ class PromptService(BaseService):
                     "import_batch_id": import_batch_id,
                     "federation_source": federation_source,
                 },
-                db=db,
             )
 
             # Structured logging: Log successful prompt creation
@@ -1335,7 +1334,6 @@ class PromptService(BaseService):
                             "federation_source": federation_source,
                             "conflict_strategy": conflict_strategy,
                         },
-                        db=db,
                     )
 
                 logger.info("Bulk registered %s prompts, updated %s prompts in chunk", len(prompts_to_add), len(prompts_to_update))
@@ -2422,7 +2420,6 @@ class PromptService(BaseService):
                 user_agent=modified_user_agent,
                 new_values={"name": prompt.name, "version": prompt.version},
                 context={"modified_via": modified_via},
-                db=db,
             )
 
             structured_logger.log(
@@ -2647,7 +2644,6 @@ class PromptService(BaseService):
                     team_id=prompt.team_id,
                     new_values={"enabled": prompt.enabled},
                     context={"action": "activate" if activate else "deactivate"},
-                    db=db,
                 )
 
                 structured_logger.log(
@@ -2767,7 +2763,6 @@ class PromptService(BaseService):
             resource_name=prompt.name,
             team_id=prompt.team_id,
             context={"include_inactive": include_inactive},
-            db=db,
         )
 
         structured_logger.log(
@@ -2859,7 +2854,6 @@ class PromptService(BaseService):
                 user_email=user_email,
                 team_id=prompt_team_id,
                 old_values={"name": prompt_name},
-                db=db,
             )
 
             # Structured logging: Log successful prompt deletion

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -622,7 +622,6 @@ class ResourceService(BaseService):
                     "import_batch_id": import_batch_id,
                     "federation_source": federation_source,
                 },
-                db=db,
             )
 
             # Structured logging: Log successful resource creation
@@ -998,7 +997,6 @@ class ResourceService(BaseService):
                             "federation_source": federation_source,
                             "conflict_strategy": conflict_strategy,
                         },
-                        db=db,
                     )
 
                 logger.info("Bulk registered %s resources, updated %s resources in chunk", len(resources_to_add), len(resources_to_update))
@@ -2750,7 +2748,6 @@ class ResourceService(BaseService):
                     context={
                         "action": "activate" if activate else "deactivate",
                     },
-                    db=db,
                 )
 
                 # Structured logging: Log successful resource state change
@@ -3153,7 +3150,6 @@ class ResourceService(BaseService):
                     "modified_via": modified_via,
                     "changes": ", ".join(changes) if changes else "metadata only",
                 },
-                db=db,
             )
 
             # Structured logging: Log successful resource update
@@ -3399,7 +3395,6 @@ class ResourceService(BaseService):
                     "uri": resource_uri,
                     "name": resource_name,
                 },
-                db=db,
             )
 
             # Structured logging: Log successful resource deletion

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1157,7 +1157,6 @@ class ServerService(BaseService):
             user_id="system",
             team_id=getattr(server, "team_id", None),
             context={"enabled": server.enabled},
-            db=db,
         )
 
         return server_read

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -2071,7 +2071,6 @@ class ToolService(BaseService):
                     "import_batch_id": import_batch_id,
                     "federation_source": federation_source,
                 },
-                db=db,
             )
 
             # Structured logging: Log successful tool creation
@@ -2377,7 +2376,6 @@ class ToolService(BaseService):
                     resource_type="tool",
                     resource_id=None,
                     details={"count": len(tools_to_add) + len(tools_to_update), "import_batch_id": import_batch_id},
-                    db=db,
                 )
 
         except Exception as e:
@@ -3368,7 +3366,6 @@ class ToolService(BaseService):
                 old_values={
                     "name": tool_name,
                 },
-                db=db,
             )
 
             # Structured logging: Log successful tool deletion
@@ -3542,7 +3539,6 @@ class ToolService(BaseService):
                     context={
                         "action": "activate" if activate else "deactivate",
                     },
-                    db=db,
                 )
 
                 # Structured logging: Log successful tool state change
@@ -6462,7 +6458,6 @@ class ToolService(BaseService):
                     "modified_via": modified_via,
                     "changes": ", ".join(changes) if changes else "metadata only",
                 },
-                db=db,
             )
 
             # Structured logging: Log successful tool update

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -202,6 +202,10 @@ async def test_with_mock():
         assert result["status"] == "ok"
 ```
 
+### Asserting on Mocked Call Arguments
+
+For regression tests that assert a specific keyword argument was (or was not) passed to a mocked call, add a small module-level `_assert_*` helper instead of repeating the inspection logic in every test. See `test_*_audit_no_db.py` under `tests/unit/mcpgateway/services/` for the pattern (`_assert_no_db_passed`), which checks `call_args_list` for an absent `db=` kwarg and validates `action`/`resource_type` correctness.
+
 ## Coverage Workflow
 
 1. Run coverage: `make coverage` or `make htmlcov`

--- a/tests/integration/test_audit_trail_transaction_isolation.py
+++ b/tests/integration/test_audit_trail_transaction_isolation.py
@@ -1,0 +1,614 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_audit_trail_transaction_isolation.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for audit trail transaction isolation.
+
+Tests verify that audit trail uses separate database sessions and that
+main resource operations commit successfully even when audit logging fails.
+This validates the separate session pattern documented in AGENTS.md.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import AuditTrail, Base, Resource, Tool
+from mcpgateway.schemas import ResourceCreate, ToolCreate
+from mcpgateway.services.audit_trail_service import AuditTrailService
+from mcpgateway.services.resource_service import ResourceService
+from mcpgateway.services.tool_service import ToolService
+
+
+@pytest.fixture
+def test_db_engine():
+    """Create test database engine with thread-safe SQLite."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def test_db_session(test_db_engine):
+    """Create test database session."""
+    TestSessionLocal = sessionmaker(bind=test_db_engine)
+    session = TestSessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def audit_service():
+    """Create audit trail service instance."""
+    return AuditTrailService()
+
+
+@pytest.fixture(autouse=True)
+def enable_audit_trail(monkeypatch):
+    """Enable audit trail for all tests in this module."""
+    monkeypatch.setattr(settings, "audit_trail_enabled", True)
+
+
+@pytest.fixture(autouse=True)
+def patch_session_local(test_db_engine, monkeypatch):
+    """Patch SessionLocal to use test database.
+
+    Patches both mcpgateway.db.SessionLocal (used by most code) and the
+    module-local reference in audit_trail_service (imported at module
+    level via ``from mcpgateway.db import SessionLocal``) so that audit
+    writes land in the same in-memory SQLite instance as the main writes.
+    """
+    TestSessionLocal = sessionmaker(bind=test_db_engine)
+    monkeypatch.setattr("mcpgateway.db.SessionLocal", TestSessionLocal)
+    monkeypatch.setattr("mcpgateway.services.audit_trail_service.SessionLocal", TestSessionLocal)
+
+
+class TestAuditTrailSeparateSession:
+    """Tests for audit trail separate session pattern."""
+
+    def test_audit_trail_separate_session_pattern(self, test_db_session, audit_service):
+        """Verify audit trail uses separate session from main transaction.
+
+        This test validates that:
+        1. Main resource uses request-scoped session
+        2. Audit logging creates its own independent session
+        3. Both transactions complete successfully
+        4. Both records persist in the database
+        """
+        # Create a tool directly in the main session
+        tool = Tool(
+            id="tool-123",
+            original_name="test-tool",
+            name="test-tool",
+            description="Test tool for audit isolation",
+            input_schema={"type": "object"},
+            gateway_id="gw-1",
+            team_id="public",
+        )
+        test_db_session.add(tool)
+        test_db_session.commit()
+
+        # Call audit service directly (it should create its own session)
+        audit_entry = audit_service.log_action(
+            action="CREATE",
+            resource_type="tool",
+            resource_id=tool.id,
+            user_id="test-user@example.com",
+            resource_name=tool.name,
+            db=None,  # Force separate session creation
+        )
+
+        # Verify audit entry was created
+        assert audit_entry is not None
+
+        # Verify tool exists in database (using fresh query)
+        tool_query = select(Tool).where(Tool.id == tool.id)
+        tool_result = test_db_session.execute(tool_query).scalar_one_or_none()
+        assert tool_result is not None
+        assert tool_result.name == "test-tool"
+
+        # Verify audit entry exists in database (using fresh query)
+        audit_query = select(AuditTrail).where(
+            AuditTrail.resource_type == "tool",
+            AuditTrail.resource_id == tool.id,
+            AuditTrail.action == "CREATE",
+        )
+        audit_result = test_db_session.execute(audit_query).scalar_one_or_none()
+        assert audit_result is not None
+        assert audit_result.user_id == "test-user@example.com"
+        assert audit_result.success is True
+
+    def test_audit_failure_does_not_rollback_main_resource(self, test_db_session, audit_service):
+        """Verify main resource commits even if audit logging fails.
+
+        This test validates the best-effort audit pattern:
+        1. Main resource creation succeeds
+        2. Audit logging fails (simulated)
+        3. Main resource still persists in database
+        4. No audit entry is created (audit failed gracefully)
+        """
+        # Create a tool directly in the main session
+        tool = Tool(
+            id="tool-456",
+            original_name="test-tool-resilient",
+            name="test-tool-resilient",
+            description="Test tool for audit failure resilience",
+            input_schema={"type": "object"},
+            gateway_id="gw-1",
+            team_id="public",
+        )
+        test_db_session.add(tool)
+        test_db_session.commit()
+
+        # Mock SessionLocal to raise exception when audit tries to create session
+        with patch("mcpgateway.services.audit_trail_service.SessionLocal") as mock_session_local:
+            mock_session_local.side_effect = RuntimeError("Simulated session creation failure")
+
+            # Call audit service - should fail gracefully
+            audit_entry = audit_service.log_action(
+                action="CREATE",
+                resource_type="tool",
+                resource_id=tool.id,
+                user_id="test-user@example.com",
+                db=None,
+            )
+
+            # Audit should return None on failure
+            assert audit_entry is None
+
+        # Verify tool still exists in database
+        tool_query = select(Tool).where(Tool.id == tool.id)
+        tool_result = test_db_session.execute(tool_query).scalar_one_or_none()
+        assert tool_result is not None
+        assert tool_result.name == "test-tool-resilient"
+
+        # Verify no audit entry was created (audit failed)
+        audit_query = select(AuditTrail).where(
+            AuditTrail.resource_type == "tool",
+            AuditTrail.resource_id == tool.id,
+        )
+        audit_result = test_db_session.execute(audit_query).scalar_one_or_none()
+        assert audit_result is None
+
+    def test_audit_and_main_resource_both_persist(self, test_db_session, audit_service):
+        """Verify both audit and main resource transactions complete independently.
+
+        This test validates transaction isolation:
+        1. Main resource commits in request-scoped session
+        2. Audit entry commits in separate session
+        3. Both persist independently
+        4. Querying either record succeeds
+        """
+        # Create a tool directly in the main session
+        tool = Tool(
+            id="tool-789",
+            original_name="test-tool-independent",
+            name="test-tool-independent",
+            description="Test tool for independent persistence",
+            input_schema={"type": "object"},
+            gateway_id="gw-1",
+            team_id="public",
+        )
+        test_db_session.add(tool)
+        test_db_session.commit()
+
+        # Call audit service (creates separate session)
+        audit_entry = audit_service.log_action(
+            action="CREATE",
+            resource_type="tool",
+            resource_id=tool.id,
+            user_id="test-user@example.com",
+            resource_name=tool.name,
+            db=None,
+        )
+
+        assert audit_entry is not None
+
+        # Close and reopen session to ensure we're reading from database
+        test_db_session.close()
+        from mcpgateway.db import SessionLocal
+
+        fresh_session = SessionLocal()
+        try:
+            # Verify tool persisted
+            tool_query = select(Tool).where(Tool.id == tool.id)
+            tool_result = fresh_session.execute(tool_query).scalar_one_or_none()
+            assert tool_result is not None
+            assert tool_result.name == "test-tool-independent"
+
+            # Verify audit entry persisted
+            audit_query = select(AuditTrail).where(
+                AuditTrail.resource_type == "tool",
+                AuditTrail.resource_id == tool.id,
+                AuditTrail.action == "CREATE",
+            )
+            audit_result = fresh_session.execute(audit_query).scalar_one_or_none()
+            assert audit_result is not None
+            assert audit_result.user_id == "test-user@example.com"
+            assert audit_result.success is True
+
+            # Verify they are independent records
+            assert tool_result.id == audit_result.resource_id
+        finally:
+            fresh_session.close()
+
+    def test_audit_service_creates_own_session_when_none_provided(self, test_db_session, audit_service):
+        """Verify audit service creates its own session when db parameter is None.
+
+        This test validates the core separate session behavior:
+        1. Call log_action without db parameter
+        2. Audit service creates its own SessionLocal()
+        3. Audit entry persists
+        """
+        # Call log_action without providing db parameter
+        audit_entry = audit_service.log_action(
+            action="TEST_ACTION",
+            resource_type="test_resource",
+            resource_id="test-123",
+            user_id="test-user@example.com",
+            db=None,  # Explicitly pass None to trigger separate session creation
+        )
+
+        # Verify audit entry was created and returned
+        assert audit_entry is not None
+
+        # Verify audit entry persisted in database
+        audit_query = select(AuditTrail).where(
+            AuditTrail.resource_type == "test_resource",
+            AuditTrail.resource_id == "test-123",
+            AuditTrail.action == "TEST_ACTION",
+        )
+        audit_result = test_db_session.execute(audit_query).scalar_one_or_none()
+        assert audit_result is not None
+        assert audit_result.user_id == "test-user@example.com"
+
+    def test_main_session_rollback_does_not_affect_audit(self, test_db_session, audit_service):
+        """Verify that rolling back main session does not affect audit entries.
+
+        This test validates transaction isolation in failure scenarios:
+        1. Create tool (triggers audit)
+        2. Rollback main session
+        3. Tool does not persist
+        4. Audit entry still persists (separate transaction)
+        """
+        # Create a tool directly in the main session
+        tool = Tool(
+            id="tool-rollback",
+            original_name="test-tool-rollback",
+            name="test-tool-rollback",
+            description="Test tool for rollback isolation",
+            input_schema={"type": "object"},
+            gateway_id="gw-1",
+            team_id="public",
+        )
+        test_db_session.add(tool)
+
+        # Call audit service BEFORE committing (creates separate session)
+        audit_entry = audit_service.log_action(
+            action="CREATE",
+            resource_type="tool",
+            resource_id=tool.id,
+            user_id="test-user@example.com",
+            resource_name=tool.name,
+            db=None,
+        )
+
+        assert audit_entry is not None
+
+        # Rollback the main session (simulating a failure)
+        test_db_session.rollback()
+
+        # Verify tool does NOT exist in database
+        tool_query = select(Tool).where(Tool.id == tool.id)
+        tool_result = test_db_session.execute(tool_query).scalar_one_or_none()
+        assert tool_result is None
+
+        # Verify audit entry DOES exist (separate transaction committed)
+        audit_query = select(AuditTrail).where(
+            AuditTrail.resource_type == "tool",
+            AuditTrail.resource_id == tool.id,
+            AuditTrail.action == "CREATE",
+        )
+        audit_result = test_db_session.execute(audit_query).scalar_one_or_none()
+        assert audit_result is not None
+        assert audit_result.user_id == "test-user@example.com"
+        assert audit_result.success is True
+
+
+class TestAuditTrailSessionLifecycle:
+    """Tests for audit trail session lifecycle management."""
+
+    def test_audit_service_closes_own_session(self, audit_service, monkeypatch):
+        """Verify audit service properly closes its own session.
+
+        This test validates resource cleanup:
+        1. Audit service creates session
+        2. Session is closed after use
+        3. No session leaks
+        """
+        # Track session lifecycle
+        session_created = False
+        session_closed = False
+
+        class MockSession:
+            def __init__(self):
+                nonlocal session_created
+                session_created = True
+                self.committed = False
+                self.rolled_back = False
+
+            def add(self, obj):
+                pass
+
+            def commit(self):
+                self.committed = True
+
+            def refresh(self, obj):
+                pass
+
+            def rollback(self):
+                self.rolled_back = True
+
+            def close(self):
+                nonlocal session_closed
+                session_closed = True
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.close()
+
+        # Patch SessionLocal to return our mock
+        monkeypatch.setattr("mcpgateway.services.audit_trail_service.SessionLocal", MockSession)
+        monkeypatch.setattr("mcpgateway.services.audit_trail_service.AuditTrail", lambda **kwargs: MagicMock())
+
+        # Call log_action without db parameter
+        audit_service.log_action(
+            action="TEST_ACTION",
+            resource_type="test_resource",
+            resource_id="test-123",
+            user_id="test-user@example.com",
+            db=None,
+        )
+
+        # Verify session was created and closed
+        assert session_created is True
+        assert session_closed is True
+
+    def test_audit_service_handles_session_exception(self, audit_service, monkeypatch):
+        """Verify audit service handles session exceptions gracefully.
+
+        This test validates error handling:
+        1. Session operation raises exception
+        2. Exception is caught and logged
+        3. Session is rolled back and closed
+        4. log_action returns None
+        """
+        session_rolled_back = False
+        session_closed = False
+
+        class FailingSession:
+            def __init__(self):
+                pass
+
+            def add(self, obj):
+                raise RuntimeError("Simulated session failure")
+
+            def commit(self):
+                pass
+
+            def refresh(self, obj):
+                pass
+
+            def rollback(self):
+                nonlocal session_rolled_back
+                session_rolled_back = True
+
+            def close(self):
+                nonlocal session_closed
+                session_closed = True
+
+        # Patch SessionLocal to return failing session
+        monkeypatch.setattr("mcpgateway.services.audit_trail_service.SessionLocal", FailingSession)
+        monkeypatch.setattr("mcpgateway.services.audit_trail_service.AuditTrail", lambda **kwargs: MagicMock())
+
+        # Call log_action - should handle exception gracefully
+        result = audit_service.log_action(
+            action="TEST_ACTION",
+            resource_type="test_resource",
+            resource_id="test-123",
+            user_id="test-user@example.com",
+            db=None,
+        )
+
+        # Verify exception was handled
+        assert result is None
+        assert session_rolled_back is True
+        assert session_closed is True
+
+
+class TestCrossServiceAuditBehavior:
+    """Integration tests that exercise the full service call stack.
+
+    Unlike TestAuditTrailSeparateSession (which calls log_action directly),
+    these tests invoke ToolService and ResourceService end-to-end so that
+    audit writes happen as a side-effect of the service operation — the
+    same path taken in production.
+
+    Scenarios verified:
+    1. A successful tool registration produces an AuditTrail row committed in
+       its own session, independently of the tool's session.
+    2. A successful resource registration produces an AuditTrail row.
+    3. When the audit DB session factory raises on creation, the main resource
+       is still committed and no exception propagates to the caller.
+    """
+
+    async def test_tool_service_register_creates_audit_entry(self, test_db_engine, test_db_session):
+        """Creating a tool via ToolService writes an audit entry in a separate session.
+
+        Steps:
+        1. Call ToolService.register_tool() with a minimal ToolCreate payload.
+        2. Open a fresh session to read back the Tool and AuditTrail rows.
+        3. Assert both rows exist and the AuditTrail references the correct resource_id.
+        """
+        tool_service = ToolService()
+
+        tool_payload = ToolCreate(
+            name="cross-service-tool",
+            url="http://example.com/tool",
+            description="Tool for cross-service audit test",
+            integration_type="REST",
+            request_type="POST",
+            input_schema={"type": "object"},
+        )
+
+        with patch.object(tool_service, "_notify_tool_added", new_callable=AsyncMock):
+            TestSessionLocal = sessionmaker(bind=test_db_engine)
+            db = TestSessionLocal()
+            try:
+                result = await tool_service.register_tool(
+                    db=db,
+                    tool=tool_payload,
+                    created_by="auditor@example.com",
+                    owner_email="auditor@example.com",
+                )
+            finally:
+                db.close()
+
+        assert result is not None
+        assert result.name == "cross-service-tool"
+
+        # Verify both rows via a fresh session (isolates from above transactions)
+        fresh_session = sessionmaker(bind=test_db_engine)()
+        try:
+            tool_row = fresh_session.execute(select(Tool).where(Tool.name == "cross-service-tool")).scalar_one_or_none()
+            assert tool_row is not None, "Tool row missing after register_tool()"
+
+            audit_row = fresh_session.execute(
+                select(AuditTrail).where(
+                    AuditTrail.resource_type == "tool",
+                    AuditTrail.action == "create_tool",
+                    AuditTrail.resource_id == str(tool_row.id),
+                )
+            ).scalar_one_or_none()
+            assert audit_row is not None, "AuditTrail row missing after register_tool()"
+            assert audit_row.user_id == "auditor@example.com"
+            assert audit_row.success is True
+        finally:
+            fresh_session.close()
+
+    async def test_resource_service_register_creates_audit_entry(self, test_db_engine, test_db_session):
+        """Creating a resource via ResourceService writes an audit entry in a separate session."""
+        resource_service = ResourceService()
+
+        resource_payload = ResourceCreate(
+            uri="resource://cross-service-test/doc.txt",
+            name="cross-service-resource",
+            description="Resource for cross-service audit test",
+            content="hello world",
+            mime_type="text/plain",
+        )
+
+        with patch.object(resource_service, "_notify_resource_added", new_callable=AsyncMock):
+            TestSessionLocal = sessionmaker(bind=test_db_engine)
+            db = TestSessionLocal()
+            try:
+                result = await resource_service.register_resource(
+                    db=db,
+                    resource=resource_payload,
+                    created_by="auditor@example.com",
+                    owner_email="auditor@example.com",
+                )
+            finally:
+                db.close()
+
+        assert result is not None
+        assert result.name == "cross-service-resource"
+
+        fresh_session = sessionmaker(bind=test_db_engine)()
+        try:
+            resource_row = fresh_session.execute(select(Resource).where(Resource.name == "cross-service-resource")).scalar_one_or_none()
+            assert resource_row is not None, "Resource row missing after register_resource()"
+
+            audit_row = fresh_session.execute(
+                select(AuditTrail).where(
+                    AuditTrail.resource_type == "resource",
+                    AuditTrail.action == "create_resource",
+                    AuditTrail.resource_id == str(resource_row.id),
+                )
+            ).scalar_one_or_none()
+            assert audit_row is not None, "AuditTrail row missing after register_resource()"
+            assert audit_row.user_id == "auditor@example.com"
+            assert audit_row.success is True
+        finally:
+            fresh_session.close()
+
+    async def test_tool_service_register_survives_audit_failure(self, test_db_engine, test_db_session):
+        """A failing audit session must not prevent the tool row from being committed.
+
+        Simulates an unreachable audit DB by patching SessionLocal in
+        audit_trail_service to raise on construction.  The tool registration
+        must complete without raising, the Tool row must persist, and no
+        AuditTrail row should exist.
+        """
+        tool_service = ToolService()
+
+        tool_payload = ToolCreate(
+            name="resilient-tool",
+            url="http://example.com/resilient",
+            description="Tool for audit-failure resilience test",
+            integration_type="REST",
+            request_type="POST",
+            input_schema={"type": "object"},
+        )
+
+        with (
+            patch.object(tool_service, "_notify_tool_added", new_callable=AsyncMock),
+            patch(
+                "mcpgateway.services.audit_trail_service.SessionLocal",
+                side_effect=RuntimeError("audit DB unavailable"),
+            ),
+        ):
+            TestSessionLocal = sessionmaker(bind=test_db_engine)
+            db = TestSessionLocal()
+            try:
+                result = await tool_service.register_tool(
+                    db=db,
+                    tool=tool_payload,
+                    created_by="auditor@example.com",
+                    owner_email="auditor@example.com",
+                )
+            finally:
+                db.close()
+
+        # Service must complete without raising
+        assert result is not None
+        assert result.name == "resilient-tool"
+
+        fresh_session = sessionmaker(bind=test_db_engine)()
+        try:
+            tool_row = fresh_session.execute(select(Tool).where(Tool.name == "resilient-tool")).scalar_one_or_none()
+            assert tool_row is not None, "Tool row was not committed despite audit failure"
+
+            audit_row = fresh_session.execute(
+                select(AuditTrail).where(
+                    AuditTrail.resource_type == "tool",
+                    AuditTrail.resource_id == str(tool_row.id),
+                )
+            ).scalar_one_or_none()
+            assert audit_row is None, "AuditTrail row should not exist when audit session creation fails"
+        finally:
+            fresh_session.close()

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -161,12 +161,15 @@ class TestLogin:
         with (
             patch("mcpgateway.routers.auth.EmailAuthService") as mock_auth_service,
             patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock) as mock_create_token,
+            patch("mcpgateway.routers.auth.settings") as mock_settings,
         ):
             mock_service = MagicMock()
             mock_service.authenticate_user = AsyncMock(return_value=mock_user)
             mock_auth_service.return_value = mock_service
 
             mock_create_token.return_value = ("test_token", 3600)
+            mock_settings.sso_enabled = False
+            mock_settings.csrf_rotate_on_login = False
 
             login_request = LoginRequest(email="test@example.com", password="password123")  # pragma: allowlist secret
 
@@ -228,12 +231,15 @@ class TestLogin:
         with (
             patch("mcpgateway.routers.auth.EmailAuthService") as mock_auth_service,
             patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock) as mock_create_token,
+            patch("mcpgateway.routers.auth.settings") as mock_settings,
         ):
             mock_service = MagicMock()
             mock_service.authenticate_user = AsyncMock(return_value=mock_user)
             mock_auth_service.return_value = mock_service
 
             mock_create_token.return_value = ("test_token", 3600)
+            mock_settings.sso_enabled = False
+            mock_settings.csrf_rotate_on_login = False
 
             login_request = LoginRequest(username="user@domain.com", password="password123")  # pragma: allowlist secret
 
@@ -248,7 +254,7 @@ class TestLogin:
         with (
             patch("mcpgateway.routers.auth.EmailAuthService") as mock_auth_service,
             patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock) as mock_create_token,
-            patch("mcpgateway.config.settings") as mock_settings,
+            patch("mcpgateway.routers.auth.settings") as mock_settings,
             patch("jwt.decode", return_value={"jti": "session-123"}),
             patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
             patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
@@ -258,6 +264,7 @@ class TestLogin:
             mock_auth_service.return_value = mock_service
 
             mock_create_token.return_value = ("test_token", 3600)
+            mock_settings.sso_enabled = False
             mock_settings.csrf_rotate_on_login = True
             mock_settings.csrf_secret_key = "secret"
             mock_settings.csrf_token_expiry = 60

--- a/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
@@ -88,7 +88,7 @@ class TestGatewayAuditNoDb:
             gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}, "resources": {}, "tools": {}}, [], [], [], []))
             gateway_service._notify_gateway_added = AsyncMock()
             await gateway_service.register_gateway(db, GatewayCreate(name="g", url="https://example.com", transport="SSE"))
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="create_gateway", resource_type="gateway")
 
     @pytest.mark.asyncio
@@ -115,7 +115,7 @@ class TestGatewayAuditNoDb:
             gateway_service._update_or_create_resources = AsyncMock(return_value=[])
             gateway_service._update_or_create_prompts = AsyncMock(return_value=[])
             await gateway_service.update_gateway(db, "gw-1", GatewayUpdate(description="updated"))
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="update_gateway", resource_type="gateway")
 
     @pytest.mark.asyncio
@@ -127,7 +127,7 @@ class TestGatewayAuditNoDb:
             gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
             gateway_service._notify_gateway_activated = AsyncMock(); gateway_service._notify_gateway_deactivated = AsyncMock(); gateway_service._notify_gateway_offline = AsyncMock()
             await gateway_service.set_gateway_state(db, "gw-1", activate=False, reachable=True)
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="set_gateway_state", resource_type="gateway")
 
     @pytest.mark.asyncio
@@ -138,5 +138,5 @@ class TestGatewayAuditNoDb:
             db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
             gateway_service._notify_gateway_deleted = AsyncMock()
             await gateway_service.delete_gateway(db, "gw-1")
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="delete_gateway", resource_type="gateway")

--- a/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
@@ -25,11 +25,18 @@ def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | N
     return result
 
 
-def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+def _assert_no_db_passed(mock_audit: MagicMock, *, expected_action: str | None = None, resource_type: str | None = None) -> None:
     """Assert that none of the log_action calls received a ``db`` argument."""
-    for call in mock_audit.log_action.call_args_list:
+    calls = mock_audit.log_action.call_args_list
+    for call in calls:
         assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
         assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+    if expected_action is not None:
+        actions = [call.kwargs.get("action") for call in calls]
+        assert expected_action in actions, f"expected action {expected_action!r} not found in calls: {actions}"
+    if resource_type is not None:
+        for call in calls:
+            assert call.kwargs.get("resource_type") == resource_type, f"unexpected resource_type in call: {call}"
 
 
 @pytest.fixture(autouse=True)
@@ -82,7 +89,20 @@ class TestGatewayAuditNoDb:
             gateway_service._notify_gateway_added = AsyncMock()
             await gateway_service.register_gateway(db, GatewayCreate(name="g", url="https://example.com", transport="SSE"))
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="create_gateway", resource_type="gateway")
+
+    @pytest.mark.asyncio
+    async def test_register_gateway_audit_failure_does_not_block_already_committed_gateway(self, gateway_service, db):
+        """If audit_trail.log_action() raises, the gateway row is already committed (db.commit ran first)."""
+        with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
+            mock_audit.log_action = MagicMock(side_effect=Exception("audit backend unavailable"))
+            db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalars_list=[])])
+            db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock(); db.add_all = Mock()
+            gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}, "resources": {}, "tools": {}}, [], [], [], []))
+            gateway_service._notify_gateway_added = AsyncMock()
+            with pytest.raises(Exception, match="audit backend unavailable"):
+                await gateway_service.register_gateway(db, GatewayCreate(name="g", url="https://example.com", transport="SSE"))
+            db.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_gateway(self, gateway_service, db, gateway_db):
@@ -96,7 +116,7 @@ class TestGatewayAuditNoDb:
             gateway_service._update_or_create_prompts = AsyncMock(return_value=[])
             await gateway_service.update_gateway(db, "gw-1", GatewayUpdate(description="updated"))
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="update_gateway", resource_type="gateway")
 
     @pytest.mark.asyncio
     async def test_set_gateway_state(self, gateway_service, db, gateway_db):
@@ -108,7 +128,7 @@ class TestGatewayAuditNoDb:
             gateway_service._notify_gateway_activated = AsyncMock(); gateway_service._notify_gateway_deactivated = AsyncMock(); gateway_service._notify_gateway_offline = AsyncMock()
             await gateway_service.set_gateway_state(db, "gw-1", activate=False, reachable=True)
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="set_gateway_state", resource_type="gateway")
 
     @pytest.mark.asyncio
     async def test_delete_gateway(self, gateway_service, db, gateway_db):
@@ -119,4 +139,4 @@ class TestGatewayAuditNoDb:
             gateway_service._notify_gateway_deleted = AsyncMock()
             await gateway_service.delete_gateway(db, "gw-1")
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="delete_gateway", resource_type="gateway")

--- a/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for gateway audit_trail.log_action db handling."""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from mcpgateway.db import Gateway as DbGateway
+from mcpgateway.schemas import GatewayCreate, GatewayRead, GatewayUpdate
+from mcpgateway.services.gateway_service import GatewayService
+
+_R = TypeVar("_R")
+
+
+def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | None = None, rowcount: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    result.rowcount = rowcount
+    scalars_proxy = MagicMock()
+    scalars_proxy.all.return_value = scalars_list or []
+    result.scalars.return_value = scalars_proxy
+    return result
+
+
+def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+    """Assert that none of the log_action calls received a ``db`` argument."""
+    for call in mock_audit.log_action.call_args_list:
+        assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
+        assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+
+
+@pytest.fixture(autouse=True)
+def _patch_models(monkeypatch):
+    def _fake_validate(d):
+        m = MagicMock()
+        m.masked.return_value = m
+        m.skipped_tools = []
+        return m
+    monkeypatch.setattr(GatewayRead, "model_validate", staticmethod(_fake_validate))
+    yield
+
+
+@pytest.fixture
+def gateway_service():
+    return GatewayService()
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def gateway_db():
+    gw = MagicMock(spec=DbGateway)
+    gw.id = "gw-1"
+    gw.name = "gateway-1"
+    gw.url = "https://example.com"
+    gw.team_id = None
+    gw.enabled = True
+    gw.reachable = True
+    gw.tools = []
+    gw.resources = []
+    gw.prompts = []
+    gw.auth_value = None
+    gw.oauth_config = None
+    gw.transport = "SSE"
+    return gw
+
+
+class TestGatewayAuditNoDb:
+    @pytest.mark.asyncio
+    async def test_register_gateway(self, gateway_service, db):
+        with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalars_list=[])])
+            db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock(); db.add_all = Mock()
+            gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}, "resources": {}, "tools": {}}, [], [], [], []))
+            gateway_service._notify_gateway_added = AsyncMock()
+            await gateway_service.register_gateway(db, GatewayCreate(name="g", url="https://example.com", transport="SSE"))
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_update_gateway(self, gateway_service, db, gateway_db):
+        with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=gateway_db))
+            db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock(); db.delete = Mock(); db.add_all = Mock(); db.flush = Mock()
+            gateway_service._notify_gateway_updated = AsyncMock()
+            gateway_service._update_or_create_tools = AsyncMock(return_value=[])
+            gateway_service._update_or_create_resources = AsyncMock(return_value=[])
+            gateway_service._update_or_create_prompts = AsyncMock(return_value=[])
+            await gateway_service.update_gateway(db, "gw-1", GatewayUpdate(description="updated"))
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_set_gateway_state(self, gateway_service, db, gateway_db):
+        with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=gateway_db))
+            db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock()
+            gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
+            gateway_service._notify_gateway_activated = AsyncMock(); gateway_service._notify_gateway_deactivated = AsyncMock(); gateway_service._notify_gateway_offline = AsyncMock()
+            await gateway_service.set_gateway_state(db, "gw-1", activate=False, reachable=True)
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_delete_gateway(self, gateway_service, db, gateway_db):
+        with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=gateway_db, rowcount=1))
+            db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
+            gateway_service._notify_gateway_deleted = AsyncMock()
+            await gateway_service.delete_gateway(db, "gw-1")
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -719,7 +719,7 @@ class TestGatewayService:
     async def test_register_gateway_encrypts_oauth_sensitive_values(self, gateway_service, test_db, monkeypatch):
         """register_gateway encrypts oauth_config secrets before persistence."""
         test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
-        test_db.flush = Mock()
+        test_db.commit = Mock()
         test_db.refresh = Mock()
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
         gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))

--- a/tests/unit/mcpgateway/services/test_gateway_service_helpers.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_helpers.py
@@ -880,7 +880,6 @@ async def test_process_deleting_gateway_hard_deletes_and_finalizes():
     service._hard_delete_gateway.assert_called_once_with(db, gateway)
     db.commit.assert_called_once()
     service._finalize_gateway_deletion.assert_awaited_once_with(
-        db=db,
         gateway_id="gw-1",
         gateway_info={"id": "gw-1", "name": "gw-name", "url": "http://example.com"},
         gateway_name="gw-name",
@@ -1123,7 +1122,6 @@ async def test_finalize_gateway_deletion_runs_cache_event_and_audit_finalizers(m
     gateway_info = {"id": "gw-1", "name": "gw-name", "url": "http://example.com"}
 
     await service._finalize_gateway_deletion(
-        db=db,
         gateway_id="gw-1",
         gateway_info=gateway_info,
         gateway_name="gw-name",

--- a/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Regression tests: audit_trail.log_action() must NEVER receive a shared
+``db`` session from prompt-service CRUD paths.
+
+Passing the caller's ``db`` session caused inactive-transaction errors
+when the audit trail wrote to the same connection that the CRUD operation
+was using.  The fix ensures each audit write creates its own session.
+
+These tests call the real service methods (with a mocked DB layer) and
+then assert that every ``audit_trail.log_action()`` invocation was
+performed **without** a ``db`` keyword argument.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import Prompt as DbPrompt
+from mcpgateway.db import PromptMetric
+from mcpgateway.schemas import PromptArgument, PromptCreate, PromptRead, PromptUpdate
+
+from mcpgateway.services.prompt_service import (
+    PromptService,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_execute_result(*, scalar: Any = None, scalars_list: list | None = None) -> MagicMock:
+    """Return a MagicMock that mimics a SQLAlchemy Result object."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    result.scalar.return_value = scalar
+    scalars_proxy = MagicMock()
+    scalars_proxy.all.return_value = scalars_list or []
+    result.scalars.return_value = scalars_proxy
+    return result
+
+
+def _build_db_prompt(
+    *,
+    pid: int = 1,
+    name: str = "hello",
+    desc: str = "greeting",
+    template: str = "Hello, {{ name }}!",
+    is_active: bool = True,
+) -> MagicMock:
+    """Return a MagicMock that looks like a DbPrompt instance."""
+    p = MagicMock(spec=DbPrompt)
+    p.id = pid
+    p.name = name
+    p.original_name = name
+    p.custom_name = name
+    p.custom_name_slug = name
+    p.display_name = name
+    p.description = desc
+    p.template = template
+    p.argument_schema = {"properties": {"name": {"type": "string"}}, "required": ["name"]}
+    p.created_at = p.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    p.is_active = is_active
+    p.enabled = is_active
+    p.visibility = "public"
+    p.team_id = None
+    p.owner_email = "owner@example.com"
+    p.gateway_id = None
+    p.gateway = None
+    p.metrics = []
+    p.validate_arguments = Mock()
+    return p
+
+
+def _assert_no_db_kwarg(mock_audit: MagicMock) -> None:
+    """Assert that none of the log_action calls included a ``db`` keyword argument."""
+    for call in mock_audit.log_action.call_args_list:
+        assert "db" not in call.kwargs, (
+            f"audit_trail.log_action() was called with db= keyword argument: {call}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# auto-use fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _patch_promptread(monkeypatch):
+    """Bypass Pydantic validation: make PromptRead.model_validate a pass-through."""
+    monkeypatch.setattr(PromptRead, "model_validate", staticmethod(lambda d: d))
+
+
+@pytest.fixture(autouse=True)
+def reset_jinja_singleton():
+    """Reset the module-level Jinja environment singleton before each test."""
+    import mcpgateway.services.prompt_service as ps
+
+    ps._JINJA_ENV = None
+    ps._compile_jinja_template.cache_clear()
+    yield
+    ps._JINJA_ENV = None
+    ps._compile_jinja_template.cache_clear()
+
+
+@pytest.fixture
+def prompt_service():
+    return PromptService()
+
+
+# ---------------------------------------------------------------------------
+# Regression: audit_trail.log_action must NOT receive db=
+# ---------------------------------------------------------------------------
+
+
+class TestAuditTrailNoDbSession:
+    """Regression suite: CRUD audit calls must not pass the shared db session."""
+
+    @pytest.mark.asyncio
+    async def test_create_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
+        """register_prompt must call audit_trail.log_action without db=."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+
+            test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
+            test_db.add = Mock()
+            test_db.commit = Mock()
+            test_db.refresh = Mock()
+            prompt_service._notify_prompt_added = AsyncMock()
+
+            pc = PromptCreate(
+                name="audit-test",
+                description="regression test",
+                template="Hello {{ name }}!",
+                arguments=[],
+            )
+
+            await prompt_service.register_prompt(db=test_db, prompt=pc, created_by="tester")
+
+            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            _assert_no_db_kwarg(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
+        """get_prompt must call audit_trail.log_action without db=."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+
+            fake_prompt = _build_db_prompt(pid=42, name="view-test", template="Hello!")
+            test_db.execute = Mock(return_value=_make_execute_result(scalar=fake_prompt))
+
+            await prompt_service.get_prompt(
+                db=test_db,
+                prompt_id="42",
+                user="viewer",
+            )
+
+            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            _assert_no_db_kwarg(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_update_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
+        """update_prompt must call audit_trail.log_action without db=."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+
+            fake_prompt = _build_db_prompt(pid=10, name="update-test")
+            fake_prompt.team_id = "team-123"
+            test_db.get = Mock(return_value=fake_prompt)
+            test_db.execute = Mock(
+                side_effect=[
+                    _make_execute_result(scalar=fake_prompt),
+                    _make_execute_result(scalar=None),
+                ]
+            )
+            test_db.commit = Mock()
+            test_db.refresh = Mock()
+            prompt_service._notify_prompt_updated = AsyncMock()
+
+            pu = PromptUpdate(description="updated description")
+
+            await prompt_service.update_prompt(
+                db=test_db,
+                prompt_id=10,
+                prompt_update=pu,
+                modified_by="updater",
+            )
+
+            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            _assert_no_db_kwarg(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_delete_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
+        """delete_prompt must call audit_trail.log_action without db=."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+
+            fake_prompt = _build_db_prompt(pid=99, name="delete-test")
+            test_db.get = Mock(return_value=fake_prompt)
+            test_db.delete = Mock()
+            test_db.commit = Mock()
+            prompt_service._notify_prompt_deleted = AsyncMock()
+
+            await prompt_service.delete_prompt(
+                db=test_db,
+                prompt_id=99,
+            )
+
+            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            _assert_no_db_kwarg(mock_audit)

--- a/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 # Standard
 from datetime import datetime, timezone
-from typing import Any, List, Optional
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
@@ -28,12 +28,8 @@ import pytest
 
 # First-Party
 from mcpgateway.db import Prompt as DbPrompt
-from mcpgateway.db import PromptMetric
-from mcpgateway.schemas import PromptArgument, PromptCreate, PromptRead, PromptUpdate
-
-from mcpgateway.services.prompt_service import (
-    PromptService,
-)
+from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate
+from mcpgateway.services.prompt_service import PromptService
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +79,16 @@ def _build_db_prompt(
     return p
 
 
-def _assert_no_db_kwarg(mock_audit: MagicMock) -> None:
-    """Assert that none of the log_action calls included a ``db`` keyword argument."""
+def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+    """Assert that none of the log_action calls received a ``db`` argument."""
     for call in mock_audit.log_action.call_args_list:
         assert "db" not in call.kwargs, (
             f"audit_trail.log_action() was called with db= keyword argument: {call}"
+        )
+        # db is the 22nd positional parameter (0-indexed) after self;
+        # if passed positionally it would appear at index 22 in args.
+        assert len(call.args) < 23, (
+            f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
         )
 
 
@@ -149,7 +150,7 @@ class TestAuditTrailNoDbSession:
             await prompt_service.register_prompt(db=test_db, prompt=pc, created_by="tester")
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_kwarg(mock_audit)
+            _assert_no_db_passed(mock_audit)
 
     @pytest.mark.asyncio
     async def test_get_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -168,7 +169,7 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_kwarg(mock_audit)
+            _assert_no_db_passed(mock_audit)
 
     @pytest.mark.asyncio
     async def test_update_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -200,7 +201,7 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_kwarg(mock_audit)
+            _assert_no_db_passed(mock_audit)
 
     @pytest.mark.asyncio
     async def test_delete_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -221,4 +222,4 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_kwarg(mock_audit)
+            _assert_no_db_passed(mock_audit)

--- a/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
@@ -29,7 +29,7 @@ import pytest
 # First-Party
 from mcpgateway.db import Prompt as DbPrompt
 from mcpgateway.schemas import PromptCreate, PromptRead, PromptUpdate
-from mcpgateway.services.prompt_service import PromptService
+from mcpgateway.services.prompt_service import PromptError, PromptService
 
 
 # ---------------------------------------------------------------------------
@@ -79,9 +79,10 @@ def _build_db_prompt(
     return p
 
 
-def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+def _assert_no_db_passed(mock_audit: MagicMock, *, expected_action: str | None = None, resource_type: str | None = None) -> None:
     """Assert that none of the log_action calls received a ``db`` argument."""
-    for call in mock_audit.log_action.call_args_list:
+    calls = mock_audit.log_action.call_args_list
+    for call in calls:
         assert "db" not in call.kwargs, (
             f"audit_trail.log_action() was called with db= keyword argument: {call}"
         )
@@ -90,6 +91,12 @@ def _assert_no_db_passed(mock_audit: MagicMock) -> None:
         assert len(call.args) < 23, (
             f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
         )
+    if expected_action is not None:
+        actions = [call.kwargs.get("action") for call in calls]
+        assert expected_action in actions, f"expected action {expected_action!r} not found in calls: {actions}"
+    if resource_type is not None:
+        for call in calls:
+            assert call.kwargs.get("resource_type") == resource_type, f"unexpected resource_type in call: {call}"
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +157,29 @@ class TestAuditTrailNoDbSession:
             await prompt_service.register_prompt(db=test_db, prompt=pc, created_by="tester")
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="create_prompt", resource_type="prompt")
+
+    @pytest.mark.asyncio
+    async def test_register_prompt_audit_failure_does_not_block_already_committed_prompt(self, prompt_service, test_db):
+        """If audit_trail.log_action() raises, the prompt row is already committed (db.commit ran first)."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"):
+            mock_audit.log_action = MagicMock(side_effect=Exception("audit backend unavailable"))
+
+            prompt_service._notify_prompt_added = AsyncMock()
+
+            pc = PromptCreate(
+                name="audit-failure-test",
+                description="regression test",
+                template="Hello {{ name }}!",
+                arguments=[],
+            )
+
+            with pytest.raises(PromptError):
+                await prompt_service.register_prompt(db=test_db, prompt=pc, created_by="tester")
+
+            committed = test_db.query(DbPrompt).filter(DbPrompt.name == "audit-failure-test").one_or_none()
+            assert committed is not None, "prompt row should already be committed before audit_trail.log_action() runs"
 
     @pytest.mark.asyncio
     async def test_get_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -169,7 +198,7 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="view_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
     async def test_update_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -201,7 +230,7 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="update_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
     async def test_delete_prompt_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -222,7 +251,7 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="delete_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
     async def test_set_prompt_state_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -249,7 +278,7 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="set_prompt_state", resource_type="prompt")
 
     @pytest.mark.asyncio
     async def test_get_prompt_details_audit_no_db_kwarg(self, prompt_service, test_db):
@@ -270,4 +299,4 @@ class TestAuditTrailNoDbSession:
             )
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="view_prompt_details", resource_type="prompt")

--- a/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
@@ -223,3 +223,51 @@ class TestAuditTrailNoDbSession:
 
             assert mock_audit.log_action.called, "audit_trail.log_action was not called"
             _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_set_prompt_state_audit_no_db_kwarg(self, prompt_service, test_db):
+        """set_prompt_state must call audit_trail.log_action without db=."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"), \
+             patch("mcpgateway.services.prompt_service.get_for_update") as mock_gfu:
+            mock_audit.log_action = MagicMock(return_value=None)
+
+            fake_prompt = _build_db_prompt(pid=5, name="state-test")
+            fake_prompt.enabled = False  # starting deactivated so activate=True triggers audit
+            mock_gfu.return_value = fake_prompt
+
+            test_db.commit = Mock()
+            test_db.refresh = Mock()
+            prompt_service._notify_prompt_activated = AsyncMock()
+            prompt_service._get_team_name = Mock(return_value=None)
+            prompt_service.convert_prompt_to_read = Mock(return_value={})
+
+            await prompt_service.set_prompt_state(
+                db=test_db,
+                prompt_id=5,
+                activate=True,
+            )
+
+            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_details_audit_no_db_kwarg(self, prompt_service, test_db):
+        """get_prompt_details must call audit_trail.log_action without db=."""
+        with patch("mcpgateway.services.prompt_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.prompt_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+
+            fake_prompt = _build_db_prompt(pid=7, name="details-test")
+            test_db.get = Mock(return_value=fake_prompt)
+            prompt_service._check_prompt_access = AsyncMock(return_value=True)
+            prompt_service._get_team_name = Mock(return_value=None)
+            prompt_service.convert_prompt_to_read = Mock(return_value={})
+
+            await prompt_service.get_prompt_details(
+                db=test_db,
+                prompt_id=7,
+            )
+
+            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            _assert_no_db_passed(mock_audit)

--- a/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_prompt_audit_no_db.py
@@ -156,7 +156,7 @@ class TestAuditTrailNoDbSession:
 
             await prompt_service.register_prompt(db=test_db, prompt=pc, created_by="tester")
 
-            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="create_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
@@ -197,7 +197,7 @@ class TestAuditTrailNoDbSession:
                 user="viewer",
             )
 
-            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="view_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
@@ -229,7 +229,7 @@ class TestAuditTrailNoDbSession:
                 modified_by="updater",
             )
 
-            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="update_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
@@ -250,7 +250,7 @@ class TestAuditTrailNoDbSession:
                 prompt_id=99,
             )
 
-            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="delete_prompt", resource_type="prompt")
 
     @pytest.mark.asyncio
@@ -277,7 +277,7 @@ class TestAuditTrailNoDbSession:
                 activate=True,
             )
 
-            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="set_prompt_state", resource_type="prompt")
 
     @pytest.mark.asyncio
@@ -298,5 +298,5 @@ class TestAuditTrailNoDbSession:
                 prompt_id=7,
             )
 
-            assert mock_audit.log_action.called, "audit_trail.log_action was not called"
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="view_prompt_details", resource_type="prompt")

--- a/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
@@ -10,7 +10,7 @@ import pytest
 
 from mcpgateway.db import Resource as DbResource
 from mcpgateway.schemas import ResourceCreate, ResourceRead, ResourceUpdate
-from mcpgateway.services.resource_service import ResourceService
+from mcpgateway.services.resource_service import ResourceError, ResourceService
 
 _R = TypeVar("_R")
 
@@ -25,10 +25,17 @@ def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | N
     return result
 
 
-def _assert_no_db_passed(mock_audit: MagicMock) -> None:
-    for call in mock_audit.log_action.call_args_list:
+def _assert_no_db_passed(mock_audit: MagicMock, *, expected_action: str | None = None, resource_type: str | None = None) -> None:
+    calls = mock_audit.log_action.call_args_list
+    for call in calls:
         assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
         assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+    if expected_action is not None:
+        actions = [call.kwargs.get("action") for call in calls]
+        assert expected_action in actions, f"expected action {expected_action!r} not found in calls: {actions}"
+    if resource_type is not None:
+        for call in calls:
+            assert call.kwargs.get("resource_type") == resource_type, f"unexpected resource_type in call: {call}"
 
 
 @pytest.fixture(autouse=True)
@@ -72,7 +79,19 @@ class TestResourceAuditNoDb:
             resource_service._notify_resource_added = AsyncMock()
             await resource_service.register_resource(db, ResourceCreate(uri="https://example.com/resource-1", name="resource-1", mime_type="text/plain", content="x"))
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="create_resource", resource_type="resource")
+
+    @pytest.mark.asyncio
+    async def test_register_resource_audit_failure_does_not_block_already_committed_resource(self, resource_service, db):
+        """If audit_trail.log_action() raises, the resource row is already committed (db.commit ran first)."""
+        with patch("mcpgateway.services.resource_service.audit_trail") as mock_audit, patch("mcpgateway.services.resource_service.structured_logger"):
+            mock_audit.log_action = MagicMock(side_effect=Exception("audit backend unavailable"))
+            db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
+            db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock(); db.rollback = Mock()
+            resource_service._notify_resource_added = AsyncMock()
+            with pytest.raises(ResourceError):
+                await resource_service.register_resource(db, ResourceCreate(uri="https://example.com/resource-1", name="resource-1", mime_type="text/plain", content="x"))
+            db.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_resource(self, resource_service, db, resource_db):
@@ -82,7 +101,7 @@ class TestResourceAuditNoDb:
             db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock()
             await resource_service.update_resource(db, 1, ResourceUpdate(description="updated"))
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="update_resource", resource_type="resource")
 
     @pytest.mark.asyncio
     async def test_set_resource_state(self, resource_service, db, resource_db):
@@ -92,7 +111,7 @@ class TestResourceAuditNoDb:
             db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock()
             await resource_service.set_resource_state(db, 1, activate=False)
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="set_resource_state", resource_type="resource")
 
     @pytest.mark.asyncio
     async def test_delete_resource(self, resource_service, db, resource_db):
@@ -102,7 +121,7 @@ class TestResourceAuditNoDb:
             db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
             await resource_service.delete_resource(db, 1)
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="delete_resource", resource_type="resource")
 
     @pytest.mark.asyncio
     async def test_register_resources_bulk(self, resource_service, db):
@@ -123,4 +142,4 @@ class TestResourceAuditNoDb:
             await resource_service.register_resources_bulk(db, resources, created_by="tester")
 
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="bulk_create_resources", resource_type="resource")

--- a/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for resource audit_trail.log_action db handling."""
+
+from __future__ import annotations
+
+from typing import TypeVar
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from mcpgateway.db import Resource as DbResource
+from mcpgateway.schemas import ResourceCreate, ResourceRead, ResourceUpdate
+from mcpgateway.services.resource_service import ResourceService
+
+_R = TypeVar("_R")
+
+
+def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | None = None, rowcount: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    result.rowcount = rowcount
+    scalars_proxy = MagicMock()
+    scalars_proxy.all.return_value = scalars_list or []
+    result.scalars.return_value = scalars_proxy
+    return result
+
+
+def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+    for call in mock_audit.log_action.call_args_list:
+        assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
+        assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+
+
+@pytest.fixture(autouse=True)
+def _patch_models(monkeypatch):
+    def _fake_validate(d):
+        m = MagicMock()
+        m.masked.return_value = d
+        return m
+    monkeypatch.setattr(ResourceRead, "model_validate", staticmethod(_fake_validate))
+    yield
+
+
+@pytest.fixture
+def resource_service():
+    return ResourceService()
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def resource_db():
+    res = MagicMock(spec=DbResource)
+    res.id = 1
+    res.uri = "res://1"
+    res.name = "resource-1"
+    res.enabled = True
+    res.team_id = None
+    return res
+
+
+class TestResourceAuditNoDb:
+    @pytest.mark.asyncio
+    async def test_register_resource(self, resource_service, db):
+        with patch("mcpgateway.services.resource_service.audit_trail") as mock_audit, patch("mcpgateway.services.resource_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
+            db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
+            resource_service._notify_resource_added = AsyncMock()
+            await resource_service.register_resource(db, ResourceCreate(uri="https://example.com/resource-1", name="resource-1", mime_type="text/plain", content="x"))
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_update_resource(self, resource_service, db, resource_db):
+        with patch("mcpgateway.services.resource_service.audit_trail") as mock_audit, patch("mcpgateway.services.resource_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=resource_db))
+            db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock()
+            await resource_service.update_resource(db, 1, ResourceUpdate(description="updated"))
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_set_resource_state(self, resource_service, db, resource_db):
+        with patch("mcpgateway.services.resource_service.audit_trail") as mock_audit, patch("mcpgateway.services.resource_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=resource_db))
+            db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock()
+            await resource_service.set_resource_state(db, 1, activate=False)
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_delete_resource(self, resource_service, db, resource_db):
+        with patch("mcpgateway.services.resource_service.audit_trail") as mock_audit, patch("mcpgateway.services.resource_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=resource_db, rowcount=1))
+            db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
+            await resource_service.delete_resource(db, 1)
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)

--- a/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
@@ -103,3 +103,24 @@ class TestResourceAuditNoDb:
             await resource_service.delete_resource(db, 1)
             assert mock_audit.log_action.called
             _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_register_resources_bulk(self, resource_service, db):
+        with patch("mcpgateway.services.resource_service.audit_trail") as mock_audit, \
+             patch("mcpgateway.services.resource_service.structured_logger"), \
+             patch("mcpgateway.services.resource_service.get_content_security_service") as mock_cs:
+            mock_audit.log_action = MagicMock(return_value=None)
+            mock_cs.return_value = MagicMock()  # content security that doesn't raise
+
+            # No existing resources — conflict check returns empty list
+            db.execute = Mock(return_value=_make_execute_result(scalars_list=[]))
+            db.add_all = Mock()
+            db.commit = Mock()
+            db.refresh = Mock()
+            resource_service._notify_resource_added = AsyncMock()
+
+            resources = [ResourceCreate(uri="https://example.com/bulk-1", name="bulk-1", mime_type="text/plain", content="x")]
+            await resource_service.register_resources_bulk(db, resources, created_by="tester")
+
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)

--- a/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_resource_audit_no_db.py
@@ -78,7 +78,7 @@ class TestResourceAuditNoDb:
             db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
             resource_service._notify_resource_added = AsyncMock()
             await resource_service.register_resource(db, ResourceCreate(uri="https://example.com/resource-1", name="resource-1", mime_type="text/plain", content="x"))
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="create_resource", resource_type="resource")
 
     @pytest.mark.asyncio
@@ -100,7 +100,7 @@ class TestResourceAuditNoDb:
             db.execute = Mock(return_value=_make_execute_result(scalar=resource_db))
             db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock()
             await resource_service.update_resource(db, 1, ResourceUpdate(description="updated"))
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="update_resource", resource_type="resource")
 
     @pytest.mark.asyncio
@@ -110,7 +110,7 @@ class TestResourceAuditNoDb:
             db.execute = Mock(return_value=_make_execute_result(scalar=resource_db))
             db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock()
             await resource_service.set_resource_state(db, 1, activate=False)
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="set_resource_state", resource_type="resource")
 
     @pytest.mark.asyncio
@@ -120,7 +120,7 @@ class TestResourceAuditNoDb:
             db.execute = Mock(return_value=_make_execute_result(scalar=resource_db, rowcount=1))
             db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
             await resource_service.delete_resource(db, 1)
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="delete_resource", resource_type="resource")
 
     @pytest.mark.asyncio
@@ -141,5 +141,5 @@ class TestResourceAuditNoDb:
             resources = [ResourceCreate(uri="https://example.com/bulk-1", name="bulk-1", mime_type="text/plain", content="x")]
             await resource_service.register_resources_bulk(db, resources, created_by="tester")
 
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="bulk_create_resources", resource_type="resource")

--- a/tests/unit/mcpgateway/services/test_server_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_server_audit_no_db.py
@@ -10,7 +10,7 @@ import pytest
 
 from mcpgateway.db import Server as DbServer
 from mcpgateway.schemas import ServerCreate, ServerRead, ServerUpdate
-from mcpgateway.services.server_service import ServerService
+from mcpgateway.services.server_service import ServerError, ServerService
 
 _R = TypeVar("_R")
 
@@ -25,10 +25,17 @@ def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | N
     return result
 
 
-def _assert_no_db_passed(mock_audit: MagicMock) -> None:
-    for call in mock_audit.log_action.call_args_list:
+def _assert_no_db_passed(mock_audit: MagicMock, *, expected_action: str | None = None, resource_type: str | None = None) -> None:
+    calls = mock_audit.log_action.call_args_list
+    for call in calls:
         assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
         assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+    if expected_action is not None:
+        actions = [call.kwargs.get("action") for call in calls]
+        assert expected_action in actions, f"expected action {expected_action!r} not found in calls: {actions}"
+    if resource_type is not None:
+        for call in calls:
+            assert call.kwargs.get("resource_type") == resource_type, f"unexpected resource_type in call: {call}"
 
 
 @pytest.fixture(autouse=True)
@@ -78,7 +85,18 @@ class TestServerAuditNoDb:
         server_service._notify_server_added = AsyncMock()
         await server_service.register_server(db, ServerCreate(name="server-1", description="x"))
         assert server_service._audit_trail.log_action.called
-        _assert_no_db_passed(server_service._audit_trail)
+        _assert_no_db_passed(server_service._audit_trail, expected_action="create_server", resource_type="server")
+
+    @pytest.mark.asyncio
+    async def test_register_server_audit_failure_does_not_block_already_committed_server(self, server_service, db):
+        """If audit_trail.log_action() raises, the server row is already committed (db.commit ran first)."""
+        server_service._audit_trail.log_action = MagicMock(side_effect=Exception("audit backend unavailable"))
+        db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
+        db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock(); db.rollback = Mock()
+        server_service._notify_server_added = AsyncMock()
+        with pytest.raises(ServerError):
+            await server_service.register_server(db, ServerCreate(name="server-1", description="x"))
+        db.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_server(self, server_service, db, server_db):
@@ -88,7 +106,7 @@ class TestServerAuditNoDb:
         with patch("mcpgateway.services.server_service.get_for_update", return_value=server_db):
             await server_service.update_server(db, "srv-1", ServerUpdate(description="updated"), user_email="tester@example.com")
         assert server_service._audit_trail.log_action.called
-        _assert_no_db_passed(server_service._audit_trail)
+        _assert_no_db_passed(server_service._audit_trail, expected_action="update_server", resource_type="server")
 
     @pytest.mark.asyncio
     async def test_delete_server(self, server_service, db, server_db):
@@ -98,4 +116,4 @@ class TestServerAuditNoDb:
         server_service._notify_server_deleted = AsyncMock()
         await server_service.delete_server(db, "srv-1")
         assert server_service._audit_trail.log_action.called
-        _assert_no_db_passed(server_service._audit_trail)
+        _assert_no_db_passed(server_service._audit_trail, expected_action="delete_server", resource_type="server")

--- a/tests/unit/mcpgateway/services/test_server_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_server_audit_no_db.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for server audit_trail.log_action db handling."""
+
+from __future__ import annotations
+
+from typing import TypeVar
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from mcpgateway.db import Server as DbServer
+from mcpgateway.schemas import ServerCreate, ServerRead, ServerUpdate
+from mcpgateway.services.server_service import ServerService
+
+_R = TypeVar("_R")
+
+
+def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | None = None, rowcount: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    result.rowcount = rowcount
+    scalars_proxy = MagicMock()
+    scalars_proxy.all.return_value = scalars_list or []
+    result.scalars.return_value = scalars_proxy
+    return result
+
+
+def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+    for call in mock_audit.log_action.call_args_list:
+        assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
+        assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+
+
+@pytest.fixture(autouse=True)
+def _patch_models(monkeypatch):
+    def _fake_validate(d):
+        m = MagicMock()
+        m.masked.return_value = m
+        return m
+    monkeypatch.setattr(ServerRead, "model_validate", staticmethod(_fake_validate))
+    yield
+
+
+@pytest.fixture
+def server_service():
+    svc = ServerService()
+    svc._audit_trail = MagicMock()
+    return svc
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def server_db():
+    srv = MagicMock(spec=DbServer)
+    srv.id = "srv-1"
+    srv.name = "server-1"
+    srv.enabled = True
+    srv.team_id = None
+    srv.owner_email = "tester@example.com"
+    srv.tools = []
+    srv.resources = []
+    srv.prompts = []
+    srv.a2a_agents = []
+    srv.visibility = "public"
+    return srv
+
+
+class TestServerAuditNoDb:
+    @pytest.mark.asyncio
+    async def test_register_server(self, server_service, db):
+        server_service._audit_trail.log_action = MagicMock(return_value=None)
+        db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
+        db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
+        server_service._notify_server_added = AsyncMock()
+        await server_service.register_server(db, ServerCreate(name="server-1", description="x"))
+        assert server_service._audit_trail.log_action.called
+        _assert_no_db_passed(server_service._audit_trail)
+
+    @pytest.mark.asyncio
+    async def test_update_server(self, server_service, db, server_db):
+        server_service._audit_trail.log_action = MagicMock(return_value=None)
+        db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock()
+        server_service._notify_server_updated = AsyncMock()
+        with patch("mcpgateway.services.server_service.get_for_update", return_value=server_db):
+            await server_service.update_server(db, "srv-1", ServerUpdate(description="updated"), user_email="tester@example.com")
+        assert server_service._audit_trail.log_action.called
+        _assert_no_db_passed(server_service._audit_trail)
+
+    @pytest.mark.asyncio
+    async def test_delete_server(self, server_service, db, server_db):
+        server_service._audit_trail.log_action = MagicMock(return_value=None)
+        db.execute = Mock(return_value=_make_execute_result(scalar=server_db, rowcount=1))
+        db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
+        server_service._notify_server_deleted = AsyncMock()
+        await server_service.delete_server(db, "srv-1")
+        assert server_service._audit_trail.log_action.called
+        _assert_no_db_passed(server_service._audit_trail)

--- a/tests/unit/mcpgateway/services/test_server_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_server_audit_no_db.py
@@ -84,7 +84,7 @@ class TestServerAuditNoDb:
         db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
         server_service._notify_server_added = AsyncMock()
         await server_service.register_server(db, ServerCreate(name="server-1", description="x"))
-        assert server_service._audit_trail.log_action.called
+        server_service._audit_trail.log_action.assert_called_once()
         _assert_no_db_passed(server_service._audit_trail, expected_action="create_server", resource_type="server")
 
     @pytest.mark.asyncio
@@ -105,7 +105,7 @@ class TestServerAuditNoDb:
         server_service._notify_server_updated = AsyncMock()
         with patch("mcpgateway.services.server_service.get_for_update", return_value=server_db):
             await server_service.update_server(db, "srv-1", ServerUpdate(description="updated"), user_email="tester@example.com")
-        assert server_service._audit_trail.log_action.called
+        server_service._audit_trail.log_action.assert_called_once()
         _assert_no_db_passed(server_service._audit_trail, expected_action="update_server", resource_type="server")
 
     @pytest.mark.asyncio
@@ -115,5 +115,21 @@ class TestServerAuditNoDb:
         db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
         server_service._notify_server_deleted = AsyncMock()
         await server_service.delete_server(db, "srv-1")
-        assert server_service._audit_trail.log_action.called
+        server_service._audit_trail.log_action.assert_called_once()
         _assert_no_db_passed(server_service._audit_trail, expected_action="delete_server", resource_type="server")
+
+    @pytest.mark.asyncio
+    async def test_get_server_audit_uses_system_user_id(self, server_service, db, server_db):
+        """get_server hardcodes user_id='system' for view_server audit — pin this to catch accidental changes."""
+        server_service._audit_trail.log_action = MagicMock(return_value=None)
+        db.execute = Mock(return_value=_make_execute_result(scalar=server_db))
+        server_service._check_server_access = AsyncMock(return_value=True)
+        server_service.convert_server_to_read = Mock(return_value=MagicMock())
+        await server_service.get_server(db, "srv-1")
+        server_service._audit_trail.log_action.assert_called_once()
+        call_kwargs = server_service._audit_trail.log_action.call_args.kwargs
+        assert call_kwargs["user_id"] == "system", (
+            "get_server audit must use user_id='system' (intentional system read attribution)"
+        )
+        assert call_kwargs["action"] == "view_server"
+        assert call_kwargs["resource_type"] == "server"

--- a/tests/unit/mcpgateway/services/test_tool_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_tool_audit_no_db.py
@@ -84,7 +84,7 @@ class TestToolAuditNoDb:
             db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
             db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
             await tool_service.register_tool(db, ToolCreate(name="tool-1", url="https://example.com", request_type="POST", input_schema={"type": "object"}))
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="create_tool", resource_type="tool")
 
     @pytest.mark.asyncio
@@ -108,7 +108,7 @@ class TestToolAuditNoDb:
             db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock()
             tool_service._notify_tool_updated = AsyncMock()
             await tool_service.update_tool(db, "tool-1", ToolUpdate(description="updated"), user_email="tester@example.com")
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="update_tool", resource_type="tool")
 
     @pytest.mark.asyncio
@@ -119,7 +119,7 @@ class TestToolAuditNoDb:
             db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock()
             tool_service._notify_tool_state_changed = AsyncMock()
             await tool_service.set_tool_state(db, "tool-1", activate=False, reachable=True)
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="set_tool_state", resource_type="tool")
 
     @pytest.mark.asyncio
@@ -131,5 +131,5 @@ class TestToolAuditNoDb:
             db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
             tool_service._notify_tool_deleted = AsyncMock()
             await tool_service.delete_tool(db, "tool-1")
-            assert mock_audit.log_action.called
+            mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="delete_tool", resource_type="tool")

--- a/tests/unit/mcpgateway/services/test_tool_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_tool_audit_no_db.py
@@ -10,7 +10,7 @@ import pytest
 
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.schemas import ToolCreate, ToolRead, ToolUpdate
-from mcpgateway.services.tool_service import ToolService
+from mcpgateway.services.tool_service import ToolError, ToolService
 
 _R = TypeVar("_R")
 
@@ -25,10 +25,17 @@ def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | N
     return result
 
 
-def _assert_no_db_passed(mock_audit: MagicMock) -> None:
-    for call in mock_audit.log_action.call_args_list:
+def _assert_no_db_passed(mock_audit: MagicMock, *, expected_action: str | None = None, resource_type: str | None = None) -> None:
+    calls = mock_audit.log_action.call_args_list
+    for call in calls:
         assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
         assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+    if expected_action is not None:
+        actions = [call.kwargs.get("action") for call in calls]
+        assert expected_action in actions, f"expected action {expected_action!r} not found in calls: {actions}"
+    if resource_type is not None:
+        for call in calls:
+            assert call.kwargs.get("resource_type") == resource_type, f"unexpected resource_type in call: {call}"
 
 
 @pytest.fixture(autouse=True)
@@ -78,7 +85,18 @@ class TestToolAuditNoDb:
             db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
             await tool_service.register_tool(db, ToolCreate(name="tool-1", url="https://example.com", request_type="POST", input_schema={"type": "object"}))
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="create_tool", resource_type="tool")
+
+    @pytest.mark.asyncio
+    async def test_register_tool_audit_failure_does_not_block_already_committed_tool(self, tool_service, db):
+        """If audit_trail.log_action() raises, the tool row is already committed (db.commit ran first)."""
+        with patch("mcpgateway.services.tool_service.audit_trail") as mock_audit, patch("mcpgateway.services.tool_service.structured_logger"):
+            mock_audit.log_action = MagicMock(side_effect=Exception("audit backend unavailable"))
+            db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
+            db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock(); db.rollback = Mock()
+            with pytest.raises(ToolError):
+                await tool_service.register_tool(db, ToolCreate(name="tool-1", url="https://example.com", request_type="POST", input_schema={"type": "object"}))
+            db.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_tool(self, tool_service, db, tool_db):
@@ -91,7 +109,7 @@ class TestToolAuditNoDb:
             tool_service._notify_tool_updated = AsyncMock()
             await tool_service.update_tool(db, "tool-1", ToolUpdate(description="updated"), user_email="tester@example.com")
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="update_tool", resource_type="tool")
 
     @pytest.mark.asyncio
     async def test_set_tool_state(self, tool_service, db, tool_db):
@@ -102,7 +120,7 @@ class TestToolAuditNoDb:
             tool_service._notify_tool_state_changed = AsyncMock()
             await tool_service.set_tool_state(db, "tool-1", activate=False, reachable=True)
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="set_tool_state", resource_type="tool")
 
     @pytest.mark.asyncio
     async def test_delete_tool(self, tool_service, db, tool_db):
@@ -114,4 +132,4 @@ class TestToolAuditNoDb:
             tool_service._notify_tool_deleted = AsyncMock()
             await tool_service.delete_tool(db, "tool-1")
             assert mock_audit.log_action.called
-            _assert_no_db_passed(mock_audit)
+            _assert_no_db_passed(mock_audit, expected_action="delete_tool", resource_type="tool")

--- a/tests/unit/mcpgateway/services/test_tool_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_tool_audit_no_db.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for tool audit_trail.log_action db handling."""
+
+from __future__ import annotations
+
+from typing import TypeVar
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.schemas import ToolCreate, ToolRead, ToolUpdate
+from mcpgateway.services.tool_service import ToolService
+
+_R = TypeVar("_R")
+
+
+def _make_execute_result(*, scalar: _R | None = None, scalars_list: list[_R] | None = None, rowcount: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    result.rowcount = rowcount
+    scalars_proxy = MagicMock()
+    scalars_proxy.all.return_value = scalars_list or []
+    result.scalars.return_value = scalars_proxy
+    return result
+
+
+def _assert_no_db_passed(mock_audit: MagicMock) -> None:
+    for call in mock_audit.log_action.call_args_list:
+        assert "db" not in call.kwargs, f"audit_trail.log_action() was called with db= keyword argument: {call}"
+        assert len(call.args) < 23, f"audit_trail.log_action() received too many positional args (db may be positional): {call}"
+
+
+@pytest.fixture(autouse=True)
+def _patch_models(monkeypatch):
+    def _fake_validate(d):
+        m = MagicMock()
+        m.masked.return_value = m
+        return m
+    monkeypatch.setattr(ToolRead, "model_validate", staticmethod(_fake_validate))
+    yield
+
+
+@pytest.fixture
+def tool_service():
+    return ToolService()
+
+
+@pytest.fixture
+def db():
+    return MagicMock()
+
+
+@pytest.fixture
+def tool_db():
+    tool = MagicMock(spec=DbTool)
+    tool.id = "tool-1"
+    tool.name = "tool-1"
+    tool.enabled = True
+    tool.team_id = None
+    tool.output_schema = None
+    tool.input_schema = {"type": "object"}
+    tool.description = "test tool"
+    tool.visibility = "public"
+    tool.owner_email = "tester@example.com"
+    tool.gateway_id = None
+    tool.auth_type = None
+    tool.auth_value = None
+    return tool
+
+
+class TestToolAuditNoDb:
+    @pytest.mark.asyncio
+    async def test_register_tool(self, tool_service, db):
+        with patch("mcpgateway.services.tool_service.audit_trail") as mock_audit, patch("mcpgateway.services.tool_service.structured_logger"):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(side_effect=[_make_execute_result(scalar=None), _make_execute_result(scalar=None)])
+            db.add = Mock(); db.commit = Mock(); db.refresh = Mock(); db.flush = Mock()
+            await tool_service.register_tool(db, ToolCreate(name="tool-1", url="https://example.com", request_type="POST", input_schema={"type": "object"}))
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_update_tool(self, tool_service, db, tool_db):
+        with patch("mcpgateway.services.tool_service.audit_trail") as mock_audit, patch("mcpgateway.services.tool_service.structured_logger"), \
+             patch("mcpgateway.services.tool_service.get_for_update", return_value=tool_db), \
+             patch("mcpgateway.services.tool_service._get_registry_cache", return_value=AsyncMock()), \
+             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=AsyncMock()):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock(); db.expire = Mock()
+            tool_service._notify_tool_updated = AsyncMock()
+            await tool_service.update_tool(db, "tool-1", ToolUpdate(description="updated"), user_email="tester@example.com")
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_set_tool_state(self, tool_service, db, tool_db):
+        with patch("mcpgateway.services.tool_service.audit_trail") as mock_audit, patch("mcpgateway.services.tool_service.structured_logger"), \
+             patch("mcpgateway.services.tool_service.get_for_update", return_value=tool_db):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.commit = Mock(); db.refresh = Mock(); db.rollback = Mock()
+            tool_service._notify_tool_state_changed = AsyncMock()
+            await tool_service.set_tool_state(db, "tool-1", activate=False, reachable=True)
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)
+
+    @pytest.mark.asyncio
+    async def test_delete_tool(self, tool_service, db, tool_db):
+        with patch("mcpgateway.services.tool_service.audit_trail") as mock_audit, patch("mcpgateway.services.tool_service.structured_logger"), \
+             patch("mcpgateway.services.tool_service.get_for_update", return_value=tool_db):
+            mock_audit.log_action = MagicMock(return_value=None)
+            db.execute = Mock(return_value=_make_execute_result(scalar=tool_db, rowcount=1))
+            db.delete = Mock(); db.commit = Mock(); db.rollback = Mock(); db.expire = Mock()
+            tool_service._notify_tool_deleted = AsyncMock()
+            await tool_service.delete_tool(db, "tool-1")
+            assert mock_audit.log_action.called
+            _assert_no_db_passed(mock_audit)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -7992,6 +7992,9 @@ class TestToolServiceBulkImport:
         db.commit.assert_called_once()
         db.refresh.assert_called_once_with(db_tool)
         mock_logging_services["audit_trail"].log_action.assert_called_once()
+        audit_kwargs = mock_logging_services["audit_trail"].log_action.call_args.kwargs
+        assert audit_kwargs["action"] == "bulk_create_tools"
+        assert audit_kwargs["details"]["count"] == 1  # 1 added, 1 skipped — only adds counted
 
     def test_process_tool_chunk_team_updates_only(self, mock_logging_services):
         service = ToolService()
@@ -8025,7 +8028,9 @@ class TestToolServiceBulkImport:
         db.add_all.assert_not_called()
         db.commit.assert_called_once()
         mock_logging_services["audit_trail"].log_action.assert_called_once()
-        assert mock_logging_services["audit_trail"].log_action.call_args.kwargs["action"] == "bulk_update_tools"
+        audit_kwargs = mock_logging_services["audit_trail"].log_action.call_args.kwargs
+        assert audit_kwargs["action"] == "bulk_update_tools"
+        assert audit_kwargs["details"]["count"] == 1
 
     def test_process_tool_chunk_private_exception_rolls_back(self):
         service = ToolService()

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -476,6 +476,7 @@ async def test_admin_login_handler_paths(monkeypatch):
     mock_db = MagicMock()
 
     monkeypatch.setattr(admin.settings, "email_auth_enabled", True)
+    monkeypatch.setattr(admin.settings, "sso_enabled", False)
     monkeypatch.setattr(admin.settings, "password_change_enforcement_enabled", False)
     monkeypatch.setattr(admin.settings, "detect_default_password_on_login", False)
 
@@ -514,6 +515,7 @@ async def test_admin_login_handler_default_password(monkeypatch):
     mock_db.commit = MagicMock(side_effect=Exception("commit failed"))
 
     monkeypatch.setattr(admin.settings, "email_auth_enabled", True)
+    monkeypatch.setattr(admin.settings, "sso_enabled", False)
     monkeypatch.setattr(admin.settings, "password_change_enforcement_enabled", True)
     monkeypatch.setattr(admin.settings, "detect_default_password_on_login", True)
     monkeypatch.setattr(admin.settings, "require_password_change_for_default_password", True)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -5920,7 +5920,7 @@ class TestUtilityFunctions:
         monkeypatch.setattr(main_mod.session_registry, "set_session_owner", AsyncMock())
         monkeypatch.setattr(main_mod.session_registry, "respond", AsyncMock(return_value=None))
         monkeypatch.setattr(main_mod.session_registry, "register_respond_task", MagicMock())
-        monkeypatch.setattr(main_mod.asyncio, "create_task", MagicMock(return_value=MagicMock()))
+        monkeypatch.setattr(main_mod.asyncio, "create_task", MagicMock(return_value=AsyncMock()))
 
         remove_session = AsyncMock(side_effect=Exception("boom"))
         monkeypatch.setattr(main_mod.session_registry, "remove_session", remove_session)


### PR DESCRIPTION
> **Note:** This PR was re-created from #3084 due to repository maintenance. Your code and branch are intact. @Lang-Akshay please verify everything looks good.

# fix: Resolve "transaction is inactive" error in tool/resource/gateway/prompt registration

## Description
Fixes issue #2871 where REST tool registration and other resource operations fail with **"This transaction is inactive"** error.

## Root Cause
The issue occurred due to **multiple database commits on the same SQLAlchemy session**:

1. **Tool creation commits** (line 1149 in tool_service.py): `db.commit()` completes the transaction
2. **Audit logging reuses same session**: `audit_trail.log_action(db=db)` attempts to use the already-committed session
3. **Transaction state becomes inactive**: SQLAlchemy marks the session as post-commit, making it unable to execute further operations
4. **Error cascade**: When errors occur, `db.rollback()` fails because the transaction is already inactive

This issue was **intermittent** because:
- Timing and concurrent access patterns affected when connections became deassociated
- Only manifested when transaction state was interrupted during the audit logging phase

## Solution
**Use separate database sessions for audit logging** instead of reusing the already-committed main session.

### Changes made:
- Removed `db=db` parameter from **22 audit_trail.log_action()** calls across:
  - `tool_service.py` (5 calls): create, bulk operations, delete, state changes, updates
  - `resource_service.py` (5 calls): create, bulk operations, delete, state changes, updates
  - `gateway_service.py` (4 calls): create, delete, state changes, updates
  - `server_service.py` (1 call): view server
  - `prompt_service.py` (7 calls): create, bulk operations, delete, state changes, updates, view

Each audit log now creates its own isolated session that:
- ✅ Commits independently without affecting the main transaction
- ✅ Handles cleanup automatically via context managers
- ✅ Doesn't exhaust connection pools (quick INSERT → COMMIT → release)
- ✅ Provides better error isolation

## Performance Impact
**Positive impact:**
- Eliminates error-prone cascading failures
- Improves reliability of concurrent operations
- Follows SQLAlchemy best practices for session isolation
- No connection pool exhaustion (sessions are short-lived INSERT operations)

## Testing
- ✅ Tool table entry created successfully without requiring application restart
- ✅ Code follows existing patterns in structured_logger.py (uses `fresh_db_session()`)
- ✅ No breaking changes to public APIs

## Files Changed
- `mcpgateway/services/tool_service.py` - 5 audit calls updated
- `mcpgateway/services/resource_service.py` - 5 audit calls updated
- `mcpgateway/services/gateway_service.py` - 4 audit calls updated
- `mcpgateway/services/prompt_service.py` - 7 audit calls updated
- `mcpgateway/services/server_service.py` - 1 audit call updated

## Unrelated test fixes included in this PR
Two test files contain small fixes unrelated to the `db=db` audit-trail change:

- `tests/unit/mcpgateway/routers/test_auth.py`: added `mock_settings.sso_enabled = False` and `mock_settings.csrf_rotate_on_login = False` to three login tests.
- `tests/unit/mcpgateway/test_admin_module.py`: added `monkeypatch.setattr(admin.settings, "sso_enabled", False)` to two login tests.

These tests started failing after SSO/CSRF settings were added to `main`. The fixes are minimal (one attribute set per test) and are included here because they were required to keep the test suite green on this branch.

## Closes
Closes #2871