### PR TITLE
[FEATURE][PLUGINS]: Add HTTP header filter plugin for sensitive data protection

### DIFF
--- a/plugins/header_filter/README.md
+++ b/plugins/header_filter/README.md
@@ -11,7 +11,7 @@ The Header Filter Plugin prevents sensitive authentication and authorization hea
 - **Configurable filtering**: Define which headers to filter via YAML configuration
 - **Case-insensitive matching**: Headers are matched case-insensitively
 - **Passthrough support**: Allow specific headers through even if they're in the filter list
-- **Multi-hook support**: Works on tool_pre_invoke, resource_pre_fetch, prompt_prehook, and agent_pre_invoke
+- **Multi-hook support**: Works on tool_pre_invoke and agent_pre_invoke
 - **Logging**: Optional logging of filtered headers for audit purposes
 
 ## Configuration
@@ -24,7 +24,7 @@ plugins:
     kind: "plugins.header_filter.header_filter_plugin.HeaderFilter"
     description: "Filters sensitive headers before sending to MCP endpoints"
     version: "1.0.0"
-    hooks: ["tool_pre_invoke"]
+    hooks: ["tool_pre_invoke", "agent_pre_invoke"]
     mode: "permissive"  # or "enforce"
     priority: 20
     config:
@@ -39,13 +39,14 @@ plugins:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `filter_headers` | List[str] | `["Cookie", "Set-Cookie"]` | Headers to filter (case-insensitive) |
+| `filter_headers` | List[str] | `["X-Vault-Tokens", "Cookie", "Set-Cookie"]` | Headers to filter (case-insensitive) |
 | `log_filtered_headers` | bool | `true` | Whether to log filtered headers |
 | `allow_passthrough_headers` | List[str] | `[]` | Headers to always allow through |
 
 ### Conservative Default Filtered Headers
 
 By default (in config.yaml), the plugin filters only these headers:
+- `X-Vault-Tokens` - Vault authentication tokens
 - `Cookie` - Session cookies
 - `Set-Cookie` - Cookie setting headers
 

--- a/plugins/header_filter/__init__.py
+++ b/plugins/header_filter/__init__.py
@@ -7,5 +7,3 @@ SPDX-License-Identifier: Apache-2.0
 
 Header filter plugin implementation for filtering sensitive headers.
 """
-
-# Made with Bob

--- a/plugins/header_filter/config.yaml
+++ b/plugins/header_filter/config.yaml
@@ -6,7 +6,7 @@ plugins:
     description: "Filters sensitive headers before sending to MCP endpoints"
     version: "1.0.0"
     author: "Adrian Popa"
-    hooks: ["tool_pre_invoke"]  # Start with tool_pre_invoke only
+    hooks: ["tool_pre_invoke", "agent_pre_invoke"]
     tags: ["security", "headers", "filtering"]
     mode: "permissive"  # Start in permissive mode for safety
     priority: 20  # Lower number = higher priority (runs first). Run after vault plugin (priority 10)
@@ -36,5 +36,3 @@ plugin_settings:
   fail_on_plugin_error: false
   enable_plugin_api: true
   plugin_health_check_interval: 60
-
-# Made with Bob

--- a/plugins/header_filter/header_filter_plugin.py
+++ b/plugins/header_filter/header_filter_plugin.py
@@ -9,11 +9,8 @@ Header Filter Plugin.
 Filters sensitive headers before sending requests to MCP endpoints.
 Prevents leakage of authentication tokens, cookies, and other sensitive data.
 
-Hook: tool_pre_invoke, resource_pre_fetch, prompt_prehook, agent_pre_invoke
+Hook: tool_pre_invoke, agent_pre_invoke
 """
-
-# Standard
-from typing import Set
 
 # Third-Party
 from pydantic import BaseModel, Field
@@ -26,10 +23,6 @@ from mcpgateway.plugins.framework import (
     Plugin,
     PluginConfig,
     PluginContext,
-    PromptPrehookPayload,
-    PromptPrehookResult,
-    ResourcePreFetchPayload,
-    ResourcePreFetchResult,
     ToolPreInvokePayload,
     ToolPreInvokeResult,
 )
