### PR TITLE
feat(security): add CSRF token validation for state-changing requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,47 @@ JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes
 # PRODUCTION: Use a strong, unique value
 AUTH_ENCRYPTION_SECRET=my-test-salt
 
+# -----------------------------------------------------------------------------
+# CSRF Protection Configuration
+# -----------------------------------------------------------------------------
+# Cross-Site Request Forgery protection for state-changing operations
+
+# Enable CSRF protection (default: true)
+CSRF_ENABLED=true
+
+# Secret key for CSRF token generation (falls back to JWT_SECRET_KEY if empty)
+CSRF_SECRET_KEY=
+
+# HTTP header name for CSRF token
+CSRF_TOKEN_NAME=X-CSRF-Token
+
+# Cookie name for CSRF token
+CSRF_COOKIE_NAME=csrf_token
+
+# CSRF token expiration time in seconds (default: 3600 = 1 hour)
+CSRF_TOKEN_EXPIRY=3600
+
+# Set Secure flag on CSRF cookie (HTTPS only, default: true)
+CSRF_COOKIE_SECURE=true
+
+# SameSite attribute for CSRF cookie (Strict, Lax, or None)
+CSRF_COOKIE_SAMESITE=Strict
+
+# Set HttpOnly flag on CSRF cookie (false allows JavaScript to read for API calls)
+CSRF_COOKIE_HTTPONLY=false
+
+# Validate Referer header for CSRF protection (default: true)
+CSRF_CHECK_REFERER=true
+
+# Rotate CSRF token on user login for enhanced security (default: true)
+CSRF_ROTATE_ON_LOGIN=true
+
+# Additional trusted origins for CSRF validation (JSON array)
+CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
+
+# Paths exempt from CSRF protection (JSON array)
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics"]
+
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values
 PLATFORM_ADMIN_EMAIL=admin@example.com
@@ -192,7 +233,7 @@ ALLOW_PUBLIC_VISIBILITY=true
 HOST=0.0.0.0
 
 # Local origin used for CORS/cookies in development examples
-APP_DOMAIN=http://localhost
+APP_DOMAIN=http://localhost:8080
 
 # Enable Admin UI and Admin API for local development
 MCPGATEWAY_UI_ENABLED=true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-09T16:19:53Z",
+  "generated_at": "2026-05-09T18:27:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 581,
+        "line_number": 622,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 776,
+        "line_number": 817,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1049,
+        "line_number": 1090,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1075,
+        "line_number": 1116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1124,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1162,
+        "line_number": 1203,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1167,
+        "line_number": 1208,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1172,
+        "line_number": 1213,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1178,
+        "line_number": 1219,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1208,
+        "line_number": 1249,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1269,
+        "line_number": 1310,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4222,7 +4222,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4207,
+        "line_number": 4209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4230,7 +4230,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4842,
+        "line_number": 4849,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4238,7 +4238,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4844,
+        "line_number": 4851,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4246,7 +4246,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15307,
+        "line_number": 15314,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4952,7 +4952,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 248,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4960,7 +4960,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2759,
+        "line_number": 2775,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5032,7 +5032,7 @@
         "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 202,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5042,7 +5042,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5050,7 +5050,7 @@
         "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 402,
+        "line_number": 428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5058,7 +5058,7 @@
         "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 684,
+        "line_number": 710,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5068,7 +5068,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 708,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8736,7 +8736,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1112,
+        "line_number": 1114,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-09T18:27:54Z",
+  "generated_at": "2026-05-09T19:35:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -7018,7 +7018,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7028,7 +7028,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7036,7 +7036,7 @@
         "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 522,
+        "line_number": 566,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7044,7 +7044,7 @@
         "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 657,
+        "line_number": 701,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7052,7 +7052,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1421,
+        "line_number": 1465,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7060,7 +7060,7 @@
         "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1490,
+        "line_number": 1534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7068,7 +7068,7 @@
         "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1594,
+        "line_number": 1638,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7076,7 +7076,7 @@
         "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1625,
+        "line_number": 1669,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7084,7 +7084,7 @@
         "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1642,
+        "line_number": 1686,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7092,7 +7092,7 @@
         "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1676,
+        "line_number": 1720,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7100,7 +7100,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2135,
+        "line_number": 2179,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7138,7 +7138,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 275,
+        "line_number": 373,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9118,7 +9118,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2523,
+        "line_number": 2565,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9126,7 +9126,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2811,
+        "line_number": 2853,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1436,10 +1436,11 @@ def _admin_cookie_path(request: Request) -> str:
         request: Incoming request used to read ASGI ``root_path``.
 
     Returns:
-        Admin cookie path scoped under the deployed app root.
+        Cookie path scoped to the deployed app root so admin-originated
+        non-/admin mutations can carry the same double-submit token.
     """
     root_path = _resolve_root_path(request)
-    return f"{root_path}/admin" if root_path else "/admin"
+    return root_path or "/"
 
 
 def _normalize_origin_parts(scheme: str, netloc: str) -> tuple[str, str, int]:
@@ -3967,6 +3968,7 @@ async def admin_ui(
             "user_teams": user_teams,
             "mcpgateway_ui_tool_test_timeout": settings.mcpgateway_ui_tool_test_timeout,
             "allow_public_visibility": settings.allow_public_visibility,
+            "auth_header_name": settings.auth_header_name,
             "selected_team_id": selected_team_id,
             "admin_viewing_non_member_team": admin_viewing_non_member_team,
             "ui_airgapped": settings.mcpgateway_ui_airgapped,
@@ -4716,6 +4718,11 @@ async def _admin_logout(request: Request) -> Response:
 
     # Always clear local JWT session cookie.
     clear_auth_cookie(response)
+
+    # Clear CSRF token cookie
+    from mcpgateway.services.csrf_service import clear_csrf_cookie
+    clear_csrf_cookie(response, settings)
+
     use_secure = (settings.environment == "production") or settings.secure_cookies
     response.delete_cookie(
         key="sso_id_token_hint",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -167,15 +167,14 @@ class SecurityConfigurationError(Exception):
 
 
 def calculate_entropy(text: str) -> float:
+    """Calculate Shannon entropy to detect low-randomness secrets.
+
+    Args:
+        text (str): The secret string to evaluate.
+
+    Returns:
+        float: The calculated entropy score.
     """
-        Calculate Shannon entropy to detect low-randomness secrets.
-
-        Args:
-            text (str): The secret string to evaluate.
-
-        Returns:
-            float: The calculated entropy score.
-        """
     if not text:
         return 0.0
     probabilities = [text.count(c) / len(text) for c in set(text)]
@@ -420,6 +419,41 @@ class Settings(BaseSettings):
     )
     embed_environment_in_tokens: bool = Field(default=False, description="Embed environment claim in gateway-issued JWTs for environment isolation")
     validate_token_environment: bool = Field(default=False, description="Reject tokens with mismatched environment claim (tokens without env claim are allowed)")
+
+    # CSRF Protection Configuration
+    csrf_enabled: bool = Field(default=True, description="Enable CSRF protection for state-changing operations")
+    csrf_secret_key: str = Field(default="", description="Secret key for CSRF token generation (falls back to jwt_secret_key if empty)")
+    csrf_token_name: str = Field(default="X-CSRF-Token", description="HTTP header name for CSRF token")
+    csrf_cookie_name: str = Field(default="mcpgateway_csrf_token", description="Cookie name for CSRF token")
+    csrf_token_expiry: int = Field(default=3600, description="CSRF token expiration time in seconds")
+    csrf_cookie_secure: bool = Field(default=True, description="Set Secure flag on CSRF cookie (HTTPS only)")
+    csrf_cookie_samesite: str = Field(default="Strict", description="SameSite attribute for CSRF cookie (Strict, Lax, or None)")
+    csrf_cookie_httponly: bool = Field(default=False, description="Set HttpOnly flag on CSRF cookie (False allows JavaScript to read for API calls)")
+    csrf_check_referer: bool = Field(default=True, description="Validate Referer header for CSRF protection")
+    csrf_rotate_on_login: bool = Field(default=True, description="Rotate CSRF token on user login for enhanced security")
+    csrf_trusted_origins: List[str] = Field(default_factory=list, description="Additional trusted origins for CSRF validation")
+    csrf_exempt_paths: List[str] = Field(
+        default_factory=lambda: [
+            "/health",
+            "/auth/login",
+            "/auth/logout",
+            "/auth/refresh",
+            "/auth/email/login",
+            "/auth/email/register",
+            "/auth/email/forgot-password",
+            "/auth/email/reset-password",
+            "/admin",  # Exempt: all admin routes use per-route enforce_admin_csrf dependency
+            "/admin/login",
+            "/admin/forgot-password",
+            "/admin/reset-password",
+            "/oauth/fetch-tools",  # Exempt: OAuth callback uses enforce_fetch_tools_csrf with origin+double-submit
+            "/docs",
+            "/redoc",
+            "/openapi.json",
+            "/metrics",
+        ],
+        description="Paths exempt from CSRF protection",
+    )
 
     # JSON Schema Validation for registration (Tool Input Schemas, Prompt schemas, etc)
     json_schema_validation_strict: bool = Field(default=True, description="Strict schema validation mode - reject invalid JSON schemas")
@@ -1269,6 +1303,10 @@ class Settings(BaseSettings):
             if self.debug and not self.dev_mode:
                 logger.warning("🐛 SECURITY WARNING: Debug mode is enabled in non-dev mode. This may leak sensitive information! Set DEBUG=false for production.")
 
+        # CSRF secret key fallback to JWT secret key
+        if not self.csrf_secret_key:
+            self.csrf_secret_key = self.jwt_secret_key.get_secret_value()
+
         return self
 
     def get_security_warnings(self) -> List[str]:
@@ -1332,7 +1370,7 @@ class Settings(BaseSettings):
         security_score: int
 
     def get_security_status(self) -> SecurityStatus:
-        """Get comprehensive security status and enforces fail-closed logic in production.
+        """Get comprehensive security status and enforce fail-closed logic in production.
 
         Returns:
             SecurityStatus: Dictionary containing security status information including score and warnings.
@@ -1357,11 +1395,10 @@ class Settings(BaseSettings):
         is_prod = self.environment == "production"
         remediation_cmd = "Run 'python3 -m mcpgateway.scripts.init_secrets' to generate secure keys."
 
-        # Evaluate specific critical secrets
         critical_secrets = {
             "JWT_SECRET_KEY": self.jwt_secret_key.get_secret_value(),
             "AUTH_ENCRYPTION_SECRET": self.auth_encryption_secret.get_secret_value(),
-            "BASIC_AUTH_PASSWORD": self.basic_auth_password.get_secret_value()
+            "BASIC_AUTH_PASSWORD": self.basic_auth_password.get_secret_value(),
         }
 
         for name, value in critical_secrets.items():
@@ -1369,14 +1406,13 @@ class Settings(BaseSettings):
                 continue
             is_sentinel = value in self.SENTINEL_VALUES
             is_weak = value.lower() in self.WEAK_VALUES or calculate_entropy(value) < 3.5
-            # Check for empty or "UNCONFIGURED" values
+
             if is_sentinel:
                 error_msg = f"{name} is not configured. Running with default or empty values in production is prohibited as it leaves the gateway unprotected."
                 if is_prod:
                     return self._build_security_response("FAIL", "ERR_MISSING_CONFIG", error_msg, remediation_cmd)
                 logger.warning(f"DEV WARNING: {error_msg} {remediation_cmd}")
 
-            # Check for known weak values
             if self.require_strong_secrets and is_weak:
                 error_msg = f"Weak {name} detected. Using default values in production exposes the gateway to unauthorized access."
                 return self._build_security_response("FAIL", "ERR_WEAK_SECRET", error_msg, remediation_cmd)
@@ -1400,36 +1436,16 @@ class Settings(BaseSettings):
         }
 
     def log_critical_issues(self, status: SecurityStatus) -> None:
-        """
-        Logs critical security issues and provides remediation steps.
 
-        Args:
-            status (SecurityStatus): The security status dictionary to log.
-        """
+        """Log critical security issues and remediation steps."""
         if status["status"] == "FAIL":
-            # [Requirement]: Explain specific risk
             logger.critical(f"[SECURITY FATAL] {status['message']}")
-
-            # [Requirement]: Include generation command
             if status["remediation"]:
                 logger.info(f"REMEDIATION: {status['remediation']}")
-
-            # [Requirement]: Reference documentation
             logger.info("REFERENCE: For full security configuration guide, see: https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/operations/config-validation.md")
 
     def _build_security_response(self, status: str, code: str, msg: str, remediation: str) -> SecurityStatus:
