### PR TITLE
fix(schemas): widen ServerCapabilities capability fields from Dict[str, bool] to Dict[str, Any] to match MCP SDK permissive approach

### DIFF
--- a/mcpgateway/common/models.py
+++ b/mcpgateway/common/models.py
@@ -363,13 +363,13 @@ class ClientCapabilities(BaseModel):
     """Capabilities that a client may support.
 
     Attributes:
-        roots (Optional[Dict[str, bool]]): Capabilities related to root management.
+        roots (Optional[Dict[str, Any]]): Capabilities related to root management.
         sampling (Optional[Dict[str, Any]]): Capabilities related to LLM sampling.
         elicitation (Optional[Dict[str, Any]]): Capabilities related to elicitation (MCP 2025-06-18).
         experimental (Optional[Dict[str, Dict[str, Any]]]): Experimental capabilities.
     """
 
-    roots: Optional[Dict[str, bool]] = None
+    roots: Optional[Dict[str, Any]] = None
     sampling: Optional[Dict[str, Any]] = None
     elicitation: Optional[Dict[str, Any]] = None
     experimental: Optional[Dict[str, Dict[str, Any]]] = None

--- a/tests/unit/mcpgateway/test_models.py
+++ b/tests/unit/mcpgateway/test_models.py
@@ -437,6 +437,18 @@ class TestMCPTypes:
         assert minimal.logging is None
         assert minimal.experimental is None
 
+    def test_server_capabilities_non_boolean_values(self):
+        """Test ServerCapabilities accepts non-boolean values (MCP SDK extra='allow')."""
+        caps = ServerCapabilities(
+            prompts={"listChanged": True, "customField": "string_value"},
+            resources={"subscribe": True, "listChanged": True, "maxSize": 1024},
+            tools={"listChanged": True, "parallelism": 4, "metadata": {"key": "val"}},
+        )
+        assert caps.prompts == {"listChanged": True, "customField": "string_value"}
+        assert caps.resources["maxSize"] == 1024
+        assert caps.tools["parallelism"] == 4
+        assert caps.tools["metadata"] == {"key": "val"}
+
     def test_initialize_request(self):
         """Test InitializeRequest model."""
         request = InitializeRequest(

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -457,6 +457,18 @@ class TestMCPTypes:
         assert minimal.logging is None
         assert minimal.experimental is None
 
+    def test_server_capabilities_non_boolean_values(self):
+        """Test ServerCapabilities accepts non-boolean values (MCP SDK extra='allow')."""
+        caps = ServerCapabilities(
+            prompts={"listChanged": True, "customField": "string_value"},
+            resources={"subscribe": True, "listChanged": True, "maxSize": 1024},
+            tools={"listChanged": True, "parallelism": 4, "metadata": {"key": "val"}},
+        )
+        assert caps.prompts == {"listChanged": True, "customField": "string_value"}
+        assert caps.resources["maxSize"] == 1024
+        assert caps.tools["parallelism"] == 4
+        assert caps.tools["metadata"] == {"key": "val"}
+
     def test_initialize_request(self):
         """Test InitializeRequest model."""
         request = InitializeRequest(


### PR DESCRIPTION
> **Note:** This PR was re-created from #3075 due to repository maintenance. Your code and branch are intact. @omorros please verify everything looks good.

  ## 🔗 Related Issue                                                                                                           Closes #3063                                                                                                                                                                                                                                                ---                                                                                                                                                                                                                                                         ## 📝 Summary                                                                                                               
  The MCP SDK's `ToolsCapability` uses `extra: "allow"`, so MCP servers can return arbitrary extra fields in their
  capabilities response. Our `ServerCapabilities` model typed `prompts`, `resources`, and `tools` as `Dict[str, bool]`, which 
  rejects non-boolean values during `PydanticGateway.model_validate()` when plugins are enabled. Widened these three fields to
   `Dict[str, Any]` to match the SDK's permissive approach.

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | ✅      |
  | Unit tests                | `make test`     | ✅      |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [ ] Tests added/updated for changes
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  Single file change (`mcpgateway/common/models.py`). Existing tests continue to pass since boolean values are valid `Any`. No
   new tests needed as the fix is purely relaxing a type constraint.
