### PR TITLE
feat(auth): add OAuth header client credentials support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,11 @@ This release delivers **enterprise security hardening**, **comprehensive RBAC im
 * **README Rationalization** ([#2365](https://github.com/IBM/mcp-context-forge/issues/2365)) - Streamlined and reorganized project README
 * **SonarQube Cleanup** ([#2367](https://github.com/IBM/mcp-context-forge/issues/2367), [#2371](https://github.com/IBM/mcp-context-forge/issues/2371), [#2372](https://github.com/IBM/mcp-context-forge/issues/2372), [#2377](https://github.com/IBM/mcp-context-forge/issues/2377), [#2382](https://github.com/IBM/mcp-context-forge/issues/2382)) - Fixed redundant ternary, removed dead code, replaced deprecated `datetime.utcnow()`, cleaned up unused imports
 
+#### OAuth Client Credentials Authentication
+* Added support for sending client credentials either in the request body (default behavior) or in the HTTP headers **for the Client Credentials grant type only**
+* Configuration exposed via a UI dropdown selector
+* Enables compliance with environments enforcing strict security policies for sensitive credentials
+* Other OAuth grant types are not affected
 ---
 
 ## [1.0.0-BETA-2] - 2026-01-20 - Performance, Scale & Reliability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,8 +260,8 @@ This release delivers **enterprise security hardening**, **comprehensive RBAC im
 * **README Rationalization** ([#2365](https://github.com/IBM/mcp-context-forge/issues/2365)) - Streamlined and reorganized project README
 * **SonarQube Cleanup** ([#2367](https://github.com/IBM/mcp-context-forge/issues/2367), [#2371](https://github.com/IBM/mcp-context-forge/issues/2371), [#2372](https://github.com/IBM/mcp-context-forge/issues/2372), [#2377](https://github.com/IBM/mcp-context-forge/issues/2377), [#2382](https://github.com/IBM/mcp-context-forge/issues/2382)) - Fixed redundant ternary, removed dead code, replaced deprecated `datetime.utcnow()`, cleaned up unused imports
 
-#### OAuth Client Credentials Authentication
-* Added support for sending client credentials either in the request body (default behavior) or in the HTTP headers **for the Client Credentials grant type only**
+#### OAuth Client Authentication Handling
+* Added support for sending client credentials either in the request body (default behavior) or in the HTTP headers for the **Client Credentials** and **Password** grant types.
 * Configuration exposed via a UI dropdown selector
 * Enables compliance with environments enforcing strict security policies for sensitive credentials
 * Other OAuth grant types are not affected

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -9306,6 +9306,11 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
                     if scopes:
                         oauth_config["scopes"] = scopes
 
+                # Handle credentials location (body or header)
+                oauth_credentials_location = str(form.get("oauth_credentials_location", ""))
+                if oauth_credentials_location in ("body", "header"):
+                    oauth_config["credentials_location"] = oauth_credentials_location
+
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields: grant_type={oauth_grant_type}, issuer={oauth_issuer}")
                 LOGGER.info(f"DEBUG: Complete oauth_config = {oauth_config}")
 
@@ -12495,6 +12500,11 @@ async def admin_add_a2a_agent(
                     scopes = [s.strip() for s in oauth_scopes_str.replace(",", " ").split() if s.strip()]
                     if scopes:
                         oauth_config["scopes"] = scopes
+
+                # Handle credentials location (body or header)
+                oauth_credentials_location = str(form.get("oauth_credentials_location", ""))
+                if oauth_credentials_location in ("body", "header"):
+                    oauth_config["credentials_location"] = oauth_credentials_location
 
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields: grant_type={oauth_grant_type}, issuer={oauth_issuer}")
                 LOGGER.info(f"DEBUG: Complete oauth_config = {oauth_config}")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1826,6 +1826,11 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
+
+                # Handle credentials location (body or header)
+                oauth_credentials_location = str(form.get("oauth_credentials_location", ""))
+                if oauth_credentials_location in ("body", "header"):
+                    oauth_config["credentials_location"] = oauth_credentials_location
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(
@@ -2000,6 +2005,11 @@ async def admin_edit_server(
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
+
+                # Handle credentials location (body or header)
+                oauth_credentials_location = str(form.get("oauth_credentials_location", ""))
+                if oauth_credentials_location in ("body", "header"):
+                    oauth_config["credentials_location"] = oauth_credentials_location
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(
@@ -9580,6 +9590,11 @@ async def admin_edit_gateway(
                     scopes = [s.strip() for s in oauth_scopes_str.replace(",", " ").split() if s.strip()]
                     if scopes:
                         oauth_config["scopes"] = scopes
+
+                # Handle credentials location (body or header)
+                oauth_credentials_location = str(form.get("oauth_credentials_location", ""))
+                if oauth_credentials_location in ("body", "header"):
+                    oauth_config["credentials_location"] = oauth_credentials_location
 
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_grant_type}, issuer={oauth_issuer}")
 

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -245,8 +245,10 @@ class OAuthManager:
         request_headers = {}
 
         if credentials_location == "header":
+            from urllib.parse import quote  # pylint: disable=import-outside-toplevel
+
             # Send credentials via Authorization header (Basic Auth)
-            auth_string = f"{client_id}:{client_secret}"
+            auth_string = f"{quote(client_id, safe='')}:{quote(client_secret, '')}"
             auth_header = base64.b64encode(auth_string.encode()).decode()
             request_headers["Authorization"] = f"Basic {auth_header}"
             token_data = {

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -271,7 +271,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data, headers=request_headers if request_headers else None, timeout=self.request_timeout)
+                response = await client.post(token_url, data=token_data, headers=request_headers or None, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # GitHub returns form-encoded responses, not JSON
@@ -380,7 +380,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data, headers=request_headers if request_headers else None, timeout=self.request_timeout)
+                response = await client.post(token_url, data=token_data, headers=request_headers or None, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # Handle both JSON and form-encoded responses

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -240,12 +240,27 @@ class OAuthManager:
             except Exception as e:
                 logger.warning(f"Failed to decrypt client secret: {e}, using encrypted version")
 
-        # Prepare token request data
-        token_data = {
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-        }
+        # Prepare token request data and headers based on credentials_location
+        credentials_location = credentials.get("credentials_location", "body")
+        request_headers = {}
+
+        if credentials_location == "header":
+            # Send credentials via Authorization header (Basic Auth)
+            auth_string = f"{client_id}:{client_secret}"
+            auth_header = base64.b64encode(auth_string.encode()).decode()
+            request_headers["Authorization"] = f"Basic {auth_header}"
+            token_data = {
+                "grant_type": "client_credentials",
+            }
+            logger.debug("Using Authorization header for OAuth credentials")
+        else:
+            # Default: Send credentials in request body
+            token_data = {
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            }
+            logger.debug("Using request body for OAuth credentials")
 
         if scopes:
             token_data["scope"] = " ".join(scopes) if isinstance(scopes, list) else scopes
@@ -254,7 +269,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
+                response = await client.post(token_url, data=token_data, headers=request_headers if request_headers else None, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # GitHub returns form-encoded responses, not JSON
@@ -331,20 +346,30 @@ class OAuthManager:
             except Exception as e:
                 logger.warning(f"Failed to decrypt client secret: {e}, using encrypted version")
 
-        # Prepare token request data
+        # Prepare token request data and headers based on credentials_location
+        credentials_location = credentials.get("credentials_location", "body")
+        request_headers = {}
+
+        # Base token data for password grant
         token_data = {
             "grant_type": "password",
             "username": username,
             "password": password,
         }
 
-        # Add client_id (required by most providers including Keycloak)
-        if client_id:
-            token_data["client_id"] = client_id
-
-        # Add client_secret if present (some providers require it, others don't)
-        if client_secret:
-            token_data["client_secret"] = client_secret
+        if credentials_location == "header" and client_id and client_secret:
+            # Send client credentials via Authorization header (Basic Auth)
+            auth_string = f"{client_id}:{client_secret}"
+            auth_header = base64.b64encode(auth_string.encode()).decode()
+            request_headers["Authorization"] = f"Basic {auth_header}"
+            logger.debug("Using Authorization header for OAuth client credentials")
+        else:
+            # Default: Send client credentials in request body
+            if client_id:
+                token_data["client_id"] = client_id
+            if client_secret:
+                token_data["client_secret"] = client_secret
+            logger.debug("Using request body for OAuth client credentials")
 
         if scopes:
             token_data["scope"] = " ".join(scopes) if isinstance(scopes, list) else scopes
@@ -353,7 +378,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
+                response = await client.post(token_url, data=token_data, headers=request_headers if request_headers else None, timeout=self.request_timeout)
                 response.raise_for_status()
 
                 # Handle both JSON and form-encoded responses

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5647,7 +5647,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   </div>
                   <div>
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Credentials location
+                      Credentials Location
                     </label>
                     <select name="oauth_credentials_location" class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300">
                       <option value="body" selected>Request Body (Default)</option>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5645,6 +5645,18 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       read:user")
                     </p>
                   </div>
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Credentials location
+                    </label>
+                    <select name="oauth_credentials_location" class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300">
+                      <option value="body" selected>Request Body (Default)</option>
+                      <option value="header">Authorization Header (Basic Auth)</option>
+                    </select>
+                    <p class="mt-1 text-sm text-gray-500">
+                      Choose where to send client credentials. Some OAuth servers require Basic Auth header instead of body parameters.
+                    </p>
+                  </div>
                 </div>
               </div>
 
@@ -7093,6 +7105,18 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     <p class="mt-1 text-sm text-gray-500">
                       Space-separated list of OAuth scopes (e.g., "repo
                       read:user")
+                    </p>
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Credentials Location
+                    </label>
+                    <select name="oauth_credentials_location" class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300">
+                      <option value="body" selected>Request Body (Default)</option>
+                      <option value="header">Authorization Header (Basic Auth)</option>
+                    </select>
+                    <p class="mt-1 text-sm text-gray-500">
+                      Choose where to send client credentials. Some OAuth servers require Basic Auth header instead of body parameters.
                     </p>
                   </div>
                 </div>

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -602,6 +602,57 @@ class TestAdminServerRoutes:
         assert server_create.oauth_enabled is False
         assert server_create.oauth_config is None
 
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_credentials_location(self, mock_register_server, mock_request, mock_db):
+        """Test adding server with OAuth credentials location specified."""
+        # 1. Setup mock form data including oauth_credentials_location
+        form_data = FakeForm({
+            "name": "Test Server OAuth Location",
+            "oauth_enabled": "on",
+            "oauth_authorization_server": "https://auth.example.com",
+            "oauth_credentials_location": "header"
+        })
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        # 2. Call admin_add_server
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        # 3. Verify response
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+
+        # 4. Verify register_server was called with correct oauth_config
+        mock_register_server.assert_called_once()
+        call_args = mock_register_server.call_args
+        server_create = call_args[0][1] # second arg is server object
+
+        assert server_create.oauth_enabled == True
+        assert server_create.oauth_config is not None
+        assert server_create.oauth_config.get("authorization_servers") == ["https://auth.example.com"]
+        assert server_create.oauth_config.get("credentials_location") == "header"
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_credentials_location_invalid(self, mock_register_server, mock_request, mock_db):
+        """Test adding server with invalid OAuth credentials location (should be ignored)."""
+        form_data = FakeForm({
+            "name": "Test Server Invalid OAuth Location",
+            "oauth_enabled": "on",
+            "oauth_authorization_server": "https://auth.example.com",
+            "oauth_credentials_location": "invalid_value"
+        })
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert result.status_code == 200
+
+        mock_register_server.assert_called_once()
+        server_create = mock_register_server.call_args[0][1]
+
+        # Verify key is NOT present (so it defaults to body in manager)
+        assert server_create.oauth_config is not None
+        assert "credentials_location" not in server_create.oauth_config
+
     async def test_admin_add_server_missing_required_field_returns_422(self, mock_request, mock_db):
         """Cover the KeyError handler in admin_add_server."""
         mock_request.form = AsyncMock(return_value=FakeForm({"description": "no name"}))
@@ -3900,6 +3951,117 @@ class TestOAuthFunctionality:
         assert gateway_create.oauth_config is None
 
     @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_oauth_credentials_location(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with OAuth credentials location (header/body/invalid)."""
+        # Case 1: Header
+        form_data_header = FakeForm({
+            "name": "OAuth_Gateway_Header",
+            "url": "https://example.com",
+            # Basic OAuth fields to trigger assembly
+            "oauth_grant_type": "client_credentials",
+            "oauth_issuer": "https://auth.example.com",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "s",
+            "oauth_token_url": "https://auth.example.com/token",
+            "oauth_authorization_url": "https://auth.example.com/auth",
+            "oauth_credentials_location": "header"
+        })
+        mock_request.form = AsyncMock(return_value=form_data_header)
+
+        # Mock dependencies (TeamService, MetadataCapture, Encryption)
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_enc,
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta
+        ):
+            mock_enc.return_value.encrypt_secret_async = AsyncMock(return_value="enc")
+            mock_meta.return_value = {
+                "created_by": "test",
+                "created_from_ip": "127.0.0.1",
+                "created_via": "web",
+                "created_user_agent": "test-agent"
+            }
+
+            await admin_add_gateway(mock_request, mock_db, user={"email": "u", "db": mock_db})
+
+            # Verify "header" saved
+            assert mock_register_gateway.called
+            gw_create = mock_register_gateway.call_args[0][1]
+            assert gw_create.oauth_config["credentials_location"] == "header"
+
+        # Case 2: Body
+        mock_register_gateway.reset_mock()
+        form_data_body = FakeForm({
+            "name": "OAuth_Gateway_Body",
+            "url": "https://example.com",
+            "oauth_grant_type": "client_credentials",
+            "oauth_issuer": "https://auth.example.com",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "s",
+            "oauth_token_url": "https://auth.example.com/token",
+            "oauth_authorization_url": "https://auth.example.com/auth",
+            "oauth_credentials_location": "body"
+        })
+        mock_request.form = AsyncMock(return_value=form_data_body)
+
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_enc,
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta
+        ):
+            mock_enc.return_value.encrypt_secret_async = AsyncMock(return_value="enc")
+            mock_meta.return_value = {
+                "created_by": "test",
+                "created_from_ip": "127.0.0.1",
+                "created_via": "web",
+                "created_user_agent": "test-agent"
+            }
+
+            await admin_add_gateway(mock_request, mock_db, user={"email": "u", "db": mock_db})
+
+            # Verify "body" saved
+            assert mock_register_gateway.called
+            gw_create = mock_register_gateway.call_args[0][1]
+            assert gw_create.oauth_config["credentials_location"] == "body"
+
+        # Case 3: Invalid/Unset (defaults to omitted, which manager treats as body)
+        mock_register_gateway.reset_mock()
+        form_data_invalid = FakeForm({
+            "name": "OAuth_Gateway_Invalid",
+            "url": "https://example.com",
+            "oauth_grant_type": "client_credentials",
+            "oauth_issuer": "https://auth.example.com",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "s",
+            "oauth_token_url": "https://auth.example.com/token",
+            "oauth_authorization_url": "https://auth.example.com/auth",
+            "oauth_credentials_location": "invalid_value"
+        })
+        mock_request.form = AsyncMock(return_value=form_data_invalid)
+
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_enc,
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta
+        ):
+            mock_enc.return_value.encrypt_secret_async = AsyncMock(return_value="enc")
+            mock_meta.return_value = {
+                "created_by": "test",
+                "created_from_ip": "127.0.0.1",
+                "created_via": "web",
+                "created_user_agent": "test-agent"
+            }
+
+            await admin_add_gateway(mock_request, mock_db, user={"email": "u", "db": mock_db})
+
+            # Verify key NOT present
+            gw_create = mock_register_gateway.call_args[0][1]
+            assert "credentials_location" not in gw_create.oauth_config
+
+    @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_oauth_config_none_string(self, mock_register_gateway, mock_request, mock_db):
         """Test adding gateway with oauth_config as 'None' string."""
         form_data = FakeForm({"name": "No_OAuth_Gateway", "url": "https://example.com", "oauth_config": "None"})
@@ -4176,6 +4338,7 @@ class TestOAuthFunctionality:
                 "oauth_username": "u",
                 "oauth_password": "p",
                 "oauth_scopes": "a, b c",
+                "oauth_credentials_location": "header",
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
@@ -4199,6 +4362,7 @@ class TestOAuthFunctionality:
             gateway_update = mock_update_gateway.call_args.args[2]
             assert gateway_update.oauth_config["client_secret"] == "enc-secret"
             assert gateway_update.oauth_config["scopes"] == ["a", "b", "c"]
+            assert gateway_update.oauth_config["credentials_location"] == "header"
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_assembled_minimal_fields_covers_false_branches(self, mock_update_gateway, mock_request, mock_db, monkeypatch):


### PR DESCRIPTION
> **Note:** This PR was re-created from #2814 due to repository maintenance. Your code and branch are intact. @0xAttra please verify everything looks good.

# ✨ Feature / Enhancement PR

## 🚀 Summary (1-2 sentences)
_What does this PR add or change?_
This PR adds support for sending client credentials either in the request body (default behavior) or in the request headers for the **Client Credentials grant type only** for both Gateway and A2A registrations.

The option is configurable via a UI dropdown, allowing users to explicitly choose their preferred method.

This is required for compatibility with environments that enforce strict security policies and mandate that sensitive credentials be passed through HTTP headers.

Previously, client credentials were always sent in the request body.

References:
- [OAuth 2.0 - RFC 6749, Section 2.3](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3)

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [x] CHANGELOG updated (if user-facing)