### PR TITLE
feat(security):  Enforce Content Size Limits for resources and prompts (fixes #538 US-1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,19 @@ ALLOW_PUBLIC_VISIBILITY=true
 # SSRF_BLOCKED_NETWORKS=["169.254.169.254/32","169.254.169.123/32","fd00::1/128","169.254.0.0/16","fe80::/10","100.64.0.0/10"]
 # The 100.64.0.0/10 range is Carrier-Grade NAT (CGNAT) which some cloud providers use
 
+# -----------------------------------------------------------------------------
+# Content Security - Size Limits
+# -----------------------------------------------------------------------------
+# Maximum content sizes (in bytes) to prevent DoS attacks via large uploads
+
+# Maximum size for resource content (default: 102400 = 100KB)
+# Resources exceeding this limit will be rejected with 413 Payload Too Large
+# CONTENT_MAX_RESOURCE_SIZE=102400
+
+# # Maximum size for prompt templates (default: 10240 = 10KB)
+# # Prompts exceeding this limit will be rejected with 413 Payload Too Large
+# CONTENT_MAX_PROMPT_SIZE=10240
+
 # =============================================================================
 # Project defaults (batteries-included overrides)
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -106,8 +106,8 @@ ALLOW_PUBLIC_VISIBILITY=true
 # Resources exceeding this limit will be rejected with 413 Payload Too Large
 # CONTENT_MAX_RESOURCE_SIZE=102400
 
-# # Maximum size for prompt templates (default: 10240 = 10KB)
-# # Prompts exceeding this limit will be rejected with 413 Payload Too Large
+# Maximum size for prompt templates (default: 10240 = 10KB)
+# Prompts exceeding this limit will be rejected with 413 Payload Too Large
 # CONTENT_MAX_PROMPT_SIZE=10240
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ These settings are enabled by default for security—only disable for backward c
 | `REQUIRE_JTI` | Require JTI claim in tokens for revocation support | `true` |
 | `REQUIRE_TOKEN_EXPIRATION` | Require exp claim in tokens | `true` |
 | `PUBLIC_REGISTRATION_ENABLED` | Allow public user self-registration | `false` |
+
 ### 🛡️ Content Security
 
 Content size limits prevent DoS attacks and ensure system stability:
@@ -756,8 +757,7 @@ Content size limits prevent DoS attacks and ensure system stability:
 | `CONTENT_MAX_RESOURCE_SIZE` | Maximum resource content size (bytes) | `102400` (100KB) |
 | `CONTENT_MAX_PROMPT_SIZE` | Maximum prompt template size (bytes) | `10240` (10KB) |
 
-**Note:** Existing content is not affected. See [Content Limits Migration Guide](docs/MIGRATION_CONTENT_LIMITS.md) for details.
-
+**Note:** Size limits apply only to new create/update operations. Existing content is not retroactively validated.
 
 ### ⚙️ Project Defaults (Dev Setup)
 

--- a/README.md
+++ b/README.md
@@ -747,6 +747,17 @@ These settings are enabled by default for security—only disable for backward c
 | `REQUIRE_JTI` | Require JTI claim in tokens for revocation support | `true` |
 | `REQUIRE_TOKEN_EXPIRATION` | Require exp claim in tokens | `true` |
 | `PUBLIC_REGISTRATION_ENABLED` | Allow public user self-registration | `false` |
+### 🛡️ Content Security
+
+Content size limits prevent DoS attacks and ensure system stability:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CONTENT_MAX_RESOURCE_SIZE` | Maximum resource content size (bytes) | `102400` (100KB) |
+| `CONTENT_MAX_PROMPT_SIZE` | Maximum prompt template size (bytes) | `10240` (10KB) |
+
+**Note:** Existing content is not affected. See [Content Limits Migration Guide](docs/MIGRATION_CONTENT_LIMITS.md) for details.
+
 
 ### ⚙️ Project Defaults (Dev Setup)
 

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -410,6 +410,12 @@ mcpContextForge:
     # SSRF_ALLOW_PRIVATE_NETWORKS: "false"
     # SSRF_ALLOWED_NETWORKS: '["10.96.0.0/12"]' # example only, adjust to your cluster CIDR
 
+    # ─ Content Security - Size Limits ─
+    # Maximum content sizes (bytes) to prevent DoS via oversized uploads.
+    # Exceeding these returns HTTP 413 Payload Too Large.
+    CONTENT_MAX_RESOURCE_SIZE: "102400"        # 100KB default (min 1KB, max 10MB)
+    CONTENT_MAX_PROMPT_SIZE: "10240"           # 10KB default (min 512B, max 1MB)
+
     # ─ Logging ─
     LOG_LEVEL: INFO                  # DEBUG, INFO, WARNING, ERROR, CRITICAL
     LOG_FORMAT: json                 # json or text format

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -669,6 +669,31 @@ mcpContextForge:
     (`SSRF_ALLOW_LOCALHOST=true`, `SSRF_ALLOW_PRIVATE_NETWORKS=true`, `SSRF_DNS_FAIL_CLOSED=false`) so bundled test services can register without extra setup.
     Keep production deployments on strict SSRF values unless you explicitly need internal destination access.
 
+### Content Security - Size Limits
+
+Content size limits prevent DoS attacks and resource exhaustion from oversized content submissions. Validation occurs at the service layer before database writes and returns **HTTP 413 Payload Too Large** with structured error details.
+
+| Setting                      | Description                                      | Default   | Range           |
+| ---------------------------- | ------------------------------------------------ | --------- | --------------- |
+| `CONTENT_MAX_RESOURCE_SIZE`  | Maximum resource content size (bytes)            | `102400` (100KB) | 1KB – 10MB |
+| `CONTENT_MAX_PROMPT_SIZE`    | Maximum prompt template size (bytes)             | `10240` (10KB)   | 512B – 1MB |
+
+!!! note "Scope"
+    Size limits apply only to new create and update operations. Existing content is not retroactively validated.
+
+!!! example "Error Response"
+    Oversized content returns a structured 413 response:
+    ```json
+    {
+      "detail": {
+        "error": "Resource content size limit exceeded",
+        "message": "Resource content size (195.3 KB) exceeds maximum allowed size (100.0 KB)",
+        "actual_size": 200000,
+        "max_size": 102400
+      }
+    }
+    ```
+
 ### Ed25519 Certificate Signing
 
 ContextForge supports **Ed25519 digital signatures** for certificate validation and integrity verification.

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -425,7 +425,20 @@ The CI pipeline automatically verifies SRI hashes on every build to detect unexp
 - [x] Hashes use SHA-384 algorithm (W3C recommended)
 - [ ] Review SRI hashes after any CDN library updates
 
-### 9. Container Security
+### 9. Content Size Limits
+
+Configure content size limits to prevent DoS via oversized resource or prompt submissions:
+
+```bash
+# Defaults shown — adjust to your workload requirements
+CONTENT_MAX_RESOURCE_SIZE=102400  # 100KB for resources (range: 1KB–10MB)
+CONTENT_MAX_PROMPT_SIZE=10240     # 10KB for prompt templates (range: 512B–1MB)
+```
+
+- [ ] Review default size limits for your use case
+- [ ] Monitor 413 responses in logs for legitimate content being blocked
+
+### 10. Container Security
 
 ```bash
 # Run containers with security constraints
@@ -443,7 +456,7 @@ docker run \
 - [ ] Set resource limits (CPU, memory)
 - [ ] Scan images for vulnerabilities
 
-### 10. Secrets Management
+### 11. Secrets Management
 
 - [ ] **Never store secrets in environment variables directly**
 - [ ] Use a secrets management system (Vault, AWS Secrets Manager, etc.)
@@ -451,7 +464,7 @@ docker run \
 - [ ] Restrict container access to secrets
 - [ ] Never commit `.env` files to version control
 
-### 11. MCP Server Validation
+### 12. MCP Server Validation
 
 Before connecting any MCP server:
 
@@ -461,7 +474,7 @@ Before connecting any MCP server:
 - [ ] Monitor server behavior for anomalies
 - [ ] Implement rate limiting for untrusted servers
 
-### 12. Database Security
+### 13. Database Security
 
 - [ ] Use TLS for database connections
 - [ ] Configure strong passwords
@@ -469,7 +482,7 @@ Before connecting any MCP server:
 - [ ] Enable audit logging
 - [ ] Regular backups with encryption
 
-### 13. Monitoring & Logging
+### 14. Monitoring & Logging
 
 - [ ] Set up structured logging without sensitive data
 - [ ] Configure log rotation and secure storage
@@ -477,7 +490,7 @@ Before connecting any MCP server:
 - [ ] Set up anomaly detection
 - [ ] Create incident response procedures
 
-### 14. Integration Security
+### 15. Integration Security
 
 ContextForge should be integrated with:
 
@@ -487,7 +500,7 @@ ContextForge should be integrated with:
 - [ ] SIEM for security monitoring
 - [ ] Load balancer with TLS termination
 
-### 15. Well-Known URI Security
+### 16. Well-Known URI Security
 
 Configure well-known URIs appropriately for your deployment:
 
@@ -511,7 +524,7 @@ Security considerations:
 - [ ] Update security.txt Expires field before expiration
 - [ ] Consider custom well-known files only if necessary
 
-### 16. Downstream Application Security
+### 17. Downstream Application Security
 
 Applications consuming ContextForge data must:
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12103,7 +12103,7 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
             return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=409)
         if isinstance(ex, ContentSizeError):
             LOGGER.error(f"ContentSizeError in admin_add_resource: {ex}")
-            return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=413)
+            return ORJSONResponse(content={"message": str(ex), "success": False, "actual_size": ex.actual_size, "max_size": ex.max_size}, status_code=413)
         LOGGER.error(f"Error in admin_add_resource: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
@@ -12195,7 +12195,7 @@ async def admin_edit_resource(
             return ORJSONResponse(status_code=409, content={"message": str(ex), "success": False})
         if isinstance(ex, ContentSizeError):
             LOGGER.error(f"ContentSizeError in admin_edit_resource: {ex}")
-            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False})
+            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False, "actual_size": ex.actual_size, "max_size": ex.max_size})
         LOGGER.error(f"Error in admin_edit_resource: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
@@ -12432,7 +12432,7 @@ async def admin_add_prompt(request: Request, db: Session = Depends(get_db), user
             return ORJSONResponse(status_code=422, content={"message": str(ex), "success": False, "field": ex.field_name})
         if isinstance(ex, ContentSizeError):
             LOGGER.error(f"ContentSizeError in admin_add_prompt: {ex}")
-            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False})
+            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False, "actual_size": ex.actual_size, "max_size": ex.max_size})
         LOGGER.error(f"Error in admin_add_prompt: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
@@ -12536,7 +12536,7 @@ async def admin_edit_prompt(
             return ORJSONResponse(status_code=422, content={"message": str(ex), "success": False, "field": ex.field_name})
         if isinstance(ex, ContentSizeError):
             LOGGER.error(f"ContentSizeError in admin_edit_prompt: {ex}")
-            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False})
+            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False, "actual_size": ex.actual_size, "max_size": ex.max_size})
         LOGGER.error(f"Error in admin_edit_prompt: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -125,6 +125,7 @@ from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictE
 from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.catalog_service import catalog_service
+from mcpgateway.services.content_security import ContentSizeError
 from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, PasswordValidationError
 from mcpgateway.services.encryption_service import get_encryption_service
 from mcpgateway.services.export_service import ExportError, ExportService
@@ -12100,6 +12101,9 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
         if isinstance(ex, ResourceURIConflictError):
             LOGGER.error(f"ResourceURIConflictError in admin_add_resource: {ex}")
             return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=409)
