### PR TITLE
feat(plugins): add Source Scanner plugin scaffold with Semgrep integration

### DIFF
--- a/mcpgateway/routers/source_scanner_router.py
+++ b/mcpgateway/routers/source_scanner_router.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/source_scanner_router.py
+
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Arnav
+
+FastAPI Router for Source Scanner Results API.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Annotated, Any, Dict, List, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.db import get_db
+from mcpgateway.services.logging_service import LoggingService
+from plugins.source_scanner.storage.repository import ScanRepository
+
+REPOSITORY_AVAILABLE = True
+
+
+logger = LoggingService().get_logger(__name__)
+
+source_scanner_router = APIRouter(
+    prefix="/source-scanner",
+    tags=["Source Scanner"],
+    dependencies=[Depends(get_current_user)],
+)
+
+
+class FindingResponse(BaseModel):
+    """Single finding response."""
+
+    id: int
+    scanner: str
+    severity: str
+    rule_id: str
+    message: str
+    file_path: Optional[str] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    code_snippet: Optional[str] = None
+    help_url: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ScanSummaryResponse(BaseModel):
+    """Scan summary statistics."""
+
+    error_count: int = 0
+    warning_count: int = 0
+    info_count: int = 0
+
+
+class ScanResponse(BaseModel):
+    """Scan record response."""
+
+    id: int
+    repo_url: str
+    ref: Optional[str] = None
+    commit_sha: Optional[str] = None
+    languages: Optional[str] = None
+    blocked: bool = False
+    block_reason: Optional[str] = None
+    summary: ScanSummaryResponse
+    created_at: str
+
+    class Config:
+        from_attributes = True
+
+
+class ScanWithFindingsResponse(ScanResponse):
+    """Scan response with findings."""
+
+    findings: Annotated[list[FindingResponse], Field(default_factory=list)]
+
+
+@source_scanner_router.get("/scans/{scan_id}", response_model=ScanWithFindingsResponse)
+async def get_scan(
+    scan_id: int,
+    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Retrieve a scan record with all associated findings."""
+    if not REPOSITORY_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Repository not available")
+
+    repository = ScanRepository(db)
+    scan = repository.get_scan_by_id(scan_id)
+
+    if not scan:
+        logger.warning(f"Scan {scan_id} not found")
+        raise HTTPException(status_code=404, detail=f"Scan {scan_id} not found")
+
+    findings_response = [
+        FindingResponse(
+            id=f.id,
+            scanner=f.scanner,
+            severity=f.severity,
+            rule_id=f.rule_id,
+            message=f.message,
+            file_path=f.file_path,
+            line=f.line,
+            column=f.column,
+            code_snippet=f.code_snippet,
+            help_url=f.help_url,
+        )
+        for f in scan.findings
+    ]
+
+    return ScanWithFindingsResponse(
+        id=scan.id,
+        repo_url=scan.repo_url,
+        ref=scan.ref,
+        commit_sha=scan.commit_sha,
+        languages=scan.languages,
+        blocked=scan.blocked,
+        block_reason=scan.block_reason,
+        summary=ScanSummaryResponse(
+            error_count=int(scan.error_count),
+            warning_count=int(scan.warning_count),
+            info_count=int(scan.info_count),
+        ),
+        created_at=scan.created_at.isoformat(),
+        findings=findings_response,
+    )
+
+
+@source_scanner_router.get("/scans/{scan_id}/findings", response_model=List[FindingResponse])
+async def get_scan_findings(
+    scan_id: int,
+    severity: Optional[str] = Query(None, description="Filter by severity (ERROR|WARNING|INFO)"),
+    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Retrieve findings for a scan with optional severity filtering."""
+    if not REPOSITORY_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Repository not available")
+
+    if severity and severity not in ("ERROR", "WARNING", "INFO"):
+        raise HTTPException(status_code=400, detail="Invalid severity")
+
+    repository = ScanRepository(db)
+    scan = repository.get_scan_by_id(scan_id)
+    if not scan:
+        raise HTTPException(status_code=404, detail=f"Scan {scan_id} not found")
+
+    findings = repository.get_findings_by_severity(scan_id, severity) if severity else repository.get_findings_for_scan(scan_id)
+
+    return [
+        FindingResponse(
+            id=f.id,
+            scanner=f.scanner,
+            severity=f.severity,
+            rule_id=f.rule_id,
+            message=f.message,
+            file_path=f.file_path,
+            line=f.line,
+            column=f.column,
+            code_snippet=f.code_snippet,
+            help_url=f.help_url,
+        )
+        for f in findings
+    ]
+
+
+@source_scanner_router.get("/latest/{repo_url:path}", response_model=ScanWithFindingsResponse)
+async def get_latest_scan(
+    repo_url: str,
+    commit_sha: str = Query(..., description="Commit SHA to lookup"),
+    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Retrieve the latest scan for a repository and commit SHA."""
+    if not REPOSITORY_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Repository not available")
+
+    repository = ScanRepository(db)
+    scan = repository.get_latest_scan_for_commit(repo_url, commit_sha)
+
+    if not scan:
+        logger.info(f"No scan found for repo={repo_url}, commit={commit_sha}")
+        raise HTTPException(status_code=404, detail=f"No scan found for commit {commit_sha} in {repo_url}")
+
+    findings_response = [
+        FindingResponse(
+            id=f.id,
+            scanner=f.scanner,
+            severity=f.severity,
+            rule_id=f.rule_id,
+            message=f.message,
+            file_path=f.file_path,
+            line=f.line,
+            column=f.column,
+            code_snippet=f.code_snippet,
+            help_url=f.help_url,
+        )
+        for f in scan.findings
+    ]
+
+    return ScanWithFindingsResponse(
+        id=scan.id,
+        repo_url=scan.repo_url,
+        ref=scan.ref,
+        commit_sha=scan.commit_sha,
+        languages=scan.languages,
+        blocked=scan.blocked,
+        block_reason=scan.block_reason,
+        summary=ScanSummaryResponse(
+            error_count=int(scan.error_count),
+            warning_count=int(scan.warning_count),
+            info_count=int(scan.info_count),
+        ),
+        created_at=scan.created_at.isoformat(),
+        findings=findings_response,
+    )
+
+
+@source_scanner_router.get("/repos/{repo_url:path}/scans", response_model=List[ScanResponse])
+async def list_repo_scans(
+    repo_url: str,
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Retrieve paginated list of scans for a repository."""
+    if not REPOSITORY_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Repository not available")
+
+    repository = ScanRepository(db)
+    scans = repository.get_scans_for_repo(repo_url, limit=limit, offset=offset)
+
+    return [
+        ScanResponse(
+            id=scan.id,
+            repo_url=scan.repo_url,
+            ref=scan.ref,
+            commit_sha=scan.commit_sha,
+            languages=scan.languages,
+            blocked=scan.blocked,
+            block_reason=scan.block_reason,
+            summary=ScanSummaryResponse(
+                error_count=int(scan.error_count),
+                warning_count=int(scan.warning_count),
+                info_count=int(scan.info_count),
+            ),
+            created_at=scan.created_at.isoformat(),
+        )
+        for scan in scans
+    ]
+
+
+@source_scanner_router.get("/health")
+async def health_check(current_user: Dict[str, Any] = Depends(get_current_user)):
+    """Verify Source Scanner API is operational."""
+    return {"status": "ok", "repository_available": REPOSITORY_AVAILABLE}

--- a/mcpgateway/routers/source_scanner_router.py
+++ b/mcpgateway/routers/source_scanner_router.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./mcpgateway/routers/source_scanner_router.py
 
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 

--- a/plugins/source_scanner/Interface_alignment.md
+++ b/plugins/source_scanner/Interface_alignment.md
@@ -1,0 +1,106 @@
+# Source Scanner – Interface Alignment Checklist
+
+This document defines the agreed interfaces and responsibilities between components in the Source Scanner plugin, to avoid implementation mismatch and duplicated logic.
+
+All contributors should align with the following rules before implementing their components.
+
+---
+
+## 1. Finding schema & severity
+
+- `Finding.severity` **must be one of**:
+  - `"ERROR"`
+  - `"WARNING"`
+  - `"INFO"`
+- Scanner runners (Semgrep / Bandit) **must not introduce new severity levels**
+- Severity normalization and ordering are handled centrally (Normalizer / Policy), **not inside individual scanners**
+
+---
+
+## 2. Deduplication responsibility
+
+- **Scanners do NOT perform deduplication**
+- Each scanner returns a raw `List[Finding]`
+- Merging and deduplication across scanners is handled by:
+
+```python
+ParserNormalizer.merge_dedup(...)
+```
+
+- Deduplication relies on a stable key (e.g. `Finding.dedup_key()` or equivalent canonical fields)
+
+---
+
+## 3. Policy evaluation (single entry point)
+
+All block / allow decisions go through:
+
+```python
+PolicyChecker.evaluate(
+    findings: List[Finding],
+    threshold: str,
+    fail_on_critical: bool,
+)
+```
+
+- Scanners and normalizers **must not enforce policy decisions**
+- Policy logic is centralized and configurable
+
+---
+
+## 4. Configuration shape
+
+`SourceScannerConfig` supports both configuration styles.
+
+### Top-level config
+
+```yaml
+semgrep:
+  enabled: true
+bandit:
+  enabled: true
+```
+
+### Nested config
+
+```yaml
+scanners:
+  semgrep:
+    enabled: true
+  bandit:
+    enabled: true
+```
+
+- Config merging / normalization is handled inside `SourceScannerConfig`
+- Downstream components should assume a **normalized config object**
+
+---
+
+## 5. Subprocess execution utility
+
+All external commands **must** use:
+
+```python
+utils.exec.run_command(...)
+```
+
+`run_command` behavior:
+- Returns `ExecResult`
+- **Does not raise on timeout**
+- Sets `ExecResult.timed_out = True` instead
+
+Callers decide how to map timeouts or failures into domain-specific errors.
+
+---
+
+## 6. Scan failure behavior (important)
+
+- Current hook implementation is **fail-open**
+- Behavior for **enforce mode + scan failure** (e.g. clone error, scanner binary missing) is:
+  - Explicitly configurable
+  - Documented in `design.md`
+  - Final enforcement behavior may be implemented later
+
+---
+
+If any component behavior is unclear, please check `design.md` or align with the Technical Lead before implementation.

--- a/plugins/source_scanner/README.md
+++ b/plugins/source_scanner/README.md
@@ -1,0 +1,32 @@
+# Source Scanner Plugin
+
+## Purpose
+Provides pre-deployment static analysis of MCP server source code using Semgrep and Bandit, with normalized findings stored for policy evaluation. The plugin is designed to run as part of the MCP Gateway pre-registration and pre-deployment hooks, enabling shift-left security checks before MCP servers are added to the runtime or catalog.
+
+## Structure
+- `source_scanner.py`: Main plugin class and hooks
+- `config.py`: Configuration parsing and normalization
+- `policy.py`: Policy evaluation logic
+- `repo_fetcher.py`: Git repository cloning and checkout
+- `errors.py`: Defines shared exception types used across the plugin
+- `language_detector.py`: Detects programming languages used in the target repository
+- `types.py`: Defines core data models for the plugin
+- `scanners/`: Tool-specific scanner runners (Semgrep, Bandit)
+- `parsing/`: Normalizer for scanner outputs
+- `storage/`: Persistence layer for scan records (currently SQLAlchemy ORM)
+- `utils/`: Execution helpers, subprocess wrappers
+- `plugin-manifest.yaml`: Plugin registration
+- `Interface_alignment.md` and `design.md`: Design decisions and interface contracts
+- `storage/`: SQLAlchemy persistence layer for scan records (used with ScanRepository)
+
+## Status
+- Implemented in this PR:
+  - Semgrep runner
+  - Plugin skeleton and registration
+  - Normalized findings
+- Partially implemented / follow-up PRs:
+  - Bandit runner
+  - Parsing normalizer
+  - Language detection
+  - Repo fetcher adjustments
+  - Full test coverage

--- a/plugins/source_scanner/__init__.py
+++ b/plugins/source_scanner/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/__init__.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi
 

--- a/plugins/source_scanner/__init__.py
+++ b/plugins/source_scanner/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi
+
+Source Scanner Plugin Package.
+"""

--- a/plugins/source_scanner/config.py
+++ b/plugins/source_scanner/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/config.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 
@@ -97,6 +97,7 @@ class SourceScannerConfig(BaseModel):
     cache_ttl_hours: int = 168  # 1 week
 
     def model_post_init(self, __context: Any) -> None:
+        """Merge nested scanner configuration into top-level fields after validation."""
         # If user provides config.scanners.*, merge into top-level fields
         if self.scanners is not None:
             self.semgrep = self.scanners.semgrep

--- a/plugins/source_scanner/config.py
+++ b/plugins/source_scanner/config.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/config.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi, Ayo
+
+Configuration models for Source Scanner Plugin.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any, List, Literal, Optional
+
+# Third-Party
+from pydantic import BaseModel, Field
+
+
+class SemgrepConfig(BaseModel):
+    """Semgrep scanner configuration.
+
+    Attributes:
+        enabled: Whether Semgrep is enabled.
+        rulesets: List of ruleset identifiers (e.g., p/security-audit).
+        extra_args: Additional CLI arguments.
+    """
+
+    enabled: bool = True
+    rulesets: List[str] = Field(
+        default_factory=lambda: [
+            "p/security-audit",
+            "p/owasp-top-ten",
+            "p/python",
+            "p/javascript",
+        ]
+    )
+    extra_args: List[str] = Field(default_factory=list)
+    timeout_seconds: int = 600  # Default scan timeout of 10 minutes
+
+
+class BanditConfig(BaseModel):
+    """Bandit scanner configuration.
+
+    Attributes:
+        enabled: Whether Bandit is enabled.
+        severity: Minimum severity level (low/medium/high).
+        confidence: Minimum confidence level (low/medium/high).
+    """
+
+    enabled: bool = True
+    severity: Literal["low", "medium", "high"] = "medium"
+    confidence: Literal["low", "medium", "high"] = "medium"
+
+
+class ScannersConfig(BaseModel):
+    """Generic scanner configuration.
+
+    Attributes:
+        bandit: Bandit configuration.
+        semgrep: Semgrep configuration.
+    """
+
+    semgrep: SemgrepConfig = Field(default_factory=SemgrepConfig)
+    bandit: BanditConfig = Field(default_factory=BanditConfig)
+
+
+class SourceScannerConfig(BaseModel):
+    """Configuration for source scanner plugin.
+
+    Attributes:
+        scanners: Generic scanner configurations.
+        semgrep: Semgrep configuration.
+        bandit: Bandit configuration.
+        severity_threshold: Minimum severity to block (ERROR|WARNING|INFO).
+        fail_on_critical: Whether to block on threshold violations.
+        clone_timeout_seconds: Timeout for git clone operations.
+        scan_timeout_seconds: Timeout for scan operations.
+        max_repo_size_mb: Maximum repository size in MB.
+        github_token_env: Environment variable for GitHub token.
+        cache_by_commit: Whether to cache results by commit SHA.
+        cache_ttl_hours: Cache time-to-live in hours.
+    """
+
+    scanners: Optional[ScannersConfig] = None
+    semgrep: SemgrepConfig = Field(default_factory=SemgrepConfig)
+    bandit: BanditConfig = Field(default_factory=BanditConfig)
+
+    severity_threshold: Literal["ERROR", "WARNING", "INFO"] = "WARNING"  # ERROR | WARNING | INFO
+    fail_on_critical: bool = True
+    clone_timeout_seconds: int = 120
+    scan_timeout_seconds: int = 600
+    max_repo_size_mb: Optional[int] = 500
+    github_token_env: str = "GITHUB_TOKEN"
+    cache_by_commit: bool = True
+    cache_ttl_hours: int = 168  # 1 week
+
+    def model_post_init(self, __context: Any) -> None:
+        # If user provides config.scanners.*, merge into top-level fields
+        if self.scanners is not None:
+            self.semgrep = self.scanners.semgrep
+            self.bandit = self.scanners.bandit

--- a/plugins/source_scanner/errors.py
+++ b/plugins/source_scanner/errors.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/errors.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi
+
+Shared exception types for Source Scanner Plugin.
+"""
+
+# Future
+from __future__ import annotations
+
+
+class SourceScannerError(Exception):
+    """Base exception for source scanner plugin."""
+
+
+class RepoFetchError(SourceScannerError):
+    """Repository fetch/clone operation failed."""
+
+
+class CloneTimeoutError(RepoFetchError):
+    """Git clone operation timed out."""
+
+
+class RepoSizeLimitError(RepoFetchError):
+    """Repository exceeds size limit."""
+
+
+class CheckoutError(RepoFetchError):
+    """Git checkout operation failed."""
+
+
+class ScannerError(SourceScannerError):
+    """Scanner execution failed."""
+
+
+class ScannerTimeoutError(ScannerError):
+    """Scanner execution timed out."""
+
+
+class ScannerNotFoundError(ScannerError):
+    """Scanner executable not found."""
+
+
+class ParseError(SourceScannerError):
+    """Failed to parse scanner output."""
+
+
+class PolicyError(SourceScannerError):
+    """Policy evaluation failed."""

--- a/plugins/source_scanner/language_detector.py
+++ b/plugins/source_scanner/language_detector.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -- coding: utf-8 --
+"""
+Location: ./plugins/source_scanner/language_detector.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Ayo
+
+"""
+
+# Standard
+import logging
+from pathlib import Path
+from typing import List, Set
+
+logger = logging.getLogger(__name__)
+
+
+class LanguageDetector:
+    """Detect programming languages in a repo"""
+
+    EXTENSION_MAP = {
+        ".py": "python",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".jsx": "javascript",
+        ".tsx": "typescript",
+        ".java": "java",
+        ".go": "go",
+        ".rs": "rust",
+        ".rb": "ruby",
+        ".php": "php",
+        ".c": "c",
+        ".cpp": "cpp",
+        ".cs": "csharp",
+    }
+
+    def detect(self, repo_path: str) -> List[str]:
+        """
+        Detect languages in repository
+
+        Args:
+            repo_path: Path to repository
+
+        Returns:
+            List of detected language names (e.f., ["Python", "javascript"])
+        """
+        path = Path(repo_path)
+        languages: Set[str] = set()
+
+        for file_path in path.rglob("*"):
+            if file_path.is_file():
+                ext = file_path.suffix.lower()
+                if ext in self.EXTENSION_MAP:
+                    languages.add(self.EXTENSION_MAP[ext])
+
+        detected = sorted(list(languages))
+        logger.info(f"Detected languages: {detected}")
+        return detected

--- a/plugins/source_scanner/plugin-manifest.yaml
+++ b/plugins/source_scanner/plugin-manifest.yaml
@@ -1,0 +1,37 @@
+name: "SourceScannerPlugin"
+kind: "plugins.source_scanner.source_scanner.SourceScannerPlugin"
+
+description: "Scan MCP server source code for security vulnerabilities using Semgrep and Bandit"
+author: "MCP Gateway Team"
+version: "0.1.0"
+
+available_hooks:
+  - "server_pre_register"
+  - "catalog_pre_deploy"
+
+default_configs:
+  scanners:
+    semgrep:
+      enabled: true
+      rulesets:
+        - "p/security-audit"
+        - "p/owasp-top-ten"
+        - "p/python"
+        - "p/javascript"
+      extra_args: []
+    bandit:
+      enabled: true
+      severity: "medium"
+      confidence: "medium"
+
+  severity_threshold: "WARNING"
+  fail_on_critical: true
+
+  clone_timeout_seconds: 120
+  scan_timeout_seconds: 600
+  max_repo_size_mb: 500
+
+  github_token_env: "GITHUB_TOKEN"
+
+  cache_by_commit: true
+  cache_ttl_hours: 168

--- a/plugins/source_scanner/policy.py
+++ b/plugins/source_scanner/policy.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/policy.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi, Ayo
+
+Policy evaluation for scan findings.
+"""
+
+# Standard
+from typing import List
+
+# Local
+from .types import Finding, PolicyDecision
+
+
+class PolicyChecker:
+    """Evaluates findings against policy thresholds."""
+
+    # Severity ordering: ERROR > WARNING > INFO
+    _SEVERITY_ORDER = {"ERROR": 3, "WARNING": 2, "INFO": 1}
+
+    def evaluate(
+        self,
+        findings: List[Finding],
+        threshold: str,
+        fail_on_critical: bool,
+    ) -> PolicyDecision:
+        """Evaluate findings against policy."""
+
+        # Normalize/validate threshold
+        thr = threshold.upper()
+        if thr not in self._SEVERITY_ORDER:
+            # Default safe behavior: treat unknown threshold as WARNING
+            thr = "WARNING"
+
+        thr_value = self._SEVERITY_ORDER[thr]
+
+        # Findings that meet or exceed threshold
+        violating = [f for f in findings if self._SEVERITY_ORDER.get(f.severity, 0) >= thr_value]
+
+        # Audit mode: never block, just report
+        if not fail_on_critical:
+            return PolicyDecision(blocked=False)
+
+        # Enforce mode: block if any violations exist
+        if violating:
+            error_count = sum(1 for f in findings if f.severity == "ERROR")
+            warning_count = sum(1 for f in findings if f.severity == "WARNING")
+            info_count = sum(1 for f in findings if f.severity == "INFO")
+
+            reason = f"Policy threshold {thr} violated: " f"{error_count} ERROR, {warning_count} WARNING, {info_count} INFO findings."
+            return PolicyDecision(blocked=True, reason=reason)
+
+        return PolicyDecision(blocked=False)

--- a/plugins/source_scanner/policy.py
+++ b/plugins/source_scanner/policy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/policy.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 

--- a/plugins/source_scanner/repo_fetcher.py
+++ b/plugins/source_scanner/repo_fetcher.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -- coding: utf-8 --
+"""
+Location: ./plugins/source_scanner/repo_fetcher.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors:
+
+"""

--- a/plugins/source_scanner/repo_fetcher.py
+++ b/plugins/source_scanner/repo_fetcher.py
@@ -2,8 +2,121 @@
 # -- coding: utf-8 --
 """
 Location: ./plugins/source_scanner/repo_fetcher.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
-Authors:
+Authors: Ayo, Agnetha
 
+Handles git clone, checkout and workspace cleanup
 """
+
+# Standard
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Callable, Optional, Tuple
+
+# Local
+from .errors import CloneTimeoutError, RepoFetchError, RepoSizeLimitError
+from .utils.exec import run_command
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Workspace:
+    """Cloned repo workspace"""
+
+    path: str
+    commit_sha: str
+
+
+class RepoFetcher:
+    """Fetch and manage repo workspaces"""
+
+    async def fetch(
+        self,
+        repo_url: str,
+        ref: Optional[str] = None,
+        clone_timeout: int = 120,
+        max_size_mb: Optional[int] = 500,
+    ) -> Tuple[Workspace, Callable[[], None]]:
+        """
+        Clone repository and checkout ref.
+
+        Args:
+            repo_url: Git repository URL
+            ref: Branch/tag/commit to checkout (default: default branch)
+            clone_timeout: Timeout for clone operation in seconds
+            max_size_mb: Maximum repo size in MB (None = no limit)
+
+        Returns:
+            Tuple of (Workspace, cleanup_function)
+
+        Raises:
+            CloneTimeoutError: If clone exceeds timeout
+            RepoSizeLimitError: If repo exceeds size limit
+            RepoFetchError: For other fetch failures
+        """
+        temp_dir = tempfile.mkdtemp(prefix="source_scanner_")
+
+        try:
+            logger.info(f"Cloning {repo_url} to {temp_dir}")
+
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd.extend(["--branch", ref])
+            cmd.extend(["--", repo_url, temp_dir])
+
+            result = await run_command(cmd, timeout_seconds=clone_timeout)
+
+            if result.timed_out:
+                raise CloneTimeoutError(f"Clone exceeded {clone_timeout}s timeout")
+
+            if result.returncode != 0:
+                raise RepoFetchError(f"Clone failed: {result.stderr}")
+
+            if max_size_mb:
+                size_mb = self._get_dir_size_mb(temp_dir)
+                if size_mb > max_size_mb:
+                    raise RepoSizeLimitError(f"Repository size {size_mb}MB exceeds limit {max_size_mb}MB")
+            commit_sha = await self._get_commit_sha(temp_dir)
+
+            workspace = Workspace(path=temp_dir, commit_sha=commit_sha)
+
+            def cleanup_fn() -> None:
+                self._cleanup(temp_dir)
+
+            logger.info(f"Repository cloned successfully: {commit_sha}")
+            return workspace, cleanup_fn
+
+        except Exception:
+            # Cleanup on failure
+            self._cleanup(temp_dir)
+            raise
+
+    async def _get_commit_sha(self, repo_path: str) -> str:
+        """Get current commit SHA."""
+        result = await run_command(["git", "rev-parse", "HEAD"], cwd=repo_path, timeout_seconds=5)
+
+        if result.returncode != 0:
+            return "unknown"
+
+        return result.stdout.strip()
+
+    def _get_dir_size_mb(self, path: str) -> float:
+        """Calculate directory size in MB."""
+        total = 0
+        for entry in Path(path).rglob("*"):
+            if entry.is_file():
+                total += entry.stat().st_size
+        return total / (1024 * 1024)
+
+    def _cleanup(self, path: str) -> None:
+        """Remove temporary directory."""
+        try:
+            shutil.rmtree(path, ignore_errors=True)
+            logger.debug(f"Cleaned up {path}")
+        except Exception as e:
+            logger.warning(f"Failed to cleanup {path}: {e}")

--- a/plugins/source_scanner/scanners/__init__.py
+++ b/plugins/source_scanner/scanners/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/scanners/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi
+
+Scanners package.
+"""

--- a/plugins/source_scanner/scanners/__init__.py
+++ b/plugins/source_scanner/scanners/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/scanners/__init__.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi
 

--- a/plugins/source_scanner/scanners/semgrep_runner.py
+++ b/plugins/source_scanner/scanners/semgrep_runner.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Semgrep scanner runner for Source Scanner.
+
+Location: ./plugins/source_scanner/scanners/semgrep_runner.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+This module implements Semgrep CLI integration for static code analysis.
+Parses SARIF output into normalized Finding objects.
+"""
+
+# Standard
+import json
+import subprocess
+from typing import Any, Literal
+
+# First-Party
+from plugins.source_scanner.types import Finding
+
+
+class SemgrepRunner:
+    def __init__(self, config: dict[str, Any]):
+        self.config = config
+        self.enabled = config.get("enabled", True)
+        self.rulesets = config.get("rulesets", ["p/security-audit"])
+        self.extra_args = config.get("extra_args", [])
+        self.timeout = config.get("timeout", 300)
+
+    def run(self, repo_url: str, temp_folder: str) -> list[Finding]:
+        try:
+            # Clone repository
+            _clone_repo(repo_url, temp_folder)
+
+            # Build and run semgrep command
+            command = self.build_command(temp_folder)
+            result = subprocess.run(command, capture_output=True, text=True, timeout=self.timeout)
+
+            # Parse output even if semgrep finds issues (return code 1 is normal)
+            if result.returncode not in (0, 1):
+                raise Exception(f"Semgrep failed: {result.stderr}")
+
+            data: dict[str, Any] = json.loads(result.stdout) if result.stdout else {}
+            findings = self.parse_sarif_output(data)
+
+            # Print message based on findings
+            if not findings:
+                print("No findings detected.")
+            else:
+                print(f"Found {len(findings)} issue(s):")
+                for f in findings:
+                    print(f"  [{f.severity}] {f.rule_id} at {f.file_path}:{f.line}")
+
+            return findings
+        finally:
+            self.delete_temp_repo(temp_folder)
+
+    def build_command(self, repo_path: str) -> list[str]:
+        """Build semgrep command with configured rulesets and arguments."""
+        return self._build_command(repo_path)
+
+    def parse_sarif_output(self, sarif_data: dict[str, Any]) -> list[Finding]:
+        """Parse SARIF output into Finding objects."""
+        return self._parse_sarif_output(sarif_data)
+
+    def _build_command(self, repo_path: str) -> list[str]:
+        command = ["semgrep", "scan"]
+
+        # Add configured rulesets
+        for ruleset in self.rulesets:
+            command.extend(["--config", ruleset])
+
+        # Add extra arguments
+        command.extend(self.extra_args)
+
+        # Add output format
+        command.append("--json")
+
+        # Add target repository path
+        command.append(repo_path)
+        return command
+
+    def _parse_sarif_output(self, sarif_data: dict[str, Any]) -> list[Finding]:
+        findings: list[Finding] = []
+
+        # Handle error case
+        if "error" in sarif_data:
+            return findings
+
+        # Parse results from semgrep JSON output
+        results = sarif_data.get("results", [])
+
+        for result in results:
+            finding = Finding(
+                scanner="semgrep",
+                severity=_map_severity(result.get("severity", "INFO")),
+                rule_id=result.get("check_id", "unknown"),
+                message=result.get("extra", {}).get("message", result.get("message", "")),
+                file_path=result.get("path", None),
+                line=result.get("start", {}).get("line", None),
+                column=result.get("start", {}).get("col", None),
+                code_snippet=result.get("extra", {}).get("lines", None),
+                help_url=result.get("extra", {}).get("doc_url", None),
+            )
+            findings.append(finding)
+
+        return findings
+
+    def delete_temp_repo(self, temp_folder: str) -> None:
+        try:
+            subprocess.run(["rm", "-rf", temp_folder], check=True)
+        except Exception as e:
+            print(f"Warning: Failed to delete temp folder {temp_folder}: {e}")
+
+
+def _clone_repo(repo_url: str, temp_folder: str) -> None:
+    """Clone repository to temporary folder."""
+    subprocess.run(["git", "clone", "--depth", "1", repo_url, temp_folder], check=True)
+
+
+Severity = Literal["ERROR", "WARNING", "INFO"]
+
+
+def _map_severity(semgrep_severity: str) -> Severity:
+    """Map semgrep severity to normalized severity level."""
+    severity_map: dict[str, Severity] = {
+        "ERROR": "ERROR",
+        "WARNING": "WARNING",
+        "INFO": "INFO",
+        "HIGH": "ERROR",
+        "MEDIUM": "WARNING",
+        "LOW": "INFO",
+    }
+    return severity_map.get(semgrep_severity.upper(), "INFO")

--- a/plugins/source_scanner/source_scanner.py
+++ b/plugins/source_scanner/source_scanner.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/source_scanner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi
+
+Source Scanner Plugin.
+Performs static analysis on MCP server source code using Semgrep and Bandit
+to detect security vulnerabilities before deployment.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import Optional
+
+# First-Party
+from mcpgateway.plugins.framework import (
+    CatalogPreDeployPayload,
+    CatalogPreDeployResult,
+    Plugin,
+    PluginConfig,
+    PluginContext,
+    ServerPreRegisterPayload,
+    ServerPreRegisterResult,
+)
+
+# Local
+from .config import SourceScannerConfig
+from .errors import SourceScannerError
+from .policy import PolicyChecker
+from .types import Finding, ScanResult, ScanSummary
+
+# from pydantic import BaseModel, Field
+
+
+# Components (to be imported when implemented)
+# from .repo_fetcher import RepoFetcher
+# from .language_detector import LanguageDetector
+# from .scanners.semgrep_runner import SemgrepRunner
+# from .scanners.bandit_runner import BanditRunner
+# from .parsing.normalizer import ParserNormalizer
+# from .storage.repository import ScanRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SourceScannerPlugin(Plugin):
+    """Scan MCP server source code for security vulnerabilities.
+
+    Workflow:
+        1. Extract repo_url and ref from payload
+        2. Check cache (if enabled)
+        3. Clone repository (RepoFetcher)
+        4. Detect languages (LanguageDetector)
+        5. Run scanners (Semgrep, Bandit)
+        6. Normalize findings (ParserNormalizer)
+        7. Calculate summary
+        8. Evaluate policy (PolicyChecker)
+        9. Store results (if enabled)
+        10. Cleanup temporary files
+        11. Return decision (block/allow)
+    """
+
+    def __init__(self, config: PluginConfig) -> None:
+        """Initialize the source scanner plugin.
+
+        Args:
+            config: Plugin configuration.
+        """
+        # super().__init__(config)
+        self._cfg = SourceScannerConfig(**(config.config or {}))
+
+        # Initialize components
+        # TODO: Uncomment when components are implemented
+        # self._repo_fetcher = RepoFetcher()
+        # self._language_detector = LanguageDetector()
+        # self._semgrep_runner = SemgrepRunner()
+        # self._bandit_runner = BanditRunner()
+        # self._normalizer = ParserNormalizer()
+        # self._policy_checker = PolicyChecker()
+        # self._scan_repo_store = ScanRepository() if self._cfg.cache_by_commit else None
+
+        # logger.info(
+            # "SourceScannerPlugin initialized",
+            # extra={
+                # "semgrep_enabled": self._cfg.semgrep.enabled,
+                # "bandit_enabled": self._cfg.bandit.enabled,
+                # "severity_threshold": self._cfg.severity_threshold,
+                # "fail_on_critical": self._cfg.fail_on_critical,
+            # },
+        # )
+
+    async def _scan_workflow(
+        self,
+        repo_url: str,
+        ref: Optional[str] = None,
+    ) -> ScanResult:
+        """Execute complete scan workflow.
+
+        Args:
+            repo_url: Repository URL to scan.
+            ref: Branch/tag/commit reference.
+
+        Returns:
+            Complete scan results with findings and policy decision.
+
+        Raises:
+            SourceScannerError: If scan workflow fails.
+        """
+        logger.info(f"Starting scan for {repo_url} (ref={ref})")
+
+        cleanup_fn = None
+
+        try:
+            # Step 1: Check cache (if enabled)
+            # TODO: if self._cfg.cache_by_commit and self._scan_repo_store:
+            #           cached = await self._scan_repo_store.get_by_commit(repo_url, commit_sha)
+            #           if cached and not expired:
+            #               return cached
+
+            # Step 2: Clone & Checkout
+            # TODO: workspace, cleanup_fn = await self._repo_fetcher.fetch(
+            #           repo_url=repo_url,
+            #           ref=ref,
+            #           clone_timeout=self._cfg.clone_timeout_seconds,
+            #           max_size_mb=self._cfg.max_repo_size_mb,
+            #       )
+            # TODO: commit_sha = workspace.commit_sha
+
+            # Step 3: Detect languages
+            # TODO: languages = self._language_detector.detect(workspace.path)
+            languages = []  # placeholder
+
+            # Step 4: Run scanners
+            # findings_by_scanner: list[list[Finding]] = []
+
+            # Run Semgrep (if enabled)
+            # if self._cfg.semgrep.enabled:
+                # logger.info("Running Semgrep scanner")
+                # TODO: findings = await self._semgrep_runner.run(
+                #           repo_path=workspace.path,
+                #           config=self._cfg.semgrep,
+                #           timeout_s=self._cfg.scan_timeout_seconds,
+                #       )
+                # TODO: findings_by_scanner.append(findings)
+
+            # Run Bandit (if Python detected and enabled)
+            # if "python" in languages and self._cfg.bandit.enabled:
+                # logger.info("Running Bandit scanner")
+                # TODO: findings = await self._bandit_runner.run(
+                #           repo_path=workspace.path,
+                #           config=self._cfg.bandit,
+                #           timeout_s=self._cfg.scan_timeout_seconds,
+                #       )
+                # TODO: findings_by_scanner.append(findings)
+
+            # Step 5: Merge & Deduplicate
+            # TODO: merged_findings = self._normalizer.merge_dedup(findings_by_scanner)
+            merged_findings = []  # placeholder
+
+            # Step 6: Calculate summary
+            summary = ScanSummary(
+                error_count=sum(1 for f in merged_findings if f.severity == "ERROR"),
+                warning_count=sum(1 for f in merged_findings if f.severity == "WARNING"),
+                info_count=sum(1 for f in merged_findings if f.severity == "INFO"),
+            )
+
+            logger.info(
+                "Scan summary",
+                extra={
+                    "errors": summary.error_count,
+                    "warnings": summary.warning_count,
+                    "info": summary.info_count,
+                },
+            )
+
+            # Step 7: Evaluate policy
+            decision = self._policy_checker.evaluate(
+                findings=merged_findings,
+                threshold=self._cfg.severity_threshold,
+                fail_on_critical=self._cfg.fail_on_critical,
+            )
+
+            # Step 8: Build result
+            result = ScanResult(
+                repo_url=repo_url,
+                ref=ref,
+                commit_sha=None,  # TODO: workspace.commit_sha
+                languages=languages,
+                findings=merged_findings,
+                summary=summary,
+                blocked=decision.blocked,
+                block_reason=decision.reason,
+            )
+
+            # Step 9: Store results (if cache enabled)
+            # TODO: if self._cfg.cache_by_commit and self._scan_repo_store:
+            #           await self._scan_repo_store.save(result)
+
+            logger.info(
+                "Scan complete",
+                extra={
+                    "blocked": result.blocked,
+                    "findings_count": len(result.findings),
+                },
+            )
+
+            return result
+
+        except SourceScannerError as e:
+            logger.error(f"Scan failed: {e}", exc_info=True)
+            raise
+        except Exception as e:
+            logger.error(f"Unexpected error during scan: {e}", exc_info=True)
+            raise SourceScannerError(f"Scan failed: {e}") from e
+        finally:
+            # Step 10: Cleanup
+            if cleanup_fn:
+                try:
+                    cleanup_fn()
+                    logger.debug("Cleanup completed")
+                except Exception as e:
+                    logger.warning(f"Cleanup failed: {e}")
+
+    async def server_pre_register(
+        self,
+        payload: ServerPreRegisterPayload,
+        context: PluginContext,
+    ) -> ServerPreRegisterResult:
+        """Scan source code before server registration.
+
+        Args:
+            payload: Server registration payload.
+            context: Plugin execution context.
+
+        Returns:
+            Result blocking if critical findings exist, or allowing.
+        """
+        logger.info("server_pre_register hook triggered")
+
+        try:
+            # TODO: Extract repo_url and ref from payload
+            # Example payload structure (to be confirmed):
+            # payload.server.source = {
+            #     "type": "github",
+            #     "repo": "https://github.com/org/mcp-server",
+            #     "ref": "main"  # or branch/tag/commit
+            # }
+
+            # TODO: repo_url = payload.server.source.get("repo")
+            # TODO: ref = payload.server.source.get("ref")
+
+            # TODO: if not repo_url:
+            #           logger.warning("No repo_url in payload, allowing registration")
+            #           return ServerPreRegisterResult(continue_processing=True)
+
+            # TODO: result = await self._scan_workflow(repo_url, ref)
+
+            # TODO: if result.blocked:
+            #           return ServerPreRegisterResult(
+            #               continue_processing=False,
+            #               violation=PluginViolation(
+            #                   reason="Security vulnerabilities detected",
+            #                   description=result.block_reason or "Critical findings in source code",
+            #                   code="SOURCE_SCAN_BLOCKED",
+            #                   details={
+            #                       "findings_count": len(result.findings),
+            #                       "error_count": result.summary.error_count,
+            #                       "warning_count": result.summary.warning_count,
+            #                   },
+            #               ),
+            #           )
+
+            # Placeholder: allow all registrations until implemented
+            logger.warning("server_pre_register not fully implemented, allowing")
+            # NOTE: Current implementation is fail-open.
+            # Enforce-mode scan failure behavior will be configurable.
+            return ServerPreRegisterResult(continue_processing=True)
+
+        except Exception as e:
+            logger.error(f"server_pre_register failed: {e}", exc_info=True)
+            # Fail open: allow registration but log error
+            # NOTE: Current implementation is fail-open.
+            # Enforce-mode scan failure behavior will be configurable.
+            return ServerPreRegisterResult(continue_processing=True)
+
+    async def catalog_pre_deploy(
+        self,
+        payload: CatalogPreDeployPayload,
+        context: PluginContext,
+    ) -> CatalogPreDeployResult:
+        """Scan source code before catalog deployment.
+
+        Args:
+            payload: Catalog deployment payload.
+            context: Plugin execution context.
+
+        Returns:
+            Result blocking if critical findings exist, or allowing.
+        """
+        logger.info("catalog_pre_deploy hook triggered")
+
+        try:
+            # TODO: Extract repo_url and ref from payload
+            # Example payload structure (to be confirmed):
+            # payload.catalog.source = {
+            #     "type": "github",
+            #     "repo": "https://github.com/org/mcp-catalog",
+            #     "ref": "main"
+            # }
+
+            # TODO: repo_url = payload.catalog.source.get("repo")
+            # TODO: ref = payload.catalog.source.get("ref")
+
+            # TODO: if not repo_url:
+            #           logger.warning("No repo_url in payload, allowing deployment")
+            #           return CatalogPreDeployResult(continue_processing=True)
+
+            # TODO: result = await self._scan_workflow(repo_url, ref)
+
+            # TODO: if result.blocked:
+            #           return CatalogPreDeployResult(
+            #               continue_processing=False,
+            #               violation=PluginViolation(
+            #                   reason="Security vulnerabilities detected",
+            #                   description=result.block_reason or "Critical findings in source code",
+            #                   code="SOURCE_SCAN_BLOCKED",
+            #                   details={
+            #                       "findings_count": len(result.findings),
+            #                       "error_count": result.summary.error_count,
+            #                       "warning_count": result.summary.warning_count,
+            #                   },
+            #               ),
+            #           )
+
+            # Placeholder: allow all deployments until implemented
+            logger.warning("catalog_pre_deploy not fully implemented, allowing")
+            return CatalogPreDeployResult(continue_processing=True)
+
+        except Exception as e:
+            logger.error(f"catalog_pre_deploy failed: {e}", exc_info=True)
+            # Fail open: allow deployment but log error
+            return CatalogPreDeployResult(continue_processing=True)

--- a/plugins/source_scanner/storage/__init__.py
+++ b/plugins/source_scanner/storage/__init__.py
@@ -1,7 +1,7 @@
 #!usr/bin/env python
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/storage/__init__.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 

--- a/plugins/source_scanner/storage/__init__.py
+++ b/plugins/source_scanner/storage/__init__.py
@@ -1,0 +1,21 @@
+#!usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/storage/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Arnav
+
+Storage layer package for Source Scanner.
+
+Exports models and repository for database access.
+"""
+
+from plugins.source_scanner.storage.models import ScanRecord, FindingRecord, Base
+from plugins.source_scanner.storage.repository import ScanRepository
+
+__all__ = [
+    "ScanRecord",
+    "FindingRecord",
+    "Base",
+    "ScanRepository",
+]

--- a/plugins/source_scanner/storage/models.py
+++ b/plugins/source_scanner/storage/models.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/storage/models.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Arnav
+
+SQLAlchemy ORM models for Source Scanner persistence layer.
+
+Note: This module defines the persistence layer for storing scan results and findings.
+Currently, it is used internally by the repository layer.
+Full integration with admin UI / caching / deployment hooks will be added in follow-up PRs.
+"""
+
+# Standard
+#
+from datetime import datetime, timezone
+
+# Third-Party
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import declarative_base, Mapped, mapped_column, relationship
+
+Base = declarative_base()
+
+
+class ScanRecord(Base):
+    """ORM model for scan records."""
+
+    __tablename__ = "source_scanner_scans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    repo_url: Mapped[str] = mapped_column(String(2048), nullable=False, index=True)
+    ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    commit_sha: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    languages: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    blocked: Mapped[bool] = mapped_column(Boolean, default=False)
+    block_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_count: Mapped[int] = mapped_column(Integer, default=0)
+    warning_count: Mapped[int] = mapped_column(Integer, default=0)
+    info_count: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
+
+    findings: Mapped[list["FindingRecord"]] = relationship("FindingRecord", back_populates="scan", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        Index("idx_scan_commit_created", "commit_sha", "created_at"),
+        Index("idx_scan_repo_created", "repo_url", "created_at"),
+    )
+
+    def __repr__(self) -> str:
+        commit_val = getattr(self, "commit_sha", None)
+        commit_display: str | None = commit_val[:8] if commit_val else None
+        return f"<ScanRecord(id={self.id}, repo={self.repo_url}, commit={commit_display})>"
+
+
+class FindingRecord(Base):
+    """ORM model for individual findings within a scan."""
+
+    __tablename__ = "source_scanner_findings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    scan_id: Mapped[int] = mapped_column(Integer, ForeignKey("source_scanner_scans.id"), nullable=False, index=True)
+    scanner: Mapped[str] = mapped_column(String(64), nullable=False)
+    severity: Mapped[str] = mapped_column(String(16), nullable=False, index=True)
+    rule_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    file_path: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    line: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    column: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    code_snippet: Mapped[str | None] = mapped_column(Text, nullable=True)
+    help_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    dedup_key: Mapped[str | None] = mapped_column(String(512), nullable=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+
+    scan: Mapped["ScanRecord"] = relationship("ScanRecord", back_populates="findings")
+
+    __table_args__ = (
+        UniqueConstraint("scan_id", "dedup_key", name="uq_finding_scan_dedup"),
+        Index("idx_finding_severity", "severity"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<FindingRecord(id={self.id}, scanner={self.scanner}, rule={self.rule_id}, severity={self.severity})>"

--- a/plugins/source_scanner/storage/models.py
+++ b/plugins/source_scanner/storage/models.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/storage/models.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 
@@ -48,6 +48,7 @@ class ScanRecord(Base):
     )
 
     def __repr__(self) -> str:
+        """Return a concise string representation of the scan record."""
         commit_val = getattr(self, "commit_sha", None)
         commit_display: str | None = commit_val[:8] if commit_val else None
         return f"<ScanRecord(id={self.id}, repo={self.repo_url}, commit={commit_display})>"
@@ -80,4 +81,5 @@ class FindingRecord(Base):
     )
 
     def __repr__(self) -> str:
+        """Return a concise string representation of the finding."""
         return f"<FindingRecord(id={self.id}, scanner={self.scanner}, rule={self.rule_id}, severity={self.severity})>"

--- a/plugins/source_scanner/storage/repository.py
+++ b/plugins/source_scanner/storage/repository.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/storage/repository.py
 
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Arnav
 

--- a/plugins/source_scanner/storage/repository.py
+++ b/plugins/source_scanner/storage/repository.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/storage/repository.py
+
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Arnav
+
+Repository layer for Source Scanner persistence.
+
+Provides CRUD access to ScanRecord and FindingRecord.
+Currently uses SQLAlchemy; designed for incremental integration.
+"""
+
+# Standard
+# from datetime import datetime, timezone
+from typing import List, Optional
+
+# Third-Party
+from sqlalchemy.orm import Session
+
+# First-Party
+from plugins.source_scanner.storage.models import FindingRecord, ScanRecord
+from plugins.source_scanner.types import Finding
+
+#
+
+
+class ScanRepository:
+    """Repository for accessing and storing scan records."""
+
+    def __init__(self, db: Session):
+        """Initialize repository with database session.
+
+        Args:
+            db: SQLAlchemy database session.
+        """
+        self.db = db
+
+    def create_scan(
+        self,
+        repo_url: str,
+        ref: Optional[str],
+        commit_sha: Optional[str],
+        languages: List[str],
+        findings: List[Finding],
+        blocked: bool,
+        block_reason: Optional[str],
+    ) -> ScanRecord:
+        """Persist a completed scan to the database.
+
+        Creates a ScanRecord with associated FindingRecords. Deduplication
+        is handled via unique constraint on (scan_id, dedup_key).
+
+        Args:
+            repo_url: Git repository URL.
+            ref: Branch/tag/commit reference (user input).
+            commit_sha: Resolved commit SHA.
+            languages: List of detected languages.
+            findings: Normalized findings from scanners.
+            blocked: Policy decision result.
+            block_reason: Reason for block if applicable.
+
+        Returns:
+            ScanRecord object with findings attached.
+        """
+        # Count findings by severity for summary stats
+        error_count = sum(1 for f in findings if f.severity == "ERROR")
+        warning_count = sum(1 for f in findings if f.severity == "WARNING")
+        info_count = sum(1 for f in findings if f.severity == "INFO")
+
+        # Create ScanRecord with metadata
+        scan = ScanRecord(
+            repo_url=repo_url,
+            ref=ref,
+            commit_sha=commit_sha,
+            languages=",".join(languages) if languages else None,
+            blocked=blocked,
+            block_reason=block_reason,
+            error_count=error_count,
+            warning_count=warning_count,
+            info_count=info_count,
+        )
+        self.db.add(scan)
+        self.db.flush()  # Get scan ID without committing yet
+
+        # Create FindingRecords for each finding
+        for finding in findings:
+            key_tuple = finding.dedup_key()  # dedup_key() returns a tuple
+
+            # Serialize tuple to a string for the DB column
+            dedup_key: str = "|".join([str(x) for x in key_tuple])
+
+            finding_record = FindingRecord(
+                scan_id=scan.id,
+                scanner=finding.scanner,
+                severity=finding.severity,
+                rule_id=finding.rule_id,
+                message=finding.message,
+                file_path=finding.file_path,
+                line=finding.line,
+                column=finding.column,
+                code_snippet=finding.code_snippet,
+                help_url=finding.help_url,
+                dedup_key=dedup_key,
+            )
+            self.db.add(finding_record)
+
+        # Commit all changes at once
+        self.db.commit()
+        return scan
+
+    def get_scan_by_id(self, scan_id: int) -> Optional[ScanRecord]:
+        """Retrieve a scan record by ID.
+
+        Args:
+            scan_id: Primary key of the scan.
+
+        Returns:
+            ScanRecord if found, None otherwise.
+        """
+        return self.db.query(ScanRecord).filter(ScanRecord.id == scan_id).first()
+
+    def get_findings_for_scan(self, scan_id: int) -> List[FindingRecord]:
+        """Retrieve all findings for a given scan.
+
+        Args:
+            scan_id: Primary key of the scan.
+
+        Returns:
+            List of FindingRecord objects, ordered by severity then file_path.
+        """
+        # Severity order: ERROR > WARNING > INFO
+        severity_order = {"ERROR": 0, "WARNING": 1, "INFO": 2}
+
+        findings = self.db.query(FindingRecord).filter(FindingRecord.scan_id == scan_id).all()
+
+        # Sort by severity first, then by file_path
+        findings.sort(key=lambda f: (severity_order.get(getattr(f, "severity", ""), 3), getattr(f, "file_path", "") or ""))
+
+        # findings.sort(key=lambda f: (severity_order.get(f.severity, 3), f.file_path or ""))
+        return findings
+
+    def get_latest_scan_for_commit(
+        self,
+        repo_url: str,
+        commit_sha: str,
+    ) -> Optional[ScanRecord]:
+        """Retrieve the most recent scan for a given commit SHA.
+
+        Args:
+            repo_url: Git repository URL.
+            commit_sha: Commit hash.
+
+        Returns:
+            Most recent ScanRecord if found, None otherwise.
+        """
+        return (
+            self.db.query(ScanRecord)
+            .filter(
+                ScanRecord.repo_url == repo_url,
+                ScanRecord.commit_sha == commit_sha,
+            )
+            .order_by(ScanRecord.created_at.desc())
+            .first()
+        )
+
+    def get_scans_for_repo(
+        self,
+        repo_url: str,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> List[ScanRecord]:
+        """Retrieve recent scans for a repository with pagination.
+
+        Args:
+            repo_url: Git repository URL.
+            limit: Maximum number of results to return.
+            offset: Number of results to skip.
+
+        Returns:
+            List of ScanRecord objects ordered by creation time (newest first).
+        """
+        return self.db.query(ScanRecord).filter(ScanRecord.repo_url == repo_url).order_by(ScanRecord.created_at.desc()).offset(offset).limit(limit).all()
+
+    def get_findings_by_severity(
+        self,
+        scan_id: int,
+        severity: str,
+    ) -> List[FindingRecord]:
+        """Retrieve findings of a specific severity for a scan.
+
+        Args:
+            scan_id: Primary key of the scan.
+            severity: Severity level (ERROR|WARNING|INFO).
+
+        Returns:
+            List of FindingRecord objects matching the severity.
+        """
+        return (
+            self.db.query(FindingRecord)
+            .filter(
+                FindingRecord.scan_id == scan_id,
+                FindingRecord.severity == severity,
+            )
+            .order_by(FindingRecord.file_path)
+            .all()
+        )
+
+    def delete_scan(self, scan_id: int) -> bool:
+        """Delete a scan and all its associated findings.
+
+        Args:
+            scan_id: Primary key of the scan to delete.
+
+        Returns:
+            True if scan was deleted, False if not found.
+        """
+        scan = self.db.query(ScanRecord).filter(ScanRecord.id == scan_id).first()
+        if not scan:
+            return False
+
+        self.db.delete(scan)  # Cascade delete handles findings
+        self.db.commit()
+        return True

--- a/plugins/source_scanner/types.py
+++ b/plugins/source_scanner/types.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/types.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 

--- a/plugins/source_scanner/types.py
+++ b/plugins/source_scanner/types.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/types.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi, Ayo
+
+Data schemas for findings and scan results.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import List, Literal, Optional
+
+# Third-Party
+from pydantic import BaseModel, Field
+
+
+class Finding(BaseModel):
+    """Unified finding schema from any scanner.
+
+    Attributes:
+        scanner: Source scanner tool name (e.g., "semgrep", "bandit").
+        severity: Normalized severity level (ERROR|WARNING|INFO).
+        rule_id: Rule identifier for deduplication.
+        message: Human-readable description.
+        file_path: Relative path to the problematic file.
+        line: Line number where issue occurs.
+        column: Column number where issue occurs.
+        code_snippet: Code context around the issue.
+        help_url: Link to rule documentation.
+    """
+
+    scanner: str
+    severity: Literal["ERROR", "WARNING", "INFO"]  # ERROR | WARNING | INFO
+    rule_id: str
+    message: str
+    file_path: Optional[str] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    code_snippet: Optional[str] = None
+    help_url: Optional[str] = None
+
+    def dedup_key(self) -> tuple[str, str, Optional[str], Optional[int], str]:
+        """Generate deduplication key.
+
+        Returns:
+            Tuple of (scanner, rule_id, file_path, line, message).
+        """
+        return (
+            self.scanner,
+            self.rule_id,
+            self.file_path,
+            self.line,
+            self.message,
+        )
+
+
+class ScanSummary(BaseModel):
+    """Summary statistics for scan results.
+
+    Attributes:
+        error_count: Number of ERROR-level findings.
+        warning_count: Number of WARNING-level findings.
+        info_count: Number of INFO-level findings.
+    """
+
+    error_count: int = 0
+    warning_count: int = 0
+    info_count: int = 0
+
+    @property
+    def total_findings(self) -> int:
+        """Calculate total findings count."""
+        return self.error_count + self.warning_count + self.info_count
+
+
+class ScanResult(BaseModel):
+    """Complete scan result contract.
+
+    Attributes:
+        repo_url: Repository URL that was scanned.
+        ref: Branch/tag/commit reference requested.
+        commit_sha: Resolved commit SHA after checkout.
+        languages: Detected programming languages.
+        findings: All normalized findings.
+        summary: Aggregated statistics.
+        blocked: Whether policy blocked the workflow.
+        block_reason: Explanation if blocked.
+    """
+
+    repo_url: str
+    ref: Optional[str] = None
+    commit_sha: Optional[str] = None
+    languages: List[str] = Field(default_factory=list)
+    findings: List[Finding] = Field(default_factory=lambda: [])
+    summary: ScanSummary = Field(default_factory=ScanSummary)
+    blocked: bool = False
+    block_reason: Optional[str] = None
+
+
+class PolicyDecision(BaseModel):
+    """Result of policy evaluation.
+
+    Attributes:
+        blocked: Whether the workflow should be blocked.
+        reason: Explanation for blocking, if applicable.
+    """
+
+    blocked: bool
+    reason: Optional[str] = None
+    scan_duration_seconds: Optional[float] = None

--- a/plugins/source_scanner/utils/__init__.py
+++ b/plugins/source_scanner/utils/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/utils/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Ayo
+
+Utils package
+"""

--- a/plugins/source_scanner/utils/__init__.py
+++ b/plugins/source_scanner/utils/__init__.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Location: ./plugins/source_scanner/utils/__init__.py
-Copyright 2025
+"""Location: ./plugins/source_scanner/language_detector.py
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Ayo
 
-Utils package
 """

--- a/plugins/source_scanner/utils/exec.py
+++ b/plugins/source_scanner/utils/exec.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/source_scanner/utils/exec.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi, Ayo
+
+Subprocess wrapper with timeout, stdout/stderr capture, and return code handling.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+from typing import List, Optional
+
+
+class ExecResult:
+    """Result of subprocess execution.
+
+    Attributes:
+        returncode: Exit code of the process.
+        stdout: Standard output as string.
+        stderr: Standard error as string.
+        timed_out: Whether the process timed out.
+    """
+
+    def __init__(
+        self,
+        returncode: int,
+        stdout: str,
+        stderr: str,
+        timed_out: bool = False,
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.timed_out = timed_out
+
+    def __repr__(self) -> str:
+        return f"ExecResult(returncode={self.returncode}, " f"timed_out={self.timed_out}, " f"stdout_len={len(self.stdout)}, " f"stderr_len={len(self.stderr)})"
+
+
+async def run_command(
+    cmd: List[str],
+    timeout_seconds: Optional[int] = None,
+    cwd: Optional[str] = None,
+    env: Optional[dict[str, str]] = None,
+) -> ExecResult:
+    """Execute a command with optional timeout.
+
+    Notes:
+        This utility never raises on timeout; it returns ExecResult(timed_out=True)
+        and captures any partial stdout/stderr where possible. Callers decide how
+        to map failures into domain-specific exceptions.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+    )
+
+    try:
+        if timeout_seconds is not None:
+            stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout_seconds)
+        else:
+            stdout_b, stderr_b = await proc.communicate()
+
+        stdout = (stdout_b or b"").decode("utf-8", errors="replace")
+        stderr = (stderr_b or b"").decode("utf-8", errors="replace")
+        return ExecResult(returncode=proc.returncode or 0, stdout=stdout, stderr=stderr, timed_out=False)
+
+    except asyncio.TimeoutError:
+        # Mark timeout and ensure process is terminated
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+        # Best-effort: wait shortly for pipes to flush
+        stdout = ""
+        stderr = ""
+        try:
+            stdout_b, stderr_b = await proc.communicate()
+            stdout = (stdout_b or b"").decode("utf-8", errors="replace")
+            stderr = (stderr_b or b"").decode("utf-8", errors="replace")
+        except Exception:
+            # If communicate fails after kill, return empty outputs
+            pass
+
+        return ExecResult(
+            returncode=proc.returncode if proc.returncode is not None else -1,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=True,
+        )

--- a/plugins/source_scanner/utils/exec.py
+++ b/plugins/source_scanner/utils/exec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Location: ./plugins/source_scanner/utils/exec.py
-Copyright 2025
+Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Xinyi, Ayo
 
@@ -33,12 +33,14 @@ class ExecResult:
         stderr: str,
         timed_out: bool = False,
     ) -> None:
+        """Create an execution result container for a completed command."""
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
         self.timed_out = timed_out
 
     def __repr__(self) -> str:
+        """Return a summary string of the execution result."""
         return f"ExecResult(returncode={self.returncode}, " f"timed_out={self.timed_out}, " f"stdout_len={len(self.stdout)}, " f"stderr_len={len(self.stderr)})"
 
 

--- a/tests/unit/plugins/test_source_scanner/__init__.py
+++ b/tests/unit/plugins/test_source_scanner/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/__init__.py
+Copyright: 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+Unit tests for MCP Source Scanner Plugin.
+
+This package contains comprehensive unit tests for the SourceScannerPlugin,
+covering:
+- Language detection (test_language_detector.py)
+- Git operations (test_git_manager.py)
+- Semgrep scanner integration (test_semgrep_scanner.py)
+- Bandit scanner integration (test_bandit_scanner.py)
+- Finding parsing and validation (test_finding_parser.py)
+- Finding deduplication (test_finding_deduplication.py)
+- Severity filtering (test_severity_filtering.py)
+- Plugin integration and hooks (test_source_scanner_plugin.py)
+- Cache management (test_cache_manager.py)
+
+Test Structure:
+- conftest.py: Shared pytest fixtures and configuration
+- test_*.py: Individual test modules (one per component)
+
+Running Tests locally:
+    pytest tests/unit/plugins/test_source_scanner/ -v
+    pytest tests/unit/plugins/test_source_scanner/ --cov=mcpgateway.plugins.source_scanner
+"""

--- a/tests/unit/plugins/test_source_scanner/__init__.py
+++ b/tests/unit/plugins/test_source_scanner/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 Location: tests/unit/plugins/test_source_scanner/__init__.py
-Copyright: 2025
+Copyright: 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Yaser
 Unit tests for MCP Source Scanner Plugin.

--- a/tests/unit/plugins/test_source_scanner/conftest.py
+++ b/tests/unit/plugins/test_source_scanner/conftest.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/__init__.py
+Copyright: 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+Unit tests for MCP Source Scanner Plugin.
+Shared pytest fixtures and configuration for source scanner tests."""
+
+# Standard
+from pathlib import Path
+from typing import Any, Dict
+
+# Third-Party
+import pytest
+from pytest import TestReport
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom pytest markers."""
+    config.addinivalue_line("markers", "requires_semgrep: marks tests that require semgrep installed")
+    config.addinivalue_line("markers", "requires_bandit: marks tests that require bandit installed")
+    config.addinivalue_line("markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')")
+    config.addinivalue_line("markers", "integration: marks tests as integration tests")
+
+
+# ===== Directory Fixtures =====
+
+
+@pytest.fixture
+def python_project_dir(tmp_path: Path) -> Path:
+    """Create mock Python project directory with pyproject.toml."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'test-project'\n")
+    return tmp_path
+
+
+@pytest.fixture
+def js_project_dir(tmp_path: Path) -> Path:
+    """Create mock JavaScript project directory with package.json."""
+    package_json = tmp_path / "package.json"
+    package_json.write_text('{"name": "test-app", "version": "1.0.0"}\n')
+    return tmp_path
+
+
+@pytest.fixture
+def go_project_dir(tmp_path: Path) -> Path:
+    """Create mock Go project directory with go.mod."""
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text("module github.com/org/project\n\ngo 1.21\n")
+    return tmp_path
+
+
+@pytest.fixture
+def java_maven_project_dir(tmp_path: Path) -> Path:
+    """Create mock Java Maven project directory with pom.xml."""
+    pom = tmp_path / "pom.xml"
+    pom.write_text(
+        '<?xml version="1.0"?>\n'
+        "<project>\n"
+        "  <modelVersion>4.0.0</modelVersion>\n"
+        "  <groupId>com.example</groupId>\n"
+        "  <artifactId>test-app</artifactId>\n"
+        "  <version>1.0.0</version>\n"
+        "</project>\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def ruby_project_dir(tmp_path: Path) -> Path:
+    """Create mock Ruby project directory with Gemfile."""
+    gemfile = tmp_path / "Gemfile"
+    gemfile.write_text("source 'https://rubygems.org'\n\ngem 'rails'\n")
+    return tmp_path
+
+
+@pytest.fixture
+def php_project_dir(tmp_path: Path) -> Path:
+    """Create mock PHP project directory with composer.json."""
+    composer = tmp_path / "composer.json"
+    composer.write_text('{"name": "org/project", "type": "library"}\n')
+    return tmp_path
+
+
+@pytest.fixture
+def mixed_project_dir(tmp_path: Path) -> Path:
+    """Create project with multiple languages."""
+    # Python
+    (tmp_path / "script.py").write_text("print('hello')")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='test'\n")
+
+    # JavaScript
+    (tmp_path / "index.js").write_text("console.log('hello');")
+    (tmp_path / "package.json").write_text('{"name": "test"}\n')
+
+    return tmp_path
+
+
+@pytest.fixture
+def empty_directory(tmp_path: Path) -> Path:
+    """Create empty directory (no project markers)."""
+    return tmp_path
+
+
+# ===== Scanner Configuration Fixtures =====
+
+
+@pytest.fixture
+def semgrep_scanner_config() -> Dict[str, Any]:
+    """Configuration for Semgrep scanner."""
+    return {"enabled": True, "rulesets": ["p/security-audit", "p/owasp-top-ten"], "extra_args": []}
+
+
+@pytest.fixture
+def bandit_scanner_config() -> Dict[str, Any]:
+    """Configuration for Bandit scanner."""
+    return {"enabled": True, "severity": "medium", "confidence": "medium"}
+
+
+@pytest.fixture
+def plugin_config() -> Dict[str, Any]:
+    """Configuration for SourceScannerPlugin."""
+    return {
+        "scanners": {"semgrep": {"enabled": True, "rulesets": ["p/security-audit", "p/owasp-top-ten"], "extra_args": []}, "bandit": {"enabled": True, "severity": "medium", "confidence": "medium"}},
+        "severity_threshold": "WARNING",
+        "fail_on_critical": True,
+        "clone_timeout_seconds": 120,
+        "scan_timeout_seconds": 600,
+        "max_repo_size_mb": 500,
+        "cache_by_commit": True,
+        "cache_ttl_hours": 168,
+    }
+
+
+# ===== Mock Output Fixtures =====
+
+
+@pytest.fixture
+def mock_semgrep_sarif_output() -> Dict[str, Any]:
+    """Mock SARIF output from Semgrep."""
+    return {
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "Semgrep", "version": "1.45.0", "informationUri": "https://semgrep.dev"}},
+                "results": [
+                    {
+                        "ruleId": "python.django.security.sql-injection",
+                        "level": "error",
+                        "message": {"text": "SQL injection vulnerability detected"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "handlers.py"},
+                                    "region": {"startLine": 45, "startColumn": 20, "endLine": 45, "endColumn": 63, "snippet": {"text": 'query = f"SELECT * FROM users WHERE id = {user_id}"'}},
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def mock_semgrep_sarif_empty() -> Dict[str, Any]:
+    """Mock empty SARIF output from Semgrep (no findings)."""
+    return {
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "runs": [{"tool": {"driver": {"name": "Semgrep", "version": "1.45.0"}}, "results": []}],
+    }
+
+
+@pytest.fixture
+def mock_bandit_json_output() -> Dict[str, Any]:
+    """Mock JSON output from Bandit."""
+    return {
+        "metrics": {"_totals": {"CRITICAL": 1, "HIGH": 1, "MEDIUM": 0, "LOW": 0}},
+        "results": [
+            {
+                "test_id": "B201",
+                "test_name": "flask_debug_true",
+                "issue_severity": "HIGH",
+                "issue_confidence": "MEDIUM",
+                "issue_text": "Flask debug mode is on",
+                "line_number": 10,
+                "filename": "app.py",
+                "line_range": [10, 11],
+            },
+            {
+                "test_id": "B301",
+                "test_name": "pickle",
+                "issue_severity": "CRITICAL",
+                "issue_confidence": "HIGH",
+                "issue_text": "Possible deserialization using the pickle module detected",
+                "line_number": 25,
+                "filename": "app.py",
+                "line_range": [25, 26],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_bandit_json_empty() -> Dict[str, Any]:
+    """Mock empty JSON output from Bandit (no findings)."""
+    return {"metrics": {"_totals": {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}}, "results": []}
+
+
+# ===== Sample Object Fixtures =====
+
+
+@pytest.fixture
+def sample_finding() -> Dict[str, Any]:
+    """Create sample Finding object."""
+    return {
+        "rule_id": "B201",
+        "rule_name": "Flask debug enabled",
+        "severity": "HIGH",
+        "file_path": "app.py",
+        "line_number": 10,
+        "column_number": 1,
+        "message": "Flask debug mode is enabled",
+        "code_snippet": "app.run(debug=True)",
+        "remediation": "Set debug=False in production",
+        "documentation_url": "https://bandit.readthedocs.io/",
+    }
+
+
+@pytest.fixture
+def critical_finding() -> Dict[str, Any]:
+    """Create sample CRITICAL severity finding."""
+    return {
+        "rule_id": "B301",
+        "rule_name": "Pickle vulnerability",
+        "severity": "CRITICAL",
+        "file_path": "app.py",
+        "line_number": 25,
+        "column_number": 5,
+        "message": "Possible deserialization using pickle module",
+        "code_snippet": "data = pickle.loads(user_input)",
+        "remediation": "Use json instead of pickle",
+        "documentation_url": "https://bandit.readthedocs.io/",
+    }
+
+
+@pytest.fixture
+def sample_findings_list() -> list[Dict[str, Any]]:
+    """Create list of sample findings with different severities."""
+    return [
+        {"rule_id": "B201", "severity": "HIGH", "file_path": "app.py", "line_number": 10},
+        {"rule_id": "B301", "severity": "CRITICAL", "file_path": "app.py", "line_number": 25},
+        {"rule_id": "B601", "severity": "MEDIUM", "file_path": "database.py", "line_number": 42},
+        {"rule_id": "B602", "severity": "LOW", "file_path": "utils.py", "line_number": 5},
+    ]
+
+
+@pytest.fixture
+def sample_sarif_result() -> Dict[str, Any]:
+    """Sample SARIF result structure."""
+    return {
+        "ruleId": "python.django.security.sql-injection",
+        "level": "error",
+        "message": {"text": "SQL injection via string concatenation"},
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": "handlers.py"},
+                    "region": {"startLine": 45, "startColumn": 20, "snippet": {"text": 'query = f"SELECT * FROM users WHERE id = {user_id}"'}},
+                }
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def sample_bandit_result() -> Dict[str, Any]:
+    """Sample Bandit result structure."""
+    return {
+        "test_id": "B201",
+        "test_name": "flask_debug_true",
+        "issue_severity": "HIGH",
+        "issue_confidence": "MEDIUM",
+        "issue_text": "Flask debug mode is on",
+        "line_number": 10,
+        "filename": "app.py",
+        "line_range": [10, 11],
+    }
+
+
+# ===== Vulnerable Code Fixtures =====
+
+
+@pytest.fixture
+def vulnerable_python_code(tmp_path: Path) -> Path:
+    """Create Python file with security vulnerabilities."""
+    code = tmp_path / "app.py"
+    code.write_text(
+        "import pickle\n"
+        "from flask import Flask, request\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.route('/process')\n"
+        "def process():\n"
+        "    user_id = request.args.get('id')\n"
+        "    # SQL Injection vulnerability\n"
+        "    query = f'SELECT * FROM users WHERE id = {user_id}'\n"
+        "    # Result: SQL injection possible\n"
+        "    return query\n\n"
+        "if __name__ == '__main__':\n"
+        "    # Flask debug mode enabled\n"
+        "    app.run(debug=True)\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def vulnerable_javascript_code(tmp_path: Path) -> Path:
+    """Create JavaScript file with security vulnerabilities."""
+    code = tmp_path / "app.js"
+    code.write_text(
+        "const express = require('express');\n"
+        "const app = express();\n\n"
+        "app.get('/eval', (req, res) => {\n"
+        "    const userInput = req.query.code;\n"
+        "    // Code injection vulnerability\n"
+        "    eval(userInput);\n"
+        "    res.send('OK');\n"
+        "});\n"
+    )
+    return tmp_path
+
+
+# ===== Git Fixtures =====
+
+
+@pytest.fixture
+def mock_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create mock Git repository."""
+    repo_path = tmp_path / "test_repo"
+    repo_path.mkdir()
+    (repo_path / ".git").mkdir()
+    (repo_path / "README.md").write_text("# Test Repository\n")
+    return repo_path
+
+
+# ===== Duplicate Findings Fixtures =====
+
+
+@pytest.fixture
+def duplicate_findings() -> list[Dict[str, Any]]:
+    """Create list of findings with duplicates."""
+    return [
+        {"rule_id": "B201", "file_path": "app.py", "line_number": 10, "severity": "HIGH", "message": "Flask debug enabled"},
+        {"rule_id": "B201", "file_path": "app.py", "line_number": 10, "severity": "HIGH", "message": "Flask debug enabled"},
+        {"rule_id": "B301", "file_path": "app.py", "line_number": 25, "severity": "CRITICAL", "message": "Pickle vulnerability"},
+    ]
+
+
+@pytest.fixture
+def no_duplicate_findings() -> list[Dict[str, Any]]:
+    """Create list of unique findings."""
+    return [
+        {"rule_id": "B201", "file_path": "app.py", "line_number": 10, "severity": "HIGH"},
+        {"rule_id": "B301", "file_path": "app.py", "line_number": 25, "severity": "CRITICAL"},
+        {"rule_id": "B601", "file_path": "database.py", "line_number": 42, "severity": "MEDIUM"},
+    ]
+
+
+# ===== Server Request Fixtures =====
+
+
+@pytest.fixture
+def mock_server_request() -> Dict[str, Any]:
+    """Mock server registration request with GitHub source."""
+    return {"name": "test-mcp-server", "source": {"type": "github", "repo": "org/mcp-server", "branch": "main"}, "enabled": True}
+
+
+@pytest.fixture
+def mock_server_request_with_tag() -> Dict[str, Any]:
+    """Mock server registration request with git tag."""
+    return {"name": "test-mcp-server", "source": {"type": "github", "repo": "org/mcp-server", "tag": "v1.0.0"}, "enabled": True}
+
+
+@pytest.fixture
+def mock_server_request_with_commit() -> Dict[str, Any]:
+    """Mock server registration request with commit SHA."""
+    return {"name": "test-mcp-server", "source": {"type": "github", "repo": "org/mcp-server", "commit_sha": "abc123def456"}, "enabled": True}
+
+
+# Dictionary to store test results
+test_results: Dict[str, list[tuple[str, str]]] = {}
+
+
+def pytest_runtest_logreport(report: TestReport) -> None:
+    """Hook to capture test results."""
+    if report.when == "call":
+        test_class = report.nodeid.split("::")[0].split("/")[-1]
+        test_name = report.nodeid.split("::")[-1]
+        if test_class not in test_results:
+            test_results[test_class] = []
+        test_results[test_class].append((test_name, report.outcome))
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Hook to print custom summary at the end of the test session."""
+    print("\n\nCustom Test Summary:")
+    for test_class, results in test_results.items():
+        passed_tests = [test for test, outcome in results if outcome == "passed"]
+        failed_tests = [test for test, outcome in results if outcome == "failed"]
+        print(f"\n{test_class} - {len(passed_tests)} tests PASSED")
+        for test in passed_tests:
+            print(f"✅ {test}")
+        if failed_tests:
+            print(f"\n❌ FAILED: {len(failed_tests)} tests")
+            for test in failed_tests:
+                print(f"❌ {test}")

--- a/tests/unit/plugins/test_source_scanner/conftest.py
+++ b/tests/unit/plugins/test_source_scanner/conftest.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 Location: tests/unit/plugins/test_source_scanner/__init__.py
-Copyright: 2025
+Copyright: 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Yaser
 Unit tests for MCP Source Scanner Plugin.

--- a/tests/unit/plugins/test_source_scanner/test_config.py
+++ b/tests/unit/plugins/test_source_scanner/test_config.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_config.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.config import BanditConfig, ScannersConfig, SemgrepConfig, SourceScannerConfig
+
+
+def test_semgrep_config_defaults() -> None:
+    config = SemgrepConfig()
+
+    assert config.enabled is True
+    assert config.rulesets == ["p/security-audit", "p/owasp-top-ten", "p/python", "p/javascript"]
+    assert config.extra_args == []
+    assert config.timeout_seconds == 600
+
+
+def test_bandit_config_defaults() -> None:
+    config = BanditConfig()
+
+    assert config.enabled is True
+    assert config.severity == "medium"
+    assert config.confidence == "medium"
+
+
+def test_scanners_config_defaults() -> None:
+    config = ScannersConfig()
+
+    assert isinstance(config.semgrep, SemgrepConfig)
+    assert isinstance(config.bandit, BanditConfig)
+
+
+def test_source_scanner_config_defaults() -> None:
+    config = SourceScannerConfig()
+
+    assert isinstance(config.semgrep, SemgrepConfig)
+    assert isinstance(config.bandit, BanditConfig)
+    assert config.severity_threshold == "WARNING"
+    assert config.fail_on_critical is True
+    assert config.clone_timeout_seconds == 120
+    assert config.scan_timeout_seconds == 600
+    assert config.max_repo_size_mb == 500
+    assert config.github_token_env == "GITHUB_TOKEN"
+    assert config.cache_by_commit is True
+    assert config.cache_ttl_hours == 168
+
+
+def test_source_scanner_config_merges_scanners() -> None:
+    scanners = ScannersConfig(
+        semgrep=SemgrepConfig(enabled=False, rulesets=["p/python"], extra_args=["--strict"], timeout_seconds=123),
+        bandit=BanditConfig(enabled=False, severity="low", confidence="high"),
+    )
+    config = SourceScannerConfig(
+        scanners=scanners,
+        semgrep=SemgrepConfig(enabled=True, rulesets=["p/security-audit"], extra_args=[], timeout_seconds=999),
+        bandit=BanditConfig(enabled=True, severity="high", confidence="low"),
+    )
+
+    assert config.semgrep.enabled is False
+    assert config.semgrep.rulesets == ["p/python"]
+    assert config.semgrep.extra_args == ["--strict"]
+    assert config.semgrep.timeout_seconds == 123
+    assert config.bandit.enabled is False
+    assert config.bandit.severity == "low"
+    assert config.bandit.confidence == "high"

--- a/tests/unit/plugins/test_source_scanner/test_errors.py
+++ b/tests/unit/plugins/test_source_scanner/test_errors.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_errors.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.errors import (
+    CheckoutError,
+    CloneTimeoutError,
+    ParseError,
+    PolicyError,
+    RepoFetchError,
+    RepoSizeLimitError,
+    ScannerError,
+    ScannerNotFoundError,
+    ScannerTimeoutError,
+    SourceScannerError,
+)
+
+
+def test_exception_hierarchy() -> None:
+    assert issubclass(RepoFetchError, SourceScannerError)
+    assert issubclass(CloneTimeoutError, RepoFetchError)
+    assert issubclass(RepoSizeLimitError, RepoFetchError)
+    assert issubclass(CheckoutError, RepoFetchError)
+
+    assert issubclass(ScannerError, SourceScannerError)
+    assert issubclass(ScannerTimeoutError, ScannerError)
+    assert issubclass(ScannerNotFoundError, ScannerError)
+
+    assert issubclass(ParseError, SourceScannerError)
+    assert issubclass(PolicyError, SourceScannerError)

--- a/tests/unit/plugins/test_source_scanner/test_exec.py
+++ b/tests/unit/plugins/test_source_scanner/test_exec.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_exec.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# Standard
+import sys
+
+# Third-Party
+import pytest
+
+# First-Party
+from plugins.source_scanner.utils.exec import ExecResult, run_command
+
+
+def test_exec_result_repr() -> None:
+    result = ExecResult(returncode=0, stdout="out", stderr="err", timed_out=False)
+
+    text = repr(result)
+
+    assert "returncode=0" in text
+    assert "timed_out=False" in text
+    assert "stdout_len=3" in text
+    assert "stderr_len=3" in text
+
+
+@pytest.mark.asyncio
+async def test_run_command_success() -> None:
+    result = await run_command([sys.executable, "-c", "print('hello')"])
+
+    assert result.returncode == 0
+    assert result.timed_out is False
+    assert "hello" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_run_command_captures_stderr() -> None:
+    result = await run_command([sys.executable, "-c", "import sys; sys.stderr.write('oops')"])
+
+    assert result.returncode == 0
+    assert result.timed_out is False
+    assert "oops" in result.stderr
+
+
+@pytest.mark.asyncio
+async def test_run_command_timeout() -> None:
+    result = await run_command([sys.executable, "-c", "import time; time.sleep(1)"], timeout_seconds=0.01)
+
+    assert result.timed_out is True
+    assert result.returncode != 0

--- a/tests/unit/plugins/test_source_scanner/test_policy.py
+++ b/tests/unit/plugins/test_source_scanner/test_policy.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_policy.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.policy import PolicyChecker
+from plugins.source_scanner.types import Finding
+
+
+def _finding(severity: str) -> Finding:
+    return Finding(
+        scanner="semgrep",
+        severity=severity,  # type: ignore[arg-type]
+        rule_id="rule",
+        message="issue",
+        file_path="app.py",
+        line=1,
+    )
+
+
+def test_policy_blocks_on_threshold_violation() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("ERROR"), _finding("WARNING"), _finding("INFO")]
+
+    decision = checker.evaluate(findings, threshold="WARNING", fail_on_critical=True)
+
+    assert decision.blocked is True
+    assert decision.reason is not None
+    assert "Policy threshold WARNING violated" in decision.reason
+    assert "1 ERROR" in decision.reason
+    assert "1 WARNING" in decision.reason
+    assert "1 INFO" in decision.reason
+
+
+def test_policy_allows_when_no_violations() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("WARNING"), _finding("INFO")]
+
+    decision = checker.evaluate(findings, threshold="ERROR", fail_on_critical=True)
+
+    assert decision.blocked is False
+    assert decision.reason is None
+
+
+def test_policy_audit_mode_never_blocks() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("ERROR")]
+
+    decision = checker.evaluate(findings, threshold="ERROR", fail_on_critical=False)
+
+    assert decision.blocked is False
+
+
+def test_policy_unknown_threshold_defaults_to_warning() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("WARNING")]
+
+    decision = checker.evaluate(findings, threshold="unknown", fail_on_critical=True)
+
+    assert decision.blocked is True
+    assert decision.reason is not None
+
+
+def test_policy_info_threshold_includes_info() -> None:
+    checker = PolicyChecker()
+    findings = [_finding("INFO")]
+
+    decision = checker.evaluate(findings, threshold="INFO", fail_on_critical=True)
+
+    assert decision.blocked is True

--- a/tests/unit/plugins/test_source_scanner/test_semgrep_runner.py
+++ b/tests/unit/plugins/test_source_scanner/test_semgrep_runner.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_semgrep_runner.py
+Copyright: 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+
+Unit tests for Semgrep runner integration.
+Test coverage includes:
+- Initialization with various configurations
+- Command building with different rulesets and arguments
+- SARIF output parsing (empty, single, multiple findings)
+- Severity mapping (all severity levels)
+- Finding object validation
+- Error handling
+"""
+
+# Standard
+from tempfile import mkdtemp
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from plugins.source_scanner.scanners.semgrep_runner import SemgrepRunner
+from plugins.source_scanner.types import Finding
+
+
+class TestSemgrepRunnerInitialization:
+
+    def test_init_with_default_config(self) -> None:
+        """Test initialization uses defaults when config is minimal."""
+        config = {"enabled": True}
+        runner = SemgrepRunner(config)
+
+        assert runner.enabled is True, "enabled should be True from config"
+        assert runner.rulesets == ["p/security-audit"], f"Expected default ruleset ['p/security-audit'], got {runner.rulesets}"
+        assert runner.extra_args == [], f"Expected empty extra_args, got {runner.extra_args}"
+        assert runner.timeout == 300, f"Expected default timeout 300, got {runner.timeout}"
+
+    def test_init_with_custom_config(self) -> None:
+        """Test initialization with all custom configuration values."""
+        config = {
+            "enabled": True,
+            "rulesets": ["p/security-audit", "p/python", "p/javascript"],
+            "extra_args": ["--verbose", "--timeout=60"],
+            "timeout": 600,
+        }
+        runner = SemgrepRunner(config)
+
+        assert runner.enabled is True, "enabled should match config"
+        assert len(runner.rulesets) == 3, f"Expected 3 rulesets, got {len(runner.rulesets)}"
+        assert "p/python" in runner.rulesets, "p/python should be in rulesets"
+        assert runner.extra_args == ["--verbose", "--timeout=60"], f"extra_args mismatch: {runner.extra_args}"
+        assert runner.timeout == 600, f"Expected timeout 600, got {runner.timeout}"
+
+    def test_init_disabled_scanner(self) -> None:
+        """Test initialization when scanner is disabled."""
+        config = {"enabled": False}
+        runner = SemgrepRunner(config)
+
+        assert runner.enabled is False, "enabled should be False"
+
+
+class TestCommandBuilding:
+    """Test suite for Semgrep command construction."""
+
+    def test_build_command_basic_structure(self) -> None:
+        """Test basic command includes all required parts."""
+        config = {"rulesets": ["p/security-audit"]}
+        runner = SemgrepRunner(config)
+
+        command = runner.build_command("/tmp/repo")
+
+        assert "semgrep" in command, f"Command should start with 'semgrep': {command}"
+        assert "scan" in command, f"Command should include 'scan': {command}"
+        assert "--config" in command, f"Command should include '--config' flag: {command}"
+        assert "p/security-audit" in command, f"Command should include ruleset: {command}"
+        assert "--json" in command, f"Command should include '--json' output format: {command}"
+        assert "/tmp/repo" in command, f"Command should include repo path: {command}"
+
+    def test_build_command_multiple_rulesets(self) -> None:
+        """Test command building with multiple rulesets."""
+        config = {"rulesets": ["p/security-audit", "p/python", "p/owasp-top-ten"]}
+        runner = SemgrepRunner(config)
+
+        command = runner.build_command("/tmp/repo")
+
+        config_count = command.count("--config")
+        assert config_count == 3, f"Expected 3 '--config' flags, got {config_count}"
+        assert "p/security-audit" in command, "p/security-audit not in command"
+        assert "p/python" in command, "p/python not in command"
+        assert "p/owasp-top-ten" in command, "p/owasp-top-ten not in command"
+
+    def test_build_command_with_extra_arguments(self) -> None:
+        """Test command building includes extra arguments."""
+        config = {"extra_args": ["--verbose", "--timeout=30", "--strict"]}
+        runner = SemgrepRunner(config)
+
+        command = runner.build_command("/tmp/repo")
+
+        assert "--verbose" in command, f"--verbose not in command: {command}"
+        assert "--timeout=30" in command, f"--timeout=30 not in command: {command}"
+        assert "--strict" in command, f"--strict not in command: {command}"
+
+    def test_build_command_empty_rulesets(self) -> None:
+        """Test command building with empty rulesets list."""
+        config: dict[str, Any] = {"rulesets": []}
+        runner = SemgrepRunner(config)
+
+        command = runner.build_command("/tmp/repo")
+
+        assert "semgrep" in command, "Command should still be valid"
+        assert "--json" in command, "JSON output should still be included"
+
+
+class TestSARIFParsing:
+    """Test suite for Semgrep SARIF output parsing."""
+
+    def test_parse_empty_results(self) -> None:
+        """Test parsing empty results returns empty list."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {"results": []}
+        findings = runner.parse_sarif_output(sarif)
+
+        assert isinstance(findings, list), f"Expected list, got {type(findings)}"
+        assert len(findings) == 0, f"Expected empty list, got {len(findings)} findings"
+
+    def test_parse_single_finding(self) -> None:
+        """Test parsing single finding from output."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif = {
+            "results": [
+                {
+                    "check_id": "python.django.sql-injection",
+                    "severity": "ERROR",
+                    "message": "SQL injection",
+                    "path": "app.py",
+                    "start": {"line": 42, "col": 10},
+                    "extra": {"message": "Parameterized query needed", "lines": "query = f'SELECT * FROM users WHERE id={uid}'", "doc_url": "https://semgrep.dev/r/sql-injection"},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert len(findings) == 1, f"Expected 1 finding, got {len(findings)}"
+        finding = findings[0]
+        assert finding.scanner == "semgrep", f"scanner should be 'semgrep', got {finding.scanner}"
+        assert finding.rule_id == "python.django.sql-injection", f"rule_id mismatch: {finding.rule_id}"
+        assert finding.severity == "ERROR", f"severity should be ERROR, got {finding.severity}"
+        assert finding.file_path == "app.py", f"file_path mismatch: {finding.file_path}"
+        assert finding.line == 42, f"line should be 42, got {finding.line}"
+        assert finding.column == 10, f"column should be 10, got {finding.column}"
+
+    def test_parse_multiple_findings(self) -> None:
+        """Test parsing multiple findings."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif = {
+            "results": [
+                {
+                    "check_id": "rule.one",
+                    "severity": "ERROR",
+                    "message": "Issue 1",
+                    "path": "file1.py",
+                    "start": {"line": 10},
+                },
+                {
+                    "check_id": "rule.two",
+                    "severity": "WARNING",
+                    "message": "Issue 2",
+                    "path": "file2.py",
+                    "start": {"line": 20},
+                },
+                {
+                    "check_id": "rule.three",
+                    "severity": "INFO",
+                    "message": "Issue 3",
+                    "path": "file3.py",
+                    "start": {"line": 30},
+                },
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert len(findings) == 3, f"Expected 3 findings, got {len(findings)}"
+        assert findings[0].rule_id == "rule.one", "First finding rule_id mismatch"
+        assert findings[1].rule_id == "rule.two", "Second finding rule_id mismatch"
+        assert findings[2].rule_id == "rule.three", "Third finding rule_id mismatch"
+
+    def test_parse_error_in_sarif(self) -> None:
+        """Test handling error field in output."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif = {"error": "Semgrep execution failed"}
+        findings = runner.parse_sarif_output(sarif)
+
+        assert len(findings) == 0, f"Expected empty list on error, got {len(findings)}"
+
+    def test_parse_missing_optional_fields(self) -> None:
+        """Test handling missing optional fields gracefully."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif = {
+            "results": [
+                {
+                    "check_id": "rule.minimal",
+                    "severity": "INFO",
+                    "message": "Minimal finding",
+                    "path": "file.py",
+                    "start": {"line": 5},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert len(findings) == 1, "Should parse minimal finding"
+        finding = findings[0]
+        assert finding.column is None, f"column should be None, got {finding.column}"
+        assert finding.code_snippet is None, f"code_snippet should be None, got {finding.code_snippet}"
+        assert finding.help_url is None, f"help_url should be None, got {finding.help_url}"
+
+    def test_parse_missing_start_line_defaults_to_none(self) -> None:
+        """Test missing start.line field defaults to None."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "INFO",
+                    "message": "Issue",
+                    "path": "file.py",
+                    "start": {},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].line is None, f"line should be None when missing, got {findings[0].line}"
+
+
+class TestSeverityMapping:
+    """Test suite for severity level mapping."""
+
+    def test_severity_error_stays_error(self) -> None:
+        """Test ERROR severity maps to ERROR."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "ERROR",
+                    "message": "Error msg",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "ERROR", f"ERROR should map to ERROR, got {findings[0].severity}"
+
+    def test_severity_warning_stays_warning(self) -> None:
+        """Test WARNING severity maps to WARNING."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "WARNING",
+                    "message": "Warn msg",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "WARNING", f"WARNING should map to WARNING, got {findings[0].severity}"
+
+    def test_severity_info_stays_info(self) -> None:
+        """Test INFO severity maps to INFO."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "INFO",
+                    "message": "Info msg",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "INFO", f"INFO should map to INFO, got {findings[0].severity}"
+
+    def test_severity_high_maps_to_error(self) -> None:
+        """Test HIGH severity maps to ERROR."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "HIGH",
+                    "message": "High severity",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "ERROR", f"HIGH should map to ERROR, got {findings[0].severity}"
+
+    def test_severity_medium_maps_to_warning(self) -> None:
+        """Test MEDIUM severity maps to WARNING."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "MEDIUM",
+                    "message": "Medium severity",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "WARNING", f"MEDIUM should map to WARNING, got {findings[0].severity}"
+
+    def test_severity_low_maps_to_info(self) -> None:
+        """Test LOW severity maps to INFO."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "LOW",
+                    "message": "Low severity",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "INFO", f"LOW should map to INFO, got {findings[0].severity}"
+
+    def test_severity_unknown_defaults_to_info(self) -> None:
+        """Test unknown severity defaults to INFO."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "CRITICAL",  # not in mapping
+                    "message": "Unknown severity",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "INFO", f"Unknown severity should default to INFO, got {findings[0].severity}"
+
+    def test_severity_case_insensitive(self) -> None:
+        """Test severity mapping is case-insensitive."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "error",  # lowercase
+                    "message": "Lowercase error",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].severity == "ERROR", f"Lowercase 'error' should map to ERROR, got {findings[0].severity}"
+
+
+class TestFindingObject:
+    """Test suite for Finding object validation."""
+
+    def test_finding_object_scanner_field(self) -> None:
+        """Test Finding object has correct scanner field."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "rule",
+                    "severity": "INFO",
+                    "message": "Test",
+                    "path": "file.py",
+                    "start": {"line": 1},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+
+        assert findings[0].scanner == "semgrep", f"scanner should be 'semgrep', got {findings[0].scanner}"
+
+    def test_finding_object_all_attributes(self) -> None:
+        """Test Finding object has all required attributes."""
+        config: dict[str, Any] = {}
+        runner = SemgrepRunner(config)
+
+        sarif: dict[str, Any] = {
+            "results": [
+                {
+                    "check_id": "test.rule.id",
+                    "severity": "ERROR",
+                    "message": "Test message",
+                    "path": "test/file.py",
+                    "start": {"line": 99, "col": 42},
+                    "extra": {"message": "Detailed message", "lines": "code = vulnerable()", "doc_url": "https://docs.example.com/rule"},
+                }
+            ]
+        }
+        findings = runner.parse_sarif_output(sarif)
+        finding = findings[0]
+
+        assert hasattr(finding, "scanner"), "Finding should have 'scanner' attribute"
+        assert hasattr(finding, "rule_id"), "Finding should have 'rule_id' attribute"
+        assert hasattr(finding, "severity"), "Finding should have 'severity' attribute"
+        assert hasattr(finding, "message"), "Finding should have 'message' attribute"
+        assert hasattr(finding, "file_path"), "Finding should have 'file_path' attribute"
+        assert hasattr(finding, "line"), "Finding should have 'line' attribute"
+        assert hasattr(finding, "column"), "Finding should have 'column' attribute"
+        assert hasattr(finding, "code_snippet"), "Finding should have 'code_snippet' attribute"
+        assert hasattr(finding, "help_url"), "Finding should have 'help_url' attribute"
+
+
+@pytest.mark.requires_semgrep
+class TestIntegration:
+    """Integration tests requiring actual semgrep installation."""
+
+    def test_run_returns_list(self) -> None:
+        """Test run method returns a list."""
+        config: dict[str, Any] = {"rulesets": ["p/security-audit"]}
+        runner = SemgrepRunner(config)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='{"results": []}')
+            findings = runner.run("https://github.com/test/repo.git", mkdtemp())
+
+            assert isinstance(findings, list), f"run() should return list, got {type(findings)}"
+
+    def test_run_returns_findings_list(self) -> None:
+        """Test run method returns list of Finding objects."""
+        config: dict[str, Any] = {"rulesets": ["p/security-audit"]}
+        runner = SemgrepRunner(config)
+
+        mock_output = '{"results": [{"check_id": "rule1", "severity": "INFO", "message": "Test", "path": "file.py", "start": {"line": 1}}]}'
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=mock_output)
+            findings = runner.run("https://github.com/test/repo.git", mkdtemp())
+
+            assert all(isinstance(f, Finding) for f in findings), "All items should be Finding objects"

--- a/tests/unit/plugins/test_source_scanner/test_storage_models.py
+++ b/tests/unit/plugins/test_source_scanner/test_storage_models.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_storage_models.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# First-Party
+from plugins.source_scanner.storage.models import FindingRecord, ScanRecord
+
+
+def test_scan_record_repr_includes_short_commit() -> None:
+    record = ScanRecord(repo_url="https://example.com/repo.git", commit_sha="abcdef1234567890")
+
+    result = repr(record)
+
+    assert "commit=abcdef12" in result
+    assert "repo=https://example.com/repo.git" in result
+
+
+def test_scan_record_table_columns_include_expected_fields() -> None:
+    columns = {column.name for column in ScanRecord.__table__.columns}
+
+    assert "repo_url" in columns
+    assert "commit_sha" in columns
+    assert "created_at" in columns
+    assert "blocked" in columns
+
+
+def test_finding_record_repr_includes_key_fields() -> None:
+    finding = FindingRecord(
+        scan_id=1,
+        scanner="semgrep",
+        severity="ERROR",
+        rule_id="rule.id",
+        message="Issue found",
+    )
+
+    result = repr(finding)
+
+    assert "scanner=semgrep" in result
+    assert "rule=rule.id" in result
+    assert "severity=ERROR" in result
+
+
+def test_finding_record_has_dedup_unique_constraint() -> None:
+    constraint_names = {constraint.name for constraint in FindingRecord.__table__.constraints if constraint.name}
+
+    assert "uq_finding_scan_dedup" in constraint_names

--- a/tests/unit/plugins/test_source_scanner/test_storage_repository.py
+++ b/tests/unit/plugins/test_source_scanner/test_storage_repository.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Location: tests/unit/plugins/test_source_scanner/test_storage_repository.py
+Copyright: 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Yaser
+"""
+
+# Standard
+from typing import Optional
+from unittest.mock import MagicMock, Mock
+
+# Third-Party
+import pytest
+
+# First-Party
+from plugins.source_scanner.storage.models import ScanRecord
+from plugins.source_scanner.storage.repository import ScanRepository
+from plugins.source_scanner.types import Finding
+
+
+@pytest.fixture
+def mock_db() -> MagicMock:
+    """Mock SQLAlchemy Session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def repository(mock_db: MagicMock) -> ScanRepository:
+    """Create ScanRepository with mocked database."""
+    return ScanRepository(mock_db)
+
+
+def _create_finding(
+    scanner: str = "semgrep",
+    severity: str = "ERROR",
+    rule_id: str = "rule.id",
+    message: str = "Issue found",
+    file_path: Optional[str] = "app.py",
+    line: Optional[int] = 10,
+) -> Finding:
+    """Helper to create Finding objects."""
+    return Finding(
+        scanner=scanner,
+        severity=severity,  # type: ignore[arg-type]
+        rule_id=rule_id,
+        message=message,
+        file_path=file_path,
+        line=line,
+    )
+
+
+class TestScanRepositoryCreateScan:
+    """Tests for create_scan method."""
+
+    def test_create_scan_with_findings(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test creating a scan record with findings."""
+        findings = [
+            _create_finding(severity="ERROR"),
+            _create_finding(severity="WARNING"),
+            _create_finding(severity="INFO"),
+        ]
+
+        # Mock the scan object returned after flush
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.query.return_value.filter.return_value.first.return_value = None  # type: ignore[attr-defined]
+        repository.db.flush = MagicMock(side_effect=lambda: setattr(mock_scan, "id", 1))
+
+        repository.create_scan(
+            repo_url="https://github.com/test/repo.git",
+            ref="main",
+            commit_sha="abc123def456",
+            languages=["python", "javascript"],
+            findings=findings,
+            blocked=False,
+            block_reason=None,
+        )
+
+        # Verify db.add was called for scan
+        assert isinstance(repository.db.add, MagicMock) and repository.db.add.call_count >= 1
+        # Verify db.commit was called
+        assert isinstance(repository.db.commit, MagicMock) and repository.db.commit.call_count >= 1
+
+    def test_create_scan_counts_severity(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test that create_scan correctly counts findings by severity."""
+        findings = [
+            _create_finding(severity="ERROR"),
+            _create_finding(severity="ERROR"),
+            _create_finding(severity="WARNING"),
+            _create_finding(severity="INFO"),
+            _create_finding(severity="INFO"),
+            _create_finding(severity="INFO"),
+        ]
+
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.flush = MagicMock(side_effect=lambda: setattr(mock_scan, "id", 1))
+
+        repository.create_scan(
+            repo_url="https://github.com/test/repo.git",
+            ref="main",
+            commit_sha="abc123def456",
+            languages=[],
+            findings=findings,
+            blocked=False,
+            block_reason=None,
+        )
+
+        # Verify ScanRecord was created with correct counts
+        assert isinstance(repository.db.add, MagicMock) and repository.db.add.call_count >= 1
+
+
+class TestScanRepositoryGetScan:
+    """Tests for get_scan_by_id method."""
+
+    def test_get_scan_by_id_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving scan by ID when it exists."""
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.query.return_value.filter.return_value.first.return_value = mock_scan  # type: ignore[attr-defined]
+
+        result = repository.get_scan_by_id(1)
+
+        assert result == mock_scan
+        repository.db.query.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_get_scan_by_id_not_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving scan by ID when it does not exist."""
+        repository.db.query.return_value.filter.return_value.first.return_value = None  # type: ignore[attr-defined]
+
+        result = repository.get_scan_by_id(999)
+
+        assert result is None
+
+
+class TestScanRepositoryGetFindings:
+    """Tests for get_findings_for_scan method."""
+
+    def test_get_findings_for_scan_sorted(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test that findings are sorted by severity and file_path."""
+        findings = [
+            Mock(severity="INFO", file_path="z.py"),
+            Mock(severity="ERROR", file_path="b.py"),
+            Mock(severity="WARNING", file_path="a.py"),
+        ]
+
+        repository.db.query.return_value.filter.return_value.all.return_value = findings  # type: ignore[attr-defined]
+
+        result = repository.get_findings_for_scan(1)
+
+        # Verify sorting: ERROR (0), WARNING (1), INFO (2)
+        assert result[0].severity == "ERROR"
+        assert result[1].severity == "WARNING"
+        assert result[2].severity == "INFO"
+
+    def test_get_findings_for_scan_empty(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test getting findings when scan has none."""
+        repository.db.query.return_value.filter.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        result = repository.get_findings_for_scan(1)
+
+        assert result == []
+
+
+class TestScanRepositoryGetLatestScan:
+    """Tests for get_latest_scan_for_commit method."""
+
+    def test_get_latest_scan_for_commit_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving latest scan for a commit."""
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.commit_sha = "abc123"
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_scan  # type: ignore[attr-defined]
+
+        result = repository.get_latest_scan_for_commit("https://github.com/test/repo", "abc123")
+
+        assert result == mock_scan
+
+    def test_get_latest_scan_for_commit_not_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving latest scan when none exists."""
+        repository.db.query.return_value.filter.return_value.order_by.return_value.first.return_value = None  # type: ignore[attr-defined]
+
+        result = repository.get_latest_scan_for_commit("https://github.com/test/repo", "abc123")
+
+        assert result is None
+
+
+class TestScanRepositoryGetScansForRepo:
+    """Tests for get_scans_for_repo method."""
+
+    def test_get_scans_for_repo_with_pagination(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving scans with pagination."""
+        mock_scans = [Mock(spec=ScanRecord) for _ in range(3)]
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = mock_scans  # type: ignore[attr-defined]
+
+        result = repository.get_scans_for_repo("https://github.com/test/repo", limit=10, offset=0)
+
+        assert len(result) == 3
+        assert result == mock_scans
+
+    def test_get_scans_for_repo_default_pagination(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test that default pagination limits to 10."""
+        repository.db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        repository.get_scans_for_repo("https://github.com/test/repo")
+
+        # Verify limit(10) was called with default
+        repository.db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.assert_called_with(10)  # type: ignore[attr-defined]
+
+
+class TestScanRepositoryGetFindingsBySeverity:
+    """Tests for get_findings_by_severity method."""
+
+    def test_get_findings_by_severity_error(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving ERROR-level findings."""
+        mock_findings = [Mock(severity="ERROR") for _ in range(2)]
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = mock_findings  # type: ignore[attr-defined]
+
+        result = repository.get_findings_by_severity(1, "ERROR")
+
+        assert len(result) == 2
+
+    def test_get_findings_by_severity_warning(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving WARNING-level findings."""
+        mock_findings = [Mock(severity="WARNING") for _ in range(1)]
+
+        repository.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = mock_findings  # type: ignore[attr-defined]
+
+        result = repository.get_findings_by_severity(1, "WARNING")
+
+        assert len(result) == 1
+
+    def test_get_findings_by_severity_empty(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test retrieving findings of specific severity when none exist."""
+        repository.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        result = repository.get_findings_by_severity(1, "ERROR")
+
+        assert result == []
+
+
+class TestScanRepositoryDeleteScan:
+    """Tests for delete_scan method."""
+
+    def test_delete_scan_success(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test deleting a scan that exists."""
+        mock_scan = Mock(spec=ScanRecord)
+        mock_scan.id = 1
+
+        repository.db.query.return_value.filter.return_value.first.return_value = mock_scan  # type: ignore[attr-defined]
+        repository.db.delete = MagicMock()  # type: ignore[attr-defined]
+        repository.db.commit = MagicMock()  # type: ignore[attr-defined]
+
+        result = repository.delete_scan(1)
+
+        assert result is True
+        repository.db.delete.assert_called_once_with(mock_scan)
+        repository.db.commit.assert_called()
+
+    def test_delete_scan_not_found(self, repository: ScanRepository, mock_db: MagicMock) -> None:
+        """Test deleting a scan that does not exist."""
+        repository.db.query.return_value.filter.return_value.first.return_value = None  # type: ignore[attr-defined]
+        repository.db.delete = MagicMock()  # type: ignore[attr-defined]
+
+        result = repository.delete_scan(999)
+
+        assert result is False
+        repository.db.delete.assert_not_called()


### PR DESCRIPTION
> **Note:** This PR was re-created from #2818 due to repository maintenance. Your code and branch are intact. @kukoyio please verify everything looks good.

## Issue
issue #2217 

## 📝 Summary
This PR updates the Source Scanner Plugin based on feedback from the previous draft PR and adds new functionality.

---

## Update/fixes
- Semgrep runner updated: uses utils.exec.run_command, replaced print() with logging, updated copyright headers to 2026.
- Addressed issues raised in review from the scaffold PR (sync/async alignment, subprocess safety, temp repo handling).

---

## New functionality
- LanguageDetector implemented for detecting repository languages.
- RepoFetcher implemented for cloning repositories in a reusable way.
- source_scanner.py added: contains the main plugin class and hooks (mostly commented code; will be uncommented as Bandit runner and other components are completed).

## Remaining / follow-up
- Bandit runner is nearly complete but still requires tweaks.
- Parsing/normalizer module is not yet finished.
- Tests for Bandit runner and language detection need to be completed.
- Full test coverage is not yet achieved (coverage currently ~42%).
- REPOSITORY_AVAILABLE = True still hardcoded, plan is for it to be dynamically determined
- Admin UI

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   passes     |
| Unit tests                | `make test`     |   passing for implemented files     | 
| Coverage ≥ 80%            | `make coverage` |    42%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---
