### PR TITLE
feat(security): add secrets generation CLI

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-08T05:43:22Z",
+  "generated_at": "2026-05-08T06:13:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -326,7 +326,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 493,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -334,7 +334,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 959,
+        "line_number": 961,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 961,
+        "line_number": 963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1613,
+        "line_number": 1615,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1828,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6264,
+        "line_number": 6266,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6761,
+        "line_number": 6763,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6773,
+        "line_number": 6775,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6845,
+        "line_number": 6847,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7926,
+        "line_number": 7928,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,9 @@ check-env-dev:
 	@echo "🔎  Validating .env (dev, warnings do not fail)..."
 	@python -c "import sys; from mcpgateway.scripts import validate_env as ve; sys.exit(ve.main(env_file='.env', exit_on_warnings=False))"
 
-
+.PHONY: init-secrets
+init-secrets: ## Generate secure secrets for the gateway (US-3)
+	python3 -m mcpgateway.scripts.init_secrets
 
 # =============================================================================
 # ▶️ SERVE

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/scripts/init_secrets.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Eleni Kechrioti
+
+Secrets Initialization Script.
+This script generates cryptographically secure secrets for JWT signing,
+encryption, and administrative passwords. It supports writing to a file,
+overwriting existing configurations, or piping to stdout.
+
+Usage:
+    python -m mcpgateway.scripts.init_secrets --output .env.secrets
+    python -m mcpgateway.scripts.init_secrets --stdout --force
+"""
+
+# Standard
+import argparse
+import os
+import secrets
+import sys
+
+
+def generate_token(nbytes: int) -> str:
+    """
+    Generate a cryptographically secure token.
+
+    Args:
+        nbytes (int): Number of bytes for the token generation.
+
+    Returns:
+        str: A URL-safe base64 encoded string.
+    """
+    return secrets.token_urlsafe(nbytes)
+
+
+def main() -> None:
+    """
+    Main entry point for the secrets generation CLI.
+
+    Parses arguments, generates required secrets for the Gateway,
+    and handles file I/O operations or stdout printing.
+    """
+    parser = argparse.ArgumentParser(description="Generate secure secrets for MCP Gateway deployment.")
+    parser.add_argument("--output", type=str, default=".env.secrets", help="Output file path")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing file if it exists")
+    parser.add_argument("--stdout", action="store_true", help="Print secrets to stdout instead of a file")
+
+    args = parser.parse_args()
+
+    # Define the required secrets and their byte lengths
+    # 32 bytes -> 43 chars (Keys), 18 bytes -> 24 chars (Passwords)
+    secrets_map = {
+        "JWT_SECRET_KEY": generate_token(32),
+        "AUTH_ENCRYPTION_SECRET": generate_token(32),
+        "BASIC_AUTH_PASSWORD": generate_token(18),
+        "PLATFORM_ADMIN_PASSWORD": generate_token(18),
+    }
+
+    output_lines = [f"{key}={val}" for key, val in secrets_map.items()]
+    output_content = "\n".join(output_lines) + "\n"
+
+    # Handle Standard Output
+    if args.stdout:
+        print(output_content, end="")
+        return
+
+    # Acceptance Criteria: Prevent accidental overwrite
+    if os.path.exists(args.output) and not args.force:
+        print("Error: File already exists")
+        print("Suggest using --force to overwrite")
+        sys.exit(1)
+
+    # File Writing
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write("# Generated via: python -m mcpgateway.scripts.init_secrets\n")
+            f.write(output_content)
+
+        print(f"Secrets written to {args.output}")
+        print("\nHow to use this file:")
+        print(f"1. Review the generated secrets in {args.output}")
+        print("2. Merge these into your production environment or .env file.")
+        print("3. IMPORTANT: Keep this file secure and never commit it to Git.")
+
+    except OSError as e:
+        print(f"Error: Could not write to file {args.output}: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -77,6 +77,9 @@ def main() -> None:
             f.write("# Generated via: python -m mcpgateway.scripts.init_secrets\n")
             f.write(output_content)
 
+        # Set restrictive permissions (read/write only for the owner)
+        os.chmod(args.output, 0o600)
+
         print(f"Secrets written to {args.output}")
         print("\nHow to use this file:")
         print(f"1. Review the generated secrets in {args.output}")

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -21,6 +21,45 @@ import secrets
 import sys
 
 
+def _secure_open_flags(force: bool) -> int:
+    """
+    Build secure file-open flags for writing generated secrets.
+
+    Args:
+        force: Whether an existing file may be overwritten.
+
+    Returns:
+        int: Flags suitable for os.open().
+    """
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_TRUNC if force else os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _write_secrets_file(output_path: str, output_content: str, force: bool) -> None:
+    """
+    Write generated secrets to a file with owner-only permissions from creation.
+
+    Args:
+        output_path: File path to write.
+        output_content: Generated environment content.
+        force: Whether an existing file may be overwritten.
+    """
+    fd = os.open(output_path, _secure_open_flags(force), 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        f = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with f:
+            f.write("# Generated via: python -m mcpgateway.scripts.init_secrets\n")
+            f.write(output_content)
+    except Exception:
+        if fd != -1:
+            os.close(fd)
+        raise
+
+
 def generate_token(nbytes: int) -> str:
     """
     Generate a cryptographically secure token.
