### PR TITLE
feat(security): implement environment-aware defaults and fail-closed secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3182,7 +3182,7 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # Defaults to TRUE if ENVIRONMENT=production.
 # If set to true, the gateway will FAIL TO START if critical secrets are weak or missing.
 # Set to false only for local testing. NOT RECOMMENDED for production!
-REQUIRE_STRONG_SECRETS=true
+# REQUIRE_STRONG_SECRETS=true
 
 # =============================================================================
 # ToolOps Configuration

--- a/.env.example
+++ b/.env.example
@@ -3171,14 +3171,14 @@ PLUGINS_CLI_MARKUP_MODE=rich
 
 # ------------------------------------------------------------------------------
 # SECURITY-CRITICAL: Values below MUST be changed for production deployments!
-# Defaults are for LOCAL DEVELOPMENT ONLY. Using defaults in production 
+# Defaults are for LOCAL DEVELOPMENT ONLY. Using defaults in production
 # exposes your deployment to full compromise.
 #
 # Generate secure keys using: python -m mcpgateway.scripts.init_secrets
 # Manual fallback: python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
 # ------------------------------------------------------------------------------
 
-# REQUIRE_STRONG_SECRETS: 
+# REQUIRE_STRONG_SECRETS:
 # Defaults to TRUE if ENVIRONMENT=production.
 # If set to true, the gateway will FAIL TO START if critical secrets are weak or missing.
 # Set to false only for local testing. NOT RECOMMENDED for production!

--- a/.env.example
+++ b/.env.example
@@ -3169,14 +3169,20 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # Minimum length for passwords
 # MIN_PASSWORD_LENGTH=12
 
-# Enforce strong secrets (set to true to fail startup on critical issues)
-# Default is false to maintain backward compatibility
-# REQUIRE_STRONG_SECRETS=false
+# ------------------------------------------------------------------------------
+# SECURITY-CRITICAL: Values below MUST be changed for production deployments!
+# Defaults are for LOCAL DEVELOPMENT ONLY. Using defaults in production 
+# exposes your deployment to full compromise.
+#
+# Generate secure keys using: python -m mcpgateway.scripts.init_secrets
+# Manual fallback: python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+# ------------------------------------------------------------------------------
 
-# Security validation thresholds
-# Set to false to allow startup with security warnings
-# NOT RECOMMENDED for production!
-# REQUIRE_STRONG_SECRETS=false
+# REQUIRE_STRONG_SECRETS: 
+# Defaults to TRUE if ENVIRONMENT=production.
+# If set to true, the gateway will FAIL TO START if critical secrets are weak or missing.
+# Set to false only for local testing. NOT RECOMMENDED for production!
+REQUIRE_STRONG_SECRETS=true
 
 # =============================================================================
 # ToolOps Configuration

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-08T06:13:38Z",
+  "generated_at": "2026-05-08T06:46:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -250,7 +250,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1064,
+        "line_number": 1077,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1152,
+        "line_number": 1165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1502,
+        "line_number": 1515,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2868,
+        "line_number": 2881,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2959,
+        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3002,
+        "line_number": 3015,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3007,
+        "line_number": 3020,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3012,
+        "line_number": 3025,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2364,7 +2364,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2372,7 +2372,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 426,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2380,7 +2380,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 792,
+        "line_number": 793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2388,7 +2388,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1209,
+        "line_number": 1210,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2396,7 +2396,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1213,
+        "line_number": 1214,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4934,7 +4934,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 228,
+        "line_number": 250,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4942,7 +4942,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2613,
+        "line_number": 2763,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@
 
 ---
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **Environment-Aware Security Defaults** – `REQUIRE_STRONG_SECRETS` now defaults to `true` when `ENVIRONMENT=production`. Production deployments using default or weak secrets will now fail to start by default to ensure a "fail-safe" state.
+
+### Changed
+
+- **Audit Logging** – Added explicit audit-friendly logging when `REQUIRE_STRONG_SECRETS=false` is used as an override in production environments.
+- **Configuration Documentation** – Updated `.env.example` to document the new environment-aware default behavior and security enforcement logic.
+
+---
+
 ## [1.0.0] - 2026-04-30 - General Availability - Technical Debt, Security Hardening, Catalog Improvements, A2A Improvements, MCP Standard Review and Sync
 
 ### Overview

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -33,6 +33,7 @@ These settings are enabled by default for security—only disable for backward c
 | `REQUIRE_TOKEN_EXPIRATION` | Require exp claim in tokens | `true` |
 | `PUBLIC_REGISTRATION_ENABLED` | Allow public user self-registration | `false` |
 | `PROTECT_ALL_ADMINS` | Prevent any admin from being demoted or deactivated via API/UI | `true` |
+|`REQUIRE_STRONG_SECRETS`|Enforces strong secret validation. Automatically defaults to true in production to ensure fail-safe deployments.|`true` (prod) / `false` (dev)|
 
 ### ⚙️ Project Defaults (Dev Setup)
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2,7 +2,7 @@
 """Location: ./mcpgateway/config.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti, Manav Gupta
+Authors: Mihai Criveti, Manav Gupta, Eleni Kechrioti
 
 ContextForge AI Gateway Configuration.
 This module defines configuration settings for ContextForge AI Gateway using Pydantic.
@@ -1005,6 +1005,10 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Values used to detect unconfigured or insecure deployment states
+    SENTINEL_VALUES: ClassVar[list[str]] = ["", "UNCONFIGURED"]
+    WEAK_VALUES: ClassVar[list[str]] = ["my-test-key", "my-test-salt", "changeme", "secret", "password"]
+
     # database-backed polling settings for session message delivery
     poll_interval: float = Field(default=1.0, description="Initial polling interval in seconds for checking new session messages")
     max_interval: float = Field(default=5.0, description="Maximum polling interval in seconds when the session is idle")
@@ -1269,6 +1273,10 @@ class Settings(BaseSettings):
     class SecurityStatus(TypedDict):
         """TypedDict for comprehensive security status."""
 
+        status: str  # SUCCESS, FAIL, or WARN
+        code: Optional[str]  # e.g., ERR_MISSING_CONFIG
+        message: str
+        remediation: Optional[str]  # Instructions to fix the issue
         secure_secrets: bool
         auth_enabled: bool
         ssl_verification: bool
@@ -1279,18 +1287,40 @@ class Settings(BaseSettings):
         security_score: int
 
     def get_security_status(self) -> SecurityStatus:
-        """Get comprehensive security status.
+        """Get comprehensive security status and enforces fail-closed logic in production.
 
         Returns:
             SecurityStatus: Dictionary containing security status information including score and warnings.
         """
 