@@ -49,7 +42,7 @@ class HeaderFilterConfig(BaseModel):
         allow_passthrough_headers: Set of headers to always allow through (overrides filter_headers).
     """
 
-    filter_headers: Set[str] = Field(
+    filter_headers: set[str] = Field(
         default_factory=lambda: {
             "Authorization",
             "Cookie",
@@ -62,15 +55,15 @@ class HeaderFilterConfig(BaseModel):
         }
     )
     log_filtered_headers: bool = True
-    allow_passthrough_headers: Set[str] = Field(default_factory=set)
+    allow_passthrough_headers: set[str] = Field(default_factory=set)
 
 
 class HeaderFilter(Plugin):
     """Header filter plugin that removes sensitive headers before sending to MCP endpoints.
 
     This plugin prevents sensitive authentication and authorization headers from being
-    leaked to MCP servers. It runs on all pre-invoke hooks (tool, resource, prompt, agent)
-    to ensure consistent header filtering across all MCP operations.
+    leaked to MCP servers. It runs on pre-invoke hooks for tools and agents where HTTP
+    headers are available in the payload.
 
     Security considerations:
     - Headers are filtered case-insensitively
@@ -130,7 +123,7 @@ class HeaderFilter(Plugin):
 
         return filtered_headers, removed_headers
 
-    async def tool_pre_invoke(self, payload: ToolPreInvokePayload, context: PluginContext) -> ToolPreInvokeResult:
+    async def tool_pre_invoke(self, payload: ToolPreInvokePayload, context: PluginContext) -> ToolPreInvokeResult:  # pylint: disable=unused-argument
         """Filter headers before tool invocation.
 
         Args:
@@ -151,62 +144,10 @@ class HeaderFilter(Plugin):
         if removed:
             if self._sconfig.log_filtered_headers:
                 logger.info(f"Filtered {len(removed)} header(s) from {context_name}: {', '.join(removed)}")
-            payload.headers = HttpHeaderPayload(root=filtered_headers)
-            return ToolPreInvokeResult(modified_payload=payload)
+            modified = payload.model_copy(update={"headers": HttpHeaderPayload(root=filtered_headers)})
+            return ToolPreInvokeResult(modified_payload=modified)
 
         return ToolPreInvokeResult()
-
-    async def resource_pre_fetch(self, payload: ResourcePreFetchPayload, context: PluginContext) -> ResourcePreFetchResult:  # pylint: disable=unused-argument
-        """Filter headers before resource fetch.
-
-        Args:
-            payload: The resource payload containing headers.
-            context: Plugin execution context.
-
-        Returns:
-            Result with filtered headers.
-        """
-        if not payload.headers:
-            return ResourcePreFetchResult()
-
-        headers = payload.headers.model_dump()
-        context_name = f"resource:{payload.uri}"
-
-        filtered_headers, removed = self._filter_headers(headers, context_name)
-
-        if removed:
-            if self._sconfig.log_filtered_headers:
-                logger.info(f"Filtered {len(removed)} header(s) from {context_name}: {', '.join(removed)}")
-            payload.headers = HttpHeaderPayload(root=filtered_headers)
-            return ResourcePreFetchResult(modified_payload=payload)
-
-        return ResourcePreFetchResult()
-
-    async def prompt_prehook(self, payload: PromptPrehookPayload, context: PluginContext) -> PromptPrehookResult:  # pylint: disable=unused-argument
-        """Filter headers before prompt execution.
-
-        Args:
-            payload: The prompt payload containing headers.
-            context: Plugin execution context.
-
-        Returns:
-            Result with filtered headers.
-        """
-        if not payload.headers:
-            return PromptPrehookResult()
-
-        headers = payload.headers.model_dump()
-        context_name = f"prompt:{payload.name}"
-
-        filtered_headers, removed = self._filter_headers(headers, context_name)
-
-        if removed:
-            if self._sconfig.log_filtered_headers:
-                logger.info(f"Filtered {len(removed)} header(s) from {context_name}: {', '.join(removed)}")
-            payload.headers = HttpHeaderPayload(root=filtered_headers)
-            return PromptPrehookResult(modified_payload=payload)
-
-        return PromptPrehookResult()
 
     async def agent_pre_invoke(self, payload: AgentPreInvokePayload, context: PluginContext) -> AgentPreInvokeResult:  # pylint: disable=unused-argument
         """Filter headers before agent invocation.
