### PR TITLE
[FIX][UI]: Correct pagination display when DB-to-Pydantic conversion fails (#2851)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -697,16 +697,18 @@ def _get_user_team_roles(db: Session, user_email: str) -> Dict[str, str]:
     return get_user_team_roles(db, user_email)
 
 
-def _adjust_pagination_for_conversion_failures(pagination: "PaginationMeta", failed_count: int) -> None:
+def _adjust_pagination_for_conversion_failures(pagination: "PaginationMeta", failed_count: int, rendered_count: int) -> None:
     """Adjust pagination metadata to account for DB-to-Pydantic conversion failures.
 
     When items on the current page fail to convert, the "Showing X of Y" display
     would otherwise count items that aren't actually displayed. This adjusts
     total_items and recomputes derived fields (total_pages, has_next, has_prev).
+    Also sets page_items to the actual number of successfully rendered items.
 
     Args:
         pagination: The PaginationMeta object to adjust (modified in-place).
         failed_count: Number of items that failed conversion on the current page.
+        rendered_count: Number of items successfully converted and rendered on the current page.
     """
     if failed_count > 0:
         pagination.total_items = max(0, pagination.total_items - failed_count)
@@ -715,6 +717,8 @@ def _adjust_pagination_for_conversion_failures(pagination: "PaginationMeta", fai
         # so the page number must match the displayed data.
         pagination.has_next = pagination.page < pagination.total_pages
         pagination.has_prev = pagination.page > 1
+    # Always set page_items to reflect actual rendered count (even if failed_count == 0)
+    pagination.page_items = rendered_count
 
 
 def _get_span_entity_performance(
@@ -2386,7 +2390,7 @@ async def admin_servers_partial_html(
         except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
             failed_count += 1
             LOGGER.exception(f"Failed to convert server {getattr(s, 'id', 'unknown')} ({getattr(s, 'name', 'unknown')}): {e}")
-    _adjust_pagination_for_conversion_failures(pagination, failed_count)
+    _adjust_pagination_for_conversion_failures(pagination, failed_count, len(servers_pydantic))
     data = jsonable_encoder(servers_pydantic)
 
     # End the read-only transaction before template rendering to avoid idle-in-transaction timeouts.
@@ -8032,7 +8036,7 @@ async def admin_tools_partial_html(
         except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
             failed_count += 1
             LOGGER.exception(f"Failed to convert tool {getattr(t, 'id', 'unknown')} ({getattr(t, 'name', 'unknown')}): {e}")
-    _adjust_pagination_for_conversion_failures(pagination, failed_count)
+    _adjust_pagination_for_conversion_failures(pagination, failed_count, len(tools_pydantic))
 
     # Serialize tools
     data = jsonable_encoder(tools_pydantic)
@@ -8606,7 +8610,7 @@ async def admin_prompts_partial_html(
         except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
             failed_count += 1
             LOGGER.exception(f"Failed to convert prompt {getattr(p, 'id', 'unknown')} ({getattr(p, 'name', 'unknown')}): {e}")
-    _adjust_pagination_for_conversion_failures(pagination, failed_count)
+    _adjust_pagination_for_conversion_failures(pagination, failed_count, len(prompts_pydantic))
 
     data = jsonable_encoder(prompts_pydantic)
 
@@ -8811,7 +8815,7 @@ async def admin_gateways_partial_html(
         except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
             failed_count += 1
             LOGGER.exception(f"Failed to convert gateway {getattr(g, 'id', 'unknown')} ({getattr(g, 'name', 'unknown')}): {e}")
-    _adjust_pagination_for_conversion_failures(pagination, failed_count)
+    _adjust_pagination_for_conversion_failures(pagination, failed_count, len(gateways_pydantic))
     data = jsonable_encoder(gateways_pydantic)
 
     # End the read-only transaction before template rendering to avoid idle-in-transaction timeouts.
@@ -9391,7 +9395,7 @@ async def admin_resources_partial_html(
         except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
             failed_count += 1
             LOGGER.exception(f"Failed to convert resource {getattr(r, 'id', 'unknown')} ({getattr(r, 'name', 'unknown')}): {e}")
-    _adjust_pagination_for_conversion_failures(pagination, failed_count)
+    _adjust_pagination_for_conversion_failures(pagination, failed_count, len(resources_pydantic))
 
     data = jsonable_encoder(resources_pydantic)
 
@@ -10273,7 +10277,7 @@ async def admin_a2a_partial_html(
         except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
             failed_count += 1
             LOGGER.exception(f"Failed to convert a2a agent {getattr(a, 'id', 'unknown')} ({getattr(a, 'name', 'unknown')}): {e}")
-    _adjust_pagination_for_conversion_failures(pagination, failed_count)
+    _adjust_pagination_for_conversion_failures(pagination, failed_count, len(a2a_agents_pydantic))
     data = jsonable_encoder(a2a_agents_pydantic)
 
     # End the read-only transaction before template rendering to avoid idle-in-transaction timeouts.

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7292,6 +7292,7 @@ class PaginationMeta(BaseModel):
     total_pages: int = Field(..., description="Total number of pages", ge=0)
     has_next: bool = Field(..., description="Whether there is a next page")
     has_prev: bool = Field(..., description="Whether there is a previous page")
+    page_items: Optional[int] = Field(None, description="Actual number of items on current page (after conversion failures)", ge=0)
     next_cursor: Optional[str] = Field(None, description="Cursor for next page (cursor-based only)")
     prev_cursor: Optional[str] = Field(None, description="Cursor for previous page (cursor-based only)")
 

--- a/mcpgateway/templates/pagination_controls.html
+++ b/mcpgateway/templates/pagination_controls.html
@@ -21,6 +21,7 @@
   totalPages: {{ pagination.total_pages }},
   hasNext: {{ 'true' if pagination.has_next else 'false' }},
   hasPrev: {{ 'true' if pagination.has_prev else 'false' }},
+  pageItems: {{ pagination.page_items if pagination.page_items is not none else 'null' }},
   targetSelector: '{{ hx_target|default('#tools-table') }}',
   swapStyle: '{{ hx_swap|default('innerHTML') }}',
   tableName: '{{ table_name|default('') }}',
@@ -185,7 +186,7 @@
   <!-- Page Info -->
   <div class="text-sm text-gray-700 dark:text-gray-300">
     <span
-      x-text="totalItems === 0 ? 'No items found' : `Showing ${Math.min((currentPage - 1) * perPage + 1, totalItems)} - ${Math.min(currentPage * perPage, totalItems)} of ${totalItems.toLocaleString()} items`"
+      x-text="totalItems === 0 ? 'No items found' : `Showing ${Math.min((currentPage - 1) * perPage + 1, totalItems)} - ${pageItems !== null ? Math.min((currentPage - 1) * perPage + pageItems, totalItems) : Math.min(currentPage * perPage, totalItems)} of ${totalItems.toLocaleString()} items`"
     ></span>
   </div>
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -17472,58 +17472,66 @@ class TestAdjustPaginationForConversionFailures:
 
     def test_decrements_total_items_by_failed_count(self):
         pagination = self._make_pagination(total_items=100)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=3)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=3, rendered_count=17)
         assert pagination.total_items == 97
         assert pagination.total_pages == 5
         assert pagination.has_next is True
         assert pagination.has_prev is False
+        assert pagination.page_items == 17
 
     def test_zero_failures_leaves_total_unchanged(self):
         pagination = self._make_pagination(total_items=50)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=0)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=0, rendered_count=20)
         assert pagination.total_items == 50
+        assert pagination.page_items == 20
 
     def test_floors_at_zero_when_failures_exceed_total(self):
         pagination = self._make_pagination(total_items=2)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=5)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=5, rendered_count=0)
         assert pagination.total_items == 0
         assert pagination.total_pages == 0
         assert pagination.has_next is False
         assert pagination.has_prev is False
+        assert pagination.page_items == 0
 
     def test_exact_match_results_in_zero(self):
         pagination = self._make_pagination(total_items=10)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=10)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=10, rendered_count=0)
         assert pagination.total_items == 0
         assert pagination.total_pages == 0
+        assert pagination.page_items == 0
 
     def test_total_items_already_zero(self):
         pagination = self._make_pagination(total_items=0)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=3)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=3, rendered_count=0)
         assert pagination.total_items == 0
