### PR TITLE
[TESTING][SECURITY]: Add OWASP A01 direct and ZAP DAST test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1255,6 +1255,7 @@ testing-up:                                ## Start testing stack (Locust + A2A 
 	@echo "Fast Test Server     http://localhost:8880         MCP benchmark target"
 	@echo "A2A Echo Agent       http://localhost:9100         A2A protocol target"
 	@echo "MCP Inspector        http://localhost:6274         Interactive MCP client"
+	@echo "OWASP ZAP            http://localhost:8090         DAST daemon (default ZAP_TARGET_URL=http://nginx:80)"
 	@echo ""
 	@echo "   📝 Auto-registered:"
 	@echo "      • MCP gateway: fast_test (from fast_test_server)"
@@ -1272,7 +1273,7 @@ testing-down:                              ## Stop testing stack
 .PHONY: testing-status
 testing-status:                            ## Show status of testing services
 	@echo "🧪 Testing stack status:"
-	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(fast_test|a2a_echo_agent|locust|mcp_inspector)" || \
+	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(fast_test|a2a_echo_agent|locust|mcp_inspector|zap)" || \
 		echo "   No testing services running. Start with 'make testing-up'"
 	@WORKERS=$$($(COMPOSE_CMD_MONITOR) ps | grep -c "locust_worker" || true); \
 		echo "   🦗 Locust workers: $$WORKERS"
@@ -6693,8 +6694,10 @@ db-fix-head: ## Fix multiple heads issue
 # help: test-ui-record       - Run Playwright UI tests and record videos + screenshots (headless)
 # help: test-ui-update-snapshots - Update Playwright visual regression snapshots
 # help: test-ui-clean        - Clean up Playwright test artifacts
+# help: test-owasp           - Run OWASP access-control security tests (no ZAP required)
+# help: test-zap             - Run ZAP DAST security scan (requires ZAP daemon; set ZAP_BASE_URL)
 
-.PHONY: playwright-install playwright-install-all playwright-preflight test-ui test-ui-headless test-ui-headless-parallel test-ui-debug test-ui-smoke test-ui-ci-smoke test-ui-parallel test-ui-report test-ui-coverage test-ui-screenshots test-ui-record test-ui-update-snapshots test-ui-clean
+.PHONY: playwright-install playwright-install-all playwright-preflight test-ui test-ui-headless test-ui-headless-parallel test-ui-debug test-ui-smoke test-ui-ci-smoke test-ui-parallel test-ui-report test-ui-coverage test-ui-screenshots test-ui-record test-ui-update-snapshots test-ui-clean test-zap test-owasp
 
 # Playwright test variables
 PLAYWRIGHT_DIR := tests/playwright
@@ -6703,6 +6706,14 @@ PLAYWRIGHT_SCREENSHOTS := $(PLAYWRIGHT_DIR)/screenshots
 PLAYWRIGHT_VIDEOS := $(PLAYWRIGHT_DIR)/videos
 PLAYWRIGHT_SLOWMO ?= 750
 TEST_BASE_URL ?= http://localhost:8080
+ZAP_BASE_URL   ?= http://localhost:8090
+ZAP_API_KEY    ?= changeme
+# URL ZAP uses internally to spider the app. nginx exposes port 80 on mcpnet
+# (host sees it as 8080 via port mapping), so ZAP inside Docker must use port 80.
+# Works on both Linux and macOS/Windows Docker Desktop.
+# Override only if your setup differs (e.g. a standalone ZAP outside mcpnet).
+ZAP_TARGET_URL ?= http://nginx:80
+ZAP_REPORTS   := tests/reports
 # Optional install flags for Playwright browser installation (e.g. --with-deps in Linux CI)
 PLAYWRIGHT_INSTALL_FLAGS ?=
 PLAYWRIGHT_CI_SMOKE_TESTS := \
@@ -6887,6 +6898,38 @@ test-ui-clean:
 	@rm -rf test-results/
 	@rm -f playwright-report-*.html test-results-*.xml
 	@echo "✅ Playwright artifacts cleaned!"
+
+## --- OWASP / ZAP Security Testing ------------------------------------------
+test-owasp: playwright-install  ## 🔒 Run OWASP access-control security tests (no ZAP required)
+	@echo "🔒 Running OWASP access-control security tests..."
+	@$(MAKE) --no-print-directory playwright-preflight
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@mkdir -p $(ZAP_REPORTS)
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
+		export TEST_BASE_URL='$(TEST_BASE_URL)' && \
+		uv run --active pytest tests/playwright/security/owasp/ \
+			-v -m owasp_a01 --tb=short \
+			|| { echo '❌ OWASP security tests failed!'; exit 1; }"
+	@echo "✅ OWASP security tests completed!"
+
+test-zap: playwright-install  ## 🔒 Run ZAP DAST security scan (requires ZAP daemon; set ZAP_BASE_URL)
+	@echo "🔒 Running ZAP DAST security scan against $(TEST_BASE_URL)..."
+	@if [ -z "$(ZAP_BASE_URL)" ]; then \
+		echo "❌ ZAP_BASE_URL is not set. Start the testing stack with: make testing-up"; \
+		exit 1; \
+	fi
+	@$(MAKE) --no-print-directory playwright-preflight
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@mkdir -p $(ZAP_REPORTS)
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
+		export TEST_BASE_URL='$(TEST_BASE_URL)' && \
+		export ZAP_BASE_URL='$(ZAP_BASE_URL)' && \
+		export ZAP_API_KEY='$(ZAP_API_KEY)' && \
+		export ZAP_TARGET_URL='$(ZAP_TARGET_URL)' && \
+		uv run --active pytest tests/playwright/security/owasp/ \
+			-v -m owasp_a01_zap --tb=short \
+			|| { echo '❌ ZAP DAST scan failed!'; exit 1; }"
+	@echo "✅ ZAP DAST scan completed! Reports in $(ZAP_REPORTS)/"
 
 ## --- Combined Testing -------------------------------------------------------
 test-all: test test-js test-ui-headless

--- a/Makefile
+++ b/Makefile
@@ -1255,7 +1255,8 @@ testing-up:                                ## Start testing stack (Locust + A2A 
 	@echo "Fast Test Server     http://localhost:8880         MCP benchmark target"
 	@echo "A2A Echo Agent       http://localhost:9100         A2A protocol target"
 	@echo "MCP Inspector        http://localhost:6274         Interactive MCP client"
-	@echo "OWASP ZAP            http://localhost:8090         DAST daemon (default ZAP_TARGET_URL=http://nginx:80)"
+	@echo ""
+	@echo "   🔒 For DAST security scanning, also start ZAP: make testing-zap-up"
 	@echo ""
 	@echo "   📝 Auto-registered:"
 	@echo "      • MCP gateway: fast_test (from fast_test_server)"
@@ -1267,13 +1268,13 @@ testing-up:                                ## Start testing stack (Locust + A2A 
 .PHONY: testing-down
 testing-down:                              ## Stop testing stack
 	@echo "🧪 Stopping testing stack..."
-	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector down --remove-orphans
+	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector --profile dast down --remove-orphans
 	@echo "✅ Testing stack stopped."
 
 .PHONY: testing-status
 testing-status:                            ## Show status of testing services
 	@echo "🧪 Testing stack status:"
-	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(fast_test|a2a_echo_agent|locust|mcp_inspector|zap)" || \
+	@$(COMPOSE_CMD_MONITOR) ps | grep -E "(fast_test|a2a_echo_agent|locust|mcp_inspector)" || \
 		echo "   No testing services running. Start with 'make testing-up'"
 	@WORKERS=$$($(COMPOSE_CMD_MONITOR) ps | grep -c "locust_worker" || true); \
 		echo "   🦗 Locust workers: $$WORKERS"
@@ -1281,6 +1282,24 @@ testing-status:                            ## Show status of testing services
 .PHONY: testing-logs
 testing-logs:                              ## Show testing stack logs
 	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector logs -f --tail=100
+
+.PHONY: testing-zap-up
+testing-zap-up:                            ## Start OWASP ZAP DAST daemon (requires testing stack)
+	@echo "🔒 Starting OWASP ZAP DAST daemon..."
+	$(COMPOSE_CMD_MONITOR) --profile dast up -d
+	@echo ""
+	@echo "✅ ZAP DAST daemon started!"
+	@echo ""
+	@echo "   OWASP ZAP API:    http://localhost:8090"
+	@echo "   OWASP ZAP Web UI: http://localhost:8091"
+	@echo ""
+	@echo "   Run security tests: make test-zap"
+
+.PHONY: testing-zap-down
+testing-zap-down:                          ## Stop OWASP ZAP DAST daemon
+	@echo "🔒 Stopping ZAP DAST daemon..."
+	$(COMPOSE_CMD_MONITOR) --profile dast down --remove-orphans
+	@echo "✅ ZAP stopped."
 
 # =============================================================================
 # help: 🔍 MCP INSPECTOR (Interactive MCP Client)

--- a/Makefile
+++ b/Makefile
@@ -1291,7 +1291,7 @@ testing-zap-up:                            ## Start OWASP ZAP DAST daemon (requi
 	@echo "✅ ZAP DAST daemon started!"
 	@echo ""
 	@echo "   OWASP ZAP API:    http://localhost:8090"
-	@echo "   OWASP ZAP Web UI: http://localhost:8091"
+	@echo "   OWASP ZAP API UI: http://localhost:8090/UI"
 	@echo ""
 	@echo "   Run security tests: make test-zap"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2445,4 +2445,4 @@ services:
         reservations:
           cpus: '0.5'
           memory: 1G
