### PR TITLE
[CHORE][RUST]: ADR-0041 — Top-Level Rust Workspace

### DIFF
--- a/docs/docs/architecture/adr/041-top-level-rust-workspace.md
+++ b/docs/docs/architecture/adr/041-top-level-rust-workspace.md
@@ -13,7 +13,7 @@ The repository is primarily Python-based with some Rust usage (e.g. plugins, too
 Adopt **Option 1: workspace at repository root**.
 
 - Add a root `Cargo.toml` defining a Rust workspace.
-- Include **all** Rust crates as workspace members: `mcpgateway_rust/`, `tools_rust/`, and `plugins_rust/`. **Supersedes** (build layout) [ADR-0039](039-adopt-fully-independent-plugin-crates-architecture.md) plugin crates remain independent per ADR-0039, but are now workspace members so they are built and tested with one root-level workflow instead of per-crate Make setup.
+- Include **all** Rust crates as workspace members: `mcpgateway_rust/`, `tools_rust/`, and `plugins_rust/`. Plugin crates remain independent per ADR-0039, but are now workspace members so they are built and tested with one root-level workflow instead of per-crate Make setup.
 - Keep the existing directory layout: Python in `mcpgateway/`, `plugins/`, etc.; Rust crates remain where they are and are referenced from the root workspace.
 - PyO3/maturin bindings and CI for Rust builds and tests follow this workspace (see [#3027](https://github.com/IBM/mcp-context-forge/issues/3027) for make targets and acceptance criteria).
 
@@ -21,7 +21,7 @@ Adopt **Option 1: workspace at repository root**.
 
 ### Positive
 
-- Single `cargo build` / `cargo test / maturin build` at repo root for all Rust code.
+- Single `cargo build` / `cargo test` / `maturin build` at repo root for all Rust code.
 - Centralized dependency management and simpler CI.
 - Easier cross-crate refactors; natural place to add future Rust components.
 - **Maturin** (by default with a top-level workspace) uses the root `.venv` instead of creating venvs at lower levels—one shared Python environment and simpler dev setup.

--- a/docs/docs/architecture/adr/041-top-level-rust-workspace.md
+++ b/docs/docs/architecture/adr/041-top-level-rust-workspace.md
@@ -1,0 +1,42 @@
+# ADR-0041: Top-Level Rust Workspace (Cargo.toml at Repository Root)
+
+- *Status:* Accepted
+- *Date:* 2026-02-26
+- *Deciders:* Core Engineering Team
+
+## Context
+
+The repository is primarily Python-based with some Rust usage (e.g. plugins, tools). There was no structured Rust workspace, no single command to build/test all Rust code, and no clear pattern for adding performance-critical components. Issue [#3027](https://github.com/IBM/mcp-context-forge/issues/3027) evaluated several layout options.
+
+## Decision
+
+Adopt **Option 1: workspace at repository root**.
+
+- Add a root `Cargo.toml` defining a Rust workspace.
+- Include **all** Rust crates as workspace members: `mcpgateway_rust/`, `tools_rust/`, and `plugins_rust/`. **Supersedes** (build layout) [ADR-0039](039-adopt-fully-independent-plugin-crates-architecture.md) plugin crates remain independent per ADR-0039, but are now workspace members so they are built and tested with one root-level workflow instead of per-crate Make setup.
+- Keep the existing directory layout: Python in `mcpgateway/`, `plugins/`, etc.; Rust crates remain where they are and are referenced from the root workspace.
+- PyO3/maturin bindings and CI for Rust builds and tests follow this workspace (see [#3027](https://github.com/IBM/mcp-context-forge/issues/3027) for make targets and acceptance criteria).
+
+## Consequences
+
+### Positive
+
+- Single `cargo build` / `cargo test / maturin build` at repo root for all Rust code.
+- Centralized dependency management and simpler CI.
+- Easier cross-crate refactors; natural place to add future Rust components.
+- **Maturin** (by default with a top-level workspace) uses the root `.venv` instead of creating venvs at lower levels—one shared Python environment and simpler dev setup.
+
+### Negative
+
+- Rust and Python directories live side-by-side at root; language boundary is less visually isolated than a dedicated `rust/` folder.
+
+## Alternatives Considered
+
+- **Option 2 (dedicated `mcpgateway_rust/` as workspace root)**: Clearer language boundary but extra `cd`/Make indirection and no single root-level workspace for plugins.
+- **Option 3 (hybrid `rust/` folder with gateway_core boundary)**: Deferred; can be revisited if we want a stricter FFI boundary.
+- **Option 4+ (Rust as services / split repos / full rewrite)**: Out of scope for this decision.
+
+## Related
+
+- Issue: [https://github.com/IBM/mcp-context-forge/issues/3027](https://github.com/IBM/mcp-context-forge/issues/3027)
+- **Supersedes** (build layout): [ADR-0039](039-adopt-fully-independent-plugin-crates-architecture.md)—plugin crates remain independent per ADR-0039, but are now workspace members so they are built and tested with one root-level workflow instead of per-crate Make setup.

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -42,5 +42,7 @@ This page tracks all significant design decisions made for ContextForge project,
 | 0037  | External Plugin STDIO Launch with Command/Env Overrides | Accepted | Extensibility | 2026-01-28 |
 | 0038  | Experimental Rust Transport Backend (Streamable HTTP) | Proposed | Performance | 2025-12-26 |
 | 0039  | Adopt Fully Independent Plugin Crates Architecture | Accepted | Architecture | 2026-02-13 |
+| 0040  | Flexible Admin UI Section Visibility | Accepted | User Interface | 2026-02-16 |
+| 0041  | Top-Level Rust Workspace (Cargo.toml at Repository Root) | Accepted | Architecture | 2026-02-26 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.


### PR DESCRIPTION
Introduce ADR-0041 which mandates a repository-root Cargo.toml workspace that includes all Rust crates (mcpgateway_rust/, tools_rust/, plugins_rust/). The ADR documents the rationale, decision to keep existing layout while centralizing Rust builds/tests, and consequences (single cargo/maturin workflow, centralized deps, shared venv). Update the ADR index to list ADR-0040 and ADR-0041.

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3027

---

## 📝 Summary
Add **ADR-0041: Top-Level Rust Workspace (Cargo.toml at Repository Root)** and refresh the ADR index.

- **New ADR** `docs/docs/architecture/adr/041-top-level-rust-workspace.md`: Mandates a root `Cargo.toml` workspace including `mcpgateway_rust/`, `tools_rust/`, and `plugins_rust/`. Documents rationale (no prior workspace, single build/test story), decision (Option 1 from #3027; keep existing dir layout; supersedes ADR-0039 build layout so plugins are workspace members), and consequences (single `cargo`/maturin workflow, centralized deps, shared root `.venv`).
- **ADR index** `docs/docs/architecture/adr/index.md`: Add rows for ADR-0040 (Flexible Admin UI Section Visibility) and ADR-0041 (Top-Level Rust Workspace).

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command          | Status |
|---------------------------|------------------|--------|
| Lint suite                | `make lint`      |    ✅    |
| Unit tests                | `make test`      |   ✅     |
| Coverage ≥ 80%            | `make coverage`  |    ✅    |
| Docs build                | `make docs`      |   ✅     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`) — N/A (docs only)
- [x] Tests added/updated for changes — N/A (ADR docs)
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
- ADR-0041 supersedes only the *build layout* aspect of ADR-0039; plugin crates remain independent per ADR-0039 but are now workspace members for a single root-level workflow.