+        is_prod = self.environment == "production"
+        remediation_cmd = "Run 'python3 -m mcpgateway.scripts.init_secrets' to generate secure keys."
+
+        # Evaluate specific critical secrets
+        critical_secrets = {"JWT_SECRET_KEY": self.jwt_secret_key.get_secret_value(), "AUTH_ENCRYPTION_SECRET": self.auth_encryption_secret.get_secret_value()}
+
+        for name, value in critical_secrets.items():
+            # Check for empty or "UNCONFIGURED" values
+            if value in self.SENTINEL_VALUES:
+                error_msg = f"{name} is not configured. Running with default or empty values in production is prohibited as it leaves the gateway unprotected."
+                if is_prod:
+                    return self._build_security_response("FAIL", "ERR_MISSING_CONFIG", error_msg, remediation_cmd)
+
+            # Check for known weak values
+            if self.require_strong_secrets and value in self.WEAK_VALUES:
+                error_msg = f"Weak {name} detected. Using default values in production exposes the gateway to unauthorized access."
+                if is_prod:
+                    return self._build_security_response("FAIL", "ERR_WEAK_SECRET", error_msg, remediation_cmd)
+
         # Compute a security score: 100 minus 10 for each warning
         security_score = max(0, 100 - 10 * len(self.get_security_warnings()))
 
         return {
-            "secure_secrets": (self.jwt_secret_key.get_secret_value() if isinstance(self.jwt_secret_key, SecretStr) else self.jwt_secret_key)
-            not in ("my-test-key", "my-test-key-but-now-longer-than-32-bytes"),  # nosec B105 - checking for default values
+            "status": "SUCCESS",
+            "code": None,
+            "message": "Security validation passed.",
+            "remediation": None,
+            "secure_secrets": self.jwt_secret_key.get_secret_value() not in self.WEAK_VALUES,
             "auth_enabled": self.auth_required,
             "ssl_verification": not self.skip_ssl_verify,
             "debug_disabled": not self.debug,
@@ -1298,6 +1328,39 @@ class Settings(BaseSettings):
             "ui_protected": not self.mcpgateway_ui_enabled or self.auth_required,
             "warnings": self.get_security_warnings(),
             "security_score": security_score,
+        }
+
+    def log_critical_issues(self, status: SecurityStatus) -> None:
+        """
+        Logs critical security issues and provides remediation steps.
+        """
+        if status["status"] == "FAIL":
+            # [Requirement]: Explain specific risk
+            logger.critical(f"[SECURITY FATAL] {status['message']}")
+
+            # [Requirement]: Include generation command
+            if status["remediation"]:
+                logger.info(f"REMEDIATION: {status['remediation']}")
+
+            # [Requirement]: Reference documentation
+            logger.info("REFERENCE: For full security configuration guide, see: https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/operations/config-validation.md")
+
+    def _build_security_response(self, status: str, code: str, msg: str, remediation: str) -> SecurityStatus:
+        """Helper to build a failure response for get_security_status."""
+        logger.error(f"[{code}] CRITICAL SECURITY ISSUE: {msg}")
+        return {
+            "status": status,
+            "code": code,
+            "message": f"{msg} (Code: {code})",
+            "remediation": remediation,
+            "secure_secrets": False,
+            "auth_enabled": self.auth_required,
+            "ssl_verification": not self.skip_ssl_verify,
+            "debug_disabled": not self.debug,
+            "cors_restricted": False,
+            "ui_protected": False,
+            "warnings": [msg],
+            "security_score": 0,
         }
 
     # Max retries for HTTP requests
@@ -3085,6 +3148,17 @@ def get_settings(**kwargs: Any) -> Settings:
     cfg.validate_transport()
     # Ensure sqlite DB directories exist if needed.
     cfg.validate_database()
+    # Get the status (SUCCESS/FAIL) based on sentinel and weak values
+    security_status = cfg.get_security_status()
+
+    if security_status["status"] == "FAIL":
+        # Log the critical issues (remediation, risk, documentation)
+        cfg.log_critical_issues(security_status)
+
+        # Fail-Closed ONLY in production
+        if cfg.environment == "production":
+            logger.error("FAIL-CLOSED: Gateway startup aborted due to critical security risks.")
+            sys.exit(1)
     # Return the one-and-only Settings instance (cached).
     return cfg
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -162,17 +162,6 @@ UI_HIDE_SECTION_ALIASES = {
 }
 
 
-def get_default_require_strong_secrets() -> bool:
-    """
-    Dynamically determine the default for REQUIRE_STRONG_SECRETS.
-    Returns True if ENVIRONMENT is 'production', otherwise False.
-
-    Returns:
-        bool: True if ENVIRONMENT is 'production', otherwise False.
-    """
-    return os.getenv("ENVIRONMENT", "development").lower() == "production"
-
-
 class SecurityConfigurationError(Exception):
     """Exception for critical security configuration issues."""
     pass