+        assert pagination.page_items == 0
 
     def test_single_failure(self):
         pagination = self._make_pagination(total_items=1)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=1)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=1, rendered_count=0)
         assert pagination.total_items == 0
         assert pagination.total_pages == 0
+        assert pagination.page_items == 0
 
     def test_recomputes_has_next_on_boundary(self):
         """When failures reduce total_pages, has_next should become False."""
         pagination = self._make_pagination(total_items=21, page=1, per_page=20)
         assert pagination.has_next is True
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=2)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=2, rendered_count=18)
         assert pagination.total_items == 19
         assert pagination.total_pages == 1
         assert pagination.has_next is False
+        assert pagination.page_items == 18
 
     def test_page_not_clamped_when_total_pages_shrinks(self):
         """Page is NOT clamped because data was already fetched for this page."""
         pagination = self._make_pagination(total_items=41, page=3, per_page=20)
-        _adjust_pagination_for_conversion_failures(pagination, failed_count=2)
+        _adjust_pagination_for_conversion_failures(pagination, failed_count=2, rendered_count=18)
         assert pagination.total_items == 39
         assert pagination.total_pages == 2
         assert pagination.page == 3  # stays at queried page, not clamped
+        assert pagination.page_items == 18
         assert pagination.has_next is False
         assert pagination.has_prev is True
 