+        if isinstance(ex, ContentSizeError):
+            LOGGER.error(f"ContentSizeError in admin_add_resource: {ex}")
+            return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=413)
         LOGGER.error(f"Error in admin_add_resource: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
@@ -12189,6 +12193,9 @@ async def admin_edit_resource(
         if isinstance(ex, ResourceURIConflictError):
             LOGGER.error(f"ResourceURIConflictError in admin_edit_resource: {ex}")
             return ORJSONResponse(status_code=409, content={"message": str(ex), "success": False})
+        if isinstance(ex, ContentSizeError):
+            LOGGER.error(f"ContentSizeError in admin_edit_resource: {ex}")
+            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False})
         LOGGER.error(f"Error in admin_edit_resource: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
@@ -12423,6 +12430,9 @@ async def admin_add_prompt(request: Request, db: Session = Depends(get_db), user
         if isinstance(ex, PromptArgumentsJSONError):
             LOGGER.error(f"PromptArgumentsJSONError in admin_add_prompt: {ex}")
             return ORJSONResponse(status_code=422, content={"message": str(ex), "success": False, "field": ex.field_name})
+        if isinstance(ex, ContentSizeError):
+            LOGGER.error(f"ContentSizeError in admin_add_prompt: {ex}")
+            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False})
         LOGGER.error(f"Error in admin_add_prompt: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
@@ -12524,6 +12534,9 @@ async def admin_edit_prompt(
         if isinstance(ex, PromptArgumentsJSONError):
             LOGGER.error(f"PromptArgumentsJSONError in admin_edit_prompt: {ex}")
             return ORJSONResponse(status_code=422, content={"message": str(ex), "success": False, "field": ex.field_name})
+        if isinstance(ex, ContentSizeError):
+            LOGGER.error(f"ContentSizeError in admin_edit_prompt: {ex}")
+            return ORJSONResponse(status_code=413, content={"message": str(ex), "success": False})
         LOGGER.error(f"Error in admin_edit_prompt: {ex}")
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -835,19 +835,12 @@ class SecurityValidator:
                 ...
             ValueError: Template contains potentially dangerous expressions
 
-            Length limit testing:
-
-            >>> long_template = 'a' * 65537
-            >>> SecurityValidator.validate_template(long_template)
-            Traceback (most recent call last):
-                ...
-            ValueError: Template exceeds maximum length of 65536
+            Length limit note: size validation is performed at the service layer
+            using configurable limits (ContentSecurityService). This validator
+            only checks encoding, dangerous patterns, and SSTI prevention.
         """
         if not value:
             return value
-
-        if len(value) > cls.MAX_TEMPLATE_LENGTH:
-            raise ValueError(f"Template exceeds maximum length of {cls.MAX_TEMPLATE_LENGTH}")
 
         # Block dangerous tags but allow Jinja2 syntax {{ }} and {% %} (uses precompiled regex)
         if _DANGEROUS_TEMPLATE_TAGS_RE.search(value):

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,7 +76,9 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')  # noqa: DUO138 - no ReDoS: inner groups require literal ; and = delimiters preventing backtrack ambiguity
+_MIME_TYPE_RE: Pattern[str] = re.compile(  # noqa: DUO138 - no ReDoS: inner groups require literal ; and = delimiters preventing backtrack ambiguity
+    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
+)
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1557,6 +1557,10 @@ class Settings(BaseSettings):
     tool_rate_limit: int = 100  # requests per minute
     tool_concurrent_limit: int = 10
 
+    # Content Security - Size Limits
+    content_max_resource_size: int = Field(default=102400, ge=1024, le=10485760, description="Maximum size in bytes for resource content (default: 100KB)")  # 100KB  # Minimum 1KB  # Maximum 10MB
+    content_max_prompt_size: int = Field(default=10240, ge=512, le=1048576, description="Maximum size in bytes for prompt templates (default: 10KB)")  # 10KB  # Minimum 512 bytes  # Maximum 1MB
+
     # MCP Session Pool - reduces per-request latency from ~20ms to ~1-2ms
     # Disabled by default for safety. Enable explicitly in production after testing.
     mcp_session_pool_enabled: bool = False

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2152,6 +2152,16 @@ async def database_exception_handler(_request: Request, exc: IntegrityError):
     return ORJSONResponse(status_code=409, content=ErrorFormatter.format_database_error(exc))
 
 
+@app.exception_handler(ContentSizeError)
+async def content_size_exception_handler(_request: Request, exc: ContentSizeError):
+    """Handle content size limit violations globally.
+
+    Returns 413 Payload Too Large with structured error details including
+    actual size, maximum allowed size, and a human-readable message.
+    """
+    return ORJSONResponse(status_code=413, content={"error": f"{exc.content_type} size limit exceeded", "message": str(exc), "actual_size": exc.actual_size, "max_size": exc.max_size})
+
+
 # RFC 9110 §5.6.2 'token' pattern for header field names:
 #   token = 1*tchar
 #   tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2163,7 +2163,7 @@ async def content_size_exception_handler(_request: Request, exc: ContentSizeErro
     Returns:
         ORJSONResponse: A 413 Payload Too Large response with structured error details.
     """
-    return ORJSONResponse(status_code=413, content={"error": f"{exc.content_type} size limit exceeded", "message": str(exc), "actual_size": exc.actual_size, "max_size": exc.max_size})
+    return ORJSONResponse(status_code=413, content={"detail": {"error": f"{exc.content_type} size limit exceeded", "message": str(exc), "actual_size": exc.actual_size, "max_size": exc.max_size}})
 
 
 # RFC 9110 §5.6.2 'token' pattern for header field names:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -134,6 +134,7 @@ from mcpgateway.schemas import (
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
 from mcpgateway.services.cancellation_service import cancellation_service
 from mcpgateway.services.completion_service import CompletionService
+from mcpgateway.services.content_security import ContentSizeError
 from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.export_service import ExportError, ExportService
 from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayDuplicateConflictError, GatewayError, GatewayNameConflictError, GatewayNotFoundError
@@ -5411,6 +5412,9 @@ async def create_resource(
     except IntegrityError as e:
         logger.error(f"Integrity error while creating resource: {e}")
         raise HTTPException(status_code=409, detail=ErrorFormatter.format_database_error(e))
+    except ContentSizeError as e:
+        logger.error(f"Content size exceeded in creating resource: {e}")
+        raise HTTPException(status_code=413, detail={"error": f"{e.content_type} size limit exceeded", "message": str(e), "actual_size": e.actual_size, "max_size": e.max_size})
 
 
 @resource_router.get("/{resource_id}")
@@ -5591,6 +5595,9 @@ async def update_resource(
         raise HTTPException(status_code=409, detail=ErrorFormatter.format_database_error(e))
     except ResourceURIConflictError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except ContentSizeError as e:
+        logger.error(f"Content size exceeded in updating resource: {e}")
+        raise HTTPException(status_code=413, detail={"error": f"{e.content_type} size limit exceeded", "message": str(e), "actual_size": e.actual_size, "max_size": e.max_size})
     db.commit()
     db.close()
     await invalidate_resource_cache(resource_id)
@@ -5915,6 +5922,9 @@ async def create_prompt(
             # If there is an integrity error, return a 409 Conflict error
             logger.error(f"Integrity error while creating prompt: {e}")
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=ErrorFormatter.format_database_error(e))
+        if isinstance(e, ContentSizeError):
+            logger.error(f"Content size exceeded in creating prompt: {e}")
+            raise HTTPException(status_code=413, detail={"error": f"{e.content_type} size limit exceeded", "message": str(e), "actual_size": e.actual_size, "max_size": e.max_size})
         # For any other unexpected errors, return a 500 Internal Server Error
         logger.error(f"Unexpected error while creating prompt: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred while creating the prompt")
@@ -6109,6 +6119,9 @@ async def update_prompt(
         if isinstance(e, PromptError):
             # If there is a general prompt error, return a 400 Bad Request error
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        if isinstance(e, ContentSizeError):
+            logger.error(f"Content size exceeded in updating prompt: {e}")
+            raise HTTPException(status_code=413, detail={"error": f"{e.content_type} size limit exceeded", "message": str(e), "actual_size": e.actual_size, "max_size": e.max_size})
         # For any other unexpected errors, return a 500 Internal Server Error
         logger.error(f"Unexpected error while updating prompt: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred while updating the prompt")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2156,8 +2156,12 @@ async def database_exception_handler(_request: Request, exc: IntegrityError):
 async def content_size_exception_handler(_request: Request, exc: ContentSizeError):
     """Handle content size limit violations globally.
 
-    Returns 413 Payload Too Large with structured error details including
-    actual size, maximum allowed size, and a human-readable message.
+    Args:
+        _request: The incoming request (unused, required by FastAPI handler interface).
+        exc: The ContentSizeError with actual_size, max_size, and content_type.
+
+    Returns:
+        ORJSONResponse: A 413 Payload Too Large response with structured error details.
     """
     return ORJSONResponse(status_code=413, content={"error": f"{exc.content_type} size limit exceeded", "message": str(exc), "actual_size": exc.actual_size, "max_size": exc.max_size})
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1890,7 +1890,10 @@ class ResourceUpdate(BaseModelWithConfigDict):
     @field_validator("content")
     @classmethod
     def validate_content(cls, v: Optional[Union[str, bytes]]) -> Optional[Union[str, bytes]]:
-        """Validate content size and safety
+        """Validate content safety.
+
+        Note: Size validation is performed at the service layer using configurable limits.
+        This validator only checks encoding and dangerous patterns.
 
         Args:
             v (Union[str, bytes]): Value to validate
@@ -1904,9 +1907,7 @@ class ResourceUpdate(BaseModelWithConfigDict):
         if v is None:
             return v
 
-        if len(v) > SecurityValidator.MAX_CONTENT_LENGTH:
-            raise ValueError(f"Content exceeds maximum length of {SecurityValidator.MAX_CONTENT_LENGTH}")
-
+        # Validate UTF-8 encoding for bytes
         if isinstance(v, bytes):
             try:
                 text = v.decode("utf-8")
@@ -1914,6 +1915,8 @@ class ResourceUpdate(BaseModelWithConfigDict):
                 raise ValueError("Content must be UTF-8 decodable")
         else:
             text = v
+
+        # Check for dangerous HTML patterns
         # Runtime pattern matching (not precompiled to allow test monkeypatching)
         if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, text, re.IGNORECASE):
             raise ValueError("Content contains HTML tags that may cause display issues")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1761,7 +1761,10 @@ class ResourceCreate(BaseModel):
     @field_validator("content")
     @classmethod
     def validate_content(cls, v: Optional[Union[str, bytes]]) -> Optional[Union[str, bytes]]:
-        """Validate content size and safety
+        """Validate content safety.
+
+        Note: Size validation is performed at the service layer using configurable limits.
+        This validator only checks encoding and dangerous patterns.
 
         Args:
             v (Union[str, bytes]): Value to validate
@@ -1775,9 +1778,7 @@ class ResourceCreate(BaseModel):
         if v is None:
             return v
 
-        if len(v) > SecurityValidator.MAX_CONTENT_LENGTH:
-            raise ValueError(f"Content exceeds maximum length of {SecurityValidator.MAX_CONTENT_LENGTH}")
-
+        # Validate UTF-8 encoding for bytes
         if isinstance(v, bytes):
             try:
                 text = v.decode("utf-8")
@@ -1785,6 +1786,8 @@ class ResourceCreate(BaseModel):
                 raise ValueError("Content must be UTF-8 decodable")
         else:
             text = v
+
+        # Check for dangerous HTML patterns
         # Runtime pattern matching (not precompiled to allow test monkeypatching)
         if re.search(SecurityValidator.DANGEROUS_HTML_PATTERN, text, re.IGNORECASE):
             raise ValueError("Content contains HTML tags that may cause display issues")

--- a/mcpgateway/services/content_security.py
+++ b/mcpgateway/services/content_security.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/content_security.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Content Security Service for ContextForge.
+Provides validation for user-submitted content including size limits,
+MIME type restrictions, and malicious pattern detection.
+
+This module implements (Content Size Limits) from issue #538.
+"""
+
+# Standard
+import hashlib
+import logging
+import threading
+from typing import Optional, Union
+
+# First-Party
+from mcpgateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_pii_for_logging(user_email: Optional[str] = None, ip_address: Optional[str] = None) -> dict:
+    """Sanitize PII data for secure logging.
+
+    Args:
+        user_email: User email to sanitize (returns first 8 chars of SHA256 hash)
+        ip_address: IP address to sanitize (masks last octet)
+
+    Returns:
+        Dictionary with sanitized values suitable for logging
+
+    Examples:
+        >>> result = _sanitize_pii_for_logging("user@example.com", "192.168.1.100")
+        >>> 'user_hash' in result and 'ip_subnet' in result
+        True
+        >>> result = _sanitize_pii_for_logging(None, None)
+        >>> result
+        {'user_hash': None, 'ip_subnet': None}
+    """
+    user_hash = None
+    if user_email:
+        user_hash = hashlib.sha256(user_email.encode()).hexdigest()[:8]
+
+    ip_subnet = None
+    if ip_address:
+        # Mask last octet for IPv4, or last segment for IPv6
+        if ":" in ip_address:  # IPv6
+            parts = ip_address.split(":")
+            ip_subnet = ":".join(parts[:-1]) + ":xxxx"
+        else:  # IPv4
+            ip_subnet = ip_address.rsplit(".", 1)[0] + ".xxx"
+
+    return {"user_hash": user_hash, "ip_subnet": ip_subnet}
+
+
+def _format_bytes(bytes_val: int) -> str:
+    """Format bytes as human-readable size.
+
+    Args:
+        bytes_val: Size in bytes
+
+    Returns:
+        Human-readable size string (e.g., "195.3 KB")
+
+    Examples:
+        >>> _format_bytes(1024)
+        '1.0 KB'
+        >>> _format_bytes(1536)
+        '1.5 KB'
+        >>> _format_bytes(1048576)
+        '1.0 MB'
+        >>> _format_bytes(500)
+        '500 B'
+    """
+    if bytes_val < 1024:
+        return f"{bytes_val} B"
+
+    size_kb = bytes_val / 1024.0
+    if size_kb < 1024:
+        return f"{size_kb:.1f} KB"
+
+    size_mb = size_kb / 1024.0
+    if size_mb < 1024:
+        return f"{size_mb:.1f} MB"
+
+    size_gb = size_mb / 1024.0
+    return f"{size_gb:.1f} GB"
+
+
+class ContentSizeError(Exception):
+    """Raised when content exceeds size limits."""
+
+    def __init__(self, content_type: str, actual_size: int, max_size: int):
+        """Initialize ContentSizeError with size details.
+
+        Args:
+            content_type: Type of content (e.g., "Resource content", "Prompt template")
+            actual_size: Actual size of the content in bytes
+            max_size: Maximum allowed size in bytes
+        """
+        self.content_type = content_type
+        self.actual_size = actual_size
+        self.max_size = max_size
+
+        # Format sizes for human readability
+        actual_formatted = _format_bytes(actual_size)
+        max_formatted = _format_bytes(max_size)
+
+        super().__init__(f"{content_type} size ({actual_formatted}) exceeds " f"maximum allowed size ({max_formatted})")
+
+
+class ContentSecurityService:
+    """Service for validating content security constraints.
+
+    This service provides validation for:
+    - Content size limits
+    - MIME type restrictions (US-2, future)
+    - Malicious pattern detection (US-3, future)
+    - Template syntax validation (US-4, future)
+
+    Examples:
+        >>> service = ContentSecurityService()
+        >>> service.validate_resource_size("x" * 50000)  # 50KB - OK
+        >>> try:
+        ...     service.validate_resource_size("x" * 200000)  # 200KB - Too large
+        ... except ContentSizeError as e:
+        ...     print(f"Error: {e.actual_size} > {e.max_size}")
+        Error: 200000 > 102400
+    """
+
+    def __init__(self):
+        """Initialize the content security service."""
+        self.max_resource_size = settings.content_max_resource_size
+        self.max_prompt_size = settings.content_max_prompt_size
+        logger.info("ContentSecurityService initialized: " f"max_resource_size={self.max_resource_size}, " f"max_prompt_size={self.max_prompt_size}")
+
+    def validate_resource_size(self, content: Union[str, bytes], uri: Optional[str] = None, user_email: Optional[str] = None, ip_address: Optional[str] = None) -> None:
+        """Validate resource content size.
+
+        Args:
+            content: The resource content to validate (string or bytes)
+            uri: Optional resource URI for logging
+            user_email: Optional user email for logging
+            ip_address: Optional IP address for logging
+
+        Raises:
+            ContentSizeError: If content exceeds maximum size
+
+        Examples:
+            >>> service = ContentSecurityService()
+            >>> service.validate_resource_size("small content")  # OK
+            >>> try:
+            ...     service.validate_resource_size("x" * 200000)
+            ... except ContentSizeError:
+            ...     print("Too large")
+            Too large
+        """
+        content_bytes = content.encode("utf-8") if isinstance(content, str) else content
+        actual_size = len(content_bytes)
+
+        if actual_size > self.max_resource_size:
+            # Log security violation with sanitized PII
+            sanitized = _sanitize_pii_for_logging(user_email, ip_address)
+            logger.warning(
+                "Resource size limit exceeded", extra={"actual_size": actual_size, "max_size": self.max_resource_size, "content_type": "resource", "uri_provided": uri is not None, **sanitized}
+            )
+            raise ContentSizeError("Resource content", actual_size, self.max_resource_size)
+
+        logger.debug(f"Resource size validation passed: {actual_size} bytes")
+
+    def validate_prompt_size(self, template: str, name: Optional[str] = None, user_email: Optional[str] = None, ip_address: Optional[str] = None) -> None:
+        """Validate prompt template size.
+
+        Args:
+            template: The prompt template to validate
+            name: Optional prompt name for logging
+            user_email: Optional user email for logging
+            ip_address: Optional IP address for logging
+
+        Raises:
+            ContentSizeError: If template exceeds maximum size
+
+        Examples:
+            >>> service = ContentSecurityService()
+            >>> service.validate_prompt_size("Hello {{user}}")  # OK
+            >>> try:
+            ...     service.validate_prompt_size("x" * 20000)
+            ... except ContentSizeError:
+            ...     print("Too large")
+            Too large
+        """
+        template_bytes = template.encode("utf-8") if isinstance(template, str) else template
+        actual_size = len(template_bytes)
+
+        if actual_size > self.max_prompt_size:
+            # Log security violation with sanitized PII
+            sanitized = _sanitize_pii_for_logging(user_email, ip_address)
+            logger.warning("Prompt size limit exceeded", extra={"actual_size": actual_size, "max_size": self.max_prompt_size, "content_type": "prompt", "name_provided": name is not None, **sanitized})
+            raise ContentSizeError("Prompt template", actual_size, self.max_prompt_size)
+
+        logger.debug(f"Prompt size validation passed: {actual_size} bytes")
+
+
+# Singleton instance with thread-safe initialization
+_content_security_service: Optional[ContentSecurityService] = None
+_content_security_service_lock = threading.Lock()
+
+
+def get_content_security_service() -> ContentSecurityService:
+    """Get or create the singleton ContentSecurityService instance.
+
+    Thread-safe singleton implementation using double-checked locking pattern
+    to prevent race conditions (CWE-362).
+
+    Returns:
+        ContentSecurityService: The singleton instance
+
+    Examples:
+        >>> service1 = get_content_security_service()
+        >>> service2 = get_content_security_service()
+        >>> service1 is service2
+        True
+    """
+    global _content_security_service  # pylint: disable=global-statement
+
+    # First check (without lock for performance)
+    if _content_security_service is None:
+        # Acquire lock for thread-safe initialization
+        with _content_security_service_lock:
+            # Second check (with lock to prevent race condition)
+            if _content_security_service is None:
+                _content_security_service = ContentSecurityService()
+
+    return _content_security_service

--- a/mcpgateway/services/content_security.py
+++ b/mcpgateway/services/content_security.py
@@ -235,3 +235,13 @@ def get_content_security_service() -> ContentSecurityService:
                 _content_security_service = ContentSecurityService()
 
     return _content_security_service
+
+
+def reset_content_security_service() -> None:
+    """Reset the singleton instance so it re-reads settings on next access.
+
+    Intended for test teardown when monkeypatching size limits.
+    """
+    global _content_security_service  # pylint: disable=global-statement
+    with _content_security_service_lock:
+        _content_security_service = None

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -47,6 +47,7 @@ from mcpgateway.plugins.framework import get_plugin_manager, GlobalContext, Plug
 from mcpgateway.schemas import PromptCreate, PromptMetrics, PromptRead, PromptUpdate, TopPerformer
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
+from mcpgateway.services.content_security import ContentSizeError, get_content_security_service
 from mcpgateway.services.event_service import EventService
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.mcp_session_pool import get_mcp_session_pool, TransportType
@@ -636,6 +637,7 @@ class PromptService(BaseService):
             IntegrityError: If a database integrity error occurs.
             PromptNameConflictError: If a prompt with the same name already exists.
             PromptError: For other prompt registration errors
+            ContentSizeError: For template size exceed
 
         Examples:
             >>> import logging
@@ -664,6 +666,14 @@ class PromptService(BaseService):
             >>> logging.disable(logging.NOTSET)
         """
         try:
+            content_security = get_content_security_service()
+            content_security.validate_prompt_size(
+                template=prompt.template,
+                name=prompt.name,
+                user_email=created_by or owner_email,
+                ip_address=created_from_ip,
+            )
+
             # Validate template syntax
             self._validate_template(prompt.template)
 
@@ -831,6 +841,19 @@ class PromptService(BaseService):
                 custom_fields={"prompt_name": prompt.name, "visibility": visibility},
             )
             raise se
+        except ContentSizeError as cse:
+            db.rollback()
+
+            structured_logger.log(
+                level="ERROR",
+                message=f"Prompt template size limit exceeded: {cse.actual_size} bytes (max: {cse.max_size} bytes)",
+                event_type="prompt_size_exceed",
+                component="prompt_service",
+                user_id=created_by,
+                user_email=owner_email,
+                custom_fields={"prompt_name": prompt.name, "visibility": visibility},
+            )
+            raise cse
         except Exception as e:
             db.rollback()
 
@@ -976,6 +999,10 @@ class PromptService(BaseService):
 
                 for prompt in chunk:
                     try:
+                        # Validate template size BEFORE any processing
+                        content_security = get_content_security_service()
+                        content_security.validate_prompt_size(template=prompt.template, name=prompt.name, user_email=created_by, ip_address=created_from_ip)
+
                         # Validate template syntax
                         self._validate_template(prompt.template)
 
@@ -2004,6 +2031,7 @@ class PromptService(BaseService):
             IntegrityError: If a database integrity error occurs.
             PromptNameConflictError: If a prompt with the same name already exists.
             PromptError: For other update errors
+            ContentSizeError: For template size exceed
 
         Examples:
             >>> import logging
@@ -2093,6 +2121,14 @@ class PromptService(BaseService):
             if prompt_update.description is not None:
                 prompt.description = prompt_update.description
             if prompt_update.template is not None:
+                # Validate template size before updating
+                content_security = get_content_security_service()
+                content_security.validate_prompt_size(
+                    template=prompt_update.template,
+                    name=prompt.name,
+                    user_email=modified_by or user_email,
+                    ip_address=modified_from_ip,
+                )
                 prompt.template = prompt_update.template
                 self._validate_template(prompt.template)
                 # Clear template cache to reduce memory growth
@@ -2239,6 +2275,20 @@ class PromptService(BaseService):
                 error=pnce,
             )
             raise pnce
+        except ContentSizeError as cse:
+            db.rollback()
+            logger.error(f"Prompt template size limit exceeded: {cse.actual_size} bytes (max: {cse.max_size} bytes)")
+            structured_logger.log(
+                level="ERROR",
+                message="Prompt update failed - Template size exceeded",
+                event_type="prompt_update_failed",
+                component="prompt_service",
+                user_email=user_email,
+                resource_type="prompt",
+                resource_id=str(prompt_id),
+                error=cse,
+            )
+            raise cse
         except Exception as e:
             db.rollback()
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -59,6 +59,7 @@ from mcpgateway.observability import create_span
 from mcpgateway.schemas import ResourceCreate, ResourceMetrics, ResourceRead, ResourceSubscription, ResourceUpdate, TopPerformer
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
+from mcpgateway.services.content_security import ContentSizeError, get_content_security_service
 from mcpgateway.services.event_service import EventService
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.mcp_session_pool import get_mcp_session_pool, TransportType
@@ -401,6 +402,7 @@ class ResourceService(BaseService):
             IntegrityError: If a database integrity error occurs.
             ResourceURIConflictError: If a resource with the same URI already exists.
             ResourceError: For other resource registration errors
+            ContentSizeError: For content size exceed
 
         Examples:
             >>> from mcpgateway.services.resource_service import ResourceService
@@ -422,6 +424,22 @@ class ResourceService(BaseService):
         """
         try:
             logger.info(f"Registering resource: {resource.uri}")
+
+            # Validate content size BEFORE any database operations
+            content_security = get_content_security_service()
+            content_to_validate = ""
+
+            # Extract content from resource for validation
+            # Use raw bytes for accurate size measurement to prevent bypass via non-UTF-8 content
+            if hasattr(resource, "content") and resource.content:
+                if isinstance(resource.content, bytes):
+                    # Validate using raw bytes to get accurate size
+                    content_to_validate = resource.content
+                else:
+                    # Convert string to bytes for consistent size measurement
+                    content_to_validate = str(resource.content)
+
+            content_security.validate_resource_size(content=content_to_validate, uri=resource.uri, user_email=created_by, ip_address=created_from_ip)
 
             # Extract gateway_id from resource if present
             gateway_id = getattr(resource, "gateway_id", None)
@@ -564,6 +582,21 @@ class ResourceService(BaseService):
                 },
             )
             raise rce
+        except ContentSizeError as cse:
+
+            structured_logger.log(
+                level="ERROR",
+                message=f"Resource content size limit exceeded: {cse.actual_size} bytes (max: {cse.max_size} bytes)",
+                event_type="resource_size_exceed",
+                component="resource_service",
+                user_id=created_by,
+                user_email=owner_email,
+                custom_fields={
+                    "resource_uri": resource.uri,
+                    "visibility": visibility,
+                },
+            )
+            raise cse
         except Exception as e:
             db.rollback()
 
@@ -677,6 +710,16 @@ class ResourceService(BaseService):
 
                 for resource in chunk:
                     try:
+                        # Validate content size before processing
+                        if hasattr(resource, "content") and resource.content:
+                            content_security = get_content_security_service()
+                            content_security.validate_resource_size(
+                                content=resource.content,
+                                uri=resource.uri,
+                                user_email=created_by,
+                                ip_address=created_from_ip,
+                            )
+
                         # Use provided parameters or schema values
                         resource_team_id = team_id if team_id is not None else getattr(resource, "team_id", None)
                         resource_owner_email = owner_email or getattr(resource, "owner_email", None) or created_by
@@ -2699,6 +2742,7 @@ class ResourceService(BaseService):
             ResourceError: For other update errors
             IntegrityError: If a database integrity error occurs.
             Exception: For unexpected errors
+            ContentSizeError: For content size exceed
 
         Example:
             >>> from mcpgateway.services.resource_service import ResourceService
@@ -2765,6 +2809,15 @@ class ResourceService(BaseService):
 
             # Update content if provided
             if resource_update.content is not None:
+                # Validate content size before updating
+                content_security = get_content_security_service()
+                content_security.validate_resource_size(
+                    content=resource_update.content,
+                    uri=resource_update.uri or resource.uri,
+                    user_email=modified_by or user_email,
+                    ip_address=modified_from_ip,
+                )
+
                 # Determine content storage
                 is_text = resource.mime_type and resource.mime_type.startswith("text/") or isinstance(resource_update.content, str)
 
@@ -2895,6 +2948,20 @@ class ResourceService(BaseService):
                 error=ie,
             )
             raise ie
+        except ContentSizeError as cse:
+
+            structured_logger.log(
+                level="ERROR",
+                message=f"Resource content size limit exceeded: {cse.actual_size} bytes (max: {cse.max_size} bytes)",
+                event_type="resource_content_size_exceed",
+                component="resource_service",
+                resource_type="resource",
+                user_id=modified_by,
+                user_email=user_email,
+                resource_id=str(resource_id),
+                error=cse,
+            )
+            raise cse
         except ResourceURIConflictError as pe:
             logger.error(f"Resource URI conflict: {pe}")
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -583,7 +583,7 @@ class ResourceService(BaseService):
             )
             raise rce
         except ContentSizeError as cse:
-
+            db.rollback()
             structured_logger.log(
                 level="ERROR",
                 message=f"Resource content size limit exceeded: {cse.actual_size} bytes (max: {cse.max_size} bytes)",
@@ -2949,7 +2949,7 @@ class ResourceService(BaseService):
             )
             raise ie
         except ContentSizeError as cse:
-
+            db.rollback()
             structured_logger.log(
                 level="ERROR",
                 message=f"Resource content size limit exceeded: {cse.actual_size} bytes (max: {cse.max_size} bytes)",

--- a/tests/integration/test_content_size_limits.py
+++ b/tests/integration/test_content_size_limits.py
@@ -1,0 +1,716 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for content size limits
+
+This module tests the acceptance criteria:
+- Resource content exceeding 100KB limit returns 413
+- Prompt template exceeding 10KB limit returns 413
+- Content within limits succeeds
+- Error responses include size limit information
+- Size validation applies to both create and update operations
+"""
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from starlette.testclient import TestClient
+
+from mcpgateway.auth import get_current_user
+from mcpgateway.utils.verify_credentials import require_auth
+from mcpgateway.db import Base
+from mcpgateway.main import app
+from mcpgateway.middleware.rbac import (
+    get_current_user_with_permissions,
+    get_db as rbac_get_db,
+    get_permission_service,
+)
+
+
+class MockPermissionService:
+    """Mock permission service that always grants access."""
+
+    def __init__(self, always_grant=True):
+        self.always_grant = always_grant
+
+    async def check_permission(self, *args, **kwargs):
+        return self.always_grant
+
+
+@pytest.fixture
+def test_app():
+    """Create test app with proper database setup."""
+    mp = MonkeyPatch()
+
+    # Create temp SQLite file
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    # Patch settings
+    from mcpgateway.config import settings
+
+    mp.setattr(settings, "database_url", url, raising=False)
+
+    import mcpgateway.db as db_mod
+    import mcpgateway.main as main_mod
+
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestingSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestingSessionLocal, raising=False)
+    mp.setattr(main_mod, "engine", engine, raising=False)
+
+    # Create schema
+    Base.metadata.create_all(bind=engine)
+
+    # Create mock user for basic auth
+    mock_email_user = MagicMock()
+    mock_email_user.email = "test_user@example.com"
+    mock_email_user.full_name = "Test User"
+    mock_email_user.is_admin = True
+    mock_email_user.is_active = True
+
+    async def mock_user_with_permissions():
+        """Mock user context for RBAC."""
+        db_session = TestingSessionLocal()
+        try:
+            yield {
+                "email": "test_user@example.com",
+                "full_name": "Test User",
+                "is_admin": True,
+                "ip_address": "127.0.0.1",
+                "user_agent": "test-client",
+                "db": db_session,
+            }
+        finally:
+            db_session.close()
+
+    def mock_get_permission_service(*args, **kwargs):
+        """Return a mock permission service that always grants access."""
+        return MockPermissionService(always_grant=True)
+
+    def override_get_db():
+        """Override database dependency to return our test database."""
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # Patch the PermissionService class to always return our mock
+    with patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService):
+        app.dependency_overrides[require_auth] = lambda: "test_user"
+        app.dependency_overrides[get_current_user] = lambda: mock_email_user
+        app.dependency_overrides[get_current_user_with_permissions] = mock_user_with_permissions
+        app.dependency_overrides[get_permission_service] = mock_get_permission_service
+        app.dependency_overrides[rbac_get_db] = override_get_db
+
+        yield app
+
+        # Cleanup
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_current_user_with_permissions, None)
+        app.dependency_overrides.pop(get_permission_service, None)
+        app.dependency_overrides.pop(rbac_get_db, None)
+
+    mp.undo()
+    engine.dispose()
+    os.close(fd)
+    os.unlink(path)
+
+
+@pytest.fixture
+def client(test_app):
+    """Create test client."""
+    return TestClient(test_app)
+
+
+@pytest.fixture
+def auth_headers() -> dict[str, str]:
+    """Dummy Bearer token accepted by the overridden dependency."""
+    return {"Authorization": "Bearer test.token.size_limits"}
+
+
+
+import pytest
+from fastapi import status
+
+
+class TestResourceSizeLimits:
+    """Test resource content size limits."""
+
+    def test_create_resource_within_limit(self, client, auth_headers):
+        """Test creating resource with content within size limit (50KB)."""
+        content = "x" * 50000  # 50KB - well under 100KB limit
+        response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://resource-small",
+                "name": "Small Resource",
+                "content": content
+            },
+            headers=auth_headers
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["uri"] == "test://resource-small"
+
+    def test_create_resource_at_limit(self, client, auth_headers):
+        """Test creating resource with content at exact size limit (100KB)."""
+        content = "x" * 102400  # Exactly 100KB
+        response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://resource-at-limit",
+                "name": "At Limit Resource",
+                "content": content
+            },
+            headers=auth_headers
+        )
+        # Should succeed at exact limit
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_create_resource_exceeds_limit(self, client, auth_headers):
+        """Test creating resource with oversized content returns 413."""
+        content = "x" * 200000  # 200KB - over 100KB limit
+        response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://resource-large",
+                "name": "Large Resource",
+                "content": content
+            },
+            headers=auth_headers
+        )
+
+        # Should return 413 Payload Too Large
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+        # Verify error response structure
+        data = response.json()
+        assert "detail" in data
+        detail = data["detail"]
+
+        # Verify error includes size information
+        assert "actual_size" in detail
+        assert "max_size" in detail
+        assert "error" in detail
+        assert "message" in detail
+
+        # Verify size values
+        assert detail["actual_size"] == 200000
+        assert detail["max_size"] == 102400
+        assert detail["actual_size"] > detail["max_size"]
+
+        # Verify error message is clear
+        assert "size limit exceeded" in detail["error"].lower()
+
+    def test_create_resource_one_byte_over(self, client, auth_headers):
+        """Test creating resource one byte over limit returns 413."""
+        content = "x" * 102401  # 100KB + 1 byte
+        response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://resource-one-over",
+                "name": "One Over Resource",
+                "content": content
+            },
+            headers=auth_headers
+        )
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+    def test_create_resource_unicode_content(self, client, auth_headers):
+        """Test size validation handles Unicode content correctly."""
+        # Unicode emoji characters are 4 bytes each in UTF-8
+        content = "🎉" * 30000  # 30000 * 4 = 120KB
+        response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://resource-unicode",
+                "name": "Unicode Resource",
+                "content": content
+            },
+            headers=auth_headers
+        )
+        # Should be rejected as it exceeds 100KB
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+
+class TestPromptSizeLimits:
+    """Test prompt template size limits."""
+
+    def test_create_prompt_within_limit(self, client, auth_headers):
+        """Test creating prompt with template within size limit (5KB)."""
+        template = "x" * 5000  # 5KB - well under 10KB limit
+        response = client.post(
+            "/api/prompts",
+            json={
+                "name": "small_prompt",
+                "template": template,
+                "description": "Small test prompt"
+            },
+            headers=auth_headers
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["name"] == "small_prompt"
+
+    def test_create_prompt_at_limit(self, client, auth_headers):
+        """Test creating prompt with template at exact size limit (10KB)."""
+        template = "x" * 10240  # Exactly 10KB
+        response = client.post(
+            "/api/prompts",
+            json={
+                "name": "at_limit_prompt",
+                "template": template,
+                "description": "At limit test prompt"
+            },
+            headers=auth_headers
+        )
+        # Should succeed at exact limit
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_create_prompt_exceeds_limit(self, client, auth_headers):
+        """Test creating prompt with oversized template returns 413."""
+        template = "x" * 20000  # 20KB - over 10KB limit
+        response = client.post(
+            "/api/prompts",
+            json={
+                "name": "large_prompt",
+                "template": template,
+                "description": "Large test prompt"
+            },
+            headers=auth_headers
+        )
+
+        # Should return 413 Payload Too Large
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+        # Verify error response structure
+        data = response.json()
+        assert "detail" in data
+        detail = data["detail"]
+
+        # Verify error includes size information
+        assert "actual_size" in detail
+        assert "max_size" in detail
+        assert "error" in detail
+        assert "message" in detail
+
+        # Verify size values
+        assert detail["actual_size"] == 20000
+        assert detail["max_size"] == 10240
+        assert detail["actual_size"] > detail["max_size"]
+
+        # Verify error message is clear
+        assert "size limit exceeded" in detail["error"].lower()
+
+    def test_create_prompt_one_byte_over(self, client, auth_headers):
+        """Test creating prompt one byte over limit returns 413."""
+        template = "x" * 10241  # 10KB + 1 byte
+        response = client.post(
+            "/api/prompts",
+            json={
+                "name": "one_over_prompt",
+                "template": template,
+                "description": "One over test prompt"
+            },
+            headers=auth_headers
+        )
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+    def test_create_prompt_unicode_template(self, client, auth_headers):
+        """Test size validation handles Unicode templates correctly."""
+        # Unicode emoji characters are 4 bytes each in UTF-8
+        template = "🎉" * 3000  # 3000 * 4 = 12KB
+        response = client.post(
+            "/api/prompts",
+            json={
+                "name": "unicode_prompt",
+                "template": template,
+                "description": "Unicode test prompt"
+            },
+            headers=auth_headers
+        )
+        # Should be rejected as it exceeds 10KB
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+
+class TestSizeValidationConsistency:
+    """Test that size validation applies consistently across operations."""
+
+    def test_resource_validation_on_create_and_update(self, client, auth_headers):
+        """Test size validation applies to both create and update operations."""
+        # First, create a small resource
+        small_content = "x" * 1000  # 1KB
+        create_response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://update-test",
+                "name": "Update Test Resource",
+                "content": small_content
+            },
+            headers=auth_headers
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+        resource_id = create_response.json()["id"]
+
+        # Try to update with oversized content
+        large_content = "x" * 200000  # 200KB
+        update_response = client.put(
+            f"/api/resources/{resource_id}",
+            json={"content": large_content},
+            headers=auth_headers
+        )
+
+        # Update should also be rejected with 413
+        assert update_response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+        # Verify error structure
+        data = update_response.json()
+        assert "detail" in data
+        assert "actual_size" in data["detail"]
+        assert "max_size" in data["detail"]
+
+    def test_prompt_validation_on_create_and_update(self, client, auth_headers):
+        """Test size validation applies to both create and update operations."""
+        # First, create a small prompt
+        small_template = "x" * 1000  # 1KB
+        create_response = client.post(
+            "/api/prompts",
+            json={
+                "name": "update_test_prompt",
+                "template": small_template,
+                "description": "Update test"
+            },
+            headers=auth_headers
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+        prompt_id = create_response.json()["id"]
+
+        # Try to update with oversized template
+        large_template = "x" * 20000  # 20KB
+        update_response = client.put(
+            f"/api/prompts/{prompt_id}",
+            json={"template": large_template},
+            headers=auth_headers
+        )
+
+        # Update should also be rejected with 413
+        assert update_response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+        # Verify error structure
+        data = update_response.json()
+        assert "detail" in data
+        assert "actual_size" in data["detail"]
+        assert "max_size" in data["detail"]
+
+
+class TestErrorMessageClarity:
+    """Test that error messages are clear and helpful."""
+
+    def test_resource_error_message_clarity(self, client, auth_headers):
+        """Test resource error message provides clear guidance."""
+        content = "x" * 200000  # 200KB
+        response = client.post(
+            "/api/resources",
+            json={
+                "uri": "test://error-message-test",
+                "name": "Error Message Test",
+                "content": content
+            },
+            headers=auth_headers
+        )
+
+        data = response.json()
+        detail = data["detail"]
+
+        # Error message should be human-readable
+        assert "message" in detail
+        message = detail["message"]
+        assert "Resource content" in message
+        assert "200000" in message  # Actual size
+        assert "102400" in message  # Max size
+        assert "exceeds" in message.lower()
+
+    def test_prompt_error_message_clarity(self, client, auth_headers):
+        """Test prompt error message provides clear guidance."""
+        template = "x" * 20000  # 20KB
+        response = client.post(
+            "/api/prompts",
+            json={
+                "name": "error_message_test",
+                "template": template,
+                "description": "Error message test"
+            },
+            headers=auth_headers
+        )
+
+        data = response.json()
+        detail = data["detail"]
+
+        # Error message should be human-readable
+        assert "message" in detail
+        message = detail["message"]
+        assert "Prompt template" in message
+        assert "20000" in message  # Actual size
+        assert "10240" in message  # Max size
+        assert "exceeds" in message.lower()
+
+
+
+
+def test_bulk_resource_registration_with_oversized_content(test_app, client, auth_headers):
+    """Test that bulk resource registration validates content size for each resource.
+
+    This test verifies that when registering multiple resources in bulk,
+    oversized resources are rejected and reported in the error statistics.
+    """
+    from mcpgateway.schemas import ResourceCreate
+    from mcpgateway.services.resource_service import ResourceService
+    from mcpgateway.db import get_db
+
+    # Create a mix of valid and oversized resources
+    resources = [
+        ResourceCreate(
+            uri="resource://test/small1",
+            name="Small Resource 1",
+            content="x" * 1000,  # 1KB - OK
+            description="Small resource"
+        ),
+        ResourceCreate(
+            uri="resource://test/large1",
+            name="Large Resource 1",
+            content="x" * 200000,  # 200KB - Too large
+            description="Oversized resource"
+        ),
+        ResourceCreate(
+            uri="resource://test/small2",
+            name="Small Resource 2",
+            content="y" * 2000,  # 2KB - OK
+            description="Another small resource"
+        ),
+        ResourceCreate(
+            uri="resource://test/large2",
+            name="Large Resource 2",
+            content="z" * 150000,  # 150KB - Too large
+            description="Another oversized resource"
+        ),
+    ]
+
+    # Get database session
+    db = next(get_db())
+
+    # Call bulk registration
+    service = ResourceService()
+    import asyncio
+    result = asyncio.run(
+        service.register_resources_bulk(
+            db=db,
+            resources=resources,
+            created_by="test@example.com",
+            created_from_ip="127.0.0.1",
+            conflict_strategy="skip"
+        )
+    )
+
+    # Verify results
+    assert result["created"] == 2, "Should create 2 valid resources"
+    assert result["failed"] == 2, "Should fail 2 oversized resources"
+    assert len(result["errors"]) == 2, "Should have 2 error messages"
+
+    # Check error messages contain size information
+    errors_text = " ".join(result["errors"])
+    assert "200000" in errors_text or "150000" in errors_text, "Errors should mention actual sizes"
+    assert "102400" in errors_text, "Errors should mention the size limit"
+    assert "resource://test/large1" in errors_text or "resource://test/large2" in errors_text, \
+        "Errors should identify the problematic resources"
+
+
+def test_prompt_update_with_oversized_template(test_app, client, auth_headers):
+    """Test that updating a prompt with an oversized template returns 413.
+
+    This test verifies that the update_prompt method validates template size
+    and rejects oversized templates with appropriate error response.
+    """
+    # First create a prompt with valid template
+    response = client.post(
+        "/api/prompts",
+        json={
+            "name": "test-prompt-for-update",
+            "template": "Small template",
+            "description": "Test prompt"
+        },
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    prompt_data = response.json()
+    prompt_id = prompt_data["id"]
+
+    # Try to update with oversized template (20KB)
+    oversized_template = "x" * 20000
+    response = client.put(
+        f"/api/prompts/{prompt_id}",
+        json={
+            "template": oversized_template
+        },
+        headers=auth_headers
+    )
+
+    # Should return 413 Payload Too Large
+    assert response.status_code == 413
+
+    data = response.json()
+    detail = data["detail"]
+
+    # Verify error details
+    assert "message" in detail
+    assert "actual_size" in detail
+    assert "max_size" in detail
+    assert detail["actual_size"] == 20000
+    assert detail["max_size"] == 10240
+    assert "Prompt template" in detail["message"]
+    assert "exceeds" in detail["message"].lower()
+
+    # Verify the prompt was not updated
+    response = client.get(f"/api/prompts/{prompt_id}", headers=auth_headers)
+    assert response.status_code == 200
+    prompt_data = response.json()
+    assert prompt_data["template"] == "Small template"  # Original template unchanged
+
+
+def test_prompt_update_with_valid_template(test_app, client, auth_headers):
+    """Test that updating a prompt with a valid-sized template succeeds.
+
+    This test verifies that templates within the size limit can be updated successfully.
+    """
+    # First create a prompt
+    response = client.post(
+        "/api/prompts",
+        json={
+            "name": "test-prompt-for-valid-update",
+            "template": "Original template",
+            "description": "Test prompt"
+        },
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    prompt_data = response.json()
+    prompt_id = prompt_data["id"]
+
+    # Update with valid-sized template (5KB)
+    new_template = "y" * 5000
+    response = client.put(
+        f"/api/prompts/{prompt_id}",
+        json={
+            "template": new_template
+        },
+        headers=auth_headers
+    )
+
+    # Should succeed
+    assert response.status_code == 200
+
+    # Verify the prompt was updated
+    response = client.get(f"/api/prompts/{prompt_id}", headers=auth_headers)
+    assert response.status_code == 200
+    prompt_data = response.json()
+    assert prompt_data["template"] == new_template
+
+
+def test_resource_update_with_oversized_content(test_app, client, auth_headers):
+    """Test that updating a resource with oversized content returns 413.
+
+    This test verifies that the update_resource method validates content size
+    and rejects oversized content with appropriate error response.
+    """
+    # First create a resource with valid content
+    response = client.post(
+        "/api/resources",
+        json={
+            "uri": "resource://test/update-test",
+            "name": "Test Resource for Update",
+            "content": "Small content",
+            "description": "Test resource"
+        },
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    resource_data = response.json()
+    resource_id = resource_data["id"]
+
+    # Try to update with oversized content (200KB)
+    oversized_content = "x" * 200000
+    response = client.put(
+        f"/api/resources/{resource_id}",
+        json={
+            "content": oversized_content
+        },
+        headers=auth_headers
+    )
+
+    # Should return 413 Payload Too Large
+    assert response.status_code == 413
+
+    data = response.json()
+    detail = data["detail"]
+
+    # Verify error details
+    assert "message" in detail
+    assert "actual_size" in detail
+    assert "max_size" in detail
+    assert detail["actual_size"] == 200000
+    assert detail["max_size"] == 102400
+    assert "Resource content" in detail["message"]
+    assert "exceeds" in detail["message"].lower()
+
+    # Verify the resource was not updated
+    response = client.get(f"/api/resources/{resource_id}", headers=auth_headers)
+    assert response.status_code == 200
+    resource_data = response.json()
+    assert resource_data["content"] == "Small content"  # Original content unchanged
+
+
+def test_resource_update_with_valid_content(test_app, client, auth_headers):
+    """Test that updating a resource with valid-sized content succeeds.
+
+    This test verifies that content within the size limit can be updated successfully.
+    """
+    # First create a resource
+    response = client.post(
+        "/api/resources",
+        json={
+            "uri": "resource://test/valid-update",
+            "name": "Test Resource for Valid Update",
+            "content": "Original content",
+            "description": "Test resource"
+        },
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    resource_data = response.json()
+    resource_id = resource_data["id"]
+
+    # Update with valid-sized content (50KB)
+    new_content = "y" * 50000
+    response = client.put(
+        f"/api/resources/{resource_id}",
+        json={
+            "content": new_content
+        },
+        headers=auth_headers
+    )
+
+    # Should succeed
+    assert response.status_code == 200
+
+    # Verify the resource was updated
+    response = client.get(f"/api/resources/{resource_id}", headers=auth_headers)
+    assert response.status_code == 200
+    resource_data = response.json()
+    assert resource_data["content"] == new_content

--- a/tests/integration/test_content_size_limits.py
+++ b/tests/integration/test_content_size_limits.py
@@ -136,8 +136,6 @@ def auth_headers() -> dict[str, str]:
     return {"Authorization": "Bearer test.token.size_limits"}
 
 
-
-import pytest
 from fastapi import status
 
 
@@ -147,15 +145,7 @@ class TestResourceSizeLimits:
     def test_create_resource_within_limit(self, client, auth_headers):
         """Test creating resource with content within size limit (50KB)."""
         content = "x" * 50000  # 50KB - well under 100KB limit
-        response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://resource-small",
-                "name": "Small Resource",
-                "content": content
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/resources", json={"uri": "test://resource-small", "name": "Small Resource", "content": content}, headers=auth_headers)
         assert response.status_code == status.HTTP_201_CREATED
         data = response.json()
         assert data["uri"] == "test://resource-small"
@@ -163,30 +153,14 @@ class TestResourceSizeLimits:
     def test_create_resource_at_limit(self, client, auth_headers):
         """Test creating resource with content at exact size limit (100KB)."""
         content = "x" * 102400  # Exactly 100KB
-        response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://resource-at-limit",
-                "name": "At Limit Resource",
-                "content": content
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/resources", json={"uri": "test://resource-at-limit", "name": "At Limit Resource", "content": content}, headers=auth_headers)
         # Should succeed at exact limit
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_create_resource_exceeds_limit(self, client, auth_headers):
         """Test creating resource with oversized content returns 413."""
         content = "x" * 200000  # 200KB - over 100KB limit
-        response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://resource-large",
-                "name": "Large Resource",
-                "content": content
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/resources", json={"uri": "test://resource-large", "name": "Large Resource", "content": content}, headers=auth_headers)
 
         # Should return 413 Payload Too Large
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
@@ -213,30 +187,14 @@ class TestResourceSizeLimits:
     def test_create_resource_one_byte_over(self, client, auth_headers):
         """Test creating resource one byte over limit returns 413."""
         content = "x" * 102401  # 100KB + 1 byte
-        response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://resource-one-over",
-                "name": "One Over Resource",
-                "content": content
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/resources", json={"uri": "test://resource-one-over", "name": "One Over Resource", "content": content}, headers=auth_headers)
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
     def test_create_resource_unicode_content(self, client, auth_headers):
         """Test size validation handles Unicode content correctly."""
         # Unicode emoji characters are 4 bytes each in UTF-8
         content = "🎉" * 30000  # 30000 * 4 = 120KB
-        response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://resource-unicode",
-                "name": "Unicode Resource",
-                "content": content
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/resources", json={"uri": "test://resource-unicode", "name": "Unicode Resource", "content": content}, headers=auth_headers)
         # Should be rejected as it exceeds 100KB
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
@@ -247,15 +205,7 @@ class TestPromptSizeLimits:
     def test_create_prompt_within_limit(self, client, auth_headers):
         """Test creating prompt with template within size limit (5KB)."""
         template = "x" * 5000  # 5KB - well under 10KB limit
-        response = client.post(
-            "/api/prompts",
-            json={
-                "name": "small_prompt",
-                "template": template,
-                "description": "Small test prompt"
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/prompts", json={"name": "small_prompt", "template": template, "description": "Small test prompt"}, headers=auth_headers)
         assert response.status_code == status.HTTP_201_CREATED
         data = response.json()
         assert data["name"] == "small_prompt"
@@ -263,30 +213,14 @@ class TestPromptSizeLimits:
     def test_create_prompt_at_limit(self, client, auth_headers):
         """Test creating prompt with template at exact size limit (10KB)."""
         template = "x" * 10240  # Exactly 10KB
-        response = client.post(
-            "/api/prompts",
-            json={
-                "name": "at_limit_prompt",
-                "template": template,
-                "description": "At limit test prompt"
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/prompts", json={"name": "at_limit_prompt", "template": template, "description": "At limit test prompt"}, headers=auth_headers)
         # Should succeed at exact limit
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_create_prompt_exceeds_limit(self, client, auth_headers):
         """Test creating prompt with oversized template returns 413."""
         template = "x" * 20000  # 20KB - over 10KB limit
-        response = client.post(
-            "/api/prompts",
-            json={
-                "name": "large_prompt",
-                "template": template,
-                "description": "Large test prompt"
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/prompts", json={"name": "large_prompt", "template": template, "description": "Large test prompt"}, headers=auth_headers)
 
         # Should return 413 Payload Too Large
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
@@ -313,30 +247,14 @@ class TestPromptSizeLimits:
     def test_create_prompt_one_byte_over(self, client, auth_headers):
         """Test creating prompt one byte over limit returns 413."""
         template = "x" * 10241  # 10KB + 1 byte
-        response = client.post(
-            "/api/prompts",
-            json={
-                "name": "one_over_prompt",
-                "template": template,
-                "description": "One over test prompt"
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/prompts", json={"name": "one_over_prompt", "template": template, "description": "One over test prompt"}, headers=auth_headers)
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
     def test_create_prompt_unicode_template(self, client, auth_headers):
         """Test size validation handles Unicode templates correctly."""
         # Unicode emoji characters are 4 bytes each in UTF-8
         template = "🎉" * 3000  # 3000 * 4 = 12KB
-        response = client.post(
-            "/api/prompts",
-            json={
-                "name": "unicode_prompt",
-                "template": template,
-                "description": "Unicode test prompt"
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/prompts", json={"name": "unicode_prompt", "template": template, "description": "Unicode test prompt"}, headers=auth_headers)
         # Should be rejected as it exceeds 10KB
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
@@ -348,25 +266,13 @@ class TestSizeValidationConsistency:
         """Test size validation applies to both create and update operations."""
         # First, create a small resource
         small_content = "x" * 1000  # 1KB
-        create_response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://update-test",
-                "name": "Update Test Resource",
-                "content": small_content
-            },
-            headers=auth_headers
-        )
+        create_response = client.post("/api/resources", json={"uri": "test://update-test", "name": "Update Test Resource", "content": small_content}, headers=auth_headers)
         assert create_response.status_code == status.HTTP_201_CREATED
         resource_id = create_response.json()["id"]
 
         # Try to update with oversized content
         large_content = "x" * 200000  # 200KB
-        update_response = client.put(
-            f"/api/resources/{resource_id}",
-            json={"content": large_content},
-            headers=auth_headers
-        )
+        update_response = client.put(f"/api/resources/{resource_id}", json={"content": large_content}, headers=auth_headers)
 
         # Update should also be rejected with 413
         assert update_response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
@@ -381,25 +287,13 @@ class TestSizeValidationConsistency:
         """Test size validation applies to both create and update operations."""
         # First, create a small prompt
         small_template = "x" * 1000  # 1KB
-        create_response = client.post(
-            "/api/prompts",
-            json={
-                "name": "update_test_prompt",
-                "template": small_template,
-                "description": "Update test"
-            },
-            headers=auth_headers
-        )
+        create_response = client.post("/api/prompts", json={"name": "update_test_prompt", "template": small_template, "description": "Update test"}, headers=auth_headers)
         assert create_response.status_code == status.HTTP_201_CREATED
         prompt_id = create_response.json()["id"]
 
         # Try to update with oversized template
         large_template = "x" * 20000  # 20KB
-        update_response = client.put(
-            f"/api/prompts/{prompt_id}",
-            json={"template": large_template},
-            headers=auth_headers
-        )
+        update_response = client.put(f"/api/prompts/{prompt_id}", json={"template": large_template}, headers=auth_headers)
 
         # Update should also be rejected with 413
         assert update_response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
@@ -417,15 +311,7 @@ class TestErrorMessageClarity:
     def test_resource_error_message_clarity(self, client, auth_headers):
         """Test resource error message provides clear guidance."""
         content = "x" * 200000  # 200KB
-        response = client.post(
-            "/api/resources",
-            json={
-                "uri": "test://error-message-test",
-                "name": "Error Message Test",
-                "content": content
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/resources", json={"uri": "test://error-message-test", "name": "Error Message Test", "content": content}, headers=auth_headers)
 
         data = response.json()
         detail = data["detail"]
@@ -434,22 +320,15 @@ class TestErrorMessageClarity:
         assert "message" in detail
         message = detail["message"]
         assert "Resource content" in message
-        assert "200000" in message  # Actual size
-        assert "102400" in message  # Max size
         assert "exceeds" in message.lower()
+        # Verify raw size values are available in the detail response
+        assert detail["actual_size"] == 200000
+        assert detail["max_size"] == 102400
 
     def test_prompt_error_message_clarity(self, client, auth_headers):
         """Test prompt error message provides clear guidance."""
         template = "x" * 20000  # 20KB
-        response = client.post(
-            "/api/prompts",
-            json={
-                "name": "error_message_test",
-                "template": template,
-                "description": "Error message test"
-            },
-            headers=auth_headers
-        )
+        response = client.post("/api/prompts", json={"name": "error_message_test", "template": template, "description": "Error message test"}, headers=auth_headers)
 
         data = response.json()
         detail = data["detail"]
@@ -458,11 +337,10 @@ class TestErrorMessageClarity:
         assert "message" in detail
         message = detail["message"]
         assert "Prompt template" in message
-        assert "20000" in message  # Actual size
-        assert "10240" in message  # Max size
         assert "exceeds" in message.lower()
-
-
+        # Verify raw size values are available in the detail response
+        assert detail["actual_size"] == 20000
+        assert detail["max_size"] == 10240
 
 
 def test_bulk_resource_registration_with_oversized_content(test_app, client, auth_headers):
@@ -477,30 +355,10 @@ def test_bulk_resource_registration_with_oversized_content(test_app, client, aut
 
     # Create a mix of valid and oversized resources
     resources = [
-        ResourceCreate(
-            uri="resource://test/small1",
-            name="Small Resource 1",
-            content="x" * 1000,  # 1KB - OK
-            description="Small resource"
-        ),
-        ResourceCreate(
-            uri="resource://test/large1",
-            name="Large Resource 1",
-            content="x" * 200000,  # 200KB - Too large
-            description="Oversized resource"
-        ),
-        ResourceCreate(
-            uri="resource://test/small2",
-            name="Small Resource 2",
-            content="y" * 2000,  # 2KB - OK
-            description="Another small resource"
-        ),
-        ResourceCreate(
-            uri="resource://test/large2",
-            name="Large Resource 2",
-            content="z" * 150000,  # 150KB - Too large
-            description="Another oversized resource"
-        ),
+        ResourceCreate(uri="resource://test/small1", name="Small Resource 1", content="x" * 1000, description="Small resource"),  # 1KB - OK
+        ResourceCreate(uri="resource://test/large1", name="Large Resource 1", content="x" * 200000, description="Oversized resource"),  # 200KB - Too large
+        ResourceCreate(uri="resource://test/small2", name="Small Resource 2", content="y" * 2000, description="Another small resource"),  # 2KB - OK
+        ResourceCreate(uri="resource://test/large2", name="Large Resource 2", content="z" * 150000, description="Another oversized resource"),  # 150KB - Too large
     ]
 
     # Get database session
@@ -509,27 +367,18 @@ def test_bulk_resource_registration_with_oversized_content(test_app, client, aut
     # Call bulk registration
     service = ResourceService()
     import asyncio
-    result = asyncio.run(
-        service.register_resources_bulk(
-            db=db,
-            resources=resources,
-            created_by="test@example.com",
-            created_from_ip="127.0.0.1",
-            conflict_strategy="skip"
-        )
-    )
+
+    result = asyncio.run(service.register_resources_bulk(db=db, resources=resources, created_by="test@example.com", created_from_ip="127.0.0.1", conflict_strategy="skip"))
 
     # Verify results
     assert result["created"] == 2, "Should create 2 valid resources"
     assert result["failed"] == 2, "Should fail 2 oversized resources"
     assert len(result["errors"]) == 2, "Should have 2 error messages"
 
-    # Check error messages contain size information
+    # Check error messages contain size and URI information
     errors_text = " ".join(result["errors"])
-    assert "200000" in errors_text or "150000" in errors_text, "Errors should mention actual sizes"
-    assert "102400" in errors_text, "Errors should mention the size limit"
-    assert "resource://test/large1" in errors_text or "resource://test/large2" in errors_text, \
-        "Errors should identify the problematic resources"
+    assert "exceeds" in errors_text.lower(), "Errors should mention size exceeds limit"
+    assert "resource://test/large1" in errors_text or "resource://test/large2" in errors_text, "Errors should identify the problematic resources"
 
 
 def test_prompt_update_with_oversized_template(test_app, client, auth_headers):
@@ -539,28 +388,14 @@ def test_prompt_update_with_oversized_template(test_app, client, auth_headers):
     and rejects oversized templates with appropriate error response.
     """
     # First create a prompt with valid template
-    response = client.post(
-        "/api/prompts",
-        json={
-            "name": "test-prompt-for-update",
-            "template": "Small template",
-            "description": "Test prompt"
-        },
-        headers=auth_headers
-    )
+    response = client.post("/api/prompts", json={"name": "test-prompt-for-update", "template": "Small template", "description": "Test prompt"}, headers=auth_headers)
     assert response.status_code == 201
     prompt_data = response.json()
     prompt_id = prompt_data["id"]
 
     # Try to update with oversized template (20KB)
     oversized_template = "x" * 20000
-    response = client.put(
-        f"/api/prompts/{prompt_id}",
-        json={
-            "template": oversized_template
-        },
-        headers=auth_headers
-    )
+    response = client.put(f"/api/prompts/{prompt_id}", json={"template": oversized_template}, headers=auth_headers)
 
     # Should return 413 Payload Too Large
     assert response.status_code == 413
@@ -590,28 +425,14 @@ def test_prompt_update_with_valid_template(test_app, client, auth_headers):
     This test verifies that templates within the size limit can be updated successfully.
     """
     # First create a prompt
-    response = client.post(
-        "/api/prompts",
-        json={
-            "name": "test-prompt-for-valid-update",
-            "template": "Original template",
-            "description": "Test prompt"
-        },
-        headers=auth_headers
-    )
+    response = client.post("/api/prompts", json={"name": "test-prompt-for-valid-update", "template": "Original template", "description": "Test prompt"}, headers=auth_headers)
     assert response.status_code == 201
     prompt_data = response.json()
     prompt_id = prompt_data["id"]
 
     # Update with valid-sized template (5KB)
     new_template = "y" * 5000
-    response = client.put(
-        f"/api/prompts/{prompt_id}",
-        json={
-            "template": new_template
-        },
-        headers=auth_headers
-    )
+    response = client.put(f"/api/prompts/{prompt_id}", json={"template": new_template}, headers=auth_headers)
 
     # Should succeed
     assert response.status_code == 200
@@ -631,14 +452,7 @@ def test_resource_update_with_oversized_content(test_app, client, auth_headers):
     """
     # First create a resource with valid content
     response = client.post(
-        "/api/resources",
-        json={
-            "uri": "resource://test/update-test",
-            "name": "Test Resource for Update",
-            "content": "Small content",
-            "description": "Test resource"
-        },
-        headers=auth_headers
+        "/api/resources", json={"uri": "resource://test/update-test", "name": "Test Resource for Update", "content": "Small content", "description": "Test resource"}, headers=auth_headers
     )
     assert response.status_code == 201
     resource_data = response.json()
@@ -646,13 +460,7 @@ def test_resource_update_with_oversized_content(test_app, client, auth_headers):
 
     # Try to update with oversized content (200KB)
     oversized_content = "x" * 200000
-    response = client.put(
-        f"/api/resources/{resource_id}",
-        json={
-            "content": oversized_content
-        },
-        headers=auth_headers
-    )
+    response = client.put(f"/api/resources/{resource_id}", json={"content": oversized_content}, headers=auth_headers)
 
     # Should return 413 Payload Too Large
     assert response.status_code == 413
@@ -683,14 +491,7 @@ def test_resource_update_with_valid_content(test_app, client, auth_headers):
     """
     # First create a resource
     response = client.post(
-        "/api/resources",
-        json={
-            "uri": "resource://test/valid-update",
-            "name": "Test Resource for Valid Update",
-            "content": "Original content",
-            "description": "Test resource"
-        },
-        headers=auth_headers
+        "/api/resources", json={"uri": "resource://test/valid-update", "name": "Test Resource for Valid Update", "content": "Original content", "description": "Test resource"}, headers=auth_headers
     )
     assert response.status_code == 201
     resource_data = response.json()
@@ -698,13 +499,7 @@ def test_resource_update_with_valid_content(test_app, client, auth_headers):
 
     # Update with valid-sized content (50KB)
     new_content = "y" * 50000
-    response = client.put(
-        f"/api/resources/{resource_id}",
-        json={
-            "content": new_content
-        },
-        headers=auth_headers
-    )
+    response = client.put(f"/api/resources/{resource_id}", json={"content": new_content}, headers=auth_headers)
 
     # Should succeed
     assert response.status_code == 200

--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -795,11 +795,11 @@ class TestSecurityValidation:
                 PromptCreate(name="test_prompt", template=payload)
             logger.debug(f"Validation error: {exc_info.value}")
 
-        # Invalid templates - too long
-        logger.debug("Testing template that exceeds max length")
-        with pytest.raises(ValidationError) as exc_info:
-            PromptCreate(name="test_prompt", template="x" * (SecurityValidator.MAX_TEMPLATE_LENGTH + 1))
-        logger.debug(f"Validation error: {exc_info.value}")
+        # Template size validation is enforced at the service layer (returns 413),
+        # not at the Pydantic schema level. Verify oversized template passes schema.
+        logger.debug("Testing template exceeding max length passes schema (validated at service layer)")
+        oversized = PromptCreate(name="test_prompt", template="x" * (SecurityValidator.MAX_TEMPLATE_LENGTH + 1))
+        assert len(oversized.template) == SecurityValidator.MAX_TEMPLATE_LENGTH + 1
 
     def test_prompt_argument_validation(self):
         """Test prompt argument validation."""

--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -700,9 +700,13 @@ class TestSecurityValidation:
                 print(f"❌ Valid content rejected: type={type(content).__name__}, length={len(content)} -> {err}")
                 raise
 
-        # Invalid content - too large
-        logger.debug("Testing content that exceeds max length")
-        must_fail("x" * (SecurityValidator.MAX_CONTENT_LENGTH + 1), "Content too large")
+        # Content size validation is enforced at the service layer (returns 413),
+        # not at the Pydantic schema level. Schema only validates encoding and
+        # dangerous patterns. Verify oversized content passes schema validation.
+        logger.debug("Testing content exceeding max length passes schema (validated at service layer)")
+        oversized = "x" * (SecurityValidator.MAX_CONTENT_LENGTH + 1)
+        resource = ResourceCreate(uri="test://uri", name="Resource", content=oversized)
+        assert resource.content == oversized
 
         # Invalid content - HTML tags
         for i, payload in enumerate(self.XSS_PAYLOADS[:5]):
@@ -1582,11 +1586,11 @@ class TestSpecificAttackVectors:
         resource = ResourceCreate(uri="test.txt", name="Large Resource", content=zip_bomb_content)
         assert len(resource.content) == 1000000
 
-        # But prevent extremely large content
-        logger.debug("Testing content exceeding max length")
-        with pytest.raises(ValidationError) as exc_info:
-            ResourceCreate(uri="test.txt", name="Too Large Resource", content="A" * (SecurityValidator.MAX_CONTENT_LENGTH + 1))
-        logger.debug(f"Validation error: {exc_info.value}")
+        # Content size is now enforced at the service layer (returns 413),
+        # not at the Pydantic schema level. Verify schema accepts oversized content.
+        logger.debug("Testing oversized content passes schema (validated at service layer)")
+        oversized_resource = ResourceCreate(uri="test.txt", name="Too Large Resource", content="A" * (SecurityValidator.MAX_CONTENT_LENGTH + 1))
+        assert len(oversized_resource.content) == SecurityValidator.MAX_CONTENT_LENGTH + 1
 
     def test_cache_poisoning_prevention(self):
         """Test cache poisoning attack prevention."""

--- a/tests/unit/mcpgateway/services/test_content_security.py
+++ b/tests/unit/mcpgateway/services/test_content_security.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for content security service."""
+
+import pytest
+
+from mcpgateway.services.content_security import (
+    ContentSecurityService,
+    ContentSizeError,
+    _format_bytes,
+    _sanitize_pii_for_logging,
+    get_content_security_service,
+)
+
+
+class TestFormatBytes:
+    """Test the _format_bytes helper function."""
+
+    def test_format_bytes_less_than_kb(self):
+        """Test formatting bytes less than 1KB."""
+        assert _format_bytes(500) == "500 B"
+        assert _format_bytes(1023) == "1023 B"
+
+    def test_format_bytes_kb(self):
+        """Test formatting kilobytes."""
+        assert _format_bytes(1024) == "1.0 KB"
+        assert _format_bytes(2048) == "2.0 KB"
+        assert _format_bytes(1536) == "1.5 KB"
+        assert _format_bytes(102400) == "100.0 KB"
+
+    def test_format_bytes_mb(self):
+        """Test formatting megabytes."""
+        assert _format_bytes(1048576) == "1.0 MB"
+        assert _format_bytes(2097152) == "2.0 MB"
+        assert _format_bytes(1572864) == "1.5 MB"
+
+    def test_format_bytes_gb(self):
+        """Test formatting gigabytes."""
+        assert _format_bytes(1073741824) == "1.0 GB"
+        assert _format_bytes(2147483648) == "2.0 GB"
+        assert _format_bytes(1610612736) == "1.5 GB"
+
+    def test_format_bytes_zero(self):
+        """Test formatting zero bytes."""
+        assert _format_bytes(0) == "0 B"
+
+
+class TestSanitizePiiForLogging:
+    """Test the _sanitize_pii_for_logging helper function."""
+
+    def test_sanitize_email_only(self):
+        """Test sanitizing email address only."""
+        result = _sanitize_pii_for_logging(user_email="user@example.com")
+        assert result["user_hash"] is not None
+        assert len(result["user_hash"]) == 8
+        assert result["ip_subnet"] is None
+
+    def test_sanitize_ipv4_only(self):
+        """Test sanitizing IPv4 address only."""
+        result = _sanitize_pii_for_logging(ip_address="192.168.1.100")
+        assert result["user_hash"] is None
+        assert result["ip_subnet"] == "192.168.1.xxx"
+
+    def test_sanitize_ipv6(self):
+        """Test sanitizing IPv6 address."""
+        result = _sanitize_pii_for_logging(ip_address="2001:db8::1")
+        assert result["ip_subnet"] == "2001:db8::xxxx"
+
+    def test_sanitize_both(self):
+        """Test sanitizing both email and IP."""
+        result = _sanitize_pii_for_logging(
+            user_email="admin@test.com",
+            ip_address="10.0.0.1"
+        )
+        assert result["user_hash"] is not None
+        assert result["ip_subnet"] == "10.0.0.xxx"
+
+    def test_sanitize_none_values(self):
+        """Test with None values."""
+        result = _sanitize_pii_for_logging()
+        assert result["user_hash"] is None
+        assert result["ip_subnet"] is None
+
+
+class TestContentSizeError:
+    """Test the ContentSizeError exception."""
+
+    def test_content_size_error_attributes(self):
+        """Test ContentSizeError has correct attributes."""
+        error = ContentSizeError("Resource content", 200000, 102400)
+        assert error.content_type == "Resource content"
+        assert error.actual_size == 200000
+        assert error.max_size == 102400
+
+    def test_content_size_error_message(self):
+        """Test ContentSizeError message formatting."""
+        error = ContentSizeError("Resource content", 200000, 102400)
+        message = str(error)
+        assert "Resource content" in message
+        assert "195.3 KB" in message  # 200000 bytes formatted
+        assert "100.0 KB" in message  # 102400 bytes formatted
+        assert "exceeds" in message.lower()
+
+
+class TestContentSecurityService:
+    """Test the ContentSecurityService class."""
+
+    def test_service_initialization(self):
+        """Test service initializes with correct limits."""
+        service = ContentSecurityService()
+        assert service.max_resource_size == 102400  # 100KB
+        assert service.max_prompt_size == 10240  # 10KB
+
+    def test_validate_resource_size_within_limit(self):
+        """Test validating resource content within limit."""
+        service = ContentSecurityService()
+        content = "x" * 50000  # 50KB
+        # Should not raise
+        service.validate_resource_size(content)
+
+    def test_validate_resource_size_at_limit(self):
+        """Test validating resource content at exact limit."""
+        service = ContentSecurityService()
+        content = "x" * 102400  # Exactly 100KB
+        # Should not raise
+        service.validate_resource_size(content)
+
+    def test_validate_resource_size_exceeds_limit(self):
+        """Test validating resource content exceeding limit."""
+        service = ContentSecurityService()
+        content = "x" * 200000  # 200KB
+        with pytest.raises(ContentSizeError) as exc_info:
+            service.validate_resource_size(content)
+        
+        error = exc_info.value
+        assert error.actual_size == 200000
+        assert error.max_size == 102400
+
+    def test_validate_resource_size_with_bytes(self):
+        """Test validating resource content as bytes."""
+        service = ContentSecurityService()
+        content = b"x" * 50000
+        # Should not raise
+        service.validate_resource_size(content)
+
+    def test_validate_resource_size_with_logging_context(self):
+        """Test validating with logging context (uri, user, ip)."""
+        service = ContentSecurityService()
+        content = "x" * 200000
+        with pytest.raises(ContentSizeError):
+            service.validate_resource_size(
+                content,
+                uri="test://resource",
+                user_email="user@example.com",
+                ip_address="192.168.1.1"
+            )
+
+    def test_validate_prompt_size_within_limit(self):
+        """Test validating prompt template within limit."""
+        service = ContentSecurityService()
+        template = "x" * 5000  # 5KB
+        # Should not raise
+        service.validate_prompt_size(template)
+
+    def test_validate_prompt_size_at_limit(self):
+        """Test validating prompt template at exact limit."""
+        service = ContentSecurityService()
+        template = "x" * 10240  # Exactly 10KB
+        # Should not raise
+        service.validate_prompt_size(template)
+
+    def test_validate_prompt_size_exceeds_limit(self):
+        """Test validating prompt template exceeding limit."""
+        service = ContentSecurityService()
+        template = "x" * 20000  # 20KB
+        with pytest.raises(ContentSizeError) as exc_info:
+            service.validate_prompt_size(template)
+        
+        error = exc_info.value
+        assert error.actual_size == 20000
+        assert error.max_size == 10240
+
+    def test_validate_prompt_size_with_bytes(self):
+        """Test validating prompt template as bytes."""
+        service = ContentSecurityService()
+        template = b"x" * 5000
+        # Should not raise
+        service.validate_prompt_size(template)
+
+    def test_validate_prompt_size_with_logging_context(self):
+        """Test validating with logging context (name, user, ip)."""
+        service = ContentSecurityService()
+        template = "x" * 20000
+        with pytest.raises(ContentSizeError):
+            service.validate_prompt_size(
+                template,
+                name="test_prompt",
+                user_email="user@example.com",
+                ip_address="10.0.0.1"
+            )
+
+
+class TestGetContentSecurityService:
+    """Test the singleton getter function."""
+
+    def test_get_service_returns_singleton(self):
+        """Test that get_content_security_service returns same instance."""
+        service1 = get_content_security_service()
+        service2 = get_content_security_service()
+        assert service1 is service2
+
+    def test_get_service_thread_safe(self):
+        """Test that singleton is thread-safe."""
+        import threading
+        
+        results = []
+        
+        def get_service():
+            service = get_content_security_service()
+            results.append(id(service))
+        
+        # Create multiple threads
+        threads = [threading.Thread(target=get_service) for _ in range(10)]
+        
+        # Start all threads
+        for thread in threads:
+            thread.start()
+        
+        # Wait for all threads
+        for thread in threads:
+            thread.join()
+        
+        # All threads should get the same instance
+        assert len(set(results)) == 1
+
+# Made with Bob

--- a/tests/unit/mcpgateway/services/test_content_security.py
+++ b/tests/unit/mcpgateway/services/test_content_security.py
@@ -9,6 +9,7 @@ from mcpgateway.services.content_security import (
     _format_bytes,
     _sanitize_pii_for_logging,
     get_content_security_service,
+    reset_content_security_service,
 )
 
 
@@ -67,10 +68,7 @@ class TestSanitizePiiForLogging:
 
     def test_sanitize_both(self):
         """Test sanitizing both email and IP."""
-        result = _sanitize_pii_for_logging(
-            user_email="admin@test.com",
-            ip_address="10.0.0.1"
-        )
+        result = _sanitize_pii_for_logging(user_email="admin@test.com", ip_address="10.0.0.1")
         assert result["user_hash"] is not None
         assert result["ip_subnet"] == "10.0.0.xxx"
 
@@ -130,7 +128,7 @@ class TestContentSecurityService:
         content = "x" * 200000  # 200KB
         with pytest.raises(ContentSizeError) as exc_info:
             service.validate_resource_size(content)
-        
+
         error = exc_info.value
         assert error.actual_size == 200000
         assert error.max_size == 102400
@@ -147,12 +145,7 @@ class TestContentSecurityService:
         service = ContentSecurityService()
         content = "x" * 200000
         with pytest.raises(ContentSizeError):
-            service.validate_resource_size(
-                content,
-                uri="test://resource",
-                user_email="user@example.com",
-                ip_address="192.168.1.1"
-            )
+            service.validate_resource_size(content, uri="test://resource", user_email="user@example.com", ip_address="192.168.1.1")
 
     def test_validate_prompt_size_within_limit(self):
         """Test validating prompt template within limit."""
@@ -174,7 +167,7 @@ class TestContentSecurityService:
         template = "x" * 20000  # 20KB
         with pytest.raises(ContentSizeError) as exc_info:
             service.validate_prompt_size(template)
-        
+
         error = exc_info.value
         assert error.actual_size == 20000
         assert error.max_size == 10240
@@ -191,12 +184,7 @@ class TestContentSecurityService:
         service = ContentSecurityService()
         template = "x" * 20000
         with pytest.raises(ContentSizeError):
-            service.validate_prompt_size(
-                template,
-                name="test_prompt",
-                user_email="user@example.com",
-                ip_address="10.0.0.1"
-            )
+            service.validate_prompt_size(template, name="test_prompt", user_email="user@example.com", ip_address="10.0.0.1")
 
 
 class TestGetContentSecurityService:
@@ -211,25 +199,30 @@ class TestGetContentSecurityService:
     def test_get_service_thread_safe(self):
         """Test that singleton is thread-safe."""
         import threading
-        
+
         results = []
-        
+
         def get_service():
             service = get_content_security_service()
             results.append(id(service))
-        
+
         # Create multiple threads
         threads = [threading.Thread(target=get_service) for _ in range(10)]
-        
+
         # Start all threads
         for thread in threads:
             thread.start()
-        
+
         # Wait for all threads
         for thread in threads:
             thread.join()
-        
+
         # All threads should get the same instance
         assert len(set(results)) == 1
 
-# Made with Bob
+    def test_reset_creates_new_instance(self):
+        """Test that reset_content_security_service allows a new instance."""
+        service1 = get_content_security_service()
+        reset_content_security_service()
+        service2 = get_content_security_service()
+        assert service1 is not service2

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -404,6 +404,46 @@ class TestPromptService:
     # ──────────────────────────────────────────────────────────────────
 
     @pytest.mark.asyncio
+    async def test_register_prompt_content_size_error(self, prompt_service, test_db):
+        """Test that ContentSizeError is caught and re-raised during prompt registration."""
+        from mcpgateway.services.content_security import ContentSizeError
+        
+        test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
+        test_db.rollback = Mock()
+        
+        # Mock get_content_security_service to return a mock that raises ContentSizeError
+        mock_security_service = Mock()
+        mock_security_service.validate_prompt_size.side_effect = ContentSizeError(
+            content_type="Prompt template",
+            actual_size=15000,
+            max_size=10240
+        )
+        
+        with patch("mcpgateway.services.prompt_service.get_content_security_service", return_value=mock_security_service):
+            # Use 15KB template - passes Pydantic (65KB limit) but fails ContentSizeError (10KB limit)
+            prompt = PromptCreate(
+                name="large-prompt",
+                description="A prompt with large template",
+                template="x" * 15000,  # 15KB template
+            )
+            
+            with pytest.raises(ContentSizeError) as exc_info:
+                await prompt_service.register_prompt(
+                    test_db,
+                    prompt,
+                    created_by="user@example.com",
+                    owner_email="user@example.com",
+                )
+            
+            # Verify the error details
+            assert exc_info.value.actual_size == 15000
+            assert exc_info.value.max_size == 10240
+            assert exc_info.value.content_type == "Prompt template"
+            
+            # Verify rollback was called
+            test_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_get_prompt_with_metadata(self, prompt_service, test_db):
         """Test get_prompt accepts metadata."""
         db_prompt = _build_db_prompt(template="Hello!")
@@ -991,6 +1031,45 @@ class TestPromptService:
         with pytest.raises(PromptError) as exc_info:
             await prompt_service.update_prompt(test_db, 1, upd)
         assert "Failed to update prompt" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_prompt_content_size_error(self, prompt_service, test_db):
+        """Test that ContentSizeError is caught and re-raised during prompt update."""
+        from mcpgateway.services.content_security import ContentSizeError
+        
+        existing = _build_db_prompt()
+        existing.team_id = "team-123"
+        test_db.get = Mock(return_value=existing)
+        test_db.execute = Mock(
+            side_effect=[
+                _make_execute_result(scalar=existing),
+                _make_execute_result(scalar=None),
+            ]
+        )
+        test_db.rollback = Mock()
+        
+        # Mock get_content_security_service to return a mock that raises ContentSizeError
+        mock_security_service = Mock()
+        mock_security_service.validate_prompt_size.side_effect = ContentSizeError(
+            content_type="Prompt template",
+            actual_size=15000,
+            max_size=10240
+        )
+        
+        with patch("mcpgateway.services.prompt_service.get_content_security_service", return_value=mock_security_service):
+            # Use 15KB template - passes Pydantic (65KB limit) but fails ContentSizeError (10KB limit)
+            upd = PromptUpdate(template="x" * 15000)  # 15KB template
+            
+            with pytest.raises(ContentSizeError) as exc_info:
+                await prompt_service.update_prompt(test_db, 1, upd)
+            
+            # Verify the error details
+            assert exc_info.value.actual_size == 15000
+            assert exc_info.value.max_size == 10240
+            assert exc_info.value.content_type == "Prompt template"
+            
+            # Verify rollback was called
+            test_db.rollback.assert_called_once()
 
     # ──────────────────────────────────────────────────────────────────
     #   set state

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -407,10 +407,10 @@ class TestPromptService:
     async def test_register_prompt_content_size_error(self, prompt_service, test_db):
         """Test that ContentSizeError is caught and re-raised during prompt registration."""
         from mcpgateway.services.content_security import ContentSizeError
-        
+
         test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
         test_db.rollback = Mock()
-        
+
         # Mock get_content_security_service to return a mock that raises ContentSizeError
         mock_security_service = Mock()
         mock_security_service.validate_prompt_size.side_effect = ContentSizeError(
@@ -418,7 +418,7 @@ class TestPromptService:
             actual_size=15000,
             max_size=10240
         )
-        
+
         with patch("mcpgateway.services.prompt_service.get_content_security_service", return_value=mock_security_service):
             # Use 15KB template - passes Pydantic (65KB limit) but fails ContentSizeError (10KB limit)
             prompt = PromptCreate(
@@ -426,7 +426,7 @@ class TestPromptService:
                 description="A prompt with large template",
                 template="x" * 15000,  # 15KB template
             )
-            
+
             with pytest.raises(ContentSizeError) as exc_info:
                 await prompt_service.register_prompt(
                     test_db,
@@ -434,12 +434,12 @@ class TestPromptService:
                     created_by="user@example.com",
                     owner_email="user@example.com",
                 )
-            
+
             # Verify the error details
             assert exc_info.value.actual_size == 15000
             assert exc_info.value.max_size == 10240
             assert exc_info.value.content_type == "Prompt template"
-            
+
             # Verify rollback was called
             test_db.rollback.assert_called_once()
 
@@ -1036,7 +1036,7 @@ class TestPromptService:
     async def test_update_prompt_content_size_error(self, prompt_service, test_db):
         """Test that ContentSizeError is caught and re-raised during prompt update."""
         from mcpgateway.services.content_security import ContentSizeError
-        
+
         existing = _build_db_prompt()
         existing.team_id = "team-123"
         test_db.get = Mock(return_value=existing)
@@ -1047,7 +1047,7 @@ class TestPromptService:
             ]
         )
         test_db.rollback = Mock()
-        
+
         # Mock get_content_security_service to return a mock that raises ContentSizeError
         mock_security_service = Mock()
         mock_security_service.validate_prompt_size.side_effect = ContentSizeError(
@@ -1055,19 +1055,19 @@ class TestPromptService:
             actual_size=15000,
             max_size=10240
         )
-        
+
         with patch("mcpgateway.services.prompt_service.get_content_security_service", return_value=mock_security_service):
             # Use 15KB template - passes Pydantic (65KB limit) but fails ContentSizeError (10KB limit)
             upd = PromptUpdate(template="x" * 15000)  # 15KB template
-            
+
             with pytest.raises(ContentSizeError) as exc_info:
                 await prompt_service.update_prompt(test_db, 1, upd)
-            
+
             # Verify the error details
             assert exc_info.value.actual_size == 15000
             assert exc_info.value.max_size == 10240
             assert exc_info.value.content_type == "Prompt template"
-            
+
             # Verify rollback was called
             test_db.rollback.assert_called_once()
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -2055,6 +2055,73 @@ class TestErrorHandling:
         mock_db.rollback.assert_called_once()
 
 
+
+class TestResourceServiceContentSizeError:
+    """Tests for ContentSizeError handling in resource service."""
+
+    @pytest.mark.asyncio
+    async def test_register_resource_content_size_error(self, resource_service, mock_db, sample_resource_create):
+        """Test that ContentSizeError is caught and re-raised during resource registration."""
+        from mcpgateway.services.content_security import ContentSizeError
+        
+        mock_db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        
+        # Mock get_content_security_service to return a mock that raises ContentSizeError
+        mock_security_service = MagicMock()
+        mock_security_service.validate_resource_size.side_effect = ContentSizeError(
+            content_type="Resource content",
+            actual_size=150000,
+            max_size=102400
+        )
+        
+        with patch("mcpgateway.services.resource_service.get_content_security_service", return_value=mock_security_service):
+            # Create a resource with large content
+            large_resource = sample_resource_create
+            large_resource.content = "x" * 150000  # 150KB content
+            
+            with pytest.raises(ContentSizeError) as exc_info:
+                await resource_service.register_resource(
+                    mock_db,
+                    large_resource,
+                    created_by="user@example.com",
+                    owner_email="user@example.com",
+                )
+            
+            # Verify the error details
+            assert exc_info.value.actual_size == 150000
+            assert exc_info.value.max_size == 102400
+            assert exc_info.value.content_type == "Resource content"
+
+    @pytest.mark.asyncio
+    async def test_update_resource_content_size_error(self, resource_service, mock_db, mock_resource):
+        """Test that ContentSizeError is caught and re-raised during resource update."""
+        from mcpgateway.services.content_security import ContentSizeError
+        from mcpgateway.schemas import ResourceUpdate
+        
+        mock_resource.owner_email = "user@example.com"
+        mock_db.get = MagicMock(return_value=mock_resource)
+        mock_db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        
+        # Mock get_content_security_service to return a mock that raises ContentSizeError
+        mock_security_service = MagicMock()
+        mock_security_service.validate_resource_size.side_effect = ContentSizeError(
+            content_type="Resource content",
+            actual_size=150000,
+            max_size=102400
+        )
+        
+        with patch("mcpgateway.services.resource_service.get_content_security_service", return_value=mock_security_service):
+            # Update with large content
+            update = ResourceUpdate(content="x" * 150000)  # 150KB content
+            
+            with pytest.raises(ContentSizeError) as exc_info:
+                await resource_service.update_resource(mock_db, 1, update)
+            
+            # Verify the error details
+            assert exc_info.value.actual_size == 150000
+            assert exc_info.value.max_size == 102400
+            assert exc_info.value.content_type == "Resource content"
+
 class TestResourceServiceMetricsExtended:
     """Extended tests for resource service metrics."""
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -2063,9 +2063,9 @@ class TestResourceServiceContentSizeError:
     async def test_register_resource_content_size_error(self, resource_service, mock_db, sample_resource_create):
         """Test that ContentSizeError is caught and re-raised during resource registration."""
         from mcpgateway.services.content_security import ContentSizeError
-        
+
         mock_db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
-        
+
         # Mock get_content_security_service to return a mock that raises ContentSizeError
         mock_security_service = MagicMock()
         mock_security_service.validate_resource_size.side_effect = ContentSizeError(
@@ -2073,12 +2073,12 @@ class TestResourceServiceContentSizeError:
             actual_size=150000,
             max_size=102400
         )
-        
+
         with patch("mcpgateway.services.resource_service.get_content_security_service", return_value=mock_security_service):
             # Create a resource with large content
             large_resource = sample_resource_create
             large_resource.content = "x" * 150000  # 150KB content
-            
+
             with pytest.raises(ContentSizeError) as exc_info:
                 await resource_service.register_resource(
                     mock_db,
@@ -2086,7 +2086,7 @@ class TestResourceServiceContentSizeError:
                     created_by="user@example.com",
                     owner_email="user@example.com",
                 )
-            
+
             # Verify the error details
             assert exc_info.value.actual_size == 150000
             assert exc_info.value.max_size == 102400
@@ -2097,11 +2097,11 @@ class TestResourceServiceContentSizeError:
         """Test that ContentSizeError is caught and re-raised during resource update."""
         from mcpgateway.services.content_security import ContentSizeError
         from mcpgateway.schemas import ResourceUpdate
-        
+
         mock_resource.owner_email = "user@example.com"
         mock_db.get = MagicMock(return_value=mock_resource)
         mock_db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
-        
+
         # Mock get_content_security_service to return a mock that raises ContentSizeError
         mock_security_service = MagicMock()
         mock_security_service.validate_resource_size.side_effect = ContentSizeError(
@@ -2109,14 +2109,14 @@ class TestResourceServiceContentSizeError:
             actual_size=150000,
             max_size=102400
         )
-        
+
         with patch("mcpgateway.services.resource_service.get_content_security_service", return_value=mock_security_service):
             # Update with large content
             update = ResourceUpdate(content="x" * 150000)  # 150KB content
-            
+
             with pytest.raises(ContentSizeError) as exc_info:
                 await resource_service.update_resource(mock_db, 1, update)
-            
+
             # Verify the error details
             assert exc_info.value.actual_size == 150000
             assert exc_info.value.max_size == 102400

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -2413,6 +2413,29 @@ class TestAdminResourceRoutes:
         result = await admin_add_resource(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, JSONResponse)
         assert result.status_code == 500
+    @patch.object(ResourceService, "register_resource")
+    async def test_admin_add_resource_content_size_error(self, mock_register_resource, mock_request, mock_db, monkeypatch):
+        """Test adding resource with ContentSizeError."""
+        from mcpgateway.services.content_security import ContentSizeError
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            lambda *_args, **_kwargs: {"created_by": "u", "created_from_ip": None, "created_via": "ui", "created_user_agent": None, "import_batch_id": None, "federation_source": None},
+        )
+
+        mock_register_resource.side_effect = ContentSizeError(
+            content_type="resource",
+            actual_size=200000,
+            max_size=102400
+        )
+
+        result = await admin_add_resource(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 413
+
 
     @patch.object(ResourceService, "register_resource")
     async def test_admin_add_resource_validation_conflict_and_rollback_failure(self, mock_register_resource, mock_request, mock_db, monkeypatch):
@@ -2461,7 +2484,34 @@ class TestAdminResourceRoutes:
         assert mock_update_resource.call_args[0][1] == uri
 
     @patch.object(ResourceService, "update_resource")
-    async def test_admin_edit_resource_error_handlers(self, mock_update_resource, mock_request, mock_db, monkeypatch):
+    async def test_admin_edit_resource_content_size_error(self, mock_request, mock_db, monkeypatch):
+        """Test editing resource with ContentSizeError."""
+        from mcpgateway.services.content_security import ContentSizeError
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+            lambda *_args, **_kwargs: {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None, "version": 1},
+        )
+
+        form_data = FakeForm({"uri": "/test/resource", "name": "Updated", "mimeType": "text/plain", "content": "x", "template": "t"})
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        # Mock the module-level resource_service instance
+        mock_update = AsyncMock(side_effect=ContentSizeError(
+            content_type="resource",
+            actual_size=200000,
+            max_size=102400
+        ))
+        monkeypatch.setattr("mcpgateway.admin.resource_service.update_resource", mock_update)
+
+        result = await admin_edit_resource("test-id", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 413
+
+    async def test_admin_edit_resource_error_handlers(self, mock_request, mock_db, monkeypatch):
         """Cover admin_edit_resource error branches (permission, validation, integrity, conflict, generic)."""
         # First-Party
         from mcpgateway.services.resource_service import ResourceURIConflictError
@@ -2474,24 +2524,34 @@ class TestAdminResourceRoutes:
         form_data = FakeForm({"uri": "/test/resource", "name": "Updated", "mimeType": "text/plain", "content": "x", "template": "t"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        mock_update_resource.side_effect = PermissionError("nope")
+        # Test PermissionError
+        mock_update = AsyncMock(side_effect=PermissionError("nope"))
+        monkeypatch.setattr("mcpgateway.admin.resource_service.update_resource", mock_update)
         response = await admin_edit_resource("res-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert response.status_code == 403
 
+        # Test ValidationError
         error_details = [InitErrorDetails(type="missing", loc=("name",), input={})]
-        mock_update_resource.side_effect = ValidationError.from_exception_data("test", error_details)
+        mock_update = AsyncMock(side_effect=ValidationError.from_exception_data("test", error_details))
+        monkeypatch.setattr("mcpgateway.admin.resource_service.update_resource", mock_update)
         response = await admin_edit_resource("res-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert response.status_code == 422
 
-        mock_update_resource.side_effect = IntegrityError("stmt", {}, Exception("constraint"))
+        # Test IntegrityError
+        mock_update = AsyncMock(side_effect=IntegrityError("stmt", {}, Exception("constraint")))
+        monkeypatch.setattr("mcpgateway.admin.resource_service.update_resource", mock_update)
         response = await admin_edit_resource("res-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert response.status_code == 409
 
-        mock_update_resource.side_effect = ResourceURIConflictError("conflict")
+        # Test ResourceURIConflictError
+        mock_update = AsyncMock(side_effect=ResourceURIConflictError("conflict"))
+        monkeypatch.setattr("mcpgateway.admin.resource_service.update_resource", mock_update)
         response = await admin_edit_resource("res-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert response.status_code == 409
 
-        mock_update_resource.side_effect = Exception("boom")
+        # Test generic Exception
+        mock_update = AsyncMock(side_effect=Exception("boom"))
+        monkeypatch.setattr("mcpgateway.admin.resource_service.update_resource", mock_update)
         response = await admin_edit_resource("res-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert response.status_code == 500
 
@@ -2660,7 +2720,7 @@ class TestAdminPromptRoutes:
     @patch.object(PromptService, "register_prompt")
     async def test_admin_add_prompt_error_handlers(self, mock_register_prompt, mock_request, mock_db, monkeypatch):
         """Cover ValidationError/IntegrityError/name conflict and generic exception paths in admin_add_prompt."""
-        # First-Party
+        from mcpgateway.services.content_security import ContentSizeError
         from mcpgateway.services.prompt_service import PromptNameConflictError
 
         team_service = MagicMock()
@@ -2702,6 +2762,14 @@ class TestAdminPromptRoutes:
         mock_register_prompt.side_effect = RuntimeError("boom")
         resp = await admin_add_prompt(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert resp.status_code == 500
+        mock_register_prompt.side_effect = ContentSizeError(
+            content_type="prompt",
+            actual_size=20000,
+            max_size=10240
+        )
+        resp = await admin_add_prompt(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert resp.status_code == 413
+
 
     @patch.object(PromptService, "update_prompt")
     async def test_admin_edit_prompt_name_change(self, mock_update_prompt, mock_request, mock_db):
@@ -2825,6 +2893,16 @@ class TestAdminPromptRoutes:
         mock_update_prompt.side_effect = Exception("boom")
         response = await admin_edit_prompt("p1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert response.status_code == 500
+        from mcpgateway.services.content_security import ContentSizeError
+
+        mock_update_prompt.side_effect = ContentSizeError(
+            content_type="prompt",
+            actual_size=20000,
+            max_size=10240
+        )
+        response = await admin_edit_prompt("p1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert response.status_code == 413
+
 
     @patch.object(PromptService, "set_prompt_state")
     async def test_admin_set_prompt_state_edge_cases(self, mock_toggle_status, mock_request, mock_db):

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1089,6 +1089,9 @@ class TestResourceEndpoints:
         data = response.json()
         # Default response is a plain list (include_pagination=False by default)
         assert isinstance(data, list)
+        assert len(data) == 1 and data[0]["name"] == "Test Resource"
+        mock_list_resources.assert_called_once()
+
     @patch("mcpgateway.main.resource_service.update_resource")
     def test_update_resource_content_size_error(self, mock_update, test_client, auth_headers):
         """Test update_resource returns 413 for content size limit exceeded."""
@@ -1113,6 +1116,8 @@ class TestResourceEndpoints:
         response = test_client.post("/resources/", json=req, headers=auth_headers)
 
         assert response.status_code == 200  # route returns 200 on success
+        mock_create.assert_called_once()
+
     @patch("mcpgateway.main.resource_service.register_resource")
     def test_create_resource_content_size_error(self, mock_create, test_client, auth_headers):
         """Test create_resource returns 413 for content size limit exceeded."""
@@ -1307,6 +1312,10 @@ class TestPromptEndpoints:
     def test_update_prompt_validation_and_integrity_errors(self, mock_update, exc, status_code, test_client, auth_headers):
         """Test update_prompt error branches for validation/integrity errors."""
         mock_update.side_effect = exc
+        req = {"description": "Updated description"}
+        response = test_client.put("/prompts/test_prompt", json=req, headers=auth_headers)
+        assert response.status_code == status_code
+
     @patch("mcpgateway.main.prompt_service.register_prompt")
     def test_create_prompt_content_size_error(self, mock_create, test_client, auth_headers):
         """Test create_prompt returns 413 for content size limit exceeded."""

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1089,8 +1089,20 @@ class TestResourceEndpoints:
         data = response.json()
         # Default response is a plain list (include_pagination=False by default)
         assert isinstance(data, list)
-        assert len(data) == 1 and data[0]["name"] == "Test Resource"
-        mock_list_resources.assert_called_once()
+    @patch("mcpgateway.main.resource_service.update_resource")
+    def test_update_resource_content_size_error(self, mock_update, test_client, auth_headers):
+        """Test update_resource returns 413 for content size limit exceeded."""
+        # First-Party
+        from mcpgateway.services.content_security import ContentSizeError
+
+        mock_update.side_effect = ContentSizeError("Resource", 150000, 102400)
+        req = {"content": "x" * 150000}
+        response = test_client.put("/resources/1", json=req, headers=auth_headers)
+        assert response.status_code == 413
+        data = response.json()["detail"]
+        assert data["error"] == "Resource size limit exceeded"
+        assert data["actual_size"] == 150000
+        assert data["max_size"] == 102400
 
     @patch("mcpgateway.main.resource_service.register_resource")
     def test_create_resource_endpoint(self, mock_create, test_client, auth_headers):
@@ -1101,6 +1113,21 @@ class TestResourceEndpoints:
         response = test_client.post("/resources/", json=req, headers=auth_headers)
 
         assert response.status_code == 200  # route returns 200 on success
+    @patch("mcpgateway.main.resource_service.register_resource")
+    def test_create_resource_content_size_error(self, mock_create, test_client, auth_headers):
+        """Test create_resource returns 413 for content size limit exceeded."""
+        # First-Party
+        from mcpgateway.services.content_security import ContentSizeError
+
+        mock_create.side_effect = ContentSizeError("Resource", 150000, 102400)
+        req = {"resource": {"uri": "test/resource", "name": "Test Resource", "content": "x" * 150000}, "team_id": None, "visibility": "private"}
+        response = test_client.post("/resources/", json=req, headers=auth_headers)
+        assert response.status_code == 413
+        data = response.json()["detail"]
+        assert data["error"] == "Resource size limit exceeded"
+        assert data["actual_size"] == 150000
+        assert data["max_size"] == 102400
+
         mock_create.assert_called_once()
 
     @patch("mcpgateway.main.resource_service.read_resource")
@@ -1280,9 +1307,35 @@ class TestPromptEndpoints:
     def test_update_prompt_validation_and_integrity_errors(self, mock_update, exc, status_code, test_client, auth_headers):
         """Test update_prompt error branches for validation/integrity errors."""
         mock_update.side_effect = exc
-        req = {"description": "Updated description"}
+    @patch("mcpgateway.main.prompt_service.register_prompt")
+    def test_create_prompt_content_size_error(self, mock_create, test_client, auth_headers):
+        """Test create_prompt returns 413 for content size limit exceeded."""
+        # First-Party
+        from mcpgateway.services.content_security import ContentSizeError
+
+        mock_create.side_effect = ContentSizeError("Prompt", 15000, 10240)
+        req = {"prompt": {"name": "test_prompt", "template": "x" * 15000}, "team_id": None, "visibility": "private"}
+        response = test_client.post("/prompts/", json=req, headers=auth_headers)
+        assert response.status_code == 413
+        data = response.json()["detail"]
+        assert data["error"] == "Prompt size limit exceeded"
+        assert data["actual_size"] == 15000
+        assert data["max_size"] == 10240
+
+    @patch("mcpgateway.main.prompt_service.update_prompt")
+    def test_update_prompt_content_size_error(self, mock_update, test_client, auth_headers):
+        """Test update_prompt returns 413 for content size limit exceeded."""
+        # First-Party
+        from mcpgateway.services.content_security import ContentSizeError
+
+        mock_update.side_effect = ContentSizeError("Prompt", 15000, 10240)
+        req = {"template": "x" * 15000}
         response = test_client.put("/prompts/test_prompt", json=req, headers=auth_headers)
-        assert response.status_code == status_code
+        assert response.status_code == 413
+        data = response.json()["detail"]
+        assert data["error"] == "Prompt size limit exceeded"
+        assert data["actual_size"] == 15000
+        assert data["max_size"] == 10240
 
     @patch("mcpgateway.main.prompt_service.delete_prompt")
     def test_delete_prompt_endpoint_secondary(self, mock_delete, test_client, auth_headers):

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -226,12 +226,14 @@ def test_resource_update_content_and_description():
     truncated = ResourceUpdate.validate_description(long_desc)
     assert len(truncated) == SecurityValidator.MAX_DESCRIPTION_LENGTH
 
-    with pytest.raises(ValueError):
-        ResourceUpdate.validate_content("x" * (SecurityValidator.MAX_CONTENT_LENGTH + 1))
+    # Size validation is now done at service layer, not schema layer
+    # Schema layer only validates encoding and dangerous patterns
 
+    # Test UTF-8 encoding validation
     with pytest.raises(ValueError):
         ResourceUpdate.validate_content(b"\xff\xfe\xfd")
 
+    # Test dangerous HTML pattern detection
     with pytest.raises(ValueError):
         ResourceUpdate.validate_content("<script>alert(1)</script>")
 

--- a/tests/unit/mcpgateway/validation/test_validators.py
+++ b/tests/unit/mcpgateway/validation/test_validators.py
@@ -234,9 +234,9 @@ def test_validate_template_valid():
 
 
 def test_validate_template_too_long():
-    with pytest.raises(ValueError):
-        SecurityValidator.validate_template("a" * 101)
-    SecurityValidator.validate_template("a" * 100)
+    """Template length is now enforced at service layer, not schema validator."""
+    assert SecurityValidator.validate_template("a" * 101) == "a" * 101
+    assert SecurityValidator.validate_template("a" * 100) == "a" * 100
 
 
 def test_validate_template_dangerous_tag():

--- a/tests/unit/mcpgateway/validation/test_validators_advanced.py
+++ b/tests/unit/mcpgateway/validation/test_validators_advanced.py
@@ -586,14 +586,14 @@ def test_validate_template_dangerous():
 
 
 def test_validate_template_length():
-    """Test template length validation."""
+    """Test template length passes schema validation (size enforced at service layer)."""
     # At limit (10000 chars)
     valid_template = "a" * 10000
     assert SecurityValidator.validate_template(valid_template) == valid_template
 
-    # Over limit
-    with pytest.raises(ValueError, match="exceeds maximum length"):
-        SecurityValidator.validate_template("a" * 10001)
+    # Over limit - schema no longer rejects; size enforcement is at service layer
+    over_limit = "a" * 10001
+    assert SecurityValidator.validate_template(over_limit) == over_limit
 
 
 # =============================================================================


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Associated with #538 US-1

---

## 📝 Summary
_What does this PR do and why?_

Implements **User Story 1 (US-1)** from [issue #538](https://github.com/IBM/mcp-context-forge/issues/538): Security - Enforce Content Size Limits. This PR adds configurable content size validation to prevent DoS attacks, resource exhaustion, and ensure data quality.

---
## 🔒 Security Impact
DoS Prevention: Blocks oversized content submissions that could exhaust memory/storage
Resource Management: Enforces configurable limits on resource content (100KB default) and prompt templates (10KB default)
Audit Trail: Logs all size limit violations with user context for security monitoring

## ✨ Changes Made

### Core Implementation

1. **Content Security Service** ([`mcpgateway/services/content_security.py`](mcpgateway/services/content_security.py))
   - New [`ContentSecurityService`](mcpgateway/services/content_security.py:40) class for centralized validation
   - [`validate_resource_size()`](mcpgateway/services/content_security.py:65) - validates resource content against configured limits
   - [`validate_prompt_size()`](mcpgateway/services/content_security.py:96) - validates prompt templates against configured limits
   - [`ContentSizeError`](mcpgateway/services/content_security.py:23) exception with detailed size information
   - Singleton pattern via [`get_content_security_service()`](mcpgateway/services/content_security.py:132)

2. **Configuration** ([`mcpgateway/config.py`](mcpgateway/config.py:1477-1478))
   - [`content_max_resource_size`](mcpgateway/config.py:1477): 100KB default (configurable 1KB-10MB)
   - [`content_max_prompt_size`](mcpgateway/config.py:1478): 10KB default (configurable 512B-1MB)

3. **Service Integration**
   - [`resource_service.py`](mcpgateway/services/resource_service.py:437-448): Size validation before database operations
   - [`prompt_service.py`](mcpgateway/services/prompt_service.py:467-473): Size validation before template processing
   - Validation applies to both **create** and **update** operations

4. **Error Handling** ([`main.py`](mcpgateway/main.py:128), [`admin.py`](mcpgateway/admin.py:125))
   - Returns **413 Payload Too Large** with structured error response
   - Includes `actual_size`, `max_size`, `error`, and `message` fields
   - Clear, actionable error messages for clients

---

### Testing

Comprehensive integration tests ([`tests/integration/test_content_size_limits.py`](tests/integration/test_content_size_limits.py)):
- ✅ Content within limits succeeds
- ✅ Content at exact limit succeeds  
- ✅ Content exceeding limit returns 413
- ✅ One byte over limit returns 413
- ✅ Unicode content size calculated correctly (UTF-8 bytes)
- ✅ Validation applies to both create and update operations
- ✅ Bulk operations validate each item
- ✅ Error responses include size details

---

**Reproduce** 
1. Start the gateway with config.yaml
(e.g. make dev or python -m mcpgateway.main)

- visit prompts and try to create and also update one with a large template size greater than 10KB  
- visit resource and try to create and also update one with a large content size greater than 100KB 
- Visit admin and public APIs for prompts and resources try to create and update with large sized content 

2. observation

- Should see and error 
- create and update is not allowed 


---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 📋 Acceptance Criteria Met

From issue #538 US-1:

- ✅ Resource content exceeding 100KB limit returns 413 Payload Too Large
- ✅ Prompt template exceeding 10KB limit returns 413 Payload Too Large  
- ✅ Content within limits succeeds
- ✅ Error responses include size limit information
- ✅ Size validation applies to both create and update operations
- ✅ Security violations logged with user context

## 🔧 Configuration

```bash
# Environment variables (optional - defaults shown)
CONTENT_MAX_RESOURCE_SIZE=102400  # 100KB for resources
CONTENT_MAX_PROMPT_SIZE=10240     # 10KB for prompt templates
```

## 🚀 Usage Example

```python
# Automatic validation on resource creation
POST /api/resources
{
  "uri": "test://resource",
  "content": "..." # Validated against 100KB limit
}

# Returns 413 if oversized:
{
  "detail": {
    "error": "Content size limit exceeded",
    "message": "Resource content size (200000 bytes) exceeds maximum allowed size (102400 bytes)",
    "actual_size": 200000,
    "max_size": 102400
  }
}
```

## 📊 Impact

- **Security**: Prevents resource exhaustion attacks
- **Performance**: Validation occurs before database operations (fail-fast)
- **Compatibility**: Non-breaking change with sensible defaults
- **Observability**: All violations logged for security monitoring

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    PASS       |
| Unit tests                | `make test`     |     PASS   |
| Coverage ≥ 80%            | `make coverage` |   99%     |

---

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] Tests added/updated for changes
- [X] Documentation updated (if applicable)
- [X] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
