### PR TITLE
docs(quickstart): add 5-minute quick-start with PowerShell examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ContextForge MCP Gateway is a feature-rich gateway, proxy and MCP Registry that 
 
 | Resource | Description |
 |----------|-------------|
-| **[5-Minute Setup](https://github.com/IBM/mcp-context-forge/issues/2503)** | Get started fast — uvx, Docker, Compose, or local dev |
+| **[5-Minute Setup](docs/QUICKSTART.md)** | Get started fast — uvx, Docker, Compose, or local dev |
 | **[Getting Help](https://github.com/IBM/mcp-context-forge/issues/2504)** | Support options, FAQ, community channels |
 | **[Issue Guide](https://github.com/IBM/mcp-context-forge/issues/2502)** | How to file bugs, request features, contribute |
 | **[Full Documentation](https://ibm.github.io/mcp-context-forge/)** | Complete guides, tutorials, API reference |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ContextForge MCP Gateway is a feature-rich gateway, proxy and MCP Registry that 
 
 | Resource | Description |
 |----------|-------------|
-| **[5-Minute Setup](docs/QUICKSTART.md)** | Get started fast — uvx, Docker, Compose, or local dev |
+| **[5-Minute Setup](docs/QUICKSTART.md)** | Get started fast — uvx + first API call (Bash/PowerShell) |
 | **[Getting Help](https://github.com/IBM/mcp-context-forge/issues/2504)** | Support options, FAQ, community channels |
 | **[Issue Guide](https://github.com/IBM/mcp-context-forge/issues/2502)** | How to file bugs, request features, contribute |
 | **[Full Documentation](https://ibm.github.io/mcp-context-forge/)** | Complete guides, tutorials, API reference |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,80 @@
+# 5-Minute Setup & First Steps
+
+Get **ContextForge** up and running in under 5 minutes.
+
+## 1. Quick Start with uvx
+
+Use `uvx` to run the gateway instantly without manual installation.
+
+### Bash / Zsh
+
+```bash
+BASIC_AUTH_PASSWORD=pass \
+MCPGATEWAY_UI_ENABLED=true \
+MCPGATEWAY_ADMIN_API_ENABLED=true \
+PLATFORM_ADMIN_EMAIL=admin@example.com \
+PLATFORM_ADMIN_PASSWORD=changeme \
+PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
+uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
+```
+
+### Windows (PowerShell)
+
+```powershell
+$Env:BASIC_AUTH_PASSWORD="pass"
+$Env:MCPGATEWAY_UI_ENABLED="true"
+$Env:MCPGATEWAY_ADMIN_API_ENABLED="true"
+$Env:PLATFORM_ADMIN_EMAIL="admin@example.com"
+$Env:PLATFORM_ADMIN_PASSWORD="changeme"
+$Env:PLATFORM_ADMIN_FULL_NAME="Platform Administrator"
+
+uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
+```
+
+---
+
+## 2. Your First API Call
+
+Generate a token and query the version endpoint.
+
+### API Call - Bash / Zsh
+
+```bash
+# Generate token
+export MCPGATEWAY_BEARER_TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token \
+    --username admin@example.com --exp 10080 --secret my-test-key)
+
+# Query endpoint
+curl -s -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
+     http://127.0.0.1:4444/version | jq
+```
+
+### API Call - Windows (PowerShell)
+
+```powershell
+# Generate token (must match JWT_SECRET_KEY used by the gateway)
+$token = python -m mcpgateway.utils.create_jwt_token `
+  --username "admin@example.com" `
+  --exp 10080 `
+  --secret "my-test-key"
+
+$headers = @{ Authorization = "Bearer $token" }
+
+Invoke-RestMethod -Uri "http://localhost:4444/version" -Headers $headers | ConvertTo-Json
+```
+
+---
+
+## 3. Local Development
+
+> **Note:** There is no root-level `requirements.txt`. This project uses `pyproject.toml`, `uv`, and `Makefile`.
+
+To set up your local development environment:
+
+```bash
+# Install dependencies with uv
+uv sync
+
+# Or using Make
+make install
+```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,6 +10,7 @@ Use `uvx` to run the gateway instantly without manual installation.
 
 ```bash
 BASIC_AUTH_PASSWORD=pass \
+JWT_SECRET_KEY=my-test-key \
 MCPGATEWAY_UI_ENABLED=true \
 MCPGATEWAY_ADMIN_API_ENABLED=true \
 PLATFORM_ADMIN_EMAIL=admin@example.com \
@@ -22,6 +23,7 @@ uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
 
 ```powershell
 $Env:BASIC_AUTH_PASSWORD="pass"
+$Env:JWT_SECRET_KEY="my-test-key"
 $Env:MCPGATEWAY_UI_ENABLED="true"
 $Env:MCPGATEWAY_ADMIN_API_ENABLED="true"
 $Env:PLATFORM_ADMIN_EMAIL="admin@example.com"
@@ -60,7 +62,7 @@ $token = python -m mcpgateway.utils.create_jwt_token `
 
 $headers = @{ Authorization = "Bearer $token" }
 
-Invoke-RestMethod -Uri "http://localhost:4444/version" -Headers $headers | ConvertTo-Json
+Invoke-RestMethod -Uri "http://127.0.0.1:4444/version" -Headers $headers | ConvertTo-Json
 ```
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -33,6 +33,11 @@ $Env:PLATFORM_ADMIN_FULL_NAME="Platform Administrator"
 uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
 ```
 
+Once the gateway starts, open:
+
+- Admin UI: http://localhost:4444/admin
+- API Docs: http://localhost:4444/docs (requires JWT bearer token for API calls)
+
 ---
 
 ## 2. Your First API Call
@@ -78,5 +83,5 @@ To set up your local development environment:
 uv sync
 
 # Or using Make
-make install
+make install-dev
 ```


### PR DESCRIPTION
> **Note:** This PR was re-created from #2686 due to repository maintenance. Your code and branch are intact. @oaslananka please verify everything looks good.

Partially addresses #2503

Adds a concise 5-minute quick-start guide covering uvx and local dev setup.
Includes Windows PowerShell equivalents and clarifies that the project uses pyproject.toml + uv (no root requirements.txt).