@@ -1015,7 +1004,7 @@ class Settings(BaseSettings):
     min_secret_length: int = 32
     min_password_length: int = 12
     require_strong_secrets: bool = Field(
-        default_factory=get_default_require_strong_secrets,
+        default=False,
         description="Enforces strong secret validation. Defaults to True in production, False in development for ease of testing. When enabled, secrets are checked against a list of weak values and must meet minimum length and entropy requirements.",
     )
 
@@ -1044,14 +1033,34 @@ class Settings(BaseSettings):
     # Values used to detect unconfigured or insecure deployment states
     SENTINEL_VALUES: ClassVar[list[str]] = ["", "UNCONFIGURED"]
     WEAK_VALUES: ClassVar[list[str]] = [
-        "my-test-key", "my-test-salt", "changeme", "secret", "password",
-        "test-secret", "my-secret", "12345678"
+        "my-test-key",
+        "my-test-key-but-now-longer-than-32-bytes",
+        "my-test-salt",
+        "changeme",
+        "secret",
+        "password",
+        "test-secret",
+        "my-secret",
+        "12345678",
     ]
 
     # database-backed polling settings for session message delivery
     poll_interval: float = Field(default=1.0, description="Initial polling interval in seconds for checking new session messages")
     max_interval: float = Field(default=5.0, description="Maximum polling interval in seconds when the session is idle")
     backoff_factor: float = Field(default=1.5, description="Multiplier used to gradually increase the polling interval during inactivity")
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_environment_aware_defaults(cls, data: Any) -> Any:
+        """Apply defaults that depend on other settings values."""
+        if not isinstance(data, dict):
+            return data
+
+        values: dict[str, Any] = dict(data)
+        if "require_strong_secrets" not in values:
+            environment = str(values.get("environment", "development")).lower()
+            values["require_strong_secrets"] = environment == "production"
+        return values
 
     # redis configurations for Maintaining Chat Sessions in multi-worker environment
     llmchat_session_ttl: int = Field(default=300, description="Seconds for active_session key TTL")
@@ -1332,6 +1341,22 @@ class Settings(BaseSettings):
             SecurityStatus: Dictionary containing security status information including score and warnings.
         """
 
+        if self.client_mode:
+            return {
+                "status": "SUCCESS",
+                "code": None,
+                "message": "Security validation skipped in client mode.",
+                "remediation": None,
+                "secure_secrets": True,
+                "auth_enabled": self.auth_required,
+                "ssl_verification": not self.skip_ssl_verify,
+                "debug_disabled": not self.debug,
+                "cors_restricted": "*" not in self.allowed_origins if self.cors_enabled else True,
+                "ui_protected": not self.mcpgateway_ui_enabled or self.auth_required,
+                "warnings": [],
+                "security_score": 100,
+            }
+
         is_prod = self.environment == "production"
         remediation_cmd = "Run 'python3 -m mcpgateway.scripts.init_secrets' to generate secure keys."
 
@@ -1343,7 +1368,7 @@ class Settings(BaseSettings):
         }
 
         for name, value in critical_secrets.items():
-            if name == "BASIC_AUTH_PASSWORD" and not self.mcpgateway_ui_enabled:
+            if name == "BASIC_AUTH_PASSWORD" and not (self.mcpgateway_ui_enabled or self.api_allow_basic_auth or self.docs_allow_basic_auth):
                 continue
             is_sentinel = value in self.SENTINEL_VALUES
             is_weak = value.lower() in self.WEAK_VALUES or calculate_entropy(value) < 3.5
@@ -1358,10 +1383,7 @@ class Settings(BaseSettings):
             # Check for known weak values
             if self.require_strong_secrets and is_weak:
                 error_msg = f"Weak {name} detected. Using default values in production exposes the gateway to unauthorized access."
-                if is_prod:
-                    return self._build_security_response("FAIL", "ERR_WEAK_SECRET", error_msg, remediation_cmd)
-                else:
-                    logger.warning(f"DEV WARNING: {error_msg} {remediation_cmd}")
+                return self._build_security_response("FAIL", "ERR_WEAK_SECRET", error_msg, remediation_cmd)
 
         # Compute a security score: 100 minus 10 for each warning
         security_score = max(0, 100 - 10 * len(self.get_security_warnings()))

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -164,7 +164,6 @@ UI_HIDE_SECTION_ALIASES = {
 
 class SecurityConfigurationError(Exception):
     """Exception for critical security configuration issues."""
-    pass
 
 
 def calculate_entropy(text: str) -> float:
@@ -1377,8 +1376,7 @@ class Settings(BaseSettings):
                 error_msg = f"{name} is not configured. Running with default or empty values in production is prohibited as it leaves the gateway unprotected."
                 if is_prod:
                     return self._build_security_response("FAIL", "ERR_MISSING_CONFIG", error_msg, remediation_cmd)
-                else:
-                    logger.warning(f"DEV WARNING: {error_msg} {remediation_cmd}")
+                logger.warning(f"DEV WARNING: {error_msg} {remediation_cmd}")
 
             # Check for known weak values
             if self.require_strong_secrets and is_weak:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -161,6 +161,15 @@ UI_HIDE_SECTION_ALIASES = {
 }
 
 
+def get_default_require_strong_secrets() -> bool:
+    """
+    Dynamically determine the default for REQUIRE_STRONG_SECRETS.
+    Returns True if ENVIRONMENT is 'production', otherwise False.
+    Required by US-1 for environment-aware security enforcement.
+    """
+    return os.getenv("ENVIRONMENT", "development").lower() == "production"
+
+
 class Settings(BaseSettings):
     """
     ContextForge AI Gateway configuration settings.