@@ -222,26 +163,18 @@ class HeaderFilter(Plugin):
             return AgentPreInvokeResult()
 
         headers = payload.headers.model_dump()
-        context_name = f"agent:{payload.name}"
+        context_name = f"agent:{payload.agent_id}"
 
         filtered_headers, removed = self._filter_headers(headers, context_name)
 
         if removed:
             if self._sconfig.log_filtered_headers:
                 logger.info(f"Filtered {len(removed)} header(s) from {context_name}: {', '.join(removed)}")
-            payload.headers = HttpHeaderPayload(root=filtered_headers)
-            return AgentPreInvokeResult(modified_payload=payload)
+            modified = payload.model_copy(update={"headers": HttpHeaderPayload(root=filtered_headers)})
+            return AgentPreInvokeResult(modified_payload=modified)
 
         return AgentPreInvokeResult()
 
     async def shutdown(self) -> None:
-        """Shutdown the plugin gracefully.
-
-        Returns:
-            None.
-        """
+        """Shutdown the plugin gracefully."""
         logger.info("Header filter plugin shutting down")
-        return None
-
-
-# Made with Bob

--- a/tests/unit/mcpgateway/plugins/plugins/header_filter/__init__.py
+++ b/tests/unit/mcpgateway/plugins/plugins/header_filter/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Header Filter Plugin."""

--- a/tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py
+++ b/tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py
@@ -12,6 +12,7 @@ import pytest
 
 # First-Party
 from mcpgateway.plugins.framework import (
+    AgentPreInvokePayload,
     GlobalContext,
     HttpHeaderPayload,
     PluginConfig,
@@ -22,7 +23,7 @@ from mcpgateway.plugins.framework import (
 )
 
 # Import the Header Filter plugin
-from plugins.header_filter.header_filter_plugin import HeaderFilter
+from plugins.header_filter.header_filter_plugin import HeaderFilter, HeaderFilterConfig
 
 
 class TestHeaderFilterPluginFunctionality:
@@ -54,13 +55,13 @@ class TestHeaderFilterPluginFunctionality:
         global_context = GlobalContext(request_id="test-1")
         return PluginContext(global_context=global_context)
 
+    # ── tool_pre_invoke tests ─────────────────────────────────────────
+
     @pytest.mark.asyncio
     async def test_no_headers_returns_empty_result(self, plugin_config, plugin_context):
         """Test that missing headers returns empty result."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload without headers
-        payload = ToolPreInvokePayload(name="test_tool", arguments={}, headers=None)
+        payload = ToolPreInvokePayload(name="test_tool", args={}, headers=None)
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
@@ -71,12 +72,10 @@ class TestHeaderFilterPluginFunctionality:
     async def test_authorization_header_is_filtered(self, plugin_config, plugin_context):
         """Test that Authorization header is filtered."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload with Authorization header
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
-            headers=HttpHeaderPayload(root={"Content-Type": "application/json", "Authorization": "Bearer secret_token"}),
+            args={},
+            headers=HttpHeaderPayload({"Content-Type": "application/json", "Authorization": "Bearer secret_token"}),
         )
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
@@ -90,12 +89,10 @@ class TestHeaderFilterPluginFunctionality:
     async def test_cookie_header_is_filtered(self, plugin_config, plugin_context):
         """Test that Cookie header is filtered."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload with Cookie header
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
-            headers=HttpHeaderPayload(root={"Content-Type": "application/json", "Cookie": "session=abc123"}),
+            args={},
+            headers=HttpHeaderPayload({"Content-Type": "application/json", "Cookie": "session=abc123"}),
         )
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
@@ -108,13 +105,11 @@ class TestHeaderFilterPluginFunctionality:
     async def test_multiple_sensitive_headers_filtered(self, plugin_config, plugin_context):
         """Test that multiple sensitive headers are filtered."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload with multiple sensitive headers
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
+            args={},
             headers=HttpHeaderPayload(
-                root={
+                {
                     "Content-Type": "application/json",
                     "Authorization": "Bearer token",
                     "Cookie": "session=xyz",
@@ -127,11 +122,9 @@ class TestHeaderFilterPluginFunctionality:
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
         assert result.modified_payload is not None
-        # Sensitive headers should be removed
         assert "Authorization" not in result.modified_payload.headers.root
         assert "Cookie" not in result.modified_payload.headers.root
         assert "X-API-Key" not in result.modified_payload.headers.root
-        # Safe headers should remain
         assert "Content-Type" in result.modified_payload.headers.root
         assert "User-Agent" in result.modified_payload.headers.root
 
@@ -139,17 +132,15 @@ class TestHeaderFilterPluginFunctionality:
     async def test_case_insensitive_filtering(self, plugin_config, plugin_context):
         """Test that header filtering is case-insensitive."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload with mixed-case headers
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
+            args={},
             headers=HttpHeaderPayload(
-                root={
+                {
                     "content-type": "application/json",
-                    "authorization": "Bearer token",  # lowercase
-                    "COOKIE": "session=xyz",  # uppercase
-                    "X-Api-Key": "secret",  # mixed case
+                    "authorization": "Bearer token",
+                    "COOKIE": "session=xyz",
+                    "X-Api-Key": "secret",
                 }
             ),
         )
