### PR TITLE
[FIX][API]: Replace bare excepts with except Exception across codebase

### DIFF
--- a/mcp-servers/python/python_sandbox_server/src/python_sandbox_server/server_fastmcp.py
+++ b/mcp-servers/python/python_sandbox_server/src/python_sandbox_server/server_fastmcp.py
@@ -626,7 +626,7 @@ class PythonSandbox:
                     # Try to use repr for better display (like IPython)
                     display_str = repr(result)
                     stdout_output = stdout_output + display_str
-                except:
+                except Exception:
                     stdout_output = stdout_output + str(result)
             else:
                 # Look for result variable in assignments

--- a/tests/migration/utils/migration_runner.py
+++ b/tests/migration/utils/migration_runner.py
@@ -225,7 +225,7 @@ class MigrationTestRunner:
                 try:
                     logs = self.container_manager.get_container_logs(container_id)
                     error_details += f"\n\nContainer logs:\n{logs}"
-                except:
+                except Exception:
                     pass
 
             result = MigrationResult(
@@ -511,7 +511,7 @@ class MigrationTestRunner:
                         if "%" in cpu_str:
                             try:
                                 metrics["cpu_percent"] = float(cpu_str.replace("%", "").strip())
-                            except:
+                            except Exception:
                                 pass
                         # Parse memory usage
                         if "/" in mem_str:
@@ -524,7 +524,7 @@ class MigrationTestRunner:
                                     metrics["memory_mb"] = float(mem_used.replace("MiB", "").strip())
                                 elif "MB" in mem_used:
                                     metrics["memory_mb"] = float(mem_used.replace("MB", "").strip())
-                            except:
+                            except Exception:
                                 pass
 
         except Exception as e:

--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -992,7 +992,7 @@ class TestSecurityValidation:
         start = time.time()
         try:
             ToolCreate(name="short", url=self.VALID_URL)
-        except:
+        except Exception:
             pass
         short_time = time.time() - start
 
@@ -1000,7 +1000,7 @@ class TestSecurityValidation:
         start = time.time()
         try:
             ToolCreate(name="a" * 50, url=self.VALID_URL)
-        except:
+        except Exception:
             pass
         long_time = time.time() - start
 
@@ -2085,14 +2085,14 @@ class TestSecurityBestPractices:
             start = time.time()
             try:
                 ToolCreate(name="valid_name", url="https://example.com")
-            except:
+            except Exception:
                 pass
             valid_times.append(time.perf_counter() - start)
 
             start = time.perf_counter()
             try:
                 ToolCreate(name="<script>alert('XSS')</script>", url="https://example.com")
-            except:
+            except Exception:
                 pass
             invalid_times.append(time.perf_counter() - start)
 


### PR DESCRIPTION
Replace 9 bare `except:` with `except Exception:` across 3 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.