### PR TITLE
fix(auth): correct RFC 8414 well-known URL construction for path-based issuers

### DIFF
--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -16,7 +16,7 @@ This module handles OAuth 2.0 Dynamic Client Registration (DCR) including:
 from datetime import datetime, timezone
 import logging
 from typing import Any, Dict, List
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 # Third-Party
 import httpx
@@ -98,7 +98,7 @@ class DcrService:
         # well-known URI string... between the host component and any existing path
         # component of the issuer's identifier".
         # See: https://datatracker.ietf.org/doc/html/rfc8414#section-3.1
-        parsed = urlparse(normalized_issuer)
+        parsed = urlsplit(normalized_issuer)
         rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server"
         if parsed.path:
             rfc8414_url += parsed.path

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -314,6 +314,80 @@ class TestDiscoverASMetadata:
             expected_url = "https://as.example.com/.well-known/oauth-authorization-server/tenant1/realm1"
             assert call_url == expected_url
 
+    @pytest.mark.asyncio
+    async def test_discover_as_metadata_rfc8414_path_with_semicolon_params(self):
+        """Test RFC 8414 URL preserves semicolon path parameters.
+
+        urlparse() strips ;params from the last path segment into a separate
+        attribute, losing data. urlsplit() preserves the full path.
+        """
+        # First-Party
+        from mcpgateway.services.dcr_service import _metadata_cache
+
+        _metadata_cache.clear()
+
+        dcr_service = DcrService()
+        issuer = "https://as.example.com/tenant;v=1"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(return_value={"issuer": issuer})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(dcr_service, "_get_client", return_value=mock_client):
+            await dcr_service.discover_as_metadata(issuer)
+
+            call_url = mock_client.get.call_args_list[0][0][0]
+            expected_url = "https://as.example.com/.well-known/oauth-authorization-server/tenant;v=1"
+            assert call_url == expected_url
+
+    @pytest.mark.asyncio
+    async def test_discover_as_metadata_oidc_fallback_appends_for_path_issuer(self):
+        """Test that OIDC fallback appends (not inserts) for path-based issuers.
+
+        RFC 8414 inserts between host and path, but OIDC Discovery 1.0 Section 4.1
+        appends to the issuer. Verify both URLs are constructed correctly when the
+        RFC 8414 attempt fails and falls back to OIDC.
+        """
+        # First-Party
+        from mcpgateway.services.dcr_service import _metadata_cache
+
+        _metadata_cache.clear()
+
+        dcr_service = DcrService()
+        issuer = "https://as.example.com/tenant1"
+
+        mock_response_404 = MagicMock()
+        mock_response_404.status_code = 404
+
+        mock_response_200 = MagicMock()
+        mock_response_200.status_code = 200
+        mock_response_200.json = MagicMock(return_value={"issuer": issuer})
+
+        call_count = [0]
+
+        async def get_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return mock_response_404
+            return mock_response_200
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=get_side_effect)
+
+        with patch.object(dcr_service, "_get_client", return_value=mock_client):
+            await dcr_service.discover_as_metadata(issuer)
+
+            calls = mock_client.get.call_args_list
+            assert len(calls) == 2
+
+            # RFC 8414: inserted between host and path
+            assert calls[0][0][0] == "https://as.example.com/.well-known/oauth-authorization-server/tenant1"
+            # OIDC: appended to issuer
+            assert calls[1][0][0] == "https://as.example.com/tenant1/.well-known/openid-configuration"
+
 
 class TestRegisterClient:
     """Test client registration (RFC 7591)."""


### PR DESCRIPTION
> **Note:** This PR was re-created from #3089 due to repository maintenance. Your code and branch are intact. @sumant-pangotra please verify everything looks good.

# 🐛 Bug-fix PR

---

## 📌 Summary
Fixed incorrect RFC 8414 `.well-known` discovery URL construction in `DcrService`. When an OAuth issuer URL includes a path (common in multi-tenant environments), the service was previously appending the well-known segment to the end of the URL instead of inserting it after the host as required by the spec. This caused errors during Dynamic Client Registration (DCR).
Closes #3088

## 🔁 Reproduction Steps

1. Configure an issuer with a path: `https://auth.example.com/tenant-1`.
2. Observe `discover_as_metadata` attempting to fetch: `https://auth.example.com/tenant-1/.well-known/oauth-authorization-server`.
3. Expected URL per RFC 8414 Section 3.1: `https://auth.example.com/.well-known/oauth-authorization-server/tenant-1`.

## 🐞 Root Cause
The logic inside `discover_as_metadata` used string concatenation/stripping that didn't account for URL path components.

## 💡 Fix Description
1. **URL Re-construction**: Switched to `urllib.parse.urlparse` to robustly decompose and reconstruct the discovery URL.
2. **Insertion Logic**: Implemented logic to insert the `/.well-known/oauth-authorization-server` suffix between the `netloc` and the `path`.
3. **Normalization**: Enhanced stripping of trailing slashes at the start of the service method to ensure internal consistency and cache hits regardless of whether the input issuer has a trailing slash.
4. **New Test Case**: Added `test_discover_as_metadata_rfc8414_path_construction` to [tests/unit/mcpgateway/services/test_dcr_service.py:L248](./tests/unit/mcpgateway/services/test_dcr_service.py#L248) to verify correct URL construction for path-based issuers and prevent regressions.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Pass   |
| Unit tests                            | `make test`          | Pass   |
| Coverage ≥ 80 %                       | `make coverage`      | Pass   |
| Manual regression no longer fails     | Unit tests for paths | Pass   |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