@@ -157,17 +148,14 @@ class TestHeaderFilterPluginFunctionality:
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
         assert result.modified_payload is not None
-        # All sensitive headers should be removed regardless of case
         assert "authorization" not in result.modified_payload.headers.root
         assert "COOKIE" not in result.modified_payload.headers.root
         assert "X-Api-Key" not in result.modified_payload.headers.root
-        # Safe header should remain
         assert "content-type" in result.modified_payload.headers.root
 
     @pytest.mark.asyncio
     async def test_passthrough_headers_not_filtered(self, plugin_context):
         """Test that passthrough headers are not filtered even if in filter list."""
-        # Create config with passthrough headers
         config = PluginConfig(
             name="TestHeaderFilter",
             description="Test",
@@ -180,41 +168,34 @@ class TestHeaderFilterPluginFunctionality:
             priority=20,
             config={
                 "filter_headers": ["Authorization", "Cookie"],
-                "allow_passthrough_headers": ["Authorization"],  # Allow Authorization through
+                "allow_passthrough_headers": ["Authorization"],
             },
         )
-
         plugin = HeaderFilter(config)
-
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
-            headers=HttpHeaderPayload(root={"Authorization": "Bearer token", "Cookie": "session=xyz"}),
+            args={},
+            headers=HttpHeaderPayload({"Authorization": "Bearer token", "Cookie": "session=xyz"}),
         )
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
         assert result.modified_payload is not None
-        # Authorization should pass through
         assert "Authorization" in result.modified_payload.headers.root