@@ -981,7 +990,10 @@ class Settings(BaseSettings):
     # Security validation thresholds
     min_secret_length: int = 32
     min_password_length: int = 12
-    require_strong_secrets: bool = False  # Default to False for backward compatibility, will be enforced in 1.0.0
+    require_strong_secrets: bool = Field(
+        default_factory=get_default_require_strong_secrets,
+        description="Enforces strong secret validation. Defaults to True in production, False in development for ease of testing. When enabled, secrets are checked against a list of weak values and must meet minimum length and entropy requirements.",
+    )
 
     llmchat_enabled: bool = Field(default=True, description="Enable LLM Chat feature")
     mcpgateway_stdio_transport_enabled: bool = Field(

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -51,6 +51,7 @@ Examples:
 from functools import lru_cache
 from importlib.resources import files
 import logging
+import math
 import os
 from pathlib import Path
 import re
@@ -165,9 +166,32 @@ def get_default_require_strong_secrets() -> bool:
     """
     Dynamically determine the default for REQUIRE_STRONG_SECRETS.
     Returns True if ENVIRONMENT is 'production', otherwise False.
-    Required by US-1 for environment-aware security enforcement.
+
+    Returns:
+        bool: True if ENVIRONMENT is 'production', otherwise False.
     """
     return os.getenv("ENVIRONMENT", "development").lower() == "production"
+
+
+class SecurityConfigurationError(Exception):
+    """Exception for critical security configuration issues."""
+    pass
+
+
+def calculate_entropy(text: str) -> float:
+    """
+        Calculate Shannon entropy to detect low-randomness secrets.
+
+        Args:
+            text (str): The secret string to evaluate.
+
+        Returns:
+            float: The calculated entropy score.
+        """
+    if not text:
+        return 0.0
+    probabilities = [text.count(c) / len(text) for c in set(text)]
+    return -sum(p * math.log2(p) for p in probabilities)
 
 
 class Settings(BaseSettings):
@@ -1019,7 +1043,10 @@ class Settings(BaseSettings):
 
     # Values used to detect unconfigured or insecure deployment states
     SENTINEL_VALUES: ClassVar[list[str]] = ["", "UNCONFIGURED"]
-    WEAK_VALUES: ClassVar[list[str]] = ["my-test-key", "my-test-salt", "changeme", "secret", "password"]
+    WEAK_VALUES: ClassVar[list[str]] = [
+        "my-test-key", "my-test-salt", "changeme", "secret", "password",
+        "test-secret", "my-secret", "12345678"
+    ]
 
     # database-backed polling settings for session message delivery
     poll_interval: float = Field(default=1.0, description="Initial polling interval in seconds for checking new session messages")
@@ -1309,20 +1336,32 @@ class Settings(BaseSettings):
         remediation_cmd = "Run 'python3 -m mcpgateway.scripts.init_secrets' to generate secure keys."
 
         # Evaluate specific critical secrets
-        critical_secrets = {"JWT_SECRET_KEY": self.jwt_secret_key.get_secret_value(), "AUTH_ENCRYPTION_SECRET": self.auth_encryption_secret.get_secret_value()}
+        critical_secrets = {
+            "JWT_SECRET_KEY": self.jwt_secret_key.get_secret_value(),
+            "AUTH_ENCRYPTION_SECRET": self.auth_encryption_secret.get_secret_value(),
+            "BASIC_AUTH_PASSWORD": self.basic_auth_password.get_secret_value()
+        }
 
         for name, value in critical_secrets.items():
+            if name == "BASIC_AUTH_PASSWORD" and not self.mcpgateway_ui_enabled:
+                continue
+            is_sentinel = value in self.SENTINEL_VALUES
+            is_weak = value.lower() in self.WEAK_VALUES or calculate_entropy(value) < 3.5
             # Check for empty or "UNCONFIGURED" values
-            if value in self.SENTINEL_VALUES:
+            if is_sentinel:
                 error_msg = f"{name} is not configured. Running with default or empty values in production is prohibited as it leaves the gateway unprotected."
                 if is_prod:
                     return self._build_security_response("FAIL", "ERR_MISSING_CONFIG", error_msg, remediation_cmd)
+                else:
+                    logger.warning(f"DEV WARNING: {error_msg} {remediation_cmd}")
 
             # Check for known weak values
-            if self.require_strong_secrets and value in self.WEAK_VALUES:
+            if self.require_strong_secrets and is_weak:
                 error_msg = f"Weak {name} detected. Using default values in production exposes the gateway to unauthorized access."
                 if is_prod:
                     return self._build_security_response("FAIL", "ERR_WEAK_SECRET", error_msg, remediation_cmd)
+                else:
+                    logger.warning(f"DEV WARNING: {error_msg} {remediation_cmd}")
 
         # Compute a security score: 100 minus 10 for each warning
         security_score = max(0, 100 - 10 * len(self.get_security_warnings()))
@@ -1345,6 +1384,9 @@ class Settings(BaseSettings):
     def log_critical_issues(self, status: SecurityStatus) -> None:
         """
         Logs critical security issues and provides remediation steps.
+
+        Args:
+            status (SecurityStatus): The security status dictionary to log.
         """
         if status["status"] == "FAIL":
             # [Requirement]: Explain specific risk
@@ -1358,7 +1400,18 @@ class Settings(BaseSettings):
             logger.info("REFERENCE: For full security configuration guide, see: https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/operations/config-validation.md")
 
     def _build_security_response(self, status: str, code: str, msg: str, remediation: str) -> SecurityStatus:
-        """Helper to build a failure response for get_security_status."""
+        """
+        Helper to build a failure response for get_security_status.
+
+        Args:
+            status (str): The overall security status (e.g., "FAIL").
+            code (str): The specific error code.
+            msg (str): The error description.
+            remediation (str): The suggested fix for the user.
+
+        Returns:
+            SecurityStatus: A dictionary containing the structured security response.
+        """
         logger.error(f"[{code}] CRITICAL SECURITY ISSUE: {msg}")
         return {
             "status": status,
@@ -3143,6 +3196,9 @@ def get_settings(**kwargs: Any) -> Settings:
     Returns:
         Settings: A cached instance of the Settings class.
 
+    Raises:
+        SecurityConfigurationError: If critical security checks fail in production.
+
     Examples:
         >>> settings = get_settings()
         >>> isinstance(settings, Settings)
@@ -3166,11 +3222,7 @@ def get_settings(**kwargs: Any) -> Settings:
     if security_status["status"] == "FAIL":
         # Log the critical issues (remediation, risk, documentation)
         cfg.log_critical_issues(security_status)
-
-        # Fail-Closed ONLY in production
-        if cfg.environment == "production":
-            logger.error("FAIL-CLOSED: Gateway startup aborted due to critical security risks.")
-            sys.exit(1)
+        raise SecurityConfigurationError(security_status["message"])
     # Return the one-and-only Settings instance (cached).
     return cfg
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3,7 +3,7 @@
 """Location: ./mcpgateway/main.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
+Authors: Mihai Criveti, Eleni Kechrioti
 
 ContextForge AI Gateway - Main FastAPI Application.
 
@@ -90,7 +90,7 @@ from mcpgateway.common.models import InitializeResult
 from mcpgateway.common.models import JSONRPCError as PydanticJSONRPCError
 from mcpgateway.common.models import ListResourceTemplatesResult, LogLevel, Root
 from mcpgateway.common.validators import SecurityValidator
-from mcpgateway.config import settings
+from mcpgateway.config import get_settings, SecurityConfigurationError, settings
 from mcpgateway.db import A2AAgent as DbA2AAgent
 from mcpgateway.db import A2APushNotificationConfig
 from mcpgateway.db import A2ATask as DbA2ATask
@@ -1843,62 +1843,58 @@ def validate_security_configuration():
      Raises: Passthrough Errors/Exceptions but doesn't raise any of its own.
     """
     logger.info("🔒 Validating security configuration...")
+    try:
+        current_settings = get_settings()
+        # Get security status
+        security_status: settings.SecurityStatus = current_settings.get_security_status()
+        security_warnings = security_status["warnings"]
 
-    # Get security status
-    security_status: settings.SecurityStatus = settings.get_security_status()
-    security_warnings = security_status["warnings"]
+        log_security_warnings(security_warnings)
 
-    log_security_warnings(security_warnings)
+        # Warn about ephemeral storage without strict user-in-DB mode
+        if not getattr(current_settings, "require_user_in_db", False):
+            is_ephemeral = ":memory:" in settings.database_url or settings.database_url == "sqlite:///./mcp.db"
+            if is_ephemeral:
+                logger.warning("Using potentially ephemeral storage with platform admin bootstrap enabled. Consider using persistent storage or setting REQUIRE_USER_IN_DB=true for production.")
 
-    # Critical security checks (fail startup only if REQUIRE_STRONG_SECRETS=true)
-    critical_issues = []
+        # Warn about default JWT issuer/audience in non-development environments
+        if current_settings.environment != "development":
+            if current_settings.jwt_issuer == "mcpgateway":
+                logger.warning("Using default JWT_ISSUER in %s environment. Set a unique JWT_ISSUER per environment to prevent cross-environment token acceptance.", settings.environment)
+            if current_settings.jwt_audience == "mcpgateway-api":
+                logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", settings.environment)
 
-    if settings.jwt_secret_key in ("my-test-key", "my-test-key-but-now-longer-than-32-bytes") and not settings.dev_mode:  # nosec B105 - checking for default values
-        critical_issues.append("Using default JWT secret in non-dev mode. Set JWT_SECRET_KEY environment variable!")
+        # UAID Cross-Gateway Routing Security Check
+        if not current_settings.uaid_allowed_domains:
+            if not current_settings.auth_required:
+                logger.error(
+                    "⚠️  INSECURE CONFIGURATION: UAID_ALLOWED_DOMAINS is empty AND AUTH_REQUIRED=false. "
+                    "Cross-gateway routing is enabled without domain restrictions or authentication. "
+                    "This allows UAID-based agents to route to ANY remote gateway without validation. "
+                    "STRONGLY RECOMMENDED: Set UAID_ALLOWED_DOMAINS to restrict routing to trusted domains only."
+                )
+            else:
+                logger.warning(
+                    "⚠️  UAID_ALLOWED_DOMAINS is empty - cross-gateway routing allows ALL domains. "
+                    "Any UAID-based agent can route to any remote gateway endpoint. "
+                    "RECOMMENDED: Configure UAID_ALLOWED_DOMAINS to restrict routing to trusted gateways only. "
+                    'Example: UAID_ALLOWED_DOMAINS=["trusted-gateway.example.com", "partner.org"]'
+                )
 
-    if settings.basic_auth_password.get_secret_value() == "changeme" and settings.mcpgateway_ui_enabled:  # nosec B105 - checking for default value
-        critical_issues.append("Admin UI enabled with default password. Set BASIC_AUTH_PASSWORD environment variable!")
-
-    log_critical_issues(critical_issues)
-
-    # UAID Cross-Gateway Routing Security Check
-    if not settings.uaid_allowed_domains:
-        if not settings.auth_required:
-            logger.error(
-                "⚠️  INSECURE CONFIGURATION: UAID_ALLOWED_DOMAINS is empty AND AUTH_REQUIRED=false. "
-                "Cross-gateway routing is enabled without domain restrictions or authentication. "
-                "This allows UAID-based agents to route to ANY remote gateway without validation. "
-                "STRONGLY RECOMMENDED: Set UAID_ALLOWED_DOMAINS to restrict routing to trusted domains only."
-            )
-        else:
+        # Audit logging for explicit security overrides in production
+        if current_settings.environment == "production" and not current_settings.require_strong_secrets:
             logger.warning(
-                "⚠️  UAID_ALLOWED_DOMAINS is empty - cross-gateway routing allows ALL domains. "
-                "Any UAID-based agent can route to any remote gateway endpoint. "
-                "RECOMMENDED: Configure UAID_ALLOWED_DOMAINS to restrict routing to trusted gateways only. "
-                'Example: UAID_ALLOWED_DOMAINS=["trusted-gateway.example.com", "partner.org"]'
+                "SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. "
+                "This override is being logged for audit purposes as per US-1 requirements."
             )
 
-    # Warn about ephemeral storage without strict user-in-DB mode
-    if not getattr(settings, "require_user_in_db", False):
-        is_ephemeral = ":memory:" in settings.database_url or settings.database_url == "sqlite:///./mcp.db"
-        if is_ephemeral:
-            logger.warning("Using potentially ephemeral storage with platform admin bootstrap enabled. Consider using persistent storage or setting REQUIRE_USER_IN_DB=true for production.")
+        log_security_recommendations(security_status)
+    except SecurityConfigurationError as e:
+        logger.critical(f"FAIL-CLOSED: {e}")
+        # Standard
+        import sys
 
-    # Warn about default JWT issuer/audience in non-development environments
-    if settings.environment != "development":
-        if settings.jwt_issuer == "mcpgateway":
-            logger.warning("Using default JWT_ISSUER in %s environment. Set a unique JWT_ISSUER per environment to prevent cross-environment token acceptance.", settings.environment)
-        if settings.jwt_audience == "mcpgateway-api":
-            logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", settings.environment)
-
-    # Audit logging for explicit security overrides in production
-    if settings.environment == "production" and not settings.require_strong_secrets:
-        logger.warning(
-            "SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. "
-            "This override is being logged for audit purposes as per US-1 requirements."
-        )
-
-    log_security_recommendations(security_status)
+        sys.exit(1)
 
 
 def log_security_warnings(security_warnings: list[str]):

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1891,9 +1891,6 @@ def validate_security_configuration():
         log_security_recommendations(security_status)
     except SecurityConfigurationError as e:
         logger.critical(f"FAIL-CLOSED: {e}")
-        # Standard
-        import sys
-
         sys.exit(1)
 
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1891,6 +1891,13 @@ def validate_security_configuration():
         if settings.jwt_audience == "mcpgateway-api":
             logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", settings.environment)
 
+    # Audit logging for explicit security overrides in production
+    if settings.environment == "production" and not settings.require_strong_secrets:
+        logger.warning(
+            "SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. "
+            "This override is being logged for audit purposes as per US-1 requirements."
+        )
+
     log_security_recommendations(security_status)
 
 

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -56,3 +56,24 @@ def test_proceed_development_mode():
     # Validation status should be SUCCESS to allow development flow
     status = cfg.get_security_status()
     assert status["status"] == "SUCCESS"
+
+
+def test_environment_aware_default_production(monkeypatch):
+    """US-1: Verify that REQUIRE_STRONG_SECRETS defaults to True in production."""
+    # Simulate production environment via env var
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    # In production, even without passing require_strong_secrets, it should be True
+    with pytest.raises(SystemExit) as cm:
+        get_settings(jwt_secret_key="weak-key")
+    assert cm.value.code == 1
+
+
+def test_environment_aware_default_development(monkeypatch):
+    """US-1: Verify that REQUIRE_STRONG_SECRETS defaults to False in development."""
+    # Simulate development environment
+    monkeypatch.setenv("ENVIRONMENT", "development")
+
+    # In development, it should proceed despite the weak key
+    cfg = get_settings(jwt_secret_key="weak-key")
+    assert cfg.require_strong_secrets is False

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/test_config_security.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Eleni Kechrioti
+
+Security enforcement unit tests for US-2 (Fail-Closed logic).
+Verifies that the gateway terminates execution when critical secrets are
+unconfigured or weak in production environments.
+"""
+
+# Standard
+import pytest
+
+# First-Party
+from mcpgateway.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    """
+    Clears the lru_cache for get_settings before each test to ensure
+    fresh configuration evaluation.
+    """
+    get_settings.cache_clear()
+    yield
+
+
+def test_fail_closed_production_missing_jwt_secret():
+    """Verify that production startup fails if JWT_SECRET_KEY is empty."""
+    with pytest.raises(SystemExit) as cm:
+        get_settings(environment="production", jwt_secret_key="", auth_encryption_secret="secure-test-secret-32-characters-min")
+    # Ensure application exits with code 1
+    assert cm.value.code == 1
+
+
+def test_fail_closed_production_missing_auth_secret():
+    """Verify that production startup fails if AUTH_ENCRYPTION_SECRET is unconfigured."""
+    with pytest.raises(SystemExit) as cm:
+        get_settings(environment="production", jwt_secret_key="secure-test-secret-32-characters-min", auth_encryption_secret="UNCONFIGURED")
+    assert cm.value.code == 1
+
+
+def test_fail_closed_production_weak_secret():
+    """Verify that production startup fails if weak secrets are detected."""
+    with pytest.raises(SystemExit) as cm:
+        get_settings(environment="production", jwt_secret_key="my-test-key", require_strong_secrets=True)
+    assert cm.value.code == 1
+
+
+def test_proceed_development_mode():
+    """Ensure development environment allows startup with warnings for local testing."""
+    # Development mode should return settings object instead of exiting
+    cfg = get_settings(environment="development", jwt_secret_key="my-test-key", auth_encryption_secret="UNCONFIGURED")
+
+    # Validation status should be SUCCESS to allow development flow
+    status = cfg.get_security_status()
+    assert status["status"] == "SUCCESS"

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -13,7 +13,7 @@ unconfigured or weak in production environments.
 import pytest
 
 # First-Party
-from mcpgateway.config import get_settings, SecurityConfigurationError
+from mcpgateway.config import Settings, get_settings, SecurityConfigurationError
 
 
 @pytest.fixture(autouse=True)
@@ -115,3 +115,11 @@ def test_client_mode_skips_fail_closed_secret_enforcement():
     status = cfg.get_security_status()
     assert status["status"] == "SUCCESS"
     assert status["message"] == "Security validation skipped in client mode."
+
+
+def test_apply_environment_aware_defaults_non_dict_passthrough():
+    """Verify non-dict inputs pass through unchanged in the model validator."""
+    sentinel = ("not", "a", "dict")
+
+    apply_defaults = getattr(Settings, "apply_environment_aware_defaults")
+    assert apply_defaults(sentinel) is sentinel

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -9,9 +9,8 @@ Verifies that the gateway terminates execution when critical secrets are
 unconfigured or weak in production environments.
 """
 
-# Standard
+# Third-Party
 import pytest
-import logging
 
 # First-Party
 from mcpgateway.config import get_settings, SecurityConfigurationError
@@ -30,13 +29,13 @@ def clear_settings_cache():
 def test_fail_closed_production_missing_jwt_secret():
     """Verify that production startup fails if JWT_SECRET_KEY is empty."""
     with pytest.raises(SecurityConfigurationError):
-        get_settings(environment="production", jwt_secret_key="", auth_encryption_secret="secure-test-secret-32-characters-min")
+        get_settings(environment="production", jwt_secret_key="", auth_encryption_secret="secure-test-secret-32-characters-min")  # pragma: allowlist secret  # pragma: allowlist secret
 
 
 def test_fail_closed_production_missing_auth_secret():
     """Verify that production startup fails if AUTH_ENCRYPTION_SECRET is unconfigured."""
     with pytest.raises(SecurityConfigurationError):
-        get_settings(environment="production", jwt_secret_key="secure-test-secret-32-characters-min", auth_encryption_secret="UNCONFIGURED")
+        get_settings(environment="production", jwt_secret_key="secure-test-secret-32-characters-min", auth_encryption_secret="UNCONFIGURED")  # pragma: allowlist secret  # pragma: allowlist secret
 
 
 def test_fail_closed_production_weak_secret():
@@ -45,17 +44,43 @@ def test_fail_closed_production_weak_secret():
         get_settings(environment="production", jwt_secret_key="my-test-key", require_strong_secrets=True)
 
 
-def test_proceed_development_mode(caplog):
-    """Ensure development environment allows startup with warnings for local testing."""
-    with caplog.at_level(logging.WARNING):
-        # Development mode should return settings object instead of exiting
-        cfg = get_settings(environment="development", jwt_secret_key="my-test-key", auth_encryption_secret="UNCONFIGURED")
+def test_require_strong_secrets_fails_closed_outside_production():
+    """Verify explicit strong secret enforcement fails closed in any environment."""
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(environment="staging", jwt_secret_key="my-test-key", require_strong_secrets=True)
 
-        # Validation status should be SUCCESS to allow development flow
-        status = cfg.get_security_status()
-        assert status["status"] == "SUCCESS"
-        assert "DEV WARNING" in caplog.text
-        assert "AUTH_ENCRYPTION_SECRET" in caplog.text or "UNCONFIGURED" in caplog.text
+
+def test_fail_closed_production_legacy_default_jwt_secret():
+    """Verify that production startup fails for the documented default JWT secret."""
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(
+            environment="production",
+            jwt_secret_key="my-test-key-but-now-longer-than-32-bytes",
+            auth_encryption_secret="secure-test-secret-32-characters-min",  # pragma: allowlist secret
+        )
+
+
+def test_fail_closed_basic_auth_password_when_api_basic_auth_enabled():
+    """Verify that default Basic auth credentials fail closed when API Basic auth is enabled."""
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(
+            environment="production",
+            jwt_secret_key="secure-test-secret-32-characters-min",
+            auth_encryption_secret="another-secure-test-secret-32-chars",  # pragma: allowlist secret
+            mcpgateway_ui_enabled=False,
+            api_allow_basic_auth=True,
+            basic_auth_password="changeme",  # pragma: allowlist secret
+        )
+
+
+def test_proceed_development_mode():
+    """Ensure development environment allows startup with warnings for local testing."""
+    # Development mode should return settings object instead of exiting.
+    cfg = get_settings(environment="development", jwt_secret_key="my-test-key", auth_encryption_secret="UNCONFIGURED")  # pragma: allowlist secret  # pragma: allowlist secret
+
+    # Validation status should be SUCCESS to allow development flow.
+    status = cfg.get_security_status()
+    assert status["status"] == "SUCCESS"
 
 
 def test_environment_aware_default_production(monkeypatch):
@@ -68,6 +93,12 @@ def test_environment_aware_default_production(monkeypatch):
         get_settings(jwt_secret_key="weak-key")
 
 
+def test_environment_aware_default_production_kwargs():
+    """Verify production kwargs enable strong secret enforcement by default."""
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(environment="production", jwt_secret_key="weak-key", auth_encryption_secret="secure-test-secret-32-characters-min")  # pragma: allowlist secret
+
+
 def test_environment_aware_default_development(monkeypatch):
     """Verify that REQUIRE_STRONG_SECRETS defaults to False in development."""
     # Simulate development environment
@@ -76,3 +107,11 @@ def test_environment_aware_default_development(monkeypatch):
     # In development, it should proceed despite the weak key
     cfg = get_settings(jwt_secret_key="weak-key")
     assert cfg.require_strong_secrets is False
+
+
+def test_client_mode_skips_fail_closed_secret_enforcement():
+    """Verify client mode bypasses server secret enforcement."""
+    cfg = get_settings(client_mode=True, environment="production", jwt_secret_key="weak", auth_encryption_secret="UNCONFIGURED", require_strong_secrets=True)  # pragma: allowlist secret
+    status = cfg.get_security_status()
+    assert status["status"] == "SUCCESS"
+    assert status["message"] == "Security validation skipped in client mode."

--- a/tests/unit/mcpgateway/test_main_helpers_extra.py
+++ b/tests/unit/mcpgateway/test_main_helpers_extra.py
@@ -68,8 +68,65 @@ def test_validate_security_configuration(monkeypatch: pytest.MonkeyPatch):
     main.validate_security_configuration()
 
 
+def test_validate_security_configuration_logs_default_jwt_warnings(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    fake_settings = SimpleNamespace(
+        get_security_status=lambda: {"warnings": [], "secure_secrets": False, "auth_enabled": False},
+        require_user_in_db=False,
+        require_strong_secrets=False,
+        jwt_issuer="mcpgateway",
+        jwt_audience="mcpgateway-api",
+        environment="production",
+        uaid_allowed_domains=["trusted.example.com"],
+        auth_required=True,
+    )
+    monkeypatch.setattr(main, "get_settings", lambda: fake_settings)
+
+    caplog.set_level("WARNING")
+
+    main.validate_security_configuration()
+
+    assert any("Using default JWT_ISSUER" in record.message for record in caplog.records)
+    assert any("Using default JWT_AUDIENCE" in record.message for record in caplog.records)
+
+
+def test_validate_security_configuration_logs_insecure_uaid_config(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    fake_settings = SimpleNamespace(
+        get_security_status=lambda: {"warnings": [], "secure_secrets": False, "auth_enabled": False},
+        require_user_in_db=False,
+        require_strong_secrets=False,
+        jwt_issuer="custom-issuer",
+        jwt_audience="custom-audience",
+        environment="production",
+        uaid_allowed_domains=[],
+        auth_required=False,
+    )
+    monkeypatch.setattr(main, "get_settings", lambda: fake_settings)
+
+    caplog.set_level("ERROR")
+
+    main.validate_security_configuration()
+
+    assert any("UAID_ALLOWED_DOMAINS is empty AND AUTH_REQUIRED=false" in record.message for record in caplog.records)
+
+
 def test_log_critical_issues_enforced(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(main.settings, "require_strong_secrets", True)
 
     with pytest.raises(SystemExit):
         main.log_critical_issues(["issue"])
+
+
+def test_validate_security_configuration_security_error_exits(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    def _raise_security_error():
+        raise main.SecurityConfigurationError("boom")
+
+    monkeypatch.setattr(main, "get_settings", _raise_security_error)
+    monkeypatch.setattr(main.sys, "exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+
+    caplog.set_level("CRITICAL")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main.validate_security_configuration()
+
+    assert excinfo.value.code == 1
+    assert any("FAIL-CLOSED: boom" in record.message for record in caplog.records)


### PR DESCRIPTION
> **Note:** This PR was re-created from #2847 due to repository maintenance. Your code and branch are intact. @EleniKechrioti please verify everything looks good.

## Related Issue
Partially addresses #2595 . Implements US-1 (Environment-Aware Defaults) and US-2 (Fail-Closed on Unconfigured Secrets).

---

## Summary
This PR implements the **Fail-Closed** security mechanism for **US-2**. It ensures the Gateway terminates execution if critical security secrets are missing, unconfigured, or weak when running in production mode.

**Key Changes:**

### Environment-Aware Enforcement (US-1)
- **Dynamic Defaults:** Implemented `default_factory` for `require_strong_secrets`, automatically enabling enforcement (`true`) in `production` and disabling it (`false`) in `development`.
- **Audit Logging:** Added explicit security audit logs when enforcement is manually overridden in production environments.

### Fail-Closed Mechanism (US-2)
- **Sentinel & Weak Secret Detection:** Added logic to block execution if `JWT_SECRET_KEY` or `AUTH_ENCRYPTION_SECRET` are missing, weak, or set to default values.
- **Enforcement Logic:** Enhanced `get_settings()` to trigger a `SystemExit` in production mode when critical security risks are detected.
- **Remediation Guidance:** Implemented clear error messaging with specific error codes, pointing operators to the `init_secrets` script and official IBM security docs.

### Documentation & Testing
- **Docs Update:** Updated `.env.example`, `CHANGELOG.md`, and `configuration.md` to document the new environment-aware behavior and breaking changes.
- **Automated Testing:** Added 6 comprehensive unit tests in `tests/test_config_security.py` covering all environment-specific scenarios.

---

## Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)

---

## Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | Pass   |
| Unit tests                | `make test`     | Pass   |
| Coverage ≥ 80%            | `make coverage` | Pass   |

*Note: Verified specifically with `pytest tests/test_config_security.py`.*

---

## Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (References added in logs)
- [x] No secrets or credentials committed

---

## Notes
Manual verification performed:
1. `ENVIRONMENT=production` with empty secrets correctly triggers `SystemExit(1)`.
2. `ENVIRONMENT=development` correctly proceeds with warnings.
3. Remediation logs point to `init_secrets` script and official IBM documentation.