### PR DESCRIPTION
## Problem

Fixes #2851

When items fail Pydantic validation during admin list views, the pagination "Showing X - Y of Z" display was incorrect. The server correctly adjusted `total_items` (Z value) via `_adjust_pagination_for_conversion_failures()`, but the X-Y range was computed client-side using `currentPage * perPage` instead of the actual number of rendered items.

**Example:** If 2 of 20 rows fail conversion, the UI displayed "Showing 1 - 20 of 98 items" while only 18 rows were actually rendered.

## Solution

Added `page_items` field to track actual rendered item count and updated the template to use it when available.

### Changes

1. **Schema Enhancement** (`mcpgateway/schemas.py`)
   - Added optional `page_items` field to `PaginationMeta` class

2. **Helper Function Update** (`mcpgateway/admin.py`)
   - Updated `_adjust_pagination_for_conversion_failures()` to accept `rendered_count` parameter
   - Sets `pagination.page_items = rendered_count`

3. **Endpoint Updates** (`mcpgateway/admin.py`)
   - Updated 6 admin partial endpoints to pass `len(items_pydantic)`:
     - `/admin/servers/partial`
     - `/admin/tools/partial`
     - `/admin/prompts/partial`
     - `/admin/gateways/partial`
     - `/admin/resources/partial`
     - `/admin/a2a/partial`

4. **Template Update** (`mcpgateway/templates/pagination_controls.html`)
   - Added `pageItems` to Alpine.js data initialization
   - Updated display logic to use `pageItems` when available, falling back to calculated value

5. **Test Updates** (`tests/unit/mcpgateway/test_admin.py`)
   - Updated `TestAdjustPaginationForConversionFailures` class (8 test methods)
   - Added assertions for `page_items` field

## Result

**Before:** 20 items requested, 2 fail → "Showing 1 - 20 of 98 items" (18 rows displayed) ❌  
**After:** 20 items requested, 2 fail → "Showing 1 - 18 of 98 items" (18 rows displayed) ✅

## Backward Compatibility

✅ Fully backward compatible:
- `page_items` is optional (defaults to `None`)
- Template checks `pageItems !== null` before using it
- Endpoints not using conversion failure tracking continue working unchanged

## Related

- Builds on PR #2846 which introduced `_adjust_pagination_for_conversion_failures()`
- Fixes issue #2851

## Testing

All pagination-related test failures have been fixed. Remaining test failures are pre-existing issues unrelated to this change (auth/RBAC, app naming, plugin settings).