@@ -65,20 +104,8 @@ def main() -> None:
         print(output_content, end="")
         return
 
-    # Acceptance Criteria: Prevent accidental overwrite
-    if os.path.exists(args.output) and not args.force:
-        print("Error: File already exists")
-        print("Suggest using --force to overwrite")
-        sys.exit(1)
-
-    # File Writing
     try:
-        with open(args.output, "w", encoding="utf-8") as f:
-            f.write("# Generated via: python -m mcpgateway.scripts.init_secrets\n")
-            f.write(output_content)
-
-        # Set restrictive permissions (read/write only for the owner)
-        os.chmod(args.output, 0o600)
+        _write_secrets_file(args.output, output_content, args.force)
 
         print(f"Secrets written to {args.output}")
         print("\nHow to use this file:")
@@ -86,6 +113,10 @@ def main() -> None:
         print("2. Merge these into your production environment or .env file.")
         print("3. IMPORTANT: Keep this file secure and never commit it to Git.")
 
+    except FileExistsError:
+        print("Error: File already exists")
+        print("Suggest using --force to overwrite")
+        sys.exit(1)
     except OSError as e:
         print(f"Error: Could not write to file {args.output}: {e}")
         sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,7 @@ Changelog = "https://github.com/IBM/mcp-context-forge/blob/main/CHANGELOG.md"
 mcpgateway = "mcpgateway.cli:main"
 mcpplugins = "cpex.tools.cli:main"
 cforge = "mcpgateway.tools.cli:main"
