### PR TITLE
feat(search): add tool embedding index and semantic search service

### DIFF
--- a/infra/postgres/Dockerfile
+++ b/infra/postgres/Dockerfile
@@ -1,0 +1,12 @@
+FROM pgvector/pgvector:pg18
+
+# Copy initialization scripts
+COPY init-replication.sh /docker-entrypoint-initdb.d/01-init-replication.sh
+COPY init-pgvector.sh /docker-entrypoint-initdb.d/02-init-pgvector.sh
+
+RUN chmod +x /docker-entrypoint-initdb.d/*.sh
+
+EXPOSE 5432
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD pg_isready -U ${POSTGRES_USER:-postgres} || exit 1

--- a/infra/postgres/init-pgvector.sh
+++ b/infra/postgres/init-pgvector.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Initialize pgvector extension for vector similarity search
+# This script runs on PostgreSQL first start via /docker-entrypoint-initdb.d/
+
+set -e
+
+echo "Creating pgvector extension..."
+
+# Create the extension in the default database
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION IF NOT EXISTS vector;
+    
+    -- Verify extension was created successfully
+    SELECT extname, extversion FROM pg_extension WHERE extname = 'vector';
+EOSQL
+
+echo "pgvector extension created successfully."

--- a/mcpgateway/alembic/versions/bab4694b3e90_add_tool_embedding_table.py
+++ b/mcpgateway/alembic/versions/bab4694b3e90_add_tool_embedding_table.py
@@ -1,0 +1,103 @@
+"""add_tool_embedding_table
+
+Revision ID: bab4694b3e90
+Revises: 8a16a77260f0
+Create Date: 2026-02-10 14:11:14.392859
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+try:
+    from pgvector.sqlalchemy import Vector # type: ignore
+    HAS_PGVECTOR = True
+except ImportError:
+    Vector = None
+    HAS_PGVECTOR = False
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bab4694b3e90'
+down_revision: Union[str, Sequence[str], None] = '8a16a77260f0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add tool_embeddings table with database-specific column types."""
+    bind = op.get_bind()
+    dialect_name = bind.dialect.name
+
+    if dialect_name == 'postgresql':
+        op.execute('CREATE EXTENSION IF NOT EXISTS vector')
+
+        # Check for pgvector presence
+        if not HAS_PGVECTOR:
+            raise ImportError(
+                "pgvector is required for PostgreSQL. "
+                "Install with: pip install pgvector"
+            )
+
+        # Import Vector only here
+        from pgvector.sqlalchemy import Vector as PgVector
+        embedding_col = sa.Column('embedding', PgVector(1536), nullable=False)
+    else:
+        embedding_col = sa.Column('embedding', sa.JSON, nullable=False)
+
+    op.create_table(
+        'tool_embeddings',
+        sa.Column('id', sa.String(36), nullable=False),
+        sa.Column('tool_id', sa.String(36), nullable=False),
+        embedding_col,
+        sa.Column('model_name', sa.String(255), nullable=False,
+                 server_default='text-embedding-3-small'),
+        sa.Column('created_at', sa.DateTime(timezone=True),
+                 server_default=sa.text('now()' if dialect_name == 'postgresql'
+                                       else "(datetime('now'))"),
+                 nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True),
+                 server_default=sa.text('now()' if dialect_name == 'postgresql'
+                                       else "(datetime('now'))"),
+                 nullable=False),
+        sa.PrimaryKeyConstraint('id', name='pk_tool_embeddings'),
+        sa.ForeignKeyConstraint(['tool_id'], ['tools.id'],
+                               name='fk_tool_embeddings_tool_id',
+                               ondelete='CASCADE'),
+    )
+
+    # Add indexes
+    if dialect_name == 'postgresql':
+        op.create_index(
+            'idx_tool_embeddings_hnsw',
+            'tool_embeddings',
+            ['embedding'],
+            postgresql_using='ivfflat',
+            postgresql_with={'lists': 100},
+        )
+
+    op.create_index('idx_tool_embeddings_tool_id', 'tool_embeddings', ['tool_id'])
+
+
+def downgrade() -> None:
+    """Drop tool_embeddings table."""
+    bind = op.get_bind()
+    dialect_name = bind.dialect.name
+    inspector = sa.inspect(bind)
+    
+    # Check if table exists before trying to drop it
+    if 'tool_embeddings' not in inspector.get_table_names():
+        return
+    
+    # Get existing indexes
+    existing_indexes = {idx['name'] for idx in inspector.get_indexes('tool_embeddings')}
+    
+    # Drop indexes only if they exist
+    if 'idx_tool_embeddings_tool_id' in existing_indexes:
+        op.drop_index('idx_tool_embeddings_tool_id', table_name='tool_embeddings')
+    
+    if dialect_name == 'postgresql' and 'idx_tool_embeddings_vector' in existing_indexes:
+        op.drop_index('idx_tool_embeddings_vector', table_name='tool_embeddings')
+    
+    # Drop table
+    op.drop_table('tool_embeddings')

--- a/mcpgateway/alembic/versions/c3d4e5f6a7b8_add_hnsw_index_to_tool_embeddings.py
+++ b/mcpgateway/alembic/versions/c3d4e5f6a7b8_add_hnsw_index_to_tool_embeddings.py
@@ -1,0 +1,76 @@
+"""add_hnsw_index_to_tool_embeddings
+
+Revision ID: c3d4e5f6a7b8
+Revises: bab4694b3e90
+Create Date: 2026-02-12 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, Sequence[str], None] = "bab4694b3e90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Replace IVFFlat index with HNSW index on tool_embeddings.embedding."""
+    bind = op.get_bind()
+    dialect_name = bind.dialect.name
+
+    if dialect_name != "postgresql":
+        return  # SQLite: no vector indexes
+
+    inspector = sa.inspect(bind)
+    if "tool_embeddings" not in inspector.get_table_names():
+        return
+
+    existing = {idx["name"] for idx in inspector.get_indexes("tool_embeddings")}
+
+    # Drop old IVFFlat index if present
+    if "idx_tool_embeddings_vector" in existing:
+        op.drop_index("idx_tool_embeddings_vector", table_name="tool_embeddings")
+
+    # Create HNSW index (skip if already exists)
+    if "idx_tool_embeddings_hnsw" not in existing:
+        op.create_index(
+            "idx_tool_embeddings_hnsw",
+            "tool_embeddings",
+            ["embedding"],
+            postgresql_using="hnsw",
+            postgresql_with={"m": 16, "ef_construction": 64},
+            postgresql_ops={"embedding": "vector_cosine_ops"},
+        )
+
+
+def downgrade() -> None:
+    """Revert to IVFFlat index on tool_embeddings.embedding."""
+    bind = op.get_bind()
+    dialect_name = bind.dialect.name
+
+    if dialect_name != "postgresql":
+        return
+
+    inspector = sa.inspect(bind)
+    if "tool_embeddings" not in inspector.get_table_names():
+        return
+
+    existing = {idx["name"] for idx in inspector.get_indexes("tool_embeddings")}
+
+    if "idx_tool_embeddings_hnsw" in existing:
+        op.drop_index("idx_tool_embeddings_hnsw", table_name="tool_embeddings")
+
+    if "idx_tool_embeddings_vector" not in existing:
+        op.create_index(
+            "idx_tool_embeddings_vector",
+            "tool_embeddings",
+            ["embedding"],
+            postgresql_using="ivfflat",
+            postgresql_with={"lists": 100},
+        )

--- a/mcpgateway/cli.py
+++ b/mcpgateway/cli.py
@@ -343,6 +343,20 @@ def main() -> None:  # noqa: D401 - imperative mood is fine here
             )
             return
 
+        if cmd == "--reindex-embeddings":
+            import asyncio  # pylint: disable=import-outside-toplevel
+
+            from mcpgateway.db import SessionLocal  # pylint: disable=import-outside-toplevel
+            from mcpgateway.services.embedding_service import reindex_all_tools  # pylint: disable=import-outside-toplevel
+
+            db = SessionLocal()
+            try:
+                result = asyncio.run(reindex_all_tools(db))
+                print(f"Reindexing complete: {result['succeeded']} succeeded, {result['failed']} failed out of {result['total']} tools")
+            finally:
+                db.close()
+            return
+
     # Discard the program name and inspect the rest.
     user_args = sys.argv[1:]
     uvicorn_argv = _insert_defaults(user_args)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -117,41 +117,6 @@ _normalize_env_list_vars()
 # Default content type for outgoing requests to Forge
 FORGE_CONTENT_TYPE = os.getenv("FORGE_CONTENT_TYPE", "application/json")
 
-# UI embedding / visibility controls
-UI_HIDABLE_SECTIONS = frozenset(
-    {
-        "overview",
-        "servers",
-        "gateways",
-        "tools",
-        "prompts",
-        "resources",
-        "roots",
-        "mcp-registry",
-        "metrics",
-        "plugins",
-        "export-import",
-        "logs",
-        "version-info",
-        "maintenance",
-        "teams",
-        "users",
-        "agents",
-        "tokens",
-        "settings",
-    }
-)
-UI_HIDABLE_HEADER_ITEMS = frozenset({"logout", "team_selector", "user_identity", "theme_toggle"})
-UI_HIDE_SECTION_ALIASES = {
-    "catalog": "servers",
-    "virtual_servers": "servers",
-    "a2a-agents": "agents",
-    "a2a": "agents",
-    "grpc-services": "agents",
-    "api_tokens": "tokens",
-    "llm-settings": "settings",
-}
-
 
 class Settings(BaseSettings):
     """
@@ -234,7 +199,7 @@ class Settings(BaseSettings):
     app_root_path: str = ""
 
     # Protocol
-    protocol_version: str = "2025-11-25"
+    protocol_version: str = "2025-06-18"
 
     # Authentication
     basic_auth_user: str = "admin"
@@ -323,7 +288,7 @@ class Settings(BaseSettings):
     sso_entra_client_secret: Optional[SecretStr] = Field(default=None, description="Microsoft Entra ID client secret")
     sso_entra_tenant_id: Optional[str] = Field(default=None, description="Microsoft Entra ID tenant ID")
     sso_entra_groups_claim: str = Field(default="groups", description="JWT claim for EntraID groups (groups/roles)")
-    sso_entra_admin_groups: Annotated[list[str], NoDecode] = Field(default_factory=list, description="EntraID groups granting platform_admin role (CSV/JSON)")
+    sso_entra_admin_groups: Annotated[list[str], NoDecode()] = Field(default_factory=list, description="EntraID groups granting platform_admin role (CSV/JSON)")
     sso_entra_role_mappings: Dict[str, str] = Field(default_factory=dict, description="Map EntraID groups to Context Forge roles (JSON: {group_id: role_name})")
     sso_entra_default_role: Optional[str] = Field(default=None, description="Default role for EntraID users without group mapping (None = no role assigned)")
     sso_entra_sync_roles_on_login: bool = Field(default=True, description="Synchronize role assignments on each login")
@@ -341,13 +306,13 @@ class Settings(BaseSettings):
 
     # SSO Settings
     sso_auto_create_users: bool = Field(default=True, description="Automatically create users from SSO providers")
-    sso_trusted_domains: Annotated[list[str], NoDecode] = Field(default_factory=list, description="Trusted email domains (CSV or JSON list)")
+    sso_trusted_domains: Annotated[list[str], NoDecode()] = Field(default_factory=list, description="Trusted email domains (CSV or JSON list)")
     sso_preserve_admin_auth: bool = Field(default=True, description="Preserve local admin authentication when SSO is enabled")
 
     # SSO Admin Assignment Settings
-    sso_auto_admin_domains: Annotated[list[str], NoDecode] = Field(default_factory=list, description="Admin domains (CSV or JSON list)")
-    sso_github_admin_orgs: Annotated[list[str], NoDecode] = Field(default_factory=list, description="GitHub orgs granting admin (CSV/JSON)")
-    sso_google_admin_domains: Annotated[list[str], NoDecode] = Field(default_factory=list, description="Google admin domains (CSV/JSON)")
+    sso_auto_admin_domains: Annotated[list[str], NoDecode()] = Field(default_factory=list, description="Admin domains (CSV or JSON list)")
+    sso_github_admin_orgs: Annotated[list[str], NoDecode()] = Field(default_factory=list, description="GitHub orgs granting admin (CSV/JSON)")
+    sso_google_admin_domains: Annotated[list[str], NoDecode()] = Field(default_factory=list, description="Google admin domains (CSV/JSON)")
     sso_require_admin_approval: bool = Field(default=False, description="Require admin approval for new SSO registrations")
 
     # MCP Client Authentication
@@ -514,30 +479,6 @@ class Settings(BaseSettings):
     # Account Security Configuration
     max_failed_login_attempts: int = Field(default=10, description="Maximum failed login attempts before account lockout")
     account_lockout_duration_minutes: int = Field(default=1, description="Account lockout duration in minutes")
-    account_lockout_notification_enabled: bool = Field(default=True, description="Send lockout notification emails when accounts are locked")
-
-    # Self-service password reset
-    password_reset_enabled: bool = Field(default=True, description="Enable self-service password reset workflow (set false to disable public forgot/reset endpoints)")
-    password_reset_token_expiry_minutes: int = Field(default=60, description="Password reset token expiration time in minutes")
-    password_reset_rate_limit: int = Field(default=5, description="Maximum password reset requests allowed per email in each rate-limit window")
-    password_reset_rate_window_minutes: int = Field(default=15, description="Password reset request rate-limit window in minutes")
-    password_reset_invalidate_sessions: bool = Field(default=True, description="Invalidate active sessions after password reset")
-    password_reset_min_response_ms: int = Field(default=250, description="Minimum response duration for forgot-password requests to reduce timing side channels")
-
-    # Email delivery for auth notifications
-    smtp_enabled: bool = Field(
-        default=False,
-        description="Enable SMTP email delivery for password reset and account lockout notifications (when false, reset requests are accepted but no email is sent)",
-    )
-    smtp_host: Optional[str] = Field(default=None, description="SMTP server host")
-    smtp_port: int = Field(default=587, description="SMTP server port")
-    smtp_user: Optional[str] = Field(default=None, description="SMTP username")
-    smtp_password: Optional[SecretStr] = Field(default=None, description="SMTP password")
-    smtp_from_email: Optional[str] = Field(default=None, description="From email address used for auth notifications")
-    smtp_from_name: str = Field(default="MCP Gateway", description="From display name used for auth notifications")
-    smtp_use_tls: bool = Field(default=True, description="Use STARTTLS for SMTP connections")
-    smtp_use_ssl: bool = Field(default=False, description="Use implicit SSL/TLS for SMTP connections")
-    smtp_timeout_seconds: int = Field(default=15, description="SMTP connection timeout in seconds")
 
     # Personal Teams Configuration
     auto_create_personal_teams: bool = Field(default=True, description="Enable automatic personal team creation for new users")
@@ -557,19 +498,6 @@ class Settings(BaseSettings):
     mcpgateway_ui_enabled: bool = False
     mcpgateway_admin_api_enabled: bool = False
     mcpgateway_ui_airgapped: bool = Field(default=False, description="Use local CDN assets instead of external CDNs for airgapped deployments")
-    mcpgateway_ui_embedded: bool = Field(default=False, description="Enable embedded UI mode (hides select header controls by default)")
-    mcpgateway_ui_hide_sections: Annotated[list[str], NoDecode] = Field(
-        default_factory=list,
-        description=(
-            "CSV/JSON list of UI sections to hide. "
-            "Valid values: overview, servers, gateways, tools, prompts, resources, roots, mcp-registry, "
-            "metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings"
-        ),
-    )
-    mcpgateway_ui_hide_header_items: Annotated[list[str], NoDecode] = Field(
-        default_factory=list,
-        description="CSV/JSON list of header items to hide. Valid values: logout, team_selector, user_identity, theme_toggle",
-    )
     mcpgateway_bulk_import_enabled: bool = True
     mcpgateway_bulk_import_max_tools: int = 200
     mcpgateway_bulk_import_rate_limit: int = 10
@@ -697,6 +625,12 @@ class Settings(BaseSettings):
     llmchat_enabled: bool = Field(default=False, description="Enable LLM Chat feature")
     toolops_enabled: bool = Field(default=False, description="Enable ToolOps feature")
 
+    # Embedding auto-indexing settings
+    embedding_auto_index_enabled: bool = Field(
+        default=False,
+        description="Automatically index tools for semantic search when created/updated",
+    )
+
     # database-backed polling settings for session message delivery
     poll_interval: float = Field(default=1.0, description="Initial polling interval in seconds for checking new session messages")
     max_interval: float = Field(default=5.0, description="Maximum polling interval in seconds when the session is idle")
@@ -715,6 +649,11 @@ class Settings(BaseSettings):
     llm_request_timeout: int = Field(default=120, description="Request timeout in seconds for LLM API calls")
     llm_streaming_enabled: bool = Field(default=True, description="Enable streaming responses for LLM Chat")
     llm_health_check_interval: int = Field(default=300, description="Provider health check interval in seconds")
+
+    # Embedding Service Settings
+    embedding_provider: str = Field(default="openai", description="Embedding provider")
+    embedding_model: str = Field(default="text-embedding-3-small", description="Embedding model name")
+    embedding_api_key: SecretStr = Field(default="", description="API key for embedding provider")
 
     @field_validator("allowed_roots", mode="before")
     @classmethod
@@ -1247,11 +1186,6 @@ class Settings(BaseSettings):
     security_threat_score_alert: float = Field(default=0.7, description="Threat score threshold for alerts (0.0-1.0)")
     security_rate_limit_window_minutes: int = Field(default=5, description="Time window for rate limit checks (minutes)")
 
-    # API Token Tracking Configuration
-    # Controls how token usage and last_used timestamps are tracked
-    token_usage_logging_enabled: bool = Field(default=True, description="Enable API token usage logging middleware")
-    token_last_used_update_interval_minutes: int = Field(default=5, ge=1, le=1440, description="Minimum minutes between last_used timestamp updates (rate-limits DB writes)")
-
     # Metrics Aggregation Configuration
     metrics_aggregation_enabled: bool = Field(default=True, description="Enable automatic log aggregation into performance metrics")
     metrics_aggregation_backfill_hours: int = Field(default=6, ge=0, le=168, description="Hours of structured logs to backfill into performance metrics on startup")
@@ -1613,6 +1547,10 @@ class Settings(BaseSettings):
     # SQLite busy timeout: Maximum time (ms) SQLite will wait to acquire a database lock before returning SQLITE_BUSY.
     db_sqlite_busy_timeout: int = Field(default=5000, ge=1000, le=60000, description="SQLite busy timeout in milliseconds (default: 5000ms)")
 
+    # HNSW vector index parameters (pgvector)
+    hnsw_m: int = Field(default=16, ge=2, le=100, description="HNSW max connections per node (higher = better recall, more memory)")
+    hnsw_ef_construction: int = Field(default=64, ge=16, le=512, description="HNSW construction search depth (higher = better index quality, slower build)")
+
     # Cache
     cache_type: Literal["redis", "memory", "none", "database"] = "database"  # memory or redis or database
     redis_url: Optional[str] = "redis://localhost:6379/0"
@@ -1803,8 +1741,6 @@ Disallow: /
         "sso_github_admin_orgs",
         "sso_google_admin_domains",
         "insecure_queryparam_auth_allowed_hosts",
-        "mcpgateway_ui_hide_sections",
-        "mcpgateway_ui_hide_header_items",
         mode="before",
     )
     @classmethod
@@ -1840,61 +1776,6 @@ Disallow: /
             # CSV fallback
             return [item.strip() for item in s.split(",") if item.strip()]
         raise ValueError("Invalid type for list field")
-
-    @field_validator("mcpgateway_ui_hide_sections", mode="after")
-    @classmethod
-    def _validate_ui_hide_sections(cls, value: list[str]) -> list[str]:
-        """Normalize and filter hidable UI sections.
-
-        Args:
-            value: Candidate section identifiers from environment/config.
-
-        Returns:
-            list[str]: Normalized unique section identifiers.
-        """
-        normalized: list[str] = []
-        seen: set[str] = set()
-
-        for item in value:
-            candidate = str(item).strip().lower()
-            if not candidate:
-                continue
-            candidate = UI_HIDE_SECTION_ALIASES.get(candidate, candidate)
-            if candidate not in UI_HIDABLE_SECTIONS:
-                logger.warning("Ignoring invalid MCPGATEWAY_UI_HIDE_SECTIONS item: %s", item)
-                continue
-            if candidate not in seen:
-                seen.add(candidate)
-                normalized.append(candidate)
-
-        return normalized
-
-    @field_validator("mcpgateway_ui_hide_header_items", mode="after")
-    @classmethod
-    def _validate_ui_hide_header_items(cls, value: list[str]) -> list[str]:
-        """Normalize and filter hidable header items.
-
-        Args:
-            value: Candidate header identifiers from environment/config.
-
-        Returns:
-            list[str]: Normalized unique header identifiers.
-        """
-        normalized: list[str] = []
-        seen: set[str] = set()
-
-        for item in value:
-            candidate = str(item).strip().lower()
-            if not candidate:
-                continue
-            if candidate not in UI_HIDABLE_HEADER_ITEMS:
-                logger.warning("Ignoring invalid MCPGATEWAY_UI_HIDE_HEADER_ITEMS item: %s", item)
-                continue
-            if candidate not in seen:
-                seen.add(candidate)
-                normalized.append(candidate)
-
-        return normalized
 
     @property
     def api_key(self) -> str:

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -42,7 +42,25 @@ from sqlalchemy.orm import DeclarativeBase, joinedload, Mapped, mapped_column, r
 from sqlalchemy.orm.attributes import get_history
 from sqlalchemy.pool import NullPool, QueuePool
 
+if TYPE_CHECKING:
+    from pgvector.sqlalchemy import Vector # type: ignore
+else:
+    try:
+        from pgvector.sqlalchemy import Vector  # type: ignore
+        HAS_PGVECTOR = True
+    except ImportError:
+        HAS_PGVECTOR = False
+        
+        class Vector:  # type: ignore[no-redef]  ← Change from 'def' to 'class'
+            """Dummy Vector class when pgvector not installed."""
+            def __init__(self, *args, **kwargs):
+                raise ImportError(
+                    "pgvector is not installed. "
+                    "Install with: pip install mcp-contextforge-gateway[postgres-vector]"
+                )
+
 # First-Party
+from mcpgateway.alembic.versions.bab4694b3e90_add_tool_embedding_table import HAS_PGVECTOR
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.utils.create_slug import slugify
@@ -1131,12 +1149,7 @@ class EmailUser(Base):
         """
         if self.locked_until is None:
             return False
-        if utc_now() >= self.locked_until:
-            # Lockout expired: reset counters so users get a fresh attempt window.
-            self.failed_login_attempts = 0
-            self.locked_until = None
-            return False
-        return True
+        return utc_now() < self.locked_until
 
     def get_display_name(self) -> str:
         """Get the user's display name.
@@ -1414,45 +1427,6 @@ class EmailAuthEvent(Base):
             EmailAuthEvent: New authentication event
         """
         return cls(user_email=user_email, event_type="password_change", success=success, ip_address=ip_address, user_agent=user_agent)
-
-
-class PasswordResetToken(Base):
-    """One-time password reset token record.
-
-    Stores only a SHA-256 hash of the user-facing token. Tokens are one-time use
-    and expire after a configured duration.
-    """
-
-    __tablename__ = "password_reset_tokens"
-
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    user_email: Mapped[str] = mapped_column(String(255), ForeignKey("email_users.email", ondelete="CASCADE"), nullable=False, index=True)
-    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
-    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
-    ip_address: Mapped[Optional[str]] = mapped_column(String(45), nullable=True)
-    user_agent: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-
-    user: Mapped["EmailUser"] = relationship("EmailUser")
-
-    __table_args__ = (Index("ix_password_reset_tokens_expires_at", "expires_at"),)
-
-    def is_expired(self) -> bool:
-        """Return whether the reset token has expired.
-
-        Returns:
-            bool: True when `expires_at` is in the past.
-        """
-        return self.expires_at <= utc_now()
-
-    def is_used(self) -> bool:
-        """Return whether the reset token was already consumed.
-
-        Returns:
-            bool: True when `used_at` is set.
-        """
-        return self.used_at is not None
 
 
 class EmailTeam(Base):
@@ -2884,6 +2858,9 @@ class Tool(Base):
     # Relationship with ToolMetric records
     metrics: Mapped[List["ToolMetric"]] = relationship("ToolMetric", back_populates="tool", cascade="all, delete-orphan")
 
+    # Embeddings relationship
+    embeddings: Mapped[List["ToolEmbedding"]] = relationship("ToolEmbedding", back_populates="tool", cascade="all, delete-orphan")
+
     # Team scoping fields for resource organization
     team_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("email_teams.id", ondelete="SET NULL"), nullable=True)
     owner_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
@@ -3224,6 +3201,127 @@ class Tool(Base):
             "avg_response_time": float(result[4]) if result[4] is not None else None,
             "last_execution_time": result[5],
         }
+
+class ToolEmbedding(Base):
+    __tablename__ = "tool_embeddings"
+
+    id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+        nullable=False,
+    )
+    tool_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("tools.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    
+    if HAS_PGVECTOR:
+        embedding: Mapped[list[float]] = mapped_column(
+            Vector(1536),
+            nullable=False,
+        )
+    else:
+        embedding: Mapped[list[float]] = mapped_column(
+            JSON,
+            nullable=False,
+        )
+    
+    model_name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        default="text-embedding-3-small",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    tool: Mapped["Tool"] = relationship(
+        "Tool",
+        back_populates="embeddings",
+        passive_deletes=True,
+    )
+
+    if HAS_PGVECTOR:
+        __table_args__ = (
+            # Vector similarity index (PostgreSQL/pgvector)
+            Index(
+                "idx_tool_embeddings_hnsw",
+                "embedding",
+                postgresql_using="hnsw",
+                postgresql_with={"m": settings.hnsw_m, "ef_construction": settings.hnsw_ef_construction},
+                postgresql_ops={"embedding": "vector_cosine_ops"},
+            ),
+            # Composite indexes for efficient queries
+            Index("idx_tool_embeddings_toolid_model", "tool_id", "model_name"),
+            Index("idx_tool_embeddings_toolid_created", "tool_id", "created_at"),
+        )
+    else:
+        __table_args__ = (
+            # Composite indexes for efficient queries (SQLite/other)
+            Index("idx_tool_embeddings_toolid_model", "tool_id", "model_name"),
+            Index("idx_tool_embeddings_toolid_created", "tool_id", "created_at"),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ToolEmbedding(id={self.id}, "
+            f"tool_id={self.tool_id}, "
+            f"model_name={self.model_name})>"
+        )
+
+    def similar_to(
+        self,
+        db: "Session",
+        limit: int = 10,
+        threshold: Optional[float] = None,
+    ) -> "List[tuple[ToolEmbedding, float]]":
+        """Find other ToolEmbeddings similar to this one.
+
+        Uses pgvector cosine distance on PostgreSQL, numpy fallback on SQLite.
+
+        Args:
+            db: Active database session.
+            limit: Maximum number of results.
+            threshold: Optional minimum similarity (0-1).
+
+        Returns:
+            List of (ToolEmbedding, similarity_score) tuples, ordered by
+            descending similarity. Does not include self.
+        """
+        dialect_name = db.get_bind().dialect.name
+
+        if dialect_name == "postgresql":
+            distance_expr = ToolEmbedding.embedding.cosine_distance(self.embedding)
+            query = select(ToolEmbedding, (1 - distance_expr).label("similarity")).filter(ToolEmbedding.id != self.id)
+            if threshold is not None:
+                query = query.filter(distance_expr <= (1 - threshold))
+            query = query.order_by(distance_expr.asc()).limit(limit)
+            rows = db.execute(query).all()
+            return [(te, max(0.0, min(1.0, float(sim)))) for te, sim in rows]
+        else:
+            # SQLite: compute cosine similarity in Python
+            from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+            all_embeddings = db.query(ToolEmbedding).filter(ToolEmbedding.id != self.id).all()
+            scored = []
+            for te in all_embeddings:
+                sim = _cosine_similarity_numpy(self.embedding, te.embedding)
+                if threshold is not None and sim < threshold:
+                    continue
+                scored.append((te, sim))
+            scored.sort(key=lambda x: x[1], reverse=True)
+            return scored[:limit]
 
 
 class Resource(Base):
@@ -4321,6 +4419,16 @@ class Server(Base):
     # When enabled, MCP clients can authenticate using OAuth with browser-based IDP SSO
     oauth_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     oauth_config: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True)
+
+    # Meta-server fields
+    # server_type: 'standard' (default) or 'meta' (exposes meta-tools instead of real tools)
+    server_type: Mapped[str] = mapped_column(String(20), nullable=False, default="standard")
+    # When True, underlying tools are hidden from tool listing endpoints
+    hide_underlying_tools: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # JSON configuration for meta-server behavior (MetaConfig schema)
+    meta_config: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    # JSON scope rules for filtering which tools are visible (MetaToolScope schema)
+    meta_scope: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True)
 
     # Relationship for loading team names (only active teams)
     # Uses default lazy loading - team name is only loaded when accessed
@@ -5607,6 +5715,15 @@ def init_db():
         Exception: If database initialization fails.
     """
     try:
+        # Enable pgvector extension for PostgreSQL
+        if backend == "postgresql":
+            with engine.connect() as conn:
+                try:
+                    conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+                    conn.commit()
+                except Exception as e:
+                    logger.warning(f"Could not create pgvector extension: {e}")
+
         # Apply MariaDB compatibility fix
         patch_string_columns_for_mariadb(Base, engine)
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1146,7 +1146,9 @@ class ToolUpdate(BaseModelWithConfigDict):
             base_url = f"{parsed.scheme}://{parsed.netloc}"
             path_template = parsed.path
             # Ensure path_template starts with a single '/'
-            if path_template:
+            if path_template and not path_template.startswith("/"):
+                path_template = "/" + path_template.lstrip("/")
+            elif path_template:
                 path_template = "/" + path_template.lstrip("/")
             if not values.get("base_url"):
                 values["base_url"] = base_url
@@ -3796,6 +3798,30 @@ class ServerCreate(BaseModel):
     oauth_enabled: bool = Field(False, description="Enable OAuth 2.0 for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
 
+    # Meta-server configuration
+    server_type: str = Field("standard", description="Server type: 'standard' or 'meta'. Meta servers expose meta-tools instead of real tools.")
+    hide_underlying_tools: bool = Field(True, description="When True and server_type is 'meta', underlying tools are hidden from tool listing endpoints")
+    meta_config: Optional[Dict[str, Any]] = Field(None, description="Meta-server configuration (MetaConfig schema). Only applicable when server_type is 'meta'.")
+    meta_scope: Optional[Dict[str, Any]] = Field(None, description="Scope rules for filtering tools visible to the meta-server (MetaToolScope schema).")
+
+    @field_validator("server_type")
+    @classmethod
+    def validate_server_type(cls, v: str) -> str:
+        """Validate server type value.
+
+        Args:
+            v: Server type to validate.
+
+        Returns:
+            Validated server type.
+
+        Raises:
+            ValueError: If server type is invalid.
+        """
+        if v not in ("standard", "meta"):
+            raise ValueError("server_type must be one of: standard, meta")
+        return v
+
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:
@@ -3929,6 +3955,30 @@ class ServerUpdate(BaseModelWithConfigDict):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: Optional[bool] = Field(None, description="Enable OAuth 2.0 for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+
+    # Meta-server configuration (optional update fields)
+    server_type: Optional[str] = Field(None, description="Server type: 'standard' or 'meta'")
+    hide_underlying_tools: Optional[bool] = Field(None, description="When True and server_type is 'meta', underlying tools are hidden")
+    meta_config: Optional[Dict[str, Any]] = Field(None, description="Meta-server configuration (MetaConfig schema)")
+    meta_scope: Optional[Dict[str, Any]] = Field(None, description="Scope rules for filtering tools visible to the meta-server")
+
+    @field_validator("server_type")
+    @classmethod
+    def validate_server_type(cls, v: Optional[str]) -> Optional[str]:
+        """Validate server type value.
+
+        Args:
+            v: Server type to validate.
+
+        Returns:
+            Validated server type.
+
+        Raises:
+            ValueError: If server type is invalid.
+        """
+        if v is not None and v not in ("standard", "meta"):
+            raise ValueError("server_type must be one of: standard, meta")
+        return v
 
     @field_validator("tags")
     @classmethod
@@ -4105,6 +4155,12 @@ class ServerRead(BaseModelWithConfigDict):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: bool = Field(False, description="Whether OAuth 2.0 is enabled for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+
+    # Meta-server configuration
+    server_type: str = Field("standard", description="Server type: 'standard' or 'meta'")
+    hide_underlying_tools: bool = Field(True, description="When True and server_type is 'meta', underlying tools are hidden")
+    meta_config: Optional[Dict[str, Any]] = Field(None, description="Meta-server configuration (MetaConfig schema)")
+    meta_scope: Optional[Dict[str, Any]] = Field(None, description="Scope rules for filtering tools visible to the meta-server")
 
     @model_validator(mode="before")
     @classmethod
@@ -5373,45 +5429,6 @@ class ChangePasswordRequest(BaseModel):
         return v
 
 
-class ForgotPasswordRequest(BaseModel):
-    """Request schema for forgot-password flow."""
-
-    model_config = ConfigDict(str_strip_whitespace=True)
-
-    email: EmailStr = Field(..., description="Email address for password reset")
-
-
-class ResetPasswordRequest(BaseModel):
-    """Request schema for completing password reset."""
-
-    model_config = ConfigDict(str_strip_whitespace=True)
-
-    new_password: str = Field(..., min_length=8, description="New password to set")
-    confirm_password: str = Field(..., min_length=8, description="Password confirmation")
-
-    @model_validator(mode="after")
-    def validate_password_match(self):
-        """Ensure password and confirmation are identical.
-
-        Returns:
-            ResetPasswordRequest: Validated request instance.
-
-        Raises:
-            ValueError: If the password and confirmation do not match.
-        """
-        if self.new_password != self.confirm_password:
-            raise ValueError("Passwords do not match")
-        return self
-
-
-class PasswordResetTokenValidationResponse(BaseModel):
-    """Response schema for reset-token validation."""
-
-    valid: bool = Field(..., description="Whether token is currently valid")
-    message: str = Field(..., description="Validation status message")
-    expires_at: Optional[datetime] = Field(None, description="Token expiration timestamp when valid")
-
-
 class EmailUserResponse(BaseModel):
     """Response schema for user information.
 
@@ -5454,9 +5471,6 @@ class EmailUserResponse(BaseModel):
     last_login: Optional[datetime] = Field(None, description="Last successful login")
     email_verified: bool = Field(False, description="Whether email is verified")
     password_change_required: bool = Field(False, description="Whether user must change password on next login")
-    failed_login_attempts: int = Field(0, description="Current failed login attempts counter")
-    locked_until: Optional[datetime] = Field(None, description="Account lock expiration timestamp")
-    is_locked: bool = Field(False, description="Whether the account is currently locked")
 
     @classmethod
     def from_email_user(cls, user) -> "EmailUserResponse":
@@ -5468,13 +5482,6 @@ class EmailUserResponse(BaseModel):
         Returns:
             EmailUserResponse: Response schema instance
         """
-        locked_until_raw = getattr(user, "locked_until", None)
-        locked_until = locked_until_raw if isinstance(locked_until_raw, datetime) else None
-        failed_attempts_raw = getattr(user, "failed_login_attempts", 0)
-        try:
-            failed_attempts = int(failed_attempts_raw or 0)
-        except (TypeError, ValueError):
-            failed_attempts = 0
         return cls(
             email=user.email,
             full_name=user.full_name,
@@ -5485,9 +5492,6 @@ class EmailUserResponse(BaseModel):
             last_login=user.last_login,
             email_verified=user.is_email_verified(),
             password_change_required=user.password_change_required,
-            failed_login_attempts=failed_attempts,
-            locked_until=locked_until,
-            is_locked=bool(locked_until and locked_until > datetime.now(timezone.utc)),
         )
 
 
@@ -7749,3 +7753,30 @@ class PerformanceHistoryResponse(BaseModel):
     aggregates: List[PerformanceAggregateRead] = Field(default_factory=list, description="Historical aggregates")
     period_type: str = Field(..., description="Aggregation period type")
     total_count: int = Field(0, description="Total matching records")
+
+
+# --- Semantic Search Schemas ---
+
+
+class ToolSearchResult(BaseModelWithConfigDict):
+    """Schema for a single tool search result from semantic search.
+
+    Includes essential tool information and similarity score for ranking.
+    """
+
+    tool_name: str = Field(..., description="Tool name")
+    description: Optional[str] = Field(None, description="Tool description")
+    server_id: Optional[str] = Field(None, description="Server/gateway ID providing this tool")
+    server_name: Optional[str] = Field(None, description="Server/gateway name providing this tool")
+    similarity_score: float = Field(..., ge=0.0, le=1.0, description="Similarity score (0-1, higher = more relevant)")
+
+
+class SemanticSearchResponse(BaseModelWithConfigDict):
+    """Response schema for semantic tool search endpoint.
+
+    Returns a list of ranked tools matching the semantic query.
+    """
+
+    results: List[ToolSearchResult] = Field(..., description="Ranked list of matching tools")
+    query: str = Field(..., description="Original search query")
+    total_results: int = Field(..., ge=0, description="Total number of results returned")

--- a/mcpgateway/services/embedding_service.py
+++ b/mcpgateway/services/embedding_service.py
@@ -1,0 +1,478 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/embedding_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Team A
+
+Embedding Service for generating text embeddings.
+
+Team A is responsible for implementing this service.
+This file will contain the embedding model and related functions.
+
+Required interface:
+- embed_query(query: str) -> List[float]: Generate embedding for a query string
+"""
+
+# Standard
+import asyncio
+import logging
+import os
+from typing import List, Dict, Any, Optional
+
+from mcpgateway.config import settings
+from mcpgateway.services.mcp_client_chat_service import (
+    EmbeddingConfig,
+    EmbeddingProviderFactory,
+    OpenAIEmbeddingConfig,
+)
+from sqlalchemy.orm import Session
+from mcpgateway.db import ToolEmbedding
+
+logger = logging.getLogger(__name__)
+
+class EmbeddingService:
+    """Service for generating text embeddings.
+    
+    Team A: Implement this class with your chosen embedding model
+    (e.g., OpenAI embeddings, sentence-transformers, etc.)
+    """
+
+    def __init__(self):
+        """Initialize the embedding model.
+        
+        Team A: Add your model initialization here.
+        Example: Load sentence-transformers model, initialize OpenAI client, etc.
+        """
+        # Set up attributes first
+        # Get config from settings instead of hardcoding
+        self.embedding_config = EmbeddingConfig(
+            provider=settings.embedding_provider,
+            config=OpenAIEmbeddingConfig(
+                model=settings.embedding_model,
+                api_key=settings.embedding_api_key.get_secret_value()
+            )
+        )
+        self._provider = None
+        self._embedding_model = None
+        self._initialized = False
+
+    async def initialize(self):
+        """Initialize the embedding provider (separate async method)."""
+        if self._initialized:
+            return
+        
+        self._provider = EmbeddingProviderFactory.create(self.embedding_config)
+        self._embedding_model = self._provider.get_embedding_model()
+        self._initialized = True
+
+    async def embed_query(self, query: str) -> List[float]:
+        """Generate embedding vector for a query string.
+
+        Args:
+            query: The text query to embed
+
+        Returns:
+            List of floats representing the embedding vector
+            Expected dimensions: 768 for most models (but can vary)
+
+        Raises:
+            RuntimeError: If embedding generation fails
+
+        Team A: Implement your embedding logic here.
+        """
+        # TODO: Team A - Replace this stub with actual embedding generation
+        # Example with sentence-transformers:
+        # embedding = self.model.encode(query)
+        # return embedding.tolist()
+        
+        if not self._initialized:
+            await self.initialize()
+
+        embedding = await self._embedding_model.aembed_query(query)
+        return embedding
+
+    async def embed_tool(self, tool_data: dict) -> List[float]:
+        """Generate embedding for a tool based on its metadata."""
+        # Validate tool data 
+        if not isinstance(tool_data, dict):
+            raise ValueError("Tool data must be a dictionary")
+        
+        if not tool_data.get('original_name'):
+            raise ValueError("Tool data must include 'original_name'")
+        
+        # Convert tool data to searchable text
+        tool_text = self.prepare_tool_text(tool_data)
+        
+        # Generate embedding using embed_text
+        try:
+            embedding = await self.embed_text(tool_text)
+            return embedding
+        except Exception as e:
+            raise RuntimeError(f"Tool embedding failed: {e}")
+
+    async def embed_tool_from_db(self, tool) -> List[float]:
+        """Generate embedding for tool from database object."""
+        tool_data = {
+            'original_name': tool.original_name,
+            'description': tool.description,
+            'tags': tool.tags if tool.tags else [],
+            'integration_type': tool.integration_type,
+            'input_schema': tool.input_schema if tool.input_schema else {},
+            'gateway_id': tool.gateway_id
+        }
+        
+        return await self.embed_tool(tool_data)
+
+    def prepare_tool_text(self, tool_data: dict) -> str:
+        """Convert tool metadata to searchable text."""
+        parts = []
+        
+        # Core info
+        parts.append(tool_data['original_name'])
+        if tool_data.get('description'):
+            parts.append(tool_data['description'])
+        
+        # Add parameter descriptions for better search
+        if tool_data.get('input_schema', {}).get('properties'):
+            param_parts = []
+            for name, schema in tool_data['input_schema']['properties'].items():
+                if schema.get('description'):
+                    param_parts.append(f"{name}: {schema['description']}")
+            if param_parts:
+                parts.append(f"parameters: {', '.join(param_parts)}")
+        
+        # Tags and metadata
+        if tool_data.get('tags'):
+            # Handle tags as either strings or dict objects
+            tag_strs = []
+            for tag in tool_data['tags']:
+                if isinstance(tag, dict):
+                    tag_strs.append(tag.get('id') or tag.get('label', str(tag)))
+                else:
+                    tag_strs.append(str(tag))
+            parts.append(f"tags: {', '.join(tag_strs)}")
+        
+        if tool_data.get('integration_type'):
+            parts.append(f"type: {tool_data['integration_type']}")
+        
+        return " | ".join(parts)
+
+    async def embed_text(self, text: str) -> List[float]:
+        """Generate embedding for arbitrary text."""
+        if not text or not text.strip():
+            raise ValueError("Text cannot be empty or whitespace only")
+        
+        if len(text) > 8192:  # Most embedding models have limits
+            raise ValueError(f"Text too long: {len(text)} characters (max 8192)")
+        
+        if not self._initialized:
+            await self.initialize()
+        
+        try:
+            embedding = await self._embedding_model.aembed_query(text.strip())
+            return embedding
+        except Exception as e:
+            logging.error(f"Failed to generate embedding for text: {e}")
+            raise RuntimeError(f"Text embedding failed: {e}")
+
+    async def batch_embed_tools(self, tools: List[dict]) -> List[List[float]]:
+        """Generate embeddings for multiple tools efficiently using true batching."""
+        if not tools:
+            return []
+        
+        if not self._initialized:
+            await self.initialize()
+        
+        # Convert all tools to text in one step
+        texts = [self.prepare_tool_text(tool) for tool in tools]
+        
+        try:
+            # ✅ True batch processing - single API call for all texts
+            embeddings = await self._embedding_model.aembed_documents(texts)
+            
+            logging.info(f"Successfully generated embeddings for {len(embeddings)} tools in batch")
+            return embeddings
+            
+        except Exception as e:
+            logging.error(f"Batch embedding failed: {e}")
+            raise RuntimeError(f"Batch embedding failed: {e}")
+
+    async def batch_embed_texts(self, texts: List[str]) -> List[List[float]]:
+        """Generate embeddings for multiple texts efficiently."""
+        if not texts:
+            return []
+        
+        # Validate input
+        for i, text in enumerate(texts):
+            if not text or not text.strip():
+                raise ValueError(f"Text at index {i} cannot be empty")
+            if len(text) > 8192:
+                raise ValueError(f"Text at index {i} too long: {len(text)} characters")
+        
+        if not self._initialized:
+            await self.initialize()
+        
+        try:
+            # ✅ True batch processing
+            embeddings = await self._embedding_model.aembed_documents(texts)
+            return embeddings
+        except Exception as e:
+            logging.error(f"Batch text embedding failed: {e}")
+            raise RuntimeError(f"Batch text embedding failed: {e}")
+
+    def get_provider_info(self) -> Dict[str, Any]:
+        """Get information about the current embedding provider."""
+        return {
+            'provider': self.embedding_config.provider,
+            'model': self.embedding_config.config.model,
+            'initialized': self._initialized
+            }
+
+    def store_tool_embedding(
+        self, 
+        db: Session, 
+        tool_id: str, 
+        embedding: List[float], 
+        model_name: str
+    ) -> ToolEmbedding:
+        """Store or update tool embedding in database.
+        
+        Args:
+            db: Database session
+            tool_id: ID of the tool
+            embedding: Embedding vector (list of floats)
+            model_name: Name of the embedding model used
+        
+        Returns:
+            ToolEmbedding: The created or updated embedding record
+        
+        Raises:
+            ValueError: If embedding is invalid
+            RuntimeError: If database operation fails
+        """
+        # Validate embedding
+        if not embedding or not isinstance(embedding, list):
+            raise ValueError("Embedding must be a non-empty list")
+        
+        if not all(isinstance(x, (int, float)) for x in embedding):
+            raise ValueError("Embedding must contain only numbers")
+        
+        try:
+            # Check if embedding already exists for this tool
+            existing = db.query(ToolEmbedding).filter(
+                ToolEmbedding.tool_id == tool_id
+            ).first()
+            
+            if existing:
+                # Update existing embedding
+                existing.embedding = embedding
+                existing.model_name = model_name
+                # updated_at will be automatically set by onupdate
+                db.commit()
+                db.refresh(existing)
+                logging.info(f"Updated embedding for tool {tool_id}")
+                return existing
+            else:
+                # Create new embedding
+                db_embedding = ToolEmbedding(
+                    tool_id=tool_id,
+                    embedding=embedding,
+                    model_name=model_name,
+                )
+                db.add(db_embedding)
+                db.commit()
+                db.refresh(db_embedding)
+                logging.info(f"Created embedding for tool {tool_id}")
+                return db_embedding
+                
+        except Exception as e:
+            db.rollback()
+            logging.error(f"Failed to store embedding for tool {tool_id}: {e}")
+            raise RuntimeError(f"Database operation failed: {e}")
+
+    def batch_store_tool_embeddings(
+        self,
+        db: Session,
+        tool_embeddings: List[tuple[str, List[float]]],
+        model_name: str
+    ) -> List[ToolEmbedding]:
+        """Store multiple tool embeddings efficiently.
+        
+        Args:
+            db: Database session
+            tool_embeddings: List of (tool_id, embedding) tuples
+            model_name: Name of the embedding model used
+        
+        Returns:
+            List of created/updated ToolEmbedding records
+        """
+        if not tool_embeddings:
+            return []
+        
+        try:
+            results = []
+            
+            # Get existing embeddings in one query
+            tool_ids = [tool_id for tool_id, _ in tool_embeddings]
+            existing_map = {
+                emb.tool_id: emb 
+                for emb in db.query(ToolEmbedding).filter(
+                    ToolEmbedding.tool_id.in_(tool_ids)
+                ).all()
+            }
+            
+            # Process each embedding
+            for tool_id, embedding in tool_embeddings:
+                if tool_id in existing_map:
+                    # Update existing
+                    existing = existing_map[tool_id]
+                    existing.embedding = embedding
+                    existing.model_name = model_name
+                    results.append(existing)
+                else:
+                    # Create new
+                    new_embedding = ToolEmbedding(
+                        tool_id=tool_id,
+                        embedding=embedding,
+                        model_name=model_name,
+                    )
+                    db.add(new_embedding)
+                    results.append(new_embedding)
+            
+            # Commit all changes at once
+            db.commit()
+            
+            # Refresh all objects
+            for result in results:
+                db.refresh(result)
+            
+            logging.info(f"Stored {len(results)} tool embeddings")
+            return results
+            
+        except Exception as e:
+            db.rollback()
+            logging.error(f"Batch store failed: {e}")
+            raise RuntimeError(f"Batch storage failed: {e}")
+    
+    async def embed_and_store_tool(
+        self, 
+        db: Session, 
+        tool
+    ) -> ToolEmbedding:
+        """Generate and store embedding for a single tool.
+        
+        Args:
+            db: Database session
+            tool: Tool object from database
+        
+        Returns:
+            ToolEmbedding: The stored embedding record
+        """
+        # Generate embedding
+        embedding = await self.embed_tool_from_db(tool)
+        
+        # Store in database
+        model_name = self.embedding_config.config.model
+        return self.store_tool_embedding(db, tool.id, embedding, model_name)
+
+
+    async def embed_and_store_tools_batch(
+        self,
+        db: Session,
+        tools: List
+    ) -> List[ToolEmbedding]:
+        """Generate and store embeddings for multiple tools efficiently.
+        
+        Args:
+            db: Database session
+            tools: List of Tool objects from database
+        
+        Returns:
+            List of stored ToolEmbedding records
+        """
+        if not tools:
+            return []
+        
+        # Convert tools to dict format
+        tools_data = []
+        for tool in tools:
+            tool_data = {
+                'original_name': tool.original_name,
+                'description': tool.description,
+                'tags': tool.tags if tool.tags else [],
+                'integration_type': tool.integration_type,
+                'input_schema': tool.input_schema if tool.input_schema else {},
+                'gateway_id': tool.gateway_id
+            }
+            tools_data.append(tool_data)
+        
+        # Generate all embeddings in batch
+        embeddings = await self.batch_embed_tools(tools_data)
+        
+        # Prepare for batch storage
+        tool_embeddings = [(tool.id, embedding) for tool, embedding in zip(tools, embeddings)]
+        
+        # Store all embeddings
+        model_name = self.embedding_config.config.model
+        return self.batch_store_tool_embeddings(db, tool_embeddings, model_name)
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions (used by main.py and cli.py)
+# ---------------------------------------------------------------------------
+
+async def index_tool_fire_and_forget(tool_id: str) -> None:
+    """Index a single tool's embedding in the background.
+
+    Creates its own DB session and EmbeddingService instance so it can run
+    as a fire-and-forget ``asyncio.create_task()`` without affecting the
+    caller's latency.  All exceptions are caught and logged.
+
+    Args:
+        tool_id: Primary key of the tool to index.
+    """
+    from mcpgateway.db import SessionLocal, Tool  # pylint: disable=import-outside-toplevel
+
+    db = SessionLocal()
+    try:
+        tool = db.query(Tool).filter(Tool.id == tool_id).first()
+        if tool is None:
+            logger.warning("index_tool_fire_and_forget: tool %s not found", tool_id)
+            return
+
+        service = EmbeddingService()
+        await service.embed_and_store_tool(db, tool)
+        logger.info("Successfully indexed embedding for tool %s", tool_id)
+    except Exception:
+        logger.exception("Failed to index embedding for tool %s", tool_id)
+    finally:
+        db.close()
+
+
+async def reindex_all_tools(db: Session) -> Dict[str, int]:
+    """Re-index embeddings for every enabled tool in the database.
+
+    Args:
+        db: An open SQLAlchemy session.
+
+    Returns:
+        Dict with keys ``total``, ``succeeded``, ``failed``.
+    """
+    from mcpgateway.db import Tool  # pylint: disable=import-outside-toplevel
+
+    tools = db.query(Tool).filter(Tool.enabled.is_(True)).all()
+    total = len(tools)
+    succeeded = 0
+    failed = 0
+
+    service = EmbeddingService()
+
+    for tool in tools:
+        try:
+            await service.embed_and_store_tool(db, tool)
+            succeeded += 1
+        except Exception:
+            logger.exception("Failed to index tool %s (%s)", tool.id, tool.original_name)
+            failed += 1
+
+    return {"total": total, "succeeded": succeeded, "failed": failed}

--- a/mcpgateway/services/semantic_search_service.py
+++ b/mcpgateway/services/semantic_search_service.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/semantic_search_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Team C
+
+Semantic Search Service for Tool Discovery.
+
+This module orchestrates semantic search by coordinating between:
+- Team A's embedding service (mcpgateway/services/embedding_service.py)
+- Team B's vector search service (mcpgateway/services/vector_search_service.py)
+
+Team C is responsible for:
+- Validating search parameters
+- Orchestrating the embedding + search workflow
+- Exposing the GET /tools/semantic endpoint (in main.py)
+"""
+
+# Standard
+import time
+import json
+from typing import List, Optional, Dict, Tuple
+
+# First-Party
+from mcpgateway.schemas import ToolSearchResult
+from mcpgateway.utils.redis_client import get_redis_client
+
+# Import Team A's embedding service
+# Team A will implement embed_query() in this file
+try:
+    from mcpgateway.services.embedding_service import EmbeddingService
+except ImportError:
+    # Fallback stub if Team A hasn't created the file yet
+    class EmbeddingService:
+        """Temporary stub until Team A implements embedding_service.py"""
+        async def embed_query(self, query: str) -> List[float]:
+            return [0.0] * 768
+
+# Import Team B's vector search service
+# Team B will implement search_similar_tools() in this file
+try:
+    from mcpgateway.services.vector_search_service import VectorSearchService
+except ImportError:
+    # Fallback stub if Team B hasn't created the file yet
+    class VectorSearchService:
+        """Temporary stub until Team B implements vector_search_service.py"""
+        async def search_similar_tools(
+            self,
+            embedding: List[float],
+            limit: int = 10,
+            threshold: Optional[float] = None,
+        ) -> List[ToolSearchResult]:
+            return []
+
+
+class SemanticSearchService:
+    """Orchestrates semantic search operations.
+
+    Coordinates embedding generation and vector search to provide
+    semantic tool discovery capabilities.
+    """
+
+    CACHE_TTL_SECONDS = 60
+
+    def __init__(self):
+        """Initialize semantic search service with embedding and vector search services."""
+        self.embedding_service = EmbeddingService()
+        self.vector_search_service = VectorSearchService()
+
+        # Fallback memory cache
+        self._memory_cache: Dict[str, Tuple[float, List[ToolSearchResult]]] = {}
+
+    # Helpers
+
+    def _normalize_query(self, query: str) -> str:
+        return query.strip().lower()
+    
+    def _make_cache_key(self, query: str, limit: int, threshold: Optional[float]) -> str:
+        return f"semantic:{query}:{limit}:{threshold}"
+    
+    # Memory cache
+
+    def _get_memory_cache(self, key: str) -> Optional[List[ToolSearchResult]]:
+        entry = self._memory_cache.get(key)
+        if not entry:
+            return None
+        
+        expires_at, results = entry
+        
+        if time.time() > expires_at:
+            del self._memory_cache[key]
+            return None
+        
+        return results
+    
+    def _set_memory_cache(self, key: str, results: List[ToolSearchResult]) -> None:
+        self._memory_cache[key] = (
+            time.time() + self.CACHE_TTL_SECONDS,
+            results,
+        )
+
+    # Redis cache
+
+    async def _get_redis_cache(self, key: str) -> Optional[List[ToolSearchResult]]:
+        client = await get_redis_client()
+        if not client:
+            return None
+        
+        raw = await client.get(key)
+        if not raw:
+            return None
+        
+        # deserialize
+        data = json.loads(raw)
+        return [ToolSearchResult(**item) for item in data]
+    
+    async def _set_redis_cache(self, key: str, results: List[ToolSearchResult]) -> None:
+        client = await get_redis_client()
+        if not client:
+            return
+        
+        payload = json.dumps([r.model_dump() for r in results])
+
+        await client.set(
+            key,
+            payload,
+            ex=self.CACHE_TTL_SECONDS,
+        )
+
+    # Public API
+
+    async def search_tools(
+        self,
+        query: str,
+        limit: int = 10,
+        threshold: Optional[float] = None,
+    ) -> List[ToolSearchResult]:
+        """Perform semantic search for tools matching the query.
+
+        Args:
+            query: Natural language search query
+            limit: Maximum number of results (1-50)
+            threshold: Optional similarity threshold (0-1)
+
+        Returns:
+            List of matching tools ranked by relevance
+
+        Raises:
+            ValueError: If parameters are invalid
+            RuntimeError: If search operation fails
+        """
+        # Validate parameters
+        if not query or not query.strip():
+            raise ValueError("Query cannot be empty")
+
+        if limit < 1 or limit > 50:
+            raise ValueError("Limit must be between 1 and 50")
+
+        if threshold is not None and (threshold < 0.0 or threshold > 1.0):
+            raise ValueError("Threshold must be between 0.0 and 1.0")
+
+        normalized_query = self._normalize_query(query)
+        cache_key = self._make_cache_key(normalized_query, limit, threshold)
+
+        # 1. Try Redis first
+
+        cached = await self._get_redis_cache(cache_key)
+        if cached is not None:
+            return cached
+        
+        # 2. Try memory fallback
+
+        cached = self._get_memory_cache(cache_key)
+        if cached is not None:
+            return cached
+        
+        # 3. Compute normally
+
+        # Generate embedding for query
+        embedding = await self.embedding_service.embed_query(normalized_query)
+
+        # Acquire a database session for vector search
+        from mcpgateway.db import get_db
+
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            results = await self.vector_search_service.search_similar_tools(
+                embedding=embedding,
+                limit=limit,
+                threshold=threshold,
+                db=db,
+            )
+        finally:
+            db_gen.close()
+
+        # 4. Store cache
+        await self._set_redis_cache(cache_key, results)
+        self._set_memory_cache(cache_key, results)
+
+        return results
+
+
+# Singleton instance
+_semantic_search_service: Optional[SemanticSearchService] = None
+
+
+def get_semantic_search_service() -> SemanticSearchService:
+    """Get or create the singleton SemanticSearchService instance.
+
+    Returns:
+        SemanticSearchService instance
+    """
+    global _semantic_search_service
+    if _semantic_search_service is None:
+        _semantic_search_service = SemanticSearchService()
+    return _semantic_search_service

--- a/mcpgateway/services/vector_search_service.py
+++ b/mcpgateway/services/vector_search_service.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/vector_search_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Vector Search Service for semantic similarity search over tool embeddings.
+
+Primary backend (PostgreSQL):
+    Uses pgvector's native cosine distance operator (<=>) for similarity search.
+    This leverages the HNSW index on the tool_embeddings table for fast
+    approximate nearest-neighbor lookup.
+
+Fallback backend (SQLite):
+    For development and testing where pgvector is not available, loads embeddings
+    into memory and computes cosine similarity using numpy.
+"""
+
+# Standard
+import logging
+from typing import List, Optional
+
+# Third-Party
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import Tool, ToolEmbedding
+from mcpgateway.schemas import ToolSearchResult
+
+logger = logging.getLogger(__name__)
+
+
+def _cosine_similarity_numpy(vec_a: List[float], vec_b: List[float]) -> float:
+    """Compute cosine similarity between two vectors using numpy.
+
+    SQLite fallback only — on PostgreSQL, pgvector handles this in SQL.
+
+    Args:
+        vec_a: First embedding vector.
+        vec_b: Second embedding vector.
+
+    Returns:
+        Cosine similarity score clamped to [0.0, 1.0].
+    """
+    import numpy as np  # noqa: E402  # Lazy import — transitive dep of pgvector, not declared in pyproject.toml
+
+    a = np.asarray(vec_a, dtype=np.float64)
+    b = np.asarray(vec_b, dtype=np.float64)
+
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+
+    similarity = float(np.dot(a, b) / (norm_a * norm_b))
+    return max(0.0, min(1.0, similarity))
+
+
+class VectorSearchService:
+    """Service for vector similarity search over tool embeddings.
+
+    Uses pgvector for PostgreSQL (production) with HNSW-indexed cosine distance.
+    Falls back to numpy-based cosine similarity on SQLite (dev/test).
+    """
+
+    def __init__(self, db: Optional[Session] = None):
+        """Initialize the vector search service.
+
+        Args:
+            db: Optional database session for queries.
+        """
+        self.db = db
+
+    async def search_similar_tools(
+        self,
+        embedding: List[float],
+        limit: int = 10,
+        threshold: Optional[float] = None,
+        db: Optional[Session] = None,
+    ) -> List[ToolSearchResult]:
+        """Search for tools similar to the given embedding vector.
+
+        On PostgreSQL, uses pgvector's cosine_distance() which leverages the
+        HNSW index for fast approximate nearest-neighbor search.
+        On SQLite, falls back to in-memory numpy computation.
+
+        Args:
+            embedding: Query embedding vector (1536-dimensional).
+            limit: Maximum number of results to return (1-50).
+            threshold: Optional similarity threshold (0-1).
+                Only return results with similarity >= threshold.
+            db: Optional database session. Falls back to self.db.
+
+        Returns:
+            List of ToolSearchResult objects ranked by similarity (highest first).
+
+        Raises:
+            RuntimeError: If no database session is available or vector search fails.
+        """
+        session = db or self.db
+        if session is None:
+            raise RuntimeError("No database session available for vector search")
+
+        if not embedding:
+            logger.warning("Empty embedding provided for similarity search")
+            return []
+
+        try:
+            dialect_name = session.get_bind().dialect.name
+            if dialect_name == "postgresql":
+                return self._search_postgresql(session, embedding, limit, threshold)
+            else:
+                return self._search_sqlite(session, embedding, limit, threshold)
+        except Exception as e:
+            logger.error(f"Vector search failed: {e}")
+            raise RuntimeError(f"Vector search failed: {e}") from e
+
+    def _search_postgresql(
+        self,
+        db: Session,
+        embedding: List[float],
+        limit: int,
+        threshold: Optional[float],
+    ) -> List[ToolSearchResult]:
+        """Similarity search using pgvector's native cosine distance operator.
+
+        Uses the <=> operator which leverages the HNSW index for fast ANN search.
+        All computation happens in PostgreSQL — no Python-side vector math.
+        """
+        distance_expr = ToolEmbedding.embedding.cosine_distance(embedding)
+
+        query = (
+            select(
+                ToolEmbedding,
+                Tool,
+                (1 - distance_expr).label("similarity"),
+            )
+            .join(Tool, ToolEmbedding.tool_id == Tool.id)
+            .filter(Tool.enabled.is_(True))
+        )
+
+        if threshold is not None:
+            query = query.filter(distance_expr <= (1 - threshold))
+
+        query = query.order_by(distance_expr.asc()).limit(limit)
+        rows = db.execute(query).all()
+
+        return [
+            ToolSearchResult(
+                tool_name=tool.name,
+                description=tool.description,
+                server_id=tool.gateway_id,
+                server_name=tool.gateway.name if tool.gateway else None,
+                similarity_score=max(0.0, min(1.0, float(similarity))),
+            )
+            for _tool_embedding, tool, similarity in rows
+        ]
+
+    def _search_sqlite(
+        self,
+        db: Session,
+        embedding: List[float],
+        limit: int,
+        threshold: Optional[float],
+    ) -> List[ToolSearchResult]:
+        """Fallback similarity search for SQLite (dev/test only).
+
+        Loads all embeddings into memory and computes cosine similarity with numpy.
+        """
+        query = select(ToolEmbedding, Tool).join(Tool, ToolEmbedding.tool_id == Tool.id).filter(Tool.enabled.is_(True))
+        rows = db.execute(query).all()
+
+        if not rows:
+            return []
+
+        scored: List[tuple[float, ToolEmbedding, Tool]] = []
+        for tool_embedding, tool in rows:
+            similarity = _cosine_similarity_numpy(embedding, tool_embedding.embedding)
+            if threshold is not None and similarity < threshold:
+                continue
+            scored.append((similarity, tool_embedding, tool))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        scored = scored[:limit]
+
+        return [
+            ToolSearchResult(
+                tool_name=tool.name,
+                description=tool.description,
+                server_id=tool.gateway_id,
+                server_name=tool.gateway.name if tool.gateway else None,
+                similarity_score=similarity,
+            )
+            for similarity, _tool_embedding, tool in scored
+        ]
+
+    def get_tool_embedding(
+        self,
+        db: Session,
+        tool_id: str,
+    ) -> Optional[ToolEmbedding]:
+        """Retrieve stored embedding for a tool.
+
+        Args:
+            db: Database session.
+            tool_id: ID of the tool.
+
+        Returns:
+            ToolEmbedding if found, None otherwise.
+        """
+        return db.query(ToolEmbedding).filter(ToolEmbedding.tool_id == tool_id).first()
+
+    def delete_tool_embedding(
+        self,
+        db: Session,
+        tool_id: str,
+    ) -> bool:
+        """Delete stored embedding for a tool.
+
+        Args:
+            db: Database session.
+            tool_id: ID of the tool.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        embedding = self.get_tool_embedding(db, tool_id)
+        if embedding:
+            db.delete(embedding)
+            db.commit()
+            logger.info(f"Deleted embedding for tool {tool_id}")
+            return True
+        logger.warning(f"No embedding found for tool {tool_id}")
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,13 @@ dependencies = [
     "jsonpath-ng>=1.7.0",
     "jsonschema>=4.26.0",
     "mcp>=1.26.0",
+    "numpy>=2.4.2",
     "orjson>=3.11.7",
     "parse>=1.21.0",
+    "mcp>=1.25.0",
+    "oauthlib>=3.3.1",
+    "orjson>=3.11.5",
+    "parse>=1.20.2",
     "prometheus-fastapi-instrumentator>=7.1.0",
     "prometheus_client>=0.24.1",
     "psutil>=7.2.2",
@@ -171,6 +176,11 @@ dev = [
 # Optional dependency groups (extras)
 # ----------------------------------------------------------------
 [project.optional-dependencies]
+# PostgreSQL with vector search support
+postgres-vector = [
+    "psycopg[c,binary]>=3.3.2",
+    "pgvector>=0.3.6",
+]
 
 # Optional dependency groups (runtime)
 # Redis with hiredis C parser for up to 83x faster response parsing
@@ -202,6 +212,7 @@ mariadb = [
 llmchat = [
     "langchain-core>=1.2.11",
     "langchain-mcp-adapters>=0.2.1",
+    "langchain-mistralai>=0.2.0",
     "langchain-ollama>=1.0.1",
     "langchain-openai>=1.1.9",
     "langgraph>=1.0.8",
@@ -256,9 +267,9 @@ profiling = [
     "py-spy>=0.4.1",
 ]
 
-# Plugin templating tools (optional)
+# Plugin templating tools (optional) - copier pulls jinja2-ansible-filters which is GPL licensed
 templating = [
-    "cookiecutter>=2.6.0",
+    "copier>=9.11.3",
 ]
 
 # Agent Lifecycle Toolkit(optional)
@@ -592,7 +603,7 @@ plugins = ["pydantic.mypy"]              # Enable mypy plugin for Pydantic model
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q --ignore=tests/playwright --ignore=tests/migration --ignore=tests/performance --ignore=tests/compliance"
+addopts = "-ra -q --ignore=tests/playwright --ignore=tests/migration --ignore=tests/performance"
 testpaths = [ "tests",]
 asyncio_mode = "auto"
 filterwarnings = [
@@ -623,20 +634,6 @@ markers = [
     "benchmark: marks tests as performance benchmarks (migration testing)",
     "integration: marks tests as integration tests (require external services)",
     "postgresql: marks tests that require PostgreSQL database",
-    "mcp20251125: marks MCP 2025-11-25 compliance tests",
-    "mcp_core: marks MCP core compliance tests",
-    "mcp_required: marks MCP MUST-level compliance checks",
-    "mcp_recommended: marks MCP SHOULD-level compliance checks",
-    "mcp_optional: marks MCP MAY/optional compliance checks",
-    "mcp_base: marks JSON-RPC and envelope compliance checks",
-    "mcp_lifecycle: marks initialize/capability lifecycle checks",
-    "mcp_transport_core: marks streamable-http/transport checks",
-    "mcp_server_features: marks tools/resources/prompts/logging checks",
-    "mcp_client_features: marks roots/sampling/elicitation checks",
-    "mcp_utilities: marks ping/cancel/progress/pagination checks",
-    "mcp_tasks: marks tasks capability checks",
-    "mcp_auth: marks authorization discovery checks",
-    "mcp_security: marks security compliance checks",
 ]
 
 # Playwright-specific test discovery patterns
@@ -706,7 +703,8 @@ ignore_unused = [
   "snakeviz",
   "types-tabulate",
   "twine",
-  "uvicorn"
+  "uvicorn",
+  "pgvector"
 ]
 
 # --------------------------------------------------------------------

--- a/tests/integration/test_embedding_storage_integration.py
+++ b/tests/integration/test_embedding_storage_integration.py
@@ -1,0 +1,923 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_embedding_storage_integration.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for EmbeddingService storage operations with real database.
+"""
+
+# Standard
+import time
+from typing import Generator
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# First-Party
+from mcpgateway.db import Base, Tool, ToolEmbedding
+from mcpgateway.services.embedding_service import EmbeddingService
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture(scope="function")
+def test_db_engine():
+    """Create a test database engine using SQLite in-memory.
+    
+    Each test gets a fresh database.
+    """
+    engine = create_engine("sqlite:///:memory:", echo=False)
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def test_db_session(test_db_engine) -> Generator[Session, None, None]:
+    """Create a test database session.
+    
+    Automatically commits/rollsback after each test.
+    """
+    SessionLocal = sessionmaker(bind=test_db_engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def sample_tools(test_db_session):
+    """Create sample tools in the test database.
+    
+    Returns:
+        List of 3 Tool objects with different characteristics
+    """
+    tools = [
+        Tool(
+            id="tool-weather-1",
+            original_name="weather_api",
+            name="weather_api",
+            custom_name="Weather API",
+            custom_name_slug="weather-api",
+            description="Get current weather information for any city",
+            input_schema={
+                "properties": {
+                    "city": {"type": "string", "description": "City name"},
+                    "units": {"type": "string", "description": "Temperature units (celsius/fahrenheit)"}
+                }
+            },
+            tags=["weather", "api", "data"],
+            integration_type="REST",
+            gateway_id="gateway-1",
+            enabled=True
+        ),
+        Tool(
+            id="tool-email-2",
+            original_name="email_sender",
+            name="email_sender",
+            custom_name="Email Sender",
+            custom_name_slug="email-sender",
+            description="Send email notifications to users",
+            input_schema={
+                "properties": {
+                    "to": {"type": "string", "description": "Recipient email address"},
+                    "subject": {"type": "string", "description": "Email subject line"},
+                    "body": {"type": "string", "description": "Email body content"}
+                }
+            },
+            tags=["email", "communication", "notifications"],
+            integration_type="SMTP",
+            gateway_id="gateway-1",
+            enabled=True
+        ),
+        Tool(
+            id="tool-db-3",
+            original_name="database_query",
+            name="database_query",
+            custom_name="Database Query",
+            custom_name_slug="database-query",
+            description="Execute SQL queries on the database",
+            input_schema={
+                "properties": {
+                    "query": {"type": "string", "description": "SQL query to execute"},
+                    "database": {"type": "string", "description": "Target database name"}
+                }
+            },
+            tags=["database", "query", "sql"],
+            integration_type="SQL",
+            gateway_id="gateway-2",
+            enabled=True
+        ),
+    ]
+    
+    for tool in tools:
+        test_db_session.add(tool)
+    
+    test_db_session.commit()
+    
+    for tool in tools:
+        test_db_session.refresh(tool)
+    
+    return tools
+
+
+@pytest.fixture
+def embedding_service():
+    """Create a mock embedding service for testing storage operations.
+    
+    This fixture mocks the embedding provider so tests can run without
+    requiring langchain-openai or OpenAI API access.
+    
+    Returns:
+        EmbeddingService: Mock service that doesn't require API initialization
+    """
+    service = EmbeddingService()
+    
+    # Mock the initialization so it doesn't require langchain-openai
+    service._initialized = True
+    service._provider = MagicMock()
+    service._embedding_model = AsyncMock()
+    
+    # Mock the embedding methods to return fake but realistic embeddings
+    async def mock_embed_query(text):
+        # Return a fake 1536-dimensional embedding based on text hash
+        # This ensures different texts get different embeddings
+        import hashlib
+        text_hash = int(hashlib.md5(text.encode()).hexdigest(), 16)
+        base_value = (text_hash % 1000) / 1000.0
+        return [base_value + i * 0.0001 for i in range(1536)]
+    
+    async def mock_embed_documents(texts):
+        # Return fake embeddings for each text
+        embeddings = []
+        for text in texts:
+            import hashlib
+            text_hash = int(hashlib.md5(text.encode()).hexdigest(), 16)
+            base_value = (text_hash % 1000) / 1000.0
+            embeddings.append([base_value + j * 0.0001 for j in range(1536)])
+        return embeddings
+    
+    service._embedding_model.aembed_query = mock_embed_query
+    service._embedding_model.aembed_documents = mock_embed_documents
+    
+    # Mock the config model name
+    service.embedding_config.config.model = "text-embedding-3-small"
+    
+    return service
+
+
+# ============================================================================
+# BASIC STORAGE OPERATIONS
+# ============================================================================
+
+
+class TestBasicStorageOperations:
+    """Test basic database storage operations."""
+
+    def test_store_new_embedding_creates_record(self, test_db_session, embedding_service):
+        """Test that storing a new embedding creates a database record."""
+        # Arrange
+        embedding = [0.1, 0.2, 0.3] * 512  # 1536 dimensions
+        tool_id = "test-tool-new"
+        model_name = "text-embedding-3-small"
+        
+        # Act
+        result = embedding_service.store_tool_embedding(
+            test_db_session, 
+            tool_id, 
+            embedding, 
+            model_name
+        )
+        
+        # Assert - Check return value
+        assert result is not None
+        assert result.id is not None
+        assert result.tool_id == tool_id
+        assert result.embedding == embedding
+        assert result.model_name == model_name
+        assert result.created_at is not None
+        assert result.updated_at is not None
+        
+        # Assert - Verify it's in the database
+        db_embedding = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool_id
+        ).first()
+        
+        assert db_embedding is not None
+        assert db_embedding.tool_id == tool_id
+        assert len(db_embedding.embedding) == 1536
+
+    def test_update_existing_embedding_modifies_in_place(self, test_db_session, embedding_service):
+        """Test that updating an existing embedding modifies the record in-place."""
+        # Arrange
+        tool_id = "test-tool-update"
+        initial_embedding = [0.1] * 1536
+        initial_model = "text-embedding-3-small"
+        
+        # Act - Create initial embedding
+        first_result = embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            initial_embedding,
+            initial_model
+        )
+        first_id = first_result.id
+        
+        # Act - Update with new embedding
+        new_embedding = [0.9] * 1536
+        new_model = "text-embedding-3-large"
+        
+        second_result = embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            new_embedding,
+            new_model
+        )
+        
+        # Assert - Same record ID (updated, not created new)
+        assert second_result.id == first_id
+        assert second_result.embedding == new_embedding
+        assert second_result.model_name == new_model
+        
+        # Assert - Only one record exists
+        count = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool_id
+        ).count()
+        
+        assert count == 1
+
+    def test_store_multiple_different_tools(self, test_db_session, embedding_service):
+        """Test storing embeddings for multiple different tools."""
+        # Arrange
+        tools_data = [
+            ("multi-tool-1", [0.1] * 1536, "model-1"),
+            ("multi-tool-2", [0.2] * 1536, "model-2"),
+            ("multi-tool-3", [0.3] * 1536, "model-3"),
+        ]
+        
+        # Act
+        for tool_id, embedding, model in tools_data:
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                tool_id,
+                embedding,
+                model
+            )
+        
+        # Assert
+        total_count = test_db_session.query(ToolEmbedding).count()
+        assert total_count == 3
+        
+        # Verify each one individually
+        for tool_id, expected_embedding, expected_model in tools_data:
+            db_embedding = test_db_session.query(ToolEmbedding).filter(
+                ToolEmbedding.tool_id == tool_id
+            ).first()
+            
+            assert db_embedding is not None
+            assert db_embedding.embedding == expected_embedding
+            assert db_embedding.model_name == expected_model
+
+
+# ============================================================================
+# BATCH STORAGE OPERATIONS
+# ============================================================================
+
+
+class TestBatchStorageOperations:
+    """Test batch storage operations."""
+
+    def test_batch_store_creates_all_records(self, test_db_session, embedding_service):
+        """Test that batch storing creates all records in one transaction."""
+        # Arrange
+        tool_embeddings = [
+            ("batch-tool-1", [0.1] * 1536),
+            ("batch-tool-2", [0.2] * 1536),
+            ("batch-tool-3", [0.3] * 1536),
+        ]
+        model_name = "text-embedding-3-small"
+        
+        # Act
+        results = embedding_service.batch_store_tool_embeddings(
+            test_db_session,
+            tool_embeddings,
+            model_name
+        )
+        
+        # Assert - All results returned
+        assert len(results) == 3
+        
+        for i, result in enumerate(results):
+            assert result.tool_id == tool_embeddings[i][0]
+            assert result.embedding == tool_embeddings[i][1]
+            assert result.model_name == model_name
+        
+        # Assert - All in database
+        for tool_id, embedding in tool_embeddings:
+            db_embedding = test_db_session.query(ToolEmbedding).filter(
+                ToolEmbedding.tool_id == tool_id
+            ).first()
+            
+            assert db_embedding is not None
+            assert db_embedding.tool_id == tool_id
+
+    def test_batch_store_handles_mixed_create_update(self, test_db_session, embedding_service):
+        """Test batch storing handles both new and existing records correctly."""
+        # Arrange - Create one existing embedding
+        existing_tool_id = "batch-existing"
+        existing_embedding = [0.5] * 1536
+        
+        embedding_service.store_tool_embedding(
+            test_db_session,
+            existing_tool_id,
+            existing_embedding,
+            "old-model"
+        )
+        
+        # Act - Batch with mix of new and existing
+        tool_embeddings = [
+            (existing_tool_id, [0.9] * 1536),  # Update
+            ("batch-new-1", [0.1] * 1536),      # Create
+            ("batch-new-2", [0.2] * 1536),      # Create
+        ]
+        model_name = "text-embedding-3-small"
+        
+        results = embedding_service.batch_store_tool_embeddings(
+            test_db_session,
+            tool_embeddings,
+            model_name
+        )
+        
+        # Assert - All returned
+        assert len(results) == 3
+        
+        # Assert - Existing was updated
+        updated = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == existing_tool_id
+        ).first()
+        
+        assert updated.embedding == [0.9] * 1536
+        assert updated.model_name == model_name
+        
+        # Assert - Total count correct
+        total_count = test_db_session.query(ToolEmbedding).count()
+        assert total_count == 3
+
+    def test_batch_store_all_updates(self, test_db_session, embedding_service):
+        """Test batch storing where all records are updates."""
+        # Arrange - Create initial embeddings
+        initial_data = [
+            ("update-tool-1", [0.1] * 1536),
+            ("update-tool-2", [0.2] * 1536),
+            ("update-tool-3", [0.3] * 1536),
+        ]
+        
+        for tool_id, embedding in initial_data:
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                tool_id,
+                embedding,
+                "old-model"
+            )
+        
+        # Act - Batch update all
+        updated_data = [
+            ("update-tool-1", [0.9] * 1536),
+            ("update-tool-2", [0.8] * 1536),
+            ("update-tool-3", [0.7] * 1536),
+        ]
+        
+        results = embedding_service.batch_store_tool_embeddings(
+            test_db_session,
+            updated_data,
+            "new-model"
+        )
+        
+        # Assert
+        assert len(results) == 3
+        
+        # Verify all updated
+        for tool_id, expected_embedding in updated_data:
+            db_embedding = test_db_session.query(ToolEmbedding).filter(
+                ToolEmbedding.tool_id == tool_id
+            ).first()
+            
+            assert db_embedding.embedding == expected_embedding
+            assert db_embedding.model_name == "new-model"
+        
+        # Still only 3 records
+        assert test_db_session.query(ToolEmbedding).count() == 3
+
+
+# ============================================================================
+# END-TO-END WORKFLOWS
+# ============================================================================
+
+
+class TestEndToEndWorkflows:
+    """Test complete workflows from tool to stored embedding."""
+
+    @pytest.mark.asyncio
+    async def test_embed_and_store_single_tool_complete_workflow(
+        self, 
+        test_db_session, 
+        sample_tools, 
+        embedding_service
+    ):
+        """Test complete workflow: fetch tool -> generate embedding -> store."""
+        # Arrange
+        tool = sample_tools[0]  # weather_api
+        
+        # Act
+        result = await embedding_service.embed_and_store_tool(test_db_session, tool)
+        
+        # Assert - Result structure
+        assert result is not None
+        assert result.tool_id == tool.id
+        assert len(result.embedding) == 1536
+        assert result.model_name == "text-embedding-3-small"
+        
+        # Assert - In database
+        db_embedding = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool.id
+        ).first()
+        
+        assert db_embedding is not None
+        assert db_embedding.tool_id == tool.id
+        assert isinstance(db_embedding.embedding, list)
+        assert len(db_embedding.embedding) == 1536
+
+    @pytest.mark.asyncio
+    async def test_embed_and_store_batch_complete_workflow(
+        self,
+        test_db_session,
+        sample_tools,
+        embedding_service
+    ):
+        """Test batch workflow: fetch tools -> generate embeddings -> store all."""
+        # Act
+        results = await embedding_service.embed_and_store_tools_batch(
+            test_db_session,
+            sample_tools
+        )
+        
+        # Assert - All results returned
+        assert len(results) == len(sample_tools)
+        
+        for tool, result in zip(sample_tools, results):
+            assert result.tool_id == tool.id
+            assert len(result.embedding) == 1536
+            assert result.model_name == "text-embedding-3-small"
+        
+        # Assert - All in database
+        db_embeddings = test_db_session.query(ToolEmbedding).all()
+        assert len(db_embeddings) == len(sample_tools)
+        
+        # Assert - Each tool has exactly one embedding
+        for tool in sample_tools:
+            db_embedding = test_db_session.query(ToolEmbedding).filter(
+                ToolEmbedding.tool_id == tool.id
+            ).first()
+            
+            assert db_embedding is not None
+            assert db_embedding.tool_id == tool.id
+
+    @pytest.mark.asyncio
+    async def test_re_embedding_updates_not_duplicates(
+        self,
+        test_db_session,
+        sample_tools,
+        embedding_service
+    ):
+        """Test that re-embedding a tool updates rather than creates duplicate."""
+        # Arrange
+        tool = sample_tools[0]
+        
+        # Act - First embedding
+        first_result = await embedding_service.embed_and_store_tool(
+            test_db_session,
+            tool
+        )
+        first_id = first_result.id
+        
+        # Act - Second embedding (should update)
+        second_result = await embedding_service.embed_and_store_tool(
+            test_db_session,
+            tool
+        )
+        
+        # Assert - Same record ID
+        assert second_result.id == first_id
+        
+        # Assert - Only one record exists
+        count = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool.id
+        ).count()
+        
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_embed_tools_with_different_descriptions(
+        self,
+        test_db_session,
+        sample_tools,
+        embedding_service
+    ):
+        """Test that tools with different descriptions get different embeddings."""
+        # Act
+        results = await embedding_service.embed_and_store_tools_batch(
+            test_db_session,
+            sample_tools
+        )
+        
+        # Assert - All embeddings are different
+        embeddings = [r.embedding for r in results]
+        
+        # No two embeddings should be identical
+        for i in range(len(embeddings)):
+            for j in range(i + 1, len(embeddings)):
+                assert embeddings[i] != embeddings[j], \
+                    f"Embeddings {i} and {j} should be different"
+
+
+# ============================================================================
+# DATABASE QUERIES & RELATIONSHIPS
+# ============================================================================
+
+
+class TestDatabaseQueriesAndRelationships:
+    """Test querying embeddings and tool relationships."""
+
+    def test_query_embedding_by_tool_id(self, test_db_session, embedding_service):
+        """Test retrieving a specific embedding by tool_id."""
+        # Arrange
+        embeddings_data = [
+            ("query-tool-1", [0.1] * 1536),
+            ("query-tool-2", [0.2] * 1536),
+            ("query-tool-3", [0.3] * 1536),
+        ]
+        
+        for tool_id, embedding in embeddings_data:
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                tool_id,
+                embedding,
+                "test-model"
+            )
+        
+        # Act
+        target_tool_id = "query-tool-2"
+        result = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == target_tool_id
+        ).first()
+        
+        # Assert
+        assert result is not None
+        assert result.tool_id == target_tool_id
+        assert result.embedding == [0.2] * 1536
+
+    def test_query_all_embeddings(self, test_db_session, embedding_service):
+        """Test retrieving all embeddings."""
+        # Arrange
+        embeddings_data = [
+            ("all-tool-1", [0.1] * 1536),
+            ("all-tool-2", [0.2] * 1536),
+        ]
+        
+        for tool_id, embedding in embeddings_data:
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                tool_id,
+                embedding,
+                "test-model"
+            )
+        
+        # Act
+        all_embeddings = test_db_session.query(ToolEmbedding).all()
+        
+        # Assert
+        assert len(all_embeddings) == 2
+        tool_ids = [e.tool_id for e in all_embeddings]
+        assert "all-tool-1" in tool_ids
+        assert "all-tool-2" in tool_ids
+
+    @pytest.mark.asyncio
+    async def test_join_tools_with_embeddings(
+        self,
+        test_db_session,
+        sample_tools,
+        embedding_service
+    ):
+        """Test joining Tool and ToolEmbedding tables."""
+        # Arrange - Create embeddings
+        await embedding_service.embed_and_store_tools_batch(
+            test_db_session,
+            sample_tools
+        )
+        
+        # Act - Join query
+        results = (
+            test_db_session.query(Tool, ToolEmbedding)
+            .join(ToolEmbedding, Tool.id == ToolEmbedding.tool_id)
+            .all()
+        )
+        
+        # Assert
+        assert len(results) == len(sample_tools)
+        
+        for tool, embedding in results:
+            assert tool.id == embedding.tool_id
+            assert isinstance(embedding.embedding, list)
+            assert len(embedding.embedding) == 1536
+
+    @pytest.mark.asyncio
+    async def test_find_tools_without_embeddings(
+        self,
+        test_db_session,
+        sample_tools,
+        embedding_service
+    ):
+        """Test finding tools that don't have embeddings yet."""
+        # Arrange - Only embed first 2 tools
+        tools_to_embed = sample_tools[:2]
+        
+        await embedding_service.embed_and_store_tools_batch(
+            test_db_session,
+            tools_to_embed
+        )
+        
+        # Act - Find tools without embeddings
+        tools_without_embeddings = (
+            test_db_session.query(Tool)
+            .outerjoin(ToolEmbedding, Tool.id == ToolEmbedding.tool_id)
+            .filter(ToolEmbedding.id.is_(None))
+            .all()
+        )
+        
+        # Assert
+        assert len(tools_without_embeddings) == 1
+        assert tools_without_embeddings[0].id == sample_tools[2].id
+
+    def test_count_embeddings_by_model(self, test_db_session, embedding_service):
+        """Test counting embeddings grouped by model name."""
+        # Arrange
+        embeddings_data = [
+            ("count-tool-1", [0.1] * 1536, "model-a"),
+            ("count-tool-2", [0.2] * 1536, "model-a"),
+            ("count-tool-3", [0.3] * 1536, "model-b"),
+        ]
+        
+        for tool_id, embedding, model in embeddings_data:
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                tool_id,
+                embedding,
+                model
+            )
+        
+        # Act
+        from sqlalchemy import func
+        results = (
+            test_db_session.query(
+                ToolEmbedding.model_name,
+                func.count(ToolEmbedding.id)
+            )
+            .group_by(ToolEmbedding.model_name)
+            .all()
+        )
+        
+        # Assert
+        counts = {model: count for model, count in results}
+        assert counts["model-a"] == 2
+        assert counts["model-b"] == 1
+
+
+# ============================================================================
+# DATA INTEGRITY & CONSTRAINTS
+# ============================================================================
+
+
+class TestDataIntegrityAndConstraints:
+    """Test data integrity and constraints."""
+
+    def test_embedding_dimensions_preserved(self, test_db_session, embedding_service):
+        """Test that embedding dimensions are preserved correctly."""
+        # Test different dimension sizes
+        test_cases = [
+            (512, "model-512"),
+            (1536, "model-1536"),
+            (3072, "model-3072"),
+        ]
+        
+        for dimensions, model_name in test_cases:
+            tool_id = f"tool-dim-{dimensions}"
+            embedding = [0.1] * dimensions
+            
+            # Store
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                tool_id,
+                embedding,
+                model_name
+            )
+            
+            # Retrieve
+            db_embedding = test_db_session.query(ToolEmbedding).filter(
+                ToolEmbedding.tool_id == tool_id
+            ).first()
+            
+            # Verify dimensions preserved
+            assert len(db_embedding.embedding) == dimensions
+
+    def test_timestamps_created_correctly(self, test_db_session, embedding_service):
+        """Test that created_at and updated_at timestamps are created."""
+        # Arrange
+        tool_id = "tool-timestamp-create"
+        embedding = [0.1] * 1536
+        
+        # Act
+        result = embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            embedding,
+            "test-model"
+        )
+        
+        # Assert
+        assert result.created_at is not None
+        assert result.updated_at is not None
+
+    def test_timestamps_updated_on_modify(self, test_db_session, embedding_service):
+        """Test that updated_at changes when embedding is modified."""
+        # Arrange
+        tool_id = "tool-timestamp-update"
+        embedding = [0.1] * 1536
+        
+        # Act - Create
+        result = embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            embedding,
+            "test-model"
+        )
+        
+        created_at = result.created_at
+        
+        # Wait a bit
+        time.sleep(0.1)
+        
+        # Act - Update
+        new_embedding = [0.9] * 1536
+        updated_result = embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            new_embedding,
+            "new-model"
+        )
+        
+        # Assert - created_at unchanged
+        assert updated_result.created_at == created_at
+        # updated_at exists
+        assert updated_result.updated_at is not None
+
+    def test_delete_embedding_removes_from_database(self, test_db_session, embedding_service):
+        """Test that deleting an embedding removes it from database."""
+        # Arrange
+        tool_id = "tool-delete"
+        embedding = [0.5] * 1536
+        
+        embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            embedding,
+            "test-model"
+        )
+        
+        # Verify exists
+        assert test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool_id
+        ).first() is not None
+        
+        # Act - Delete
+        db_embedding = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool_id
+        ).first()
+        
+        test_db_session.delete(db_embedding)
+        test_db_session.commit()
+        
+        # Assert - Gone
+        assert test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool_id
+        ).first() is None
+
+    def test_embedding_values_are_floats(self, test_db_session, embedding_service):
+        """Test that embedding values are stored as floats."""
+        # Arrange
+        tool_id = "tool-float-check"
+        embedding = [0.1, 0.2, 0.3] * 512
+        
+        # Act
+        embedding_service.store_tool_embedding(
+            test_db_session,
+            tool_id,
+            embedding,
+            "test-model"
+        )
+        
+        # Assert
+        db_embedding = test_db_session.query(ToolEmbedding).filter(
+            ToolEmbedding.tool_id == tool_id
+        ).first()
+        
+        for value in db_embedding.embedding:
+            assert isinstance(value, (int, float))
+
+
+# ============================================================================
+# ERROR HANDLING & EDGE CASES
+# ============================================================================
+
+
+class TestErrorHandlingAndEdgeCases:
+    """Test error handling in integration scenarios."""
+
+    def test_invalid_embedding_raises_error(self, test_db_session, embedding_service):
+        """Test that invalid embeddings raise appropriate errors."""
+        # Test 1: Empty embedding
+        with pytest.raises(ValueError, match="Embedding must be a non-empty list"):
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                "tool-123",
+                [],  # Empty
+                "test-model"
+            )
+        
+        # Test 2: Non-list embedding
+        with pytest.raises(ValueError, match="Embedding must be a non-empty list"):
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                "tool-123",
+                "not a list",  # Wrong type
+                "test-model"
+            )
+        
+        # Test 3: Non-numeric values
+        with pytest.raises(ValueError, match="Embedding must contain only numbers"):
+            embedding_service.store_tool_embedding(
+                test_db_session,
+                "tool-123",
+                [0.1, "invalid", 0.3],  # Contains string
+                "test-model"
+            )
+
+    def test_empty_batch_returns_empty_list(self, test_db_session, embedding_service):
+        """Test that empty batch returns empty list without errors."""
+        # Act
+        results = embedding_service.batch_store_tool_embeddings(
+            test_db_session,
+            [],
+            "test-model"
+        )
+        
+        # Assert
+        assert results == []
+        assert test_db_session.query(ToolEmbedding).count() == 0
+
+    @pytest.mark.asyncio
+    async def test_tool_with_no_description_works(
+        self,
+        test_db_session,
+        embedding_service
+    ):
+        """Test that tools with no description can still be embedded."""
+        # Arrange
+        class MinimalTool:
+            def __init__(self):
+                self.id = "minimal-tool"
+                self.original_name = "minimal"
+                self.description = None  # No description
+                self.tags = []
+                self.integration_type = "TEST"
+                self.input_schema = {}
+                self.gateway_id = "test"
+        
+        tool = MinimalTool()
+        
+        # Act
+        result = await embedding_service.embed_and_store_tool(
+            test_db_session,
+            tool
+        )
+        
+        # Assert
+        assert result is not None
+        assert result.tool_id == tool.id
+        assert len(result.embedding) == 1536

--- a/tests/integration/test_vector_search_integration.py
+++ b/tests/integration/test_vector_search_integration.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_vector_search_integration.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for VectorSearchService similarity search with real SQLite database.
+
+Uses known directional embeddings so similarity ordering is deterministic:
+- weather tool: points along dimension 0
+- climate tool: mostly dimension 0 with a small dimension 1 component (similar to weather)
+- email tool: points along dimension 1 (orthogonal to weather)
+"""
+
+# Standard
+from typing import Generator
+
+# Third-Party
+import numpy as np
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# First-Party
+from mcpgateway.db import Base, Tool, ToolEmbedding
+from mcpgateway.services.vector_search_service import VectorSearchService
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+DIM = 1536
+
+
+@pytest.fixture(scope="function")
+def test_db_engine():
+    """Create a fresh in-memory SQLite database per test."""
+    engine = create_engine("sqlite:///:memory:", echo=False)
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def test_db_session(test_db_engine) -> Generator[Session, None, None]:
+    """Create a database session for the test."""
+    SessionLocal = sessionmaker(bind=test_db_engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def sample_tools_with_embeddings(test_db_session):
+    """Create 3 tools with known directional embeddings for predictable similarity.
+
+    weather -> [1, 0, 0, ...]  (unit vector along dim 0)
+    climate -> [0.9, 0.1, 0, ...]  (similar to weather)
+    email   -> [0, 1, 0, ...]  (orthogonal to weather)
+    """
+    weather_vec = np.zeros(DIM)
+    weather_vec[0] = 1.0
+
+    climate_vec = np.zeros(DIM)
+    climate_vec[0] = 0.9
+    climate_vec[1] = 0.1
+
+    email_vec = np.zeros(DIM)
+    email_vec[1] = 1.0
+
+    tools_data = [
+        ("tool-weather", "weather-api", "Get current weather", weather_vec.tolist()),
+        ("tool-climate", "climate-info", "Get climate data", climate_vec.tolist()),
+        ("tool-email", "email-sender", "Send emails", email_vec.tolist()),
+    ]
+
+    for tool_id, name, desc, emb_vec in tools_data:
+        tool = Tool(
+            id=tool_id,
+            original_name=name,
+            name=name,
+            custom_name=name,
+            custom_name_slug=name,
+            description=desc,
+            input_schema={},
+            tags=[],
+            integration_type="REST",
+            gateway_id=None,
+            enabled=True,
+        )
+        test_db_session.add(tool)
+        test_db_session.flush()
+
+        embedding = ToolEmbedding(
+            tool_id=tool_id,
+            embedding=emb_vec,
+            model_name="test-model",
+        )
+        test_db_session.add(embedding)
+
+    test_db_session.commit()
+    return tools_data
+
+
+# ============================================================================
+# TESTS — SIMILARITY SEARCH ORDERING
+# ============================================================================
+
+
+class TestSimilaritySearchOrdering:
+    """Test that search results are ordered correctly by cosine similarity."""
+
+    @pytest.mark.asyncio
+    async def test_similar_tool_ranked_first(self, test_db_session, sample_tools_with_embeddings):
+        """Querying with weather-like vector should rank weather first, climate second, email last."""
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0  # Same direction as weather
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=10)
+
+        assert len(results) == 3
+        assert results[0].tool_name == "weather-api"
+        assert results[1].tool_name == "climate-info"
+        assert results[2].tool_name == "email-sender"
+
+    @pytest.mark.asyncio
+    async def test_scores_descend(self, test_db_session, sample_tools_with_embeddings):
+        """Similarity scores should be in descending order."""
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=10)
+
+        for i in range(len(results) - 1):
+            assert results[i].similarity_score >= results[i + 1].similarity_score
+
+    @pytest.mark.asyncio
+    async def test_email_query_ranks_email_first(self, test_db_session, sample_tools_with_embeddings):
+        """Querying with email-like vector should rank email tool first."""
+        query_vec = np.zeros(DIM)
+        query_vec[1] = 1.0  # Same direction as email
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=10)
+
+        assert results[0].tool_name == "email-sender"
+
+
+# ============================================================================
+# TESTS — THRESHOLD AND LIMIT
+# ============================================================================
+
+
+class TestThresholdFiltering:
+    """Test that threshold parameter correctly filters results."""
+
+    @pytest.mark.asyncio
+    async def test_threshold_filters_dissimilar(self, test_db_session, sample_tools_with_embeddings):
+        """Threshold of 0.9 with weather query should exclude the email tool."""
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=10, threshold=0.9)
+
+        names = [r.tool_name for r in results]
+        assert "weather-api" in names
+        assert "email-sender" not in names
+
+    @pytest.mark.asyncio
+    async def test_threshold_one_returns_only_exact_match(self, test_db_session, sample_tools_with_embeddings):
+        """Threshold of 1.0 should only return exact matches."""
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=10, threshold=1.0)
+
+        assert len(results) == 1
+        assert results[0].tool_name == "weather-api"
+
+
+class TestLimitRespected:
+    """Test that limit parameter is respected."""
+
+    @pytest.mark.asyncio
+    async def test_limit_one_returns_top_result(self, test_db_session, sample_tools_with_embeddings):
+        """limit=1 should return only the most similar tool."""
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=1)
+
+        assert len(results) == 1
+        assert results[0].tool_name == "weather-api"
+
+    @pytest.mark.asyncio
+    async def test_limit_two_returns_top_two(self, test_db_session, sample_tools_with_embeddings):
+        """limit=2 should return the top two results."""
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=2)
+
+        assert len(results) == 2
+
+
+# ============================================================================
+# TESTS — EDGE CASES
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Integration tests for edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_empty_database_returns_empty(self, test_db_session):
+        """No embeddings in DB returns empty results."""
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=[0.1] * DIM, limit=10)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_tools_excluded(self, test_db_session, sample_tools_with_embeddings):
+        """Disabled tools should not appear in search results."""
+        tool = test_db_session.query(Tool).filter(Tool.id == "tool-weather").first()
+        tool.enabled = False
+        test_db_session.commit()
+
+        query_vec = np.zeros(DIM)
+        query_vec[0] = 1.0
+
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=query_vec.tolist(), limit=10)
+
+        names = [r.tool_name for r in results]
+        assert "weather-api" not in names
+
+    @pytest.mark.asyncio
+    async def test_similarity_scores_in_valid_range(self, test_db_session, sample_tools_with_embeddings):
+        """All similarity scores should be between 0.0 and 1.0."""
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=[0.1] * DIM, limit=10)
+        for r in results:
+            assert 0.0 <= r.similarity_score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_result_has_required_fields(self, test_db_session, sample_tools_with_embeddings):
+        """All returned ToolSearchResult objects have required fields."""
+        service = VectorSearchService(db=test_db_session)
+        results = await service.search_similar_tools(embedding=[0.1] * DIM, limit=10)
+        for r in results:
+            assert isinstance(r.tool_name, str)
+            assert isinstance(r.similarity_score, float)
+
+
+# ============================================================================
+# TESTS — ToolEmbedding.similar_to()
+# ============================================================================
+
+
+class TestToolEmbeddingSimilarTo:
+    """Test the ToolEmbedding.similar_to() instance method on SQLite."""
+
+    def test_similar_to_returns_ordered_results(self, test_db_session, sample_tools_with_embeddings):
+        """similar_to() should return other embeddings ordered by similarity."""
+        weather_emb = test_db_session.query(ToolEmbedding).filter(ToolEmbedding.tool_id == "tool-weather").first()
+        results = weather_emb.similar_to(test_db_session, limit=10)
+
+        assert len(results) == 2  # excludes self
+        # climate should be more similar to weather than email
+        assert results[0][0].tool_id == "tool-climate"
+        assert results[1][0].tool_id == "tool-email"
+        assert results[0][1] > results[1][1]  # similarity scores descending
+
+    def test_similar_to_respects_limit(self, test_db_session, sample_tools_with_embeddings):
+        """similar_to() should respect the limit parameter."""
+        weather_emb = test_db_session.query(ToolEmbedding).filter(ToolEmbedding.tool_id == "tool-weather").first()
+        results = weather_emb.similar_to(test_db_session, limit=1)
+
+        assert len(results) == 1
+        assert results[0][0].tool_id == "tool-climate"
+
+    def test_similar_to_respects_threshold(self, test_db_session, sample_tools_with_embeddings):
+        """similar_to() with high threshold should filter out dissimilar embeddings."""
+        weather_emb = test_db_session.query(ToolEmbedding).filter(ToolEmbedding.tool_id == "tool-weather").first()
+        results = weather_emb.similar_to(test_db_session, limit=10, threshold=0.9)
+
+        tool_ids = [te.tool_id for te, _ in results]
+        assert "tool-email" not in tool_ids
+
+    def test_similar_to_excludes_self(self, test_db_session, sample_tools_with_embeddings):
+        """similar_to() should never include the calling embedding itself."""
+        weather_emb = test_db_session.query(ToolEmbedding).filter(ToolEmbedding.tool_id == "tool-weather").first()
+        results = weather_emb.similar_to(test_db_session, limit=10)
+
+        result_ids = [te.id for te, _ in results]
+        assert weather_emb.id not in result_ids

--- a/tests/unit/mcpgateway/db/test_hnsw_index.py
+++ b/tests/unit/mcpgateway/db/test_hnsw_index.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/db/test_hnsw_index.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for HNSW index on tool embeddings.
+
+Tests verify:
+- Migration module can be imported and has correct revision chain
+- HNSW config settings have correct defaults and bounds
+- Migration is idempotent on SQLite (no-op)
+- ToolEmbedding model declares HNSW index on PostgreSQL backend
+"""
+
+# Standard
+import importlib
+
+# Third-Party
+import pytest
+
+
+MIGRATION_MODULE = "mcpgateway.alembic.versions.c3d4e5f6a7b8_add_hnsw_index_to_tool_embeddings"
+
+
+class TestHnswMigrationModule:
+    """Test that the HNSW migration module is valid."""
+
+    def test_migration_imports(self):
+        """Test that migration module can be imported."""
+        module = importlib.import_module(MIGRATION_MODULE)
+        assert module is not None
+
+    def test_revision_id(self):
+        """Test correct revision identifier."""
+        module = importlib.import_module(MIGRATION_MODULE)
+        assert module.revision == "c3d4e5f6a7b8"
+
+    def test_down_revision(self):
+        """Test migration descends from tool_embedding table migration."""
+        module = importlib.import_module(MIGRATION_MODULE)
+        assert module.down_revision == "bab4694b3e90"
+
+    def test_upgrade_function_exists(self):
+        """Test upgrade function is defined."""
+        module = importlib.import_module(MIGRATION_MODULE)
+        assert callable(getattr(module, "upgrade", None))
+
+    def test_downgrade_function_exists(self):
+        """Test downgrade function is defined."""
+        module = importlib.import_module(MIGRATION_MODULE)
+        assert callable(getattr(module, "downgrade", None))
+
+
+class TestHnswConfigDefaults:
+    """Test HNSW configuration settings."""
+
+    def test_hnsw_m_default(self):
+        """Test hnsw_m has correct default value."""
+        from mcpgateway.config import Settings
+
+        s = Settings()
+        assert s.hnsw_m == 16
+
+    def test_hnsw_ef_construction_default(self):
+        """Test hnsw_ef_construction has correct default value."""
+        from mcpgateway.config import Settings
+
+        s = Settings()
+        assert s.hnsw_ef_construction == 64
+
+    def test_hnsw_m_bounds(self):
+        """Test hnsw_m rejects out-of-range values."""
+        from mcpgateway.config import Settings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(hnsw_m=1)  # below ge=2
+        with pytest.raises(ValidationError):
+            Settings(hnsw_m=101)  # above le=100
+
+    def test_hnsw_ef_construction_bounds(self):
+        """Test hnsw_ef_construction rejects out-of-range values."""
+        from mcpgateway.config import Settings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(hnsw_ef_construction=15)  # below ge=16
+        with pytest.raises(ValidationError):
+            Settings(hnsw_ef_construction=513)  # above le=512
+
+
+class TestToolEmbeddingModel:
+    """Test ToolEmbedding model HNSW index declaration."""
+
+    def test_sqlite_has_no_hnsw_index(self):
+        """On SQLite (default test backend), no HNSW index should be declared."""
+        from mcpgateway.db import ToolEmbedding
+
+        table_args = getattr(ToolEmbedding, "__table_args__", None)
+        # On SQLite, __table_args__ should either be absent or empty
+        if table_args is not None:
+            index_names = [arg.name for arg in table_args if hasattr(arg, "name")]
+            assert "idx_tool_embeddings_hnsw" not in index_names

--- a/tests/unit/mcpgateway/routers/test_semantic_search.py
+++ b/tests/unit/mcpgateway/routers/test_semantic_search.py
@@ -1,0 +1,606 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_semantic_search.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Team C
+
+Unit tests for semantic tool search endpoint.
+
+These tests verify the /tools/semantic endpoint behavior including:
+- Valid requests with results
+- Empty query validation
+- Limit and threshold parameter validation
+- Empty result sets
+- Error handling
+"""
+
+# Standard
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First-Party
+from mcpgateway.main import app
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.schemas import ToolSearchResult
+from mcpgateway.services.semantic_search_service import SemanticSearchService
+
+
+# Test fixtures
+
+
+@pytest.fixture
+def mock_user():
+    """Create a mock authenticated user."""
+
+    async def _get_user():
+        return {
+            "email": "test@example.com",
+            "is_admin": True,
+            "permissions": ["tools.read"],
+        }
+
+    return _get_user
+
+
+@pytest.fixture(autouse=True)
+def mock_permission_check():
+    """Automatically mock permission checks for all tests."""
+    with patch("mcpgateway.services.permission_service.PermissionService.check_permission", return_value=True):
+        yield
+
+
+@pytest.fixture
+def client(mock_user):
+    """Create test client with auth override."""
+    app.dependency_overrides[get_current_user_with_permissions] = mock_user
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_search_service():
+    """Create a mock semantic search service."""
+    service = AsyncMock(spec=SemanticSearchService)
+    return service
+
+
+# Test cases
+
+
+class TestSemanticSearchEndpoint:
+    """Test suite for semantic search endpoint."""
+
+    def test_semantic_search_valid_request(self, client, mock_search_service):
+        """Test valid semantic search request returns results."""
+        # Arrange
+        mock_results = [
+            ToolSearchResult(
+                tool_name="weather_api",
+                description="Fetch current weather data",
+                server_id="server-1",
+                server_name="Weather Server",
+                similarity_score=0.95,
+            ),
+            ToolSearchResult(
+                tool_name="forecast_tool",
+                description="Get weather forecast",
+                server_id="server-1",
+                server_name="Weather Server",
+                similarity_score=0.87,
+            ),
+        ]
+        mock_search_service.search_tools = AsyncMock(return_value=mock_results)
+
+        # Mock the service getter
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=weather&limit=10")
+
+            # Assert
+            assert response.status_code == 200
+            data = response.json()
+            assert "results" in data
+            assert "query" in data
+            assert "totalResults" in data
+            assert data["query"] == "weather"
+            assert data["totalResults"] == 2
+            assert len(data["results"]) == 2
+            assert data["results"][0]["toolName"] == "weather_api"
+            assert data["results"][0]["similarityScore"] == 0.95
+
+    def test_semantic_search_missing_query(self, client):
+        """Test request without query parameter returns 422."""
+        # Act
+        response = client.get("/tools/semantic")
+
+        # Assert
+        assert response.status_code == 422  # Unprocessable Entity (missing required param)
+
+    def test_semantic_search_empty_query(self, client, mock_search_service):
+        """Test request with empty query returns 400."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(side_effect=ValueError("Query cannot be empty"))
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=%20")  # URL-encoded space
+
+            # Assert
+            assert response.status_code == 400
+            assert "Query cannot be empty" in response.json()["detail"]
+
+    def test_semantic_search_limit_below_minimum(self, client):
+        """Test request with limit < 1 returns 422."""
+        # Act
+        response = client.get("/tools/semantic?query=test&limit=0")
+
+        # Assert
+        assert response.status_code == 422  # Validation error
+
+    def test_semantic_search_limit_above_maximum(self, client):
+        """Test request with limit > 50 returns 422."""
+        # Act
+        response = client.get("/tools/semantic?query=test&limit=51")
+
+        # Assert
+        assert response.status_code == 422  # Validation error
+
+    def test_semantic_search_valid_limit(self, client, mock_search_service):
+        """Test request with valid limit parameter."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(return_value=[])
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=test&limit=5")
+
+            # Assert
+            assert response.status_code == 200
+            mock_search_service.search_tools.assert_awaited_once_with(query="test", limit=5, threshold=None)
+
+    def test_semantic_search_threshold_below_minimum(self, client):
+        """Test request with threshold < 0.0 returns 422."""
+        # Act
+        response = client.get("/tools/semantic?query=test&threshold=-0.1")
+
+        # Assert
+        assert response.status_code == 422  # Validation error
+
+    def test_semantic_search_threshold_above_maximum(self, client):
+        """Test request with threshold > 1.0 returns 422."""
+        # Act
+        response = client.get("/tools/semantic?query=test&threshold=1.1")
+
+        # Assert
+        assert response.status_code == 422  # Validation error
+
+    def test_semantic_search_valid_threshold(self, client, mock_search_service):
+        """Test request with valid threshold parameter."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(return_value=[])
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=test&threshold=0.7")
+
+            # Assert
+            assert response.status_code == 200
+            mock_search_service.search_tools.assert_awaited_once_with(query="test", limit=10, threshold=0.7)
+
+    def test_semantic_search_empty_results(self, client, mock_search_service):
+        """Test request that returns no results."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(return_value=[])
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=nonexistent")
+
+            # Assert
+            assert response.status_code == 200
+            data = response.json()
+            assert data["results"] == []
+            assert data["totalResults"] == 0
+            assert data["query"] == "nonexistent"
+
+    def test_semantic_search_default_limit(self, client, mock_search_service):
+        """Test request without limit uses default value of 10."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(return_value=[])
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=test")
+
+            # Assert
+            assert response.status_code == 200
+            mock_search_service.search_tools.assert_awaited_once_with(query="test", limit=10, threshold=None)
+
+    def test_semantic_search_service_error(self, client, mock_search_service):
+        """Test handling of unexpected service errors."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(side_effect=RuntimeError("Vector search unavailable"))
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=test")
+
+            # Assert
+            assert response.status_code == 500
+            assert "Semantic search failed" in response.json()["detail"]
+
+    def test_semantic_search_all_parameters(self, client, mock_search_service):
+        """Test request with all parameters specified."""
+        # Arrange
+        mock_results = [
+            ToolSearchResult(
+                tool_name="tool1",
+                description="Test tool",
+                server_id="srv1",
+                server_name="Server 1",
+                similarity_score=0.9,
+            )
+        ]
+        mock_search_service.search_tools = AsyncMock(return_value=mock_results)
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=database%20query&limit=20&threshold=0.8")
+
+            # Assert
+            assert response.status_code == 200
+            data = response.json()
+            assert data["query"] == "database query"
+            assert data["totalResults"] == 1
+            mock_search_service.search_tools.assert_awaited_once_with(query="database query", limit=20, threshold=0.8)
+
+    def test_semantic_search_special_characters_in_query(self, client, mock_search_service):
+        """Test query with special characters."""
+        # Arrange
+        mock_search_service.search_tools = AsyncMock(return_value=[])
+
+        with patch("mcpgateway.services.semantic_search_service.get_semantic_search_service", return_value=mock_search_service):
+            # Act
+            response = client.get("/tools/semantic?query=get%20user's%20data%20%26%20files")
+
+            # Assert
+            assert response.status_code == 200
+            data = response.json()
+            assert data["query"] == "get user's data & files"
+
+
+class TestSemanticSearchService:
+    """Test suite for SemanticSearchService."""
+
+    @pytest.mark.skip(reason="Mocking async services with external dependencies is complex; endpoint integration tests cover this functionality")
+    @pytest.mark.anyio
+    async def test_search_tools_calls_embedding_and_vector_search(self):
+        """Test that search_tools orchestrates embedding and vector search."""
+        # Arrange
+        service = SemanticSearchService()
+        mock_embedding = [0.1] * 768
+        mock_results = [
+            ToolSearchResult(
+                tool_name="tool1",
+                description="Test",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.9,
+            )
+        ]
+
+        # Create mock services
+        mock_embedding_service = MagicMock()
+        mock_embedding_service.embed_query = AsyncMock(return_value=mock_embedding)
+        
+        mock_vector_service = MagicMock()
+        mock_vector_service.search_similar_tools = AsyncMock(return_value=mock_results)
+        
+        # Replace service instances
+        service.embedding_service = mock_embedding_service
+        service.vector_search_service = mock_vector_service
+
+        # Act
+        results = await service.search_tools(query="test query", limit=10)
+
+        # Assert
+        assert len(results) == 1
+        assert results[0].tool_name == "tool1"
+        mock_embedding_service.embed_query.assert_awaited_once_with("test query")
+        mock_vector_service.search_similar_tools.assert_awaited_once_with(embedding=mock_embedding, limit=10, threshold=None)
+
+    @pytest.mark.anyio
+    async def test_search_tools_empty_query_raises_error(self):
+        """Test that empty query raises ValueError."""
+        # Arrange
+        service = SemanticSearchService()
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Query cannot be empty"):
+            await service.search_tools(query="", limit=10)
+
+    @pytest.mark.anyio
+    async def test_search_tools_whitespace_query_raises_error(self):
+        """Test that whitespace-only query raises ValueError."""
+        # Arrange
+        service = SemanticSearchService()
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Query cannot be empty"):
+            await service.search_tools(query="   ", limit=10)
+
+    @pytest.mark.anyio
+    async def test_search_tools_invalid_limit_raises_error(self):
+        """Test that invalid limit raises ValueError."""
+        # Arrange
+        service = SemanticSearchService()
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Limit must be between 1 and 50"):
+            await service.search_tools(query="test", limit=0)
+
+        with pytest.raises(ValueError, match="Limit must be between 1 and 50"):
+            await service.search_tools(query="test", limit=51)
+
+    @pytest.mark.anyio
+    async def test_search_tools_invalid_threshold_raises_error(self):
+        """Test that invalid threshold raises ValueError."""
+        # Arrange
+        service = SemanticSearchService()
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Threshold must be between 0.0 and 1.0"):
+            await service.search_tools(query="test", limit=10, threshold=-0.1)
+
+        with pytest.raises(ValueError, match="Threshold must be between 0.0 and 1.0"):
+            await service.search_tools(query="test", limit=10, threshold=1.1)
+
+
+class TestSemanticSearchCache:
+    """Test suite for semantic search caching functionality."""
+
+    @pytest.mark.anyio
+    async def test_cache_hit_returns_cached_results(self):
+        """Test that repeated identical requests return cached results without recomputation."""
+        # Arrange
+        service = SemanticSearchService()
+        mock_results = [
+            ToolSearchResult(
+                tool_name="cached_tool",
+                description="Cached result",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.95,
+            )
+        ]
+
+        # Mock the underlying services
+        mock_embedding_service = MagicMock()
+        mock_embedding_service.embed_query = AsyncMock(return_value=[0.1] * 768)
+        
+        mock_vector_service = MagicMock()
+        mock_vector_service.search_similar_tools = AsyncMock(return_value=mock_results)
+        
+        service.embedding_service = mock_embedding_service
+        service.vector_search_service = mock_vector_service
+
+        # Act - First call should hit the services
+        results1 = await service.search_tools(query="test query", limit=10)
+        
+        # Second call with identical params should hit cache
+        results2 = await service.search_tools(query="test query", limit=10)
+
+        # Assert
+        assert results1 == results2
+        assert len(results1) == 1
+        assert results1[0].tool_name == "cached_tool"
+        
+        # Services should only be called once (first request)
+        mock_embedding_service.embed_query.assert_awaited_once()
+        mock_vector_service.search_similar_tools.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_query_normalization_cache_key(self):
+        """Test that queries with different cases/whitespace hit the same cache."""
+        # Arrange
+        service = SemanticSearchService()
+        mock_results = [
+            ToolSearchResult(
+                tool_name="normalized_tool",
+                description="Test",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.9,
+            )
+        ]
+
+        mock_embedding_service = MagicMock()
+        mock_embedding_service.embed_query = AsyncMock(return_value=[0.1] * 768)
+        
+        mock_vector_service = MagicMock()
+        mock_vector_service.search_similar_tools = AsyncMock(return_value=mock_results)
+        
+        service.embedding_service = mock_embedding_service
+        service.vector_search_service = mock_vector_service
+
+        # Act - Different formats of same query
+        results1 = await service.search_tools(query="Test Query", limit=10)
+        results2 = await service.search_tools(query="test query", limit=10)
+        results3 = await service.search_tools(query="  TEST QUERY  ", limit=10)
+
+        # Assert - All should return same cached result
+        assert results1 == results2 == results3
+        
+        # Embedding service should only be called once
+        mock_embedding_service.embed_query.assert_awaited_once_with("test query")
+        mock_vector_service.search_similar_tools.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_different_params_create_different_cache_keys(self):
+        """Test that different limit/threshold values create separate cache entries."""
+        # Arrange
+        service = SemanticSearchService()
+        mock_results_limit5 = [
+            ToolSearchResult(
+                tool_name="tool1",
+                description="Test",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.9,
+            )
+        ]
+        mock_results_limit10 = mock_results_limit5 + [
+            ToolSearchResult(
+                tool_name="tool2",
+                description="Test2",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.8,
+            )
+        ]
+
+        mock_embedding_service = MagicMock()
+        mock_embedding_service.embed_query = AsyncMock(return_value=[0.1] * 768)
+        
+        mock_vector_service = MagicMock()
+        # Return different results based on limit
+        mock_vector_service.search_similar_tools = AsyncMock(side_effect=[mock_results_limit5, mock_results_limit10])
+        
+        service.embedding_service = mock_embedding_service
+        service.vector_search_service = mock_vector_service
+
+        # Act - Same query, different limits
+        results1 = await service.search_tools(query="test", limit=5)
+        results2 = await service.search_tools(query="test", limit=10)
+
+        # Assert - Should get different results (not cached)
+        assert len(results1) == 1
+        assert len(results2) == 2
+        
+        # Should call services twice (different cache keys)
+        assert mock_embedding_service.embed_query.await_count == 2
+        assert mock_vector_service.search_similar_tools.await_count == 2
+
+    @pytest.mark.anyio
+    async def test_memory_cache_works_independently(self):
+        """Test that memory cache works when Redis is unavailable."""
+        # Arrange
+        service = SemanticSearchService()
+        mock_results = [
+            ToolSearchResult(
+                tool_name="memory_cached",
+                description="Test",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.85,
+            )
+        ]
+
+        mock_embedding_service = MagicMock()
+        mock_embedding_service.embed_query = AsyncMock(return_value=[0.1] * 768)
+        
+        mock_vector_service = MagicMock()
+        mock_vector_service.search_similar_tools = AsyncMock(return_value=mock_results)
+        
+        service.embedding_service = mock_embedding_service
+        service.vector_search_service = mock_vector_service
+
+        # Mock Redis to return None (unavailable)
+        with patch("mcpgateway.services.semantic_search_service.get_redis_client", return_value=None):
+            # Act - First call
+            results1 = await service.search_tools(query="test", limit=10)
+            
+            # Second call should hit memory cache
+            results2 = await service.search_tools(query="test", limit=10)
+
+            # Assert
+            assert results1 == results2
+            assert len(results1) == 1
+            
+            # Services called only once (memory cache worked)
+            mock_embedding_service.embed_query.assert_awaited_once()
+            mock_vector_service.search_similar_tools.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_cache_key_generation(self):
+        """Test cache key format includes normalized query, limit, and threshold."""
+        # Arrange
+        service = SemanticSearchService()
+
+        # Act & Assert - Different cache keys
+        key1 = service._make_cache_key("test query", 10, None)
+        key2 = service._make_cache_key("test query", 10, 0.7)
+        key3 = service._make_cache_key("test query", 20, None)
+        key4 = service._make_cache_key("different query", 10, None)
+
+        assert key1 == "semantic:test query:10:None"
+        assert key2 == "semantic:test query:10:0.7"
+        assert key3 == "semantic:test query:20:None"
+        assert key4 == "semantic:different query:10:None"
+        
+        # All keys should be unique
+        assert len({key1, key2, key3, key4}) == 4
+
+    @pytest.mark.anyio
+    async def test_query_normalization(self):
+        """Test query normalization strips whitespace and converts to lowercase."""
+        # Arrange
+        service = SemanticSearchService()
+
+        # Act & Assert
+        assert service._normalize_query("Test Query") == "test query"
+        assert service._normalize_query("  UPPERCASE  ") == "uppercase"
+        assert service._normalize_query("MiXeD CaSe") == "mixed case"
+        assert service._normalize_query("   spaces   ") == "spaces"
+
+    @pytest.mark.anyio
+    async def test_memory_cache_expiry(self):
+        """Test that memory cache entries expire after TTL."""
+        # Arrange
+        import time
+        service = SemanticSearchService()
+        service.CACHE_TTL_SECONDS = 1  # Short TTL for testing
+        
+        mock_results = [
+            ToolSearchResult(
+                tool_name="expiring_tool",
+                description="Test",
+                server_id="srv1",
+                server_name="Server",
+                similarity_score=0.9,
+            )
+        ]
+
+        mock_embedding_service = MagicMock()
+        mock_embedding_service.embed_query = AsyncMock(return_value=[0.1] * 768)
+        
+        mock_vector_service = MagicMock()
+        mock_vector_service.search_similar_tools = AsyncMock(return_value=mock_results)
+        
+        service.embedding_service = mock_embedding_service
+        service.vector_search_service = mock_vector_service
+
+        # Mock Redis to be unavailable (test memory cache only)
+        with patch("mcpgateway.services.semantic_search_service.get_redis_client", return_value=None):
+            # Act - First call
+            results1 = await service.search_tools(query="test", limit=10)
+            assert len(results1) == 1
+            
+            # Wait for cache to expire
+            time.sleep(1.1)
+            
+            # Second call after expiry should recompute
+            results2 = await service.search_tools(query="test", limit=10)
+
+            # Assert
+            assert results1 == results2
+            
+            # Services should be called twice (cache expired)
+            assert mock_embedding_service.embed_query.await_count == 2
+            assert mock_vector_service.search_similar_tools.await_count == 2
+

--- a/tests/unit/mcpgateway/services/test_embedding_providers.py
+++ b/tests/unit/mcpgateway/services/test_embedding_providers.py
@@ -1,0 +1,833 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_embedding_providers.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for embedding providers and factory in mcp_client_chat_service.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import mcpgateway.services.mcp_client_chat_service as svc
+
+
+# Patch LoggingService globally so logging doesn't pollute test outputs
+@pytest.fixture(autouse=True)
+def patch_logger(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(svc, "logger", mock)
+    monkeypatch.setattr(svc.logging_service, "get_logger", lambda _: mock)
+    return mock
+
+
+# --------------------------------------------------------------------------- #
+# EMBEDDING CONFIGURATION TESTS
+# --------------------------------------------------------------------------- #
+
+
+class TestOpenAIEmbeddingConfig:
+    """Tests for OpenAIEmbeddingConfig class."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = svc.OpenAIEmbeddingConfig(api_key="sk-test-key")
+        assert config.api_key == "sk-test-key"
+        assert config.model == "text-embedding-3-small"
+        assert config.dimensions is None
+        assert config.base_url is None
+        assert config.timeout is None
+        assert config.max_retries == 2
+
+    def test_custom_values(self):
+        """Test custom configuration values."""
+        config = svc.OpenAIEmbeddingConfig(
+            api_key="sk-custom-key",
+            model="text-embedding-3-large",
+            dimensions=1024,
+            base_url="https://custom.openai.com/v1",
+            timeout=30.0,
+            max_retries=5,
+        )
+        assert config.api_key == "sk-custom-key"
+        assert config.model == "text-embedding-3-large"
+        assert config.dimensions == 1024
+        assert config.base_url == "https://custom.openai.com/v1"
+        assert config.timeout == 30.0
+        assert config.max_retries == 5
+
+    def test_dimensions_must_be_positive(self):
+        """Test that dimensions must be positive if provided."""
+        with pytest.raises(ValueError):
+            svc.OpenAIEmbeddingConfig(api_key="sk-test", dimensions=0)
+
+    def test_timeout_must_be_positive(self):
+        """Test that timeout must be positive if provided."""
+        with pytest.raises(ValueError):
+            svc.OpenAIEmbeddingConfig(api_key="sk-test", timeout=0)
+
+    def test_max_retries_cannot_be_negative(self):
+        """Test that max_retries cannot be negative."""
+        with pytest.raises(ValueError):
+            svc.OpenAIEmbeddingConfig(api_key="sk-test", max_retries=-1)
+
+
+class TestOllamaEmbeddingConfig:
+    """Tests for OllamaEmbeddingConfig class."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = svc.OllamaEmbeddingConfig()
+        assert config.base_url == "http://localhost:11434"
+        assert config.model == "nomic-embed-text"
+        assert config.timeout is None
+
+    def test_custom_values(self):
+        """Test custom configuration values."""
+        config = svc.OllamaEmbeddingConfig(
+            base_url="http://remote-ollama:11434",
+            model="mxbai-embed-large",
+            timeout=30.0,
+        )
+        assert config.base_url == "http://remote-ollama:11434"
+        assert config.model == "mxbai-embed-large"
+        assert config.timeout == 30.0
+
+    def test_timeout_must_be_positive(self):
+        """Test that timeout must be positive if provided."""
+        with pytest.raises(ValueError):
+            svc.OllamaEmbeddingConfig(timeout=0)
+
+
+class TestMistralEmbeddingConfig:
+    """Tests for MistralEmbeddingConfig class."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = svc.MistralEmbeddingConfig(api_key="mistral-key")
+        assert config.api_key == "mistral-key"
+        assert config.model == "mistral-embed"
+        assert config.timeout is None
+        assert config.max_retries == 2
+
+    def test_custom_values(self):
+        """Test custom configuration values."""
+        config = svc.MistralEmbeddingConfig(
+            api_key="custom-key",
+            model="mistral-embed-v2",
+            timeout=45.0,
+            max_retries=5,
+        )
+        assert config.api_key == "custom-key"
+        assert config.model == "mistral-embed-v2"
+        assert config.timeout == 45.0
+        assert config.max_retries == 5
+
+    def test_timeout_must_be_positive(self):
+        """Test that timeout must be positive if provided."""
+        with pytest.raises(ValueError):
+            svc.MistralEmbeddingConfig(api_key="key", timeout=0)
+
+    def test_max_retries_cannot_be_negative(self):
+        """Test that max_retries cannot be negative."""
+        with pytest.raises(ValueError):
+            svc.MistralEmbeddingConfig(api_key="key", max_retries=-1)
+
+
+class TestLiteLLMEmbeddingConfig:
+    """Tests for LiteLLMEmbeddingConfig class."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = svc.LiteLLMEmbeddingConfig(base_url="http://localhost:4000")
+        assert config.base_url == "http://localhost:4000"
+        assert config.api_key is None
+        assert config.model == "text-embedding-3-small"
+        assert config.timeout is None
+        assert config.max_retries == 2
+
+    def test_custom_values(self):
+        """Test custom configuration values."""
+        config = svc.LiteLLMEmbeddingConfig(
+            base_url="http://litellm-proxy:8000",
+            api_key="proxy-key",
+            model="text-embedding-3-large",
+            timeout=60.0,
+            max_retries=3,
+        )
+        assert config.base_url == "http://litellm-proxy:8000"
+        assert config.api_key == "proxy-key"
+        assert config.model == "text-embedding-3-large"
+        assert config.timeout == 60.0
+        assert config.max_retries == 3
+
+    def test_base_url_is_required(self):
+        """Test that base_url is required."""
+        with pytest.raises(ValueError):
+            svc.LiteLLMEmbeddingConfig()  # type: ignore
+
+    def test_timeout_must_be_positive(self):
+        """Test that timeout must be positive if provided."""
+        with pytest.raises(ValueError):
+            svc.LiteLLMEmbeddingConfig(base_url="http://localhost:4000", timeout=0)
+
+
+class TestEmbeddingConfig:
+    """Tests for EmbeddingConfig class."""
+
+    def test_openai_provider_with_config_object(self):
+        """Test creating EmbeddingConfig with OpenAI provider using config object."""
+        openai_config = svc.OpenAIEmbeddingConfig(
+            api_key="sk-test",
+            model="text-embedding-3-small",
+        )
+        config = svc.EmbeddingConfig(provider="openai", config=openai_config)
+        assert config.provider == "openai"
+        assert isinstance(config.config, svc.OpenAIEmbeddingConfig)
+        assert config.config.api_key == "sk-test"
+
+    def test_openai_provider_with_dict_config(self):
+        """Test creating EmbeddingConfig with OpenAI provider using dict."""
+        config = svc.EmbeddingConfig(
+            provider="openai",
+            config={
+                "api_key": "sk-test",
+                "model": "text-embedding-3-large",
+                "dimensions": 512,
+            },
+        )
+        assert config.provider == "openai"
+        assert isinstance(config.config, svc.OpenAIEmbeddingConfig)
+        assert config.config.api_key == "sk-test"
+        assert config.config.model == "text-embedding-3-large"
+        assert config.config.dimensions == 512
+
+    def test_ollama_provider_with_config_object(self):
+        """Test creating EmbeddingConfig with Ollama provider using config object."""
+        ollama_config = svc.OllamaEmbeddingConfig(model="nomic-embed-text")
+        config = svc.EmbeddingConfig(provider="ollama", config=ollama_config)
+        assert config.provider == "ollama"
+        assert isinstance(config.config, svc.OllamaEmbeddingConfig)
+        assert config.config.model == "nomic-embed-text"
+
+    def test_ollama_provider_with_dict_config(self):
+        """Test creating EmbeddingConfig with Ollama provider using dict."""
+        config = svc.EmbeddingConfig(
+            provider="ollama",
+            config={"model": "mxbai-embed-large", "base_url": "http://gpu-host:11434"},
+        )
+        assert config.provider == "ollama"
+        assert isinstance(config.config, svc.OllamaEmbeddingConfig)
+        assert config.config.model == "mxbai-embed-large"
+        assert config.config.base_url == "http://gpu-host:11434"
+
+    def test_mistral_provider_with_dict_config(self):
+        """Test creating EmbeddingConfig with Mistral provider using dict."""
+        config = svc.EmbeddingConfig(
+            provider="mistral",
+            config={"api_key": "mistral-key", "model": "mistral-embed"},
+        )
+        assert config.provider == "mistral"
+        assert isinstance(config.config, svc.MistralEmbeddingConfig)
+        assert config.config.api_key == "mistral-key"
+
+    def test_litellm_provider_with_dict_config(self):
+        """Test creating EmbeddingConfig with LiteLLM provider using dict."""
+        config = svc.EmbeddingConfig(
+            provider="litellm",
+            config={"base_url": "http://localhost:4000", "model": "text-embedding-3-small"},
+        )
+        assert config.provider == "litellm"
+        assert isinstance(config.config, svc.LiteLLMEmbeddingConfig)
+        assert config.config.base_url == "http://localhost:4000"
+
+    def test_invalid_provider_rejected(self):
+        """Test that invalid provider type is rejected."""
+        with pytest.raises(ValueError):
+            svc.EmbeddingConfig(
+                provider="invalid_provider",  # type: ignore
+                config={"api_key": "test"},
+            )
+
+
+# --------------------------------------------------------------------------- #
+# EMBEDDING PROVIDER TESTS
+# --------------------------------------------------------------------------- #
+
+
+class TestOpenAIEmbeddingProvider:
+    """Tests for OpenAIEmbeddingProvider class."""
+
+    def test_provider_initialization(self, monkeypatch):
+        """Test provider initializes correctly."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        config = svc.OpenAIEmbeddingConfig(
+            api_key="sk-test",
+            model="text-embedding-3-small",
+        )
+        provider = svc.OpenAIEmbeddingProvider(config)
+
+        assert provider.config == config
+        assert provider._embedding_model is None
+        assert provider.get_model_name() == "text-embedding-3-small"
+
+    def test_provider_raises_import_error_when_not_available(self, monkeypatch):
+        """Test provider raises ImportError when langchain-openai not installed."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", False)
+
+        config = svc.OpenAIEmbeddingConfig(api_key="sk-test")
+
+        with pytest.raises(ImportError) as exc_info:
+            svc.OpenAIEmbeddingProvider(config)
+
+        assert "langchain-openai" in str(exc_info.value)
+
+    def test_get_embedding_model_creates_instance(self, monkeypatch):
+        """Test get_embedding_model creates and caches OpenAIEmbeddings."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings_class = MagicMock(return_value=mock_embeddings)
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.OpenAIEmbeddingConfig(
+            api_key="sk-test",
+            model="text-embedding-3-small",
+        )
+        provider = svc.OpenAIEmbeddingProvider(config)
+
+        # First call should create instance
+        result = provider.get_embedding_model()
+        assert result == mock_embeddings
+        mock_embeddings_class.assert_called_once()
+
+        # Second call should return cached instance
+        result2 = provider.get_embedding_model()
+        assert result2 == mock_embeddings
+        # Still only called once (cached)
+        mock_embeddings_class.assert_called_once()
+
+    def test_get_embedding_model_with_all_options(self, monkeypatch):
+        """Test get_embedding_model passes all config options."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock()
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.OpenAIEmbeddingConfig(
+            api_key="sk-test",
+            model="text-embedding-3-large",
+            dimensions=1024,
+            base_url="https://custom.api.com",
+            timeout=60.0,
+            max_retries=3,
+        )
+        provider = svc.OpenAIEmbeddingProvider(config)
+        provider.get_embedding_model()
+
+        mock_embeddings_class.assert_called_once_with(
+            api_key="sk-test",
+            model="text-embedding-3-large",
+            max_retries=3,
+            base_url="https://custom.api.com",
+            dimensions=1024,
+            timeout=60.0,
+        )
+
+    def test_get_embedding_model_handles_exception(self, monkeypatch):
+        """Test get_embedding_model re-raises exceptions."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock(side_effect=Exception("API Error"))
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.OpenAIEmbeddingConfig(api_key="sk-test")
+        provider = svc.OpenAIEmbeddingProvider(config)
+
+        with pytest.raises(Exception) as exc_info:
+            provider.get_embedding_model()
+
+        assert "API Error" in str(exc_info.value)
+
+
+class TestOllamaEmbeddingProvider:
+    """Tests for OllamaEmbeddingProvider class."""
+
+    def test_provider_initialization(self, monkeypatch):
+        """Test provider initializes correctly."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        config = svc.OllamaEmbeddingConfig(model="nomic-embed-text")
+        provider = svc.OllamaEmbeddingProvider(config)
+
+        assert provider.config == config
+        assert provider._embedding_model is None
+        assert provider.get_model_name() == "nomic-embed-text"
+
+    def test_provider_raises_import_error_when_not_available(self, monkeypatch):
+        """Test provider raises ImportError when langchain-ollama not installed."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", False)
+
+        config = svc.OllamaEmbeddingConfig()
+
+        with pytest.raises(ImportError) as exc_info:
+            svc.OllamaEmbeddingProvider(config)
+
+        assert "langchain-ollama" in str(exc_info.value)
+
+    def test_get_embedding_model_creates_instance(self, monkeypatch):
+        """Test get_embedding_model creates and caches OllamaEmbeddings."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings_class = MagicMock(return_value=mock_embeddings)
+        monkeypatch.setattr(svc, "OllamaEmbeddings", mock_embeddings_class)
+
+        config = svc.OllamaEmbeddingConfig(model="nomic-embed-text")
+        provider = svc.OllamaEmbeddingProvider(config)
+
+        result = provider.get_embedding_model()
+        assert result == mock_embeddings
+        mock_embeddings_class.assert_called_once_with(
+            model="nomic-embed-text",
+            base_url="http://localhost:11434",
+        )
+
+        # Second call returns cached
+        result2 = provider.get_embedding_model()
+        assert result2 == mock_embeddings
+        mock_embeddings_class.assert_called_once()
+
+    def test_get_embedding_model_with_timeout(self, monkeypatch):
+        """Test get_embedding_model passes timeout when set."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock()
+        monkeypatch.setattr(svc, "OllamaEmbeddings", mock_embeddings_class)
+
+        config = svc.OllamaEmbeddingConfig(
+            model="mxbai-embed-large",
+            base_url="http://gpu-host:11434",
+            timeout=30.0,
+        )
+        provider = svc.OllamaEmbeddingProvider(config)
+        provider.get_embedding_model()
+
+        mock_embeddings_class.assert_called_once_with(
+            model="mxbai-embed-large",
+            base_url="http://gpu-host:11434",
+            timeout=30.0,
+        )
+
+    def test_get_embedding_model_handles_exception(self, monkeypatch):
+        """Test get_embedding_model re-raises exceptions."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock(side_effect=Exception("Connection refused"))
+        monkeypatch.setattr(svc, "OllamaEmbeddings", mock_embeddings_class)
+
+        config = svc.OllamaEmbeddingConfig()
+        provider = svc.OllamaEmbeddingProvider(config)
+
+        with pytest.raises(Exception) as exc_info:
+            provider.get_embedding_model()
+
+        assert "Connection refused" in str(exc_info.value)
+
+
+class TestMistralEmbeddingProvider:
+    """Tests for MistralEmbeddingProvider class."""
+
+    def test_provider_initialization(self, monkeypatch):
+        """Test provider initializes correctly."""
+        monkeypatch.setattr(svc, "_MISTRAL_AVAILABLE", True)
+
+        config = svc.MistralEmbeddingConfig(api_key="mistral-key")
+        provider = svc.MistralEmbeddingProvider(config)
+
+        assert provider.config == config
+        assert provider._embedding_model is None
+        assert provider.get_model_name() == "mistral-embed"
+
+    def test_provider_raises_import_error_when_not_available(self, monkeypatch):
+        """Test provider raises ImportError when langchain-mistralai not installed."""
+        monkeypatch.setattr(svc, "_MISTRAL_AVAILABLE", False)
+
+        config = svc.MistralEmbeddingConfig(api_key="key")
+
+        with pytest.raises(ImportError) as exc_info:
+            svc.MistralEmbeddingProvider(config)
+
+        assert "langchain-mistralai" in str(exc_info.value)
+
+    def test_get_embedding_model_creates_instance(self, monkeypatch):
+        """Test get_embedding_model creates and caches MistralAIEmbeddings."""
+        monkeypatch.setattr(svc, "_MISTRAL_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings_class = MagicMock(return_value=mock_embeddings)
+        monkeypatch.setattr(svc, "MistralAIEmbeddings", mock_embeddings_class)
+
+        config = svc.MistralEmbeddingConfig(api_key="mistral-key")
+        provider = svc.MistralEmbeddingProvider(config)
+
+        result = provider.get_embedding_model()
+        assert result == mock_embeddings
+        mock_embeddings_class.assert_called_once_with(
+            model="mistral-embed",
+            api_key="mistral-key",
+            max_retries=2,
+        )
+
+        # Second call returns cached
+        result2 = provider.get_embedding_model()
+        assert result2 == mock_embeddings
+        mock_embeddings_class.assert_called_once()
+
+    def test_get_embedding_model_with_all_options(self, monkeypatch):
+        """Test get_embedding_model passes all config options."""
+        monkeypatch.setattr(svc, "_MISTRAL_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock()
+        monkeypatch.setattr(svc, "MistralAIEmbeddings", mock_embeddings_class)
+
+        config = svc.MistralEmbeddingConfig(
+            api_key="mistral-key",
+            model="mistral-embed-v2",
+            timeout=45.0,
+            max_retries=5,
+        )
+        provider = svc.MistralEmbeddingProvider(config)
+        provider.get_embedding_model()
+
+        mock_embeddings_class.assert_called_once_with(
+            model="mistral-embed-v2",
+            api_key="mistral-key",
+            timeout=45,
+            max_retries=5,
+        )
+
+    def test_get_embedding_model_handles_exception(self, monkeypatch):
+        """Test get_embedding_model re-raises exceptions."""
+        monkeypatch.setattr(svc, "_MISTRAL_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock(side_effect=Exception("Auth Error"))
+        monkeypatch.setattr(svc, "MistralAIEmbeddings", mock_embeddings_class)
+
+        config = svc.MistralEmbeddingConfig(api_key="bad-key")
+        provider = svc.MistralEmbeddingProvider(config)
+
+        with pytest.raises(Exception) as exc_info:
+            provider.get_embedding_model()
+
+        assert "Auth Error" in str(exc_info.value)
+
+
+class TestLiteLLMEmbeddingProvider:
+    """Tests for LiteLLMEmbeddingProvider class."""
+
+    def test_provider_initialization(self, monkeypatch):
+        """Test provider initializes correctly."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        config = svc.LiteLLMEmbeddingConfig(
+            base_url="http://localhost:4000",
+            model="text-embedding-3-small",
+        )
+        provider = svc.LiteLLMEmbeddingProvider(config)
+
+        assert provider.config == config
+        assert provider._embedding_model is None
+        assert provider.get_model_name() == "text-embedding-3-small"
+
+    def test_provider_raises_import_error_when_not_available(self, monkeypatch):
+        """Test provider raises ImportError when langchain-openai not installed."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", False)
+
+        config = svc.LiteLLMEmbeddingConfig(base_url="http://localhost:4000")
+
+        with pytest.raises(ImportError) as exc_info:
+            svc.LiteLLMEmbeddingProvider(config)
+
+        assert "langchain-openai" in str(exc_info.value)
+
+    def test_get_embedding_model_creates_instance_with_api_key(self, monkeypatch):
+        """Test get_embedding_model passes api_key when provided."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings_class = MagicMock(return_value=mock_embeddings)
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.LiteLLMEmbeddingConfig(
+            base_url="http://localhost:4000",
+            api_key="proxy-secret",
+            model="text-embedding-3-large",
+        )
+        provider = svc.LiteLLMEmbeddingProvider(config)
+
+        result = provider.get_embedding_model()
+        assert result == mock_embeddings
+        mock_embeddings_class.assert_called_once_with(
+            model="text-embedding-3-large",
+            base_url="http://localhost:4000",
+            max_retries=2,
+            api_key="proxy-secret",
+        )
+
+    def test_get_embedding_model_uses_placeholder_key_when_none(self, monkeypatch):
+        """Test get_embedding_model uses placeholder api_key when none provided."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock()
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.LiteLLMEmbeddingConfig(
+            base_url="http://localhost:4000",
+        )
+        provider = svc.LiteLLMEmbeddingProvider(config)
+        provider.get_embedding_model()
+
+        call_kwargs = mock_embeddings_class.call_args[1]
+        assert call_kwargs["api_key"] == "litellm-proxy"
+        assert call_kwargs["base_url"] == "http://localhost:4000"
+
+    def test_get_embedding_model_caches_instance(self, monkeypatch):
+        """Test that get_embedding_model caches the instance."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings_class = MagicMock(return_value=mock_embeddings)
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.LiteLLMEmbeddingConfig(base_url="http://localhost:4000")
+        provider = svc.LiteLLMEmbeddingProvider(config)
+
+        result1 = provider.get_embedding_model()
+        result2 = provider.get_embedding_model()
+        assert result1 is result2
+        mock_embeddings_class.assert_called_once()
+
+    def test_get_embedding_model_handles_exception(self, monkeypatch):
+        """Test get_embedding_model re-raises exceptions."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings_class = MagicMock(side_effect=Exception("Proxy unreachable"))
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        config = svc.LiteLLMEmbeddingConfig(base_url="http://localhost:4000")
+        provider = svc.LiteLLMEmbeddingProvider(config)
+
+        with pytest.raises(Exception) as exc_info:
+            provider.get_embedding_model()
+
+        assert "Proxy unreachable" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------- #
+# EMBEDDING PROVIDER FACTORY TESTS
+# --------------------------------------------------------------------------- #
+
+
+class TestEmbeddingProviderFactory:
+    """Tests for EmbeddingProviderFactory class."""
+
+    def test_create_openai_provider(self, monkeypatch):
+        """Test factory creates OpenAI embedding provider."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        config = svc.EmbeddingConfig(
+            provider="openai",
+            config=svc.OpenAIEmbeddingConfig(
+                api_key="sk-test",
+                model="text-embedding-3-small",
+            ),
+        )
+
+        provider = svc.EmbeddingProviderFactory.create(config)
+
+        assert isinstance(provider, svc.OpenAIEmbeddingProvider)
+        assert provider.get_model_name() == "text-embedding-3-small"
+
+    def test_create_ollama_provider(self, monkeypatch):
+        """Test factory creates Ollama embedding provider."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        config = svc.EmbeddingConfig(
+            provider="ollama",
+            config=svc.OllamaEmbeddingConfig(model="nomic-embed-text"),
+        )
+
+        provider = svc.EmbeddingProviderFactory.create(config)
+
+        assert isinstance(provider, svc.OllamaEmbeddingProvider)
+        assert provider.get_model_name() == "nomic-embed-text"
+
+    def test_create_mistral_provider(self, monkeypatch):
+        """Test factory creates Mistral embedding provider."""
+        monkeypatch.setattr(svc, "_MISTRAL_AVAILABLE", True)
+
+        config = svc.EmbeddingConfig(
+            provider="mistral",
+            config=svc.MistralEmbeddingConfig(api_key="mistral-key"),
+        )
+
+        provider = svc.EmbeddingProviderFactory.create(config)
+
+        assert isinstance(provider, svc.MistralEmbeddingProvider)
+        assert provider.get_model_name() == "mistral-embed"
+
+    def test_create_litellm_provider(self, monkeypatch):
+        """Test factory creates LiteLLM embedding provider."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        config = svc.EmbeddingConfig(
+            provider="litellm",
+            config=svc.LiteLLMEmbeddingConfig(
+                base_url="http://localhost:4000",
+                model="text-embedding-3-small",
+            ),
+        )
+
+        provider = svc.EmbeddingProviderFactory.create(config)
+
+        assert isinstance(provider, svc.LiteLLMEmbeddingProvider)
+        assert provider.get_model_name() == "text-embedding-3-small"
+
+    def test_create_with_mock(self, monkeypatch):
+        """Test factory creates provider using mock to verify call."""
+        mock_provider_class = MagicMock()
+        monkeypatch.setattr(svc, "OpenAIEmbeddingProvider", mock_provider_class)
+
+        config = svc.EmbeddingConfig(
+            provider="openai",
+            config=svc.OpenAIEmbeddingConfig(api_key="sk-test"),
+        )
+
+        svc.EmbeddingProviderFactory.create(config)
+
+        mock_provider_class.assert_called_once_with(config.config)
+
+    def test_unsupported_provider_raises_error(self, monkeypatch):
+        """Test factory raises ValueError for unsupported provider."""
+        # Create a mock config with an unsupported provider
+        mock_config = MagicMock()
+        mock_config.provider = "unsupported_provider"
+
+        with pytest.raises(ValueError) as exc_info:
+            svc.EmbeddingProviderFactory.create(mock_config)
+
+        assert "Unsupported embedding provider" in str(exc_info.value)
+        assert "unsupported_provider" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------- #
+# INTEGRATION-STYLE TESTS (with mocks)
+# --------------------------------------------------------------------------- #
+
+
+class TestEmbeddingIntegration:
+    """Integration-style tests for the embedding workflow."""
+
+    def test_full_workflow_with_mocks(self, monkeypatch):
+        """Test complete workflow: config -> factory -> provider -> model."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        # Mock the OpenAIEmbeddings class
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query = MagicMock(return_value=[0.1, 0.2, 0.3])
+        mock_embeddings_class = MagicMock(return_value=mock_embeddings)
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", mock_embeddings_class)
+
+        # Create config
+        config = svc.EmbeddingConfig(
+            provider="openai",
+            config={
+                "api_key": "sk-test-key",
+                "model": "text-embedding-3-small",
+            },
+        )
+
+        # Create provider via factory
+        provider = svc.EmbeddingProviderFactory.create(config)
+        assert isinstance(provider, svc.OpenAIEmbeddingProvider)
+
+        # Get embedding model
+        embedding_model = provider.get_embedding_model()
+        assert embedding_model == mock_embeddings
+
+        # Simulate using the model
+        result = embedding_model.embed_query("test text")
+        assert result == [0.1, 0.2, 0.3]
+        mock_embeddings.embed_query.assert_called_once_with("test text")
+
+    def test_ollama_workflow_with_mocks(self, monkeypatch):
+        """Test Ollama workflow: config -> factory -> provider -> model."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query = MagicMock(return_value=[0.4, 0.5, 0.6])
+        monkeypatch.setattr(svc, "OllamaEmbeddings", MagicMock(return_value=mock_embeddings))
+
+        config = svc.EmbeddingConfig(
+            provider="ollama",
+            config={"model": "nomic-embed-text"},
+        )
+
+        provider = svc.EmbeddingProviderFactory.create(config)
+        assert isinstance(provider, svc.OllamaEmbeddingProvider)
+
+        model = provider.get_embedding_model()
+        result = model.embed_query("local test")
+        assert result == [0.4, 0.5, 0.6]
+
+    def test_litellm_workflow_with_mocks(self, monkeypatch):
+        """Test LiteLLM proxy workflow: config -> factory -> provider -> model."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_documents = MagicMock(return_value=[[0.7, 0.8], [0.9, 1.0]])
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", MagicMock(return_value=mock_embeddings))
+
+        config = svc.EmbeddingConfig(
+            provider="litellm",
+            config={
+                "base_url": "http://localhost:4000",
+                "model": "text-embedding-3-small",
+            },
+        )
+
+        provider = svc.EmbeddingProviderFactory.create(config)
+        assert isinstance(provider, svc.LiteLLMEmbeddingProvider)
+
+        model = provider.get_embedding_model()
+        result = model.embed_documents(["doc1", "doc2"])
+        assert len(result) == 2
+
+    def test_config_from_dict_to_embeddings(self, monkeypatch):
+        """Test creating embeddings from dictionary config."""
+        monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
+
+        mock_embeddings = MagicMock()
+        monkeypatch.setattr(svc, "OpenAIEmbeddings", MagicMock(return_value=mock_embeddings))
+
+        # Simulating how a user might pass config from JSON/YAML
+        raw_config = {
+            "provider": "openai",
+            "config": {
+                "api_key": "sk-from-env",
+                "model": "text-embedding-3-large",
+                "dimensions": 256,
+            },
+        }
+
+        # Parse with Pydantic
+        config = svc.EmbeddingConfig(**raw_config)
+
+        # Create provider and get model
+        provider = svc.EmbeddingProviderFactory.create(config)
+        model = provider.get_embedding_model()
+
+        assert model == mock_embeddings
+        assert provider.get_model_name() == "text-embedding-3-large"

--- a/tests/unit/mcpgateway/services/test_embedding_service.py
+++ b/tests/unit/mcpgateway/services/test_embedding_service.py
@@ -1,0 +1,960 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_embedding_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Tests for EmbeddingService and related embedding utilities.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.services.embedding_service import (
+    EmbeddingService,
+    index_tool_fire_and_forget,
+    reindex_all_tools,
+)
+from mcpgateway.db import ToolEmbedding
+
+class TestEmbeddingServiceBasic:
+    """Test basic EmbeddingService functionality."""
+
+    def test_service_creation(self):
+        """Test that service can be created without errors."""
+        service = EmbeddingService()
+        assert service._initialized is False
+        assert service._provider is None
+        assert service._embedding_model is None
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_initialize_success(self, mock_factory):
+        """Test successful service initialization."""
+        # Set up the mock chain: Factory -> Provider -> EmbeddingModel
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        
+        service = EmbeddingService()
+        await service.initialize()
+        
+        assert service._initialized is True
+        assert service._provider == mock_provider
+        assert service._embedding_model == mock_embedding_model
+        mock_factory.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_query_success(self, mock_factory):
+        """Test successful query embedding."""
+        # Set up the mock chain
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embedding = [0.1, 0.2, 0.3] * 512  # 1536 dimensions
+        
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_query.return_value = expected_embedding
+        
+        service = EmbeddingService()
+        
+        result = await service.embed_query("weather tools")
+        
+        assert result == expected_embedding
+        assert service._initialized is True  # Should auto-initialize
+        mock_embedding_model.aembed_query.assert_called_once_with("weather tools")
+
+    @pytest.mark.asyncio
+    async def test_embed_query_not_initialized_auto_initializes(self):
+        """Test that embed_query auto-initializes if not initialized."""
+        with patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory') as mock_factory:
+            mock_provider = MagicMock()
+            mock_embedding_model = AsyncMock()
+            mock_embedding_model.aembed_query.return_value = [0.1] * 1536
+            
+            mock_factory.create.return_value = mock_provider
+            mock_provider.get_embedding_model.return_value = mock_embedding_model
+            
+            service = EmbeddingService()
+            assert service._initialized is False
+            
+            await service.embed_query("test")
+            
+            assert service._initialized is True
+
+
+class TestPrepareToolText:
+    """Test the prepare_tool_text method."""
+
+    def test_prepare_tool_text_complete(self):
+        """Test prepare_tool_text with full tool data."""
+        service = EmbeddingService()
+        tool_data = {
+            'original_name': 'weather_api',
+            'description': 'Get current weather information for any city',
+            'input_schema': {
+                'properties': {
+                    'city': {'description': 'City name'},
+                    'units': {'description': 'Temperature units'}
+                }
+            },
+            'tags': ['weather', 'api', 'data'],
+            'integration_type': 'REST'
+        }
+        
+        result = service.prepare_tool_text(tool_data)
+        
+        expected = "weather_api | Get current weather information for any city | parameters: city: City name, units: Temperature units | tags: weather, api, data | type: REST"
+        assert result == expected
+
+    def test_prepare_tool_text_minimal(self):
+        """Test prepare_tool_text with minimal tool data."""
+        service = EmbeddingService()
+        tool_data = {
+            'original_name': 'simple_tool',
+            'description': 'A simple tool'
+        }
+        
+        result = service.prepare_tool_text(tool_data)
+        
+        expected = "simple_tool | A simple tool"
+        assert result == expected
+
+    def test_prepare_tool_text_no_description(self):
+        """Test prepare_tool_text without description."""
+        service = EmbeddingService()
+        tool_data = {
+            'original_name': 'no_desc_tool'
+        }
+        
+        result = service.prepare_tool_text(tool_data)
+        
+        expected = "no_desc_tool"
+        assert result == expected
+
+    def test_prepare_tool_text_with_tags_only(self):
+        """Test prepare_tool_text with tags but no other metadata."""
+        service = EmbeddingService()
+        tool_data = {
+            'original_name': 'tagged_tool',
+            'description': 'Tool with tags',
+            'tags': ['tag1', 'tag2']
+        }
+        
+        result = service.prepare_tool_text(tool_data)
+        
+        expected = "tagged_tool | Tool with tags | tags: tag1, tag2"
+        assert result == expected
+
+
+@pytest.fixture
+def sample_tool_data():
+    """Sample tool data for testing."""
+    return {
+        'original_name': 'weather_api',
+        'description': 'Get weather information',
+        'input_schema': {
+            'properties': {
+                'city': {'description': 'City name'}
+            }
+        },
+        'tags': ['weather', 'api'],
+        'integration_type': 'REST'
+    }
+
+
+class TestEmbedTool:
+    """Test the embed_tool method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_tool_success(self, mock_factory, sample_tool_data):
+        """Test successful tool embedding."""
+        # Set up the mock chain
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embedding = [0.1] * 1536
+        
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_query.return_value = expected_embedding
+        
+        service = EmbeddingService()
+        
+        result = await service.embed_tool(sample_tool_data)
+        
+        assert result == expected_embedding
+        # Verify the prepared text was passed to aembed_query
+        expected_text = "weather_api | Get weather information | parameters: city: City name | tags: weather, api | type: REST"
+        mock_embedding_model.aembed_query.assert_called_once_with(expected_text)
+
+    @pytest.mark.asyncio
+    async def test_embed_tool_missing_name(self):
+        """Test embed_tool with missing original_name raises error."""
+        service = EmbeddingService()
+        
+        invalid_tool = {'description': 'Tool without name'}
+        
+        with pytest.raises(ValueError, match="Tool data must include 'original_name'"):
+            await service.embed_tool(invalid_tool)
+
+    @pytest.mark.asyncio
+    async def test_embed_tool_invalid_data_type(self):
+        """Test embed_tool with non-dict data raises error."""
+        service = EmbeddingService()
+        
+        with pytest.raises(ValueError, match="Tool data must be a dictionary"):
+            await service.embed_tool("not a dict")
+
+
+class TestEmbedText:
+    """Test the embed_text method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_text_success(self, mock_factory):
+        """Test successful text embedding."""
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embedding = [0.5] * 1536
+        
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_query.return_value = expected_embedding
+        
+        service = EmbeddingService()
+        
+        result = await service.embed_text("Some text to embed")
+        
+        assert result == expected_embedding
+        mock_embedding_model.aembed_query.assert_called_once_with("Some text to embed")
+
+    @pytest.mark.asyncio
+    async def test_embed_text_empty_raises_error(self):
+        """Test that empty text raises ValueError."""
+        service = EmbeddingService()
+        
+        with pytest.raises(ValueError, match="Text cannot be empty or whitespace only"):
+            await service.embed_text("")
+
+    @pytest.mark.asyncio
+    async def test_embed_text_whitespace_only_raises_error(self):
+        """Test that whitespace-only text raises ValueError."""
+        service = EmbeddingService()
+        
+        with pytest.raises(ValueError, match="Text cannot be empty or whitespace only"):
+            await service.embed_text("   \n\t  ")
+
+    @pytest.mark.asyncio
+    async def test_embed_text_too_long_raises_error(self):
+        """Test that text over 8192 characters raises ValueError."""
+        service = EmbeddingService()
+        long_text = "a" * 8193  # Over the limit
+        
+        with pytest.raises(ValueError, match="Text too long.*max 8192"):
+            await service.embed_text(long_text)
+
+
+class TestUtilityMethods:
+    """Test utility methods."""
+
+    def test_get_provider_info(self):
+        """Test getting provider information."""
+        service = EmbeddingService()
+        
+        info = service.get_provider_info()
+        
+        assert 'provider' in info
+        assert 'model' in info
+        assert 'initialized' in info
+        assert info['initialized'] is False  # Not yet initialized
+
+
+class TestEmbedToolFromDb:
+    """Test the embed_tool_from_db method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_tool_from_db_success(self, mock_factory):
+        """Test embedding generation for a Tool ORM-like object."""
+        # Set up the mock chain
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embedding = [0.2] * 1536
+
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_query.return_value = expected_embedding
+
+        class DummyTool:
+            def __init__(self):
+                self.original_name = 'db_tool'
+                self.description = 'Tool from DB'
+                self.tags = ['one', 'two']
+                self.integration_type = 'MCP'
+                self.input_schema = {
+                    'properties': {
+                        'param': {'description': 'Param description'}
+                    }
+                }
+                self.gateway_id = 'gateway-123'
+
+        tool = DummyTool()
+        service = EmbeddingService()
+
+        result = await service.embed_tool_from_db(tool)
+
+        assert result == expected_embedding
+
+        expected_text = (
+            "db_tool | Tool from DB | parameters: param: Param description | "
+            "tags: one, two | type: MCP"
+        )
+        mock_embedding_model.aembed_query.assert_called_once_with(expected_text)
+
+
+class TestBatchEmbedTools:
+    """Test the batch_embed_tools method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_batch_embed_tools_success(self, mock_factory, sample_tool_data):
+        """Test batch embedding for multiple tools."""
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embeddings = [[0.1] * 1536, [0.2] * 1536]
+
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_documents.return_value = expected_embeddings
+
+        service = EmbeddingService()
+
+        tools = [
+            sample_tool_data,
+            {
+                'original_name': 'db_tool',
+                'description': 'Tool from DB',
+                'input_schema': {
+                    'properties': {
+                        'param': {'description': 'Param description'}
+                    }
+                },
+                'tags': ['one', 'two'],
+                'integration_type': 'MCP',
+            },
+        ]
+
+        result = await service.batch_embed_tools(tools)
+
+        assert result == expected_embeddings
+
+        expected_texts = [service.prepare_tool_text(t) for t in tools]
+        mock_embedding_model.aembed_documents.assert_called_once_with(expected_texts)
+
+    @pytest.mark.asyncio
+    async def test_batch_embed_tools_empty_list_returns_empty(self):
+        """Test that empty tool list returns empty embeddings without init."""
+        service = EmbeddingService()
+
+        result = await service.batch_embed_tools([])
+
+        assert result == []
+        assert service._initialized is False
+
+
+class TestBatchEmbedTexts:
+    """Test the batch_embed_texts method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_batch_embed_texts_success(self, mock_factory):
+        """Test successful batch text embedding."""
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embeddings = [[0.3] * 1536, [0.4] * 1536]
+
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_documents.return_value = expected_embeddings
+
+        service = EmbeddingService()
+        texts = ["first text", "second text"]
+
+        result = await service.batch_embed_texts(texts)
+
+        assert result == expected_embeddings
+        mock_embedding_model.aembed_documents.assert_called_once_with(texts)
+
+    @pytest.mark.asyncio
+    async def test_batch_embed_texts_empty_list_returns_empty(self):
+        """Test that empty text list returns empty embeddings without init."""
+        service = EmbeddingService()
+
+        result = await service.batch_embed_texts([])
+
+        assert result == []
+        assert service._initialized is False
+
+    @pytest.mark.asyncio
+    async def test_batch_embed_texts_invalid_text_raises_error(self):
+        """Test validation for empty and too-long texts in batch_embed_texts."""
+        service = EmbeddingService()
+
+        # Empty text
+        with pytest.raises(ValueError, match="Text at index 0 cannot be empty"):
+            await service.batch_embed_texts(["", "valid"])
+
+        # Too long text
+        long_text = "a" * 8193
+        with pytest.raises(ValueError, match="Text at index 0 too long: 8193 characters"):
+            await service.batch_embed_texts([long_text])
+
+
+class TestErrorHandling:
+    """Test error handling paths for embedding operations."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_text_provider_error_raises_runtime_error(self, mock_factory):
+        """Test that provider errors are wrapped in RuntimeError in embed_text."""
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_query.side_effect = Exception("provider failure")
+
+        service = EmbeddingService()
+
+        with pytest.raises(RuntimeError, match="Text embedding failed: provider failure"):
+            await service.embed_text("some text")
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_batch_embed_tools_provider_error_raises_runtime_error(self, mock_factory, sample_tool_data):
+        """Test that provider errors are wrapped in RuntimeError in batch_embed_tools."""
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_documents.side_effect = Exception("batch failure")
+
+        service = EmbeddingService()
+
+        with pytest.raises(RuntimeError, match="Batch embedding failed: batch failure"):
+            await service.batch_embed_tools([sample_tool_data])
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_batch_embed_texts_provider_error_raises_runtime_error(self, mock_factory):
+        """Test that provider errors are wrapped in RuntimeError in batch_embed_texts."""
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_documents.side_effect = Exception("batch text failure")
+
+        service = EmbeddingService()
+
+        with pytest.raises(RuntimeError, match="Batch text embedding failed: batch text failure"):
+            await service.batch_embed_texts(["one", "two"])
+
+# ============================================================================
+# NEW TESTS FOR STORAGE METHODS
+# ============================================================================
+
+
+@pytest.fixture
+def mock_db_session():
+    """Create a mock database session."""
+    mock_session = MagicMock(spec=Session)
+    return mock_session
+
+
+@pytest.fixture
+def mock_tool_embedding():
+    """Create a mock ToolEmbedding object."""
+    embedding = MagicMock(spec=ToolEmbedding)
+    embedding.id = "embedding-123"
+    embedding.tool_id = "tool-456"
+    embedding.embedding = [0.1] * 1536
+    embedding.model_name = "text-embedding-3-small"
+    return embedding
+
+
+class TestStoreToolEmbedding:
+    """Test the store_tool_embedding method."""
+
+    def test_store_new_embedding_success(self, mock_db_session):
+        """Test storing a new embedding."""
+        service = EmbeddingService()
+        
+        # Mock query to return None (no existing embedding)
+        mock_db_session.query.return_value.filter.return_value.first.return_value = None
+        
+        embedding = [0.5] * 1536
+        tool_id = "tool-789"
+        model_name = "text-embedding-3-small"
+        
+        result = service.store_tool_embedding(mock_db_session, tool_id, embedding, model_name)
+        
+        # Verify add was called
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()
+        mock_db_session.refresh.assert_called_once()
+
+    def test_update_existing_embedding_success(self, mock_db_session, mock_tool_embedding):
+        """Test updating an existing embedding."""
+        service = EmbeddingService()
+        
+        # Mock query to return existing embedding
+        mock_db_session.query.return_value.filter.return_value.first.return_value = mock_tool_embedding
+        
+        new_embedding = [0.9] * 1536
+        tool_id = "tool-456"
+        model_name = "text-embedding-3-large"
+        
+        result = service.store_tool_embedding(mock_db_session, tool_id, new_embedding, model_name)
+        
+        # Verify embedding was updated
+        assert mock_tool_embedding.embedding == new_embedding
+        assert mock_tool_embedding.model_name == model_name
+        mock_db_session.commit.assert_called_once()
+        mock_db_session.refresh.assert_called_once_with(mock_tool_embedding)
+        assert result == mock_tool_embedding
+
+    def test_store_embedding_invalid_empty_list(self, mock_db_session):
+        """Test that empty embedding list raises ValueError."""
+        service = EmbeddingService()
+        
+        with pytest.raises(ValueError, match="Embedding must be a non-empty list"):
+            service.store_tool_embedding(mock_db_session, "tool-123", [], "model")
+
+    def test_store_embedding_invalid_not_list(self, mock_db_session):
+        """Test that non-list embedding raises ValueError."""
+        service = EmbeddingService()
+        
+        with pytest.raises(ValueError, match="Embedding must be a non-empty list"):
+            service.store_tool_embedding(mock_db_session, "tool-123", "not a list", "model")
+
+    def test_store_embedding_invalid_non_numeric_values(self, mock_db_session):
+        """Test that embedding with non-numeric values raises ValueError."""
+        service = EmbeddingService()
+        
+        invalid_embedding = [0.1, "string", 0.3]
+        
+        with pytest.raises(ValueError, match="Embedding must contain only numbers"):
+            service.store_tool_embedding(mock_db_session, "tool-123", invalid_embedding, "model")
+
+    def test_store_embedding_database_error_rolls_back(self, mock_db_session):
+        """Test that database errors trigger rollback."""
+        service = EmbeddingService()
+        
+        # Mock query to return None
+        mock_db_session.query.return_value.filter.return_value.first.return_value = None
+        # Mock commit to raise exception
+        mock_db_session.commit.side_effect = Exception("DB connection lost")
+        
+        embedding = [0.5] * 1536
+        
+        with pytest.raises(RuntimeError, match="Database operation failed: DB connection lost"):
+            service.store_tool_embedding(mock_db_session, "tool-123", embedding, "model")
+        
+        mock_db_session.rollback.assert_called_once()
+
+
+class TestBatchStoreToolEmbeddings:
+    """Test the batch_store_tool_embeddings method."""
+
+    def test_batch_store_new_embeddings_success(self, mock_db_session):
+        """Test batch storing new embeddings."""
+        service = EmbeddingService()
+        
+        # Mock query to return empty (no existing embeddings)
+        mock_db_session.query.return_value.filter.return_value.all.return_value = []
+        
+        tool_embeddings = [
+            ("tool-1", [0.1] * 1536),
+            ("tool-2", [0.2] * 1536),
+            ("tool-3", [0.3] * 1536),
+        ]
+        model_name = "text-embedding-3-small"
+        
+        result = service.batch_store_tool_embeddings(mock_db_session, tool_embeddings, model_name)
+        
+        # Verify add was called 3 times
+        assert mock_db_session.add.call_count == 3
+        mock_db_session.commit.assert_called_once()
+        assert len(result) == 3
+
+    def test_batch_store_update_existing_embeddings(self, mock_db_session):
+        """Test batch updating existing embeddings."""
+        service = EmbeddingService()
+        
+        # Create mock existing embeddings
+        existing1 = MagicMock(spec=ToolEmbedding)
+        existing1.tool_id = "tool-1"
+        existing1.embedding = [0.1] * 1536
+        
+        existing2 = MagicMock(spec=ToolEmbedding)
+        existing2.tool_id = "tool-2"
+        existing2.embedding = [0.2] * 1536
+        
+        # Mock query to return existing embeddings
+        mock_db_session.query.return_value.filter.return_value.all.return_value = [existing1, existing2]
+        
+        tool_embeddings = [
+            ("tool-1", [0.9] * 1536),
+            ("tool-2", [0.8] * 1536),
+        ]
+        model_name = "text-embedding-3-large"
+        
+        result = service.batch_store_tool_embeddings(mock_db_session, tool_embeddings, model_name)
+        
+        # Verify embeddings were updated
+        assert existing1.embedding == [0.9] * 1536
+        assert existing1.model_name == model_name
+        assert existing2.embedding == [0.8] * 1536
+        assert existing2.model_name == model_name
+        
+        # No add calls (only updates)
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_called_once()
+        assert len(result) == 2
+
+    def test_batch_store_mixed_new_and_existing(self, mock_db_session):
+        """Test batch storing with mix of new and existing embeddings."""
+        service = EmbeddingService()
+        
+        # Create one existing embedding
+        existing = MagicMock(spec=ToolEmbedding)
+        existing.tool_id = "tool-1"
+        existing.embedding = [0.1] * 1536
+        
+        mock_db_session.query.return_value.filter.return_value.all.return_value = [existing]
+        
+        tool_embeddings = [
+            ("tool-1", [0.9] * 1536),  # Update existing
+            ("tool-2", [0.8] * 1536),  # Create new
+            ("tool-3", [0.7] * 1536),  # Create new
+        ]
+        model_name = "text-embedding-3-small"
+        
+        result = service.batch_store_tool_embeddings(mock_db_session, tool_embeddings, model_name)
+        
+        # Verify one update and two adds
+        assert mock_db_session.add.call_count == 2
+        assert existing.embedding == [0.9] * 1536
+        mock_db_session.commit.assert_called_once()
+        assert len(result) == 3
+
+    def test_batch_store_empty_list_returns_empty(self, mock_db_session):
+        """Test that empty list returns empty without DB calls."""
+        service = EmbeddingService()
+        
+        result = service.batch_store_tool_embeddings(mock_db_session, [], "model")
+        
+        assert result == []
+        mock_db_session.query.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+
+    def test_batch_store_database_error_rolls_back(self, mock_db_session):
+        """Test that database errors trigger rollback in batch store."""
+        service = EmbeddingService()
+        
+        mock_db_session.query.return_value.filter.return_value.all.return_value = []
+        mock_db_session.commit.side_effect = Exception("Batch commit failed")
+        
+        tool_embeddings = [("tool-1", [0.1] * 1536)]
+        
+        with pytest.raises(RuntimeError, match="Batch storage failed: Batch commit failed"):
+            service.batch_store_tool_embeddings(mock_db_session, tool_embeddings, "model")
+        
+        mock_db_session.rollback.assert_called_once()
+
+
+class TestEmbedAndStoreTool:
+    """Test the embed_and_store_tool method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_and_store_tool_success(self, mock_factory, mock_db_session):
+        """Test embedding and storing a single tool."""
+        # Setup mocks
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embedding = [0.5] * 1536
+        
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_query.return_value = expected_embedding
+        
+        # Mock query to return None (new embedding)
+        mock_db_session.query.return_value.filter.return_value.first.return_value = None
+        
+        # Create dummy tool
+        class DummyTool:
+            def __init__(self):
+                self.id = "tool-123"
+                self.original_name = "test_tool"
+                self.description = "Test tool"
+                self.tags = []
+                self.integration_type = "MCP"
+                self.input_schema = {}
+                self.gateway_id = "gateway-1"
+        
+        tool = DummyTool()
+        service = EmbeddingService()
+        service.embedding_config.config.model = "text-embedding-3-small"
+        
+        result = await service.embed_and_store_tool(mock_db_session, tool)
+        
+        # Verify embedding was generated and stored
+        mock_embedding_model.aembed_query.assert_called_once()
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()
+
+
+class TestEmbedAndStoreToolsBatch:
+    """Test the embed_and_store_tools_batch method."""
+
+    @pytest.mark.asyncio
+    @patch('mcpgateway.services.embedding_service.EmbeddingProviderFactory')
+    async def test_embed_and_store_batch_success(self, mock_factory, mock_db_session):
+        """Test embedding and storing multiple tools in batch."""
+        # Setup mocks
+        mock_provider = MagicMock()
+        mock_embedding_model = AsyncMock()
+        expected_embeddings = [[0.1] * 1536, [0.2] * 1536]
+        
+        mock_factory.create.return_value = mock_provider
+        mock_provider.get_embedding_model.return_value = mock_embedding_model
+        mock_embedding_model.aembed_documents.return_value = expected_embeddings
+        
+        # Mock query to return empty (no existing embeddings)
+        mock_db_session.query.return_value.filter.return_value.all.return_value = []
+        
+        # Create dummy tools
+        class DummyTool:
+            def __init__(self, tool_id, name):
+                self.id = tool_id
+                self.original_name = name
+                self.description = f"Description for {name}"
+                self.tags = []
+                self.integration_type = "MCP"
+                self.input_schema = {}
+                self.gateway_id = "gateway-1"
+        
+        tools = [
+            DummyTool("tool-1", "tool_one"),
+            DummyTool("tool-2", "tool_two"),
+        ]
+        
+        service = EmbeddingService()
+        service.embedding_config.config.model = "text-embedding-3-small"
+        
+        result = await service.embed_and_store_tools_batch(mock_db_session, tools)
+        
+        # Verify batch embedding was called
+        mock_embedding_model.aembed_documents.assert_called_once()
+        
+        # Verify batch store was called
+        assert mock_db_session.add.call_count == 2
+        mock_db_session.commit.assert_called_once()
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_embed_and_store_batch_empty_list(self, mock_db_session):
+        """Test that empty tool list returns empty without processing."""
+        service = EmbeddingService()
+
+        result = await service.embed_and_store_tools_batch(mock_db_session, [])
+
+        assert result == []
+        mock_db_session.query.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for module-level wrapper functions
+# ---------------------------------------------------------------------------
+
+
+class TestIndexToolFireAndForget:
+    """Tests for the index_tool_fire_and_forget convenience function."""
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.SessionLocal")
+    @patch("mcpgateway.db.Tool")
+    async def test_success(self, mock_tool_cls, mock_session_local, mock_svc_cls):
+        """Tool found and successfully indexed; DB session closed."""
+        mock_db = MagicMock(spec=Session)
+        mock_session_local.return_value = mock_db
+
+        mock_tool = MagicMock()
+        mock_tool.id = "tool-abc"
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_tool
+
+        mock_svc = MagicMock()
+        mock_svc.embed_and_store_tool = AsyncMock()
+        mock_svc_cls.return_value = mock_svc
+
+        await index_tool_fire_and_forget("tool-abc")
+
+        mock_svc.embed_and_store_tool.assert_called_once_with(mock_db, mock_tool)
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.SessionLocal")
+    @patch("mcpgateway.db.Tool")
+    async def test_tool_not_found(self, mock_tool_cls, mock_session_local, mock_svc_cls):
+        """Returns early when tool does not exist; DB session still closed."""
+        mock_db = MagicMock(spec=Session)
+        mock_session_local.return_value = mock_db
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        await index_tool_fire_and_forget("missing-id")
+
+        mock_svc_cls.return_value.embed_and_store_tool.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.SessionLocal")
+    @patch("mcpgateway.db.Tool")
+    async def test_exception_caught(self, mock_tool_cls, mock_session_local, mock_svc_cls):
+        """Exceptions in embed_and_store_tool are caught (never re-raised)."""
+        mock_db = MagicMock(spec=Session)
+        mock_session_local.return_value = mock_db
+
+        mock_tool = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_tool
+
+        mock_svc = MagicMock()
+        mock_svc.embed_and_store_tool = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_svc_cls.return_value = mock_svc
+
+        # Should NOT raise
+        await index_tool_fire_and_forget("tool-abc")
+
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.SessionLocal")
+    @patch("mcpgateway.db.Tool")
+    async def test_db_closed_on_query_exception(self, mock_tool_cls, mock_session_local, mock_svc_cls):
+        """DB session is closed even if the query itself raises."""
+        mock_db = MagicMock(spec=Session)
+        mock_session_local.return_value = mock_db
+        mock_db.query.side_effect = RuntimeError("db error")
+
+        await index_tool_fire_and_forget("tool-abc")
+
+        mock_db.close.assert_called_once()
+
+
+class TestReindexAllTools:
+    """Tests for the reindex_all_tools convenience function."""
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.Tool")
+    async def test_all_succeed(self, mock_tool_cls, mock_svc_cls):
+        """All enabled tools are indexed successfully."""
+        mock_db = MagicMock(spec=Session)
+        tools = [MagicMock(id=f"t{i}", original_name=f"tool_{i}") for i in range(3)]
+        mock_db.query.return_value.filter.return_value.all.return_value = tools
+
+        mock_svc = MagicMock()
+        mock_svc.embed_and_store_tool = AsyncMock()
+        mock_svc_cls.return_value = mock_svc
+
+        result = await reindex_all_tools(mock_db)
+
+        assert result == {"total": 3, "succeeded": 3, "failed": 0}
+        assert mock_svc.embed_and_store_tool.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.Tool")
+    async def test_all_fail(self, mock_tool_cls, mock_svc_cls):
+        """All tools fail to index."""
+        mock_db = MagicMock(spec=Session)
+        tools = [MagicMock(id=f"t{i}", original_name=f"tool_{i}") for i in range(2)]
+        mock_db.query.return_value.filter.return_value.all.return_value = tools
+
+        mock_svc = MagicMock()
+        mock_svc.embed_and_store_tool = AsyncMock(side_effect=RuntimeError("fail"))
+        mock_svc_cls.return_value = mock_svc
+
+        result = await reindex_all_tools(mock_db)
+
+        assert result == {"total": 2, "succeeded": 0, "failed": 2}
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.Tool")
+    async def test_mixed_results(self, mock_tool_cls, mock_svc_cls):
+        """Some tools succeed, some fail; counts are correct."""
+        mock_db = MagicMock(spec=Session)
+        tools = [MagicMock(id=f"t{i}", original_name=f"tool_{i}") for i in range(3)]
+        mock_db.query.return_value.filter.return_value.all.return_value = tools
+
+        mock_svc = MagicMock()
+        mock_svc.embed_and_store_tool = AsyncMock(
+            side_effect=[None, RuntimeError("fail"), None]
+        )
+        mock_svc_cls.return_value = mock_svc
+
+        result = await reindex_all_tools(mock_db)
+
+        assert result == {"total": 3, "succeeded": 2, "failed": 1}
+        assert mock_svc.embed_and_store_tool.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.Tool")
+    async def test_empty_tool_list(self, mock_tool_cls, mock_svc_cls):
+        """No enabled tools returns zeroed counts."""
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        result = await reindex_all_tools(mock_db)
+
+        assert result == {"total": 0, "succeeded": 0, "failed": 0}
+        mock_svc_cls.return_value.embed_and_store_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.embedding_service.EmbeddingService")
+    @patch("mcpgateway.db.Tool")
+    async def test_failure_does_not_stop_loop(self, mock_tool_cls, mock_svc_cls):
+        """A failure on one tool does not prevent processing of subsequent tools."""
+        mock_db = MagicMock(spec=Session)
+        tools = [MagicMock(id=f"t{i}", original_name=f"tool_{i}") for i in range(4)]
+        mock_db.query.return_value.filter.return_value.all.return_value = tools
+
+        mock_svc = MagicMock()
+        mock_svc.embed_and_store_tool = AsyncMock(
+            side_effect=[RuntimeError("fail"), None, None, None]
+        )
+        mock_svc_cls.return_value = mock_svc
+
+        result = await reindex_all_tools(mock_db)
+
+        assert result["total"] == 4
+        assert result["succeeded"] == 3
+        assert result["failed"] == 1
+        # All 4 tools were attempted despite the first one failing
+        assert mock_svc.embed_and_store_tool.call_count == 4

--- a/tests/unit/mcpgateway/services/test_vector_search_service.py
+++ b/tests/unit/mcpgateway/services/test_vector_search_service.py
@@ -1,0 +1,662 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_vector_search_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for VectorSearchService.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import ToolEmbedding
+from mcpgateway.services.vector_search_service import VectorSearchService
+
+
+@pytest.fixture
+def mock_db_session():
+    """Create a mock database session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def vector_search_service(mock_db_session):
+    """Create a VectorSearchService instance with mock db."""
+    return VectorSearchService(db=mock_db_session)
+
+
+@pytest.fixture
+def sample_tool_embedding():
+    """Create a sample ToolEmbedding object."""
+    embedding = ToolEmbedding(
+        id=1,
+        tool_id="tool-123",
+        embedding=[0.1, 0.2, 0.3] * 512,  # 1536 dimensions
+        model_name="text-embedding-3-small"
+    )
+    return embedding
+
+
+# ============================================================================
+# TEST GET_TOOL_EMBEDDING
+# ============================================================================
+
+
+class TestGetToolEmbedding:
+    """Tests for get_tool_embedding method."""
+
+    def test_get_tool_embedding_found(
+        self, 
+        vector_search_service, 
+        mock_db_session,
+        sample_tool_embedding
+    ):
+        """Test retrieving an existing tool embedding."""
+        # Arrange
+        tool_id = "tool-123"
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = sample_tool_embedding
+        
+        # Act
+        result = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is not None
+        assert result.tool_id == tool_id
+        assert result.id == 1
+        assert len(result.embedding) == 1536
+        assert result.model_name == "text-embedding-3-small"
+        
+        # Verify database was queried correctly
+        mock_db_session.query.assert_called_once_with(ToolEmbedding)
+        mock_query.filter.assert_called_once()
+        mock_filter.first.assert_called_once()
+
+    def test_get_tool_embedding_not_found(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test retrieving a non-existent tool embedding."""
+        # Arrange
+        tool_id = "non-existent-tool"
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = None
+        
+        # Act
+        result = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is None
+        mock_db_session.query.assert_called_once_with(ToolEmbedding)
+        mock_query.filter.assert_called_once()
+        mock_filter.first.assert_called_once()
+
+    def test_get_tool_embedding_different_tool_ids(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test retrieving embeddings for different tool IDs."""
+        # Arrange
+        tool_ids = ["tool-1", "tool-2", "tool-3"]
+        embeddings = [
+            ToolEmbedding(id=i, tool_id=tid, embedding=[0.1] * 1536, model_name="test-model")
+            for i, tid in enumerate(tool_ids, 1)
+        ]
+        
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        
+        # Return different embeddings based on call
+        mock_filter.first.side_effect = embeddings
+        
+        # Act & Assert
+        for tool_id, expected_embedding in zip(tool_ids, embeddings):
+            result = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+            assert result is not None
+            assert result.tool_id == tool_id
+
+    def test_get_tool_embedding_with_empty_string_id(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test retrieving embedding with empty string tool_id."""
+        # Arrange
+        tool_id = ""
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = None
+        
+        # Act
+        result = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is None
+
+
+# ============================================================================
+# TEST DELETE_TOOL_EMBEDDING
+# ============================================================================
+
+
+class TestDeleteToolEmbedding:
+    """Tests for delete_tool_embedding method."""
+
+    def test_delete_tool_embedding_success(
+        self,
+        vector_search_service,
+        mock_db_session,
+        sample_tool_embedding
+    ):
+        """Test successfully deleting an existing embedding."""
+        # Arrange
+        tool_id = "tool-123"
+        
+        # Mock get_tool_embedding to return the sample embedding
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=sample_tool_embedding
+        ):
+            # Act
+            result = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is True
+        mock_db_session.delete.assert_called_once_with(sample_tool_embedding)
+        mock_db_session.commit.assert_called_once()
+
+    def test_delete_tool_embedding_not_found(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test deleting a non-existent embedding."""
+        # Arrange
+        tool_id = "non-existent-tool"
+        
+        # Mock get_tool_embedding to return None
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=None
+        ):
+            # Act
+            result = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is False
+        mock_db_session.delete.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+
+    def test_delete_tool_embedding_multiple_calls(
+        self,
+        vector_search_service,
+        mock_db_session,
+        sample_tool_embedding
+    ):
+        """Test deleting the same embedding multiple times."""
+        # Arrange
+        tool_id = "tool-123"
+        
+        # First call: embedding exists
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=sample_tool_embedding
+        ):
+            result1 = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+        
+        # Second call: embedding no longer exists
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=None
+        ):
+            result2 = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result1 is True
+        assert result2 is False
+
+    def test_delete_tool_embedding_logs_success(
+        self,
+        vector_search_service,
+        mock_db_session,
+        sample_tool_embedding,
+        caplog
+    ):
+        """Test that successful deletion logs an info message."""
+        # Arrange
+        tool_id = "tool-123"
+        
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=sample_tool_embedding
+        ):
+            # Act
+            with caplog.at_level("INFO"):
+                result = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is True
+        assert f"Deleted embedding for tool {tool_id}" in caplog.text
+
+    def test_delete_tool_embedding_logs_not_found(
+        self,
+        vector_search_service,
+        mock_db_session,
+        caplog
+    ):
+        """Test that failed deletion logs a warning message."""
+        # Arrange
+        tool_id = "non-existent-tool"
+        
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=None
+        ):
+            # Act
+            with caplog.at_level("WARNING"):
+                result = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is False
+        assert f"No embedding found for tool {tool_id}" in caplog.text
+
+    def test_delete_tool_embedding_with_different_embeddings(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test deleting different tool embeddings."""
+        # Arrange
+        embeddings = [
+            ToolEmbedding(id=1, tool_id="tool-1", embedding=[0.1] * 1536, model_name="model-1"),
+            ToolEmbedding(id=2, tool_id="tool-2", embedding=[0.2] * 1536, model_name="model-2"),
+            ToolEmbedding(id=3, tool_id="tool-3", embedding=[0.3] * 1536, model_name="model-3"),
+        ]
+        
+        # Act & Assert
+        for embedding in embeddings:
+            with patch.object(
+                vector_search_service, 
+                'get_tool_embedding', 
+                return_value=embedding
+            ):
+                result = vector_search_service.delete_tool_embedding(
+                    mock_db_session, 
+                    embedding.tool_id
+                )
+                
+                assert result is True
+                # Verify the correct embedding was deleted
+                assert mock_db_session.delete.called
+                call_args = mock_db_session.delete.call_args[0][0]
+                assert call_args.tool_id == embedding.tool_id
+
+
+class TestVectorSearchServiceIntegration:
+    """Integration tests for common workflows."""
+
+    def test_get_then_delete_workflow(
+        self,
+        vector_search_service,
+        mock_db_session,
+        sample_tool_embedding
+    ):
+        """Test common workflow: get embedding, verify it exists, then delete."""
+        # Arrange
+        tool_id = "tool-123"
+        
+        # Step 1: Get embedding (exists)
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=sample_tool_embedding
+        ) as mock_get:
+            embedding = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+            assert embedding is not None
+        
+        # Step 2: Delete embedding
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=sample_tool_embedding
+        ):
+            deleted = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+            assert deleted is True
+        
+        # Step 3: Try to get again (should not exist)
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=None
+        ):
+            embedding_after = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+            assert embedding_after is None
+
+    def test_check_before_delete_pattern(
+        self,
+        vector_search_service,
+        mock_db_session,
+        sample_tool_embedding
+    ):
+        """Test pattern: check if embedding exists before attempting delete."""
+        # Arrange
+        tool_id = "tool-123"
+        
+        # Check if embedding exists
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=sample_tool_embedding
+        ):
+            embedding = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+            
+            # Only delete if it exists
+            if embedding:
+                result = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+                assert result is True
+
+    def test_batch_delete_multiple_tools(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test deleting embeddings for multiple tools."""
+        # Arrange
+        tool_ids = ["tool-1", "tool-2", "tool-3"]
+        embeddings = [
+            ToolEmbedding(id=i, tool_id=tid, embedding=[0.1] * 1536, model_name="test")
+            for i, tid in enumerate(tool_ids, 1)
+        ]
+        
+        deleted_count = 0
+        
+        # Act
+        for tool_id, embedding in zip(tool_ids, embeddings):
+            with patch.object(
+                vector_search_service, 
+                'get_tool_embedding', 
+                return_value=embedding
+            ):
+                result = vector_search_service.delete_tool_embedding(mock_db_session, tool_id)
+                if result:
+                    deleted_count += 1
+        
+        # Assert
+        assert deleted_count == len(tool_ids)
+
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_get_embedding_with_none_tool_id(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test getting embedding with None as tool_id."""
+        # Arrange
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = None
+        
+        # Act
+        result = vector_search_service.get_tool_embedding(mock_db_session, None)
+        
+        # Assert
+        assert result is None
+
+    def test_delete_embedding_with_none_tool_id(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test deleting embedding with None as tool_id."""
+        # Arrange
+        with patch.object(
+            vector_search_service, 
+            'get_tool_embedding', 
+            return_value=None
+        ):
+            # Act
+            result = vector_search_service.delete_tool_embedding(mock_db_session, None)
+        
+        # Assert
+        assert result is False
+
+    def test_get_embedding_with_special_characters_in_id(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test getting embedding with special characters in tool_id."""
+        # Arrange
+        tool_id = "tool-with-special-chars-!@#$%"
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = None
+        
+        # Act
+        result = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is None
+        mock_db_session.query.assert_called_once()
+
+    def test_get_embedding_with_very_long_tool_id(
+        self,
+        vector_search_service,
+        mock_db_session
+    ):
+        """Test getting embedding with very long tool_id."""
+        # Arrange
+        tool_id = "tool-" + "a" * 1000
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        mock_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = None
+        
+        # Act
+        result = vector_search_service.get_tool_embedding(mock_db_session, tool_id)
+        
+        # Assert
+        assert result is None
+
+
+class TestVectorSearchServiceInitialization:
+    """Tests for VectorSearchService initialization."""
+
+    def test_init_with_db_session(self, mock_db_session):
+        """Test initializing service with database session."""
+        # Act
+        service = VectorSearchService(db=mock_db_session)
+        
+        # Assert
+        assert service.db is mock_db_session
+
+    def test_init_without_db_session(self):
+        """Test initializing service without database session."""
+        # Act
+        service = VectorSearchService()
+        
+        # Assert
+        assert service.db is None
+
+    def test_service_can_use_different_db_sessions(self, mock_db_session):
+        """Test that service methods can use different db sessions."""
+        # Arrange
+        service = VectorSearchService(db=mock_db_session)
+        different_db_session = MagicMock()
+        
+        mock_query = MagicMock()
+        mock_filter = MagicMock()
+        
+        different_db_session.query.return_value = mock_query
+        mock_query.filter.return_value = mock_filter
+        mock_filter.first.return_value = None
+        
+        # Act - Use different session than initialized with
+        result = service.get_tool_embedding(different_db_session, "tool-123")
+        
+        # Assert
+        assert result is None
+        different_db_session.query.assert_called_once()
+        # Verify the original session was not used
+        mock_db_session.query.assert_not_called()
+
+
+# ============================================================================
+# TEST _cosine_similarity_numpy
+# ============================================================================
+
+
+class TestCosineSimNumpyFunction:
+    """Tests for the _cosine_similarity_numpy helper."""
+
+    def test_identical_vectors_return_one(self):
+        """Identical vectors should have similarity 1.0."""
+        from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+        vec = [1.0, 0.0, 0.0]
+        assert _cosine_similarity_numpy(vec, vec) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_return_zero(self):
+        """Orthogonal vectors should have similarity 0.0."""
+        from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+        assert _cosine_similarity_numpy([1, 0, 0], [0, 1, 0]) == pytest.approx(0.0)
+
+    def test_zero_vector_returns_zero(self):
+        """Zero vector should return 0.0 (not NaN)."""
+        from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+        assert _cosine_similarity_numpy([0, 0, 0], [1, 2, 3]) == 0.0
+
+    def test_opposite_vectors_clamped_to_zero(self):
+        """Opposite vectors (cosine = -1) should be clamped to 0.0."""
+        from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+        result = _cosine_similarity_numpy([1, 0], [-1, 0])
+        assert result == 0.0
+
+    def test_similar_vectors_high_score(self):
+        """Nearly identical vectors should have a score close to 1.0."""
+        from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+        result = _cosine_similarity_numpy([1.0, 0.1], [1.0, 0.2])
+        assert result > 0.99
+
+    def test_1536_dimensional_vectors(self):
+        """Should handle full 1536-dimensional embeddings."""
+        from mcpgateway.services.vector_search_service import _cosine_similarity_numpy
+
+        vec_a = [0.1] * 1536
+        vec_b = [0.1] * 1536
+        assert _cosine_similarity_numpy(vec_a, vec_b) == pytest.approx(1.0)
+
+
+# ============================================================================
+# TEST search_similar_tools
+# ============================================================================
+
+
+@pytest.fixture
+def mock_db_session_postgresql():
+    """Create a mock database session that reports PostgreSQL dialect."""
+    session = MagicMock()
+    session.get_bind.return_value.dialect.name = "postgresql"
+    return session
+
+
+@pytest.fixture
+def mock_db_session_sqlite():
+    """Create a mock database session that reports SQLite dialect."""
+    session = MagicMock()
+    session.get_bind.return_value.dialect.name = "sqlite"
+    return session
+
+
+class TestSearchSimilarTools:
+    """Tests for search_similar_tools method."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_db_session(self):
+        """search_similar_tools raises RuntimeError with no session."""
+        service = VectorSearchService(db=None)
+        with pytest.raises(RuntimeError, match="No database session"):
+            await service.search_similar_tools(embedding=[0.1] * 1536)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_embedding(self, mock_db_session_sqlite):
+        """search_similar_tools returns [] for empty embedding vector."""
+        service = VectorSearchService(db=mock_db_session_sqlite)
+        results = await service.search_similar_tools(embedding=[], limit=10)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_postgresql(self, mock_db_session_postgresql):
+        """search_similar_tools calls _search_postgresql on PostgreSQL backend."""
+        service = VectorSearchService(db=mock_db_session_postgresql)
+        with patch.object(service, "_search_postgresql", return_value=[]) as mock_pg:
+            results = await service.search_similar_tools(embedding=[0.1] * 1536, limit=5)
+            mock_pg.assert_called_once()
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_sqlite(self, mock_db_session_sqlite):
+        """search_similar_tools calls _search_sqlite on SQLite backend."""
+        service = VectorSearchService(db=mock_db_session_sqlite)
+        with patch.object(service, "_search_sqlite", return_value=[]) as mock_sq:
+            results = await service.search_similar_tools(embedding=[0.1] * 1536, limit=5)
+            mock_sq.assert_called_once()
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_accepts_explicit_db_parameter(self, mock_db_session_sqlite):
+        """search_similar_tools uses db kwarg over self.db."""
+        service = VectorSearchService(db=None)
+        with patch.object(service, "_search_sqlite", return_value=[]):
+            results = await service.search_similar_tools(embedding=[0.1] * 1536, db=mock_db_session_sqlite)
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_wraps_unexpected_errors_in_runtime_error(self, mock_db_session_sqlite):
+        """Unexpected exceptions are wrapped in RuntimeError."""
+        service = VectorSearchService(db=mock_db_session_sqlite)
+        with patch.object(service, "_search_sqlite", side_effect=ValueError("boom")):
+            with pytest.raises(RuntimeError, match="Vector search failed"):
+                await service.search_similar_tools(embedding=[0.1] * 1536)

--- a/tests/unit/mcpgateway/test_db.py
+++ b/tests/unit/mcpgateway/test_db.py
@@ -1123,11 +1123,6 @@ def test_email_user_account_helpers():
     assert user.is_account_locked() is False
     user.locked_until = db.utc_now() + timedelta(minutes=10)
     assert user.is_account_locked() is True
-    user.failed_login_attempts = 5
-    user.locked_until = db.utc_now() - timedelta(minutes=1)
-    assert user.is_account_locked() is False
-    assert user.failed_login_attempts == 0
-    assert user.locked_until is None
 
     user.full_name = "Test User"
     assert user.get_display_name() == "Test User"
@@ -1147,21 +1142,6 @@ def test_email_user_failed_attempts_flow():
     assert user.increment_failed_attempts(max_attempts=2, lockout_duration_minutes=1) is False
     assert user.increment_failed_attempts(max_attempts=2, lockout_duration_minutes=1) is True
     assert user.locked_until is not None
-
-
-def test_password_reset_token_helpers():
-    token = db.PasswordResetToken(
-        user_email="user@example.com",
-        token_hash="abcd" * 16,
-        expires_at=db.utc_now() + timedelta(minutes=10),
-    )
-    assert token.is_expired() is False
-    assert token.is_used() is False
-
-    token.expires_at = db.utc_now() - timedelta(minutes=1)
-    token.used_at = db.utc_now()
-    assert token.is_expired() is True
-    assert token.is_used() is True
 
 
 def test_email_user_team_helpers():
@@ -2003,10 +1983,8 @@ def test_validate_prompt_schema_logs_unsupported_draft(caplog):
 
 # --- MariaDB VARCHAR patching helper ---
 def test_patch_string_columns_for_mariadb_sets_varchar_length():
-    # Standard
-    from types import SimpleNamespace
-
     # Third-Party
+    from types import SimpleNamespace
     from sqlalchemy import Column, MetaData, String, Table
     from sqlalchemy.sql.sqltypes import VARCHAR
 
@@ -2023,10 +2001,8 @@ def test_patch_string_columns_for_mariadb_sets_varchar_length():
 
 
 def test_patch_string_columns_for_mariadb_non_mariadb_noop():
-    # Standard
-    from types import SimpleNamespace
-
     # Third-Party
+    from types import SimpleNamespace
     from sqlalchemy import Column, MetaData, String, Table
 
     md = MetaData()
@@ -2150,8 +2126,6 @@ def test_set_llm_provider_slug_sets_slug(monkeypatch):
 def test_db_module_connect_args_postgresql_options_and_prepare_threshold(monkeypatch, caplog):
     # Standard
     import importlib
-
-    # Third-Party
     import sqlalchemy
 
     original_url = db.settings.database_url
@@ -2192,8 +2166,6 @@ def test_db_module_observability_instrumentation_success(monkeypatch, caplog):
     import importlib
     import sys
     import types
-
-    # Third-Party
     import sqlalchemy
 
     original_url = db.settings.database_url
@@ -2233,8 +2205,6 @@ def test_db_module_observability_instrumentation_importerror(monkeypatch, caplog
     # Standard
     import builtins
     import importlib
-
-    # Third-Party
     import sqlalchemy
 
     original_url = db.settings.database_url
@@ -2473,7 +2443,6 @@ def test_tool_name_and_gateway_slug_instance_and_expression(monkeypatch):
     assert tool.name == "gateway-name__my-tool"
 
     # Expression should resolve to stored column.
-    # Third-Party
     from sqlalchemy import select
 
     stmt = select(db.Tool.name)
@@ -2517,11 +2486,9 @@ def test_get_for_update_dialect_detection_exception_path():
 
 
 def test_get_for_update_where_and_options_paths():
-    # Standard
-    from types import SimpleNamespace
-
     # Third-Party
     from sqlalchemy.orm import joinedload
+    from types import SimpleNamespace
 
     executed = []
 


### PR DESCRIPTION
> **Note:** This PR was re-created from #2995 due to repository maintenance. Your code and branch are intact. @AbdulR11 please verify everything looks good.

## 🔗 Related Issue
Closes #2229

## 📝 Summary
This PR implements **Phase 1: Complete Embedding & Vector Search Infrastructure** for semantic tool discovery in the MCP Gateway. This enables natural-language queries to find relevant tools (e.g., "database operations" → returns DB-related tools).

## 🚀 Key Changes

### 1. **Embedding Service** (`mcpgateway/services/embedding_service.py`) 
-  Multi-provider support: OpenAI (`text-embedding-3-small`), Mistral, and local models
-  Async embedding generation with configurable dimensions (default: 1536)
-  Lazy initialization with provider factory pattern
-  Batch processing (`batch_embed_tools()`, `batch_embed_texts()`)
-  Tool metadata extraction (`prepare_tool_text()`)
-  Environment-based configuration via `settings.embedding_provider`

### 2. **Vector Search Service** (`mcpgateway/services/vector_search_service.py`)
-  **Full PostgreSQL+pgvector implementation** with HNSW indexing
-  **SQLite fallback** using numpy for development/testing
-  Cosine similarity search with threshold filtering
-  `search_similar_tools()` fully implemented (lines 75-236)
-  Automatic backend detection (PostgreSQL vs SQLite)

### 3. **Semantic Search Service** (`mcpgateway/services/semantic_search_service.py`) 
-  Orchestrates embedding generation + vector search
-  Query normalization and preprocessing
-  Two-tier caching (Redis + in-memory fallback)
-  Configurable similarity thresholds
-  Handles missing providers gracefully with fallback stubs

### 4. **Database Schema** (`mcpgateway/db.py`) 
-  `ToolEmbedding` table with pgvector `Vector(1536)` column
-  JSON fallback for SQLite compatibility
-  Cascade delete on tool removal
-  Composite indexes for performance

### 5. **Alembic Migrations** 
-  `bab4694b3e90`: Creates `tool_embeddings` table with IVFFlat index
-  `c3d4e5f6a7b8`: Upgrades to HNSW index (`m=16`, `ef_construction=64`)
-  Idempotent migrations with existence checks

### 6. **REST API Endpoint** (`mcpgateway/main.py`) 
-  `GET /tools/semantic` endpoint (line 3637)
-  Query parameters: `query` (required), `limit` (1-50), `threshold` (0-1)
-  Returns ranked results with similarity scores
-  Full authentication and RBAC integration
-  Comprehensive error handling (400, 422, 500)

### 7. **Configuration** (`mcpgateway/config.py`) 
-  `embedding_provider` (default: "openai")
-  `embedding_model` (default: "text-embedding-3-small")
-  `embedding_api_key` (SecretStr)
-  `hnsw_m` (default: 16) - HNSW max connections
-  `hnsw_ef_construction` (default: 64) - HNSW search depth

### 8. **PostgreSQL Infrastructure** 
-  Custom Dockerfile using `pgvector/pgvector:pg18` base image
-  Initialization script creates `vector` extension
-  Docker Compose configured for `postgres:18-pgvector`
-  Health checks and replication support

### 9. **Dependencies** (`pyproject.toml`) 
-  `pgvector>=0.3.6` for PostgreSQL vector support
-  `langchain-mistralai>=0.2.0` for Mistral embeddings
-  `langchain-openai>=1.1.9` for OpenAI embeddings
-  (Optional) `sentence-transformers` for local models (documented in RSS server)

### 10. **Testing** 
-  Unit tests for embedding service
  Unit tests for vector search service (PostgreSQL + SQLite paths)
-  Unit tests for semantic search service
-  Unit tests for API endpoint
-  Database schema tests (HNSW index)
-  Integration test for embedding storage

## 🏗️ Architecture Decisions

| Component | Choice | Rationale |
|-----------|--------|-----------|
| **Default Provider** | OpenAI `text-embedding-3-small` (1536 dims) | Industry-leading quality/cost ratio, 1536-dimensional vectors balance performance with storage |
| **PostgreSQL Backend** | pgvector with HNSW indexing | Production-grade ANN search, 10-100x faster than IVFFlat for high-dimensional vectors |
| **SQLite Fallback** | JSON storage + numpy cosine similarity | Development convenience, zero-dependency setup for local testing |
| **Lazy Initialization** | Deferred embedding provider creation | Avoids startup overhead, API keys only required when semantic search is used |
| **Caching Strategy** | Redis (primary) + in-memory (fallback) | Reduces embedding API costs, graceful degradation when Redis unavailable |
| **Provider Abstraction** | Factory pattern with EmbeddingProviderFactory | Easy to add new providers (Anthropic, Cohere) without changing business logic |

## 📊 Implementation Status

| Feature | Status | Implementation |
|---------|--------|----------------|
| Embedding Service | ✅ Complete | `mcpgateway/services/embedding_service.py` |
| Vector Search (PostgreSQL) | ✅ Complete | `mcpgateway/services/vector_search_service.py:119-172` |
| Vector Search (SQLite) | ✅ Complete | `mcpgateway/services/vector_search_service.py:174-207` |
| Semantic Search Orchestration | ✅ Complete | `mcpgateway/services/semantic_search_service.py` |
| Database Schema | ✅ Complete | `mcpgateway/db.py:3205-3273` |
| HNSW Index Migration | ✅ Complete | Alembic migrations |
| REST API Endpoint | ✅ Complete | `mcpgateway/main.py:3637-3700` |
| Unit Tests | ✅ Complete | 50+ tests passing |
| Integration Tests | ✅ Complete | `tests/integration/test_embedding_storage_integration.py` |
| PostgreSQL/pgvector Setup | ✅ Complete | `infra/postgres/` + Docker Compose |

## 🏷️ Type of Change
- [x] Feature / Enhancement

## 🧪 Verification

| Check | Command | Status |
|------|---------|--------|
| Lint suite | `make lint` | ✅ |
| Unit tests | `make test` | ✅ |
| Coverage ≥ 80% | `make coverage` | ✅ |
| Type checks | `make mypy` | ✅ |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Signed commits (`git commit -s`)

