### PR TITLE
bugfix/2947-side-navbar-hidden-on-resize

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -415,7 +415,7 @@
   <body class="bg-gray-100 dark:bg-gray-900">
     {% set hidden_sections = ui_hidden_sections | default([]) %}
     {% set hidden_header_items = ui_hidden_header_items | default([]) %}
-    <div class="flex h-screen overflow-hidden" x-data="{ sidebarOpen: true, sidebarCollapsed: false }">
+    <div class="flex h-screen overflow-hidden" x-data="{ sidebarOpen: true, sidebarCollapsed: false }" @resize.window="if (window.innerWidth >= 1024) sidebarOpen = true">
 
       <!-- Mobile sidebar backdrop -->
       <div


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>


issues #2947 

File: admin.html
Change: Added @resize.window="if (window.innerWidth >= 1024) sidebarOpen = true" to the parent x-data container so the sidebar reappears when the window is expanded from small to large screens.