+init-secrets = "mcpgateway.scripts.init_secrets:main"
 
 # --------------------------------------------------------------------
 #  🔧 setuptools-specific configuration

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/scripts/test_init_secrets.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Eleni Kechrioti
+
+Unit tests for the secrets initialization script.
+This module verifies token generation entropy, CLI argument handling,
+file system interactions (creation/overwrite), and stdout output.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch, mock_open
+
+# Third-Party
+import pytest
+
+# Local
+from mcpgateway.scripts.init_secrets import generate_token, main
+
+
+def test_token_entropy_and_length() -> None:
+    """
+    Verify that tokens have the correct length and sufficient entropy.
+    
+    Checks:
+    - 32 bytes input results in 43 chars (URL-safe Base64).
+    - 18 bytes input results in 24 chars.
+    - Subsequent calls produce different values.
+    """
+    assert len(generate_token(32)) == 43
+    assert len(generate_token(18)) == 24
+    # Entropy check
+    assert generate_token(32) != generate_token(32)
+
+
+@patch("os.path.exists", return_value=False)
+@patch("argparse.ArgumentParser.parse_args")
+def test_file_creation(mock_args: MagicMock, mock_exists: MagicMock) -> None:
+    """
+    Verify that the secrets file is created when it does not exist.
+    
+    Ensures that 'open' is called with the correct path and 'w' mode
+    only within the script's namespace.
+    """
+    mock_args.return_value = patch(
+        "argparse.Namespace", output="test.env", force=False, stdout=False
+    ).start()
+    
+    m = mock_open()
+    # Patch only the open inside our script's namespace to avoid side effects
+    with patch("mcpgateway.scripts.init_secrets.open", m, create=True):
+        main()
+        m.assert_called_once_with("test.env", "w", encoding="utf-8")
+
+
+@patch("os.path.exists", return_value=True)
+@patch("argparse.ArgumentParser.parse_args")
+def test_file_exists_error(mock_args: MagicMock, mock_exists: MagicMock) -> None:
+    """
+    Verify that the command fails if the file already exists without --force.
+    
+    Expects a SystemExit with code 1.
+    """
+    mock_args.return_value = patch(
+        "argparse.Namespace", output=".env.secrets", force=False, stdout=False
+    ).start()
+    
+    with pytest.raises(SystemExit) as cm:
+        main()
+    assert cm.value.code == 1
+
+
+@patch("os.path.exists", return_value=True)
+@patch("argparse.ArgumentParser.parse_args")
+def test_force_behavior(mock_args: MagicMock, mock_exists: MagicMock) -> None:
+    """
+    Verify that --force allows overwriting an existing file.
+    
+    Ensures the file is opened for writing even if os.path.exists is True.
+    """
+    mock_args.return_value = patch(
+        "argparse.Namespace", output=".env.secrets", force=True, stdout=False
+    ).start()
+    
+    m = mock_open()
+    with patch("mcpgateway.scripts.init_secrets.open", m, create=True):
+        main()
+        m.assert_called_once_with(".env.secrets", "w", encoding="utf-8")
+
+
+@patch("builtins.print")
+@patch("os.path.exists", return_value=False)
+@patch("argparse.ArgumentParser.parse_args")
+def test_stdout_behavior(
+    mock_args: MagicMock, mock_exists: MagicMock, mock_print: MagicMock
+) -> None:
+    """
+    Verify that --stdout prints to console and bypasses file writing.
+    
+    Checks that the built-in open is never called when stdout is True.
+    """
+    mock_args.return_value = patch(
+        "argparse.Namespace", output=".env.secrets", force=False, stdout=True
+    ).start()
+    
+    with patch("mcpgateway.scripts.init_secrets.open", mock_open()) as mocked_file:
+        main()
+        mocked_file.assert_not_called()
+        # Verify that output was directed to print
+        assert mock_print.called

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -11,12 +11,14 @@ file system interactions (creation/overwrite), and stdout output.
 
 # Standard
 import argparse
-from unittest.mock import MagicMock, patch, mock_open
+from pathlib import Path
+import stat
+from unittest.mock import MagicMock, patch
 
 # Third-Party
 import pytest
 
-# Local
+# First-Party
 from mcpgateway.scripts.init_secrets import generate_token, main
 
 
@@ -36,76 +38,84 @@ def test_token_entropy_and_length() -> None:
 
 
 @patch("os.chmod")
-@patch("os.path.exists", return_value=False)
 @patch("argparse.ArgumentParser.parse_args")
-def test_file_creation(mock_args: MagicMock, mock_exists: MagicMock, mock_chmod: MagicMock) -> None:
-
+def test_file_creation(mock_args: MagicMock, mock_chmod: MagicMock, tmp_path: Path) -> None:
     """Verify that the secrets file is created and permissions are set."""
-    mock_args.return_value = argparse.Namespace(
-        output="test.env", force=False, stdout=False
-    )
-    
-    m = mock_open()
-    with patch("mcpgateway.scripts.init_secrets.open", m, create=True):
-        main()
-        # Verify file was opened correctly
-        m.assert_called_once_with("test.env", "w", encoding="utf-8")
-        # Verify chmod was called with the right path and mode
-        mock_chmod.assert_called_once_with("test.env", 0o600)
+    output_path = tmp_path / "test.env"
+    mock_args.return_value = argparse.Namespace(output=str(output_path), force=False, stdout=False)
+
+    main()
+
+    assert output_path.exists()
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
+    assert "JWT_SECRET_KEY=" in output_path.read_text(encoding="utf-8")
+    mock_chmod.assert_not_called()
 
 
-@patch("os.path.exists", return_value=True)
+@patch("os.close")
+@patch("os.fchmod", side_effect=OSError("permission update failed"))
+@patch("os.open", return_value=123)
 @patch("argparse.ArgumentParser.parse_args")
