### PR TITLE
[FIX][API]: Update Ollama default endpoints to use native API

### DIFF
--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6068,12 +6068,12 @@ class LLMProviderType:
                 "description": "Anthropic Claude models",
             },
             cls.OLLAMA: {
-                "api_base": "http://localhost:11434/v1",
+                "api_base": "http://localhost:11434",
                 "default_model": "llama3.2",
                 "supports_model_list": True,
-                "models_endpoint": "/models",
+                "models_endpoint": "/api/tags",
                 "requires_api_key": False,
-                "description": "Local Ollama server (OpenAI-compatible)",
+                "description": "Local Ollama server",
             },
             cls.OPENAI_COMPATIBLE: {
                 "api_base": "http://localhost:8080/v1",

--- a/mcpgateway/llm_provider_configs.py
+++ b/mcpgateway/llm_provider_configs.py
@@ -431,11 +431,11 @@ PROVIDER_CONFIGS: Dict[str, ProviderConfigDefinition] = {
     "ollama": ProviderConfigDefinition(
         provider_type="ollama",
         display_name="Ollama",
-        description="Local Ollama server (OpenAI-compatible)",
+        description="Local Ollama server",
         requires_api_key=False,
         requires_api_base=True,
-        api_base_default="http://localhost:11434/v1",
-        api_base_help="Ollama server URL (use /v1 suffix for OpenAI compatibility)",
+        api_base_default="http://localhost:11434",
+        api_base_help="Ollama server URL (native API)",
         config_fields=[],
     ),
     "openai_compatible": ProviderConfigDefinition(

--- a/tests/unit/mcpgateway/test_db.py
+++ b/tests/unit/mcpgateway/test_db.py
@@ -2822,6 +2822,18 @@ def test_llm_provider_type_helpers():
     assert "api_base" in defaults[db.LLMProviderType.OPENAI]
 
 
+def test_ollama_provider_defaults_use_native_api():
+    """Ollama defaults must point to native API, not the OpenAI-compatible /v1 shim."""
+    defaults = db.LLMProviderType.get_provider_defaults()
+    ollama = defaults[db.LLMProviderType.OLLAMA]
+
+    assert ollama["api_base"] == "http://localhost:11434", "api_base must not include /v1"
+    assert ollama["models_endpoint"] == "/api/tags", "models_endpoint must use native Ollama endpoint"
+    assert ollama["requires_api_key"] is False
+    assert ollama["supports_model_list"] is True
+    assert "OpenAI" not in ollama["description"]
+
+
 def test_slug_listeners_gateway_a2a_agent_email_team(monkeypatch):
     monkeypatch.setattr(db, "slugify", lambda s: s.lower().replace(" ", "-"))
 

--- a/tests/unit/mcpgateway/test_llm_schemas.py
+++ b/tests/unit/mcpgateway/test_llm_schemas.py
@@ -364,6 +364,16 @@ class TestProviderConfigFunctions:
         assert "openai" in configs
         assert "ollama" in configs
 
+    def test_ollama_provider_config_uses_native_api(self):
+        from mcpgateway.llm_provider_configs import get_provider_config
+
+        ollama = get_provider_config("ollama")
+        assert ollama is not None
+        assert ollama.api_base_default == "http://localhost:11434", "must not include /v1"
+        assert ollama.requires_api_key is False
+        assert ollama.requires_api_base is True
+        assert "native" in ollama.api_base_help.lower()
+
 
 class TestAdditionalSchemas:
     """Tests for schemas not covered by other test classes."""


### PR DESCRIPTION

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes https://github.com/IBM/mcp-context-forge/issues/3264

---

## 📝 Summary

Updated Ollama API configuration to use the native Ollama API endpoint `/api/tags` for listing models instead of the OpenAI-compatible endpoint.

Changes made:

### mcpgateway/db.py 

- Changed `api_base` from `http://localhost:11434/v1` to `http://localhost:11434`
- Changed `models_endpoint` from /`models` to `/api/tags`
- Updated description from "Local Ollama server (OpenAI-compatible)" to "Local Ollama server"

### mcpgateway/llm_provider_configs.py

- Changed `api_base_default` from `http://localhost:11434/v1` to `http://localhost:11434`
- Updated `api_base_help` from `Ollama server URL (use /v1 suffix for OpenAI compatibility)` to `Ollama server URL (native API)`
- Updated description to `Local Ollama server`

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   ✅      |
| Unit tests                | `make test`     |    ✅      |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
