### PR TITLE
[FIX][API]: Accept parameterized MIME types in resource validation

### DIFF
--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,7 +76,9 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*$")
+_MIME_TYPE_RE: Pattern[str] = re.compile(
+    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
+)
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")
@@ -1545,6 +1547,13 @@ class SecurityValidator:
             >>> SecurityValidator.validate_mime_type('image/svg+xml')
             'image/svg+xml'
 
+            Valid MIME types with parameters:
+
+            >>> SecurityValidator.validate_mime_type('application/json; charset=utf-8')
+            'application/json; charset=utf-8'
+            >>> SecurityValidator.validate_mime_type('text/plain; charset=utf-8')
+            'text/plain; charset=utf-8'
+
             Invalid MIME type formats:
 
             >>> SecurityValidator.validate_mime_type('invalid')
@@ -1589,12 +1598,12 @@ class SecurityValidator:
             ...     'not in the allowed list' in str(e)
             True
 
-            Test MIME type with parameters (line 618):
+            Test MIME type with parameters:
 
             >>> try:
             ...     SecurityValidator.validate_mime_type('application/evil; charset=utf-8')
             ... except ValueError as e:
-            ...     'Invalid MIME type format' in str(e)
+            ...     'not in the allowed list' in str(e)
             True
         """
         if not value:
@@ -1606,9 +1615,9 @@ class SecurityValidator:
 
         # Common safe MIME types
         safe_mime_types = settings.validation_allowed_mime_types
-        if value not in safe_mime_types:
+        base_type = value.split(";", 1)[0].strip()
+        if value not in safe_mime_types and base_type not in safe_mime_types:
             # Allow x- vendor types and + suffixes
-            base_type = value.split(";", maxsplit=1)[0].strip()
             if not (base_type.startswith("application/x-") or base_type.startswith("text/x-") or "+" in base_type):
                 raise ValueError(f"MIME type '{value}' is not in the allowed list")
 

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,9 +76,7 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(
-    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
-)
+_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
+_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')  # noqa: DUO138 - no ReDoS: inner groups require literal ; and = delimiters preventing backtrack ambiguity
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/services/mcp_client_chat_service.py
+++ b/mcpgateway/services/mcp_client_chat_service.py
@@ -2379,6 +2379,7 @@ class MCPChatService:
         conversational agent. Must be called before using chat functionality.
 
         Raises:
+            ImportError: If LLM chat dependencies are missing.
             ConnectionError: If MCP server connection fails.
             Exception: If initialization fails.
 
@@ -3051,6 +3052,7 @@ class MCPChatService:
 
         Raises:
             RuntimeError: If service not initialized.
+            ImportError: If LLM chat dependencies are missing.
             Exception: If tool reloading or agent recreation fails.
 
         Examples:

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -17003,6 +17003,38 @@ async function handleEditResFormSubmit(e) {
     }
 }
 
+function isUiResourceUri(uri) {
+    return typeof uri === "string" && uri.trim().toLowerCase().startsWith("ui://");
+}
+
+function bindMcpAppMimeHelper(uriInputId, mimeInputId, helperId) {
+    const uriField = safeGetElement(uriInputId, true);
+    const mimeField = safeGetElement(mimeInputId, true);
+    const helperText = safeGetElement(helperId, true);
+
+    if (!uriField || !mimeField || !helperText) {
+        return;
+    }
+
+    if (mimeField.dataset.mcpAppMimeHelperBound === "true") {
+        return;
+    }
+    mimeField.dataset.mcpAppMimeHelperBound = "true";
+
+    const updateHelperVisibility = () => {
+        const shouldShow = document.activeElement === mimeField && isUiResourceUri(uriField.value);
+        helperText.classList.toggle("hidden", !shouldShow);
+    };
+
+    uriField.addEventListener("input", updateHelperVisibility);
+    mimeField.addEventListener("focus", updateHelperVisibility);
+    mimeField.addEventListener("blur", () => {
+        helperText.classList.add("hidden");
+    });
+
+    updateHelperVisibility();
+}
+
 async function handleGrpcServiceFormSubmit(e) {
     e.preventDefault();
 
@@ -17890,6 +17922,11 @@ function setupFormHandlers() {
     const resourceForm = safeGetElement("add-resource-form");
     if (resourceForm) {
         resourceForm.addEventListener("submit", handleResourceFormSubmit);
+        bindMcpAppMimeHelper(
+            "resource-uri",
+            "resource-mime-type",
+            "resource-mime-helper",
+        );
     }
 
     const promptForm = safeGetElement("add-prompt-form");
@@ -17967,6 +18004,11 @@ function setupFormHandlers() {
     const editResourceForm = safeGetElement("edit-resource-form");
     if (editResourceForm) {
         editResourceForm.addEventListener("submit", handleEditResFormSubmit);
+        bindMcpAppMimeHelper(
+            "edit-resource-uri",
+            "edit-resource-mime-type",
+            "edit-resource-mime-helper",
+        );
         editResourceForm.addEventListener("click", () => {
             if (getComputedStyle(editResourceForm).display !== "none") {
                 refreshEditors();

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -17004,7 +17004,9 @@ async function handleEditResFormSubmit(e) {
 }
 
 function isUiResourceUri(uri) {
-    return typeof uri === "string" && uri.trim().toLowerCase().startsWith("ui://");
+    return (
+        typeof uri === "string" && uri.trim().toLowerCase().startsWith("ui://")
+    );
 }
 
 function bindMcpAppMimeHelper(uriInputId, mimeInputId, helperId) {
@@ -17022,7 +17024,9 @@ function bindMcpAppMimeHelper(uriInputId, mimeInputId, helperId) {
     mimeField.dataset.mcpAppMimeHelperBound = "true";
 
     const updateHelperVisibility = () => {
-        const shouldShow = document.activeElement === mimeField && isUiResourceUri(uriField.value);
+        const shouldShow =
+            document.activeElement === mimeField &&
+            isUiResourceUri(uriField.value);
         helperText.classList.toggle("hidden", !shouldShow);
     };
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -4530,6 +4530,7 @@
                 <input
                   type="text"
                   name="uri"
+                  id="resource-uri"
                   required
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 />
@@ -4567,9 +4568,14 @@
                 <input
                   type="text"
                   name="mimeType"
+                  id="resource-mime-type"
+                  aria-describedby="resource-mime-helper"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                   placeholder="text/plain"
                 />
+                <p id="resource-mime-helper" class="mt-1 text-xs text-gray-500 dark:text-gray-400 hidden">
+                  For interactive MCP Apps use: text/html;profile=mcp-app
+                </p>
               </div>
               <div>
                 <label
@@ -9092,8 +9098,12 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         type="text"
                         name="mimeType"
                         id="edit-resource-mime-type"
+                        aria-describedby="edit-resource-mime-helper"
                         class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
+                      <p id="edit-resource-mime-helper" class="mt-1 text-xs text-gray-500 dark:text-gray-400 hidden">
+                        For interactive MCP Apps use: text/html;profile=mcp-app
+                      </p>
                     </div>
                     <!-- Removing Content form Edit Form -->
                     <!-- Remove required attribute to avoid browser validation issues -->

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -620,6 +620,43 @@ class TestAdminResourceAPIs:
         response = await client.post("/admin/resources", data=valid_form_data, headers=TEST_AUTH_HEADER)
         assert response.status_code == 409
 
+    async def test_admin_add_resource_accepts_parameterized_mime_types(self, client: AsyncClient, mock_settings):
+        """Test admin resource create/list accepts and persists parameterized MIME types."""
+        accepted_mime_types = [
+            "text/plain; charset=utf-8",
+            "application/json; charset=utf-8",
+            "text/html; profile=interactive-app",
+        ]
+
+        created_resources: list[tuple[str, str]] = []
+        for mime_value in accepted_mime_types:
+            resource_name = f"Parameterized MIME Resource {uuid.uuid4().hex[:8]}"
+            resource_uri = f"ui://resource-{uuid.uuid4().hex[:8]}"
+
+            form_data = {
+                "uri": resource_uri,
+                "name": resource_name,
+                "description": "Resource with parameterized MIME type",
+                "mimeType": mime_value,
+                "content": "UI app payload",
+            }
+
+            create_response = await client.post("/admin/resources", data=form_data, headers=TEST_AUTH_HEADER)
+            assert create_response.status_code == 200
+            create_json = create_response.json()
+            assert create_json.get("success") is True
+            created_resources.append((resource_name, mime_value))
+
+        list_response = await client.get("/admin/resources", headers=TEST_AUTH_HEADER)
+        assert list_response.status_code == 200
+        list_json = list_response.json()
+        resources = list_json["data"] if isinstance(list_json, dict) and "data" in list_json else list_json
+
+        for resource_name, mime_value in created_resources:
+            resource = next((r for r in resources if r.get("name") == resource_name), None)
+            assert resource is not None
+            assert resource.get("mimeType", resource.get("mime_type")) == mime_value
+
 
 # -------------------------
 # Test Prompt Admin APIs

--- a/tests/unit/mcpgateway/validation/test_validators_advanced.py
+++ b/tests/unit/mcpgateway/validation/test_validators_advanced.py
@@ -877,10 +877,16 @@ class TestValidateMimeType:
         assert SecurityValidator.validate_mime_type("image/jpeg") == "image/jpeg"
 
     def test_invalid_format(self):
-        with pytest.raises(ValueError, match="Invalid MIME type"):
-            SecurityValidator.validate_mime_type("invalid")
-        with pytest.raises(ValueError, match="Invalid MIME type"):
-            SecurityValidator.validate_mime_type("text/")
+        allowed_mime_types = DummySettings.validation_allowed_mime_types
+        invalid_mime_types = [
+            "invalid",
+            *(f"{mime_type};param" for mime_type in allowed_mime_types),
+            *(f"{mime_type}; charset" for mime_type in allowed_mime_types),
+            *(f"{mime_type.split('/', 1)[0]}/" for mime_type in allowed_mime_types if "/" in mime_type),
+        ]
+        for mime_type in invalid_mime_types:
+            with pytest.raises(ValueError, match="Invalid MIME type"):
+                SecurityValidator.validate_mime_type(mime_type)
 
     def test_vendor_types_allowed(self):
         assert SecurityValidator.validate_mime_type("application/x-custom") == "application/x-custom"
@@ -890,9 +896,20 @@ class TestValidateMimeType:
         assert SecurityValidator.validate_mime_type("application/vnd.api+json") == "application/vnd.api+json"
         assert SecurityValidator.validate_mime_type("image/svg+xml") == "image/svg+xml"
 
+    def test_parameterized_types_allowed(self):
+        allowed_parameterized_types = [
+            "text/plain; charset=utf-8",
+            "application/json; charset=utf-8",
+            "text/html; profile=interactive-app",
+        ]
+        for mime_type in allowed_parameterized_types:
+            assert SecurityValidator.validate_mime_type(mime_type) == mime_type
+
     def test_not_in_whitelist(self):
         with pytest.raises(ValueError, match="not in the allowed list"):
             SecurityValidator.validate_mime_type("application/evil")
+        with pytest.raises(ValueError, match="not in the allowed list"):
+            SecurityValidator.validate_mime_type("application/evil; charset=utf-8")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #3051 
Implemented full fix for parameterized MIME handling in validation logic: accepts valid MIME parameters and still rejects malformed/unsafe formats in validators.py.

Updated admin UX guidance for UI resources so MIME helper text is contextual (shown for ui:// resource flows on MIME focus) in admin.html and admin.js.

Added and refined unit coverage for MIME validation in test_validators_advanced.py.

Added and refined e2e coverage for admin resource create/list persistence of parameterized MIME values in test_admin_apis.py.

Removed profile-specific example bias from docs/tests and generalized cases to avoid single hardcoded MIME dependencies.