-def test_file_exists_error(mock_args: MagicMock, mock_exists: MagicMock) -> None:
+def test_write_failure_closes_fd(mock_args: MagicMock, mock_open: MagicMock, mock_fchmod: MagicMock, mock_close: MagicMock) -> None:
+    """Verify that a failed secure write closes the raw file descriptor."""
+    mock_args.return_value = argparse.Namespace(output="test.env", force=False, stdout=False)
+
+    with pytest.raises(SystemExit) as cm:
+        main()
+
+    assert cm.value.code == 1
+    mock_open.assert_called_once()
+    mock_fchmod.assert_called_once_with(123, 0o600)
+    mock_close.assert_called_once_with(123)
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_file_exists_error(mock_args: MagicMock, tmp_path: Path) -> None:
     """
     Verify that the command fails if the file already exists without --force.
 
     Expects a SystemExit with code 1.
     """
-    mock_args.return_value = argparse.Namespace(
-        output=".env.secrets", force=False, stdout=False
-    )
+    output_path = tmp_path / ".env.secrets"
+    output_path.write_text("existing=true\n", encoding="utf-8")
+    mock_args.return_value = argparse.Namespace(output=str(output_path), force=False, stdout=False)
 
     with pytest.raises(SystemExit) as cm:
         main()
     assert cm.value.code == 1
+    assert output_path.read_text(encoding="utf-8") == "existing=true\n"
 
 
-@patch("os.path.exists", return_value=True)
 @patch("argparse.ArgumentParser.parse_args")
-def test_force_behavior(mock_args: MagicMock, mock_exists: MagicMock) -> None:
+def test_force_behavior(mock_args: MagicMock, tmp_path: Path) -> None:
     """
     Verify that --force allows overwriting an existing file.
 
     Ensures the file is opened for writing even if os.path.exists is True.
     """
-    mock_args.return_value = argparse.Namespace(
-        output=".env.secrets", force=True, stdout=False
-    )
+    output_path = tmp_path / ".env.secrets"
+    output_path.write_text("existing=true\n", encoding="utf-8")
+    mock_args.return_value = argparse.Namespace(output=str(output_path), force=True, stdout=False)
 
-    m = mock_open()
-    with patch("mcpgateway.scripts.init_secrets.open", m, create=True):
-        main()
-        m.assert_called_once_with(".env.secrets", "w", encoding="utf-8")
+    main()
+
+    content = output_path.read_text(encoding="utf-8")
+    assert "existing=true" not in content
+    assert "AUTH_ENCRYPTION_SECRET=" in content
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
 
 
 @patch("builtins.print")
-@patch("os.path.exists", return_value=False)
 @patch("argparse.ArgumentParser.parse_args")
-def test_stdout_behavior(
-    mock_args: MagicMock, mock_exists: MagicMock, mock_print: MagicMock
-) -> None:
+def test_stdout_behavior(mock_args: MagicMock, mock_print: MagicMock) -> None:
     """
     Verify that --stdout prints to console and bypasses file writing.
 
     Checks that the built-in open is never called when stdout is True.
     """
-    mock_args.return_value = argparse.Namespace(
-        output=".env.secrets", force=False, stdout=True
-    )
+    mock_args.return_value = argparse.Namespace(output=".env.secrets", force=False, stdout=True)
 
-    with patch("mcpgateway.scripts.init_secrets.open", mock_open()) as mocked_file:
-        main()
-        mocked_file.assert_not_called()
-        # Verify that output was directed to print
-        assert mock_print.called
+    main()
+
+    mock_print.assert_called_once()
+    assert "JWT_SECRET_KEY=" in mock_print.call_args.args[0]


### PR DESCRIPTION
> **Note:** This PR was re-created from #2825 due to repository maintenance. Your code and branch are intact. @EleniKechrioti please verify everything looks good.

## Related Issue
Partially addresses #2595 . Implements US-3 (Secrets Generation CLI).

---

## Summary
This PR completes Phase 3 of the security epic by implementing the Secrets Generation CLI tool. It satisfies all acceptance criteria for US-3, providing a secure way for developers to bootstrap their production configurations.

---

##  Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | PASS   |
| Unit tests                | `make test`     | PASS   |
| Coverage ≥ 90%            | `make coverage` | PASS   |

---

## Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## Notes (optional)
Implemented with a focus on cryptographic security using the `secrets` module. 
The test suite includes 5 unit tests covering file creation, entropy, and CLI flags (`--force`, `--stdout`).
Verified in an isolated environment to bypass local dependency issues.