-        # Cookie should still be filtered
         assert "Cookie" not in result.modified_payload.headers.root
 
     @pytest.mark.asyncio
     async def test_no_filtered_headers_returns_empty_result(self, plugin_config, plugin_context):
         """Test that when no headers are filtered, empty result is returned."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload with only safe headers
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
-            headers=HttpHeaderPayload(root={"Content-Type": "application/json", "User-Agent": "TestClient/1.0"}),
+            args={},
+            headers=HttpHeaderPayload({"Content-Type": "application/json", "User-Agent": "TestClient/1.0"}),
         )
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
-        # No headers were filtered, so no modification needed
         assert result.modified_payload is None
         assert result.continue_processing
 
@@ -222,9 +203,7 @@ class TestHeaderFilterPluginFunctionality:
     async def test_empty_headers_dict_returns_empty_result(self, plugin_config, plugin_context):
         """Test that empty headers dict returns empty result."""
         plugin = HeaderFilter(plugin_config)
-
-        # Create payload with empty headers
-        payload = ToolPreInvokePayload(name="test_tool", arguments={}, headers=HttpHeaderPayload(root={}))
+        payload = ToolPreInvokePayload(name="test_tool", args={}, headers=HttpHeaderPayload({}))
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
@@ -232,9 +211,63 @@ class TestHeaderFilterPluginFunctionality:
         assert result.continue_processing
 
     @pytest.mark.asyncio
-    async def test_default_config_when_config_invalid(self, plugin_context):
-        """Test that plugin uses default config when provided config is invalid."""
-        # Create config with invalid config data
+    async def test_original_payload_not_mutated(self, plugin_config, plugin_context):
+        """Test that the original payload is not mutated (frozen model compliance)."""
+        plugin = HeaderFilter(plugin_config)
+        original_headers = {"Content-Type": "application/json", "Authorization": "Bearer token"}
+        payload = ToolPreInvokePayload(
+            name="test_tool",
+            args={},
+            headers=HttpHeaderPayload(original_headers.copy()),
+        )
+
+        result = await plugin.tool_pre_invoke(payload, plugin_context)
+
+        # Original payload should still have Authorization
+        assert "Authorization" in payload.headers.root
+        # Modified payload should not
+        assert result.modified_payload is not None
+        assert "Authorization" not in result.modified_payload.headers.root
+
+    # ── agent_pre_invoke tests ────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_agent_no_headers_returns_empty_result(self, plugin_config, plugin_context):
+        """Test agent_pre_invoke with no headers."""
+        plugin = HeaderFilter(plugin_config)
+        payload = AgentPreInvokePayload(agent_id="test-agent", messages=[], headers=None)
+
+        result = await plugin.agent_pre_invoke(payload, plugin_context)
+
+        assert result.modified_payload is None
+        assert result.continue_processing
+
+    @pytest.mark.asyncio
+    async def test_agent_headers_filtered(self, plugin_config, plugin_context):
+        """Test agent_pre_invoke filters sensitive headers."""
+        plugin = HeaderFilter(plugin_config)
+        payload = AgentPreInvokePayload(
+            agent_id="test-agent",
+            messages=[],
+            headers=HttpHeaderPayload(
+                {
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer secret",
+                    "Cookie": "session=abc",
+                }
+            ),
+        )
+
+        result = await plugin.agent_pre_invoke(payload, plugin_context)
+
+        assert result.modified_payload is not None
+        assert "Authorization" not in result.modified_payload.headers.root
+        assert "Cookie" not in result.modified_payload.headers.root
+        assert "Content-Type" in result.modified_payload.headers.root
+
+    @pytest.mark.asyncio
+    async def test_agent_passthrough_headers(self, plugin_context):
+        """Test agent_pre_invoke respects passthrough headers."""
         config = PluginConfig(
             name="TestHeaderFilter",
             description="Test",
@@ -245,16 +278,62 @@ class TestHeaderFilterPluginFunctionality:
             tags=["test"],
             mode=PluginMode.ENFORCE,
             priority=20,
-            config={"invalid_key": "invalid_value"},  # Invalid config
+            config={
+                "filter_headers": ["Authorization", "Cookie"],
+                "allow_passthrough_headers": ["Authorization"],
+            },
+        )
+        plugin = HeaderFilter(config)
+        payload = AgentPreInvokePayload(
+            agent_id="test-agent",
+            messages=[],
+            headers=HttpHeaderPayload({"Authorization": "Bearer token", "Cookie": "session=xyz"}),
         )
 
+        result = await plugin.agent_pre_invoke(payload, plugin_context)
+
+        assert result.modified_payload is not None
+        assert "Authorization" in result.modified_payload.headers.root
+        assert "Cookie" not in result.modified_payload.headers.root
+
+    @pytest.mark.asyncio
+    async def test_agent_no_filtered_headers_returns_empty_result(self, plugin_config, plugin_context):
+        """Test agent_pre_invoke returns empty result when no headers filtered."""
+        plugin = HeaderFilter(plugin_config)
+        payload = AgentPreInvokePayload(
+            agent_id="test-agent",
+            messages=[],
+            headers=HttpHeaderPayload({"Content-Type": "application/json"}),
+        )
+
+        result = await plugin.agent_pre_invoke(payload, plugin_context)
+
+        assert result.modified_payload is None
+        assert result.continue_processing
+
+    # ── Config and initialization tests ───────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_default_config_when_config_is_none(self, plugin_context):
+        """Test that plugin uses default config when config dict is None."""
+        config = PluginConfig(
+            name="TestHeaderFilter",
+            description="Test",
+            author="Test",
+            kind="plugins.header_filter.header_filter_plugin.HeaderFilter",
+            version="1.0",
+            hooks=[ToolHookType.TOOL_PRE_INVOKE],
+            tags=["test"],
+            mode=PluginMode.ENFORCE,
+            priority=20,
+            config=None,
+        )
         plugin = HeaderFilter(config)
 
-        # Plugin should still work with default config
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
-            headers=HttpHeaderPayload(root={"Authorization": "Bearer token", "Content-Type": "application/json"}),
+            args={},
+            headers=HttpHeaderPayload({"Authorization": "Bearer token", "Content-Type": "application/json"}),
         )
 
         result = await plugin.tool_pre_invoke(payload, plugin_context)
@@ -264,29 +343,99 @@ class TestHeaderFilterPluginFunctionality:
         assert "Authorization" not in result.modified_payload.headers.root
 
     @pytest.mark.asyncio
-    async def test_filter_headers_method_returns_correct_tuple(self, plugin_config):
+    async def test_default_config_when_config_causes_validation_error(self, plugin_context):
+        """Test that plugin falls back to defaults when config causes a validation error."""
+        config = PluginConfig(
+            name="TestHeaderFilter",
+            description="Test",
+            author="Test",
+            kind="plugins.header_filter.header_filter_plugin.HeaderFilter",
+            version="1.0",
+            hooks=[ToolHookType.TOOL_PRE_INVOKE],
+            tags=["test"],
+            mode=PluginMode.ENFORCE,
+            priority=20,
+            config={"filter_headers": "not-a-list", "log_filtered_headers": "not-a-bool"},
+        )
+        plugin = HeaderFilter(config)
+
+        payload = ToolPreInvokePayload(
+            name="test_tool",
+            args={},
+            headers=HttpHeaderPayload({"Authorization": "Bearer token", "Content-Type": "application/json"}),
+        )
+
+        result = await plugin.tool_pre_invoke(payload, plugin_context)
+
+        # Default config fallback should filter Authorization
+        assert result.modified_payload is not None
+        assert "Authorization" not in result.modified_payload.headers.root
+
+    def test_header_filter_config_defaults(self):
+        """Test HeaderFilterConfig has sensible defaults."""
+        cfg = HeaderFilterConfig()
+
+        assert "Authorization" in cfg.filter_headers
+        assert "Cookie" in cfg.filter_headers
+        assert "Set-Cookie" in cfg.filter_headers
+        assert "X-Vault-Tokens" in cfg.filter_headers
+        assert "X-API-Key" in cfg.filter_headers
+        assert "X-Auth-Token" in cfg.filter_headers
+        assert "Proxy-Authorization" in cfg.filter_headers
+        assert "WWW-Authenticate" in cfg.filter_headers
+        assert cfg.log_filtered_headers is True
+        assert len(cfg.allow_passthrough_headers) == 0
+
+    # ── _filter_headers internal method tests ─────────────────────────
+
+    def test_filter_headers_method_returns_correct_tuple(self, plugin_config):
         """Test that _filter_headers method returns correct tuple."""
         plugin = HeaderFilter(plugin_config)
-
         headers = {"Content-Type": "application/json", "Authorization": "Bearer token", "Cookie": "session=xyz"}
 
-        filtered, removed = plugin._filter_headers(headers, "test:context")  # pylint: disable=protected-access
+        filtered, removed = plugin._filter_headers(headers, "test:context")
 
-        # Check filtered headers
         assert "Content-Type" in filtered
         assert "Authorization" not in filtered
         assert "Cookie" not in filtered
-
-        # Check removed list
         assert "Authorization" in removed
         assert "Cookie" in removed
         assert len(removed) == 2
 
+    def test_filter_headers_empty_dict(self, plugin_config):
+        """Test _filter_headers with empty input dict."""
+        plugin = HeaderFilter(plugin_config)
+
+        filtered, removed = plugin._filter_headers({}, "test:context")
+
+        assert filtered == {}
+        assert removed == []
+
+    def test_filter_headers_all_removed(self, plugin_config):
+        """Test _filter_headers when all headers are sensitive."""
+        plugin = HeaderFilter(plugin_config)
+        headers = {"Authorization": "Bearer token", "Cookie": "session=xyz", "X-API-Key": "key"}
+
+        filtered, removed = plugin._filter_headers(headers, "test:context")
+
+        assert filtered == {}
+        assert len(removed) == 3
+
+    def test_filter_headers_none_removed(self, plugin_config):
+        """Test _filter_headers when no headers are sensitive."""
+        plugin = HeaderFilter(plugin_config)
+        headers = {"Content-Type": "application/json", "Accept": "text/html"}
+
+        filtered, removed = plugin._filter_headers(headers, "test:context")
+
+        assert filtered == headers
+        assert removed == []
+
+    # ── Integration-style scenarios ───────────────────────────────────
+
     @pytest.mark.asyncio
     async def test_passthrough_for_vault_integration(self, plugin_context):
         """Test passthrough scenario: Vault plugin manages Authorization, filter manages others."""
-        # Simulate scenario where Vault plugin handles Authorization
-        # but we want to filter other sensitive headers
         config = PluginConfig(
             name="TestHeaderFilter",
             description="Test",
@@ -299,18 +448,16 @@ class TestHeaderFilterPluginFunctionality:
             priority=20,
             config={
                 "filter_headers": ["Authorization", "Cookie", "X-API-Key"],
-                "allow_passthrough_headers": ["Authorization"],  # Vault manages this
+                "allow_passthrough_headers": ["Authorization"],
             },
         )
-
         plugin = HeaderFilter(config)
-
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
+            args={},
             headers=HttpHeaderPayload(
-                root={
-                    "Authorization": "Bearer vault_token",  # From Vault plugin
+                {
+                    "Authorization": "Bearer vault_token",
                     "Cookie": "session=abc",
                     "X-API-Key": "secret_key",
                     "Content-Type": "application/json",
@@ -321,59 +468,11 @@ class TestHeaderFilterPluginFunctionality:
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
         assert result.modified_payload is not None
-        # Authorization passes through (Vault manages it)
         assert "Authorization" in result.modified_payload.headers.root
         assert result.modified_payload.headers.root["Authorization"] == "Bearer vault_token"
-        # Other sensitive headers are filtered
         assert "Cookie" not in result.modified_payload.headers.root
         assert "X-API-Key" not in result.modified_payload.headers.root
-        # Safe headers remain
         assert "Content-Type" in result.modified_payload.headers.root
-
-    @pytest.mark.asyncio
-    async def test_gradual_rollout_scenario(self, plugin_context):
-        """Test gradual rollout: filter most headers but allow some during testing."""
-        # Scenario: Rolling out filtering gradually
-        config = PluginConfig(
-            name="TestHeaderFilter",
-            description="Test",
-            author="Test",
-            kind="plugins.header_filter.header_filter_plugin.HeaderFilter",
-            version="1.0",
-            hooks=[ToolHookType.TOOL_PRE_INVOKE],
-            tags=["test"],
-            mode=PluginMode.PERMISSIVE,  # Permissive mode for testing
-            priority=20,
-            config={
-                "filter_headers": ["Authorization", "Cookie", "X-Custom-Token", "X-API-Key"],
-                "allow_passthrough_headers": ["X-Custom-Token"],  # Temporary exception during testing
-            },
-        )
-
-        plugin = HeaderFilter(config)
-
-        payload = ToolPreInvokePayload(
-            name="test_tool",
-            arguments={},
-            headers=HttpHeaderPayload(
-                root={
-                    "Authorization": "Bearer token",
-                    "Cookie": "session=xyz",
-                    "X-Custom-Token": "custom_value",  # Allowed during testing
-                    "X-API-Key": "api_key",
-                }
-            ),
-        )
-
-        result = await plugin.tool_pre_invoke(payload, plugin_context)
-
-        assert result.modified_payload is not None
-        # X-Custom-Token passes through (temporary exception)
-        assert "X-Custom-Token" in result.modified_payload.headers.root
-        # Other sensitive headers are filtered
-        assert "Authorization" not in result.modified_payload.headers.root
-        assert "Cookie" not in result.modified_payload.headers.root
-        assert "X-API-Key" not in result.modified_payload.headers.root
 
     @pytest.mark.asyncio
     async def test_multiple_passthrough_headers(self, plugin_context):
@@ -390,17 +489,15 @@ class TestHeaderFilterPluginFunctionality:
             priority=20,
             config={
                 "filter_headers": ["Authorization", "Cookie", "X-API-Key", "X-Custom-Header"],
-                "allow_passthrough_headers": ["Authorization", "X-Custom-Header"],  # Multiple exceptions
+                "allow_passthrough_headers": ["Authorization", "X-Custom-Header"],
             },
         )
-
         plugin = HeaderFilter(config)
-
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
+            args={},
             headers=HttpHeaderPayload(
-                root={
+                {
                     "Authorization": "Bearer token",
                     "Cookie": "session=xyz",
                     "X-API-Key": "api_key",
@@ -412,10 +509,8 @@ class TestHeaderFilterPluginFunctionality:
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
         assert result.modified_payload is not None
-        # Both passthrough headers remain
         assert "Authorization" in result.modified_payload.headers.root
         assert "X-Custom-Header" in result.modified_payload.headers.root
-        # Other sensitive headers are filtered
         assert "Cookie" not in result.modified_payload.headers.root
         assert "X-API-Key" not in result.modified_payload.headers.root
 
@@ -434,19 +529,17 @@ class TestHeaderFilterPluginFunctionality:
             priority=20,
             config={
                 "filter_headers": ["Authorization", "Cookie"],
-                "allow_passthrough_headers": ["authorization"],  # lowercase in config
+                "allow_passthrough_headers": ["authorization"],
             },
         )
-
         plugin = HeaderFilter(config)
-
         payload = ToolPreInvokePayload(
             name="test_tool",
-            arguments={},
+            args={},
             headers=HttpHeaderPayload(
-                root={
-                    "Authorization": "Bearer token",  # Mixed case in request
-                    "COOKIE": "session=xyz",  # Uppercase in request
+                {
+                    "Authorization": "Bearer token",
+                    "COOKIE": "session=xyz",
                 }
             ),
         )
@@ -454,13 +547,54 @@ class TestHeaderFilterPluginFunctionality:
         result = await plugin.tool_pre_invoke(payload, plugin_context)
 
         assert result.modified_payload is not None
-        # Authorization passes through despite case difference
         assert "Authorization" in result.modified_payload.headers.root
-        # Cookie is filtered
         assert "COOKIE" not in result.modified_payload.headers.root
+
+    # ── Shutdown test ─────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_shutdown(self, plugin_config):
+        """Test graceful shutdown."""
+        plugin = HeaderFilter(plugin_config)
+
+        result = await plugin.shutdown()
+
+        assert result is None
+
+    # ── Logging behavior tests ────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_log_filtered_headers_disabled(self, plugin_context):
+        """Test that logging is suppressed when log_filtered_headers is False."""
+        config = PluginConfig(
+            name="TestHeaderFilter",
+            description="Test",
+            author="Test",
+            kind="plugins.header_filter.header_filter_plugin.HeaderFilter",
+            version="1.0",
+            hooks=[ToolHookType.TOOL_PRE_INVOKE],
+            tags=["test"],
+            mode=PluginMode.ENFORCE,
+            priority=20,
+            config={
+                "filter_headers": ["Authorization"],
+                "log_filtered_headers": False,
+            },
+        )
+        plugin = HeaderFilter(config)
+        payload = ToolPreInvokePayload(
+            name="test_tool",
+            args={},
+            headers=HttpHeaderPayload({"Authorization": "Bearer token", "Content-Type": "application/json"}),
+        )
+
+        result = await plugin.tool_pre_invoke(payload, plugin_context)
+
+        # Should still filter even with logging disabled
+        assert result.modified_payload is not None
+        assert "Authorization" not in result.modified_payload.headers.root
+        assert "Content-Type" in result.modified_payload.headers.root
 
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-
-# Made with Bob


### PR DESCRIPTION
# Header Filter Plugin

## 📝 Summary

Adds a security plugin that filters sensitive HTTP headers before sending requests to MCP endpoints. Prevents leakage of cookies, auth tokens, and other sensitive data.

**Files Added:**
- `plugins/header_filter/header_filter_plugin.py` (264 lines)
- `plugins/header_filter/config.yaml` (39 lines)
- `plugins/header_filter/README.md` (181 lines)
- `tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py` (414 lines)

---

## 🏷️ Type of Change
- [x] Feature / Enhancement

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | x    |
| Unit tests                | `make test`     | x|
| Coverage ≥ 80%            | `make coverage` | x  |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated (14 test cases)
- [x] Documentation updated (README.md)
- [x] No secrets committed

---

## 📓 Notes

**Default Config:**
```yaml
filter_headers: ["Cookie", "Set-Cookie"]
mode: "permissive"
priority: 20
```

**Key Features:**
- Case-insensitive filtering
- Per-server configuration via conditions
- Passthrough exceptions for flexibility
- Works with Vault plugin (priority 10 < 20)