-    profiles: ["testing"]
+    profiles: ["dast"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2389,3 +2389,60 @@ services:
           cpus: '0.25'
           memory: 128M
     profiles: ["inspector", "sso"]
+
+###############################################################################
+#  OWASP ZAP DAST - Dynamic Application Security Testing daemon
+#  Usage: make testing-up
+#  ZAP API:    http://localhost:8090  (set ZAP_BASE_URL=http://localhost:8090)
+#  ZAP Web UI: http://localhost:8091  (browser-based scan control)
+#
+#  Run OWASP A01 ZAP tests after the stack is up:
+#    ZAP_BASE_URL=http://localhost:8090 ZAP_API_KEY=changeme \
+#      pytest tests/playwright/security/owasp/test_a01_zap_dast.py -v -m owasp_a01_zap
+#
+#  Environment variables:
+#    ZAP_API_KEY   - ZAP API key (default: changeme)
+###############################################################################
+
+  zap:
+    image: ghcr.io/zaproxy/zaproxy:stable
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "8090:8090"    # ZAP API daemon (set ZAP_BASE_URL=http://localhost:8090)
+      - "8091:8091"    # ZAP web UI
+    command:
+      - zap.sh
+      - -daemon
+      - -port
+      - "8090"
+      - -host
+      - "0.0.0.0"
+      - -config
+      - "api.key=${ZAP_API_KEY:-changeme}"
+      - -config
+      - "api.addrs.addr.name=.*"        # Docker port-mapping arrives via bridge IP, not 127.0.0.1;
+      - -config
+      - "api.addrs.addr.regex=true"     # authentication is enforced by api.key above.
+      - -config
+      - "connection.timeoutInSecs=20"
+    environment:
+      - ZAP_API_KEY=${ZAP_API_KEY:-changeme}
+    depends_on:
+      nginx:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8090/JSON/core/view/version/?apikey=${ZAP_API_KEY:-changeme}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s    # ZAP JVM startup takes ~30-45 s
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    profiles: ["testing"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2392,9 +2392,9 @@ services:
 
 ###############################################################################
 #  OWASP ZAP DAST - Dynamic Application Security Testing daemon
-#  Usage: make testing-up
-#  ZAP API:    http://localhost:8090  (set ZAP_BASE_URL=http://localhost:8090)
-#  ZAP Web UI: http://localhost:8091  (browser-based scan control)
+#  Usage: make testing-zap-up
+#  ZAP API + UI: http://localhost:8090  (set ZAP_BASE_URL=http://localhost:8090)
+#  ZAP API UI:   http://localhost:8090/UI
 #
 #  Run OWASP A01 ZAP tests after the stack is up:
 #    ZAP_BASE_URL=http://localhost:8090 ZAP_API_KEY=changeme \
@@ -2409,8 +2409,7 @@ services:
     restart: unless-stopped
     networks: [mcpnet]
     ports:
-      - "8090:8090"    # ZAP API daemon (set ZAP_BASE_URL=http://localhost:8090)
-      - "8091:8091"    # ZAP web UI
+      - "8090:8090"    # ZAP API daemon + UI (http://localhost:8090/UI)
     command:
       - zap.sh
       - -daemon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2440,8 +2440,8 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 2G
+          memory: 16G
         reservations:
           cpus: '0.5'
-          memory: 1G
+          memory: 8G
     profiles: ["dast"]

--- a/docs/docs/testing/.pages
+++ b/docs/docs/testing/.pages
@@ -2,6 +2,7 @@ nav:
   - index.md
   - unittest.md
   - basic.md
+  - security.md
   - entra-id-e2e.md
   - performance.md
   - acceptance.md

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -12,6 +12,7 @@ This section covers the testing strategy and tools for ContextForge.
 | **Integration tests** | pytest | `tests/integration/` | Implemented |
 | **End-to-end tests** | pytest | `tests/e2e/` | Implemented |
 | **UI automation** | Playwright | `tests/playwright/` | Implemented |
+| **Security / DAST** | Playwright + OWASP ZAP | `tests/playwright/security/` | Implemented |
 | **Load testing** | Locust | `tests/loadtest/` | Implemented |
 | **Concurrency tests** | Manual (asyncio) | `tests/manual/concurrency/` | Implemented |
 | **JS unit tests** | - | - | Not yet implemented |
@@ -106,6 +107,21 @@ make eslint        # lint JavaScript
 make lint-web      # ESLint + HTMLHint + Stylelint
 make format-web    # Prettier formatting
 ```
+
+---
+
+## 🔒 Security Testing (OWASP & DAST)
+
+Two-layer coverage for OWASP A01:2021 – Broken Access Control:
+
+```bash
+make test-owasp   # Layer 1: direct Playwright access-control tests (no ZAP needed)
+make test-zap     # Layer 2: ZAP DAST scan (requires make testing-up)
+```
+
+See [Security Testing](security.md) for the full guide including environment
+variables, authentication setup, ZAP target URL configuration, and report
+locations.
 
 ---
 

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -116,7 +116,7 @@ Two-layer coverage for OWASP A01:2021 – Broken Access Control:
 
 ```bash
 make test-owasp   # Layer 1: direct Playwright access-control tests (no ZAP needed)
-make test-zap     # Layer 2: ZAP DAST scan (requires make testing-up)
+make test-zap     # Layer 2: ZAP DAST scan (requires make testing-zap-up)
 ```
 
 See [Security Testing](security.md) for the full guide including environment

--- a/docs/docs/testing/security.md
+++ b/docs/docs/testing/security.md
@@ -1,0 +1,170 @@
+# Security Testing (OWASP & DAST)
+
+ContextForge includes a two-layer security test suite focused on
+**OWASP A01:2021 – Broken Access Control**.  The layers are independent:
+Layer 1 runs in every CI environment with no extra infrastructure; Layer 2
+requires a running OWASP ZAP daemon.
+
+---
+
+## Testing Pyramid Placement
+
+| Layer | Tool | Marker | Requires |
+|-------|------|--------|----------|
+| Layer 1 – direct access control | Playwright / pytest | `owasp_a01` | Gateway only |
+| Layer 2 – ZAP DAST | OWASP ZAP + pytest | `owasp_a01_zap` | `make testing-up` |
+
+---
+
+## Layer 1 — Direct Access Control Tests
+
+**Location:** `tests/playwright/security/owasp/test_a01_broken_access_control.py`
+
+These tests call the gateway's REST API directly via Playwright's
+`APIRequestContext`.  No browser, no proxy, no ZAP.
+
+| Attack pattern | CWE | What is checked |
+|----------------|-----|-----------------|
+| Force browsing | CWE-284, CWE-862 | 7 protected endpoints return 401 for anonymous requests |
+| IDOR / cross-user | CWE-639 | User A token cannot read User B's private resources |
+| Cross-tenant | CWE-639, CWE-285 | Team-A-scoped token cannot see Team-B resources |
+| Vertical privilege escalation | CWE-269, CWE-285 | Non-admin tokens are rejected by admin-only APIs |
+| JWT tampering | CWE-345, CWE-287 | Unsigned, payload-modified, expired, `alg=none`, wrong `iss`/`aud` |
+| HTTP method access control | CWE-284 | Non-admin cannot mutate publicly readable resources |
+| CORS enforcement | CWE-942 | No wildcard or reflected `Access-Control-Allow-Origin` for arbitrary origins |
+
+### Running Layer 1
+
+```bash
+# Requires the gateway to be running (make dev or make testing-up)
+make test-owasp
+```
+
+The target defaults to `http://localhost:8080`.  Override with:
+
+```bash
+TEST_BASE_URL=http://localhost:4444 make test-owasp
+```
+
+---
+
+## Layer 2 — ZAP DAST Integration
+
+**Location:** `tests/playwright/security/owasp/test_a01_zap_dast.py`
+
+ZAP acts as an active scanner.  The test suite:
+
+1. Seeds ZAP's site tree by directly accessing each protected path
+   (`zap.core.access_url`) — necessary because ZAP's traditional spider
+   follows HTML hyperlinks and cannot discover REST API endpoints on its own.
+2. Runs ZAP's traditional spider to catch any additional HTML/UI paths.
+3. Waits for the **passive scan** queue to drain, then asserts no
+   HIGH/CRITICAL A01 alerts.
+4. Runs the **active scan** (attack payloads) and asserts no CRITICAL A01
+   alerts.
+5. Writes a JSON report to `tests/reports/`.
+
+### Prerequisites
+
+Start the full testing stack (gateway + nginx + ZAP + Locust):
+
+```bash
+make testing-up
+```
+
+ZAP is included in the `testing` profile and starts automatically.
+Wait for it to become healthy — ZAP's JVM takes 30–45 seconds to start.
+
+### Running Layer 2
+
+```bash
+make test-zap
+```
+
+This sets the required environment variables automatically and runs only the
+`owasp_a01_zap` marker.  To run manually:
+
+```bash
+ZAP_BASE_URL=http://localhost:8090 \
+ZAP_API_KEY=changeme \
+ZAP_TARGET_URL=http://host.docker.internal:8080 \
+pytest tests/playwright/security/owasp/ -v -m owasp_a01_zap
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ZAP_BASE_URL` | *(unset — skips ZAP tests)* | ZAP API daemon URL, host-visible (e.g. `http://localhost:8090`) |
+| `ZAP_API_KEY` | `changeme` | ZAP API key configured in docker-compose |
+| `TEST_BASE_URL` | `http://localhost:8080` | Gateway URL, host-visible (used for preflight health check) |
+| `ZAP_TARGET_URL` | `http://host.docker.internal:8080` | Gateway URL as seen from inside the ZAP container |
+
+!!! note "Why two URL variables?"
+    `TEST_BASE_URL` is the host-visible address used by the Python test process
+    for health checks and result verification.  `ZAP_TARGET_URL` is the address
+    ZAP itself uses when spidering and scanning — inside Docker, `localhost`
+    resolves to the ZAP container, not the host.
+    `host.docker.internal:8080` is the correct Docker-to-host address on macOS
+    and Windows.  On Linux, use the host's Docker bridge IP (typically
+    `172.17.0.1`).
+
+### Authentication
+
+ZAP authenticates automatically.  At startup the `zap` fixture:
+
+1. Generates an admin JWT using the application's own `create_jwt_token`
+   utility (`teams=None` + `is_admin=True` → admin bypass scope).
+2. Installs it as a permanent `Authorization: Bearer <token>` header on all
+   ZAP outbound requests via ZAP's **Replacer** add-on.
+
+No manual login or session configuration is required.
+
+### Scan Resilience
+
+The active scan sends thousands of attack payloads and can exhaust ZAP's
+memory in a resource-constrained environment (Docker limit: 2 GB).  The test
+handles this gracefully:
+
+- If ZAP disconnects mid-scan, the polling loop breaks and proceeds with
+  partial results.
+- After the scan, the test reconnects via a fresh ZAP client (ZAP restarts
+  automatically via `restart: unless-stopped`).
+- If ZAP is still unreachable after reconnecting, the test is **skipped**
+  with a message indicating the memory limit.  To make the active scan more
+  stable, increase ZAP's memory in `docker-compose.yml`:
+
+```yaml
+deploy:
+  resources:
+    limits:
+      memory: 4G   # increase from 2G
+```
+
+### Reports
+
+JSON alert reports are written to `tests/reports/` after each scan phase:
+
+| File pattern | Contents |
+|---|---|
+| `zap_a01_passive_failures_<ts>.json` | HIGH/CRITICAL A01 alerts from passive scan |
+| `zap_a01_active_critical_<ts>.json` | CRITICAL A01 alerts from active scan |
+| `zap_a01_full_report_<ts>.json` | All A01 alerts regardless of severity |
+
+---
+
+## Skipping ZAP Tests in CI
+
+ZAP tests are skipped automatically when `ZAP_BASE_URL` is not set.
+Standard CI runs (`make test`) do not set this variable, so only Layer 1
+runs.  Enable Layer 2 in CI by adding a ZAP daemon service to your pipeline
+and setting `ZAP_BASE_URL` before running `make test-zap`.
+
+---
+
+## See Also
+
+- [OWASP Top 10 A01:2021](https://owasp.org/Top10/A01_2021-Broken_Access_Control/)
+- [RBAC guide](../manage/rbac.md)
+- [Security features](../architecture/security-features.md)
+- [Performance / load testing](performance.md)

--- a/docs/docs/testing/security.md
+++ b/docs/docs/testing/security.md
@@ -124,24 +124,18 @@ No manual login or session configuration is required.
 
 ### Scan Resilience
 
-The active scan sends thousands of attack payloads and can exhaust ZAP's
-memory in a resource-constrained environment (Docker limit: 2 GB).  The test
-handles this gracefully:
+The test suite imports the full OpenAPI spec (300+ paths) into ZAP.  The
+default Docker memory limit is 16 GB.  The **passive scan** completes
+reliably at this limit and covers the full API surface.  The **active scan**
+(attack payloads against every endpoint) may time out or OOM on very large
+APIs and is skipped gracefully when this happens:
 
 - If ZAP disconnects mid-scan, the polling loop breaks and proceeds with
   partial results.
 - After the scan, the test reconnects via a fresh ZAP client (ZAP restarts
   automatically via `restart: unless-stopped`).
 - If ZAP is still unreachable after reconnecting, the test is **skipped**
-  with a message indicating the memory limit.  To make the active scan more
-  stable, increase ZAP's memory in `docker-compose.yml`:
-
-```yaml
-deploy:
-  resources:
-    limits:
-      memory: 4G   # increase from 2G
-```
+  with a message indicating the memory limit.
 
 ### Reports
 

--- a/docs/docs/testing/security.md
+++ b/docs/docs/testing/security.md
@@ -66,13 +66,15 @@ ZAP acts as an active scanner.  The test suite:
 
 ### Prerequisites
 
-Start the full testing stack (gateway + nginx + ZAP + Locust):
+Start the testing stack and the ZAP DAST daemon:
 
 ```bash
-make testing-up
+make testing-up        # gateway + nginx + Locust + test servers
+make testing-zap-up    # OWASP ZAP daemon (separate profile)
 ```
 
-ZAP is included in the `testing` profile and starts automatically.
+ZAP runs in its own `dast` Docker Compose profile to avoid pulling the
+heavyweight image and reserving memory during normal test runs.
 Wait for it to become healthy — ZAP's JVM takes 30–45 seconds to start.
 
 ### Running Layer 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -660,7 +660,7 @@ markers = [
     "regression: marks regression tests for previously-fixed bugs",
     "proxy: marks tests that run through a simulated proxy prefix",
     "iframe: marks tests that run inside an iframe host page",
-    "owasp_a01: marks OWASP A01:2025 Broken Access Control security tests",
+    "owasp_a01: marks OWASP A01:2021 Broken Access Control security tests",
     "owasp_a01_zap: marks OWASP A01 ZAP DAST scan tests (requires ZAP daemon; set ZAP_BASE_URL)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ playwright = [
     "pytest-html>=4.2.0",
     "pytest-playwright>=0.7.2",
     "pytest-timeout>=2.4.0",
+    "python-owasp-zap-v2.4>=0.0.21",
 ]
 
 # Convenience meta-extras
@@ -659,6 +660,8 @@ markers = [
     "regression: marks regression tests for previously-fixed bugs",
     "proxy: marks tests that run through a simulated proxy prefix",
     "iframe: marks tests that run inside an iframe host page",
+    "owasp_a01: marks OWASP A01:2025 Broken Access Control security tests",
+    "owasp_a01_zap: marks OWASP A01 ZAP DAST scan tests (requires ZAP daemon; set ZAP_BASE_URL)",
 ]
 
 # Playwright-specific test discovery patterns

--- a/tests/playwright/security/owasp/__init__.py
+++ b/tests/playwright/security/owasp/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/playwright/security/owasp/conftest.py
+++ b/tests/playwright/security/owasp/conftest.py
@@ -172,13 +172,17 @@ def two_teams_setup(owasp_admin_api: APIRequestContext, playwright: Playwright):
 
 @pytest.fixture
 def private_server_owned_by_user_a(owasp_admin_api: APIRequestContext, owasp_user_a_api: dict):
-    """Create a private server as User A and return its ID. Cleans up after test."""
-    ctx_a: APIRequestContext = owasp_user_a_api["ctx"]
+    """Create a private server via admin on behalf of User A and return its ID. Cleans up after test."""
     server_id: str | None = None
     try:
-        resp = ctx_a.post(
+        resp = owasp_admin_api.post(
             "/servers",
-            data={"server": {"name": f"owasp-priv-{uuid.uuid4().hex[:8]}", "description": "User A private server"}, "team_id": None, "visibility": "private"},
+            data={
+                "server": {"name": f"owasp-priv-{uuid.uuid4().hex[:8]}", "description": "User A private server"},
+                "team_id": None,
+                "visibility": "private",
+                "owner_email": owasp_user_a_api["email"],
+            },
         )
         assert resp.status in (200, 201), f"Failed creating private server: {resp.status} {resp.text()}"
         server_id = resp.json()["id"]
@@ -186,5 +190,4 @@ def private_server_owned_by_user_a(owasp_admin_api: APIRequestContext, owasp_use
     finally:
         if server_id:
             with suppress(Exception):
-                # Admin cleanup in case user can't delete
                 owasp_admin_api.delete(f"/servers/{server_id}")

--- a/tests/playwright/security/owasp/conftest.py
+++ b/tests/playwright/security/owasp/conftest.py
@@ -20,11 +20,11 @@ import pytest
 # First-Party
 from mcpgateway.utils.create_jwt_token import _create_jwt_token
 
-# Local
 BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
 TEST_PASSWORD = "SecureTestPass123!"
 
-def _make_jwt(email: str, *, is_admin: bool, teams=None, expires_in_minutes: int = 30) -> str:  # type: ignore[no-untyped-def]
+
+def _make_jwt(email: str, *, is_admin: bool, teams: list[str] | None = None, expires_in_minutes: int = 30) -> str:
     """Create a JWT token for OWASP A01 testing with a short-lived expiry."""
     return _create_jwt_token(
         {"sub": email},
@@ -41,6 +41,7 @@ def _api_context(playwright: Playwright, token: str) -> APIRequestContext:
         extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
     )
 
+
 @pytest.fixture(scope="module")
 def owasp_anon_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
     """Unauthenticated API context for force-browsing tests."""
@@ -50,6 +51,7 @@ def owasp_anon_api(playwright: Playwright) -> Generator[APIRequestContext, None,
     )
     yield ctx
     ctx.dispose()
+
 
 @pytest.fixture(scope="module")
 def owasp_admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
@@ -61,6 +63,7 @@ def owasp_admin_api(playwright: Playwright) -> Generator[APIRequestContext, None
     )
     yield ctx
     ctx.dispose()
+
 
 @pytest.fixture
 def owasp_user_a_api(owasp_admin_api: APIRequestContext, playwright: Playwright):

--- a/tests/playwright/security/owasp/conftest.py
+++ b/tests/playwright/security/owasp/conftest.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OWASP A01 test fixtures for cross-user and cross-tenant access control tests."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from contextlib import suppress
+import os
+from typing import Generator
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+# Local
+BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
+TEST_PASSWORD = "SecureTestPass123!"
+
+def _make_jwt(email: str, *, is_admin: bool, teams=None, expires_in_minutes: int = 30) -> str:  # type: ignore[no-untyped-def]
+    """Create a JWT token for OWASP A01 testing with a short-lived expiry."""
+    return _create_jwt_token(
+        {"sub": email},
+        expires_in_minutes=expires_in_minutes,
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+    )
+
+
+def _api_context(playwright: Playwright, token: str) -> APIRequestContext:
+    """Create a Playwright API request context with Bearer auth."""
+    return playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+
+@pytest.fixture(scope="module")
+def owasp_anon_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Unauthenticated API context for force-browsing tests."""
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+@pytest.fixture(scope="module")
+def owasp_admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Admin-authenticated API context for OWASP A01 tests (admin bypass via teams=null)."""
+    token = _make_jwt("admin@example.com", is_admin=True)
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    yield ctx
+    ctx.dispose()
+
+@pytest.fixture
+def owasp_user_a_api(owasp_admin_api: APIRequestContext, playwright: Playwright):
+    """Non-admin API context for User A, registered in the system. Cleans up after test."""
+    email = f"owasp-a-{uuid.uuid4().hex[:8]}@example.com"
+    create_resp = owasp_admin_api.post(
+        "/auth/email/admin/users",
+        data={"email": email, "password": TEST_PASSWORD, "full_name": "OWASP User A"},
+    )
+    assert create_resp.status in (200, 201), f"Failed to create User A: {create_resp.status} {create_resp.text()}"
+
+    token = _make_jwt(email, is_admin=False, teams=[])
+    ctx = _api_context(playwright, token)
+    yield {"ctx": ctx, "email": email}
+    ctx.dispose()
+    with suppress(Exception):
+        owasp_admin_api.delete(f"/auth/email/admin/users/{email}")
+
+
+@pytest.fixture
+def owasp_user_b_api(owasp_admin_api: APIRequestContext, playwright: Playwright):
+    """Non-admin API context for User B, registered in the system. Cleans up after test."""
+    email = f"owasp-b-{uuid.uuid4().hex[:8]}@example.com"
+    create_resp = owasp_admin_api.post(
+        "/auth/email/admin/users",
+        data={"email": email, "password": TEST_PASSWORD, "full_name": "OWASP User B"},
+    )
+    assert create_resp.status in (200, 201), f"Failed to create User B: {create_resp.status} {create_resp.text()}"
+
+    token = _make_jwt(email, is_admin=False, teams=[])
+    ctx = _api_context(playwright, token)
+    yield {"ctx": ctx, "email": email}
+    ctx.dispose()
+    with suppress(Exception):
+        owasp_admin_api.delete(f"/auth/email/admin/users/{email}")
+
+
+@pytest.fixture
+def two_teams_setup(owasp_admin_api: APIRequestContext, playwright: Playwright):
+    """Create two distinct teams with separate scoped tokens. Cleans up after test."""
+    suffix = uuid.uuid4().hex[:8]
+    team_a_id: str | None = None
+    team_b_id: str | None = None
+    server_a_id: str | None = None
+    server_b_id: str | None = None
+    ctx_a = None
+    ctx_b = None
+    try:
+        # Team A
+        resp_a = owasp_admin_api.post("/teams/", data={"name": f"owasp-team-a-{suffix}", "description": "OWASP Team A", "visibility": "private"})
+        assert resp_a.status in (200, 201), f"Failed creating Team A: {resp_a.status} {resp_a.text()}"
+        team_a_id = resp_a.json()["id"]
+
+        # Team B
+        resp_b = owasp_admin_api.post("/teams/", data={"name": f"owasp-team-b-{suffix}", "description": "OWASP Team B", "visibility": "private"})
+        assert resp_b.status in (200, 201), f"Failed creating Team B: {resp_b.status} {resp_b.text()}"
+        team_b_id = resp_b.json()["id"]
+
+        # Server owned by Team A
+        srv_a = owasp_admin_api.post(
+            "/servers",
+            data={"server": {"name": f"owasp-srv-a-{suffix}", "description": "Team A server"}, "team_id": team_a_id, "visibility": "team"},
+        )
+        assert srv_a.status in (200, 201), f"Failed creating Team A server: {srv_a.status} {srv_a.text()}"
+        server_a_id = srv_a.json()["id"]
+
+        # Server owned by Team B
+        srv_b = owasp_admin_api.post(
+            "/servers",
+            data={"server": {"name": f"owasp-srv-b-{suffix}", "description": "Team B server"}, "team_id": team_b_id, "visibility": "team"},
+        )
+        assert srv_b.status in (200, 201), f"Failed creating Team B server: {srv_b.status} {srv_b.text()}"
+        server_b_id = srv_b.json()["id"]
+
+        # Token scoped to Team A only
+        ctx_a = _api_context(playwright, _make_jwt("owasp-tenant-a@example.com", is_admin=False, teams=[team_a_id]))
+        # Token scoped to Team B only
+        ctx_b = _api_context(playwright, _make_jwt("owasp-tenant-b@example.com", is_admin=False, teams=[team_b_id]))
+
+        yield {
+            "team_a_id": team_a_id,
+            "team_b_id": team_b_id,
+            "server_a_id": server_a_id,
+            "server_b_id": server_b_id,
+            "ctx_team_a": ctx_a,
+            "ctx_team_b": ctx_b,
+        }
+    finally:
+        if ctx_a:
+            ctx_a.dispose()
+        if ctx_b:
+            ctx_b.dispose()
+        if server_a_id:
+            with suppress(Exception):
+                owasp_admin_api.delete(f"/servers/{server_a_id}")
+        if server_b_id:
+            with suppress(Exception):
+                owasp_admin_api.delete(f"/servers/{server_b_id}")
+        if team_a_id:
+            with suppress(Exception):
+                owasp_admin_api.delete(f"/teams/{team_a_id}")
+        if team_b_id:
+            with suppress(Exception):
+                owasp_admin_api.delete(f"/teams/{team_b_id}")
+
+
+@pytest.fixture
+def private_server_owned_by_user_a(owasp_admin_api: APIRequestContext, owasp_user_a_api: dict):
+    """Create a private server as User A and return its ID. Cleans up after test."""
+    ctx_a: APIRequestContext = owasp_user_a_api["ctx"]
+    server_id: str | None = None
+    try:
+        resp = ctx_a.post(
+            "/servers",
+            data={"server": {"name": f"owasp-priv-{uuid.uuid4().hex[:8]}", "description": "User A private server"}, "team_id": None, "visibility": "private"},
+        )
+        assert resp.status in (200, 201), f"Failed creating private server: {resp.status} {resp.text()}"
+        server_id = resp.json()["id"]
+        yield server_id
+    finally:
+        if server_id:
+            with suppress(Exception):
+                # Admin cleanup in case user can't delete
+                owasp_admin_api.delete(f"/servers/{server_id}")

--- a/tests/playwright/security/owasp/test_a01_broken_access_control.py
+++ b/tests/playwright/security/owasp/test_a01_broken_access_control.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 ContextForge Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OWASP A01:2025 – Broken Access Control direct Playwright tests.
+"""OWASP A01:2021 – Broken Access Control direct Playwright tests.
 
 Covers attack patterns NOT already tested in sibling security test files:
 
@@ -28,9 +28,9 @@ from __future__ import annotations
 
 # Standard
 import base64
+from contextlib import suppress
 import json
 import time
-from contextlib import suppress
 from typing import Any
 import uuid
 
@@ -43,25 +43,7 @@ from mcpgateway.utils.create_jwt_token import _create_jwt_token
 
 # Local
 from ..conftest import BASE_URL, TEST_PASSWORD
-
-_UNSET = object()
-
-
-def _make_jwt(email: str, *, is_admin: bool, teams=None, expires_in_minutes: int = 30) -> str:  # type: ignore[no-untyped-def]
-    """Create a JWT token for OWASP A01 testing with a short-lived expiry."""
-    return _create_jwt_token(
-        {"sub": email},
-        expires_in_minutes=expires_in_minutes,
-        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
-        teams=teams,
-    )
-
-
-def _api_context(playwright: Playwright, token: str) -> APIRequestContext:
-    return playwright.request.new_context(
-        base_url=BASE_URL,
-        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-    )
+from .conftest import _api_context, _make_jwt
 
 
 def _anon_context(playwright: Playwright) -> APIRequestContext:
@@ -175,9 +157,7 @@ class TestIDORCrossTenantObjects:
         ctx_a: APIRequestContext = two_teams_setup["ctx_team_a"]
         server_b_id: str = two_teams_setup["server_b_id"]
         resp = ctx_a.get(f"/servers/{server_b_id}")
-        assert resp.status in (403, 404), (
-            f"Team A token should not read Team B server, got {resp.status}: {resp.text()}"
-        )
+        assert resp.status in (403, 404), f"Team A token should not read Team B server, got {resp.status}: {resp.text()}"
 
     def test_team_a_token_cannot_update_team_b_server_by_id(self, two_teams_setup: dict) -> None:
         ctx_a: APIRequestContext = two_teams_setup["ctx_team_a"]
@@ -186,17 +166,13 @@ class TestIDORCrossTenantObjects:
             f"/servers/{server_b_id}",
             data={"server": {"name": "cross-tenant-takeover"}, "visibility": "public"},
         )
-        assert resp.status in (403, 404), (
-            f"Team A token should not update Team B server, got {resp.status}: {resp.text()}"
-        )
+        assert resp.status in (403, 404), f"Team A token should not update Team B server, got {resp.status}: {resp.text()}"
 
     def test_team_a_token_cannot_delete_team_b_server_by_id(self, two_teams_setup: dict) -> None:
         ctx_a: APIRequestContext = two_teams_setup["ctx_team_a"]
         server_b_id: str = two_teams_setup["server_b_id"]
         resp = ctx_a.delete(f"/servers/{server_b_id}")
-        assert resp.status in (403, 404), (
-            f"Team A token should not delete Team B server, got {resp.status}: {resp.text()}"
-        )
+        assert resp.status in (403, 404), f"Team A token should not delete Team B server, got {resp.status}: {resp.text()}"
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +198,7 @@ class TestVerticalPrivilegeEscalation:
         yield ctx
         ctx.dispose()
         with suppress(Exception):
-            owasp_admin_api.delete(f"/admin/users/{email}")
+            owasp_admin_api.delete(f"/auth/email/admin/users/{email}")
 
     def test_non_admin_cannot_list_all_users(self, non_admin_ctx: APIRequestContext) -> None:
         resp = non_admin_ctx.get("/auth/email/admin/users")
@@ -285,9 +261,7 @@ class TestJWTTampering:
         ctx = _raw_bearer_context(playwright, tampered)
         try:
             resp = ctx.get("/tokens/admin/all")
-            assert resp.status == 401, (
-                f"Tampered JWT (is_admin escalation) should be rejected with 401, got {resp.status}"
-            )
+            assert resp.status == 401, f"Tampered JWT (is_admin escalation) should be rejected with 401, got {resp.status}"
         finally:
             ctx.dispose()
 
@@ -372,9 +346,7 @@ class TestCORSEnforcement:
         try:
             resp = ctx.get("/servers")
             acao = resp.headers.get("access-control-allow-origin", "")
-            assert acao != "*", (
-                f"API must not return wildcard CORS header for arbitrary origin, got: '{acao}'"
-            )
+            assert acao != "*", f"API must not return wildcard CORS header for arbitrary origin, got: '{acao}'"
         finally:
             ctx.dispose()
 
@@ -395,9 +367,6 @@ class TestCORSEnforcement:
             # Permissive: wildcard origin OR (reflect evil origin AND allow credentials)
             reflects_evil = acao == "https://evil.example.com"
             allows_credentials = acac.lower() == "true"
-            assert not (reflects_evil and allows_credentials), (
-                f"CORS preflight must not reflect arbitrary origin with credentials. "
-                f"ACAO={acao!r} ACAC={acac!r}"
-            )
+            assert not (reflects_evil and allows_credentials), f"CORS preflight must not reflect arbitrary origin with credentials. " f"ACAO={acao!r} ACAC={acac!r}"
         finally:
             ctx.dispose()

--- a/tests/playwright/security/owasp/test_a01_broken_access_control.py
+++ b/tests/playwright/security/owasp/test_a01_broken_access_control.py
@@ -1,0 +1,403 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OWASP A01:2025 – Broken Access Control direct Playwright tests.
+
+Covers attack patterns NOT already tested in sibling security test files:
+
+  * Force browsing / unauthenticated access (CWE-284, CWE-862)
+  * IDOR – cross-user object access (CWE-639)
+  * IDOR – cross-tenant object access (CWE-639, CWE-285)
+  * Vertical privilege escalation / missing function-level auth (CWE-269, CWE-285)
+  * JWT tampering: unsigned, payload-tampered, expired, wrong issuer/audience, alg=none (CWE-345, CWE-287)
+  * HTTP method-level access control – non-admin cannot write publicly readable resources (CWE-284)
+  * CORS origin enforcement – no wildcard CORS for unauthorised origins (CWE-942)
+
+Excluded (already covered elsewhere):
+  - BOLA on tokens               → test_api_abuse_hardening.py
+  - Mass assignment               → test_api_abuse_hardening.py
+  - HTTP Parameter Pollution      → test_api_abuse_hardening.py
+  - JWT teams-claim matrix        → test_token_scope_matrix.py
+  - Non-admin can't create roles  → test_rbac_admin.py
+  - Token scope containment       → test_token_scope_matrix.py
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import base64
+import json
+import time
+from contextlib import suppress
+from typing import Any
+import uuid
+
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright
+import pytest
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+# Local
+from ..conftest import BASE_URL, TEST_PASSWORD
+
+_UNSET = object()
+
+
+def _make_jwt(email: str, *, is_admin: bool, teams=None, expires_in_minutes: int = 30) -> str:  # type: ignore[no-untyped-def]
+    """Create a JWT token for OWASP A01 testing with a short-lived expiry."""
+    return _create_jwt_token(
+        {"sub": email},
+        expires_in_minutes=expires_in_minutes,
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+    )
+
+
+def _api_context(playwright: Playwright, token: str) -> APIRequestContext:
+    return playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+
+
+def _anon_context(playwright: Playwright) -> APIRequestContext:
+    return playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Accept": "application/json"},
+    )
+
+
+def _raw_bearer_context(playwright: Playwright, raw_token: str) -> APIRequestContext:
+    """API context using a raw (potentially malformed) bearer token string."""
+    return playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {raw_token}", "Accept": "application/json"},
+    )
+
+
+def _tamper_jwt_payload(valid_jwt: str, overrides: dict[str, Any]) -> str:
+    """Base64-decode the payload section of a JWT, apply overrides, re-encode.
+
+    The signature is left intact (invalid for the modified payload), simulating
+    a client-side tampering attack without re-signing.
+    """
+    parts = valid_jwt.split(".")
+    if len(parts) != 3:
+        return valid_jwt
+    # JWT uses base64url without padding
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(padded))
+    payload.update(overrides)
+    new_payload_bytes = base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode()).rstrip(b"=")
+    return f"{parts[0]}.{new_payload_bytes.decode()}.{parts[2]}"
+
+
+# ---------------------------------------------------------------------------
+# A01-1: Force Browsing / Unauthenticated Access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01
+class TestUnauthenticatedForceBrowsing:
+    """CWE-284, CWE-862 – every protected endpoint must reject anonymous requests with 401."""
+
+    def test_anon_cannot_access_servers_endpoint(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/servers")
+            assert resp.status == 401, f"/servers should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_anon_cannot_access_teams_endpoint(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/teams/")
+            assert resp.status == 401, f"/teams/ should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_anon_cannot_access_tools_endpoint(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/tools")
+            assert resp.status == 401, f"/tools should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_anon_cannot_access_admin_user_list(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/auth/email/admin/users")
+            assert resp.status == 401, f"/auth/email/admin/users should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_anon_cannot_access_rbac_roles(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/rbac/roles")
+            assert resp.status == 401, f"/rbac/roles should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_anon_cannot_access_token_admin_list(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/tokens/admin/all")
+            assert resp.status == 401, f"/tokens/admin/all should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_anon_cannot_access_audit_events(self, playwright: Playwright) -> None:
+        ctx = _anon_context(playwright)
+        try:
+            resp = ctx.get("/api/logs/audit-trails")
+            assert resp.status == 401, f"/api/logs/audit-trails should return 401 for anonymous, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+
+# ---------------------------------------------------------------------------
+# A01-2: IDOR – Cross-Tenant Object Access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01
+class TestIDORCrossTenantObjects:
+    """CWE-639, CWE-285 – Token scoped to Team A must not access Team B's resources."""
+
+    def test_team_a_token_cannot_read_team_b_server_by_id(self, two_teams_setup: dict) -> None:
+        ctx_a: APIRequestContext = two_teams_setup["ctx_team_a"]
+        server_b_id: str = two_teams_setup["server_b_id"]
+        resp = ctx_a.get(f"/servers/{server_b_id}")
+        assert resp.status in (403, 404), (
+            f"Team A token should not read Team B server, got {resp.status}: {resp.text()}"
+        )
+
+    def test_team_a_token_cannot_update_team_b_server_by_id(self, two_teams_setup: dict) -> None:
+        ctx_a: APIRequestContext = two_teams_setup["ctx_team_a"]
+        server_b_id: str = two_teams_setup["server_b_id"]
+        resp = ctx_a.put(
+            f"/servers/{server_b_id}",
+            data={"server": {"name": "cross-tenant-takeover"}, "visibility": "public"},
+        )
+        assert resp.status in (403, 404), (
+            f"Team A token should not update Team B server, got {resp.status}: {resp.text()}"
+        )
+
+    def test_team_a_token_cannot_delete_team_b_server_by_id(self, two_teams_setup: dict) -> None:
+        ctx_a: APIRequestContext = two_teams_setup["ctx_team_a"]
+        server_b_id: str = two_teams_setup["server_b_id"]
+        resp = ctx_a.delete(f"/servers/{server_b_id}")
+        assert resp.status in (403, 404), (
+            f"Team A token should not delete Team B server, got {resp.status}: {resp.text()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# A01-3: Vertical Privilege Escalation / Missing Function-Level Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01
+class TestVerticalPrivilegeEscalation:
+    """CWE-269, CWE-285 – Non-admin authenticated users cannot call admin-only endpoints."""
+
+    @pytest.fixture(scope="class")
+    def non_admin_ctx(self, owasp_admin_api: APIRequestContext, playwright: Playwright) -> APIRequestContext:
+        """Register a non-admin user via owasp_admin_api, then yield an API context for them."""
+        email = f"nonadmin-a01-{uuid.uuid4().hex[:8]}@example.com"
+        create_resp = owasp_admin_api.post(
+            "/auth/email/admin/users",
+            data={"email": email, "password": TEST_PASSWORD, "full_name": "Non-Admin A01"},
+        )
+        assert create_resp.status in (200, 201), f"Failed to create non-admin user: {create_resp.status} {create_resp.text()}"
+        token = _make_jwt(email, is_admin=False, teams=[])
+        ctx = _api_context(playwright, token)
+        yield ctx
+        ctx.dispose()
+        with suppress(Exception):
+            owasp_admin_api.delete(f"/admin/users/{email}")
+
+    def test_non_admin_cannot_list_all_users(self, non_admin_ctx: APIRequestContext) -> None:
+        resp = non_admin_ctx.get("/auth/email/admin/users")
+        assert resp.status == 403, f"Non-admin should be denied user list, got {resp.status}: {resp.text()}"
+
+    def test_non_admin_cannot_create_user(self, non_admin_ctx: APIRequestContext) -> None:
+        resp = non_admin_ctx.post(
+            "/admin/users",
+            data={"email": f"injected-{uuid.uuid4().hex[:8]}@example.com", "password": "Pass123!", "full_name": "Injected"},
+        )
+        assert resp.status == 403, f"Non-admin should be denied user creation, got {resp.status}: {resp.text()}"
+
+    def test_non_admin_cannot_delete_user(self, non_admin_ctx: APIRequestContext) -> None:
+        resp = non_admin_ctx.delete("/auth/email/admin/users/victim@example.com")
+        assert resp.status in (403, 404), f"Non-admin should be denied user deletion, got {resp.status}: {resp.text()}"
+
+    def test_non_admin_cannot_list_all_tokens_admin(self, non_admin_ctx: APIRequestContext) -> None:
+        resp = non_admin_ctx.get("/tokens/admin/all")
+        assert resp.status == 403, f"Non-admin should be denied admin token list, got {resp.status}: {resp.text()}"
+
+    def test_non_admin_cannot_read_audit_events(self, non_admin_ctx: APIRequestContext) -> None:
+        resp = non_admin_ctx.get("/api/logs/audit-trails")
+        assert resp.status == 403, f"Non-admin should be denied audit events, got {resp.status}: {resp.text()}"
+
+    def test_non_admin_cannot_approve_pending_signups(self, non_admin_ctx: APIRequestContext) -> None:
+        # Attempt unlock endpoint (admin-only user management action)
+        resp = non_admin_ctx.post("/auth/email/admin/users/any@example.com/unlock")
+        assert resp.status in (403, 404), f"Non-admin should be denied unlock endpoint, got {resp.status}: {resp.text()}"
+
+
+# ---------------------------------------------------------------------------
+# A01-4: JWT Tampering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01
+class TestJWTTampering:
+    """CWE-345, CWE-287 – Tampered, unsigned, expired, or algorithm-confused JWTs are rejected."""
+
+    def test_unsigned_jwt_rejected(self, playwright: Playwright) -> None:
+        """A JWT with an empty signature (unsigned) must be rejected."""
+        # Build a minimal JWT with no signature (header.payload.)
+        header = base64.urlsafe_b64encode(b'{"alg":"HS256","typ":"JWT"}').rstrip(b"=").decode()
+        payload_data = json.dumps({"sub": "attacker@example.com", "is_admin": True}).encode()
+        payload_b64 = base64.urlsafe_b64encode(payload_data).rstrip(b"=").decode()
+        unsigned_jwt = f"{header}.{payload_b64}."
+        ctx = _raw_bearer_context(playwright, unsigned_jwt)
+        try:
+            resp = ctx.get("/servers")
+            assert resp.status == 401, f"Unsigned JWT should be rejected with 401, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_jwt_with_modified_is_admin_rejected(self, playwright: Playwright) -> None:
+        """A JWT with `is_admin=true` injected into payload (without re-signing) must be rejected."""
+        # Start with a valid non-admin token
+        valid_token = _make_jwt("nonadmin-tamper@example.com", is_admin=False, teams=[])
+        # Tamper payload to claim admin without re-signing
+        tampered = _tamper_jwt_payload(valid_token, {"is_admin": True})
+        ctx = _raw_bearer_context(playwright, tampered)
+        try:
+            resp = ctx.get("/tokens/admin/all")
+            assert resp.status == 401, (
+                f"Tampered JWT (is_admin escalation) should be rejected with 401, got {resp.status}"
+            )
+        finally:
+            ctx.dispose()
+
+    def test_expired_jwt_rejected(self, playwright: Playwright) -> None:
+        """A JWT with `exp` set in the past must be rejected."""
+        expired_token = _create_jwt_token(
+            {"sub": "expired@example.com", "exp": int(time.time()) - 3600},
+            user_data={"email": "expired@example.com", "is_admin": False, "auth_provider": "local"},
+        )
+        ctx = _raw_bearer_context(playwright, expired_token)
+        try:
+            resp = ctx.get("/servers")
+            assert resp.status == 401, f"Expired JWT should be rejected with 401, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_jwt_with_none_algorithm_rejected(self, playwright: Playwright) -> None:
+        """A JWT declaring `alg: none` (CVE-2015-9235 / algorithm confusion) must be rejected."""
+        header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=").decode()
+        payload_data = json.dumps({"sub": "attacker@example.com", "is_admin": True, "teams": None}).encode()
+        payload_b64 = base64.urlsafe_b64encode(payload_data).rstrip(b"=").decode()
+        # alg=none: token has no signature segment
+        none_alg_jwt = f"{header}.{payload_b64}."
+        ctx = _raw_bearer_context(playwright, none_alg_jwt)
+        try:
+            resp = ctx.get("/servers")
+            assert resp.status == 401, f"alg=none JWT should be rejected with 401, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_jwt_with_wrong_issuer_rejected(self, playwright: Playwright) -> None:
+        """A JWT from a different issuer must be rejected."""
+        wrong_iss_token = _create_jwt_token(
+            {"sub": "wrongiss@example.com", "iss": "https://evil.example.com"},
+            user_data={"email": "wrongiss@example.com", "is_admin": False, "auth_provider": "local"},
+        )
+        ctx = _raw_bearer_context(playwright, wrong_iss_token)
+        try:
+            resp = ctx.get("/servers")
+            # Must be 401 when issuer validation is active; skip if not configured
+            if resp.status == 200:
+                pytest.skip("Issuer validation not configured in this environment; skipping issuer check.")
+            assert resp.status == 401, f"Wrong-issuer JWT should be rejected with 401, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+    def test_jwt_with_wrong_audience_rejected(self, playwright: Playwright) -> None:
+        """A JWT with a mismatched audience must be rejected."""
+        wrong_aud_token = _create_jwt_token(
+            {"sub": "wrongaud@example.com", "aud": "https://other-service.example.com"},
+            user_data={"email": "wrongaud@example.com", "is_admin": False, "auth_provider": "local"},
+        )
+        ctx = _raw_bearer_context(playwright, wrong_aud_token)
+        try:
+            resp = ctx.get("/servers")
+            if resp.status == 200:
+                pytest.skip("Audience validation not configured in this environment; skipping audience check.")
+            assert resp.status == 401, f"Wrong-audience JWT should be rejected with 401, got {resp.status}"
+        finally:
+            ctx.dispose()
+
+
+# ---------------------------------------------------------------------------
+# A01-5: CORS Origin Enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01
+class TestCORSEnforcement:
+    """CWE-942 – API must not return wildcard CORS headers for arbitrary origins."""
+
+    def test_cors_does_not_return_wildcard_origin(self, playwright: Playwright) -> None:
+        """A request with an arbitrary Origin header must not receive `Access-Control-Allow-Origin: *`."""
+        ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={
+                "Origin": "https://evil.example.com",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {_make_jwt('admin@example.com', is_admin=True, teams=None)}",
+            },
+        )
+        try:
+            resp = ctx.get("/servers")
+            acao = resp.headers.get("access-control-allow-origin", "")
+            assert acao != "*", (
+                f"API must not return wildcard CORS header for arbitrary origin, got: '{acao}'"
+            )
+        finally:
+            ctx.dispose()
+
+    def test_cors_preflight_from_unknown_origin_not_fully_permissive(self, playwright: Playwright) -> None:
+        """OPTIONS preflight from an unknown origin must not return permissive CORS credentials headers."""
+        ctx = playwright.request.new_context(
+            base_url=BASE_URL,
+            extra_http_headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "Authorization, Content-Type",
+            },
+        )
+        try:
+            resp = ctx.fetch("/servers", method="OPTIONS")
+            acao = resp.headers.get("access-control-allow-origin", "")
+            acac = resp.headers.get("access-control-allow-credentials", "")
+            # Permissive: wildcard origin OR (reflect evil origin AND allow credentials)
+            reflects_evil = acao == "https://evil.example.com"
+            allows_credentials = acac.lower() == "true"
+            assert not (reflects_evil and allows_credentials), (
+                f"CORS preflight must not reflect arbitrary origin with credentials. "
+                f"ACAO={acao!r} ACAC={acac!r}"
+            )
+        finally:
+            ctx.dispose()

--- a/tests/playwright/security/owasp/test_a01_broken_access_control.py
+++ b/tests/playwright/security/owasp/test_a01_broken_access_control.py
@@ -145,7 +145,35 @@ class TestUnauthenticatedForceBrowsing:
 
 
 # ---------------------------------------------------------------------------
-# A01-2: IDOR – Cross-Tenant Object Access
+# A01-2a: IDOR – Cross-User Object Access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01
+class TestIDORCrossUserObjects:
+    """CWE-639 – User B must not read, update, or delete User A's private server."""
+
+    def test_user_b_cannot_read_user_a_private_server(self, owasp_user_b_api: dict, private_server_owned_by_user_a: str) -> None:
+        ctx_b: APIRequestContext = owasp_user_b_api["ctx"]
+        resp = ctx_b.get(f"/servers/{private_server_owned_by_user_a}")
+        assert resp.status in (403, 404), f"User B should not read User A's private server, got {resp.status}: {resp.text()}"
+
+    def test_user_b_cannot_update_user_a_private_server(self, owasp_user_b_api: dict, private_server_owned_by_user_a: str) -> None:
+        ctx_b: APIRequestContext = owasp_user_b_api["ctx"]
+        resp = ctx_b.put(
+            f"/servers/{private_server_owned_by_user_a}",
+            data={"server": {"name": "idor-takeover"}, "visibility": "public"},
+        )
+        assert resp.status in (403, 404), f"User B should not update User A's private server, got {resp.status}: {resp.text()}"
+
+    def test_user_b_cannot_delete_user_a_private_server(self, owasp_user_b_api: dict, private_server_owned_by_user_a: str) -> None:
+        ctx_b: APIRequestContext = owasp_user_b_api["ctx"]
+        resp = ctx_b.delete(f"/servers/{private_server_owned_by_user_a}")
+        assert resp.status in (403, 404), f"User B should not delete User A's private server, got {resp.status}: {resp.text()}"
+
+
+# ---------------------------------------------------------------------------
+# A01-2b: IDOR – Cross-Tenant Object Access
 # ---------------------------------------------------------------------------
 
 

--- a/tests/playwright/security/owasp/test_a01_zap_dast.py
+++ b/tests/playwright/security/owasp/test_a01_zap_dast.py
@@ -226,14 +226,43 @@ def zap() -> ZAPv2:
     return client
 
 
+# Security-sensitive path prefixes for the active scan.
+# The passive scan covers the full OpenAPI surface; the active scan focuses
+# on paths where access-control vulnerabilities are most likely.
+_ACTIVE_SCAN_PREFIXES = [
+    "/auth/",
+    "/rbac/",
+    "/tokens/",
+    "/servers",
+    "/teams/",
+    "/tools",
+    "/gateways",
+]
+
+
 @pytest.fixture(scope="module")
 def zap_context(zap: ZAPv2) -> dict:
-    """Create a new ZAP context scoped to ZAP_TARGET_URL."""
-    ctx_name = f"owasp_a01_{int(time.time())}"
-    ctx_id = zap.context.new_context(ctx_name)
-    zap.context.include_in_context(ctx_name, f"{ZAP_TARGET_URL}.*")
-    logger.info("Created ZAP context %s (id=%s) for target %s", ctx_name, ctx_id, ZAP_TARGET_URL)
-    yield {"ctx_id": ctx_id, "ctx_name": ctx_name}
+    """Create two ZAP contexts: a broad one for import/spider and a narrow one for active scan.
+
+    The broad context (``.*``) is used for OpenAPI import and spidering so ZAP
+    discovers the full API surface.  The narrow context only includes
+    security-sensitive prefixes, keeping the active scan focused and fast.
+    """
+    ts = int(time.time())
+
+    # Broad context for OpenAPI import and spider
+    broad_name = f"owasp_a01_broad_{ts}"
+    broad_id = zap.context.new_context(broad_name)
+    zap.context.include_in_context(broad_name, f"{ZAP_TARGET_URL}.*")
+
+    # Narrow context for active scan (security-sensitive prefixes only)
+    narrow_name = f"owasp_a01_scan_{ts}"
+    narrow_id = zap.context.new_context(narrow_name)
+    for prefix in _ACTIVE_SCAN_PREFIXES:
+        zap.context.include_in_context(narrow_name, f"{ZAP_TARGET_URL}{prefix}.*")
+
+    logger.info("ZAP contexts: broad=%s (id=%s), scan=%s (id=%s, %d prefixes)", broad_name, broad_id, narrow_name, narrow_id, len(_ACTIVE_SCAN_PREFIXES))
+    yield {"ctx_id": broad_id, "ctx_name": broad_name, "scan_ctx_id": narrow_id, "scan_ctx_name": narrow_name}
     # No explicit cleanup needed; ZAP contexts are ephemeral
 
 
@@ -248,58 +277,39 @@ class TestZAPAccessControlScan:
     """ZAP DAST scan tests for OWASP A01:2021 – Broken Access Control."""
 
     def test_zap_spider_discovers_protected_endpoints(self, zap: ZAPv2, zap_context: dict) -> None:
-        """Seed ZAP's site tree with protected API paths, then spider for HTML/UI paths.
+        """Import the OpenAPI spec and spider to build full site tree coverage.
 
-        ZAP's traditional spider follows HTML hyperlinks and cannot discover REST
-        API endpoints on its own.  We seed the site tree by directly accessing
-        each protected path via ``zap.core.access_url()`` — ZAP records the
-        response and then the passive/active scans operate on them.
+        FastAPI auto-generates an OpenAPI 3.x spec at ``/openapi.json``.
+        Importing it gives ZAP knowledge of all API paths, methods, and
+        parameters.  We also manually seed a handful of key paths as a
+        fallback and run the traditional spider for any HTML/UI routes.
 
-        Note: ZAP's ``openapi.import_url()`` can import the full OpenAPI spec but
-        consistently OOMs with the default 2 GB memory limit (344 paths triggers
-        immediate fetching).  Manual seeding is more reliable.
+        Requires ZAP memory >= 4 GB (set in docker-compose.yml).
         """
-        # Key protected paths covering the main security-sensitive surface area.
-        # Grouped by domain: auth, RBAC, resources, admin, observability.
-        protected_paths = [
-            # Auth & user management
-            "/auth/email/admin/users",
-            "/auth/email/login",
-            "/auth/email/signup",
-            # RBAC
-            "/rbac/roles",
-            "/rbac/permissions",
-            # Resources
-            "/servers",
-            "/tools",
-            "/gateways",
-            "/resources",
-            "/prompts",
-            "/teams/",
-            # Tokens
-            "/tokens",
-            "/tokens/admin/all",
-            # Observability & admin
-            "/api/logs/audit-trails",
-            "/health",
-            "/health/security",
-            "/metrics/prometheus",
-        ]
+        protected_paths = ["/servers", "/tools", "/teams/", "/rbac", "/auth/email", "/tokens", "/gateways"]
 
-        # --- 1. Seed the site tree by directly accessing each protected path ---
-        for path in protected_paths:
-            url = f"{ZAP_TARGET_URL}{path}"
-            try:
-                zap.core.access_url(url, followredirects="true")
-                logger.debug("Seeded ZAP site tree: %s", url)
-            except (ConnectionError, Timeout, RequestException) as exc:
-                logger.warning("access_url network error for %s: %s", url, exc)
-            except json.JSONDecodeError as exc:
-                logger.warning("access_url malformed JSON response for %s: %s", url, exc)
-            except Exception as exc:
-                logger.warning("access_url failed for %s: %s", url, exc)
+        # --- 1. Import OpenAPI spec (primary discovery mechanism) ---
+        openapi_url = f"{ZAP_TARGET_URL}/openapi.json"
+        openapi_imported = False
+        try:
+            result = zap.openapi.import_url(openapi_url, hostoverride=None, contextid=zap_context["ctx_id"])
+            logger.info("OpenAPI import result: %s", result)
+            openapi_imported = True
+        except (ConnectionError, Timeout, RequestException) as exc:
+            logger.warning("OpenAPI import failed (network): %s – falling back to manual seeding", exc)
+        except Exception as exc:
+            logger.warning("OpenAPI import failed: %s – falling back to manual seeding", exc)
 
-        # --- 2. Run the traditional spider (picks up any linked HTML/UI paths) ---
+        # --- 2. Manual seed as fallback (or belt-and-suspenders) ---
+        if not openapi_imported:
+            for path in protected_paths:
+                url = f"{ZAP_TARGET_URL}{path}"
+                try:
+                    zap.core.access_url(url, followredirects="true")
+                except Exception as exc:
+                    logger.debug("access_url failed for %s: %s", url, exc)
+
+        # --- 3. Run the traditional spider (picks up any linked HTML/UI paths) ---
         scan_id = zap.spider.scan(ZAP_TARGET_URL, contextname=zap_context["ctx_name"])
         logger.info("ZAP spider started with scan_id=%s targeting %s", scan_id, ZAP_TARGET_URL)
 
@@ -342,11 +352,13 @@ class TestZAPAccessControlScan:
             pytest.fail(f"ZAP passive scan found {len(a01_alerts)} HIGH/CRITICAL A01 alert(s):\n{summary}")
 
     def test_zap_active_scan_finds_no_critical_access_control_issues(self, zap: ZAPv2, zap_context: dict) -> None:
-        """Active scan must produce no CRITICAL A01 alerts."""
+        """Active scan of security-sensitive prefixes must produce no CRITICAL A01 alerts."""
         try:
             scan_id = zap.ascan.scan(
                 ZAP_TARGET_URL,
-                contextid=zap_context["ctx_id"],
+                recurse="true",
+                inscopeonly="true",
+                contextid=zap_context["scan_ctx_id"],
                 scanpolicyname=None,  # default policy, full strength
             )
         except (ConnectionError, Timeout, RequestException) as exc:
@@ -356,9 +368,9 @@ class TestZAPAccessControlScan:
         except Exception as exc:
             pytest.skip(f"Could not start ZAP active scan: {exc}")
 
-        logger.info("ZAP active scan started with scan_id=%s", scan_id)
+        logger.info("ZAP active scan started with scan_id=%s (in-scope only)", scan_id)
 
-        deadline = time.time() + 900  # 15 min hard cap
+        deadline = time.time() + 2700  # 45 min hard cap
         while time.time() < deadline:
             try:
                 progress = int(zap.ascan.status(scan_id))
@@ -376,7 +388,7 @@ class TestZAPAccessControlScan:
                 break
             time.sleep(5)
         else:
-            pytest.skip("Active scan exceeded 15 min timeout - results incomplete. Increase timeout or optimize scan scope.")
+            pytest.skip("Active scan exceeded 45 min timeout - results incomplete.")
 
         # ZAP may have restarted after a crash; open a fresh client and allow
         # time for ZAP to come back up before querying alerts.

--- a/tests/playwright/security/owasp/test_a01_zap_dast.py
+++ b/tests/playwright/security/owasp/test_a01_zap_dast.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 ContextForge Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OWASP A01:2025 – ZAP DAST integration layer.
+"""OWASP A01:2021 – ZAP DAST integration layer.
 
 Activated only when the ``ZAP_BASE_URL`` environment variable is set.
 Skipped silently in normal CI runs.
@@ -36,14 +36,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+from pathlib import Path
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
-from requests.exceptions import ConnectionError, Timeout, RequestException
 
 # Third-Party
 import pytest
+from requests.exceptions import ConnectionError, RequestException, Timeout
 
 logger = logging.getLogger(__name__)
 
@@ -73,11 +73,11 @@ if not ZAP_BASE_URL:
     pytest.skip("ZAP_BASE_URL not set – skipping ZAP DAST tests", allow_module_level=True)
 
 try:
+    # Third-Party
     from zapv2 import ZAPv2  # type: ignore[import-untyped]
 except ImportError as exc:  # pragma: no cover
     pytest.skip(
-        f"python-owasp-zap-v2.4 not installed: {exc}. "
-        "Install it via: pip install 'python-owasp-zap-v2.4>=0.0.21'",
+        f"python-owasp-zap-v2.4 not installed: {exc}. " "Install it via: pip install 'python-owasp-zap-v2.4>=0.0.21'",
         allow_module_level=True,
     )
 
@@ -95,6 +95,7 @@ def _make_admin_jwt() -> str:
     """Generate an admin JWT for the ZAP scanner to authenticate with."""
     # Import here so the module-level skip fires before any mcpgateway import
     # errors in environments where the package is not installed.
+    # First-Party
     from mcpgateway.utils.create_jwt_token import _create_jwt_token  # noqa: PLC0415
 
     return _create_jwt_token(
@@ -197,19 +198,12 @@ def zap() -> ZAPv2:
         )
         logger.info("ZAP Replacer: injected admin Authorization header for all requests")
     except ConnectionError as exc:
-        pytest.skip(
-            f"ZAP daemon not reachable - Error: {exc}"
-        )
+        pytest.skip(f"ZAP daemon not reachable - Error: {exc}")
     except (Timeout, RequestException) as exc:
-        pytest.skip(
-            f"ZAP request failed: {exc}"
-        )
+        pytest.skip(f"ZAP request failed: {exc}")
     except Exception as exc:
         # ZAP raises bare Exception for non-2xx; 404 means Replacer add-on not installed
-        pytest.skip(
-            f"ZAP Replacer add-on required for authenticated endpoint testing. "
-            f"Install it in ZAP or tests will only cover public endpoints. Error: {exc}"
-        )
+        pytest.skip(f"ZAP Replacer add-on required for authenticated endpoint testing. " f"Install it in ZAP or tests will only cover public endpoints. Error: {exc}")
 
     return client
 
@@ -233,7 +227,7 @@ def zap_context(zap: ZAPv2) -> dict:
 @pytest.mark.owasp_a01_zap
 @pytest.mark.slow
 class TestZAPAccessControlScan:
-    """ZAP DAST scan tests for OWASP A01:2025 – Broken Access Control."""
+    """ZAP DAST scan tests for OWASP A01:2021 – Broken Access Control."""
 
     def test_zap_spider_discovers_protected_endpoints(self, zap: ZAPv2, zap_context: dict) -> None:
         """Seed ZAP's site tree with known protected paths, then confirm they are present.
@@ -294,13 +288,8 @@ class TestZAPAccessControlScan:
 
         if a01_alerts:
             _write_report(a01_alerts, "passive_failures")
-            summary = "\n".join(
-                f"  [{a['risk']}] CWE-{a.get('cweid','?')} – {a['alert']} @ {a['url']}"
-                for a in a01_alerts
-            )
-            pytest.fail(
-                f"ZAP passive scan found {len(a01_alerts)} HIGH/CRITICAL A01 alert(s):\n{summary}"
-            )
+            summary = "\n".join(f"  [{a['risk']}] CWE-{a.get('cweid','?')} – {a['alert']} @ {a['url']}" for a in a01_alerts)
+            pytest.fail(f"ZAP passive scan found {len(a01_alerts)} HIGH/CRITICAL A01 alert(s):\n{summary}")
 
     def test_zap_active_scan_finds_no_critical_access_control_issues(self, zap: ZAPv2, zap_context: dict) -> None:
         """Active scan must produce no CRITICAL A01 alerts."""
@@ -324,9 +313,7 @@ class TestZAPAccessControlScan:
             try:
                 progress = int(zap.ascan.status(scan_id))
             except (ConnectionError, Timeout, RequestException) as exc:
-                pytest.skip(
-                    f"ZAP connection lost during active scan; proceeding with partial results. Error: {exc}"
-                )
+                pytest.skip(f"ZAP connection lost during active scan; proceeding with partial results. Error: {exc}")
                 break
             except Exception as exc:
                 logger.warning(
@@ -348,28 +335,17 @@ class TestZAPAccessControlScan:
             fresh_zap = _zap_client()
             all_alerts = fresh_zap.core.alerts()
         except (ConnectionError, Timeout, RequestException) as exc:
-            pytest.skip(
-                f"ZAP unreachable after active scan: {exc}. "
-                "If this is an OOM crash, increase the ZAP memory limit in docker-compose.yml."
-            )
+            pytest.skip(f"ZAP unreachable after active scan: {exc}. " "If this is an OOM crash, increase the ZAP memory limit in docker-compose.yml.")
         except json.JSONDecodeError as exc:
             logger.warning("ZAP returned malformed JSON after active scan (possible crash/partial response): %s", exc)
-            pytest.skip(
-                f"ZAP response unparseable after active scan: {exc}. "
-                "If this is an OOM crash, increase the ZAP memory limit in docker-compose.yml."
-            )
+            pytest.skip(f"ZAP response unparseable after active scan: {exc}. " "If this is an OOM crash, increase the ZAP memory limit in docker-compose.yml.")
 
         critical_a01 = [a for a in _filter_a01_alerts(all_alerts) if a.get("risk") == "Critical"]
 
         if critical_a01:
             _write_report(critical_a01, "active_critical")
-            summary = "\n".join(
-                f"  [Critical] CWE-{a.get('cweid','?')} – {a['alert']} @ {a['url']}"
-                for a in critical_a01
-            )
-            pytest.fail(
-                f"ZAP active scan found {len(critical_a01)} CRITICAL A01 alert(s):\n{summary}"
-            )
+            summary = "\n".join(f"  [Critical] CWE-{a.get('cweid','?')} – {a['alert']} @ {a['url']}" for a in critical_a01)
+            pytest.fail(f"ZAP active scan found {len(critical_a01)} CRITICAL A01 alert(s):\n{summary}")
 
     def test_zap_generates_a01_report_artifact(self, zap: ZAPv2) -> None:
         """Write a full A01 alert JSON report to reports/ for artifact collection."""

--- a/tests/playwright/security/owasp/test_a01_zap_dast.py
+++ b/tests/playwright/security/owasp/test_a01_zap_dast.py
@@ -283,7 +283,12 @@ class TestZAPAccessControlScan:
     def test_zap_passive_scan_finds_no_high_severity_a01_alerts(self, zap: ZAPv2) -> None:
         """After spidering, passive scan must not flag HIGH/CRITICAL A01 alerts."""
         _wait_for_passive_scan(zap, timeout=120)
-        all_alerts = zap.core.alerts()
+        try:
+            all_alerts = zap.core.alerts()
+        except (ConnectionError, Timeout, RequestException) as exc:
+            pytest.skip(f"ZAP unreachable during passive scan alert retrieval: {exc}")
+        except json.JSONDecodeError as exc:
+            pytest.skip(f"ZAP returned malformed response during passive scan: {exc}")
         a01_alerts = _filter_a01_alerts(all_alerts)
 
         if a01_alerts:
@@ -349,7 +354,12 @@ class TestZAPAccessControlScan:
 
     def test_zap_generates_a01_report_artifact(self, zap: ZAPv2) -> None:
         """Write a full A01 alert JSON report to reports/ for artifact collection."""
-        all_alerts = zap.core.alerts()
+        try:
+            all_alerts = zap.core.alerts()
+        except (ConnectionError, Timeout, RequestException) as exc:
+            pytest.skip(f"ZAP unreachable during report generation: {exc}")
+        except json.JSONDecodeError as exc:
+            pytest.skip(f"ZAP returned malformed response during report generation: {exc}")
         a01_alerts = _filter_a01_alerts(all_alerts)
         report_path = _write_report(a01_alerts, "full_report")
         assert report_path.exists(), f"Report file was not created at {report_path}"

--- a/tests/playwright/security/owasp/test_a01_zap_dast.py
+++ b/tests/playwright/security/owasp/test_a01_zap_dast.py
@@ -109,7 +109,11 @@ def _wait_for_passive_scan(zap: ZAPv2, timeout: int = 120) -> None:
     """Block until passive scan queue is empty or timeout is reached."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        remaining = int(zap.pscan.records_to_scan)
+        try:
+            remaining = int(zap.pscan.records_to_scan)
+        except (ConnectionError, Timeout, RequestException):
+            logger.warning("ZAP unreachable while polling passive scan; giving up")
+            return
         if remaining == 0:
             return
         logger.debug("Passive scan records remaining: %d", remaining)
@@ -131,13 +135,27 @@ def _filter_a01_alerts(alerts: list[dict]) -> list[dict]:
     return results
 
 
+def _reports_dir() -> Path:
+    """Return the reports/ directory path, creating it if necessary."""
+    d = Path(__file__).parent.parent.parent.parent / "reports"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def _write_report(alerts: list[dict], name: str) -> Path:
     """Write a JSON alert report to reports/ directory and return its path."""
-    reports_dir = Path(__file__).parent.parent.parent.parent / "reports"
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    report_path = reports_dir / f"zap_a01_{name}_{int(time.time())}.json"
+    report_path = _reports_dir() / f"zap_a01_{name}_{int(time.time())}.json"
     report_path.write_text(json.dumps(alerts, indent=2))
     logger.info("ZAP report written to %s", report_path)
+    return report_path
+
+
+def _write_html_report(zap: ZAPv2, name: str) -> Path:
+    """Fetch ZAP's built-in HTML report and write it to reports/."""
+    html = zap.core.htmlreport()
+    report_path = _reports_dir() / f"zap_a01_{name}_{int(time.time())}.html"
+    report_path.write_text(html)
+    logger.info("ZAP HTML report written to %s", report_path)
     return report_path
 
 
@@ -230,18 +248,45 @@ class TestZAPAccessControlScan:
     """ZAP DAST scan tests for OWASP A01:2021 – Broken Access Control."""
 
     def test_zap_spider_discovers_protected_endpoints(self, zap: ZAPv2, zap_context: dict) -> None:
-        """Seed ZAP's site tree with known protected paths, then confirm they are present.
+        """Seed ZAP's site tree with protected API paths, then spider for HTML/UI paths.
 
         ZAP's traditional spider follows HTML hyperlinks and cannot discover REST
-        API endpoints on its own.  We use zap.core.access_url() to directly fetch
-        each protected path — ZAP records the response in its site tree, which the
-        passive and active scans then operate on.  No add-ons required.
+        API endpoints on its own.  We seed the site tree by directly accessing
+        each protected path via ``zap.core.access_url()`` — ZAP records the
+        response and then the passive/active scans operate on them.
+
+        Note: ZAP's ``openapi.import_url()`` can import the full OpenAPI spec but
+        consistently OOMs with the default 2 GB memory limit (344 paths triggers
+        immediate fetching).  Manual seeding is more reliable.
         """
-        protected_paths = ["/servers", "/teams/", "/tokens", "/rbac", "/auth/email/admin"]
+        # Key protected paths covering the main security-sensitive surface area.
+        # Grouped by domain: auth, RBAC, resources, admin, observability.
+        protected_paths = [
+            # Auth & user management
+            "/auth/email/admin/users",
+            "/auth/email/login",
+            "/auth/email/signup",
+            # RBAC
+            "/rbac/roles",
+            "/rbac/permissions",
+            # Resources
+            "/servers",
+            "/tools",
+            "/gateways",
+            "/resources",
+            "/prompts",
+            "/teams/",
+            # Tokens
+            "/tokens",
+            "/tokens/admin/all",
+            # Observability & admin
+            "/api/logs/audit-trails",
+            "/health",
+            "/health/security",
+            "/metrics/prometheus",
+        ]
 
         # --- 1. Seed the site tree by directly accessing each protected path ---
-        # ZAP records every URL it touches (including auth-gated ones whose
-        # responses it receives via the Replacer-injected Bearer header).
         for path in protected_paths:
             url = f"{ZAP_TARGET_URL}{path}"
             try:
@@ -254,7 +299,7 @@ class TestZAPAccessControlScan:
             except Exception as exc:
                 logger.warning("access_url failed for %s: %s", url, exc)
 
-        # --- 2. Also run the traditional spider (picks up any linked HTML paths) ---
+        # --- 2. Run the traditional spider (picks up any linked HTML/UI paths) ---
         scan_id = zap.spider.scan(ZAP_TARGET_URL, contextname=zap_context["ctx_name"])
         logger.info("ZAP spider started with scan_id=%s targeting %s", scan_id, ZAP_TARGET_URL)
 
@@ -268,7 +313,7 @@ class TestZAPAccessControlScan:
         else:
             pytest.fail("ZAP spider did not complete within 5 minutes")
 
-        # --- 3. Check the full site tree (seeded paths + spider combined) ---
+        # --- 3. Verify the site tree has real API coverage ---
         urls = zap.core.urls(baseurl=ZAP_TARGET_URL)
         discovered = [u for path in protected_paths for u in urls if path in u]
         assert discovered, (
@@ -353,7 +398,7 @@ class TestZAPAccessControlScan:
             pytest.fail(f"ZAP active scan found {len(critical_a01)} CRITICAL A01 alert(s):\n{summary}")
 
     def test_zap_generates_a01_report_artifact(self, zap: ZAPv2) -> None:
-        """Write a full A01 alert JSON report to reports/ for artifact collection."""
+        """Write full A01 alert JSON and HTML reports to reports/ for artifact collection."""
         try:
             all_alerts = zap.core.alerts()
         except (ConnectionError, Timeout, RequestException) as exc:
@@ -361,6 +406,15 @@ class TestZAPAccessControlScan:
         except json.JSONDecodeError as exc:
             pytest.skip(f"ZAP returned malformed response during report generation: {exc}")
         a01_alerts = _filter_a01_alerts(all_alerts)
-        report_path = _write_report(a01_alerts, "full_report")
-        assert report_path.exists(), f"Report file was not created at {report_path}"
-        logger.info("A01 DAST report written: %s (%d alerts)", report_path, len(a01_alerts))
+        json_path = _write_report(a01_alerts, "full_report")
+        assert json_path.exists(), f"JSON report was not created at {json_path}"
+        logger.info("A01 DAST JSON report: %s (%d alerts)", json_path, len(a01_alerts))
+
+        try:
+            html_path = _write_html_report(zap, "full_report")
+            assert html_path.exists(), f"HTML report was not created at {html_path}"
+            logger.info("A01 DAST HTML report: %s", html_path)
+        except (ConnectionError, Timeout, RequestException) as exc:
+            logger.warning("Could not generate HTML report: %s", exc)
+        except json.JSONDecodeError as exc:
+            logger.warning("ZAP returned malformed response for HTML report: %s", exc)

--- a/tests/playwright/security/owasp/test_a01_zap_dast.py
+++ b/tests/playwright/security/owasp/test_a01_zap_dast.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 ContextForge Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OWASP A01:2025 – ZAP DAST integration layer.
+
+Activated only when the ``ZAP_BASE_URL`` environment variable is set.
+Skipped silently in normal CI runs.
+
+Requirements:
+  * A running OWASP ZAP daemon (stable Docker image recommended):
+
+    make testing-up
+
+  * ``python-owasp-zap-v2.4`` installed (included in ``playwright`` optional-dependency group).
+
+Environment variables:
+  ZAP_BASE_URL    Base URL of the ZAP API daemon (host-visible), e.g. http://localhost:8090
+  ZAP_API_KEY     ZAP API key (default: changeme)
+  TEST_BASE_URL   Target application URL (host-visible, default: http://localhost:8080)
+  ZAP_TARGET_URL  Target URL that ZAP itself uses to spider (Docker-internal).
+                  nginx listens on port 80 inside mcpnet (host sees 8080 via port mapping), so the
+                  default is http://nginx:80 — works on Linux and macOS/Windows Docker Desktop.
+                  Override for standalone ZAP outside mcpnet, e.g. http://localhost:8080.
+
+Usage::
+
+    ZAP_BASE_URL=http://localhost:8090 ZAP_API_KEY=changeme \\
+        pytest tests/playwright/security/owasp/test_a01_zap_dast.py -v -m owasp_a01_zap
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from requests.exceptions import ConnectionError, Timeout, RequestException
+
+# Third-Party
+import pytest
+
+logger = logging.getLogger(__name__)
+
+ZAP_BASE_URL = os.getenv("ZAP_BASE_URL", "")
+ZAP_API_KEY = os.getenv("ZAP_API_KEY", "changeme")
+# Host-visible URL used for: preflight health check, human-readable log messages.
+TARGET_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
+# Docker-internal URL used for: ZAP spider/scan targets and alert base-URL filtering.
+# nginx listens on port 80 inside mcpnet (default: http://nginx:80 via make test-zap).
+# Falls back to TARGET_URL so local (non-Docker) runs work unchanged.
+ZAP_TARGET_URL = os.getenv("ZAP_TARGET_URL", TARGET_URL)
+
+# A01-relevant CWEs to filter from ZAP alerts
+_A01_CWES = {
+    200,  # Exposure of Sensitive Information
+    284,  # Improper Access Control
+    285,  # Improper Authorization
+    639,  # Authorization Bypass Through User-Controlled Key
+    862,  # Missing Authorization
+    863,  # Incorrect Authorization
+    918,  # SSRF (server-side request forgery – access control boundary)
+}
+
+_HIGH_RISK_LEVELS = {"High", "Critical"}
+
+if not ZAP_BASE_URL:
+    pytest.skip("ZAP_BASE_URL not set – skipping ZAP DAST tests", allow_module_level=True)
+
+try:
+    from zapv2 import ZAPv2  # type: ignore[import-untyped]
+except ImportError as exc:  # pragma: no cover
+    pytest.skip(
+        f"python-owasp-zap-v2.4 not installed: {exc}. "
+        "Install it via: pip install 'python-owasp-zap-v2.4>=0.0.21'",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _zap_client() -> ZAPv2:
+    return ZAPv2(apikey=ZAP_API_KEY, proxies={"http": ZAP_BASE_URL, "https": ZAP_BASE_URL})
+
+
+def _make_admin_jwt() -> str:
+    """Generate an admin JWT for the ZAP scanner to authenticate with."""
+    # Import here so the module-level skip fires before any mcpgateway import
+    # errors in environments where the package is not installed.
+    from mcpgateway.utils.create_jwt_token import _create_jwt_token  # noqa: PLC0415
+
+    return _create_jwt_token(
+        {"sub": "zap-scanner@example.com"},
+        user_data={"email": "zap-scanner@example.com", "is_admin": True, "auth_provider": "local"},
+        teams=None,  # teams=None + is_admin=True → admin bypass (sees everything)
+    )
+
+
+def _wait_for_passive_scan(zap: ZAPv2, timeout: int = 120) -> None:
+    """Block until passive scan queue is empty or timeout is reached."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        remaining = int(zap.pscan.records_to_scan)
+        if remaining == 0:
+            return
+        logger.debug("Passive scan records remaining: %d", remaining)
+        time.sleep(2)
+    logger.warning("Passive scan did not finish within %ds", timeout)
+
+
+def _filter_a01_alerts(alerts: list[dict]) -> list[dict]:
+    """Return only alerts with A01-relevant CWEs at HIGH or CRITICAL risk."""
+    results = []
+    for alert in alerts:
+        try:
+            cwe = int(alert.get("cweid", 0))
+        except (ValueError, TypeError):
+            cwe = 0
+        risk = alert.get("risk", "")
+        if cwe in _A01_CWES and risk in _HIGH_RISK_LEVELS:
+            results.append(alert)
+    return results
+
+
+def _write_report(alerts: list[dict], name: str) -> Path:
+    """Write a JSON alert report to reports/ directory and return its path."""
+    reports_dir = Path(__file__).parent.parent.parent.parent / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    report_path = reports_dir / f"zap_a01_{name}_{int(time.time())}.json"
+    report_path.write_text(json.dumps(alerts, indent=2))
+    logger.info("ZAP report written to %s", report_path)
+    return report_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def zap() -> ZAPv2:
+    """Module-scoped ZAP client.
+
+    Before yielding:
+    1. Polls TARGET_URL/health until the application is up (60 s deadline).
+    2. Injects an admin Bearer token into all ZAP outbound requests via the
+       Replacer add-on so the spider can crawl authenticated endpoints.
+    """
+    # --- 1. Wait for the target application to be reachable from the host ---
+    health_url = f"{TARGET_URL}/health"
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(health_url, timeout=5)  # noqa: S310
+            logger.info("Target application is up at %s", health_url)
+            break
+        except (urllib.error.URLError, OSError):
+            logger.debug("Waiting for target app at %s …", health_url)
+            time.sleep(3)
+    else:
+        pytest.skip(f"Target app not reachable at {health_url} after 60 s – is the testing stack running?")
+
+    # --- 2. Connect to ZAP ---
+    client = _zap_client()
+    try:
+        version = client.core.version
+        logger.info("Connected to ZAP version %s at %s", version, ZAP_BASE_URL)
+    except (ConnectionError, Timeout, RequestException) as exc:
+        pytest.skip(f"Cannot connect to ZAP at {ZAP_BASE_URL}: {exc}")
+    except json.JSONDecodeError as exc:
+        logger.warning("ZAP returned malformed JSON during version check (possible crash/partial response): %s", exc)
+        pytest.skip(f"Cannot connect to ZAP at {ZAP_BASE_URL}: {exc}")
+    except Exception as exc:
+        # ZAP raises bare Exception for non-2xx HTTP responses
+        pytest.skip(f"Cannot connect to ZAP at {ZAP_BASE_URL}: {exc}")
+
+    # --- 3. Inject admin auth header for all ZAP outbound requests ---
+    # Without this the spider hits 401 on every protected path and stops after
+    # the root page, auth redirect, and /health – the 3 URLs seen in the error.
+    try:
+        token = _make_admin_jwt()
+        client.replacer.add_rule(
+            description="ZAP-scanner admin JWT",
+            enabled="true",
+            matchtype="REQ_HEADER",
+            matchregex="false",
+            matchstring="Authorization",
+            replacement=f"Bearer {token}",
+        )
+        logger.info("ZAP Replacer: injected admin Authorization header for all requests")
+    except ConnectionError as exc:
+        pytest.skip(
+            f"ZAP daemon not reachable - Error: {exc}"
+        )
+    except (Timeout, RequestException) as exc:
+        pytest.skip(
+            f"ZAP request failed: {exc}"
+        )
+    except Exception as exc:
+        # ZAP raises bare Exception for non-2xx; 404 means Replacer add-on not installed
+        pytest.skip(
+            f"ZAP Replacer add-on required for authenticated endpoint testing. "
+            f"Install it in ZAP or tests will only cover public endpoints. Error: {exc}"
+        )
+
+    return client
+
+
+@pytest.fixture(scope="module")
+def zap_context(zap: ZAPv2) -> dict:
+    """Create a new ZAP context scoped to ZAP_TARGET_URL."""
+    ctx_name = f"owasp_a01_{int(time.time())}"
+    ctx_id = zap.context.new_context(ctx_name)
+    zap.context.include_in_context(ctx_name, f"{ZAP_TARGET_URL}.*")
+    logger.info("Created ZAP context %s (id=%s) for target %s", ctx_name, ctx_id, ZAP_TARGET_URL)
+    yield {"ctx_id": ctx_id, "ctx_name": ctx_name}
+    # No explicit cleanup needed; ZAP contexts are ephemeral
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.owasp_a01_zap
+@pytest.mark.slow
+class TestZAPAccessControlScan:
+    """ZAP DAST scan tests for OWASP A01:2025 – Broken Access Control."""
+
+    def test_zap_spider_discovers_protected_endpoints(self, zap: ZAPv2, zap_context: dict) -> None:
+        """Seed ZAP's site tree with known protected paths, then confirm they are present.
+
+        ZAP's traditional spider follows HTML hyperlinks and cannot discover REST
+        API endpoints on its own.  We use zap.core.access_url() to directly fetch
+        each protected path — ZAP records the response in its site tree, which the
+        passive and active scans then operate on.  No add-ons required.
+        """
+        protected_paths = ["/servers", "/teams/", "/tokens", "/rbac", "/auth/email/admin"]
+
+        # --- 1. Seed the site tree by directly accessing each protected path ---
+        # ZAP records every URL it touches (including auth-gated ones whose
+        # responses it receives via the Replacer-injected Bearer header).
+        for path in protected_paths:
+            url = f"{ZAP_TARGET_URL}{path}"
+            try:
+                zap.core.access_url(url, followredirects="true")
+                logger.debug("Seeded ZAP site tree: %s", url)
+            except (ConnectionError, Timeout, RequestException) as exc:
+                logger.warning("access_url network error for %s: %s", url, exc)
+            except json.JSONDecodeError as exc:
+                logger.warning("access_url malformed JSON response for %s: %s", url, exc)
+            except Exception as exc:
+                logger.warning("access_url failed for %s: %s", url, exc)
+
+        # --- 2. Also run the traditional spider (picks up any linked HTML paths) ---
+        scan_id = zap.spider.scan(ZAP_TARGET_URL, contextname=zap_context["ctx_name"])
+        logger.info("ZAP spider started with scan_id=%s targeting %s", scan_id, ZAP_TARGET_URL)
+
+        deadline = time.time() + 300
+        while time.time() < deadline:
+            progress = int(zap.spider.status(scan_id))
+            logger.debug("Spider progress: %d%%", progress)
+            if progress >= 100:
+                break
+            time.sleep(3)
+        else:
+            pytest.fail("ZAP spider did not complete within 5 minutes")
+
+        # --- 3. Check the full site tree (seeded paths + spider combined) ---
+        urls = zap.core.urls(baseurl=ZAP_TARGET_URL)
+        discovered = [u for path in protected_paths for u in urls if path in u]
+        assert discovered, (
+            f"ZAP site tree contains no protected API paths among {len(urls)} known URLs. "
+            f"Target: {ZAP_TARGET_URL}. "
+            "Ensure ZAP_TARGET_URL is reachable from inside the ZAP container. "
+            "Default is http://nginx:80 (nginx internal port on mcpnet). "
+            "Override ZAP_TARGET_URL if ZAP runs outside the mcpnet network."
+        )
+        logger.info("Site tree has %d URLs; %d match protected paths", len(urls), len(discovered))
+
+    def test_zap_passive_scan_finds_no_high_severity_a01_alerts(self, zap: ZAPv2) -> None:
+        """After spidering, passive scan must not flag HIGH/CRITICAL A01 alerts."""
+        _wait_for_passive_scan(zap, timeout=120)
+        all_alerts = zap.core.alerts()
+        a01_alerts = _filter_a01_alerts(all_alerts)
+
+        if a01_alerts:
+            _write_report(a01_alerts, "passive_failures")
+            summary = "\n".join(
+                f"  [{a['risk']}] CWE-{a.get('cweid','?')} – {a['alert']} @ {a['url']}"
+                for a in a01_alerts
+            )
+            pytest.fail(
+                f"ZAP passive scan found {len(a01_alerts)} HIGH/CRITICAL A01 alert(s):\n{summary}"
+            )
+
+    def test_zap_active_scan_finds_no_critical_access_control_issues(self, zap: ZAPv2, zap_context: dict) -> None:
+        """Active scan must produce no CRITICAL A01 alerts."""
+        try:
+            scan_id = zap.ascan.scan(
+                ZAP_TARGET_URL,
+                contextid=zap_context["ctx_id"],
+                scanpolicyname=None,  # default policy, full strength
+            )
+        except (ConnectionError, Timeout, RequestException) as exc:
+            pytest.skip(f"Could not start ZAP active scan (network error): {exc}")
+        except json.JSONDecodeError as exc:
+            pytest.skip(f"Could not start ZAP active scan (malformed response): {exc}")
+        except Exception as exc:
+            pytest.skip(f"Could not start ZAP active scan: {exc}")
+
+        logger.info("ZAP active scan started with scan_id=%s", scan_id)
+
+        deadline = time.time() + 900  # 15 min hard cap
+        while time.time() < deadline:
+            try:
+                progress = int(zap.ascan.status(scan_id))
+            except (ConnectionError, Timeout, RequestException) as exc:
+                pytest.skip(
+                    f"ZAP connection lost during active scan; proceeding with partial results. Error: {exc}"
+                )
+                break
+            except Exception as exc:
+                logger.warning(
+                    "There was an issue on the ZAP scan. Error: %s",
+                    exc,
+                )
+                break
+            logger.debug("Active scan progress: %d%%", progress)
+            if progress >= 100:
+                break
+            time.sleep(5)
+        else:
+            pytest.skip("Active scan exceeded 15 min timeout - results incomplete. Increase timeout or optimize scan scope.")
+
+        # ZAP may have restarted after a crash; open a fresh client and allow
+        # time for ZAP to come back up before querying alerts.
+        time.sleep(5)
+        try:
+            fresh_zap = _zap_client()
+            all_alerts = fresh_zap.core.alerts()
+        except (ConnectionError, Timeout, RequestException) as exc:
+            pytest.skip(
+                f"ZAP unreachable after active scan: {exc}. "
+                "If this is an OOM crash, increase the ZAP memory limit in docker-compose.yml."
+            )
+        except json.JSONDecodeError as exc:
+            logger.warning("ZAP returned malformed JSON after active scan (possible crash/partial response): %s", exc)
+            pytest.skip(
+                f"ZAP response unparseable after active scan: {exc}. "
+                "If this is an OOM crash, increase the ZAP memory limit in docker-compose.yml."
+            )
+
+        critical_a01 = [a for a in _filter_a01_alerts(all_alerts) if a.get("risk") == "Critical"]
+
+        if critical_a01:
+            _write_report(critical_a01, "active_critical")
+            summary = "\n".join(
+                f"  [Critical] CWE-{a.get('cweid','?')} – {a['alert']} @ {a['url']}"
+                for a in critical_a01
+            )
+            pytest.fail(
+                f"ZAP active scan found {len(critical_a01)} CRITICAL A01 alert(s):\n{summary}"
+            )
+
+    def test_zap_generates_a01_report_artifact(self, zap: ZAPv2) -> None:
+        """Write a full A01 alert JSON report to reports/ for artifact collection."""
+        all_alerts = zap.core.alerts()
+        a01_alerts = _filter_a01_alerts(all_alerts)
+        report_path = _write_report(a01_alerts, "full_report")
+        assert report_path.exists(), f"Report file was not created at {report_path}"
+        logger.info("A01 DAST report written: %s (%d alerts)", report_path, len(a01_alerts))

--- a/uv.lock
+++ b/uv.lock
@@ -2820,6 +2820,7 @@ playwright = [
     { name = "pytest-html" },
     { name = "pytest-playwright" },
     { name = "pytest-timeout" },
+    { name = "python-owasp-zap-v2-4" },
 ]
 postgres = [
     { name = "psycopg", extra = ["binary", "c"] },
@@ -2978,6 +2979,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'fuzz'", specifier = ">=3.8.0" },
     { name = "python-json-logger", specifier = ">=4.0.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "python-owasp-zap-v2-4", marker = "extra == 'playwright'", specifier = ">=0.0.21" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", marker = "extra == 'redis-pure'", specifier = ">=7.3.0" },
     { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=7.3.0" },
@@ -4879,6 +4881,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-owasp-zap-v2-4"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zaproxy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/fc/91192ca872399544c09c1cf3053c71d87d8fc21a4a0ddba1a890940a761a/python-owasp-zap-v2.4-0.1.0.tar.gz", hash = "sha256:2af4252320b3b77a38712081422688e676e038306cf1f2792feed811235afa8b", size = 5222, upload-time = "2023-08-09T12:33:16.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/aa/2d32daaa560bd2ed4f338bc97e3ff845906c6190bf7aa778b7c7911c1844/python_owasp_zap_v2.4-0.1.0-py2.py3-none-any.whl", hash = "sha256:d4dc00387b0089d81683be01b8272577ad39fb47674377f65c7da0fd30b8abe9", size = 5418, upload-time = "2023-08-09T12:33:14.61Z" },
+]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -6706,6 +6720,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/74/8b74bae38ed7fe6793d0c15a0c8207bbb819cf287788459e5ed230996cdd/yarl-1.22.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff86011bd159a9d2dfc89c34cfd8aff12875980e3bd6a39ff097887520e60249", size = 93715, upload-time = "2025-10-06T14:11:11.739Z" },
     { url = "https://files.pythonhosted.org/packages/69/66/991858aa4b5892d57aef7ee1ba6b4d01ec3b7eb3060795d34090a3ca3278/yarl-1.22.0-cp313-cp313t-win_arm64.whl", hash = "sha256:7861058d0582b847bc4e3a4a4c46828a410bca738673f35a29ba3ca5db0b473b", size = 83857, upload-time = "2025-10-06T14:11:13.586Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zaproxy"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e9/43828866052d4154fbb11fee6cb842d3e74f46d116be626bfa53624572c0/zaproxy-0.5.0.tar.gz", hash = "sha256:3a952d7ec9af7a689a986400dcd885abf4685152119b1390ee8a42a2877636c8", size = 38597, upload-time = "2025-12-15T15:39:17.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/d0/f57fee17a8d3015ca868b120966793e76d258503056530c7b08a6d52972b/zaproxy-0.5.0-py3-none-any.whl", hash = "sha256:532125007c2381ae2d121774a7da9f69e045e040e3a448772988cc17eba472a9", size = 73295, upload-time = "2025-12-15T15:39:16.278Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🔗 Related Issue
Relates to #259

---

## 📝 Summary
Introduces two-layer DAST coverage for OWASP A01:2025 – Broken Access Control.

Layer 1 – direct Playwright API tests (no ZAP required, marker: owasp_a01):
- Force browsing: 7 endpoints must reject anonymous requests with 401
- IDOR/cross-tenant: Team A token must not access Team B resources (CWE-639)
- Vertical privilege escalation: non-admin cannot reach admin-only APIs (CWE-269/285)
- JWT tampering: unsigned, payload-modified, expired, alg=none, wrong iss/aud (CWE-345/287)
- CORS: no wildcard or reflected ACAO header for arbitrary origins (CWE-942)

Layer 2 – ZAP DAST integration (marker: owasp_a01_zap, skipped when ZAP_BASE_URL unset):
- Spider discovers protected endpoints; passive scan checks for HIGH/CRITICAL A01 CWEs; active scan checks for CRITICAL findings; JSON report written to tests/reports/

Infrastructure:
- docker-compose.yml: add zap service under --profile testing (ports 8090/8091, waits for nginx health, 60 s JVM start_period, 2 CPU / 2 GB limit)
- pyproject.toml: add python-owasp-zap-v2.4>=0.0.21 to playwright extras; register owasp_a01 and owasp_a01_zap pytest markers

Run without ZAP:  make test-owasp
Run with ZAP:     make testing-up test-zap

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [X] Other (describe below)
- [X] Testing

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] Documentation updated (if applicable)
- [X] No secrets or credentials committed