-        """
-        Helper to build a failure response for get_security_status.
-
-        Args:
-            status (str): The overall security status (e.g., "FAIL").
-            code (str): The specific error code.
-            msg (str): The error description.
-            remediation (str): The suggested fix for the user.
-
-        Returns:
-            SecurityStatus: A dictionary containing the structured security response.
-        """
+        """Build a failure response for get_security_status."""
         logger.error(f"[{code}] CRITICAL SECURITY ISSUE: {msg}")
         return {
             "status": status,
@@ -3235,11 +3251,10 @@ def get_settings(**kwargs: Any) -> Settings:
     cfg.validate_transport()
     # Ensure sqlite DB directories exist if needed.
     cfg.validate_database()
-    # Get the status (SUCCESS/FAIL) based on sentinel and weak values
-    security_status = cfg.get_security_status()
 
+    # Get the status (SUCCESS/FAIL) based on sentinel and weak values.
+    security_status = cfg.get_security_status()
     if security_status["status"] == "FAIL":
-        # Log the critical issues (remediation, risk, documentation)
         cfg.log_critical_issues(security_status)
         raise SecurityConfigurationError(security_status["message"])
     # Return the one-and-only Settings instance (cached).

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1846,7 +1846,7 @@ def validate_security_configuration():
     logger.info("🔒 Validating security configuration...")
     try:
         current_settings = get_settings()
-        # Get security status
+
         security_status: settings.SecurityStatus = current_settings.get_security_status()
         security_warnings = security_status["warnings"]
 
@@ -1854,14 +1854,15 @@ def validate_security_configuration():
 
         # Warn about ephemeral storage without strict user-in-DB mode
         if not getattr(current_settings, "require_user_in_db", False):
-            database_url = getattr(current_settings, "database_url", settings.database_url)
-            is_ephemeral = ":memory:" in database_url or database_url == "sqlite:///./mcp.db"
+
+            is_ephemeral = ":memory:" in current_settings.database_url or current_settings.database_url == "sqlite:///./mcp.db"
             if is_ephemeral:
                 logger.warning("Using potentially ephemeral storage with platform admin bootstrap enabled. Consider using persistent storage or setting REQUIRE_USER_IN_DB=true for production.")
 
         # Warn about default JWT issuer/audience in non-development environments
         if current_settings.environment != "development":
             if current_settings.jwt_issuer == "mcpgateway":
+
                 logger.warning("Using default JWT_ISSUER in %s environment. Set a unique JWT_ISSUER per environment to prevent cross-environment token acceptance.", current_settings.environment)
             if current_settings.jwt_audience == "mcpgateway-api":
                 logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", current_settings.environment)
@@ -2971,6 +2972,18 @@ if settings.security_logging_enabled or _siem_auth_source_enabled or settings.mc
     logger.info("🔐 Authentication context middleware enabled - capturing authentication security events")
 else:
     logger.info("🔐 Security event logging disabled")
+
+# Add CSRF protection middleware
+# This validates CSRF tokens on state-changing requests to prevent Cross-Site Request Forgery attacks
+# Note: Runs after AuthContextMiddleware so request.state.user is available for token validation
+if settings.csrf_enabled:
+    # First-Party
+    from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+
+    app.add_middleware(CSRFMiddleware)
+    logger.info("🛡️  CSRF protection middleware enabled - validating tokens on state-changing requests")
+else:
+    logger.info("🛡️  CSRF protection middleware disabled")
 
 # Add token usage logging middleware
 # This tracks API token usage for analytics and security monitoring
@@ -11594,9 +11607,10 @@ else:
 if settings.mcpgateway_admin_api_enabled and settings.siem_export_enabled:
     try:
         # First-Party
+        from mcpgateway.admin import enforce_admin_csrf  # pylint: disable=import-outside-toplevel
         from mcpgateway.routers.siem import router as siem_router
 
-        app.include_router(siem_router)
+        app.include_router(siem_router, dependencies=[Depends(enforce_admin_csrf)])
         logger.info("SIEM router included")
     except ImportError as e:  # pragma: no cover - optional import guard
         logger.warning(f"SIEM router not available: {e}")
@@ -11737,10 +11751,11 @@ if settings.llmchat_enabled:
         from mcpgateway.routers.llm_admin_router import llm_admin_router
         from mcpgateway.routers.llm_config_router import llm_config_router
         from mcpgateway.routers.llm_proxy_router import llm_proxy_router
+        from mcpgateway.admin import enforce_admin_csrf  # pylint: disable=import-outside-toplevel
 
         app.include_router(llm_config_router, prefix="/llm", tags=["LLM Configuration"])
         app.include_router(llm_proxy_router, prefix=settings.llm_api_prefix, tags=["LLM Proxy"])
-        app.include_router(llm_admin_router, prefix="/admin/llm", tags=["LLM Admin"])
+        app.include_router(llm_admin_router, prefix="/admin/llm", tags=["LLM Admin"], dependencies=[Depends(enforce_admin_csrf)])
         logger.info("LLM configuration, proxy, and admin routers included")
     except ImportError as e:
         logger.debug(f"LLM routers not available: {e}")
@@ -11781,7 +11796,7 @@ if ADMIN_API_ENABLED:
     # Lazy import: mcpgateway.admin is a large module (~19k lines, ~120ms cold).
     # Only load it when the admin API is actually mounted.
     # First-Party
-    from mcpgateway.admin import admin_router, set_logging_service, validate_section_permissions  # pylint: disable=import-outside-toplevel
+    from mcpgateway.admin import admin_router, enforce_admin_csrf, set_logging_service, validate_section_permissions  # pylint: disable=import-outside-toplevel
 
     set_logging_service(logging_service)
     app.include_router(admin_router)  # Admin routes imported from admin.py
@@ -11793,7 +11808,7 @@ if ADMIN_API_ENABLED:
     # First-Party
     from mcpgateway.routers.runtime_admin_router import runtime_admin_router  # pylint: disable=import-outside-toplevel
 
-    app.include_router(runtime_admin_router, prefix="/admin/runtime", tags=["Runtime Admin"])
+    app.include_router(runtime_admin_router, prefix="/admin/runtime", tags=["Runtime Admin"], dependencies=[Depends(enforce_admin_csrf)])
 else:
     logger.warning("Admin API routes not mounted - Admin API disabled via MCPGATEWAY_ADMIN_API_ENABLED=False")
 

--- a/mcpgateway/middleware/csrf_middleware.py
+++ b/mcpgateway/middleware/csrf_middleware.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/middleware/csrf_middleware.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+CSRF Protection Middleware for ContextForge.
+
+This middleware validates CSRF tokens on state-changing requests to prevent
+Cross-Site Request Forgery attacks.
+"""
+
+# Standard
+import hmac
+import logging
+from typing import Callable
+from urllib.parse import urlparse
+
+# Third-Party
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.services.csrf_service import get_csrf_service
+from mcpgateway.utils.verify_credentials import get_auth_header_value, verify_jwt_token_cached
+
+logger = logging.getLogger(__name__)
+
+# Safe HTTP methods that don't require CSRF protection
+SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
+
+
+def _extract_bearer_token(auth_header: str) -> str | None:
+    """Return a bearer token from an auth header, accepting scheme case-insensitively."""
+    scheme, separator, token = auth_header.partition(" ")
+    if separator and scheme.lower() == "bearer" and token.strip():
+        return token.strip()
+    return None
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Middleware for CSRF token validation on state-changing requests.
+
+    This middleware protects against Cross-Site Request Forgery attacks by:
+    1. Validating CSRF tokens on non-safe HTTP methods
+    2. Checking Referer/Origin headers when configured
+    3. Exempting specific paths and Bearer token requests
+
+    Examples:
+        >>> middleware = CSRFMiddleware(None)
+        >>> isinstance(middleware, CSRFMiddleware)
+        True
+        >>> # Test safe methods
+        >>> "GET" in SAFE_METHODS
+        True
+        >>> "POST" in SAFE_METHODS
+        False
+        >>> # Test path matching
+        >>> path = "/health"
+        >>> exempt_paths = ["/health", "/metrics"]
+        >>> path in exempt_paths
+        True
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """Process request and validate CSRF token if required.
+
+        Args:
+            request: Incoming HTTP request
+            call_next: Next middleware/handler in chain
+
+        Returns:
+            HTTP response or 403 error if CSRF validation fails
+
+        Examples:
+            >>> # Test CSRF validation logic
+            >>> method = "POST"
+            >>> method not in SAFE_METHODS
+            True
+            >>> # Test Bearer token detection
+            >>> auth_header = "Bearer abc123"
+            >>> auth_header.startswith("Bearer ")
+            True
+            >>> # Test origin parsing
+            >>> from urllib.parse import urlparse
+            >>> origin = "https://example.com"
+            >>> parsed = urlparse(origin)
+            >>> parsed.scheme
+            'https'
+            >>> parsed.netloc
+            'example.com'
+        """
+        # 1. Skip if CSRF protection is disabled
+        if not settings.csrf_enabled:
+            return await call_next(request)
+
+        # 1b. Skip if auth is disabled (dev mode)
+        if not getattr(settings, "auth_required", True):
+            return await call_next(request)
+
+        # 2. Skip safe methods (GET, HEAD, OPTIONS, TRACE)
+        if request.method in SAFE_METHODS:
+            return await call_next(request)
+
+        # 3. Skip exempt paths (exact or prefix match)
+        request_path = request.url.path
+        for exempt_path in settings.csrf_exempt_paths:
+            if request_path == exempt_path or request_path.startswith(exempt_path.rstrip("/") + "/"):
+                return await call_next(request)
+
+        # 4. Skip Bearer token requests (not vulnerable to CSRF)
+        auth_header = get_auth_header_value(request.headers) or ""
+        if _extract_bearer_token(auth_header):
+            return await call_next(request)
+
+        # 5. Extract CSRF token from header. Do not consume form bodies here:
+        # BaseHTTPMiddleware cannot safely replay request bodies for downstream handlers.
+        csrf_token = request.headers.get(settings.csrf_token_name)
+
+        if not csrf_token:
+            logger.warning(f"CSRF token missing for {request.method} {request.url.path}")
+            return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+        # 6. Get user_id and session_id from authenticated session
+        user_id = None
+        session_id = None
+
+        # Try to get user from request.state (set by AuthContextMiddleware)
+        if hasattr(request.state, "user") and request.state.user:
+            user = request.state.user
+            # EmailUser uses 'email' as primary key
+            user_id = user.email if hasattr(user, "email") else str(user.id) if hasattr(user, "id") else None
+
+        # Bind CSRF tokens to the verified JWT session (jti) when available
+        session_id = getattr(request.state, "jti", None)
+
+        # Fallback: derive user/session from a verified JWT when request.state
+        # was not populated yet (middleware ordering or disabled auth-context).
+        if not user_id or not session_id:
+            raw_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
+            if not raw_token:
+                auth_header = get_auth_header_value(request.headers) or ""
+                raw_token = _extract_bearer_token(auth_header)
+
+            if raw_token:
+                try:
+                    payload = await verify_jwt_token_cached(raw_token, request)
+                    user_id = payload.get("sub") or payload.get("email") or payload.get("user", {}).get("email")
+                    session_id = payload.get("jti")
+                except Exception as exc:
+                    logger.warning("CSRF fallback JWT verification failed for %s %s: %s", request.method, request.url.path, exc)
+
+        # If no user context or session binding, we can't validate the token
+        if not user_id or not session_id:
+            logger.warning(f"CSRF validation failed: no user context for {request.method} {request.url.path}")
+            return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+        # 7. Double-submit cookie validation: compare cookie token with header/form token
+        cookie_name = getattr(settings, "csrf_cookie_name", "csrf_token")
+        cookie_token = request.cookies.get(cookie_name)
+
+        if not cookie_token:
+            logger.warning(f"CSRF cookie missing for {request.method} {request.url.path}")
+            return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+        # Constant-time comparison to prevent timing attacks
+        if not hmac.compare_digest(csrf_token, cookie_token):
+            logger.warning("CSRF double-submit validation failed: cookie and header/form tokens do not match")
+            return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+        # 8. Validate CSRF token HMAC
+        csrf_service = get_csrf_service()
+        if not csrf_service.validate_csrf_token(csrf_token, user_id, session_id):
+            logger.warning(f"CSRF token HMAC validation failed for user {user_id}")
+            return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+        # 9. Check Referer/Origin if configured (fail-closed: reject if missing)
+        if settings.csrf_check_referer:
+            referer = request.headers.get("referer") or request.headers.get("origin")
+
+            # Fail closed: reject if header is missing
+            if not referer:
+                logger.warning(f"CSRF referer check failed: Referer/Origin header missing for {request.method} {request.url.path}")
+                return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+            # Parse the referer/origin
+            parsed_referer = urlparse(referer)
+            referer_origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
+
+            # Get allowed origins
+            app_domain = str(settings.app_domain)
+            parsed_app = urlparse(app_domain)
+            app_origin = f"{parsed_app.scheme}://{parsed_app.netloc}"
+
+            allowed_origins = {app_origin}
+            allowed_origins.update(settings.csrf_trusted_origins)
+
+            # Check if referer matches allowed origins
+            if referer_origin not in allowed_origins:
+                logger.warning(f"CSRF referer check failed: {referer_origin} not in allowed origins for {request.method} {request.url.path}")
+                return JSONResponse(status_code=403, content={"detail": "CSRF validation failed", "code": "CSRF_TOKEN_INVALID"})
+
+        # 10. All checks passed, continue with request
+        return await call_next(request)

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -121,6 +121,56 @@ class LoginRequest(BaseModel):
             raise ValueError("Either email or username must be provided")
 
 
+@auth_router.get("/csrf-token")
+async def get_csrf_token(request: Request, current_user: "EmailUser" = Depends(get_current_user)):
+    """Get a fresh CSRF token for the current authenticated user.
+
+    This endpoint generates a new CSRF token for the current session and sets it
+    as a cookie. Used by the frontend to refresh expired tokens.
+
+    Args:
+        request: FastAPI request object
+        current_user: Currently authenticated user
+
+    Returns:
+        dict: JSON response with csrf_token field
+
+    Raises:
+        HTTPException: If user authentication fails
+
+    Examples:
+        >>> # GET /auth/csrf-token
+        >>> # Headers: Authorization: Bearer <token>
+        >>> # Response: {"csrf_token": "abc123..."}
+    """
+    # Third-Party
+    from fastapi.responses import JSONResponse
+
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
+
+    try:
+        session_id = getattr(request.state, "jti", None)
+        if not session_id:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing session identifier")
+
+        # Generate fresh CSRF token
+        csrf_token = generate_csrf_token(user_id=current_user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+
+        # Create response with CSRF cookie
+        response = JSONResponse(content={"csrf_token": csrf_token})
+        set_csrf_cookie(response, csrf_token, settings)
+
+        return response
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating CSRF token for {current_user.email}: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to generate CSRF token")
+
+
 @auth_router.post("/login", response_model=AuthenticationResponse)
 async def login(login_request: LoginRequest, request: Request, db: Session = Depends(get_db)):
     """Authenticate user and return session JWT token.
@@ -173,6 +223,35 @@ async def login(login_request: LoginRequest, request: Request, db: Session = Dep
         access_token, expires_in = await create_access_token(user)
 
         logger.info(f"User {email} authenticated successfully")
+
+        # Generate CSRF token for session (rotate on login)
+        if settings.csrf_rotate_on_login:
+            try:
+                # Third-Party
+                import jwt
+                from fastapi.responses import JSONResponse
+
+                # First-Party
+                from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
+
+                # Decode JWT to get jti (don't verify since we just created it)
+                payload = jwt.decode(access_token, options={"verify_signature": False})
+                session_id = payload.get("jti", "")
+
+                # Generate CSRF token
+                csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+
+                auth_response = AuthenticationResponse(
+                    access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user)
+                )  # nosec B106 - OAuth2 token type, not a password
+                response = JSONResponse(content=auth_response.model_dump(mode="json"))
+
+                set_csrf_cookie(response, csrf_token, settings)
+
+                return response
+            except Exception as e:
+                logger.warning(f"Failed to set CSRF token for {user.email}: {e}")
+                # Fall back to response without CSRF token (non-critical)
 
         # Return session token for UI access and API key management
         return AuthenticationResponse(

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -295,10 +295,36 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
         # Create access token
         access_token, expires_in = await create_access_token(user)
 
-        # Return authentication response
-        return AuthenticationResponse(
-            access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user)
-        )  # nosec B106 - OAuth2 token type, not a password
+        # Generate CSRF token for session
+        # Extract jti from JWT payload for session_id
+        try:
+            # Third-Party
+            import jwt
+
+            # First-Party
+            from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
+
+            # Decode JWT to get jti (don't verify since we just created it)
+            payload = jwt.decode(access_token, options={"verify_signature": False})
+            session_id = payload.get("jti", "")
+
+            # Generate CSRF token
+            csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+
+            auth_response = AuthenticationResponse(
+                access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user)
+            )  # nosec B106 - OAuth2 token type, not a password
+            response = ORJSONResponse(content=auth_response.model_dump(mode="json"))
+
+            set_csrf_cookie(response, csrf_token, settings)
+
+            return response
+        except Exception as e:
+            logger.warning(f"Failed to set CSRF token for {user.email}: {e}")
+            # Fall back to response without CSRF token (non-critical)
+            return AuthenticationResponse(
+                access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user)
+            )  # nosec B106 - OAuth2 token type, not a password
 
     except HTTPException:
         raise  # Re-raise HTTP exceptions as-is (401, 403, etc.)

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -15,6 +15,7 @@ This module handles OAuth 2.0 Authorization Code flow endpoints including:
 # Standard
 from html import escape
 import logging
+import secrets
 from typing import Annotated, Any, Dict
 from urllib.parse import urlparse, urlunparse
 
@@ -38,8 +39,56 @@ from mcpgateway.services.oauth_manager import OAuthError, OAuthManager
 from mcpgateway.services.token_storage_service import TokenStorageService
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.paths import resolve_root_path
+from mcpgateway.utils.verify_credentials import get_auth_header_value
 
 logger = logging.getLogger(__name__)
+
+ADMIN_CSRF_COOKIE_NAME = "mcpgateway_csrf_token"
+ADMIN_CSRF_HEADER_NAME = "x-csrf-token"
+
+
+async def enforce_fetch_tools_csrf(request: Request) -> None:
+    """Validate admin CSRF token for OAuth fetch-tools mutations.
+
+    Also enforces same-origin via Origin/Referer header check to prevent
+    cross-site request forgery on this state-changing endpoint.
+    """
+    auth_header = get_auth_header_value(request.headers) or ""
+    scheme, separator, token = auth_header.partition(" ")
+    if separator and scheme.lower() == "bearer" and token.strip():
+        return
+
+    # Same-origin check: require Origin or Referer to match app domain (fail-closed)
+    origin = request.headers.get("origin")
+    referer = request.headers.get("referer")
+    candidate = origin
+    if not candidate and referer:
+        try:
+            parsed = urlparse(referer)
+            if parsed.scheme and parsed.netloc:
+                candidate = f"{parsed.scheme}://{parsed.netloc}"
+        except Exception:
+            candidate = None
+
+    if not candidate:
+        # Fail closed: missing Origin/Referer is not allowed for state-changing requests
+        raise HTTPException(status_code=403, detail="CSRF validation failed")
+
+    app_domain = str(settings.app_domain)
+    parsed_app = urlparse(app_domain)
+    app_origin = f"{parsed_app.scheme}://{parsed_app.netloc}"
+    allowed = {app_origin}
+    allowed.update(settings.csrf_trusted_origins)
+    if candidate not in allowed:
+        raise HTTPException(status_code=403, detail="CSRF validation failed")
+
+    # Double-submit cookie check
+    csrf_cookie = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
+    csrf_header = request.headers.get(ADMIN_CSRF_HEADER_NAME)
+    if not isinstance(csrf_cookie, str) or not csrf_cookie or not isinstance(csrf_header, str) or not csrf_header:
+        raise HTTPException(status_code=403, detail="CSRF validation failed")
+    if not secrets.compare_digest(csrf_header, csrf_cookie):
+        raise HTTPException(status_code=403, detail="CSRF validation failed")
 
 
 def _normalize_resource_url(url: str | None, *, preserve_query: bool = False) -> str | None:
@@ -653,10 +702,11 @@ async def oauth_callback(
                 statusDiv.innerHTML = '<p style="color: #2563eb;">Fetching tools from MCP server...</p>';
 
                 try {{
+                    const csrfToken = document.cookie.split('; ').find(row => row.startsWith('mcpgateway_csrf_token='))?.split('=')[1] || '';
                     const response = await fetch('{safe_root_path}/oauth/fetch-tools/{escape(str(gateway_id), quote=True)}', {{
                         method: 'POST',
                         credentials: 'include',
-                        headers: {{ 'Accept': 'text/html' }}
+                        headers: {{ 'Accept': 'text/html', 'X-CSRF-Token': decodeURIComponent(csrfToken) }}
                     }});
 
                     const result = await response.json();
@@ -833,6 +883,7 @@ async def get_oauth_status(
 async def fetch_tools_after_oauth(
     gateway_id: str,
     request: Request,
+    _: None = Depends(enforce_fetch_tools_csrf),
     current_user: EmailUserResponse = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:

--- a/mcpgateway/services/compliance_service.py
+++ b/mcpgateway/services/compliance_service.py
@@ -563,6 +563,17 @@ class ComplianceService:
         """
 
         def _default(obj: Any) -> Any:
+            """Fallback JSON encoder for datetime and Enum objects.
+
+            Args:
+                obj: Object to serialise.
+
+            Returns:
+                ISO-format string for datetime objects, enum value for Enum objects.
+
+            Raises:
+                TypeError: If the object type is not supported.
+            """
             if isinstance(obj, datetime):
                 return obj.isoformat()
             if isinstance(obj, Enum):

--- a/mcpgateway/services/csrf_service.py
+++ b/mcpgateway/services/csrf_service.py
@@ -1,0 +1,351 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/csrf_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+CSRF Token Service.
+
+Provides CSRF token generation and validation using HMAC-SHA256 with time-based
+windows for token expiry. Implements constant-time comparison to prevent timing
+attacks.
+
+## Security Features
+
+**Time-Window Based Tokens:**
+- Tokens are valid for a configurable time window (default: 3600 seconds)
+- Validation accepts current window and previous window (handles boundary cases)
+- Timestamp is rounded to window boundaries for consistent token generation
+
+**Constant-Time Comparison:**
+- All token comparisons use `hmac.compare_digest()` to prevent timing attacks
+- Never use `==` for token comparison
+
+**Cookie Security:**
+- HttpOnly=False (CSRF tokens must be readable by JavaScript)
+- Secure flag configurable (HTTPS-only in production)
+- SameSite configurable (Strict/Lax/None)
+- Path set to "/" for site-wide coverage
+
+## Token Format
+
+Tokens are HMAC-SHA256 hex digests (64 characters) computed from:
+```
+message = f"{user_id}:{session_id}:{timestamp}"
+timestamp = int(time.time() / expiry) * expiry  # Rounded to window boundary
+token = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+```
+
+## API Usage
+
+**Generate Token:**
+```python
+token = generate_csrf_token(
+    user_id="user@example.com",
+    session_id="abc123",
+    secret="my-secret-key",  # pragma: allowlist secret
+    expiry=3600
+)
+```
+
+**Validate Token:**
+```python
+is_valid = validate_csrf_token(
+    token=token,
+    user_id="user@example.com",
+    session_id="abc123",
+    secret="my-secret-key",  # pragma: allowlist secret
+    expiry=3600
+)
+```
+
+**Set Cookie:**
+```python
+from fastapi import Response
+set_csrf_cookie(response, token, settings)
+```
+
+**Clear Cookie:**
+```python
+clear_csrf_cookie(response, settings)
+```
+
+## Error Handling
+
+- `validate_csrf_token()` never raises exceptions
+- Returns `False` on any error or validation failure
+- Logs errors for debugging but maintains security through safe defaults
+"""
+
+# Standard
+from functools import lru_cache
+import hashlib
+import hmac
+import logging
+import time
+from typing import Any
+
+# First-Party
+from mcpgateway.config import settings as app_settings
+
+logger = logging.getLogger(__name__)
+
+
+def generate_csrf_token(user_id: str, session_id: str, secret: str, expiry: int) -> str:
+    """Generate a CSRF token using HMAC-SHA256.
+
+    The token is computed from user_id, session_id, and a timestamp rounded to
+    the expiry window boundary. This ensures the token remains valid for the
+    entire window without storing the issue time.
+
+    Args:
+        user_id: User identifier (e.g., email address)
+        session_id: Session identifier
+        secret: Secret key for HMAC computation
+        expiry: Token validity window in seconds
+
+    Returns:
+        str: HMAC-SHA256 hex digest (64 characters)
+
+    Examples:
+        >>> token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        >>> len(token)
+        64
+        >>> all(c in '0123456789abcdef' for c in token)
+        True
+
+        >>> # Tokens are deterministic within the same time window
+        >>> t1 = generate_csrf_token("user1", "sess1", "key1", 3600)
+        >>> t2 = generate_csrf_token("user1", "sess1", "key1", 3600)
+        >>> t1 == t2
+        True
+
+        >>> # Different inputs produce different tokens
+        >>> t1 = generate_csrf_token("user1", "sess1", "key1", 3600)
+        >>> t2 = generate_csrf_token("user2", "sess1", "key1", 3600)
+        >>> t1 != t2
+        True
+    """
+    # Round timestamp to expiry window boundary
+    timestamp = int(time.time() / expiry) * expiry
+
+    # Construct message
+    message = f"{user_id}:{session_id}:{timestamp}"
+
+    # Compute HMAC-SHA256
+    token = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+
+    return token
+
+
+def validate_csrf_token(token: str, user_id: str, session_id: str, secret: str, expiry: int) -> bool:
+    """Validate a CSRF token using constant-time comparison.
+
+    Validates the token against both the current time window and the previous
+    time window. This handles tokens generated just before a window boundary.
+
+    SECURITY: Uses `hmac.compare_digest()` for all comparisons to prevent
+    timing attacks. Never raises exceptions - returns False on any error.
+
+    Args:
+        token: CSRF token to validate (64-character hex string)
+        user_id: User identifier (must match token generation)
+        session_id: Session identifier (must match token generation)
+        secret: Secret key (must match token generation)
+        expiry: Token validity window in seconds (must match token generation)
+
+    Returns:
+        bool: True if token is valid for current or previous window, False otherwise
+
+    Examples:
+        >>> # Generate and validate a token
+        >>> token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        >>> validate_csrf_token(token, "user@example.com", "session123", "secret", 3600)
+        True
+
+        >>> # Wrong user_id fails validation
+        >>> validate_csrf_token(token, "wrong@example.com", "session123", "secret", 3600)
+        False
+
+        >>> # Wrong session_id fails validation
+        >>> validate_csrf_token(token, "user@example.com", "wrong_session", "secret", 3600)
+        False
+
+        >>> # Wrong secret fails validation
+        >>> validate_csrf_token(token, "user@example.com", "session123", "wrong_secret", 3600)
+        False
+
+        >>> # Invalid token format fails validation
+        >>> validate_csrf_token("invalid", "user@example.com", "session123", "secret", 3600)
+        False
+
+        >>> # Empty token fails validation
+        >>> validate_csrf_token("", "user@example.com", "session123", "secret", 3600)
+        False
+    """
+    try:
+        # Validate token format (must be 64-character hex string)
+        if not token or len(token) != 64:
+            return False
+
+        if not all(c in "0123456789abcdef" for c in token):
+            return False
+
+        # Compute expected token for current window
+        current_timestamp = int(time.time() / expiry) * expiry
+        current_message = f"{user_id}:{session_id}:{current_timestamp}"
+        current_expected = hmac.new(secret.encode(), current_message.encode(), hashlib.sha256).hexdigest()
+
+        # Check current window using constant-time comparison
+        if hmac.compare_digest(token, current_expected):
+            return True
+
+        # Compute expected token for previous window
+        previous_timestamp = current_timestamp - expiry
+        previous_message = f"{user_id}:{session_id}:{previous_timestamp}"
+        previous_expected = hmac.new(secret.encode(), previous_message.encode(), hashlib.sha256).hexdigest()
+
+        # Check previous window using constant-time comparison
+        if hmac.compare_digest(token, previous_expected):
+            return True
+
+        # Token doesn't match either window
+        return False
+
+    except Exception as e:
+        # Log error but return False (never raise)
+        logger.error("CSRF token validation error: %s", e)
+        return False
+
+
+def set_csrf_cookie(response: Any, token: str, settings: Any) -> None:
+    """Set CSRF token cookie on response.
+
+    Configures cookie with security settings from application settings:
+    - httponly=False (CSRF tokens must be readable by JavaScript)
+    - secure=settings.csrf_cookie_secure (HTTPS-only in production)
+    - samesite=settings.csrf_cookie_samesite (Strict/Lax/None)
+    - max_age=settings.csrf_token_expiry (cookie lifetime)
+    - path="/" (site-wide coverage)
+
+    Args:
+        response: FastAPI Response object
+        token: CSRF token to set in cookie
+        settings: Application settings object with CSRF configuration
+
+    Examples:
+        >>> from unittest.mock import Mock
+        >>> response = Mock()
+        >>> settings = Mock(csrf_cookie_httponly=False, csrf_cookie_secure=True, csrf_cookie_samesite="Strict", csrf_token_expiry=3600)
+        >>> set_csrf_cookie(response, "a" * 64, settings)
+        >>> response.set_cookie.called
+        True
+        >>> call_kwargs = response.set_cookie.call_args[1]
+        >>> call_kwargs['httponly']
+        False
+        >>> call_kwargs['secure']
+        True
+        >>> call_kwargs['samesite']
+        'Strict'
+        >>> call_kwargs['max_age']
+        3600
+        >>> call_kwargs['path']
+        '/'
+    """
+    cookie_name = getattr(settings, "csrf_cookie_name", "csrf_token")
+    response.set_cookie(
+        key=cookie_name,
+        value=token,
+        httponly=settings.csrf_cookie_httponly,  # Honor the setting from config
+        secure=settings.csrf_cookie_secure,
+        samesite=settings.csrf_cookie_samesite,
+        max_age=settings.csrf_token_expiry,
+        path="/",
+    )
+
+
+def clear_csrf_cookie(response: Any, settings: Any) -> None:
+    """Clear CSRF token cookie from response.
+
+    Sets cookie with max_age=0 to expire it immediately.
+
+    Args:
+        response: FastAPI Response object
+        settings: Application settings object with CSRF configuration
+
+    Examples:
+        >>> from unittest.mock import Mock
+        >>> response = Mock()
+        >>> settings = Mock(csrf_cookie_secure=True, csrf_cookie_samesite="Strict")
+        >>> clear_csrf_cookie(response, settings)
+        >>> response.set_cookie.called
+        True
+        >>> call_kwargs = response.set_cookie.call_args[1]
+        >>> call_kwargs['max_age']
+        0
+        >>> call_kwargs['httponly']
+        False
+        >>> call_kwargs['secure']
+        True
+    """
+    cookie_name = getattr(settings, "csrf_cookie_name", "csrf_token")
+    response.set_cookie(
+        key=cookie_name,
+        value="",
+        httponly=False,
+        secure=settings.csrf_cookie_secure,
+        samesite=settings.csrf_cookie_samesite,
+        max_age=0,
+        path="/",
+    )
+
+
+class CSRFService:
+    """CSRF service wrapper for dependency injection.
+
+    Provides methods for CSRF token generation and validation.
+    """
+
+    def __init__(self, secret: str, expiry: int):
+        """Initialize CSRF service.
+
+        Args:
+            secret: Secret key for HMAC computation
+            expiry: Token validity window in seconds
+        """
+        self.secret = secret
+        self.expiry = expiry
+
+    def generate_csrf_token(self, user_id: str, session_id: str) -> str:
+        """Generate a CSRF token.
+
+        Args:
+            user_id: User identifier
+            session_id: Session identifier
+
+        Returns:
+            CSRF token string
+        """
+        return generate_csrf_token(user_id, session_id, self.secret, self.expiry)
+
+    def validate_csrf_token(self, token: str, user_id: str, session_id: str) -> bool:
+        """Validate a CSRF token.
+
+        Args:
+            token: CSRF token to validate
+            user_id: User identifier
+            session_id: Session identifier
+
+        Returns:
+            True if valid, False otherwise
+        """
+        return validate_csrf_token(token, user_id, session_id, self.secret, self.expiry)
+
+
+@lru_cache(maxsize=1)
+def get_csrf_service() -> CSRFService:
+    """Get the global CSRF service instance.
+
+    Returns:
+        CSRFService instance
+    """
+    return CSRFService(secret=app_settings.csrf_secret_key, expiry=app_settings.csrf_token_expiry)

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -63,7 +63,7 @@
         // Add JWT token from cookie if available
         const jwtToken = getCookie("jwt_token");
         if (jwtToken) {
-          evt.detail.headers["Authorization"] = "Bearer " + jwtToken;
+          evt.detail.headers["{{ auth_header_name|default('Authorization') }}"] = "Bearer " + jwtToken;
         }
 
         const csrfToken = getCookie("mcpgateway_csrf_token");
@@ -108,9 +108,16 @@
           const method = (requestInit.method || methodFromRequest || "GET").toUpperCase();
           if (isUnsafeHttpMethod(method) && isSameOriginRequest(resource)) {
             const csrfToken = getCookie("mcpgateway_csrf_token");
-            if (csrfToken) {
+            const jwtToken = getCookie("jwt_token");
+            if (csrfToken || jwtToken) {
               const nextHeaders = new Headers(requestInit.headers || (resource instanceof Request ? resource.headers : undefined));
-              nextHeaders.set("X-CSRF-Token", csrfToken);
+              const authHeaderName = "{{ auth_header_name|default('Authorization') }}";
+              if (jwtToken && !nextHeaders.has(authHeaderName)) {
+                nextHeaders.set(authHeaderName, "Bearer " + jwtToken);
+              }
+              if (csrfToken) {
+                nextHeaders.set("X-CSRF-Token", csrfToken);
+              }
               requestInit.headers = nextHeaders;
             }
           }

--- a/tests/js/test_csrf_frontend.test.js
+++ b/tests/js/test_csrf_frontend.test.js
@@ -1,0 +1,714 @@
+/**
+ * Unit tests for CSRF frontend implementation in admin.js
+ *
+ * Tests cover:
+ * - Token reading from meta tag and cookie
+ * - Token refreshing from server
+ * - Automatic fetch() monkey-patching
+ * - Form auto-injection
+ * - MutationObserver for dynamic forms
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { JSDOM } from "jsdom";
+
+// Mock functions that will be extracted from admin.js
+let getCSRFToken;
+let refreshCSRFToken;
+let injectCSRFIntoForm;
+let injectCSRFIntoAllForms;
+let originalFetch;
+
+// Setup DOM environment
+let dom;
+let window;
+let document;
+
+beforeEach(() => {
+    // Create fresh DOM for each test
+    dom = new JSDOM(`
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta name="csrf-token" content="">
+        </head>
+        <body></body>
+        </html>
+    `, {
+        url: "https://example.com",
+        runScripts: "dangerously"
+    });
+
+    window = dom.window;
+    document = window.document;
+
+    // Mock console methods
+    window.console.error = vi.fn();
+    window.console.log = vi.fn();
+
+    // Mock fetch
+    originalFetch = window.fetch;
+    window.fetch = vi.fn();
+
+    // Define CSRF functions in window context
+    window.eval(`
+        function getCSRFToken() {
+            try {
+                const meta = document.querySelector('meta[name="csrf-token"]');
+                if (meta && meta.content) return meta.content;
+
+                const cookies = document.cookie.split(';');
+                for (let cookie of cookies) {
+                    const [name, value] = cookie.trim().split('=');
+                    if (name === 'csrf_token') return decodeURIComponent(value);
+                }
+            } catch (e) {
+                console.error('CSRF: failed to read cookie fallback', e);
+            }
+            console.error('CSRF: no token found — requests will fail');
+            return null;
+        }
+
+        async function refreshCSRFToken() {
+            const response = await fetch('/auth/csrf-token', {
+                method: 'GET',
+                credentials: 'include'  // pragma: allowlist secret
+            });
+            if (!response.ok) {
+                throw new Error('CSRF token refresh failed: ' + response.status);
+            }
+            const data = await response.json();
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            if (meta && data.csrf_token) {
+                meta.setAttribute('content', data.csrf_token);
+            }
+            return data.csrf_token;
+        }
+
+        function injectCSRFIntoForm(form) {
+            if (!form || form.tagName !== 'FORM') return;
+            const method = (form.method || 'GET').toUpperCase();
+            if (method === 'GET') return;
+
+            if (form.querySelector('input[name="csrf_token"][data-csrf-injected]')) return;
+
+            let input = form.querySelector('input[name="csrf_token"]');
+            if (!input) {
+                input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = 'csrf_token';
+                input.value = getCSRFToken();
+                input.setAttribute('data-csrf-injected', 'true');
+                form.appendChild(input);
+            } else {
+                input.value = getCSRFToken();
+            }
+        }
+
+        function injectCSRFIntoAllForms() {
+            document.querySelectorAll('form').forEach(injectCSRFIntoForm);
+        }
+    `);
+
+    // Extract functions from window
+    getCSRFToken = window.getCSRFToken;
+    refreshCSRFToken = window.refreshCSRFToken;
+    injectCSRFIntoForm = window.injectCSRFIntoForm;
+    injectCSRFIntoAllForms = window.injectCSRFIntoAllForms;
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+    dom.window.close();
+});
+
+describe("getCSRFToken", () => {
+    describe("Token Reading from Meta Tag", () => {
+        test("returns token from meta tag when present with valid content", () => {
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            meta.setAttribute('content', 'meta-token-123');
+
+            const token = getCSRFToken();
+            expect(token).toBe('meta-token-123');
+        });
+
+        test("returns token from cookie when meta tag is absent", () => {
+            // Remove meta tag
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            meta.remove();
+
+            // Set cookie
+            document.cookie = 'csrf_token=cookie-token-456';
+
+            const token = getCSRFToken();
+            expect(token).toBe('cookie-token-456');
+        });
+
+        test("returns token from cookie when meta tag content is empty", () => {
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            meta.setAttribute('content', '');
+
+            document.cookie = 'csrf_token=cookie-token-789';
+
+            const token = getCSRFToken();
+            expect(token).toBe('cookie-token-789');
+        });
+
+        test("returns null and logs error when both meta tag and cookie are absent", () => {
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            meta.remove();
+
+            const token = getCSRFToken();
+            expect(token).toBeNull();
+            expect(window.console.error).toHaveBeenCalledWith(
+                expect.stringContaining('CSRF: no token found')
+            );
+        });
+
+        test("prefers meta tag over cookie when both are present", () => {
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            meta.setAttribute('content', 'meta-token-priority');
+
+            document.cookie = 'csrf_token=cookie-token-ignored';
+
+            const token = getCSRFToken();
+            expect(token).toBe('meta-token-priority');
+        });
+    });
+});
+
+describe("refreshCSRFToken", () => {
+    test("calls GET /auth/csrf-token with credentials include", async () => {
+        window.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ csrf_token: 'new-token-123' })
+        });
+
+        await refreshCSRFToken();
+
+        expect(window.fetch).toHaveBeenCalledWith('/auth/csrf-token', {
+            method: 'GET',
+            credentials: 'include'  // pragma: allowlist secret
+        });
+    });
+
+    test("returns new token from response on success", async () => {
+        window.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ csrf_token: 'refreshed-token-456' })
+        });
+
+        const token = await refreshCSRFToken();
+        expect(token).toBe('refreshed-token-456');
+    });
+
+    test("updates meta tag content attribute with new token after successful refresh", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'old-token');
+
+        window.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ csrf_token: 'updated-token-789' })
+        });
+
+        await refreshCSRFToken();
+
+        expect(meta.getAttribute('content')).toBe('updated-token-789');
+    });
+
+    test("does not update meta tag if meta tag is absent in DOM", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.remove();
+
+        window.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ csrf_token: 'new-token' })
+        });
+
+        // Should not throw
+        await expect(refreshCSRFToken()).resolves.toBe('new-token');
+    });
+
+    test("throws error when /auth/csrf-token returns non-ok response", async () => {
+        window.fetch.mockResolvedValue({
+            ok: false,
+            status: 403
+        });
+
+        await expect(refreshCSRFToken()).rejects.toThrow('CSRF token refresh failed: 403');
+    });
+});
+
+describe("Fetch Monkey-Patch", () => {
+    let monkeyPatchedFetch;
+
+    beforeEach(() => {
+        // Setup monkey-patched fetch
+        const originalFetch = window.fetch;
+
+        window.eval(`
+            const _originalFetch = window.fetch;
+            window.fetch = async function(url, options = {}) {
+                const method = (options.method || 'GET').toUpperCase();
+                const safeMethods = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];
+
+                if (!safeMethods.includes(method)) {
+                    const existingHeaders = options.headers || {};
+
+                    if (!existingHeaders['X-CSRF-Token'] && !existingHeaders['x-csrf-token']) {
+                        options.headers = { ...existingHeaders, 'X-CSRF-Token': getCSRFToken() };
+                    }
+
+                    options.credentials = 'include';  // pragma: allowlist secret
+                }
+
+                const response = await _originalFetch(url, options);
+
+                if ((response.status === 401 || response.status === 403) && !options._retried) {
+                    try {
+                        const newToken = await refreshCSRFToken();
+                        options.headers['X-CSRF-Token'] = newToken;
+                        options._retried = true;
+                        return await _originalFetch(url, options);
+                    } catch (e) {
+                        console.error('CSRF: token refresh failed, returning original response', e);
+                        return response;
+                    }
+                }
+
+                return response;
+            };
+        `);
+
+        monkeyPatchedFetch = window.fetch;
+    });
+
+    test("GET request passes through without X-CSRF-Token header", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token-123');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'GET' });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers).toBeUndefined();
+    });
+
+    test("HEAD request passes through without X-CSRF-Token header", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token-123');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'HEAD' });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers).toBeUndefined();
+    });
+
+    test("POST request automatically includes X-CSRF-Token header from meta tag", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'auto-token-post');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers['X-CSRF-Token']).toBe('auto-token-post');
+    });
+
+    test("PUT request automatically includes X-CSRF-Token header from meta tag", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'auto-token-put');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'PUT' });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers['X-CSRF-Token']).toBe('auto-token-put');
+    });
+
+    test("DELETE request automatically includes X-CSRF-Token header from meta tag", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'auto-token-delete');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'DELETE' });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers['X-CSRF-Token']).toBe('auto-token-delete');
+    });
+
+    test("does not overwrite X-CSRF-Token if caller already set it manually", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'auto-token');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': 'manual-token' }
+        });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers['X-CSRF-Token']).toBe('manual-token');
+    });
+
+    test("does not overwrite x-csrf-token lowercase if caller already set it", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'auto-token');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', {
+            method: 'POST',
+            headers: { 'x-csrf-token': 'manual-lowercase-token' }
+        });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].headers['x-csrf-token']).toBe('manual-lowercase-token');
+    });
+
+    test("always includes credentials include on mutating requests", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        window.eval('_originalFetch').mockResolvedValue({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        const call = window.eval('_originalFetch').mock.calls[0];
+        expect(call[1].credentials).toBe('include');
+    });
+
+    test("401 response triggers refreshCSRFToken and retries with new token", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'old-token');
+
+        const mockFetch = window.eval('_originalFetch');
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 401 })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ csrf_token: 'new-token-401' })
+            })
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(meta.getAttribute('content')).toBe('new-token-401');
+    });
+
+    test("403 response triggers refreshCSRFToken and retries with new token", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'old-token');
+
+        const mockFetch = window.eval('_originalFetch');
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 403 })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ csrf_token: 'new-token-403' })
+            })
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(meta.getAttribute('content')).toBe('new-token-403');
+    });
+
+    test("400 response does NOT trigger token rotation or retry", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        const mockFetch = window.eval('_originalFetch');
+        mockFetch.mockResolvedValue({ ok: false, status: 400 });
+
+        const response = await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(response.status).toBe(400);
+    });
+
+    test("500 response does NOT trigger token rotation or retry", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        const mockFetch = window.eval('_originalFetch');
+        mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+        const response = await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(response.status).toBe(500);
+    });
+
+    test("retry happens ONCE only - second 401 is returned as-is without retry", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        const mockFetch = window.eval('_originalFetch');
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 401 })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ csrf_token: 'new-token' })
+            })
+            .mockResolvedValueOnce({ ok: false, status: 401 });
+
+        const response = await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(response.status).toBe(401);
+    });
+
+    test("returns original failed response if refreshCSRFToken throws during retry", async () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        const mockFetch = window.eval('_originalFetch');
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 401 })
+            .mockRejectedValueOnce(new Error('Network error'));
+
+        const response = await monkeyPatchedFetch('/api/data', { method: 'POST' });
+
+        expect(response.status).toBe(401);
+        expect(window.console.error).toHaveBeenCalledWith(
+            expect.stringContaining('CSRF: token refresh failed'),
+            expect.any(Error)
+        );
+    });
+});
+
+describe("Form Auto-Injection - injectCSRFIntoForm", () => {
+    test("POST form gets hidden input with name csrf_token injected", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'form-token-123');
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input).not.toBeNull();
+        expect(input.type).toBe('hidden');
+        expect(input.value).toBe('form-token-123');
+    });
+
+    test("PUT form gets hidden input injected", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'form-token-put');
+
+        const form = document.createElement('form');
+        form.method = 'PUT';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input).not.toBeNull();
+        expect(input.value).toBe('form-token-put');
+    });
+
+    test("GET form does NOT get hidden input injected", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'form-token-get');
+
+        const form = document.createElement('form');
+        form.method = 'GET';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input).toBeNull();
+    });
+
+    test("hidden input has data-csrf-injected attribute set to true", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input.getAttribute('data-csrf-injected')).toBe('true');
+    });
+
+    test("calling injectCSRFIntoForm twice on same form does NOT add duplicate input", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'token');
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+        injectCSRFIntoForm(form);
+
+        const inputs = form.querySelectorAll('input[name="csrf_token"]');
+        expect(inputs.length).toBe(1);
+    });
+
+    test("hidden input value comes from meta tag when meta tag is present", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'meta-form-token');
+
+        document.cookie = 'csrf_token=cookie-form-token';
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input.value).toBe('meta-form-token');
+    });
+
+    test("hidden input value comes from cookie fallback when meta tag is absent", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.remove();
+
+        document.cookie = 'csrf_token=cookie-fallback-token';
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input.value).toBe('cookie-fallback-token');
+    });
+
+    test("hidden input value is refreshed from getCSRFToken on form submit event", () => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'initial-token');
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        injectCSRFIntoForm(form);
+
+        const input = form.querySelector('input[name="csrf_token"]');
+        expect(input.value).toBe('initial-token');
+
+        // Update token
+        meta.setAttribute('content', 'updated-token');
+
+        // Trigger submit event
+        form.dispatchEvent(new window.Event('submit'));
+
+        // Value should be updated
+        expect(input.value).toBe('updated-token');
+    });
+});
+
+describe("MutationObserver", () => {
+    test("form added dynamically to DOM after page load gets hidden input injected", (done) => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'dynamic-token');
+
+        // Setup observer
+        const observer = new window.MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.tagName === 'FORM') {
+                        injectCSRFIntoForm(node);
+                    }
+                });
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        // Add form dynamically
+        const form = document.createElement('form');
+        form.method = 'POST';
+        document.body.appendChild(form);
+
+        // Wait for observer to process
+        setTimeout(() => {
+            const input = form.querySelector('input[name="csrf_token"]');
+            expect(input).not.toBeNull();
+            expect(input.value).toBe('dynamic-token');
+            observer.disconnect();
+            done();
+        }, 10);
+    });
+
+    test("form nested inside a dynamically added div gets hidden input injected", (done) => {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        meta.setAttribute('content', 'nested-token');
+
+        // Setup observer
+        const observer = new window.MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === 1) {
+                        node.querySelectorAll('form').forEach(injectCSRFIntoForm);
+                    }
+                });
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        // Add div with nested form
+        const div = document.createElement('div');
+        const form = document.createElement('form');
+        form.method = 'POST';
+        div.appendChild(form);
+        document.body.appendChild(div);
+
+        // Wait for observer to process
+        setTimeout(() => {
+            const input = form.querySelector('input[name="csrf_token"]');
+            expect(input).not.toBeNull();
+            expect(input.value).toBe('nested-token');
+            observer.disconnect();
+            done();
+        }, 10);
+    });
+
+    test("non-form element added to DOM does not cause errors", (done) => {
+        // Setup observer
+        const observer = new window.MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.tagName === 'FORM') {
+                        injectCSRFIntoForm(node);
+                    }
+                });
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        // Add non-form element
+        const div = document.createElement('div');
+        div.textContent = 'Not a form';
+        document.body.appendChild(div);
+
+        // Wait and verify no errors
+        setTimeout(() => {
+            expect(window.console.error).not.toHaveBeenCalled();
+            observer.disconnect();
+            done();
+        }, 10);
+    });
+});

--- a/tests/unit/mcpgateway/middleware/test_csrf_fixes.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_fixes.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+"""Test CSRF middleware fixes for review recommendations.
+
+Tests for the 5 issues identified in the review:
+1. Form field parsing for classic HTML form submits
+2. Double-submit cookie validation
+3. csrf_cookie_httponly setting honored
+4. Strict Referer/Origin check (fail closed)
+5. Token rotation on login
+"""
+
+# Standard
+from unittest.mock import AsyncMock, Mock, patch
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
+
+
+@pytest.fixture
+def mock_settings():
+    """Mock settings for CSRF tests."""
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock:
+        mock.csrf_enabled = True
+        mock.auth_required = True
+        mock.csrf_token_name = "X-CSRF-Token"
+        mock.csrf_cookie_name = "csrf_token"
+        mock.csrf_check_referer = True
+        mock.csrf_trusted_origins = []
+        mock.app_domain = "http://localhost:4444"
+        mock.csrf_exempt_paths = ["/health"]
+        mock.csrf_secret_key = "test-secret-key"
+        mock.csrf_token_expiry = 3600
+        mock.csrf_cookie_httponly = False
+        mock.csrf_cookie_secure = True
+        mock.csrf_cookie_samesite = "Strict"
+        yield mock
+
+
+@pytest.fixture
+def csrf_middleware(mock_settings):
+    """Create CSRF middleware instance."""
+    app = Mock()
+    return CSRFMiddleware(app)
+
+
+@pytest.mark.asyncio
+async def test_form_field_parsing_urlencoded(csrf_middleware, mock_settings):
+    """Test Issue #1: Parse CSRF token from application/x-www-form-urlencoded form field."""
+    user_id = "test@example.com"
+    session_id = "test-session-123"
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+
+    # Create mock request with form data (no header)
+    mock_request = Mock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url.path = "/api/test"
+    mock_request.headers.get = Mock(
+        side_effect=lambda key, default=None: {
+            "content-type": "application/x-www-form-urlencoded",
+            "authorization": "Bearer token",
+        }.get(key.lower(), default)
+    )
+    mock_request.cookies.get = Mock(return_value=csrf_token)
+    mock_request.body = AsyncMock(return_value=f"csrf_token={csrf_token}&other_field=value".encode())
+    mock_request.state.user = Mock(email=user_id)
+    mock_request.state.jti = session_id
+
+    # Mock call_next
+    call_next = AsyncMock(return_value=Mock(status_code=200))
+
+    # Execute middleware
+    response = await csrf_middleware.dispatch(mock_request, call_next)
+
+    # Should succeed (not return 403)
+    assert response.status_code == 200
+    call_next.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_form_field_parsing_multipart(csrf_middleware, mock_settings):
+    """Test Issue #1: Parse CSRF token from multipart/form-data form field."""
+    user_id = "test@example.com"
+    session_id = "test-session-123"
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+
+    # Create mock request with multipart form data
+    mock_request = Mock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url.path = "/api/test"
+    mock_request.headers.get = Mock(
+        side_effect=lambda key, default=None: {
+            "content-type": "multipart/form-data; boundary=----WebKitFormBoundary",
+            "authorization": "Bearer token",
+        }.get(key.lower(), default)
+    )
+    mock_request.cookies.get = Mock(return_value=csrf_token)
+
+    # Mock form() to return csrf_token
+    async def mock_form():
+        return {"csrf_token": csrf_token}
+
+    mock_request.form = mock_form
+    mock_request.state.user = Mock(email=user_id)
+    mock_request.state.jti = session_id
+
+    # Mock call_next
+    call_next = AsyncMock(return_value=Mock(status_code=200))
+
+    # Execute middleware
+    response = await csrf_middleware.dispatch(mock_request, call_next)
+
+    # Should succeed (not return 403)
+    assert response.status_code == 200
+    call_next.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_double_submit_cookie_validation(csrf_middleware, mock_settings):
+    """Test Issue #2: Validate both cookie and header/form tokens match."""
+    user_id = "test@example.com"
+    session_id = "test-session-123"
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    wrong_token = "wrong-token-value"
+
+    # Create mock request with mismatched tokens
+    mock_request = Mock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url = Mock(path="/api/test")
+    mock_request.headers = {"x-csrf-token": wrong_token, "referer": "http://localhost:4444/page"}
+    mock_request.cookies = {"csrf_token": csrf_token}
+    mock_request.state = Mock(user=Mock(email=user_id), jti=session_id)
+
+    # Mock call_next
+    call_next = AsyncMock(return_value=Mock(status_code=200))
+
+    # Execute middleware with mocked get_csrf_service
+    with patch("mcpgateway.middleware.csrf_middleware.get_csrf_service") as mock_csrf_service:
+        mock_csrf_service.return_value.validate_csrf_token.return_value = True
+        response = await csrf_middleware.dispatch(mock_request, call_next)
+
+    # Should fail with 403 (tokens don't match)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_double_submit_cookie_missing(csrf_middleware, mock_settings):
+    """Test Issue #2: Reject when cookie is missing."""
+    user_id = "test@example.com"
+    session_id = "test-session-123"
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+
+    # Create mock request with header but no cookie
+    mock_request = Mock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url = Mock(path="/api/test")
+    mock_request.headers = {"x-csrf-token": csrf_token, "referer": "http://localhost:4444/page"}
+    mock_request.cookies = {}  # No cookie
+    mock_request.state = Mock(user=Mock(email=user_id), jti=session_id)
+
+    # Mock call_next
+    call_next = AsyncMock(return_value=Mock(status_code=200))
+
+    # Execute middleware
+    response = await csrf_middleware.dispatch(mock_request, call_next)
+
+    # Should fail with 403 (cookie missing)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403
+    call_next.assert_not_called()
+
+
+def test_csrf_cookie_httponly_setting_honored():
+    """Test Issue #3: csrf_cookie_httponly setting is honored."""
+    # Test with httponly=True
+    with patch("mcpgateway.services.csrf_service.app_settings") as mock_settings:
+        mock_settings.csrf_cookie_httponly = True
+        mock_settings.csrf_cookie_secure = True
+        mock_settings.csrf_cookie_samesite = "Strict"
+        mock_settings.csrf_token_expiry = 3600
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        mock_response = Mock()
+        set_csrf_cookie(mock_response, "test-token", mock_settings)
+
+        # Verify httponly=True was passed
+        mock_response.set_cookie.assert_called_once()
+        call_kwargs = mock_response.set_cookie.call_args[1]
+        assert call_kwargs["httponly"] is True
+
+    # Test with httponly=False
+    with patch("mcpgateway.services.csrf_service.app_settings") as mock_settings:
+        mock_settings.csrf_cookie_httponly = False
+        mock_settings.csrf_cookie_secure = True
+        mock_settings.csrf_cookie_samesite = "Strict"
+        mock_settings.csrf_token_expiry = 3600
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        mock_response = Mock()
+        set_csrf_cookie(mock_response, "test-token", mock_settings)
+
+        # Verify httponly=False was passed
+        mock_response.set_cookie.assert_called_once()
+        call_kwargs = mock_response.set_cookie.call_args[1]
+        assert call_kwargs["httponly"] is False
+
+
+@pytest.mark.asyncio
+async def test_referer_check_fail_closed_missing_header(csrf_middleware, mock_settings):
+    """Test Issue #4: Reject when Referer/Origin header is missing (fail closed)."""
+    user_id = "test@example.com"
+    session_id = "test-session-123"
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+
+    # Create mock request without Referer/Origin header
+    mock_request = Mock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url = Mock(path="/api/test")
+    mock_request.headers = {"x-csrf-token": csrf_token}  # No referer
+    mock_request.cookies = {"csrf_token": csrf_token}
+    mock_request.state = Mock(user=Mock(email=user_id), jti=session_id)
+
+    # Mock call_next
+    call_next = AsyncMock(return_value=Mock(status_code=200))
+
+    # Execute middleware with mocked get_csrf_service
+    with patch("mcpgateway.middleware.csrf_middleware.get_csrf_service") as mock_csrf_service:
+        mock_csrf_service.return_value.validate_csrf_token.return_value = True
+        response = await csrf_middleware.dispatch(mock_request, call_next)
+
+    # Should fail with 403 (header missing, fail closed)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_referer_check_fail_closed_invalid_origin(csrf_middleware, mock_settings):
+    """Test Issue #4: Reject when Referer/Origin is not in allowed list."""
+    user_id = "test@example.com"
+    session_id = "test-session-123"
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+
+    # Create mock request with invalid origin
+    mock_request = Mock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url = Mock(path="/api/test")
+    mock_request.headers = {"x-csrf-token": csrf_token, "referer": "http://evil.com/attack"}
+    mock_request.cookies = {"csrf_token": csrf_token}
+    mock_request.state = Mock(user=Mock(email=user_id), jti=session_id)
+
+    # Mock call_next
+    call_next = AsyncMock(return_value=Mock(status_code=200))
+
+    # Execute middleware with mocked get_csrf_service
+    with patch("mcpgateway.middleware.csrf_middleware.get_csrf_service") as mock_csrf_service:
+        mock_csrf_service.return_value.validate_csrf_token.return_value = True
+        response = await csrf_middleware.dispatch(mock_request, call_next)
+
+    # Should fail with 403 (origin not allowed)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_token_rotation_on_login():
+    """Test Issue #5: CSRF token is rotated on login."""
+    from mcpgateway.routers.auth import login
+    from mcpgateway.routers.auth import LoginRequest
+
+    # Mock dependencies
+    mock_db = Mock()
+    mock_request = Mock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers.get = Mock(return_value="test-agent")
+
+    login_request = LoginRequest(email="test@example.com", password="password123")  # pragma: allowlist secret
+
+    with (
+        patch("mcpgateway.routers.auth.EmailAuthService") as mock_auth_service_class,
+        patch("mcpgateway.routers.auth.create_access_token") as mock_create_token,
+        patch("mcpgateway.routers.auth.settings") as mock_settings,
+        patch("jwt.decode") as mock_jwt_decode,
+        patch("mcpgateway.services.csrf_service.generate_csrf_token") as mock_gen_csrf,
+        patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+    ):
+
+        # Setup mocks
+        mock_settings.csrf_rotate_on_login = True
+        mock_settings.csrf_secret_key = "test-secret"
+        mock_settings.csrf_token_expiry = 3600
+        mock_settings.sso_enabled = False
+
+        from datetime import datetime
+
+        mock_user = Mock()
+        mock_user.email = "test@example.com"
+        mock_user.is_admin = False
+        mock_user.full_name = "Test User"
+        mock_user.is_active = True
+        mock_user.auth_provider = "email"
+        mock_user.created_at = datetime(2024, 1, 1)
+        mock_user.last_login = datetime(2024, 1, 1)
+        mock_user.email_verified = True
+        mock_user.password_change_required = False
+        mock_user.is_email_verified = Mock(return_value=True)
+        mock_user.is_account_locked = Mock(return_value=False)
+        mock_user.failed_login_attempts = 0
+        mock_user.locked_until = None
+
+        mock_auth_service = Mock()
+        mock_auth_service.authenticate_user = AsyncMock(return_value=mock_user)
+        mock_auth_service_class.return_value = mock_auth_service
+
+        mock_create_token.return_value = ("test-jwt-token", 3600)
+        mock_jwt_decode.return_value = {"jti": "test-jti-123"}
+        mock_gen_csrf.return_value = "test-csrf-token"
+
+        # Execute login
+        response = await login(login_request, mock_request, mock_db)
+
+        # Verify CSRF token was generated and set
+        mock_gen_csrf.assert_called_once_with(user_id="test@example.com", session_id="test-jti-123", secret="test-secret", expiry=3600)  # pragma: allowlist secret
+        mock_set_cookie.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -1,0 +1,655 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/test_csrf_middleware.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for CSRF middleware.
+
+Tests cover request validation, token checking, exempt paths, and referer validation.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+# First-Party
+from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+
+
+@pytest.mark.asyncio
+async def test_get_request_passes_without_token():
+    """Test that GET requests pass without CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "GET"
+    request.url.path = "/api/data"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_head_request_passes_without_token():
+    """Test that HEAD requests pass without CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "HEAD"
+    request.url.path = "/api/data"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_post_without_token_returns_403():
+    """Test that POST without CSRF token returns 403 with CSRF_TOKEN_INVALID."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_with_invalid_token_returns_403():
+    """Test that POST with invalid CSRF token returns 403 with CSRF_TOKEN_INVALID."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "invalid_token"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "invalid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = False
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = False
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_with_valid_token_succeeds():
+    """Test that POST with valid CSRF token succeeds."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = False
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_exempt_path_passes_without_token():
+    """Test that requests to exempt paths pass without CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/auth/login"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = ["/auth/login", "/auth/register"]
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_request_passes_without_csrf():
+    """Test that requests with Authorization: Bearer header pass without CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"authorization": "Bearer abc123token"}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_csrf_disabled_allows_all_requests():
+    """Test that CSRF_ENABLED=False allows all requests through."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_referer_matches_trusted_origin_passes():
+    """Test that request with matching referer passes."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {
+        "X-CSRF-Token": "valid_token",
+        "referer": "https://example.com/page"
+    }
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = True
+        mock_settings.app_domain = "https://example.com"
+        mock_settings.csrf_trusted_origins = set()
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_referer_wrong_domain_returns_403():
+    """Test that request with wrong referer domain returns 403."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {
+        "X-CSRF-Token": "valid_token",
+        "referer": "https://evil.com/page"
+    }
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = True
+        mock_settings.app_domain = "https://example.com"
+        mock_settings.csrf_trusted_origins = set()
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert b"CSRF_TOKEN_INVALID" in response.body
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_referer_absent_passes():
+    """Test that request without referer header passes (do NOT block on absence)."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = True
+        mock_settings.app_domain = "https://example.com"
+        mock_settings.csrf_trusted_origins = set()
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    # Middleware fails closed when referer/origin header is absent
+    assert response.status_code == 403
+    assert b"CSRF_TOKEN_INVALID" in response.body
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_user_context_returns_403():
+    """Test that request without user context returns 403."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "some_token"}
+    request.state = MagicMock()
+    request.state.user = None  # No user context
+    request.state.jti = None
+    request.cookies = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_put_request_requires_csrf_token():
+    """Test that PUT requests require CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "PUT"
+    request.url.path = "/api/data/123"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+
+
+@pytest.mark.asyncio
+async def test_delete_request_requires_csrf_token():
+    """Test that DELETE requests require CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "DELETE"
+    request.url.path = "/api/data/123"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+
+
+@pytest.mark.asyncio
+async def test_patch_request_requires_csrf_token():
+    """Test that PATCH requests require CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "PATCH"
+    request.url.path = "/api/data/123"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+
+
+@pytest.mark.asyncio
+async def test_options_request_passes_without_token():
+    """Test that OPTIONS requests pass without CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "OPTIONS"
+    request.url.path = "/api/data"
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_session_id_from_header():
+    """Test that session_id can be extracted from X-Session-ID header."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {
+        "X-CSRF-Token": "valid_token",
+    }
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "header_session_123"
+    request.cookies = {"csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = False
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    # Verify session_id from JWT context was used
+    mock_csrf_service.validate_csrf_token.assert_called_once_with("valid_token", "user@example.com", "header_session_123")
+
+
+@pytest.mark.asyncio
+async def test_origin_header_used_when_referer_absent():
+    """Test that Origin header is used when Referer is absent."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {
+        "X-CSRF-Token": "valid_token",
+        "origin": "https://example.com"
+    }
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = True
+        mock_settings.app_domain = "https://example.com"
+        mock_settings.csrf_trusted_origins = set()
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_trusted_origins_accepted():
+    """Test that requests from trusted origins are accepted."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {
+        "X-CSRF-Token": "valid_token",
+        "referer": "https://trusted.com/page"
+    }
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = True
+        mock_settings.app_domain = "https://example.com"
+        mock_settings.csrf_trusted_origins = {"https://trusted.com"}
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_csrf_fallback_jwt_context_from_cookie_succeeds():
+    """When request.state context is missing, middleware can derive user/jti from verified JWT cookie."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/admin/change-password-required"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = MagicMock()
+    request.state.user = None
+    request.state.jti = None
+    request.cookies = {"jwt_token": "jwt_cookie_token", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service), \
+         patch(
+             "mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached",
+             AsyncMock(return_value={"sub": "admin@example.com", "jti": "session-jti-1"}),
+         ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    mock_csrf_service.validate_csrf_token.assert_called_once_with("valid_token", "admin@example.com", "session-jti-1")
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_csrf_fallback_jwt_verification_failure_returns_403():
+    """Missing state context plus invalid JWT should fail closed."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/admin/change-password-required"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = MagicMock()
+    request.state.user = None
+    request.state.jti = None
+    request.cookies = {"jwt_token": "bad_jwt_token", "csrf_token": "valid_token"}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached", AsyncMock(side_effect=Exception("invalid token"))):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_csrf_form_post_without_header_is_rejected_without_consuming_body():
+    """Form posts must use the CSRF header so middleware does not consume bodies."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/admin/change-password-required"
+    request.headers = {"content-type": "application/x-www-form-urlencoded"}
+    request.body = AsyncMock(return_value=b"csrf_token=valid_token&current_password=a&new_password=b&confirm_password=b")
+    request.state = MagicMock()
+    request.state.user = None
+    request.state.jti = None
+    request.cookies = {"jwt_token": "jwt_cookie_token", "csrf_token": "valid_token"}
+
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service), \
+         patch(
+             "mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached",
+             AsyncMock(return_value={"sub": "admin@example.com", "jti": "session-jti-2"}),
+         ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    request.body.assert_not_awaited()
+    mock_csrf_service.validate_csrf_token.assert_not_called()
+    call_next.assert_not_awaited()

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -119,6 +119,67 @@ async def test_post_with_invalid_token_returns_403():
 
 
 @pytest.mark.asyncio
+async def test_post_with_missing_cookie_returns_403():
+    """Test that POST with no CSRF cookie returns 403."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123"}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = False
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_with_mismatched_cookie_returns_403():
+    """Test that POST with mismatched CSRF cookie returns 403."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email="user@example.com")
+    request.state.jti = "session123"
+    request.cookies = {"session_id": "session123", "csrf_token": "different_token"}
+
+    mock_csrf_service = MagicMock()
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings, \
+         patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service):
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = False
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_post_with_valid_token_succeeds():
     """Test that POST with valid CSRF token succeeds."""
     middleware = CSRFMiddleware(app=AsyncMock())

--- a/tests/unit/mcpgateway/middleware/test_http_auth_integration.py
+++ b/tests/unit/mcpgateway/middleware/test_http_auth_integration.py
@@ -226,7 +226,7 @@ class TestHttpAuthMiddlewareWithoutPlugins:
             # Request without authentication should fail (use POST for initialize)
             response = client.post("/protocol/initialize", json={})
 
-            # Should get 401 because no credentials provided
+            # Should get 401 because no credentials provided (authentication middleware returns 401)
             assert response.status_code == 401
 
     def test_health_endpoint_accessible_without_auth(self, app):

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -16,7 +16,7 @@ import pytest
 from fastapi import HTTPException
 
 # First-Party
-from mcpgateway.routers.auth import LoginRequest, get_db, login
+from mcpgateway.routers.auth import LoginRequest, get_csrf_token, get_db, login
 
 
 class TestLoginRequest:
@@ -241,6 +241,87 @@ class TestLogin:
 
             assert response.access_token == "test_token"
             mock_service.authenticate_user.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_login_csrf_rotation_sets_cookie(self, mock_request, mock_db, mock_user):
+        """Test login with csrf_rotate_on_login=True sets CSRF cookie."""
+        with (
+            patch("mcpgateway.routers.auth.EmailAuthService") as mock_auth_service,
+            patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock) as mock_create_token,
+            patch("mcpgateway.config.settings") as mock_settings,
+            patch("jwt.decode", return_value={"jti": "session-123"}),
+            patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
+            patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+        ):
+            mock_service = MagicMock()
+            mock_service.authenticate_user = AsyncMock(return_value=mock_user)
+            mock_auth_service.return_value = mock_service
+
+            mock_create_token.return_value = ("test_token", 3600)
+            mock_settings.csrf_rotate_on_login = True
+            mock_settings.csrf_secret_key = "secret"
+            mock_settings.csrf_token_expiry = 60
+
+            login_request = LoginRequest(email="test@example.com", password="password123")
+
+            response = await login(login_request, mock_request, mock_db)
+
+            assert response.status_code == 200
+            mock_generate.assert_called_once()
+            mock_set_cookie.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_csrf_token_success(self):
+        """Test CSRF token endpoint returns token and cookie."""
+        request = MagicMock()
+        request.state = SimpleNamespace(jti="session-123")
+        current_user = SimpleNamespace(email="test@example.com")
+
+        with (
+            patch("mcpgateway.config.settings") as mock_settings,
+            patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
+            patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+        ):
+            mock_settings.csrf_secret_key = "secret"
+            mock_settings.csrf_token_expiry = 60
+
+            response = await get_csrf_token(request, current_user)
+
+            assert response.status_code == 200
+            assert response.body is not None
+            mock_generate.assert_called_once_with(user_id="test@example.com", session_id="session-123", secret="secret", expiry=60)
+            mock_set_cookie.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_csrf_token_missing_jti_raises_401(self):
+        """Test CSRF token endpoint rejects missing session id."""
+        request = MagicMock()
+        request.state = SimpleNamespace()
+        current_user = SimpleNamespace(email="test@example.com")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_csrf_token(request, current_user)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_csrf_token_exception_raises_500(self):
+        """Test CSRF token endpoint handles unexpected errors."""
+        request = MagicMock()
+        request.state = SimpleNamespace(jti="session-123")
+        current_user = SimpleNamespace(email="test@example.com")
+
+        with (
+            patch("mcpgateway.routers.auth.settings") as mock_settings,
+            patch("mcpgateway.services.csrf_service.generate_csrf_token", side_effect=Exception("boom")),
+        ):
+            mock_settings.csrf_secret_key = "secret"
+            mock_settings.csrf_token_expiry = 60
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_csrf_token(request, current_user)
+
+        assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
     async def test_login_with_plain_username_fails(self, mock_request, mock_db):

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -191,6 +191,50 @@ class TestEmailAuthLoginPasswordChangeRequired:
                         assert response.access_token == "test_token_123"
                         assert response.token_type == "bearer"
 
+    @pytest.mark.asyncio
+    async def test_login_sets_csrf_cookie_when_rotation_enabled(self, mock_user_normal):
+        """Test login returns ORJSONResponse with rotated CSRF cookie."""
+        from mcpgateway.routers.email_auth import login
+        from mcpgateway.schemas import EmailLoginRequest
+
+        mock_request = MagicMock()
+        mock_request.client = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers = {"User-Agent": "TestAgent/1.0"}
+
+        mock_db = MagicMock()
+        login_request = EmailLoginRequest(email="test@example.com", password="password123")
+
+        with patch("mcpgateway.routers.email_auth.EmailAuthService") as MockAuthService:
+            mock_service = MockAuthService.return_value
+            mock_service.authenticate_user = AsyncMock(return_value=mock_user_normal)
+
+            with patch("mcpgateway.services.argon2_service.Argon2PasswordService") as MockPasswordService:
+                mock_password_service = MockPasswordService.return_value
+                mock_password_service.verify_password.return_value = False
+                mock_password_service.verify_password_async = AsyncMock(return_value=False)
+
+                with (
+                    patch("mcpgateway.routers.email_auth.settings") as mock_settings,
+                    patch("jwt.decode") as mock_jwt_decode,
+                    patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
+                    patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+                ):
+                    mock_settings.default_user_password.get_secret_value.return_value = "default_password"
+                    mock_settings.token_expiry = 60
+                    mock_settings.jwt_issuer = "test-issuer"
+                    mock_settings.jwt_audience = "test-audience"
+                    mock_settings.csrf_rotate_on_login = True
+                    mock_settings.csrf_secret_key = "secret"
+                    mock_settings.csrf_token_expiry = 60
+                    mock_jwt_decode.return_value = {"jti": "session-123"}
+
+                    response = await login(login_request, mock_request, mock_db)
+
+        assert response.status_code == 200
+        mock_generate.assert_called_once_with(user_id="test@example.com", session_id="session-123", secret="secret", expiry=60)
+        mock_set_cookie.assert_called_once()
+
 
 class TestCreateAccessTokenTeamsFormat:
     """Test cases for create_access_token teams claim format consistency.

--- a/tests/unit/mcpgateway/routers/test_metrics_maintenance.py
+++ b/tests/unit/mcpgateway/routers/test_metrics_maintenance.py
@@ -65,13 +65,14 @@ def test_metrics_cleanup_disabled(app):
     app.dependency_overrides[require_admin_auth] = lambda: "test_admin"
     client = TestClient(app)
 
-    with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
-        mock_settings.metrics_cleanup_enabled = False
+    with patch("mcpgateway.config.settings.csrf_enabled", False):
+        with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
+            mock_settings.metrics_cleanup_enabled = False
 
-        response = client.post("/api/metrics/cleanup", json={})
+            response = client.post("/api/metrics/cleanup", json={})
 
-        assert response.status_code == 400
-        assert "disabled" in response.json()["detail"].lower()
+            assert response.status_code == 400
+            assert "disabled" in response.json()["detail"].lower()
 
     app.dependency_overrides.pop(require_admin_auth, None)
 
@@ -81,36 +82,37 @@ def test_metrics_cleanup_all_tables(app):
     app.dependency_overrides[require_admin_auth] = lambda: "test_admin"
     client = TestClient(app)
 
-    with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
-        mock_settings.metrics_cleanup_enabled = True
+    with patch("mcpgateway.config.settings.csrf_enabled", False):
+        with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
+            mock_settings.metrics_cleanup_enabled = True
 
-        # Create mock result for cleanup_all
-        mock_table_result = MagicMock()
-        mock_table_result.table_name = "tool_metric"
-        mock_table_result.deleted_count = 10
-        mock_table_result.remaining_count = 100
-        mock_table_result.cutoff_date = datetime.now(timezone.utc)
-        mock_table_result.duration_seconds = 0.5
-        mock_table_result.error = None
+            # Create mock result for cleanup_all
+            mock_table_result = MagicMock()
+            mock_table_result.table_name = "tool_metric"
+            mock_table_result.deleted_count = 10
+            mock_table_result.remaining_count = 100
+            mock_table_result.cutoff_date = datetime.now(timezone.utc)
+            mock_table_result.duration_seconds = 0.5
+            mock_table_result.error = None
 
-        mock_summary = MagicMock()
-        mock_summary.total_deleted = 10
-        mock_summary.tables = {"tool_metric": mock_table_result}
-        mock_summary.duration_seconds = 0.5
-        mock_summary.started_at = datetime.now(timezone.utc)
-        mock_summary.completed_at = datetime.now(timezone.utc)
+            mock_summary = MagicMock()
+            mock_summary.total_deleted = 10
+            mock_summary.tables = {"tool_metric": mock_table_result}
+            mock_summary.duration_seconds = 0.5
+            mock_summary.started_at = datetime.now(timezone.utc)
+            mock_summary.completed_at = datetime.now(timezone.utc)
 
-        with patch("mcpgateway.services.metrics_cleanup_service.get_metrics_cleanup_service") as mock_get_service:
-            mock_service = MagicMock()
-            mock_service.cleanup_all = AsyncMock(return_value=mock_summary)
-            mock_get_service.return_value = mock_service
+            with patch("mcpgateway.services.metrics_cleanup_service.get_metrics_cleanup_service") as mock_get_service:
+                mock_service = MagicMock()
+                mock_service.cleanup_all = AsyncMock(return_value=mock_summary)
+                mock_get_service.return_value = mock_service
 
-            response = client.post("/api/metrics/cleanup", json={})
+                response = client.post("/api/metrics/cleanup", json={})
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["total_deleted"] == 10
-            assert "tool_metric" in data["tables"]
+                assert response.status_code == 200
+                data = response.json()
+                assert data["total_deleted"] == 10
+                assert "tool_metric" in data["tables"]
 
     app.dependency_overrides.pop(require_admin_auth, None)
 
@@ -120,28 +122,29 @@ def test_metrics_cleanup_specific_table(app):
     app.dependency_overrides[require_admin_auth] = lambda: "test_admin"
     client = TestClient(app)
 
-    with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
-        mock_settings.metrics_cleanup_enabled = True
+    with patch("mcpgateway.config.settings.csrf_enabled", False):
+        with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
+            mock_settings.metrics_cleanup_enabled = True
 
-        mock_result = MagicMock()
-        mock_result.table_name = "prompt_metric"
-        mock_result.deleted_count = 5
-        mock_result.remaining_count = 50
-        mock_result.cutoff_date = datetime.now(timezone.utc)
-        mock_result.duration_seconds = 0.3
-        mock_result.error = None
+            mock_result = MagicMock()
+            mock_result.table_name = "prompt_metric"
+            mock_result.deleted_count = 5
+            mock_result.remaining_count = 50
+            mock_result.cutoff_date = datetime.now(timezone.utc)
+            mock_result.duration_seconds = 0.3
+            mock_result.error = None
 
-        with patch("mcpgateway.services.metrics_cleanup_service.get_metrics_cleanup_service") as mock_get_service:
-            mock_service = MagicMock()
-            mock_service.cleanup_table = AsyncMock(return_value=mock_result)
-            mock_get_service.return_value = mock_service
+            with patch("mcpgateway.services.metrics_cleanup_service.get_metrics_cleanup_service") as mock_get_service:
+                mock_service = MagicMock()
+                mock_service.cleanup_table = AsyncMock(return_value=mock_result)
+                mock_get_service.return_value = mock_service
 
-            response = client.post("/api/metrics/cleanup", json={"table_type": "prompt"})
+                response = client.post("/api/metrics/cleanup", json={"table_type": "prompt"})
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["total_deleted"] == 5
-            assert "prompt_metric" in data["tables"]
+                assert response.status_code == 200
+                data = response.json()
+                assert data["total_deleted"] == 5
+                assert "prompt_metric" in data["tables"]
 
     app.dependency_overrides.pop(require_admin_auth, None)
 
@@ -151,18 +154,19 @@ def test_metrics_cleanup_invalid_table_type(app):
     app.dependency_overrides[require_admin_auth] = lambda: "test_admin"
     client = TestClient(app)
 
-    with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
-        mock_settings.metrics_cleanup_enabled = True
+    with patch("mcpgateway.config.settings.csrf_enabled", False):
+        with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
+            mock_settings.metrics_cleanup_enabled = True
 
-        with patch("mcpgateway.services.metrics_cleanup_service.get_metrics_cleanup_service") as mock_get_service:
-            mock_service = MagicMock()
-            mock_service.cleanup_table = AsyncMock(side_effect=ValueError("Invalid table type"))
-            mock_get_service.return_value = mock_service
+            with patch("mcpgateway.services.metrics_cleanup_service.get_metrics_cleanup_service") as mock_get_service:
+                mock_service = MagicMock()
+                mock_service.cleanup_table = AsyncMock(side_effect=ValueError("Invalid table type"))
+                mock_get_service.return_value = mock_service
 
-            response = client.post("/api/metrics/cleanup", json={"table_type": "invalid"})
+                response = client.post("/api/metrics/cleanup", json={"table_type": "invalid"})
 
-            assert response.status_code == 400
-            assert "Invalid table type" in response.json()["detail"]
+                assert response.status_code == 400
+                assert "Invalid table type" in response.json()["detail"]
 
     app.dependency_overrides.pop(require_admin_auth, None)
 
@@ -172,13 +176,14 @@ def test_metrics_rollup_disabled(app):
     app.dependency_overrides[require_admin_auth] = lambda: "test_admin"
     client = TestClient(app)
 
-    with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
-        mock_settings.metrics_rollup_enabled = False
+    with patch("mcpgateway.config.settings.csrf_enabled", False):
+        with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
+            mock_settings.metrics_rollup_enabled = False
 
-        response = client.post("/api/metrics/rollup", json={})
+            response = client.post("/api/metrics/rollup", json={})
 
-        assert response.status_code == 400
-        assert "disabled" in response.json()["detail"].lower()
+            assert response.status_code == 400
+            assert "disabled" in response.json()["detail"].lower()
 
     app.dependency_overrides.pop(require_admin_auth, None)
 
@@ -188,41 +193,42 @@ def test_metrics_rollup_success(app):
     app.dependency_overrides[require_admin_auth] = lambda: "test_admin"
     client = TestClient(app)
 
-    with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
-        mock_settings.metrics_rollup_enabled = True
+    with patch("mcpgateway.config.settings.csrf_enabled", False):
+        with patch("mcpgateway.routers.metrics_maintenance.settings") as mock_settings:
+            mock_settings.metrics_rollup_enabled = True
 
-        mock_table_result = MagicMock()
-        mock_table_result.table_name = "tool_metric"
-        mock_table_result.hours_processed = 24
-        mock_table_result.records_aggregated = 100
-        mock_table_result.rollups_created = 24
-        mock_table_result.rollups_updated = 0
-        mock_table_result.raw_deleted = 100
-        mock_table_result.duration_seconds = 1.0
-        mock_table_result.error = None
+            mock_table_result = MagicMock()
+            mock_table_result.table_name = "tool_metric"
+            mock_table_result.hours_processed = 24
+            mock_table_result.records_aggregated = 100
+            mock_table_result.rollups_created = 24
+            mock_table_result.rollups_updated = 0
+            mock_table_result.raw_deleted = 100
+            mock_table_result.duration_seconds = 1.0
+            mock_table_result.error = None
 
-        mock_summary = MagicMock()
-        mock_summary.total_hours_processed = 24
-        mock_summary.total_records_aggregated = 100
-        mock_summary.total_rollups_created = 24
-        mock_summary.total_rollups_updated = 0
-        mock_summary.tables = {"tool_metric": mock_table_result}
-        mock_summary.duration_seconds = 1.0
-        mock_summary.started_at = datetime.now(timezone.utc)
-        mock_summary.completed_at = datetime.now(timezone.utc)
+            mock_summary = MagicMock()
+            mock_summary.total_hours_processed = 24
+            mock_summary.total_records_aggregated = 100
+            mock_summary.total_rollups_created = 24
+            mock_summary.total_rollups_updated = 0
+            mock_summary.tables = {"tool_metric": mock_table_result}
+            mock_summary.duration_seconds = 1.0
+            mock_summary.started_at = datetime.now(timezone.utc)
+            mock_summary.completed_at = datetime.now(timezone.utc)
 
-        with patch("mcpgateway.services.metrics_rollup_service.get_metrics_rollup_service") as mock_get_service:
-            mock_service = MagicMock()
-            mock_service.rollup_all = AsyncMock(return_value=mock_summary)
-            mock_get_service.return_value = mock_service
+            with patch("mcpgateway.services.metrics_rollup_service.get_metrics_rollup_service") as mock_get_service:
+                mock_service = MagicMock()
+                mock_service.rollup_all = AsyncMock(return_value=mock_summary)
+                mock_get_service.return_value = mock_service
 
-            response = client.post("/api/metrics/rollup", json={"hours_back": 24})
+                response = client.post("/api/metrics/rollup", json={"hours_back": 24})
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["total_hours_processed"] == 24
-            assert data["total_records_aggregated"] == 100
-            assert "tool_metric" in data["tables"]
+                assert response.status_code == 200
+                data = response.json()
+                assert data["total_hours_processed"] == 24
+                assert data["total_records_aggregated"] == 100
+                assert "tool_metric" in data["tables"]
 
     app.dependency_overrides.pop(require_admin_auth, None)
 

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import Gateway
+from mcpgateway.routers.oauth_router import enforce_fetch_tools_csrf
 from mcpgateway.schemas import EmailUserResponse
 from mcpgateway.services.oauth_manager import OAuthError
 
@@ -99,6 +100,103 @@ class TestNormalizeResourceUrl:
 
         result = _normalize_resource_url("https://example.com/path?x=1#frag", preserve_query=True)
         assert result == "https://example.com/path?x=1"
+
+
+class TestEnforceFetchToolsCsrf:
+    """Tests for enforce_fetch_tools_csrf."""
+
+    @pytest.fixture
+    def csrf_request(self):
+        request = Mock(spec=Request)
+        request.headers = {}
+        request.cookies = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_skips_csrf(self, csrf_request):
+        csrf_request.headers = {"authorization": "Bearer abc123"}
+
+        assert await enforce_fetch_tools_csrf(csrf_request) is None
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", {"https://trusted.example.com"})
+    @pytest.mark.asyncio
+    async def test_valid_origin_with_matching_csrf_cookie_and_header(self, csrf_request):
+        csrf_request.headers = {
+            "origin": "https://gateway.example.com",
+            "x-csrf-token": "token-123",
+        }
+        csrf_request.cookies = {"mcpgateway_csrf_token": "token-123"}
+
+        assert await enforce_fetch_tools_csrf(csrf_request) is None
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", set())
+    @pytest.mark.asyncio
+    async def test_missing_origin_and_referer_raises_403(self, csrf_request):
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_fetch_tools_csrf(csrf_request)
+
+        assert exc_info.value.status_code == 403
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", set())
+    @pytest.mark.asyncio
+    async def test_invalid_origin_raises_403(self, csrf_request):
+        csrf_request.headers = {"origin": "https://evil.example.com"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_fetch_tools_csrf(csrf_request)
+
+        assert exc_info.value.status_code == 403
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", set())
+    @pytest.mark.asyncio
+    async def test_missing_csrf_cookie_raises_403(self, csrf_request):
+        csrf_request.headers = {"origin": "https://gateway.example.com", "x-csrf-token": "token-123"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_fetch_tools_csrf(csrf_request)
+
+        assert exc_info.value.status_code == 403
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", set())
+    @pytest.mark.asyncio
+    async def test_missing_csrf_header_raises_403(self, csrf_request):
+        csrf_request.headers = {"origin": "https://gateway.example.com"}
+        csrf_request.cookies = {"mcpgateway_csrf_token": "token-123"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_fetch_tools_csrf(csrf_request)
+
+        assert exc_info.value.status_code == 403
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", set())
+    @pytest.mark.asyncio
+    async def test_mismatched_csrf_cookie_and_header_raises_403(self, csrf_request):
+        csrf_request.headers = {"origin": "https://gateway.example.com", "x-csrf-token": "header-token"}
+        csrf_request.cookies = {"mcpgateway_csrf_token": "cookie-token"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_fetch_tools_csrf(csrf_request)
+
+        assert exc_info.value.status_code == 403
+
+    @patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com")
+    @patch("mcpgateway.routers.oauth_router.settings.csrf_trusted_origins", set())
+    @patch("mcpgateway.routers.oauth_router.urlparse", side_effect=Exception("parse error"))
+    @pytest.mark.asyncio
+    async def test_referer_parse_exception_raises_403(self, mock_urlparse, csrf_request):
+        csrf_request.headers = {"referer": "https://gateway.example.com", "x-csrf-token": "token-123"}
+        csrf_request.cookies = {"mcpgateway_csrf_token": "token-123"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_fetch_tools_csrf(csrf_request)
+
+        assert exc_info.value.status_code == 403
 
 
 class TestPersistLearnedAudience:

--- a/tests/unit/mcpgateway/services/test_csrf_service.py
+++ b/tests/unit/mcpgateway/services/test_csrf_service.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/test_csrf_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for CSRF service.
+
+Tests cover token generation, validation, cookie management, and edge cases.
+"""
+
+# Standard
+import time
+from unittest.mock import Mock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services.csrf_service import (
+    clear_csrf_cookie,
+    generate_csrf_token,
+    set_csrf_cookie,
+    validate_csrf_token,
+)
+
+
+class TestGenerateCSRFToken:
+    """Test cases for generate_csrf_token function."""
+
+    def test_returns_non_empty_string(self):
+        """Test that generate_csrf_token returns a non-empty string."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_returns_64_char_hex_string(self):
+        """Test that token is 64-character hex string (HMAC-SHA256)."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        assert len(token) == 64
+        assert all(c in "0123456789abcdef" for c in token)
+
+    def test_same_inputs_same_window_same_token(self):
+        """Test that same inputs in same time window produce same token."""
+        token1 = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        token2 = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        assert token1 == token2
+
+    def test_different_user_id_different_token(self):
+        """Test that different user_id produces different token."""
+        token1 = generate_csrf_token("user1@example.com", "session123", "secret", 3600)
+        token2 = generate_csrf_token("user2@example.com", "session123", "secret", 3600)
+        assert token1 != token2
+
+    def test_different_session_id_different_token(self):
+        """Test that different session_id produces different token."""
+        token1 = generate_csrf_token("user@example.com", "session1", "secret", 3600)
+        token2 = generate_csrf_token("user@example.com", "session2", "secret", 3600)
+        assert token1 != token2
+
+    def test_different_secret_different_token(self):
+        """Test that different secret produces different token."""
+        token1 = generate_csrf_token("user@example.com", "session123", "secret1", 3600)
+        token2 = generate_csrf_token("user@example.com", "session123", "secret2", 3600)
+        assert token1 != token2
+
+    def test_different_expiry_different_token(self):
+        """Test that different expiry window produces different token."""
+        token1 = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        token2 = generate_csrf_token("user@example.com", "session123", "secret", 7200)
+        # May be same or different depending on current time alignment
+        # Just verify both are valid tokens
+        assert len(token1) == 64
+        assert len(token2) == 64
+
+
+class TestValidateCSRFToken:
+    """Test cases for validate_csrf_token function."""
+
+    def test_valid_token_returns_true(self):
+        """Test that a valid token returns True."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        result = validate_csrf_token(token, "user@example.com", "session123", "secret", 3600)
+        assert result is True
+
+    def test_previous_window_token_returns_true(self):
+        """Test that token from previous window is still valid (boundary case)."""
+        # Generate token with current time
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+
+        # Token should be valid in current window
+        result = validate_csrf_token(token, "user@example.com", "session123", "secret", 3600)
+        assert result is True
+
+        # Note: Testing actual previous window requires time manipulation
+        # which is complex. The validation logic accepts previous window tokens.
+
+    def test_wrong_user_id_returns_false(self):
+        """Test that wrong user_id returns False."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        result = validate_csrf_token(token, "wrong@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_wrong_session_id_returns_false(self):
+        """Test that wrong session_id returns False."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        result = validate_csrf_token(token, "user@example.com", "wrong_session", "secret", 3600)
+        assert result is False
+
+    def test_wrong_secret_returns_false(self):
+        """Test that wrong secret returns False."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        result = validate_csrf_token(token, "user@example.com", "session123", "wrong_secret", 3600)
+        assert result is False
+
+    def test_tampered_token_returns_false(self):
+        """Test that tampered token returns False."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        # Tamper with token by changing a character
+        tampered = token[:-1] + ("0" if token[-1] != "0" else "1")
+        result = validate_csrf_token(tampered, "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_garbage_token_returns_false(self):
+        """Test that garbage token returns False without raising."""
+        result = validate_csrf_token("not_a_valid_token", "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_empty_string_returns_false(self):
+        """Test that empty string returns False without raising."""
+        result = validate_csrf_token("", "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_none_token_returns_false(self):
+        """Test that None token returns False without raising."""
+        # validate_csrf_token expects str, but should handle None gracefully
+        try:
+            result = validate_csrf_token(None, "user@example.com", "session123", "secret", 3600)
+            assert result is False
+        except Exception:
+            # If it raises, that's also acceptable for None input
+            pass
+
+    def test_short_token_returns_false(self):
+        """Test that token shorter than 64 chars returns False."""
+        result = validate_csrf_token("abc123", "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_long_token_returns_false(self):
+        """Test that token longer than 64 chars returns False."""
+        token = "a" * 65
+        result = validate_csrf_token(token, "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_non_hex_token_returns_false(self):
+        """Test that token with non-hex characters returns False."""
+        token = "g" * 64  # 'g' is not a hex character
+        result = validate_csrf_token(token, "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+    def test_uppercase_hex_token_returns_false(self):
+        """Test that uppercase hex token returns False (expects lowercase)."""
+        token = generate_csrf_token("user@example.com", "session123", "secret", 3600)
+        uppercase_token = token.upper()
+        result = validate_csrf_token(uppercase_token, "user@example.com", "session123", "secret", 3600)
+        assert result is False
+
+
+class TestSetCSRFCookie:
+    """Test cases for set_csrf_cookie function."""
+
+    def test_sets_cookie_with_correct_parameters(self):
+        """Test that cookie is set with correct security parameters."""
+        response = Mock()
+        settings = Mock(
+            csrf_cookie_name="csrf_token",
+            csrf_cookie_secure=True,
+            csrf_cookie_samesite="Strict",
+            csrf_token_expiry=3600,
+            csrf_cookie_httponly=False,
+        )
+        token = "a" * 64
+
+        set_csrf_cookie(response, token, settings)
+
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args[1]
+
+        assert call_kwargs["key"] == "csrf_token"
+        assert call_kwargs["value"] == token
+        assert call_kwargs["httponly"] is False  # Must be readable by JS
+        assert call_kwargs["secure"] is True
+        assert call_kwargs["samesite"] == "Strict"
+        assert call_kwargs["max_age"] == 3600
+        assert call_kwargs["path"] == "/"
+
+    def test_httponly_always_false(self):
+        """Test that httponly is always False (CSRF tokens must be readable by JS)."""
+        response = Mock()
+        settings = Mock(
+            csrf_cookie_name="csrf_token",
+            csrf_cookie_secure=False,
+            csrf_cookie_samesite="Lax",
+            csrf_token_expiry=7200,
+            csrf_cookie_httponly=False,
+        )
+        token = "b" * 64
+
+        set_csrf_cookie(response, token, settings)
+
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["httponly"] is False
+
+    def test_respects_settings_secure_flag(self):
+        """Test that secure flag comes from settings."""
+        response = Mock()
+        settings = Mock(
+            csrf_cookie_name="csrf_token",
+            csrf_cookie_secure=False,
+            csrf_cookie_samesite="Lax",
+            csrf_token_expiry=3600
+        )
+        token = "c" * 64
+
+        set_csrf_cookie(response, token, settings)
+
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["secure"] is False
+
+    def test_respects_settings_samesite(self):
+        """Test that samesite comes from settings."""
+        response = Mock()
+        settings = Mock(
+            csrf_cookie_name="csrf_token",
+            csrf_cookie_secure=True,
+            csrf_cookie_samesite="None",
+            csrf_token_expiry=3600
+        )
+        token = "d" * 64
+
+        set_csrf_cookie(response, token, settings)
+
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["samesite"] == "None"
+
+
+class TestClearCSRFCookie:
+    """Test cases for clear_csrf_cookie function."""
+
+    def test_clears_cookie_with_max_age_zero(self):
+        """Test that cookie is cleared with max_age=0."""
+        response = Mock()
+        settings = Mock(
+            csrf_cookie_name="csrf_token",
+            csrf_cookie_secure=True,
+            csrf_cookie_samesite="Strict"
+        )
+
+        clear_csrf_cookie(response, settings)
+
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args[1]
+
+        assert call_kwargs["key"] == "csrf_token"
+        assert call_kwargs["value"] == ""
+        assert call_kwargs["max_age"] == 0
+        assert call_kwargs["httponly"] is False
+        assert call_kwargs["secure"] is True
+        assert call_kwargs["samesite"] == "Strict"
+        assert call_kwargs["path"] == "/"
+
+    def test_respects_settings_when_clearing(self):
+        """Test that settings are respected when clearing cookie."""
+        response = Mock()
+        settings = Mock(
+            csrf_cookie_name="csrf_token",
+            csrf_cookie_secure=False,
+            csrf_cookie_samesite="Lax"
+        )
+
+        clear_csrf_cookie(response, settings)
+
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["secure"] is False
+        assert call_kwargs["samesite"] == "Lax"

--- a/tests/unit/mcpgateway/services/test_csrf_service.py
+++ b/tests/unit/mcpgateway/services/test_csrf_service.py
@@ -10,14 +10,16 @@ Tests cover token generation, validation, cookie management, and edge cases.
 
 # Standard
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 # Third-Party
 import pytest
 
 # First-Party
 from mcpgateway.services.csrf_service import (
+    CSRFService,
     clear_csrf_cookie,
+    get_csrf_service,
     generate_csrf_token,
     set_csrf_cookie,
     validate_csrf_token,
@@ -164,6 +166,22 @@ class TestValidateCSRFToken:
         result = validate_csrf_token(uppercase_token, "user@example.com", "session123", "secret", 3600)
         assert result is False
 
+    def test_previous_window_compare_digest_path_returns_true(self):
+        """Test that a previous-window match is accepted."""
+        token = "a" * 64
+
+        with patch("mcpgateway.services.csrf_service.hmac.compare_digest", side_effect=[False, True]):
+            result = validate_csrf_token(token, "user@example.com", "session123", "secret", 3600)
+
+        assert result is True
+
+    def test_validation_exception_returns_false(self):
+        """Test that validation exceptions are handled and return False."""
+        with patch("mcpgateway.services.csrf_service.hmac.new", side_effect=Exception("boom")):
+            result = validate_csrf_token("a" * 64, "user@example.com", "session123", "secret", 3600)
+
+        assert result is False
+
 
 class TestSetCSRFCookie:
     """Test cases for set_csrf_cookie function."""
@@ -282,3 +300,41 @@ class TestClearCSRFCookie:
         call_kwargs = response.set_cookie.call_args[1]
         assert call_kwargs["secure"] is False
         assert call_kwargs["samesite"] == "Lax"
+
+
+class TestCSRFService:
+    """Test cases for CSRFService wrapper."""
+
+    def test_init_sets_secret_and_expiry(self):
+        service = CSRFService("secret", 3600)
+        assert service.secret == "secret"
+        assert service.expiry == 3600
+
+    def test_generate_csrf_token_delegates(self):
+        service = CSRFService("secret", 3600)
+
+        with patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="token") as mock_generate:
+            assert service.generate_csrf_token("user@example.com", "session123") == "token"
+
+        mock_generate.assert_called_once_with("user@example.com", "session123", "secret", 3600)
+
+    def test_validate_csrf_token_delegates(self):
+        service = CSRFService("secret", 3600)
+
+        with patch("mcpgateway.services.csrf_service.validate_csrf_token", return_value=True) as mock_validate:
+            assert service.validate_csrf_token("token", "user@example.com", "session123") is True
+
+        mock_validate.assert_called_once_with("token", "user@example.com", "session123", "secret", 3600)
+
+
+def test_get_csrf_service_uses_app_settings():
+    with patch("mcpgateway.services.csrf_service.app_settings") as mock_settings:
+        mock_settings.csrf_secret_key = "secret"
+        mock_settings.csrf_token_expiry = 3600
+
+        get_csrf_service.cache_clear()
+        service = get_csrf_service()
+
+    assert isinstance(service, CSRFService)
+    assert service.secret == "secret"
+    assert service.expiry == 3600

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4204,10 +4204,10 @@ class TestAdminUIRoute:
         mock_gateways.return_value = []
         mock_roots.return_value = []
 
-        # Mock settings
-        with patch("mcpgateway.admin.settings") as mock_settings:
-            mock_settings.app_root_path = "/custom/root"
-            mock_settings.gateway_tool_name_separator = "__"
+        # Mock settings with actual values instead of MagicMock
+        with patch.object(settings, "app_root_path", "/custom/root"), \
+             patch.object(settings, "gateway_tool_name_separator", "__"), \
+             patch.object(settings, "jwt_secret_key", "test-secret-key-with-minimum-32-bytes"):
 
             await admin_ui(
                 request=mock_request,
@@ -21838,7 +21838,7 @@ class TestAdminCsrfProtection:
         request = MagicMock()
         request.scope = {"root_path": "/mounted"}
 
-        assert admin_mod._admin_cookie_path(request) == "/mounted/admin"
+        assert admin_mod._admin_cookie_path(request) == "/mounted"
 
     def test_admin_cookie_path_falls_back_to_settings_root_path(self, monkeypatch):
         # First-Party
@@ -21848,7 +21848,7 @@ class TestAdminCsrfProtection:
         request = MagicMock()
         request.scope = {"root_path": ""}
 
-        assert admin_mod._admin_cookie_path(request) == "/api/proxy/mcp/admin"
+        assert admin_mod._admin_cookie_path(request) == "/api/proxy/mcp"
 
     def test_admin_cookie_path_normalizes_settings_root_path(self, monkeypatch):
         # First-Party
@@ -21858,7 +21858,7 @@ class TestAdminCsrfProtection:
         request = MagicMock()
         request.scope = {"root_path": ""}
 
-        assert admin_mod._admin_cookie_path(request) == "/api/proxy/mcp/admin"
+        assert admin_mod._admin_cookie_path(request) == "/api/proxy/mcp"
 
     def test_admin_cookie_path_returns_default_when_both_scope_and_settings_empty(self, monkeypatch):
         # First-Party
@@ -21868,7 +21868,7 @@ class TestAdminCsrfProtection:
         request = MagicMock()
         request.scope = {"root_path": ""}
 
-        assert admin_mod._admin_cookie_path(request) == "/admin"
+        assert admin_mod._admin_cookie_path(request) == "/"
 
     def test_admin_cookie_path_strips_trailing_slash_from_scope_root_path(self, monkeypatch):
         # First-Party
@@ -21878,7 +21878,7 @@ class TestAdminCsrfProtection:
         request = MagicMock()
         request.scope = {"root_path": "/mounted/"}
 
-        assert admin_mod._admin_cookie_path(request) == "/mounted/admin"
+        assert admin_mod._admin_cookie_path(request) == "/mounted"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -838,7 +838,9 @@ async def test_admin_ui_with_team_filter_and_cookie(monkeypatch):
 
     response = await admin.admin_ui(request, "team-1", True, mock_db, user=user)
     assert isinstance(response, HTMLResponse)
-    assert "jwt_token" in response.headers.get("set-cookie", "")
+    # Check that JWT token cookie is set (may be alongside other cookies like csrf_token)
+    set_cookie_header = response.headers.get("set-cookie", "")
+    assert "jwt_token=" in set_cookie_header or any("jwt_token=" in cookie for cookie in response.headers.getlist("set-cookie"))
     context = request.app.state.templates.TemplateResponse.call_args[0][2]
     assert context["selected_team_id"] == "team-1"
     assert len(context["tools"]) == 1

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -230,6 +230,21 @@ def _import_fresh_main_module(
 class TestConditionalPaths:
     """Test conditional code paths to improve coverage."""
 
+    def test_import_logs_csrf_disabled_when_setting_is_false(self, monkeypatch, caplog):
+        """Import-time CSRF middleware setup should log the disabled branch when CSRF is off."""
+        caplog.set_level("INFO")
+
+        _import_fresh_main_module(
+            monkeypatch,
+            overrides={
+                "csrf_enabled": False,
+            },
+        )
+
+        assert any(
+            "CSRF protection middleware disabled" in rec.message for rec in caplog.records
+        )
+
     def test_import_uses_rust_mcp_proxy_when_enabled(self, monkeypatch):
         """When boot mode is edge, the ingress mount selects rust-internal by default."""
         module = _import_fresh_main_module(
@@ -339,6 +354,33 @@ class TestConditionalPaths:
 
         assert module.mcp_transport_app.__class__.__name__ == "MCPRuntimeHeaderTransportWrapper"
         assert any("python-rust-built-disabled" in rec.message for rec in caplog.records)
+
+    def test_import_includes_siem_router_with_admin_csrf_dependency(self, monkeypatch):
+        """When SIEM export and admin API are enabled, the SIEM router is mounted with admin CSRF enforcement."""
+        include_calls = []
+        from fastapi.applications import FastAPI
+
+        original_include_router = FastAPI.include_router
+
+        def _capture_include_router(self, router, *args, **kwargs):  # noqa: ANN001
+            include_calls.append((router, kwargs.get("dependencies")))
+            return original_include_router(self, router, *args, **kwargs)
+
+        monkeypatch.setattr(FastAPI, "include_router", _capture_include_router)
+
+        _import_fresh_main_module(
+            monkeypatch,
+            overrides={
+                "mcpgateway_admin_api_enabled": True,
+                "siem_export_enabled": True,
+            },
+        )
+
+        assert any(
+            deps
+            and any(getattr(dep.dependency, "__name__", None) == "enforce_admin_csrf" for dep in deps)
+            for _, deps in include_calls
+        )
 
     def test_redis_initialization_path(self, test_client, auth_headers):
         """Test Redis initialization path by mocking settings."""

--- a/tests/unit/mcpgateway/test_main_helpers_extra.py
+++ b/tests/unit/mcpgateway/test_main_helpers_extra.py
@@ -78,8 +78,10 @@ def test_validate_security_configuration_logs_default_jwt_warnings(monkeypatch: 
         environment="production",
         uaid_allowed_domains=["trusted.example.com"],
         auth_required=True,
+        database_url="sqlite:///./mcp.db",
     )
     monkeypatch.setattr(main, "get_settings", lambda: fake_settings)
+
 
     caplog.set_level("WARNING", logger="mcpgateway")
 
@@ -99,10 +101,11 @@ def test_validate_security_configuration_logs_insecure_uaid_config(monkeypatch: 
         environment="production",
         uaid_allowed_domains=[],
         auth_required=False,
+        database_url="sqlite:///./mcp.db",
     )
     monkeypatch.setattr(main, "get_settings", lambda: fake_settings)
 
-    caplog.set_level("ERROR")
+    caplog.set_level("ERROR", logger="mcpgateway")
 
     main.validate_security_configuration()
 
@@ -123,7 +126,7 @@ def test_validate_security_configuration_security_error_exits(monkeypatch: pytes
     monkeypatch.setattr(main, "get_settings", _raise_security_error)
     monkeypatch.setattr(main.sys, "exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
 
-    caplog.set_level("CRITICAL")
+    caplog.set_level("CRITICAL", logger="mcpgateway")
 
     with pytest.raises(SystemExit) as excinfo:
         main.validate_security_configuration()

--- a/tests/unit/mcpgateway/test_rpc_backward_compatibility.py
+++ b/tests/unit/mcpgateway/test_rpc_backward_compatibility.py
@@ -37,44 +37,46 @@ class TestRPCBackwardCompatibility:
     def test_old_format_tool_invocation_with_backward_compatibility(self, client, mock_db):
         """Test that old format (direct tool name as method) still works with backward compatibility."""
         with patch("mcpgateway.config.settings.auth_required", False):
-            with patch("mcpgateway.main.get_db", return_value=mock_db):
-                with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
-                    with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
-                        mock_invoke.return_value = {"result": "success", "data": "test data from old format"}
+            with patch("mcpgateway.config.settings.csrf_enabled", False):
+                with patch("mcpgateway.main.get_db", return_value=mock_db):
+                    with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
+                        with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
+                            mock_invoke.return_value = {"result": "success", "data": "test data from old format"}
 
-                        # Old format: tool name directly as method
-                        request_body = {"jsonrpc": "2.0", "method": "my_custom_tool", "params": {"query": "test query", "limit": 10}, "id": 123}
+                            # Old format: tool name directly as method
+                            request_body = {"jsonrpc": "2.0", "method": "my_custom_tool", "params": {"query": "test query", "limit": 10}, "id": 123}
 
-                        response = client.post("/rpc", json=request_body)
+                            response = client.post("/rpc", json=request_body)
 
-                        assert response.status_code == 200
-                        result = response.json()
-                        assert result["jsonrpc"] == "2.0"
-                        assert "result" in result
-                        assert result["result"]["result"] == "success"
-                        assert result["result"]["data"] == "test data from old format"
-                        assert result["id"] == 123
+                            assert response.status_code == 200
+                            result = response.json()
+                            assert result["jsonrpc"] == "2.0"
+                            assert "result" in result
+                            assert result["result"]["result"] == "success"
+                            assert result["result"]["data"] == "test data from old format"
+                            assert result["id"] == 123
 
-                        # Verify the tool was invoked with correct parameters
-                        mock_invoke.assert_called_once()
-                        call_args = mock_invoke.call_args
-                        assert call_args.kwargs["name"] == "my_custom_tool"
+                            # Verify the tool was invoked with correct parameters
+                            mock_invoke.assert_called_once()
+                            call_args = mock_invoke.call_args
+                            assert call_args.kwargs["name"] == "my_custom_tool"
                         assert call_args.kwargs["arguments"] == {"query": "test query", "limit": 10}
 
     def test_new_format_tool_invocation_still_works(self, client, mock_db):
         """Test that new format (tools/call method) continues to work."""
         with patch("mcpgateway.config.settings.auth_required", False):
-            with patch("mcpgateway.main.get_db", return_value=mock_db):
-                with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
-                    with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
-                        mock_invoke.return_value = {"result": "success", "data": "test data from new format"}
+            with patch("mcpgateway.config.settings.csrf_enabled", False):
+                with patch("mcpgateway.main.get_db", return_value=mock_db):
+                    with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
+                        with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
+                            mock_invoke.return_value = {"result": "success", "data": "test data from new format"}
 
-                        # New format: tools/call method
-                        request_body = {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "my_custom_tool", "arguments": {"query": "test query", "limit": 10}}, "id": 456}
+                            # New format: tools/call method
+                            request_body = {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "my_custom_tool", "arguments": {"query": "test query", "limit": 10}}, "id": 456}
 
-                        response = client.post("/rpc", json=request_body)
+                            response = client.post("/rpc", json=request_body)
 
-                        assert response.status_code == 200
+                            assert response.status_code == 200
                         result = response.json()
                         assert result["jsonrpc"] == "2.0"
                         assert "result" in result
@@ -91,47 +93,55 @@ class TestRPCBackwardCompatibility:
     def test_both_formats_invoke_same_tool(self, client, mock_db):
         """Test that both old and new formats can invoke the same tool successfully."""
         with patch("mcpgateway.config.settings.auth_required", False):
-            with patch("mcpgateway.main.get_db", return_value=mock_db):
-                with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
-                    with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
-                        mock_invoke.return_value = {"result": "success"}
+            with patch("mcpgateway.config.settings.csrf_enabled", False):
+                with patch("mcpgateway.main.get_db", return_value=mock_db):
+                    with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
+                        with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
+                            mock_invoke.return_value = {"result": "success"}
 
-                        # Test old format
-                        old_format_request = {"jsonrpc": "2.0", "method": "search_tool", "params": {"query": "old format"}, "id": 1}
+                            # Test old format
+                            old_format_request = {"jsonrpc": "2.0", "method": "search_tool", "params": {"query": "old format"}, "id": 1}
 
-                        response_old = client.post("/rpc", json=old_format_request)
-                        assert response_old.status_code == 200
+                            response_old = client.post("/rpc", json=old_format_request)
+                            assert response_old.status_code == 200
 
-                        # Reset mock
-                        mock_invoke.reset_mock()
+                            # Verify first call
+                            assert mock_invoke.call_count == 1
+                            call_args = mock_invoke.call_args
+                            assert call_args.kwargs["name"] == "search_tool"
+                            assert call_args.kwargs["arguments"]["query"] == "old format"
 
-                        # Test new format
-                        new_format_request = {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_tool", "arguments": {"query": "new format"}}, "id": 2}
+                            # Reset mock
+                            mock_invoke.reset_mock()
 
-                        response_new = client.post("/rpc", json=new_format_request)
-                        assert response_new.status_code == 200
+                            # Test new format
+                            new_format_request = {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_tool", "arguments": {"query": "new format"}}, "id": 2}
 
-                        # Both should have invoked the tool
-                        assert mock_invoke.call_count == 1
-                        call_args = mock_invoke.call_args
-                        assert call_args.kwargs["name"] == "search_tool"
-                        assert call_args.kwargs["arguments"]["query"] == "new format"
+                            response_new = client.post("/rpc", json=new_format_request)
+                            assert response_new.status_code == 200
+
+                            # Verify second call after reset
+                            assert mock_invoke.call_count == 1
+                            call_args = mock_invoke.call_args
+                            assert call_args.kwargs["name"] == "search_tool"
+                            assert call_args.kwargs["arguments"]["query"] == "new format"
 
     def test_invalid_method_still_returns_error(self, client, mock_db):
         """Test that truly invalid methods still return an error."""
         with patch("mcpgateway.config.settings.auth_required", False):
-            with patch("mcpgateway.main.get_db", return_value=mock_db):
-                with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
-                    with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
-                        # Simulate tool not found
-                        mock_invoke.side_effect = ValueError("Tool not found")
+            with patch("mcpgateway.config.settings.csrf_enabled", False):
+                with patch("mcpgateway.main.get_db", return_value=mock_db):
+                    with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)):
+                        with patch("mcpgateway.main.tool_service.invoke_tool", new_callable=AsyncMock) as mock_invoke:
+                            # Simulate tool not found
+                            mock_invoke.side_effect = ValueError("Tool not found")
 
-                        # Gateway forwarding has been removed, so just expect error from tool failure
-                        request_body = {"jsonrpc": "2.0", "method": "completely_invalid_method", "params": {}, "id": 999}
+                            # Gateway forwarding has been removed, so just expect error from tool failure
+                            request_body = {"jsonrpc": "2.0", "method": "completely_invalid_method", "params": {}, "id": 999}
 
-                        response = client.post("/rpc", json=request_body)
+                            response = client.post("/rpc", json=request_body)
 
-                        assert response.status_code == 200
+                            assert response.status_code == 200
                         result = response.json()
                         assert result["jsonrpc"] == "2.0"
                         assert "error" in result


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #543

---

## 📝 Summary
_What does this PR do and why?_

Implements a unified CSRF protection system for ContextForge and binds CSRF tokens to authenticated JWT sessions (via verified `jti`). The change replaces the legacy admin‑only CSRF path with a single, consistent CSRF cookie/header across UI and API flows, backed by configurable settings. It adds middleware enforcement for unsafe methods, a `/auth/csrf-token` refresh endpoint, and Admin UI updates (meta tags + JS injection) so forms/fetch automatically carry the CSRF header. Default exemptions are expanded for admin login/reset flows and path exemptions now support prefix matching. Tests and templates are updated to align with the unified CSRF cookie name and behavior.

Key implementation points:
- CSRF token generation/validation uses `csrf_secret_key` and JWT `jti` session binding.
- Admin UI now relies on the unified CSRF token and metadata in `admin.html` + `admin.js`.
- Auth and password‑reset templates read the unified CSRF cookie.
- Exempt paths include `/admin/login`, `/admin/forgot-password`, `/admin/reset-password` with prefix support.
- Updated unit tests for admin and CSRF middleware.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command                                                                 | Status |
|---------------------------|-------------------------------------------------------------------------|--------|
| Lint suite                | `make lint`                                                             |        |
| Unit tests                | `make test` | ✅ |
| Coverage ≥ 80%            | `make coverage`                                                         |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
