### PR TITLE
[FEATURE][SECURITY]: Implement IP-based access control (#536)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3023,3 +3023,31 @@ PLUGINS_CLI_MARKUP_MODE=rich
 #     "is_system_role": true
 # }]
 # MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_FILE=additional_roles_in_db.json
+
+# =============================================================================
+# IP Access Control
+# =============================================================================
+
+# Enable IP-based access control middleware
+# IP_CONTROL_ENABLED=false
+
+# IP control mode: 'disabled', 'allowlist' (deny by default), 'blocklist' (allow by default)
+# IP_CONTROL_MODE=disabled
+
+# Log-only mode: log denials without blocking (dry-run)
+# IP_CONTROL_LOG_ONLY=false
+
+# Paths to skip IP control checks (comma-separated)
+# IP_CONTROL_SKIP_PATHS=["/health", "/healthz", "/ready"]
+
+# Trust X-Forwarded-For / X-Real-IP headers for client IP extraction
+# IP_CONTROL_TRUST_PROXY_HEADERS=false
+
+# Cache TTL in seconds for IP evaluation results (0 to disable caching)
+# IP_CONTROL_CACHE_TTL=300
+
+# Maximum number of entries in the IP evaluation cache
+# IP_CONTROL_CACHE_SIZE=10000
+
+# Default priority for new IP rules (lower = higher priority)
+# IP_CONTROL_DEFAULT_PRIORITY=100

--- a/mcpgateway/alembic/versions/1d27bc0a81f5_add_ip_access_control_tables.py
+++ b/mcpgateway/alembic/versions/1d27bc0a81f5_add_ip_access_control_tables.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Add ip_rules and ip_blocks tables for IP-based access control.
 
-Revision ID: z9j0k1l2m3n4
+Revision ID: 1d27bc0a81f5
 Revises: b2d9c6e4f1a7
-Create Date: 2026-02-24 12:00:00.000000
+Create Date: 2026-02-26 13:33:43.653087
 """
 
 # Standard
@@ -14,7 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "z9j0k1l2m3n4"
+revision: str = "1d27bc0a81f5"
 down_revision: Union[str, Sequence[str], None] = "b2d9c6e4f1a7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/mcpgateway/alembic/versions/z9j0k1l2m3n4_add_ip_access_control_tables.py
+++ b/mcpgateway/alembic/versions/z9j0k1l2m3n4_add_ip_access_control_tables.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Add ip_rules and ip_blocks tables for IP-based access control.
+
+Revision ID: z9j0k1l2m3n4
+Revises: b2d9c6e4f1a7
+Create Date: 2026-02-24 12:00:00.000000
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "z9j0k1l2m3n4"
+down_revision: Union[str, Sequence[str], None] = "b2d9c6e4f1a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create ip_rules and ip_blocks tables."""
+    inspector = sa.inspect(op.get_bind())
+    existing_tables = inspector.get_table_names()
+
+    if "ip_rules" not in existing_tables:
+        op.create_table(
+            "ip_rules",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column("ip_pattern", sa.String(45), nullable=False),
+            sa.Column("rule_type", sa.String(10), nullable=False),
+            sa.Column("priority", sa.Integer, nullable=False, server_default="100"),
+            sa.Column("path_pattern", sa.String(500), nullable=True),
+            sa.Column("description", sa.Text, nullable=True),
+            sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.text("1")),
+            sa.Column("created_by", sa.String(255), nullable=True),
+            sa.Column("updated_by", sa.String(255), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("hit_count", sa.Integer, nullable=False, server_default="0"),
+            sa.Column("last_hit_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("metadata_json", sa.JSON, nullable=True),
+        )
+        op.create_index("idx_ip_rules_active_priority", "ip_rules", ["is_active", "priority"])
+
+    if "ip_blocks" not in existing_tables:
+        op.create_table(
+            "ip_blocks",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column("ip_address", sa.String(45), nullable=False),
+            sa.Column("reason", sa.Text, nullable=False),
+            sa.Column("blocked_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("blocked_by", sa.String(255), nullable=True),
+            sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.text("1")),
+            sa.Column("unblocked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("unblocked_by", sa.String(255), nullable=True),
+        )
+        op.create_index("idx_ip_blocks_active_expires", "ip_blocks", ["is_active", "expires_at"])
+        op.create_index("idx_ip_blocks_ip_active", "ip_blocks", ["ip_address", "is_active"])
+
+
+def downgrade() -> None:
+    """Drop ip_rules and ip_blocks tables."""
+    inspector = sa.inspect(op.get_bind())
+    existing_tables = inspector.get_table_names()
+
+    if "ip_blocks" in existing_tables:
+        op.drop_index("idx_ip_blocks_ip_active", table_name="ip_blocks")
+        op.drop_index("idx_ip_blocks_active_expires", table_name="ip_blocks")
+        op.drop_table("ip_blocks")
+
+    if "ip_rules" in existing_tables:
+        op.drop_index("idx_ip_rules_active_priority", table_name="ip_rules")
+        op.drop_table("ip_rules")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1241,6 +1241,26 @@ class Settings(BaseSettings):
         description="Enable permission audit logging for RBAC checks (writes a row per permission check)",
     )
 
+    # IP Access Control Configuration
+    # Controls IP-based access control with allowlist/blocklist modes.
+    ip_control_enabled: bool = Field(default=False, description="Enable IP-based access control middleware")
+    ip_control_mode: str = Field(
+        default="disabled",
+        description="IP control mode: 'disabled' (no enforcement), 'allowlist' (deny by default, allow matched), 'blocklist' (allow by default, deny matched)",
+    )
+    ip_control_log_only: bool = Field(default=False, description="Log IP denials without blocking (dry-run mode)")
+    ip_control_skip_paths: List[str] = Field(
+        default_factory=lambda: ["/health", "/healthz", "/ready"],
+        description="Paths to skip IP control checks (e.g. health endpoints)",
+    )
+    ip_control_trust_proxy_headers: bool = Field(
+        default=False,
+        description="Trust X-Forwarded-For and X-Real-IP headers for client IP extraction",
+    )
+    ip_control_cache_ttl: int = Field(default=300, ge=0, description="TTL in seconds for IP evaluation cache (0 to disable)")
+    ip_control_cache_size: int = Field(default=10000, ge=1, description="Maximum number of entries in the IP evaluation cache")
+    ip_control_default_priority: int = Field(default=100, ge=1, description="Default priority for new IP rules (lower = higher priority)")
+
     # Security Logging Configuration
     # Security event logging is disabled by default for performance.
     # When enabled, it logs authentication attempts, authorization failures, and security events.

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6127,6 +6127,78 @@ class LLMModel(Base):
         return f"<LLMModel(id='{self.id}', model_id='{self.model_id}', provider_id='{self.provider_id}')>"
 
 
+# ---------------------------------------------------------------------------
+# IP Access Control Models
+# ---------------------------------------------------------------------------
+
+
+class IPRule(Base):
+    """IP access control rule for allowlist/blocklist evaluation.
+
+    Rules are evaluated in priority order (ascending). First matching rule wins.
+    """
+
+    __tablename__ = "ip_rules"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    ip_pattern: Mapped[str] = mapped_column(String(45), nullable=False)
+    rule_type: Mapped[str] = mapped_column(String(10), nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=100)
+    path_pattern: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    updated_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    hit_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_hit_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+
+    __table_args__ = (Index("idx_ip_rules_active_priority", "is_active", "priority"),)
+
+    def __repr__(self) -> str:
+        """Return string representation.
+
+        Returns:
+            String representation of the IP rule.
+        """
+        return f"<IPRule(id='{self.id}', ip_pattern='{self.ip_pattern}', rule_type='{self.rule_type}')>"
+
+
+class IPBlock(Base):
+    """Temporary IP block for immediate access denial.
+
+    Blocks override all rules and expire automatically after a configured duration.
+    """
+
+    __tablename__ = "ip_blocks"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    ip_address: Mapped[str] = mapped_column(String(45), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    blocked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    blocked_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    unblocked_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    unblocked_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+
+    __table_args__ = (
+        Index("idx_ip_blocks_active_expires", "is_active", "expires_at"),
+        Index("idx_ip_blocks_ip_active", "ip_address", "is_active"),
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation.
+
+        Returns:
+            String representation of the IP block.
+        """
+        return f"<IPBlock(id='{self.id}', ip_address='{self.ip_address}', is_active={self.is_active})>"
+
+
 class AuditTrail(Base):
     """Comprehensive audit trail for data access and changes.
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2023,6 +2023,14 @@ else:
 # Add security headers middleware
 app.add_middleware(SecurityHeadersMiddleware)
 
+# Add IP access control middleware (before validation, after security headers)
+if settings.ip_control_enabled:
+    # First-Party
+    from mcpgateway.middleware.ip_control import IPControlMiddleware
+
+    app.add_middleware(IPControlMiddleware)
+    logger.info(f"IP access control middleware enabled (mode={settings.ip_control_mode}, log_only={settings.ip_control_log_only})")
+
 # Add validation middleware if explicitly enabled
 if settings.validation_middleware_enabled:
     app.add_middleware(ValidationMiddleware)
@@ -7722,6 +7730,14 @@ if settings.mcpgateway_tool_cancellation_enabled:
         logger.debug("Orchestrate router not available")
 else:
     logger.info("Tool cancellation feature disabled - cancellation endpoints not available")
+
+# IP access control router (admin endpoints for managing rules and blocks)
+if settings.ip_control_enabled:
+    # First-Party
+    from mcpgateway.routers.ip_control_router import router as ip_control_router
+
+    app.include_router(ip_control_router)
+    logger.info("IP access control router included")
 
 # Feature flags for admin UI and API
 UI_ENABLED = settings.mcpgateway_ui_enabled

--- a/mcpgateway/middleware/ip_control.py
+++ b/mcpgateway/middleware/ip_control.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/middleware/ip_control.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+IP Access Control Middleware.
+
+This middleware evaluates incoming requests against IP allowlist/blocklist rules
+and optionally blocks denied IPs with a 403 response.
+
+Examples:
+    >>> from mcpgateway.middleware.ip_control import IPControlMiddleware  # doctest: +SKIP
+    >>> app.add_middleware(IPControlMiddleware)  # doctest: +SKIP
+"""
+
+# Standard
+import logging
+from typing import Callable
+
+# Third-Party
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.services.ip_control_service import get_ip_control_service
+
+logger = logging.getLogger(__name__)
+
+
+class IPControlMiddleware(BaseHTTPMiddleware):
+    """Middleware that enforces IP-based access control.
+
+    Evaluates each request's client IP against configured rules and temporary
+    blocks. Denied requests receive a 403 JSON response unless log_only mode
+    is enabled (dry-run).
+    """
+
+    def __init__(self, app, **kwargs):
+        """Initialize middleware with skip paths from settings.
+
+        Args:
+            app: ASGI application.
+            **kwargs: Additional middleware keyword arguments.
+        """
+        super().__init__(app, **kwargs)
+        self._skip_paths: frozenset = frozenset(settings.ip_control_skip_paths)
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """Process request through IP access control.
+
+        Args:
+            request: Incoming HTTP request.
+            call_next: Next middleware/handler in chain.
+
+        Returns:
+            HTTP response.
+        """
+        # 1. Skip configured paths (health checks, etc.)
+        if request.url.path in self._skip_paths:
+            return await call_next(request)
+
+        # 2. Extract client IP
+        client_ip = self._extract_client_ip(request)
+
+        # 3. Evaluate IP
+        service = get_ip_control_service()
+        allowed = service.evaluate_ip(client_ip, request.url.path)
+
+        # 4. Store on request state
+        request.state.client_ip = client_ip
+        request.state.ip_control_result = allowed
+
+        # 5. Handle denied
+        if not allowed:
+            if settings.ip_control_log_only:
+                logger.warning(f"IP control: would deny {client_ip} for {request.url.path} (log-only mode)")
+            else:
+                logger.warning(f"IP control: denied {client_ip} for {request.url.path}")
+                return JSONResponse(
+                    status_code=403,
+                    content={
+                        "detail": "Access denied by IP access control policy",
+                        "error": "ip_blocked",
+                    },
+                )
+
+        return await call_next(request)
+
+    def _extract_client_ip(self, request: Request) -> str:
+        """Extract the client IP from the request.
+
+        Checks proxy headers if trusted, then falls back to request.client.host.
+
+        Args:
+            request: HTTP request.
+
+        Returns:
+            Client IP address string.
+        """
+        if settings.ip_control_trust_proxy_headers:
+            # X-Forwarded-For: client, proxy1, proxy2
+            forwarded_for = request.headers.get("x-forwarded-for")
+            if forwarded_for:
+                # First IP is the original client
+                return forwarded_for.split(",")[0].strip()
+
+            # X-Real-IP (single IP)
+            real_ip = request.headers.get("x-real-ip")
+            if real_ip:
+                return real_ip.strip()
+
+        # Fallback to direct connection
+        if request.client:
+            return request.client.host
+        return "unknown"

--- a/mcpgateway/routers/ip_control_router.py
+++ b/mcpgateway/routers/ip_control_router.py
@@ -1,0 +1,323 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/ip_control_router.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+IP Access Control Router.
+
+This module provides REST API endpoints for managing IP-based access control
+rules, temporary blocks, testing, and status.
+
+Examples:
+    >>> from mcpgateway.routers.ip_control_router import router
+    >>> from fastapi import APIRouter
+    >>> isinstance(router, APIRouter)
+    True
+"""
+
+# Standard
+import logging
+from typing import Generator, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import SessionLocal
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_admin_permission
+from mcpgateway.schemas import (
+    IPBlockCreate,
+    IPBlockResponse,
+    IPControlStatusResponse,
+    IPRuleCreate,
+    IPRuleListResponse,
+    IPRuleResponse,
+    IPRuleUpdate,
+    IPTestRequest,
+    IPTestResponse,
+)
+from mcpgateway.services.ip_control_service import get_ip_control_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/ip-control", tags=["IP Access Control"])
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Get database session for dependency injection.
+
+    Yields:
+        Session: SQLAlchemy database session
+
+    Raises:
+        Exception: Re-raises any exception after rollback.
+
+    Examples:
+        >>> gen = get_db()
+        >>> db = next(gen)
+        >>> hasattr(db, 'close')
+        True
+    """
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            try:
+                db.invalidate()
+            except Exception:
+                pass  # nosec B110 - Best effort cleanup on connection failure
+        raise
+    finally:
+        db.close()
+
+
+# ===== Rule Management Endpoints =====
+
+
+@router.post("/rules", response_model=IPRuleResponse, status_code=status.HTTP_201_CREATED)
+@require_admin_permission()
+async def create_rule(rule_data: IPRuleCreate, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Create a new IP access control rule.
+
+    Args:
+        rule_data: Rule creation data.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Returns:
+        IPRuleResponse: Created rule.
+    """
+    service = get_ip_control_service()
+    rule = service.create_rule(
+        data=rule_data.model_dump(exclude_none=True),
+        user_email=user.get("email", "system") if isinstance(user, dict) else getattr(user, "email", "system"),
+        db=db,
+    )
+    return rule
+
+
+@router.get("/rules", response_model=IPRuleListResponse)
+@require_admin_permission()
+async def list_rules(
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=1000, description="Page size"),
+    offset: int = Query(default=0, ge=0, description="Page offset"),
+    is_active: Optional[bool] = Query(default=None, description="Filter by active status"),
+    rule_type: Optional[str] = Query(default=None, description="Filter by rule type (allow/deny)"),
+):
+    """List IP access control rules with pagination.
+
+    Args:
+        user: Authenticated admin user context.
+        db: Database session.
+        limit: Page size.
+        offset: Page offset.
+        is_active: Optional active filter.
+        rule_type: Optional rule type filter.
+
+    Returns:
+        IPRuleListResponse: Paginated rules list.
+    """
+    service = get_ip_control_service()
+    rules, total = service.list_rules(db=db, limit=limit, offset=offset, is_active=is_active, rule_type=rule_type)
+    return IPRuleListResponse(rules=rules, total=total, limit=limit, offset=offset)
+
+
+@router.get("/rules/{rule_id}", response_model=IPRuleResponse)
+@require_admin_permission()
+async def get_rule(rule_id: str, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Get a single IP access control rule.
+
+    Args:
+        rule_id: Rule ID.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Returns:
+        IPRuleResponse: The requested rule.
+
+    Raises:
+        HTTPException: 404 if rule not found.
+    """
+    service = get_ip_control_service()
+    rule = service.get_rule(rule_id, db=db)
+    if rule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"IP rule {rule_id} not found")
+    return rule
+
+
+@router.patch("/rules/{rule_id}", response_model=IPRuleResponse)
+@require_admin_permission()
+async def update_rule(rule_id: str, rule_data: IPRuleUpdate, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Update an existing IP access control rule.
+
+    Args:
+        rule_id: Rule ID.
+        rule_data: Fields to update.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Returns:
+        IPRuleResponse: Updated rule.
+
+    Raises:
+        HTTPException: 404 if rule not found.
+    """
+    service = get_ip_control_service()
+    rule = service.update_rule(
+        rule_id=rule_id,
+        data=rule_data.model_dump(exclude_none=True),
+        user_email=user.get("email", "system") if isinstance(user, dict) else getattr(user, "email", "system"),
+        db=db,
+    )
+    if rule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"IP rule {rule_id} not found")
+    return rule
+
+
+@router.delete("/rules/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_admin_permission()
+async def delete_rule(rule_id: str, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Delete an IP access control rule.
+
+    Args:
+        rule_id: Rule ID.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Raises:
+        HTTPException: 404 if rule not found.
+    """
+    service = get_ip_control_service()
+    deleted = service.delete_rule(
+        rule_id=rule_id,
+        user_email=user.get("email", "system") if isinstance(user, dict) else getattr(user, "email", "system"),
+        db=db,
+    )
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"IP rule {rule_id} not found")
+
+
+# ===== Block Management Endpoints =====
+
+
+@router.post("/blocks", response_model=IPBlockResponse, status_code=status.HTTP_201_CREATED)
+@require_admin_permission()
+async def create_block(block_data: IPBlockCreate, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Create a temporary IP block.
+
+    Args:
+        block_data: Block creation data.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Returns:
+        IPBlockResponse: Created block.
+    """
+    service = get_ip_control_service()
+    block = service.create_block(
+        data=block_data.model_dump(),
+        user_email=user.get("email", "system") if isinstance(user, dict) else getattr(user, "email", "system"),
+        db=db,
+    )
+    return block
+
+
+@router.get("/blocks", response_model=list[IPBlockResponse])
+@require_admin_permission()
+async def list_blocks(
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+    active_only: bool = Query(default=True, description="Only show active non-expired blocks"),
+):
+    """List temporary IP blocks.
+
+    Args:
+        user: Authenticated admin user context.
+        db: Database session.
+        active_only: Whether to filter for active blocks only.
+
+    Returns:
+        List of IPBlockResponse.
+    """
+    service = get_ip_control_service()
+    return service.list_blocks(db=db, active_only=active_only)
+
+
+@router.delete("/blocks/{block_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_admin_permission()
+async def remove_block(block_id: str, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Remove (deactivate) a temporary IP block.
+
+    Args:
+        block_id: Block ID.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Raises:
+        HTTPException: 404 if block not found.
+    """
+    service = get_ip_control_service()
+    removed = service.remove_block(
+        block_id=block_id,
+        user_email=user.get("email", "system") if isinstance(user, dict) else getattr(user, "email", "system"),
+        db=db,
+    )
+    if not removed:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"IP block {block_id} not found")
+
+
+# ===== Diagnostic Endpoints =====
+
+
+@router.post("/test", response_model=IPTestResponse)
+@require_admin_permission()
+async def test_ip(test_data: IPTestRequest, user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Test an IP address against current rules (bypasses cache).
+
+    Args:
+        test_data: IP and path to test.
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Returns:
+        IPTestResponse: Test result.
+    """
+    service = get_ip_control_service()
+    result = service.test_ip(ip=test_data.ip_address, path=test_data.path, db=db)
+    return IPTestResponse(**result)
+
+
+@router.get("/status", response_model=IPControlStatusResponse)
+@require_admin_permission()
+async def get_status(user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+    """Get IP access control system status.
+
+    Args:
+        user: Authenticated admin user context.
+        db: Database session.
+
+    Returns:
+        IPControlStatusResponse: System status.
+    """
+    service = get_ip_control_service()
+    return IPControlStatusResponse(**service.get_status(db=db))
+
+
+@router.post("/cache/clear", status_code=status.HTTP_204_NO_CONTENT)
+@require_admin_permission()
+async def clear_cache(user=Depends(get_current_user_with_permissions)):
+    """Clear the IP control evaluation cache.
+
+    Args:
+        user: Authenticated admin user context.
+    """
+    service = get_ip_control_service()
+    service.invalidate_cache()
+    logger.info("IP control cache cleared by admin")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7763,3 +7763,119 @@ class PerformanceHistoryResponse(BaseModel):
     aggregates: List[PerformanceAggregateRead] = Field(default_factory=list, description="Historical aggregates")
     period_type: str = Field(..., description="Aggregation period type")
     total_count: int = Field(0, description="Total matching records")
+
+
+# ---------------------------------------------------------------------------
+# IP Access Control Schemas
+# ---------------------------------------------------------------------------
+
+
+class IPRuleCreate(BaseModelWithConfigDict):
+    """Schema for creating a new IP access control rule."""
+
+    ip_pattern: str = Field(..., description="IP address or CIDR notation (e.g. '10.0.0.0/8')")
+    rule_type: str = Field(..., description="Rule type: 'allow' or 'deny'")
+    priority: Optional[int] = Field(None, ge=1, description="Priority (lower = higher priority)")
+    path_pattern: Optional[str] = Field(None, description="Optional regex pattern to match request paths")
+    description: Optional[str] = Field(None, description="Human-readable description")
+    is_active: Optional[bool] = Field(True, description="Whether the rule is active")
+    expires_at: Optional[datetime] = Field(None, description="Optional expiration timestamp")
+    metadata_json: Optional[Dict[str, Any]] = Field(None, description="Optional metadata")
+
+
+class IPRuleUpdate(BaseModelWithConfigDict):
+    """Schema for updating an existing IP access control rule."""
+
+    ip_pattern: Optional[str] = Field(None, description="IP address or CIDR notation")
+    rule_type: Optional[str] = Field(None, description="Rule type: 'allow' or 'deny'")
+    priority: Optional[int] = Field(None, ge=1, description="Priority (lower = higher priority)")
+    path_pattern: Optional[str] = Field(None, description="Regex pattern to match request paths")
+    description: Optional[str] = Field(None, description="Human-readable description")
+    is_active: Optional[bool] = Field(None, description="Whether the rule is active")
+    expires_at: Optional[datetime] = Field(None, description="Optional expiration timestamp")
+    metadata_json: Optional[Dict[str, Any]] = Field(None, description="Optional metadata")
+
+
+class IPRuleResponse(BaseModelWithConfigDict):
+    """Response schema for an IP access control rule."""
+
+    id: str = Field(..., description="Rule ID")
+    ip_pattern: str = Field(..., description="IP address or CIDR notation")
+    rule_type: str = Field(..., description="Rule type: 'allow' or 'deny'")
+    priority: int = Field(..., description="Priority (lower = higher priority)")
+    path_pattern: Optional[str] = Field(None, description="Regex pattern to match request paths")
+    description: Optional[str] = Field(None, description="Human-readable description")
+    is_active: bool = Field(..., description="Whether the rule is active")
+    created_by: Optional[str] = Field(None, description="Email of user who created the rule")
+    updated_by: Optional[str] = Field(None, description="Email of user who last updated the rule")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+    expires_at: Optional[datetime] = Field(None, description="Optional expiration timestamp")
+    hit_count: int = Field(0, description="Number of times this rule matched a request")
+    last_hit_at: Optional[datetime] = Field(None, description="Last time this rule matched")
+    metadata_json: Optional[Dict[str, Any]] = Field(None, description="Optional metadata")
+
+
+class IPRuleListResponse(BaseModelWithConfigDict):
+    """Paginated response for IP access control rules."""
+
+    rules: List[IPRuleResponse] = Field(default_factory=list, description="List of IP rules")
+    total: int = Field(0, description="Total number of matching rules")
+    limit: int = Field(50, description="Page size")
+    offset: int = Field(0, description="Page offset")
+
+
+class IPBlockCreate(BaseModelWithConfigDict):
+    """Schema for creating a temporary IP block."""
+
+    ip_address: str = Field(..., description="IP address to block")
+    reason: str = Field(..., description="Reason for the block")
+    duration_minutes: int = Field(..., ge=1, description="Block duration in minutes")
+
+
+class IPBlockResponse(BaseModelWithConfigDict):
+    """Response schema for a temporary IP block."""
+
+    id: str = Field(..., description="Block ID")
+    ip_address: str = Field(..., description="Blocked IP address")
+    reason: str = Field(..., description="Reason for the block")
+    blocked_at: datetime = Field(..., description="When the block was created")
+    expires_at: datetime = Field(..., description="When the block expires")
+    blocked_by: Optional[str] = Field(None, description="Email of user who created the block")
+    is_active: bool = Field(..., description="Whether the block is still active")
+    unblocked_at: Optional[datetime] = Field(None, description="When the block was removed")
+    unblocked_by: Optional[str] = Field(None, description="Email of user who removed the block")
+
+
+class IPTestRequest(BaseModelWithConfigDict):
+    """Schema for testing an IP against current rules."""
+
+    ip_address: str = Field(..., description="IP address to test")
+    path: str = Field(default="/", description="Request path to test against")
+
+
+class IPTestResponse(BaseModelWithConfigDict):
+    """Response schema for IP test results."""
+
+    ip_address: str = Field(..., description="Tested IP address")
+    path: str = Field(..., description="Tested request path")
+    allowed: bool = Field(..., description="Whether the IP would be allowed")
+    matched_rule_id: Optional[str] = Field(None, description="ID of the matching rule")
+    matched_rule_type: Optional[str] = Field(None, description="Type of the matching rule")
+    blocked_by_temp_block: bool = Field(False, description="Whether blocked by a temporary block")
+    mode: str = Field(..., description="Current IP control mode")
+
+
+class IPControlStatusResponse(BaseModelWithConfigDict):
+    """Response schema for IP control system status."""
+
+    enabled: bool = Field(..., description="Whether IP control is enabled")
+    mode: str = Field(..., description="Current mode (disabled/allowlist/blocklist)")
+    log_only: bool = Field(..., description="Whether log-only (dry-run) mode is active")
+    total_rules: int = Field(0, description="Total number of rules")
+    active_rules: int = Field(0, description="Number of active rules")
+    total_blocks: int = Field(0, description="Total number of blocks")
+    active_blocks: int = Field(0, description="Number of active non-expired blocks")
+    cache_size: int = Field(0, description="Current cache size")
+    cache_ttl: int = Field(0, description="Cache TTL in seconds")
+    skip_paths: List[str] = Field(default_factory=list, description="Paths skipped by IP control")

--- a/mcpgateway/services/ip_control_service.py
+++ b/mcpgateway/services/ip_control_service.py
@@ -1,0 +1,745 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/ip_control_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+IP Access Control Service.
+
+This module provides IP-based access control with allowlist/blocklist evaluation,
+CIDR matching, path-scoped rules, temporary blocks, priority-based evaluation,
+and in-memory caching.
+"""
+
+# Standard
+from datetime import timedelta
+from functools import lru_cache
+import ipaddress
+import logging
+import re
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+import uuid
+
+# Third-Party
+from sqlalchemy import and_, func, select
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import IPBlock, IPRule, SessionLocal, utc_now
+from mcpgateway.services.audit_trail_service import get_audit_trail_service
+
+logger = logging.getLogger(__name__)
+
+
+class IPControlService:
+    """Service for IP-based access control evaluation and management.
+
+    Supports allowlist and blocklist modes with CIDR notation, path-scoped rules,
+    temporary blocks, priority-based evaluation, and in-memory caching.
+    """
+
+    _instance: Optional["IPControlService"] = None
+    _lock = threading.Lock()
+
+    def __new__(cls) -> "IPControlService":
+        """Ensure singleton instance.
+
+        Returns:
+            Singleton IPControlService instance.
+        """
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+    def __init__(self):
+        """Initialize the IP control service."""
+        if self._initialized:
+            return
+        self._cache: Dict[str, Tuple[bool, float]] = {}  # key -> (allowed, expire_time)
+        self._cache_lock = threading.Lock()
+        self._initialized = True
+
+    # ------------------------------------------------------------------
+    # Cache management
+    # ------------------------------------------------------------------
+
+    def invalidate_cache(self) -> None:
+        """Clear the entire evaluation cache."""
+        with self._cache_lock:
+            self._cache.clear()
+
+    def _cache_key(self, ip: str, path: str) -> str:
+        return f"{ip}|{path}"
+
+    def _cache_get(self, key: str) -> Optional[bool]:
+        """Get a cached result if present and not expired.
+
+        Args:
+            key: Cache key.
+
+        Returns:
+            Cached boolean result, or None if not cached or expired.
+        """
+        with self._cache_lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            allowed, expire_time = entry
+            if time.monotonic() > expire_time:
+                del self._cache[key]
+                return None
+            return allowed
+
+    def _cache_set(self, key: str, allowed: bool) -> None:
+        """Set a cached result with TTL.
+
+        Args:
+            key: Cache key.
+            allowed: Whether the IP was allowed.
+        """
+        ttl = settings.ip_control_cache_ttl
+        if ttl <= 0:
+            return
+        with self._cache_lock:
+            # Evict oldest entries if at capacity
+            if len(self._cache) >= settings.ip_control_cache_size:
+                # Remove ~25% of entries (oldest by expiry)
+                to_remove = max(1, settings.ip_control_cache_size // 4)
+                sorted_keys = sorted(self._cache, key=lambda k: self._cache[k][1])
+                for k in sorted_keys[:to_remove]:
+                    del self._cache[k]
+            self._cache[key] = (allowed, time.monotonic() + ttl)
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """Return cache statistics.
+
+        Returns:
+            Dict with total_entries, live_entries, expired_entries, max_size, ttl_seconds.
+        """
+        with self._cache_lock:
+            now = time.monotonic()
+            live = sum(1 for _, (__, exp) in self._cache.items() if exp > now)
+            return {
+                "total_entries": len(self._cache),
+                "live_entries": live,
+                "expired_entries": len(self._cache) - live,
+                "max_size": settings.ip_control_cache_size,
+                "ttl_seconds": settings.ip_control_cache_ttl,
+            }
+
+    # ------------------------------------------------------------------
+    # IP and path matching (static helpers)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ip_matches(ip_str: str, pattern: str) -> bool:
+        """Check if an IP address matches a pattern (single IP or CIDR).
+
+        Args:
+            ip_str: The IP address to check.
+            pattern: An IP address or CIDR network.
+
+        Returns:
+            True if the IP matches the pattern.
+        """
+        try:
+            addr = ipaddress.ip_address(ip_str)
+            if "/" in pattern:
+                network = ipaddress.ip_network(pattern, strict=False)
+                return addr in network
+            else:
+                return addr == ipaddress.ip_address(pattern)
+        except ValueError:
+            return False
+
+    @staticmethod
+    @lru_cache(maxsize=256)
+    def _compile_path_pattern(pattern: str) -> Optional[re.Pattern]:
+        """Compile and cache a path regex pattern.
+
+        Args:
+            pattern: Regex pattern string.
+
+        Returns:
+            Compiled pattern or None if invalid.
+        """
+        try:
+            return re.compile(pattern)
+        except re.error:
+            logger.warning(f"Invalid path pattern: {pattern}")
+            return None
+
+    @staticmethod
+    def _path_matches(path: str, pattern: Optional[str]) -> bool:
+        """Check if a request path matches a pattern.
+
+        Args:
+            path: The request path.
+            pattern: Optional regex pattern. None means match all paths.
+
+        Returns:
+            True if the path matches (or pattern is None).
+        """
+        if pattern is None:
+            return True
+        compiled = IPControlService._compile_path_pattern(pattern)
+        if compiled is None:
+            return False
+        return compiled.search(path) is not None
+
+    # ------------------------------------------------------------------
+    # Core evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate_ip(self, ip: str, path: str, db: Optional[Session] = None) -> bool:
+        """Evaluate whether an IP address should be allowed for a given path.
+
+        Steps:
+        1. Check in-memory cache
+        2. Check temporary blocks
+        3. Load active rules sorted by priority (ascending)
+        4. First match wins
+        5. Default: allowlist -> deny, blocklist -> allow
+
+        Args:
+            ip: Client IP address.
+            path: Request path.
+            db: Optional database session.
+
+        Returns:
+            True if the request should be allowed, False otherwise.
+        """
+        if not settings.ip_control_enabled or settings.ip_control_mode == "disabled":
+            return True
+
+        # 1. Check cache
+        cache_key = self._cache_key(ip, path)
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+
+        # Use provided session or create a new one
+        close_db = False
+        if db is None:
+            db = SessionLocal()
+            close_db = True
+
+        try:
+            allowed = self._evaluate_ip_uncached(ip, path, db)
+            self._cache_set(cache_key, allowed)
+            return allowed
+        except Exception as e:
+            logger.error(f"IP evaluation error for {ip}: {e}", exc_info=True)
+            # Fail open on error to avoid blocking legitimate traffic
+            return True
+        finally:
+            if close_db:
+                db.close()
+
+    def _evaluate_ip_uncached(self, ip: str, path: str, db: Session) -> bool:
+        """Evaluate IP without cache. Called internally by evaluate_ip.
+
+        Args:
+            ip: Client IP address.
+            path: Request path.
+            db: Database session.
+
+        Returns:
+            True if allowed, False if denied.
+        """
+        now = utc_now()
+
+        # 2. Check temporary blocks (active + not expired)
+        block_query = select(IPBlock).where(
+            and_(
+                IPBlock.is_active == True,  # noqa: E712
+                IPBlock.ip_address == ip,
+                IPBlock.expires_at > now,
+            )
+        )
+        block = db.execute(block_query).scalars().first()
+        if block is not None:
+            return False
+
+        # 3. Load active rules sorted by priority ascending
+        rules_query = (
+            select(IPRule)
+            .where(
+                and_(
+                    IPRule.is_active == True,  # noqa: E712
+                    # Exclude expired rules
+                    (IPRule.expires_at == None) | (IPRule.expires_at > now),  # noqa: E711
+                )
+            )
+            .order_by(IPRule.priority.asc())
+        )
+        rules = db.execute(rules_query).scalars().all()
+
+        # 4. First match wins
+        for rule in rules:
+            if self._ip_matches(ip, rule.ip_pattern) and self._path_matches(path, rule.path_pattern):
+                # Update hit count asynchronously (best effort)
+                try:
+                    rule.hit_count = (rule.hit_count or 0) + 1
+                    rule.last_hit_at = now
+                    db.commit()
+                except Exception:
+                    try:
+                        db.rollback()
+                    except Exception:
+                        pass
+                return rule.rule_type == "allow"
+
+        # 5. Default based on mode
+        mode = settings.ip_control_mode
+        if mode == "allowlist":
+            return False  # Not in allowlist -> deny
+        else:
+            return True  # Not in blocklist -> allow
+
+    # ------------------------------------------------------------------
+    # Test / diagnostics (bypasses cache)
+    # ------------------------------------------------------------------
+
+    def test_ip(self, ip: str, path: str, db: Session) -> Dict[str, Any]:
+        """Test an IP against current rules without caching.
+
+        Args:
+            ip: IP address to test.
+            path: Request path to test.
+            db: Database session.
+
+        Returns:
+            Dict with evaluation details.
+        """
+        if not settings.ip_control_enabled or settings.ip_control_mode == "disabled":
+            return {
+                "ip_address": ip,
+                "path": path,
+                "allowed": True,
+                "matched_rule_id": None,
+                "matched_rule_type": None,
+                "blocked_by_temp_block": False,
+                "mode": settings.ip_control_mode,
+            }
+
+        now = utc_now()
+
+        # Check temporary blocks
+        block_query = select(IPBlock).where(
+            and_(
+                IPBlock.is_active == True,  # noqa: E712
+                IPBlock.ip_address == ip,
+                IPBlock.expires_at > now,
+            )
+        )
+        block = db.execute(block_query).scalars().first()
+        if block is not None:
+            return {
+                "ip_address": ip,
+                "path": path,
+                "allowed": False,
+                "matched_rule_id": block.id,
+                "matched_rule_type": "block",
+                "blocked_by_temp_block": True,
+                "mode": settings.ip_control_mode,
+            }
+
+        # Load active rules
+        rules_query = (
+            select(IPRule)
+            .where(
+                and_(
+                    IPRule.is_active == True,  # noqa: E712
+                    (IPRule.expires_at == None) | (IPRule.expires_at > now),  # noqa: E711
+                )
+            )
+            .order_by(IPRule.priority.asc())
+        )
+        rules = db.execute(rules_query).scalars().all()
+
+        for rule in rules:
+            if self._ip_matches(ip, rule.ip_pattern) and self._path_matches(path, rule.path_pattern):
+                return {
+                    "ip_address": ip,
+                    "path": path,
+                    "allowed": rule.rule_type == "allow",
+                    "matched_rule_id": rule.id,
+                    "matched_rule_type": rule.rule_type,
+                    "blocked_by_temp_block": False,
+                    "mode": settings.ip_control_mode,
+                }
+
+        # Default
+        mode = settings.ip_control_mode
+        return {
+            "ip_address": ip,
+            "path": path,
+            "allowed": mode != "allowlist",
+            "matched_rule_id": None,
+            "matched_rule_type": None,
+            "blocked_by_temp_block": False,
+            "mode": mode,
+        }
+
+    def get_status(self, db: Session) -> Dict[str, Any]:
+        """Get IP control system status.
+
+        Args:
+            db: Database session.
+
+        Returns:
+            Status dict.
+        """
+        now = utc_now()
+
+        total_rules = db.execute(select(func.count(IPRule.id))).scalar() or 0
+        active_rules = db.execute(select(func.count(IPRule.id)).where(IPRule.is_active == True)).scalar() or 0  # noqa: E712
+        total_blocks = db.execute(select(func.count(IPBlock.id))).scalar() or 0
+        active_blocks = (
+            db.execute(
+                select(func.count(IPBlock.id)).where(
+                    and_(
+                        IPBlock.is_active == True,  # noqa: E712
+                        IPBlock.expires_at > now,
+                    )
+                )
+            ).scalar()
+            or 0
+        )
+
+        cache_stats = self.get_cache_stats()
+
+        return {
+            "enabled": settings.ip_control_enabled,
+            "mode": settings.ip_control_mode,
+            "log_only": settings.ip_control_log_only,
+            "total_rules": total_rules,
+            "active_rules": active_rules,
+            "total_blocks": total_blocks,
+            "active_blocks": active_blocks,
+            "cache_size": cache_stats["total_entries"],
+            "cache_ttl": settings.ip_control_cache_ttl,
+            "skip_paths": settings.ip_control_skip_paths,
+        }
+
+    # ------------------------------------------------------------------
+    # CRUD: Rules
+    # ------------------------------------------------------------------
+
+    def create_rule(self, data: Dict[str, Any], user_email: str, db: Session) -> IPRule:
+        """Create a new IP rule.
+
+        Args:
+            data: Rule data dict.
+            user_email: Email of user creating the rule.
+            db: Database session.
+
+        Returns:
+            Created IPRule.
+        """
+        rule = IPRule(
+            id=uuid.uuid4().hex,
+            ip_pattern=data["ip_pattern"],
+            rule_type=data["rule_type"],
+            priority=data.get("priority", settings.ip_control_default_priority),
+            path_pattern=data.get("path_pattern"),
+            description=data.get("description"),
+            is_active=data.get("is_active", True),
+            created_by=user_email,
+            updated_by=user_email,
+            expires_at=data.get("expires_at"),
+            metadata_json=data.get("metadata_json"),
+        )
+        db.add(rule)
+        db.commit()
+        db.refresh(rule)
+
+        self.invalidate_cache()
+
+        audit = get_audit_trail_service()
+        audit.log_action(
+            action="CREATE",
+            resource_type="ip_rule",
+            resource_id=rule.id,
+            user_id=user_email,
+            new_values=data,
+            db=db,
+        )
+
+        logger.info(f"IP rule created: {rule.id} ({rule.rule_type} {rule.ip_pattern})")
+        return rule
+
+    def update_rule(self, rule_id: str, data: Dict[str, Any], user_email: str, db: Session) -> Optional[IPRule]:
+        """Update an existing IP rule.
+
+        Args:
+            rule_id: ID of the rule to update.
+            data: Fields to update.
+            user_email: Email of user performing the update.
+            db: Database session.
+
+        Returns:
+            Updated IPRule or None if not found.
+        """
+        rule = db.execute(select(IPRule).where(IPRule.id == rule_id)).scalars().first()
+        if rule is None:
+            return None
+
+        old_values = {
+            "ip_pattern": rule.ip_pattern,
+            "rule_type": rule.rule_type,
+            "priority": rule.priority,
+            "path_pattern": rule.path_pattern,
+            "is_active": rule.is_active,
+        }
+
+        for key, value in data.items():
+            if hasattr(rule, key) and value is not None:
+                setattr(rule, key, value)
+        rule.updated_by = user_email
+
+        db.commit()
+        db.refresh(rule)
+
+        self.invalidate_cache()
+
+        audit = get_audit_trail_service()
+        audit.log_action(
+            action="UPDATE",
+            resource_type="ip_rule",
+            resource_id=rule.id,
+            user_id=user_email,
+            old_values=old_values,
+            new_values=data,
+            db=db,
+        )
+
+        logger.info(f"IP rule updated: {rule.id}")
+        return rule
+
+    def delete_rule(self, rule_id: str, user_email: str, db: Session) -> bool:
+        """Delete an IP rule.
+
+        Args:
+            rule_id: ID of the rule to delete.
+            user_email: Email of user performing the deletion.
+            db: Database session.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        rule = db.execute(select(IPRule).where(IPRule.id == rule_id)).scalars().first()
+        if rule is None:
+            return False
+
+        db.delete(rule)
+        db.commit()
+
+        self.invalidate_cache()
+
+        audit = get_audit_trail_service()
+        audit.log_action(
+            action="DELETE",
+            resource_type="ip_rule",
+            resource_id=rule_id,
+            user_id=user_email,
+            db=db,
+        )
+
+        logger.info(f"IP rule deleted: {rule_id}")
+        return True
+
+    def get_rule(self, rule_id: str, db: Session) -> Optional[IPRule]:
+        """Get a single IP rule by ID.
+
+        Args:
+            rule_id: Rule ID.
+            db: Database session.
+
+        Returns:
+            IPRule or None.
+        """
+        return db.execute(select(IPRule).where(IPRule.id == rule_id)).scalars().first()
+
+    def list_rules(self, db: Session, limit: int = 50, offset: int = 0, is_active: Optional[bool] = None, rule_type: Optional[str] = None) -> Tuple[List[IPRule], int]:
+        """List IP rules with pagination and filtering.
+
+        Args:
+            db: Database session.
+            limit: Page size.
+            offset: Page offset.
+            is_active: Optional filter by active status.
+            rule_type: Optional filter by rule type.
+
+        Returns:
+            Tuple of (rules list, total count).
+        """
+        query = select(IPRule)
+        count_query = select(func.count(IPRule.id))
+
+        if is_active is not None:
+            query = query.where(IPRule.is_active == is_active)
+            count_query = count_query.where(IPRule.is_active == is_active)
+        if rule_type is not None:
+            query = query.where(IPRule.rule_type == rule_type)
+            count_query = count_query.where(IPRule.rule_type == rule_type)
+
+        total = db.execute(count_query).scalar() or 0
+        rules = db.execute(query.order_by(IPRule.priority.asc()).limit(limit).offset(offset)).scalars().all()
+
+        return rules, total
+
+    # ------------------------------------------------------------------
+    # CRUD: Blocks
+    # ------------------------------------------------------------------
+
+    def create_block(self, data: Dict[str, Any], user_email: str, db: Session) -> IPBlock:
+        """Create a temporary IP block.
+
+        Args:
+            data: Block data including ip_address, reason, duration_minutes.
+            user_email: Email of user creating the block.
+            db: Database session.
+
+        Returns:
+            Created IPBlock.
+        """
+        now = utc_now()
+        block = IPBlock(
+            id=uuid.uuid4().hex,
+            ip_address=data["ip_address"],
+            reason=data["reason"],
+            blocked_at=now,
+            expires_at=now + timedelta(minutes=data["duration_minutes"]),
+            blocked_by=user_email,
+            is_active=True,
+        )
+        db.add(block)
+        db.commit()
+        db.refresh(block)
+
+        self.invalidate_cache()
+
+        audit = get_audit_trail_service()
+        audit.log_action(
+            action="CREATE",
+            resource_type="ip_block",
+            resource_id=block.id,
+            user_id=user_email,
+            new_values=data,
+            db=db,
+        )
+
+        logger.info(f"IP block created: {block.id} ({block.ip_address} for {data['duration_minutes']}m)")
+        return block
+
+    def remove_block(self, block_id: str, user_email: str, db: Session) -> bool:
+        """Remove (deactivate) a temporary IP block.
+
+        Args:
+            block_id: ID of the block to remove.
+            user_email: Email of user removing the block.
+            db: Database session.
+
+        Returns:
+            True if removed, False if not found.
+        """
+        block = db.execute(select(IPBlock).where(IPBlock.id == block_id)).scalars().first()
+        if block is None:
+            return False
+
+        block.is_active = False
+        block.unblocked_at = utc_now()
+        block.unblocked_by = user_email
+        db.commit()
+
+        self.invalidate_cache()
+
+        audit = get_audit_trail_service()
+        audit.log_action(
+            action="DELETE",
+            resource_type="ip_block",
+            resource_id=block_id,
+            user_id=user_email,
+            db=db,
+        )
+
+        logger.info(f"IP block removed: {block_id}")
+        return True
+
+    def list_blocks(self, db: Session, active_only: bool = True) -> List[IPBlock]:
+        """List IP blocks.
+
+        Args:
+            db: Database session.
+            active_only: If True, only return active non-expired blocks.
+
+        Returns:
+            List of IPBlock entries.
+        """
+        query = select(IPBlock)
+        if active_only:
+            now = utc_now()
+            query = query.where(
+                and_(
+                    IPBlock.is_active == True,  # noqa: E712
+                    IPBlock.expires_at > now,
+                )
+            )
+        return list(db.execute(query.order_by(IPBlock.blocked_at.desc())).scalars().all())
+
+    def cleanup_expired_blocks(self, db: Session) -> int:
+        """Deactivate expired blocks.
+
+        Args:
+            db: Database session.
+
+        Returns:
+            Number of blocks deactivated.
+        """
+        now = utc_now()
+        blocks = (
+            db.execute(
+                select(IPBlock).where(
+                    and_(
+                        IPBlock.is_active == True,  # noqa: E712
+                        IPBlock.expires_at <= now,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        count = 0
+        for block in blocks:
+            block.is_active = False
+            count += 1
+
+        if count > 0:
+            db.commit()
+            self.invalidate_cache()
+            logger.info(f"Cleaned up {count} expired IP blocks")
+
+        return count
+
+
+# Singleton accessor
+_ip_control_service: Optional[IPControlService] = None
+
+
+def get_ip_control_service() -> IPControlService:
+    """Get or create the singleton IPControlService instance.
+
+    Returns:
+        IPControlService instance.
+    """
+    global _ip_control_service
+    if _ip_control_service is None:
+        _ip_control_service = IPControlService()
+    return _ip_control_service

--- a/mcpgateway/services/ip_control_service.py
+++ b/mcpgateway/services/ip_control_service.py
@@ -291,7 +291,7 @@ class IPControlService:
                     try:
                         db.rollback()
                     except Exception:
-                        pass
+                        pass  # nosec B110 - Best effort cleanup on hit count update failure
                 return rule.rule_type == "allow"
 
         # 5. Default based on mode

--- a/tests/unit/mcpgateway/middleware/test_ip_control_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_ip_control_middleware.py
@@ -241,3 +241,29 @@ async def test_request_state_client_ip_set(monkeypatch):
 
     assert request.state.client_ip == "127.0.0.1"
     assert request.state.ip_control_result is True
+
+
+@pytest.mark.asyncio
+async def test_no_client_returns_unknown(monkeypatch):
+    """When request.client is None, client IP should be 'unknown'."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", [])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", False)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client = None
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = True
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        await middleware.dispatch(request, call_next)
+
+    mock_service.evaluate_ip.assert_called_once_with("unknown", "/api/tools")
+    assert request.state.client_ip == "unknown"

--- a/tests/unit/mcpgateway/middleware/test_ip_control_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_ip_control_middleware.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+"""Tests for IP access control middleware."""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+# First-Party
+from mcpgateway.middleware.ip_control import IPControlMiddleware
+
+
+@pytest.mark.asyncio
+async def test_health_paths_always_pass(monkeypatch):
+    """Health check paths should bypass IP control."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health", "/healthz", "/ready"])
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    for path in ["/health", "/healthz", "/ready"]:
+        request = MagicMock(spec=Request)
+        request.url.path = path
+        response = await middleware.dispatch(request, call_next)
+        assert response.status_code == 200
+        call_next.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_allowed_ip_passes_through(monkeypatch):
+    """An allowed IP should pass through to the handler."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", False)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "192.168.1.1"
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = True
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+    assert request.state.client_ip == "192.168.1.1"
+    assert request.state.ip_control_result is True
+
+
+@pytest.mark.asyncio
+async def test_denied_ip_returns_403(monkeypatch):
+    """A denied IP should receive a 403 JSON response."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", False)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "10.0.0.1"
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = False
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_denied_ip_log_only_passes_through(monkeypatch):
+    """In log-only mode, denied IPs should still pass through."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", False)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", True)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "10.0.0.1"
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = False
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_x_forwarded_for_extraction(monkeypatch):
+    """X-Forwarded-For header should be used for client IP when trusted."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", True)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "172.16.0.1"
+    request.headers = {"x-forwarded-for": "203.0.113.50, 70.41.3.18, 150.172.238.178"}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = True
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        await middleware.dispatch(request, call_next)
+
+    # Should extract first IP from X-Forwarded-For
+    mock_service.evaluate_ip.assert_called_once_with("203.0.113.50", "/api/tools")
+    assert request.state.client_ip == "203.0.113.50"
+
+
+@pytest.mark.asyncio
+async def test_x_real_ip_extraction(monkeypatch):
+    """X-Real-IP header should be used when X-Forwarded-For is absent."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", True)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "172.16.0.1"
+    request.headers = {"x-real-ip": "203.0.113.99"}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = True
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        await middleware.dispatch(request, call_next)
+
+    mock_service.evaluate_ip.assert_called_once_with("203.0.113.99", "/api/tools")
+    assert request.state.client_ip == "203.0.113.99"
+
+
+@pytest.mark.asyncio
+async def test_fallback_to_client_host(monkeypatch):
+    """Falls back to request.client.host when no proxy headers."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", True)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "192.168.1.50"
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = True
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        await middleware.dispatch(request, call_next)
+
+    mock_service.evaluate_ip.assert_called_once_with("192.168.1.50", "/api/tools")
+    assert request.state.client_ip == "192.168.1.50"
+
+
+@pytest.mark.asyncio
+async def test_403_response_body_format(monkeypatch):
+    """Verify 403 response body has expected format."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", ["/health"])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", False)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/tools"
+    request.client.host = "10.0.0.1"
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = False
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    # JSONResponse stores the body directly
+    import json
+    data = json.loads(response.body)
+    assert data["detail"] == "Access denied by IP access control policy"
+    assert data["error"] == "ip_blocked"
+
+
+@pytest.mark.asyncio
+async def test_request_state_client_ip_set(monkeypatch):
+    """Verify request.state.client_ip is set for allowed requests."""
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_skip_paths", [])
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_trust_proxy_headers", False)
+    monkeypatch.setattr("mcpgateway.middleware.ip_control.settings.ip_control_log_only", False)
+
+    middleware = IPControlMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+
+    request = MagicMock(spec=Request)
+    request.url.path = "/data"
+    request.client.host = "127.0.0.1"
+    request.headers = {}
+    request.state = MagicMock()
+
+    mock_service = MagicMock()
+    mock_service.evaluate_ip.return_value = True
+
+    with patch("mcpgateway.middleware.ip_control.get_ip_control_service", return_value=mock_service):
+        await middleware.dispatch(request, call_next)
+
+    assert request.state.client_ip == "127.0.0.1"
+    assert request.state.ip_control_result is True

--- a/tests/unit/mcpgateway/routers/test_ip_control_router.py
+++ b/tests/unit/mcpgateway/routers/test_ip_control_router.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+"""Tests for IP access control router endpoints."""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import pytest
+
+# Local
+from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
+
+
+_originals = patch_rbac_decorators()
+# First-Party
+from mcpgateway.routers import ip_control_router as router_mod  # noqa: E402
+from mcpgateway.schemas import IPBlockCreate, IPRuleCreate, IPRuleUpdate, IPTestRequest  # noqa: E402
+
+restore_rbac_decorators(_originals)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(rule_id="r1", ip_pattern="10.0.0.0/8", rule_type="deny", priority=100):
+    now = datetime.now(tz=timezone.utc)
+    return SimpleNamespace(
+        id=rule_id,
+        ip_pattern=ip_pattern,
+        rule_type=rule_type,
+        priority=priority,
+        path_pattern=None,
+        description="test rule",
+        is_active=True,
+        created_by="admin@example.com",
+        updated_by="admin@example.com",
+        created_at=now,
+        updated_at=now,
+        expires_at=None,
+        hit_count=0,
+        last_hit_at=None,
+        metadata_json=None,
+    )
+
+
+def _make_block(block_id="b1", ip_address="1.2.3.4"):
+    now = datetime.now(tz=timezone.utc)
+    return SimpleNamespace(
+        id=block_id,
+        ip_address=ip_address,
+        reason="suspicious activity",
+        blocked_at=now,
+        expires_at=now + timedelta(hours=1),
+        blocked_by="admin@example.com",
+        is_active=True,
+        unblocked_at=None,
+        unblocked_by=None,
+    )
+
+
+def _mock_user():
+    return {"email": "admin@example.com", "is_admin": True}
+
+
+# ---------------------------------------------------------------------------
+# get_db
+# ---------------------------------------------------------------------------
+
+
+def test_get_db_commits_on_success(monkeypatch):
+    db = MagicMock()
+    monkeypatch.setattr(router_mod, "SessionLocal", lambda: db)
+
+    gen = router_mod.get_db()
+    yielded_db = next(gen)
+    assert yielded_db is db
+
+    with pytest.raises(StopIteration):
+        gen.send(None)
+
+    db.commit.assert_called_once()
+    db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Rule CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rule_success(monkeypatch):
+    rule = _make_rule("r1")
+    mock_service = MagicMock()
+    mock_service.create_rule.return_value = rule
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    request = IPRuleCreate(ip_pattern="10.0.0.0/8", rule_type="deny", priority=100)
+    result = await router_mod.create_rule(request, user=_mock_user(), db=MagicMock())
+    assert result.id == "r1"
+
+
+@pytest.mark.asyncio
+async def test_list_rules_success(monkeypatch):
+    rules = [_make_rule("r1"), _make_rule("r2")]
+    mock_service = MagicMock()
+    mock_service.list_rules.return_value = (rules, 2)
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    result = await router_mod.list_rules(user=_mock_user(), db=MagicMock(), limit=50, offset=0, is_active=None, rule_type=None)
+    assert result.total == 2
+    assert len(result.rules) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_rule_success(monkeypatch):
+    rule = _make_rule("r1")
+    mock_service = MagicMock()
+    mock_service.get_rule.return_value = rule
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    result = await router_mod.get_rule("r1", user=_mock_user(), db=MagicMock())
+    assert result.id == "r1"
+
+
+@pytest.mark.asyncio
+async def test_get_rule_not_found(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.get_rule.return_value = None
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await router_mod.get_rule("missing", user=_mock_user(), db=MagicMock())
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_rule_success(monkeypatch):
+    rule = _make_rule("r1")
+    rule.priority = 50
+    mock_service = MagicMock()
+    mock_service.update_rule.return_value = rule
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    update = IPRuleUpdate(priority=50)
+    result = await router_mod.update_rule("r1", update, user=_mock_user(), db=MagicMock())
+    assert result.priority == 50
+
+
+@pytest.mark.asyncio
+async def test_update_rule_not_found(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.update_rule.return_value = None
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await router_mod.update_rule("missing", IPRuleUpdate(priority=50), user=_mock_user(), db=MagicMock())
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_rule_success(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.delete_rule.return_value = True
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    # Should not raise
+    await router_mod.delete_rule("r1", user=_mock_user(), db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_delete_rule_not_found(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.delete_rule.return_value = False
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await router_mod.delete_rule("missing", user=_mock_user(), db=MagicMock())
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Block CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_block_success(monkeypatch):
+    block = _make_block("b1")
+    mock_service = MagicMock()
+    mock_service.create_block.return_value = block
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    request = IPBlockCreate(ip_address="1.2.3.4", reason="test", duration_minutes=60)
+    result = await router_mod.create_block(request, user=_mock_user(), db=MagicMock())
+    assert result.id == "b1"
+
+
+@pytest.mark.asyncio
+async def test_remove_block_not_found(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.remove_block.return_value = False
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await router_mod.remove_block("missing", user=_mock_user(), db=MagicMock())
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_ip_endpoint(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.test_ip.return_value = {
+        "ip_address": "10.0.0.1",
+        "path": "/api/tools",
+        "allowed": False,
+        "matched_rule_id": "r1",
+        "matched_rule_type": "deny",
+        "blocked_by_temp_block": False,
+        "mode": "blocklist",
+    }
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    request = IPTestRequest(ip_address="10.0.0.1", path="/api/tools")
+    result = await router_mod.test_ip(request, user=_mock_user(), db=MagicMock())
+    assert result.allowed is False
+    assert result.matched_rule_id == "r1"
+
+
+@pytest.mark.asyncio
+async def test_get_status_endpoint(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.get_status.return_value = {
+        "enabled": True,
+        "mode": "blocklist",
+        "log_only": False,
+        "total_rules": 5,
+        "active_rules": 3,
+        "total_blocks": 2,
+        "active_blocks": 1,
+        "cache_size": 100,
+        "cache_ttl": 300,
+        "skip_paths": ["/health"],
+    }
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    result = await router_mod.get_status(user=_mock_user(), db=MagicMock())
+    assert result.enabled is True
+    assert result.active_rules == 3
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_endpoint(monkeypatch):
+    mock_service = MagicMock()
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    await router_mod.clear_cache(user=_mock_user())
+    mock_service.invalidate_cache.assert_called_once()

--- a/tests/unit/mcpgateway/routers/test_ip_control_router.py
+++ b/tests/unit/mcpgateway/routers/test_ip_control_router.py
@@ -268,3 +268,90 @@ async def test_clear_cache_endpoint(monkeypatch):
 
     await router_mod.clear_cache(user=_mock_user())
     mock_service.invalidate_cache.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_db error handling (rollback/invalidate paths)
+# ---------------------------------------------------------------------------
+
+
+def test_get_db_rollback_on_exception(monkeypatch):
+    """get_db rolls back and re-raises on exception during yield."""
+    db = MagicMock()
+    monkeypatch.setattr(router_mod, "SessionLocal", lambda: db)
+
+    gen = router_mod.get_db()
+    next(gen)
+
+    with pytest.raises(ValueError):
+        gen.throw(ValueError, ValueError("test error"), None)
+
+    db.rollback.assert_called_once()
+    db.close.assert_called_once()
+
+
+def test_get_db_invalidate_on_rollback_failure(monkeypatch):
+    """get_db calls invalidate() when rollback also fails."""
+    db = MagicMock()
+    db.rollback.side_effect = RuntimeError("rollback failed")
+    monkeypatch.setattr(router_mod, "SessionLocal", lambda: db)
+
+    gen = router_mod.get_db()
+    next(gen)
+
+    with pytest.raises(ValueError):
+        gen.throw(ValueError, ValueError("test error"), None)
+
+    db.rollback.assert_called_once()
+    db.invalidate.assert_called_once()
+    db.close.assert_called_once()
+
+
+def test_get_db_invalidate_also_fails(monkeypatch):
+    """get_db handles both rollback and invalidate failures gracefully."""
+    db = MagicMock()
+    db.rollback.side_effect = RuntimeError("rollback failed")
+    db.invalidate.side_effect = RuntimeError("invalidate failed")
+    monkeypatch.setattr(router_mod, "SessionLocal", lambda: db)
+
+    gen = router_mod.get_db()
+    next(gen)
+
+    with pytest.raises(ValueError):
+        gen.throw(ValueError, ValueError("test error"), None)
+
+    db.rollback.assert_called_once()
+    db.invalidate.assert_called_once()
+    db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# list_blocks endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_success(monkeypatch):
+    blocks = [_make_block("b1"), _make_block("b2")]
+    mock_service = MagicMock()
+    mock_service.list_blocks.return_value = blocks
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    result = await router_mod.list_blocks(user=_mock_user(), db=MagicMock(), active_only=True)
+    assert len(result) == 2
+    mock_service.list_blocks.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# remove_block success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_block_success(monkeypatch):
+    mock_service = MagicMock()
+    mock_service.remove_block.return_value = True
+    monkeypatch.setattr(router_mod, "get_ip_control_service", lambda: mock_service)
+
+    # Should not raise
+    await router_mod.remove_block("b1", user=_mock_user(), db=MagicMock())

--- a/tests/unit/mcpgateway/services/test_ip_control_service.py
+++ b/tests/unit/mcpgateway/services/test_ip_control_service.py
@@ -1,0 +1,475 @@
+# -*- coding: utf-8 -*-
+"""Tests for ip_control_service."""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import time
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services import ip_control_service as svc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class DummyResult:
+    """Mock query result."""
+
+    def __init__(self, items=None):
+        self._items = items or []
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._items[0] if self._items else None
+
+    def all(self):
+        return self._items
+
+
+class DummyScalar:
+    """Mock scalar result for count queries."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class DummySession:
+    """Minimal mock DB session for IP control tests."""
+
+    def __init__(self, execute_results=None):
+        self._execute_results = execute_results or []
+        self._call_idx = 0
+        self.committed = False
+        self.added = []
+
+    def execute(self, _query):
+        if self._call_idx < len(self._execute_results):
+            result = self._execute_results[self._call_idx]
+            self._call_idx += 1
+            return result
+        return DummyResult([])
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, _obj):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+    def delete(self, _obj):
+        pass
+
+
+def _make_rule(
+    rule_id="r1",
+    ip_pattern="10.0.0.0/8",
+    rule_type="deny",
+    priority=100,
+    path_pattern=None,
+    is_active=True,
+    expires_at=None,
+    hit_count=0,
+):
+    return SimpleNamespace(
+        id=rule_id,
+        ip_pattern=ip_pattern,
+        rule_type=rule_type,
+        priority=priority,
+        path_pattern=path_pattern,
+        is_active=is_active,
+        expires_at=expires_at,
+        hit_count=hit_count,
+        last_hit_at=None,
+    )
+
+
+def _make_block(block_id="b1", ip_address="1.2.3.4", is_active=True, expires_at=None):
+    now = datetime.now(tz=timezone.utc)
+    return SimpleNamespace(
+        id=block_id,
+        ip_address=ip_address,
+        is_active=is_active,
+        blocked_at=now,
+        expires_at=expires_at or (now + timedelta(hours=1)),
+        reason="test block",
+        blocked_by="admin@test.com",
+        unblocked_at=None,
+        unblocked_by=None,
+    )
+
+
+def _fresh_service():
+    """Create a fresh service instance (bypassing singleton)."""
+    service = object.__new__(svc.IPControlService)
+    service._cache = {}
+    service._cache_lock = __import__("threading").Lock()
+    service._initialized = True
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Static method tests: _ip_matches
+# ---------------------------------------------------------------------------
+
+
+def test_ip_matches_exact_ipv4():
+    assert svc.IPControlService._ip_matches("192.168.1.1", "192.168.1.1") is True
+
+
+def test_ip_matches_exact_ipv4_no_match():
+    assert svc.IPControlService._ip_matches("192.168.1.2", "192.168.1.1") is False
+
+
+def test_ip_matches_cidr_ipv4():
+    assert svc.IPControlService._ip_matches("192.168.1.100", "192.168.1.0/24") is True
+
+
+def test_ip_matches_cidr_ipv4_no_match():
+    assert svc.IPControlService._ip_matches("10.0.0.1", "192.168.1.0/24") is False
+
+
+def test_ip_matches_ipv6():
+    assert svc.IPControlService._ip_matches("::1", "::1") is True
+
+
+def test_ip_matches_ipv6_cidr():
+    assert svc.IPControlService._ip_matches("fd00::1", "fd00::/16") is True
+
+
+def test_ip_matches_invalid_ip():
+    assert svc.IPControlService._ip_matches("not-an-ip", "192.168.1.0/24") is False
+
+
+def test_ip_matches_invalid_pattern():
+    assert svc.IPControlService._ip_matches("192.168.1.1", "garbage") is False
+
+
+# ---------------------------------------------------------------------------
+# Static method tests: _path_matches
+# ---------------------------------------------------------------------------
+
+
+def test_path_matches_none_pattern():
+    """None pattern matches any path."""
+    assert svc.IPControlService._path_matches("/anything", None) is True
+
+
+def test_path_matches_regex():
+    assert svc.IPControlService._path_matches("/api/v1/tools", "^/api/") is True
+
+
+def test_path_matches_regex_no_match():
+    assert svc.IPControlService._path_matches("/health", "^/api/") is False
+
+
+def test_path_matches_invalid_regex():
+    assert svc.IPControlService._path_matches("/test", "[invalid") is False
+
+
+# ---------------------------------------------------------------------------
+# Disabled mode
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_disabled_returns_true(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", False)
+    service = _fresh_service()
+    assert service.evaluate_ip("1.2.3.4", "/anything") is True
+
+
+def test_evaluate_disabled_mode_returns_true(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "disabled")
+    service = _fresh_service()
+    assert service.evaluate_ip("1.2.3.4", "/anything") is True
+
+
+# ---------------------------------------------------------------------------
+# Blocklist mode defaults
+# ---------------------------------------------------------------------------
+
+
+def test_blocklist_default_allows(monkeypatch):
+    """In blocklist mode, IPs not matching any rule are allowed."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    session = DummySession(execute_results=[
+        DummyResult([]),  # no blocks
+        DummyResult([]),  # no rules
+    ])
+
+    service = _fresh_service()
+    assert service._evaluate_ip_uncached("9.9.9.9", "/", session) is True
+
+
+# ---------------------------------------------------------------------------
+# Allowlist mode defaults
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_default_denies(monkeypatch):
+    """In allowlist mode, IPs not matching any rule are denied."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "allowlist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    session = DummySession(execute_results=[
+        DummyResult([]),  # no blocks
+        DummyResult([]),  # no rules
+    ])
+
+    service = _fresh_service()
+    assert service._evaluate_ip_uncached("9.9.9.9", "/", session) is False
+
+
+# ---------------------------------------------------------------------------
+# Rule matching
+# ---------------------------------------------------------------------------
+
+
+def test_deny_rule_blocks_ip(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="deny")
+    session = DummySession(execute_results=[
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # one deny rule
+    ])
+
+    service = _fresh_service()
+    assert service._evaluate_ip_uncached("10.0.0.5", "/", session) is False
+
+
+def test_allow_rule_allows_ip(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "allowlist")
+
+    rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="allow")
+    session = DummySession(execute_results=[
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # one allow rule
+    ])
+
+    service = _fresh_service()
+    assert service._evaluate_ip_uncached("10.0.0.5", "/", session) is True
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering
+# ---------------------------------------------------------------------------
+
+
+def test_priority_ordering_first_match_wins(monkeypatch):
+    """Lower priority number matches first."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    allow_rule = _make_rule(rule_id="r1", ip_pattern="10.0.0.0/8", rule_type="allow", priority=10)
+    deny_rule = _make_rule(rule_id="r2", ip_pattern="10.0.0.0/8", rule_type="deny", priority=20)
+    session = DummySession(execute_results=[
+        DummyResult([]),                       # no blocks
+        DummyResult([allow_rule, deny_rule]),   # rules sorted by priority
+    ])
+
+    service = _fresh_service()
+    # The allow rule (priority 10) should match first
+    assert service._evaluate_ip_uncached("10.0.0.5", "/", session) is True
+
+
+# ---------------------------------------------------------------------------
+# Path-scoped rules
+# ---------------------------------------------------------------------------
+
+
+def test_path_pattern_match(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="deny", path_pattern="^/api/")
+    session = DummySession(execute_results=[
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # one deny rule with path pattern
+    ])
+
+    service = _fresh_service()
+    assert service._evaluate_ip_uncached("10.0.0.5", "/api/tools", session) is False
+
+
+def test_path_pattern_no_match_skips_rule(monkeypatch):
+    """A rule with a non-matching path pattern is skipped."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="deny", path_pattern="^/api/")
+    session = DummySession(execute_results=[
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # one deny rule with path pattern
+    ])
+
+    service = _fresh_service()
+    # Path /health doesn't match ^/api/ so rule is skipped -> default allow for blocklist
+    assert service._evaluate_ip_uncached("10.0.0.5", "/health", session) is True
+
+
+# ---------------------------------------------------------------------------
+# Temporary blocks
+# ---------------------------------------------------------------------------
+
+
+def test_temp_block_overrides_allow_rules(monkeypatch):
+    """Temporary blocks take precedence over allow rules."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "allowlist")
+
+    block = _make_block(ip_address="10.0.0.5")
+    allow_rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="allow")
+    session = DummySession(execute_results=[
+        DummyResult([block]),       # active block
+        DummyResult([allow_rule]),  # allow rule
+    ])
+
+    service = _fresh_service()
+    # Block should override the allow rule
+    assert service._evaluate_ip_uncached("10.0.0.5", "/", session) is False
+
+
+# ---------------------------------------------------------------------------
+# Cache tests
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    service = _fresh_service()
+    # Manually set a cache entry
+    key = service._cache_key("1.2.3.4", "/")
+    service._cache[key] = (True, time.monotonic() + 300)
+
+    # Should use cache (no DB call needed)
+    assert service.evaluate_ip("1.2.3.4", "/") is True
+
+
+def test_cache_invalidation(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    service = _fresh_service()
+    key = service._cache_key("1.2.3.4", "/")
+    service._cache[key] = (True, time.monotonic() + 300)
+
+    service.invalidate_cache()
+    assert len(service._cache) == 0
+
+
+def test_cache_ttl_expiry(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    service = _fresh_service()
+    key = service._cache_key("1.2.3.4", "/")
+    # Set expired entry
+    service._cache[key] = (True, time.monotonic() - 1)
+
+    assert service._cache_get(key) is None
+
+
+def test_cache_set_eviction(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 4)
+
+    service = _fresh_service()
+    # Fill cache to capacity
+    for i in range(4):
+        service._cache_set(f"key{i}", True)
+    assert len(service._cache) == 4
+
+    # Adding one more should trigger eviction
+    service._cache_set("key_new", False)
+    assert len(service._cache) <= 4
+
+
+def test_get_cache_stats(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    service = _fresh_service()
+    service._cache_set("k1", True)
+    stats = service.get_cache_stats()
+    assert stats["total_entries"] == 1
+    assert stats["live_entries"] == 1
+    assert stats["max_size"] == 100
+
+
+# ---------------------------------------------------------------------------
+# CRUD cache invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_create_rule_invalidates_cache(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_default_priority", 100)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+
+    service = _fresh_service()
+    service._cache_set("some_key", True)
+    assert len(service._cache) == 1
+
+    session = MagicMock()
+
+    # Mock IPRule constructor to return a mock
+    mock_rule = MagicMock()
+    mock_rule.id = "test-id"
+    mock_rule.rule_type = "deny"
+    mock_rule.ip_pattern = "10.0.0.0/8"
+    monkeypatch.setattr(svc, "IPRule", lambda **kwargs: mock_rule)
+
+    service.create_rule(
+        data={"ip_pattern": "10.0.0.0/8", "rule_type": "deny"},
+        user_email="admin@test.com",
+        db=session,
+    )
+
+    # Cache should be cleared
+    assert len(service._cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# test_ip diagnostic
+# ---------------------------------------------------------------------------
+
+
+def test_test_ip_disabled(monkeypatch):
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", False)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "disabled")
+
+    service = _fresh_service()
+    result = service.test_ip("1.2.3.4", "/", MagicMock())
+    assert result["allowed"] is True
+    assert result["mode"] == "disabled"

--- a/tests/unit/mcpgateway/services/test_ip_control_service.py
+++ b/tests/unit/mcpgateway/services/test_ip_control_service.py
@@ -473,3 +473,560 @@ def test_test_ip_disabled(monkeypatch):
     result = service.test_ip("1.2.3.4", "/", MagicMock())
     assert result["allowed"] is True
     assert result["mode"] == "disabled"
+
+
+def test_test_ip_enabled_block_match(monkeypatch):
+    """test_ip returns blocked when temp block matches."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    block = _make_block(block_id="b99", ip_address="10.0.0.1")
+    session = DummySession(execute_results=[
+        DummyResult([block]),  # block found
+    ])
+
+    service = _fresh_service()
+    result = service.test_ip("10.0.0.1", "/api/tools", session)
+    assert result["allowed"] is False
+    assert result["blocked_by_temp_block"] is True
+    assert result["matched_rule_id"] == "b99"
+    assert result["matched_rule_type"] == "block"
+
+
+def test_test_ip_enabled_rule_match(monkeypatch):
+    """test_ip returns matched rule details when a rule matches."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    rule = _make_rule(rule_id="r10", ip_pattern="10.0.0.0/8", rule_type="deny")
+    session = DummySession(execute_results=[
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # deny rule
+    ])
+
+    service = _fresh_service()
+    result = service.test_ip("10.0.0.5", "/", session)
+    assert result["allowed"] is False
+    assert result["matched_rule_id"] == "r10"
+    assert result["matched_rule_type"] == "deny"
+    assert result["blocked_by_temp_block"] is False
+
+
+def test_test_ip_enabled_allow_rule_match(monkeypatch):
+    """test_ip returns allowed when allow rule matches."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "allowlist")
+
+    rule = _make_rule(rule_id="r11", ip_pattern="10.0.0.0/8", rule_type="allow")
+    session = DummySession(execute_results=[
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # allow rule
+    ])
+
+    service = _fresh_service()
+    result = service.test_ip("10.0.0.5", "/", session)
+    assert result["allowed"] is True
+    assert result["matched_rule_id"] == "r11"
+    assert result["matched_rule_type"] == "allow"
+
+
+def test_test_ip_enabled_no_match_allowlist(monkeypatch):
+    """test_ip defaults to deny in allowlist mode with no matches."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "allowlist")
+
+    session = DummySession(execute_results=[
+        DummyResult([]),  # no blocks
+        DummyResult([]),  # no rules
+    ])
+
+    service = _fresh_service()
+    result = service.test_ip("9.9.9.9", "/", session)
+    assert result["allowed"] is False
+    assert result["matched_rule_id"] is None
+    assert result["mode"] == "allowlist"
+
+
+def test_test_ip_enabled_no_match_blocklist(monkeypatch):
+    """test_ip defaults to allow in blocklist mode with no matches."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    session = DummySession(execute_results=[
+        DummyResult([]),  # no blocks
+        DummyResult([]),  # no rules
+    ])
+
+    service = _fresh_service()
+    result = service.test_ip("9.9.9.9", "/", session)
+    assert result["allowed"] is True
+    assert result["matched_rule_id"] is None
+    assert result["mode"] == "blocklist"
+
+
+# ---------------------------------------------------------------------------
+# get_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_status(monkeypatch):
+    """get_status returns counts and settings."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_log_only", False)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+    monkeypatch.setattr(svc.settings, "ip_control_skip_paths", ["/health"])
+
+    session = DummySession(execute_results=[
+        DummyScalar(5),   # total_rules
+        DummyScalar(3),   # active_rules
+        DummyScalar(2),   # total_blocks
+        DummyScalar(1),   # active_blocks
+    ])
+
+    service = _fresh_service()
+    result = service.get_status(session)
+    assert result["enabled"] is True
+    assert result["mode"] == "blocklist"
+    assert result["total_rules"] == 5
+    assert result["active_rules"] == 3
+    assert result["total_blocks"] == 2
+    assert result["active_blocks"] == 1
+    assert result["cache_ttl"] == 300
+    assert result["skip_paths"] == ["/health"]
+
+
+# ---------------------------------------------------------------------------
+# evaluate_ip: SessionLocal creation and error paths
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_ip_creates_session_when_none(monkeypatch):
+    """evaluate_ip creates a SessionLocal when no db is passed."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    mock_db = DummySession(execute_results=[
+        DummyResult([]),  # no blocks
+        DummyResult([]),  # no rules
+    ])
+    monkeypatch.setattr(svc, "SessionLocal", lambda: mock_db)
+
+    service = _fresh_service()
+    result = service.evaluate_ip("9.9.9.9", "/")
+    assert result is True
+
+
+def test_evaluate_ip_exception_fails_open(monkeypatch):
+    """evaluate_ip returns True (fail open) on exception."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    mock_db = MagicMock()
+    mock_db.execute.side_effect = RuntimeError("DB error")
+
+    service = _fresh_service()
+    result = service.evaluate_ip("9.9.9.9", "/", db=mock_db)
+    assert result is True
+
+
+def test_evaluate_ip_closes_created_session(monkeypatch):
+    """evaluate_ip closes the session it creates, even on error."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    mock_db = MagicMock()
+    mock_db.execute.side_effect = RuntimeError("DB error")
+    monkeypatch.setattr(svc, "SessionLocal", lambda: mock_db)
+
+    service = _fresh_service()
+    service.evaluate_ip("9.9.9.9", "/")
+    mock_db.close.assert_called_once()
+
+
+def test_evaluate_ip_does_not_close_provided_session(monkeypatch):
+    """evaluate_ip does NOT close a session that was passed in."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    session = DummySession(execute_results=[
+        DummyResult([]),  # no blocks
+        DummyResult([]),  # no rules
+    ])
+    # Track close calls
+    close_called = []
+    original_close = session.close
+    session.close = lambda: close_called.append(True)
+
+    service = _fresh_service()
+    service.evaluate_ip("9.9.9.9", "/", db=session)
+    assert len(close_called) == 0
+
+
+# ---------------------------------------------------------------------------
+# Hit count rollback path
+# ---------------------------------------------------------------------------
+
+
+def test_hit_count_update_rollback_on_commit_error(monkeypatch):
+    """When hit count commit fails, rollback is attempted."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="deny", hit_count=5)
+    session = MagicMock()
+    session.execute.side_effect = [
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # deny rule
+    ]
+    session.commit.side_effect = RuntimeError("commit failed")
+
+    service = _fresh_service()
+    result = service._evaluate_ip_uncached("10.0.0.5", "/", session)
+    assert result is False
+    session.rollback.assert_called_once()
+
+
+def test_hit_count_update_rollback_also_fails(monkeypatch):
+    """When both commit and rollback fail, it should not raise."""
+    monkeypatch.setattr(svc.settings, "ip_control_enabled", True)
+    monkeypatch.setattr(svc.settings, "ip_control_mode", "blocklist")
+
+    rule = _make_rule(ip_pattern="10.0.0.0/8", rule_type="deny", hit_count=5)
+    session = MagicMock()
+    session.execute.side_effect = [
+        DummyResult([]),       # no blocks
+        DummyResult([rule]),   # deny rule
+    ]
+    session.commit.side_effect = RuntimeError("commit failed")
+    session.rollback.side_effect = RuntimeError("rollback also failed")
+
+    service = _fresh_service()
+    result = service._evaluate_ip_uncached("10.0.0.5", "/", session)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# CRUD: update_rule
+# ---------------------------------------------------------------------------
+
+
+def test_update_rule_success(monkeypatch):
+    """update_rule updates fields and invalidates cache."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    rule = _make_rule(rule_id="r1", ip_pattern="10.0.0.0/8", rule_type="deny", priority=100)
+    rule.updated_by = "admin@test.com"
+    session = MagicMock()
+    session.execute.return_value = DummyResult([rule])
+
+    service = _fresh_service()
+    service._cache_set("stale", True)
+
+    result = service.update_rule("r1", {"priority": 50}, "admin@test.com", session)
+    assert result is not None
+    assert rule.priority == 50
+    assert rule.updated_by == "admin@test.com"
+    assert len(service._cache) == 0  # cache cleared
+    session.commit.assert_called()
+    session.refresh.assert_called_with(rule)
+
+
+def test_update_rule_not_found(monkeypatch):
+    """update_rule returns None when rule is not found."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+
+    session = MagicMock()
+    session.execute.return_value = DummyResult([])
+
+    service = _fresh_service()
+    result = service.update_rule("missing", {"priority": 50}, "admin@test.com", session)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# CRUD: delete_rule
+# ---------------------------------------------------------------------------
+
+
+def test_delete_rule_success(monkeypatch):
+    """delete_rule deletes and invalidates cache."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    rule = _make_rule(rule_id="r1")
+    session = MagicMock()
+    session.execute.return_value = DummyResult([rule])
+
+    service = _fresh_service()
+    service._cache_set("stale", True)
+
+    result = service.delete_rule("r1", "admin@test.com", session)
+    assert result is True
+    session.delete.assert_called_with(rule)
+    session.commit.assert_called()
+    assert len(service._cache) == 0
+
+
+def test_delete_rule_not_found(monkeypatch):
+    """delete_rule returns False when rule is not found."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+
+    session = MagicMock()
+    session.execute.return_value = DummyResult([])
+
+    service = _fresh_service()
+    result = service.delete_rule("missing", "admin@test.com", session)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# CRUD: get_rule
+# ---------------------------------------------------------------------------
+
+
+def test_get_rule_found():
+    """get_rule returns the rule when found."""
+    rule = _make_rule(rule_id="r1")
+    session = MagicMock()
+    session.execute.return_value = DummyResult([rule])
+
+    service = _fresh_service()
+    result = service.get_rule("r1", session)
+    assert result is rule
+
+
+def test_get_rule_not_found():
+    """get_rule returns None when rule is not found."""
+    session = MagicMock()
+    session.execute.return_value = DummyResult([])
+
+    service = _fresh_service()
+    result = service.get_rule("missing", session)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# CRUD: list_rules
+# ---------------------------------------------------------------------------
+
+
+def test_list_rules_no_filters():
+    """list_rules returns all rules with count."""
+    rules = [_make_rule("r1"), _make_rule("r2")]
+    session = MagicMock()
+    session.execute.side_effect = [
+        DummyScalar(2),       # count
+        DummyResult(rules),   # rules
+    ]
+
+    service = _fresh_service()
+    result_rules, total = service.list_rules(session, limit=50, offset=0)
+    assert total == 2
+    assert len(result_rules) == 2
+
+
+def test_list_rules_with_active_filter():
+    """list_rules filters by is_active."""
+    rules = [_make_rule("r1")]
+    session = MagicMock()
+    session.execute.side_effect = [
+        DummyScalar(1),       # count
+        DummyResult(rules),   # rules
+    ]
+
+    service = _fresh_service()
+    result_rules, total = service.list_rules(session, is_active=True)
+    assert total == 1
+
+
+def test_list_rules_with_type_filter():
+    """list_rules filters by rule_type."""
+    rules = [_make_rule("r1", rule_type="deny")]
+    session = MagicMock()
+    session.execute.side_effect = [
+        DummyScalar(1),
+        DummyResult(rules),
+    ]
+
+    service = _fresh_service()
+    result_rules, total = service.list_rules(session, rule_type="deny")
+    assert total == 1
+    assert result_rules[0].rule_type == "deny"
+
+
+# ---------------------------------------------------------------------------
+# CRUD: create_block
+# ---------------------------------------------------------------------------
+
+
+def test_create_block(monkeypatch):
+    """create_block creates a block and invalidates cache."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    session = MagicMock()
+    mock_block = MagicMock()
+    mock_block.id = "block-id"
+    mock_block.ip_address = "1.2.3.4"
+    monkeypatch.setattr(svc, "IPBlock", lambda **kwargs: mock_block)
+
+    service = _fresh_service()
+    service._cache_set("stale", True)
+
+    result = service.create_block(
+        data={"ip_address": "1.2.3.4", "reason": "test", "duration_minutes": 60},
+        user_email="admin@test.com",
+        db=session,
+    )
+    assert result is mock_block
+    session.add.assert_called_with(mock_block)
+    session.commit.assert_called()
+    assert len(service._cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# CRUD: remove_block
+# ---------------------------------------------------------------------------
+
+
+def test_remove_block_success(monkeypatch):
+    """remove_block deactivates the block."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    block = _make_block(block_id="b1")
+    session = MagicMock()
+    session.execute.return_value = DummyResult([block])
+
+    service = _fresh_service()
+    service._cache_set("stale", True)
+
+    result = service.remove_block("b1", "admin@test.com", session)
+    assert result is True
+    assert block.is_active is False
+    assert block.unblocked_by == "admin@test.com"
+    assert len(service._cache) == 0
+
+
+def test_remove_block_not_found(monkeypatch):
+    """remove_block returns False when block is not found."""
+    monkeypatch.setattr(svc.settings, "audit_trail_enabled", False)
+
+    session = MagicMock()
+    session.execute.return_value = DummyResult([])
+
+    service = _fresh_service()
+    result = service.remove_block("missing", "admin@test.com", session)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# CRUD: list_blocks
+# ---------------------------------------------------------------------------
+
+
+def test_list_blocks_active_only():
+    """list_blocks with active_only=True filters."""
+    blocks = [_make_block("b1")]
+    session = MagicMock()
+    session.execute.return_value = DummyResult(blocks)
+
+    service = _fresh_service()
+    result = service.list_blocks(session, active_only=True)
+    assert len(result) == 1
+
+
+def test_list_blocks_all():
+    """list_blocks with active_only=False returns all."""
+    blocks = [_make_block("b1"), _make_block("b2")]
+    session = MagicMock()
+    session.execute.return_value = DummyResult(blocks)
+
+    service = _fresh_service()
+    result = service.list_blocks(session, active_only=False)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# cleanup_expired_blocks
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_expired_blocks_with_expired(monkeypatch):
+    """cleanup deactivates expired blocks and invalidates cache."""
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 300)
+    monkeypatch.setattr(svc.settings, "ip_control_cache_size", 100)
+
+    block1 = _make_block("b1")
+    block2 = _make_block("b2")
+    session = MagicMock()
+    session.execute.return_value = DummyResult([block1, block2])
+
+    service = _fresh_service()
+    service._cache_set("stale", True)
+
+    count = service.cleanup_expired_blocks(session)
+    assert count == 2
+    assert block1.is_active is False
+    assert block2.is_active is False
+    session.commit.assert_called_once()
+    assert len(service._cache) == 0
+
+
+def test_cleanup_expired_blocks_none_expired():
+    """cleanup returns 0 when no expired blocks exist."""
+    session = MagicMock()
+    session.execute.return_value = DummyResult([])
+
+    service = _fresh_service()
+    count = service.cleanup_expired_blocks(session)
+    assert count == 0
+    session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_ip_control_service singleton accessor
+# ---------------------------------------------------------------------------
+
+
+def test_get_ip_control_service_creates_instance(monkeypatch):
+    """get_ip_control_service creates and caches a singleton."""
+    monkeypatch.setattr(svc, "_ip_control_service", None)
+    # Reset the class-level singleton so __new__ creates fresh
+    original = svc.IPControlService._instance
+    svc.IPControlService._instance = None
+    try:
+        result = svc.get_ip_control_service()
+        assert result is not None
+        assert isinstance(result, svc.IPControlService)
+        # Second call returns same instance
+        result2 = svc.get_ip_control_service()
+        assert result2 is result
+    finally:
+        svc.IPControlService._instance = original
+        svc._ip_control_service = None
+
+
+# ---------------------------------------------------------------------------
+# _cache_set with TTL <= 0 skips caching
+# ---------------------------------------------------------------------------
+
+
+def test_cache_set_zero_ttl_skips(monkeypatch):
+    """_cache_set with TTL=0 does not store anything."""
+    monkeypatch.setattr(svc.settings, "ip_control_cache_ttl", 0)
+
+    service = _fresh_service()
+    service._cache_set("key1", True)
+    assert len(service._cache) == 0


### PR DESCRIPTION
## Related Issue
Closes #536

---

## Summary
Implements a generic IP-based access control system with:
- **Allowlist/blocklist modes** with configurable default behavior
- **CIDR notation support** for IPv4 and IPv6 address matching
- **Path-scoped rules** using regex patterns for granular control
- **Priority-based evaluation** where first matching rule wins
- **Temporary IP blocks** with automatic expiration and cleanup
- **In-memory caching** with configurable TTL and size-based eviction
- **Admin REST API** for managing rules, blocks, testing IPs, and viewing status
- **Middleware integration** with proxy header trust, log-only (dry-run) mode, and skip paths
- **8 configuration settings** via environment variables (disabled by default)

### Files added
- `mcpgateway/middleware/ip_control.py` - Request middleware with IP extraction and enforcement
- `mcpgateway/services/ip_control_service.py` - Core service with evaluation, caching, and CRUD
- `mcpgateway/routers/ip_control_router.py` - Admin API endpoints (rules, blocks, test, status, cache)
- `mcpgateway/alembic/versions/z9j0k1l2m3n4_add_ip_access_control_tables.py` - Migration
- Test files for all three layers (88 tests, 99% coverage)

### Files modified
- `mcpgateway/config.py` - Added 8 `ip_control_*` settings
- `mcpgateway/db.py` - Added `IPRule` and `IPBlock` ORM models
- `mcpgateway/schemas.py` - Added 9 Pydantic schemas
- `mcpgateway/main.py` - Conditional middleware and router registration
- `.env.example` - Added `IP_CONTROL_*` environment variables

---

## Type of Change
- [x] Feature / Enhancement

---

## Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | Pass   |
| Unit tests                | `make test`     | Pass   |
| Coverage >= 80%           | `make coverage` | 99%    |

---

## Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] No secrets or credentials committed