### PR TITLE
fix(ui): replace tojson with single-quoted literals in Fetch Tools onclick

### DIFF
--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -38,7 +38,7 @@
               🔐 Authorize
             </a>
             <!-- Row 3:  Fetch Tools -->
-            <button onclick="fetchToolsForGateway({{ gateway.id|tojson }}, {{ gateway.name|tojson }})"
+            <button onclick="fetchToolsForGateway('{{ gateway.id }}', '{{ gateway.name }}')"
               class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors"
               x-tooltip="'🔧 Fetch Tools from MCP Server'" id="fetch-tools-{{ gateway.id }}">
               🔧 Fetch Tools


### PR DESCRIPTION
> **Note:** This PR was re-created from #3100 due to repository maintenance. Your code and branch are intact. @omorros please verify everything looks good.

  ## 🔗 Related Issue
   Closes #3082                                                                                                                

  ---

  ## 📝 Summary
  The "Fetch Tools" button in `gateways_partial.html` was broken because `|tojson` outputs double-quoted JSON strings inside a
   double-quoted `onclick` attribute, corrupting HTML parsing. Replaced with single-quoted JS literals to match the working   
  pattern used everywhere else in the templates.

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | ✅     |
  | Unit tests                | `make test`     | ✅     |
  | Coverage ≥ 80%            | `make coverage` | ✅     |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [ ] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  Single line change in `gateways_partial.html:41`. The same button works correctly in `admin.html` (initial page load) which 
  already uses single quotes — this fix aligns the HTMX partial to match.
