### PR TITLE
[TESTING][PERFORMANCE]: CONC-01 gateway parallel-create manual test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ tests/migration/reports/
 tests/migration/logs/
 test-results-*.xml
 playwright-report-*.html
+.playwright-cli/
 
 # Vitest
 coverage/

--- a/Makefile
+++ b/Makefile
@@ -8275,5 +8275,5 @@ linting-workflow-commitlint:         ## 📝  Conventional Commits linting (togg
 			--to '$(COMMITLINT_TO)'"
 
 .PHONY: conc-01-gateways
-conc-01-gateways:                    ## Run CONC-01 gateways manual matrix with preflight/token automation
+conc-01-gateways:                    ## Run CONC-01 gateways manual matrix (manual env/token setup required)
 	@/bin/bash tests/manual/concurrency/run_conc_01_gateways.sh

--- a/Makefile
+++ b/Makefile
@@ -8273,3 +8273,7 @@ linting-workflow-commitlint:         ## 📝  Conventional Commits linting (togg
 			--extends @commitlint/config-conventional \
 			--from '$(COMMITLINT_FROM)' \
 			--to '$(COMMITLINT_TO)'"
+
+.PHONY: conc-01-gateways
+conc-01-gateways:                    ## Run CONC-01 gateways manual matrix with preflight/token automation
+	@/bin/bash tests/manual/concurrency/run_conc_01_gateways.sh

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -763,7 +763,8 @@ def _get_span_entity_performance(
     # Use database-native percentiles only if enabled in config and using PostgreSQL
     if dialect_name == "postgresql" and settings.use_postgresdb_percentiles:
         # Safe: uses SQLAlchemy's bindparam for the IN-list
-        stats_sql = text("""
+        stats_sql = text(
+            """
             SELECT
                 (attributes->> :json_key) AS entity,
                 COUNT(*) AS count,
@@ -782,7 +783,8 @@ def _get_span_entity_performance(
             GROUP BY entity
             ORDER BY avg_duration_ms DESC
             LIMIT :limit
-            """).bindparams(bindparam("names", expanding=True))
+            """
+        ).bindparams(bindparam("names", expanding=True))
 
         results = db.execute(
             stats_sql,
@@ -7329,7 +7331,8 @@ async def admin_get_user_edit(
         # Build Password Requirements HTML separately to avoid backslash issues inside f-strings
         if settings.password_require_uppercase or settings.password_require_lowercase or settings.password_require_numbers or settings.password_require_special:
             pr_lines = []
-            pr_lines.append(f"""                <!-- Password Requirements -->
+            pr_lines.append(
+                f"""                <!-- Password Requirements -->
                 <div class="bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded-md p-4">
                     <div class="flex items-start">
                         <svg class="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
@@ -7342,29 +7345,40 @@ async def admin_get_user_edit(
                                     <span class="inline-flex items-center justify-center w-4 h-4 bg-gray-400 text-white rounded-full text-xs mr-2">✗</span>
                                     <span>At least {settings.password_min_length} characters long</span>
                                 </div>
-            """)
+            """
+            )
             if settings.password_require_uppercase:
-                pr_lines.append("""
+                pr_lines.append(
+                    """
                                 <div class="flex items-center" id="edit-req-uppercase"><span class="inline-flex items-center justify-center w-4 h-4 bg-gray-400 text-white rounded-full text-xs mr-2">✗</span><span>Contains uppercase letters (A-Z)</span></div>
-                """)
+                """
+                )
             if settings.password_require_lowercase:
-                pr_lines.append("""
+                pr_lines.append(
+                    """
                                 <div class="flex items-center" id="edit-req-lowercase"><span class="inline-flex items-center justify-center w-4 h-4 bg-gray-400 text-white rounded-full text-xs mr-2">✗</span><span>Contains lowercase letters (a-z)</span></div>
-                """)
+                """
+                )
             if settings.password_require_numbers:
-                pr_lines.append("""
+                pr_lines.append(
+                    """
                                 <div class="flex items-center" id="edit-req-numbers"><span class="inline-flex items-center justify-center w-4 h-4 bg-gray-400 text-white rounded-full text-xs mr-2">✗</span><span>Contains numbers (0-9)</span></div>
-                """)
+                """
+                )
             if settings.password_require_special:
-                pr_lines.append("""
+                pr_lines.append(
+                    """
                                 <div class="flex items-center" id="edit-req-special"><span class="inline-flex items-center justify-center w-4 h-4 bg-gray-400 text-white rounded-full text-xs mr-2">✗</span><span>Contains special characters (!@#$%^&amp;*(),.?&quot;:{{}}|&lt;&gt;)</span></div>
-                """)
-            pr_lines.append("""
+                """
+                )
+            pr_lines.append(
+                """
                             </div>
                         </div>
                     </div>
                 </div>
-            """)
+            """
+            )
             password_requirements_html = "".join(pr_lines)
         else:
             # Intentionally an empty string for HTML insertion when no requirements apply.
@@ -17074,7 +17088,8 @@ def _get_latency_percentiles_postgresql(db: Session, cutoff_time: datetime, inte
         dict: Time-series percentile data
     """
     # PostgreSQL query with epoch-based bucketing (works for any interval including > 60 min)
-    stats_sql = text("""
+    stats_sql = text(
+        """
         SELECT
             TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM start_time) / :interval_seconds) * :interval_seconds) as bucket,
             percentile_cont(0.50) WITHIN GROUP (ORDER BY duration_ms) as p50,
@@ -17085,7 +17100,8 @@ def _get_latency_percentiles_postgresql(db: Session, cutoff_time: datetime, inte
         WHERE start_time >= :cutoff_time AND duration_ms IS NOT NULL
         GROUP BY bucket
         ORDER BY bucket
-        """)
+        """
+    )
 
     interval_seconds = interval_minutes * 60
     results = db.execute(stats_sql, {"cutoff_time": cutoff_time, "interval_seconds": interval_seconds}).fetchall()
@@ -17236,7 +17252,8 @@ def _get_timeseries_metrics_postgresql(db: Session, cutoff_time: datetime, inter
         dict: Time-series metrics data
     """
     # Use epoch-based bucketing (works for any interval including > 60 min)
-    stats_sql = text("""
+    stats_sql = text(
+        """
         SELECT
             TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM start_time) / :interval_seconds) * :interval_seconds) as bucket,
             COUNT(*) as total,
@@ -17246,7 +17263,8 @@ def _get_timeseries_metrics_postgresql(db: Session, cutoff_time: datetime, inter
         WHERE start_time >= :cutoff_time
         GROUP BY bucket
         ORDER BY bucket
-        """)
+        """
+    )
 
     interval_seconds = interval_minutes * 60
     results = db.execute(stats_sql, {"cutoff_time": cutoff_time, "interval_seconds": interval_seconds}).fetchall()
@@ -17356,11 +17374,13 @@ def _get_latency_heatmap_postgresql(db: Session, cutoff_time: datetime, hours: i
         dict: Heatmap data with time and latency dimensions
     """
     # First, get min/max durations
-    stats_query = text("""
+    stats_query = text(
+        """
         SELECT MIN(duration_ms) as min_d, MAX(duration_ms) as max_d
         FROM observability_traces
         WHERE start_time >= :cutoff_time AND duration_ms IS NOT NULL
-    """)
+    """
+    )
     stats_row = db.execute(stats_query, {"cutoff_time": cutoff_time}).fetchone()
 
     if not stats_row or stats_row.min_d is None:
@@ -17379,7 +17399,8 @@ def _get_latency_heatmap_postgresql(db: Session, cutoff_time: datetime, hours: i
     time_bucket_minutes = time_range_minutes / time_buckets
 
     # Use SQL arithmetic for 2D histogram bucketing
-    heatmap_query = text("""
+    heatmap_query = text(
+        """
         SELECT
             LEAST(GREATEST(
                 (EXTRACT(EPOCH FROM (start_time - :cutoff_time)) / 60.0 / :time_bucket_minutes)::int,
@@ -17393,7 +17414,8 @@ def _get_latency_heatmap_postgresql(db: Session, cutoff_time: datetime, hours: i
         FROM observability_traces
         WHERE start_time >= :cutoff_time AND duration_ms IS NOT NULL
         GROUP BY time_idx, latency_idx
-    """)
+    """
+    )
 
     rows = db.execute(
         heatmap_query,

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -1406,9 +1406,7 @@ class TokenScopingMiddleware:
         Returns:
             Shared secret-derived digest expected on trusted internal Rust MCP calls.
         """
-        return TokenScopingMiddleware._expected_internal_mcp_runtime_auth_header_for_secret(
-            TokenScopingMiddleware._auth_encryption_secret_value()
-        )
+        return TokenScopingMiddleware._expected_internal_mcp_runtime_auth_header_for_secret(TokenScopingMiddleware._auth_encryption_secret_value())
 
 
 # Create middleware instance

--- a/tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+++ b/tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CONC-01 manual concurrency check: parallel same-name gateway creation.
+
+This script targets the parent-scope CONC-01 scenario on /gateways.
+
+Default matrix (single command run):
+- api_smoke_20  -> N=20, API checks only
+- api_100       -> N=100, API checks only
+- api_db_100    -> N=100, API + DB uniqueness checks
+
+Environment variables:
+- CONC_BASE_URL (default: http://localhost:8000)
+- CONC_TOKEN (required)
+- CONC_NAME_PREFIX (default: conc-gw)
+- CONC_GATEWAY_URL (default: http://127.0.0.1:9000/sse)
+- CONC_DB_CHECK (default: 1; set 0 to skip DB-level uniqueness checks)
+- CONC_DB_PATH (default: mcp.db)  # used for sqlite fallback only
+- DATABASE_URL (optional; when set to postgresql://..., DB checks use Postgres)
+- CONC_CASES (optional; comma-separated case names, e.g. "api_smoke_20,api_100")
+- CONC_TIMEOUT_OVERRIDE (optional; positive int seconds applied to selected cases)
+
+Expected behavior per case:
+- Exactly 1 success (200/201)
+- Exactly N-1 conflicts (409)
+- API uniqueness count == 1
+- DB uniqueness count == 1 (when DB checks enabled)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import sys
+import time
+from collections import Counter
+from dataclasses import dataclass, replace as dataclass_replace
+from urllib.parse import urlparse
+
+import httpx
+
+try:
+    import psycopg  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - optional dependency in manual script
+    psycopg = None
+
+
+@dataclass(frozen=True)
+class _Case:
+    name: str
+    n: int
+    timeout_sec: int
+    db_check: bool
+
+
+DEFAULT_CASES = [
+    _Case(name="api_smoke_20", n=20, timeout_sec=10, db_check=False),
+    _Case(name="api_100", n=100, timeout_sec=20, db_check=False),
+    _Case(name="api_db_100", n=100, timeout_sec=20, db_check=True),
+]
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_config() -> dict[str, object]:
+    token = os.getenv("CONC_TOKEN", "").strip()
+    if not token:
+        raise ValueError("CONC_TOKEN is required")
+
+    return {
+        "base_url": os.getenv("CONC_BASE_URL", "http://localhost:8000").rstrip("/"),
+        "token": token,
+        "name_prefix": os.getenv("CONC_NAME_PREFIX", "conc-gw").strip() or "conc-gw",
+        "gateway_url": os.getenv("CONC_GATEWAY_URL", "http://127.0.0.1:9000/sse").strip(),
+        "db_check_default": _env_bool("CONC_DB_CHECK", True),
+        "db_path": os.getenv("CONC_DB_PATH", "mcp.db").strip() or "mcp.db",
+        "database_url": os.getenv("DATABASE_URL", "").strip(),
+        "cases_filter": os.getenv("CONC_CASES", "").strip(),
+        "timeout_override": os.getenv("CONC_TIMEOUT_OVERRIDE", "").strip(),
+    }
+
+
+async def _create_gateway(client: httpx.AsyncClient, base_url: str, token: str, gateway_name: str, gateway_url: str) -> int | str:
+    try:
+        response = await client.post(
+            f"{base_url}/gateways",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "name": gateway_name,
+                "url": gateway_url,
+                "visibility": "public",
+            },
+        )
+        return response.status_code
+    except Exception as exc:  # pragma: no cover - manual script behavior
+        return f"{type(exc).__name__}: {exc}"
+
+
+async def _count_gateway_name_matches_api(client: httpx.AsyncClient, base_url: str, token: str, gateway_name: str) -> int:
+    response = await client.get(
+        f"{base_url}/gateways",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise ValueError("Expected list response from GET /gateways")
+    return sum(1 for item in payload if isinstance(item, dict) and item.get("name") == gateway_name)
+
+
+def _db_mode(database_url: str) -> str:
+    if database_url.startswith("postgresql://") or database_url.startswith("postgresql+psycopg://"):
+        return "postgres"
+    return "sqlite"
+
+
+def _normalize_pg_dsn(database_url: str) -> str:
+    if database_url.startswith("postgresql+psycopg://"):
+        return "postgresql://" + database_url.split("postgresql+psycopg://", 1)[1]
+    return database_url
+
+
+def _count_gateway_name_matches_sqlite(db_path: str, gateway_name: str) -> int:
+    if not os.path.exists(db_path):
+        raise FileNotFoundError(f"Database file not found: {db_path}")
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM gateways WHERE name = ? AND visibility = ?", (gateway_name, "public"))
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        conn.close()
+
+
+def _count_gateway_name_matches_postgres(database_url: str, gateway_name: str) -> int:
+    if psycopg is None:
+        raise RuntimeError("psycopg is not installed; cannot run Postgres DB checks")
+    dsn = _normalize_pg_dsn(database_url)
+    with psycopg.connect(dsn) as conn:  # pragma: no cover - manual runtime behavior
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM gateways WHERE name = %s AND visibility = %s", (gateway_name, "public"))
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+
+
+def _count_gateway_name_matches_db(database_url: str, db_path: str, gateway_name: str) -> int:
+    mode = _db_mode(database_url)
+    if mode == "postgres":
+        return _count_gateway_name_matches_postgres(database_url, gateway_name)
+    return _count_gateway_name_matches_sqlite(db_path, gateway_name)
+
+
+async def _run_case(
+    case: _Case,
+    base_url: str,
+    token: str,
+    name_prefix: str,
+    gateway_url: str,
+    db_check_enabled: bool,
+    database_url: str,
+    db_path: str,
+) -> bool:
+    run_id = int(time.time() * 1000)
+    gateway_name = f"{name_prefix}-{case.name}-{run_id}"
+    case_gateway_url = f"{gateway_url}?conc_run={run_id}"
+
+    print("\n================================================================")
+    print(f"Case: {case.name}")
+    print("================================================================")
+    print(f"Target: POST {base_url}/gateways")
+    print(f"Requests: {case.n}")
+    print(f"Gateway name: {gateway_name}")
+    print(f"Gateway URL: {case_gateway_url}")
+    print(f"DB check: {'enabled' if (case.db_check and db_check_enabled) else 'disabled'}")
+    if case.db_check and db_check_enabled:
+        print(f"DB mode: {_db_mode(database_url)}")
+        if _db_mode(database_url) == "sqlite":
+            print(f"DB path: {db_path}")
+        else:
+            host = urlparse(_normalize_pg_dsn(database_url)).hostname or "unknown"
+            print(f"DB host: {host}")
+
+    timeout = httpx.Timeout(case.timeout_sec)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        tasks = [_create_gateway(client, base_url, token, gateway_name, case_gateway_url) for _ in range(case.n)]
+        results = await asyncio.gather(*tasks)
+        try:
+            api_unique_count = await _count_gateway_name_matches_api(client, base_url, token, gateway_name)
+        except Exception as exc:  # pragma: no cover - manual script behavior
+            print(f"\nAPI UNIQUENESS CHECK ERROR: {type(exc).__name__}: {exc}")
+            return False
+
+    db_unique_count: int | None = None
+    do_db_check = case.db_check and db_check_enabled
+    if do_db_check:
+        try:
+            db_unique_count = _count_gateway_name_matches_db(database_url, db_path, gateway_name)
+        except Exception as exc:  # pragma: no cover - manual script behavior
+            print(f"\nDB UNIQUENESS CHECK ERROR: {type(exc).__name__}: {exc}")
+            return False
+
+    counts = Counter(results)
+    print("\nStatus/Error distribution:")
+    for key, value in sorted(counts.items(), key=lambda kv: str(kv[0])):
+        print(f"  {key}: {value}")
+
+    success_count = counts.get(200, 0) + counts.get(201, 0)
+    conflict_count = counts.get(409, 0)
+    expected_conflicts = case.n - 1
+
+    print("\nAssertions:")
+    print(f"  success(200|201) == 1 -> {success_count}")
+    print(f"  conflict(409) == {expected_conflicts} -> {conflict_count}")
+    print(f"  api_unique_name_count({gateway_name}) == 1 -> {api_unique_count}")
+    if do_db_check and db_unique_count is not None:
+        print(f"  db_unique_name_count({gateway_name}) == 1 -> {db_unique_count}")
+
+    db_ok = (db_unique_count == 1) if do_db_check else True
+    if success_count == 1 and conflict_count == expected_conflicts and api_unique_count == 1 and db_ok:
+        if do_db_check:
+            print("\nPASS: API+DB same-name gateway create race behavior is correct.")
+        else:
+            print("\nPASS: API-level same-name gateway create race behavior is correct.")
+        return True
+
+    print("\nFAIL: Unexpected status distribution for CONC-01 gateways.")
+    return False
+
+
+async def _run() -> int:
+    try:
+        cfg = _build_config()
+    except ValueError as exc:
+        print(f"CONFIG ERROR: {exc}")
+        return 2
+
+    base_url = str(cfg["base_url"])
+    token = str(cfg["token"])
+    name_prefix = str(cfg["name_prefix"])
+    gateway_url = str(cfg["gateway_url"])
+    db_check_enabled = bool(cfg["db_check_default"])
+    db_path = str(cfg["db_path"])
+    database_url = str(cfg["database_url"])
+    cases_filter_raw = str(cfg["cases_filter"])
+    timeout_override_raw = str(cfg["timeout_override"])
+
+    selected_cases = DEFAULT_CASES
+    if cases_filter_raw:
+        wanted = {name.strip() for name in cases_filter_raw.split(",") if name.strip()}
+        selected_cases = [c for c in DEFAULT_CASES if c.name in wanted]
+        if not selected_cases:
+            print(f"CONFIG ERROR: CONC_CASES did not match known cases: {sorted(wanted)}")
+            return 2
+
+    timeout_override: int | None = None
+    if timeout_override_raw:
+        try:
+            parsed = int(timeout_override_raw)
+            if parsed <= 0:
+                raise ValueError
+            timeout_override = parsed
+        except ValueError:
+            print(f"CONFIG ERROR: CONC_TIMEOUT_OVERRIDE must be a positive integer, got {timeout_override_raw!r}")
+            return 2
+
+    if timeout_override is not None:
+        selected_cases = [dataclass_replace(c, timeout_sec=timeout_override) for c in selected_cases]
+
+    print("CONC-01 Parallel Gateway Create")
+    print(f"Target: POST {base_url}/gateways")
+    print(f"Cases: {len(selected_cases)}")
+    print(f"Gateway URL under test: {gateway_url}")
+    print(f"DB checks globally: {'enabled' if db_check_enabled else 'disabled'}")
+    if cases_filter_raw:
+        print(f"Case filter: {cases_filter_raw}")
+    if timeout_override is not None:
+        print(f"Timeout override: {timeout_override}s")
+
+    case_results: list[tuple[str, bool]] = []
+    for case in selected_cases:
+        ok = await _run_case(
+            case=case,
+            base_url=base_url,
+            token=token,
+            name_prefix=name_prefix,
+            gateway_url=gateway_url,
+            db_check_enabled=db_check_enabled,
+            database_url=database_url,
+            db_path=db_path,
+        )
+        case_results.append((case.name, ok))
+
+    passed = sum(1 for _, ok in case_results if ok)
+    failed = len(case_results) - passed
+    print("\n================================================================")
+    print("Summary")
+    print("================================================================")
+    for name, ok in case_results:
+        print(f"  {name}: {'PASS' if ok else 'FAIL'}")
+    print(f"  total: {len(case_results)}, passed: {passed}, failed: {failed}")
+
+    return 0 if failed == 0 else 1
+
+
+def main() -> int:
+    try:
+        return asyncio.run(_run())
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+++ b/tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
@@ -76,7 +76,7 @@ def _build_config() -> dict[str, object]:
         raise ValueError("CONC_TOKEN is required")
 
     return {
-        "base_url": os.getenv("CONC_BASE_URL", "http://localhost:8000").rstrip("/"),
+        "base_url": os.getenv("CONC_BASE_URL", "http://127.0.0.1:8000").rstrip("/"),
         "token": token,
         "name_prefix": os.getenv("CONC_NAME_PREFIX", "conc-gw").strip() or "conc-gw",
         "gateway_url": os.getenv("CONC_GATEWAY_URL", "http://127.0.0.1:9000/sse").strip(),

--- a/tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+++ b/tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """CONC-01 manual concurrency check: parallel same-name gateway creation.
 
 This script targets the parent-scope CONC-01 scenario on /gateways.
@@ -27,21 +26,24 @@ Expected behavior per case:
 - DB uniqueness count == 1 (when DB checks enabled)
 """
 
+# Future
 from __future__ import annotations
 
+# Standard
 import asyncio
+from collections import Counter
+from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 import os
 import sqlite3
-import sys
 import time
-from collections import Counter
-from dataclasses import dataclass, replace as dataclass_replace
 from urllib.parse import urlparse
 
+# Third-Party
 import httpx
 
 try:
-    import psycopg  # type: ignore[import-not-found]
+    import psycopg  # type: ignore[import-not-found]  # isort: skip
 except Exception:  # pragma: no cover - optional dependency in manual script
     psycopg = None
 
@@ -321,4 +323,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/tests/manual/concurrency/conc_01_gateways_results.md
+++ b/tests/manual/concurrency/conc_01_gateways_results.md
@@ -1,0 +1,289 @@
+# CONC-01 Gateways Manual Results (Working Notes)
+
+Date: 2026-02-25
+Scope:
+- Endpoint: `POST /gateways`
+- Goal: validate same-name parallel create behavior (`1 success`, `N-1 conflict`) and uniqueness
+- Script: `tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
+- Scope boundary: gateway endpoint only for CONC-01 (server endpoint results are out of scope for this artifact)
+
+Environment notes:
+- Local MCP translate endpoint running: `http://127.0.0.1:9000/sse`
+- SSRF localhost/private overrides enabled for local testing
+- Gateway app reachable at `http://127.0.0.1:8000`
+- DB modes exercised:
+  - SQLite (`mcp.db`) for early local runs
+  - PostgreSQL + Redis (`postgresql+psycopg://.../concurrent_test`, `redis://127.0.0.1:6379`) for parent-scope validation
+
+## Expected vs observed (gateway CONC-01)
+
+| Case | Expected | Observed |
+|------|----------|----------|
+| `api_smoke_20` | `1x 200/201`, `19x 409`, uniqueness=1 | `20x 200`, `0x 409`, uniqueness=20 |
+| `api_100` | `1x 200/201`, `99x 409`, uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, uniqueness > 1 |
+| `api_db_100` | same as `api_100` + DB uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, API/DB uniqueness > 1 |
+
+## Preflight checks
+
+- `GET /health` -> `200`
+- Token regenerated and validated against read endpoint (`GET /servers?limit=1` -> `200`)
+
+## Manual gateway duplicate smoke (same payload twice)
+
+Payload:
+```json
+{
+  "name": "conc-gw-<ts>",
+  "url": "http://127.0.0.1:9000/sse",
+  "visibility": "public"
+}
+```
+
+Observed:
+- First create -> `200`
+- Second create (same payload) -> `409` (`{"message":"Gateway name already exists"}`)
+
+Verdict: baseline duplicate behavior works in sequential flow.
+
+## Gateway script run 1 (initial matrix)
+
+Command:
+```bash
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+```
+
+Observed:
+- `api_smoke_20`: all `409` (no success)
+- `api_100`: all `409` (no success)
+- `api_db_100`: timeouts (`ConnectTimeout`/`ReadTimeout`)
+
+Interpretation:
+- URL-level duplicate checks likely collided with prior runs (fixed later by appending run-unique query param).
+
+## Gateway script run 2 (after run-unique URL fix)
+
+Command:
+```bash
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+```
+
+Observed:
+- `api_smoke_20`: `API UNIQUENESS CHECK ERROR: ReadTimeout`
+- `api_100`: `API UNIQUENESS CHECK ERROR: ReadTimeout`
+- `api_db_100`: mostly `ConnectTimeout`/`ReadTimeout`
+
+Interpretation:
+- Under concurrency, gateway create path appears sensitive to upstream initialization latency/capacity.
+
+## Controlled single-case run (higher timeout)
+
+Command:
+```bash
+CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=300 \
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+```
+
+Observed distribution:
+- `200`: `1`
+- `500`: `19`
+
+Assertions:
+- `success(200|201) == 1` -> pass
+- `conflict(409) == 19` -> fail (got `0`)
+- `api_unique_name_count(...) == 1` -> pass
+
+Verdict:
+- Concurrency acceptance (`1 success + N-1 conflict`) is **not met** for `/gateways` in current local setup.
+- Current behavior shows `500` responses under contention instead of `409`.
+
+## PostgreSQL + Redis validation run (parent-scope environment)
+
+Command:
+```bash
+CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 \
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+```
+
+Observed distribution:
+- `200`: `20`
+- `409`: `0`
+
+Assertions:
+- `success(200|201) == 1` -> fail (`20`)
+- `conflict(409) == 19` -> fail (`0`)
+- `api_unique_name_count(conc-gw-api_smoke_20-1772041688506) == 1` -> fail (`20`)
+
+Interpretation:
+- Under concurrent same-name gateway create, all requests succeeded and duplicate records were created.
+- This does **not** satisfy CONC-01 acceptance criteria for `/gateways`.
+
+## Conclusion
+
+- CONC-01 appears **passing** for `/servers`.
+- CONC-01 appears **failing** for `/gateways` in parent-scope environment (Postgres+Redis):
+  - expected `1 success + N-1 conflict + no duplicates`
+  - observed `N successes + duplicates`
+
+## Possible technical reasoning
+
+1. `NULL` behavior in Postgres unique constraints
+
+- In SQL, `NULL` means "no value"/"unknown value" (not `''` and not `0`).
+- In `Gateway`, `team_id` is nullable (`nullable=True`) and uniqueness is defined as:
+  - `UniqueConstraint("team_id", "owner_email", "slug", name="uq_team_owner_slug_gateway")`
+- Postgres treats `NULL` values as distinct in unique checks.
+- Practical effect: rows with the same `owner_email + slug` can still coexist when `team_id` is `NULL` (global/public scope).
+- This matches our observed duplicate rows for `team_id` shown as blank (`NULL`) in `psql`.
+
+2. Concurrent gateway registration path adds instability under load
+
+- For higher-concurrency cases (`api_100`, `api_db_100`), responses included a mix of `200`, `502`, and `ReadError`.
+- This indicates create requests are not all resolving to conflict handling under contention and some requests fail along network/upstream initialization paths.
+- Even with those failures, duplicates are still persisted (API and DB uniqueness counts > 1).
+
+Verification query used:
+```sql
+SELECT team_id, owner_email, slug, COUNT(*) AS cnt
+FROM gateways
+WHERE name LIKE 'conc-gw-api_smoke_20-%'
+GROUP BY team_id, owner_email, slug
+ORDER BY cnt DESC;
+```
+
+## Code references supporting this hypothesis
+
+Gateway schema and constraints:
+- `mcpgateway/db.py:4355` → `Gateway` maps to `gateways`.
+- `mcpgateway/db.py:4357` → primary key on `id`.
+- `mcpgateway/db.py:4426` → `team_id` is nullable (`nullable=True`).
+- `mcpgateway/db.py:4427` → `owner_email` field used in tenant/user scoping.
+- `mcpgateway/db.py:4359` → `slug` field.
+- `mcpgateway/db.py:4466` → unique key is `("team_id", "owner_email", "slug")`.
+
+Slug identity path:
+- `mcpgateway/db.py:6179` / `mcpgateway/db.py:6189` → `before_insert` listener sets `slug = slugify(name)`.
+- `mcpgateway/services/gateway_service.py:728` → service computes `slug_name = slugify(gateway.name)` before create checks.
+
+Create path + conflict handling:
+- `mcpgateway/services/gateway_service.py:731`-`mcpgateway/services/gateway_service.py:735` → pre-check for existing public gateway by slug.
+- `mcpgateway/services/gateway_service.py:740`-`mcpgateway/services/gateway_service.py:744` → team-scoped pre-check by slug/team.
+- `mcpgateway/services/gateway_service.py:1065`-`mcpgateway/services/gateway_service.py:1091` → gateway insert model includes `team_id`, `owner_email`, `visibility`.
+- `mcpgateway/services/gateway_service.py:1100`-`mcpgateway/services/gateway_service.py:1102` → `db.add` + `db.flush`.
+- `mcpgateway/main.py:5469`-`mcpgateway/main.py:5472` → conflict exceptions map to `409`.
+- `mcpgateway/main.py:5477`-`mcpgateway/main.py:5478` → `IntegrityError` maps to `409`.
+
+Locking helper used by pre-check:
+- `mcpgateway/db.py:5473` (`get_for_update`) and `mcpgateway/db.py:5543` (`FOR UPDATE` on PostgreSQL).
+
+Migration intent (constraint shape):
+- `mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py:41` and `mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py:87`-`mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py:88` show the gateway unique constraint composed from `team_id`, `owner_email`, and `slug`.
+
+SSRF validation context (why localhost overrides were needed in local runs):
+- `mcpgateway/schemas.py:2607` calls URL validator for gateway create.
+- `mcpgateway/common/validators.py:1246`-`mcpgateway/common/validators.py:1248` localhost blocking logic.
+- `mcpgateway/common/validators.py:1251`-`mcpgateway/common/validators.py:1266` private-network blocking logic.
+- `mcpgateway/config.py:416` and `mcpgateway/config.py:422` configure `SSRF_ALLOW_LOCALHOST` and `SSRF_ALLOW_PRIVATE_NETWORKS`.
+
+## Repeatability proof (Postgres)
+
+DB query:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:5432/concurrent_test" -c \
+"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC LIMIT 2;"
+```
+
+Observed:
+- `conc-gw-api_smoke_20-1772042731271` -> `cnt=20`
+- `conc-gw-api_smoke_20-1772042640357` -> `cnt=20`
+
+Interpretation:
+- Duplicate creation under concurrent same-name gateway create is reproducible across runs.
+
+## Postgres + Redis execution steps (what we ran)
+
+1. Started local container runtime (`colima`) and verified Docker was healthy.
+2. Started Postgres and Redis containers:
+   - `conc-postgres` on `:5432`
+   - `conc-redis` on `:6379`
+3. Switched gateway app runtime to Postgres + Redis:
+   - `DATABASE_URL=postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test`
+   - `REDIS_URL=redis://127.0.0.1:6379`
+4. Enabled local gateway URL testing for SSRF-protected validation:
+   - `SSRF_ALLOW_LOCALHOST=true`
+   - `SSRF_ALLOW_PRIVATE_NETWORKS=true`
+5. Installed Postgres driver in venv:
+   - `uv pip install "psycopg[binary]"`
+6. Restarted gateway with `make dev` and confirmed readiness via `GET /health -> 200`.
+7. Regenerated bearer token for the test shell.
+8. Ran controlled gateway concurrency case:
+   - `CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
+9. Observed API result:
+   - `200: 20`, `409: 0`, `api_unique_name_count(...)=20`
+10. Verified duplicates directly in Postgres via `psql`:
+   - `COUNT(*) = 20` for the same gateway name.
+11. Rechecked latest runs and again saw `cnt=20`, confirming repeatability.
+
+## Rerun steps (setup already running)
+
+Assumes:
+- Gateway app is already running via `make dev` with Postgres + Redis env.
+- MCP translate endpoint is already reachable at `http://127.0.0.1:9000/sse`.
+- Postgres/Redis containers are already up.
+
+Preferred one-command rerun:
+```bash
+make conc-01-gateways
+```
+
+Optional overrides for one-command rerun:
+```bash
+CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 make conc-01-gateways
+CONC_CASES=api_100 CONC_TIMEOUT_OVERRIDE=180 make conc-01-gateways
+CONC_REFRESH_TOKEN=1 make conc-01-gateways
+```
+
+What `make conc-01-gateways` automates:
+- sets default `DATABASE_URL`/`REDIS_URL` (if not already set)
+- generates `CONC_TOKEN` using `JWT_SECRET_KEY` (unless already set)
+- runs preflight checks (`/health`, auth check, translator TCP check)
+- runs `tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
+
+Manual equivalent:
+
+1. Open a fresh terminal, activate venv, and export test env:
+```bash
+cd /Users/pratik/Desktop/work/mcf/mcp-context-forge
+. /Users/pratik/.venv/mcpgateway/bin/activate
+export DATABASE_URL="postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test"
+export REDIS_URL="redis://127.0.0.1:6379"
+export CONC_TOKEN="$(
+  python -m mcpgateway.utils.create_jwt_token \
+    --username admin@example.com \
+    --exp 120 \
+    --secret "$JWT_SECRET_KEY"
+)"
+```
+
+2. Quick sanity checks:
+```bash
+curl -sS -i http://127.0.0.1:8000/health
+curl -sS -i "http://127.0.0.1:8000/servers?limit=1" -H "Authorization: Bearer $CONC_TOKEN"
+```
+
+3. Run controlled gateway concurrency case (smoke):
+```bash
+CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 \
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+```
+
+4. Verify duplicate counts in Postgres:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:5432/concurrent_test" -c \
+"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC LIMIT 3;"
+```
+
+5. Optional scale-up run:
+```bash
+CONC_CASES=api_100 CONC_TIMEOUT_OVERRIDE=180 \
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+```

--- a/tests/manual/concurrency/conc_01_gateways_results.md
+++ b/tests/manual/concurrency/conc_01_gateways_results.md
@@ -1,68 +1,135 @@
-# CONC-01 Gateway Parallel Create Results
+# CONC-01 Gateway Parallel Create: Runbook + Results
 
-Date: 2026-02-26
-Ticket scope: CONC-01 for gateway endpoint (`POST /gateways`)
+Date: 2026-03-02  
+Ticket scope: CONC-01 for gateway endpoint (`POST /gateways`)  
 Out of scope: server endpoint results
 
 ## Objective
-Validate CONC-01 acceptance for gateway create under concurrency:
-- 100 parallel creates with same name
-- Expected: exactly 1 success, 99 conflicts (`409`), no duplicates persisted
 
-## Test setup used
+Validate CONC-01 acceptance for gateway create under concurrency:
+
+- 100 parallel creates with same name
+- Expected: exactly 1 success, 99 conflicts (`409`)
+- No duplicates persisted (API and DB uniqueness count must be `1`)
+
+## Environment used
+
 - Gateway app: `http://127.0.0.1:8000`
 - Translate endpoint: `http://127.0.0.1:9000/sse`
 - DB/Cache: PostgreSQL + Redis
-- Runner: `make conc-01-gateways`
-- Script: `tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
+- Runner command: `make conc-01-gateways`
+- Test script: `tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
+- Local SSRF test overrides required when using localhost translator:
+  - `SSRF_ALLOW_LOCALHOST=true`
+  - `SSRF_ALLOW_PRIVATE_NETWORKS=true`
 
-## Repro commands
-One-command matrix:
+## Steps to run (copy/paste)
+
+### 1) Start Postgres + Redis in Docker (Colima runtime)
+
 ```bash
+colima start
+docker context use colima
+
+docker rm -f conc-postgres conc-redis 2>/dev/null || true
+
+docker run -d --name conc-postgres -p 5432:5432 \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=concurrent_test \
+  postgres:16
+
+docker run -d --name conc-redis -p 6379:6379 redis:7
+
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | rg 'conc-postgres|conc-redis'
+```
+
+### 2) Terminal A: start gateway (Postgres + Redis + local SSRF overrides)
+
+```bash
+cd /Users/pratik/Desktop/work/new_mcf/mcp-context-forge
+pkill -f "mcpgateway.main|uvicorn" || true
+
+DATABASE_URL='postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test' \
+REDIS_URL='redis://127.0.0.1:6379/0' \
+CACHE_TYPE='redis' \
+JWT_SECRET_KEY='my-test-key' \
+SSRF_ALLOW_LOCALHOST=true \
+SSRF_ALLOW_PRIVATE_NETWORKS=true \
+make dev
+```
+
+### 3) Terminal B: start translator
+
+```bash
+cd /Users/pratik/Desktop/work/new_mcf/mcp-context-forge
+python -m mcpgateway.translate --stdio "uvx mcp-server-git" --port 9000
+```
+
+### 4) Terminal C: generate token and run matrix
+
+```bash
+cd /Users/pratik/Desktop/work/new_mcf/mcp-context-forge
+export CONC_TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 120 --secret my-test-key)"
 make conc-01-gateways
 ```
 
-Focused smoke rerun:
+### 5) Optional sanity checks
+
 ```bash
-CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 make conc-01-gateways
+curl -i -H "Authorization: Bearer $CONC_TOKEN" "http://127.0.0.1:8000/servers?limit=1"
+curl -i "http://127.0.0.1:8000/health"
 ```
+
+Expected: both return `200`.
 
 ## Expected vs observed
 
-| Case | Expected | Observed |
-|------|----------|----------|
-| `api_smoke_20` | `1x 200/201`, `19x 409`, uniqueness=1 | `20x 200`, `0x 409`, uniqueness=20 |
-| `api_100` | `1x 200/201`, `99x 409`, uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, uniqueness > 1 |
-| `api_db_100` | same as above + DB uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, API/DB uniqueness > 1 |
+| Case | Expected | Observed (latest run) |
+|------|----------|-----------------------|
+| `api_smoke_20` | `1x 200/201`, `19x 409`, uniqueness=1 | `200=20`, `409=0`, API uniqueness=`20` |
+| `api_100` | `1x 200/201`, `99x 409`, uniqueness=1 | `200=49`, `500=3`, `502=32`, `ReadError=16`, `409=0`, API uniqueness=`49` |
+| `api_db_100` | same as above + DB uniqueness=1 | `200=42`, `502=37`, `ReadError=21`, `409=0`, API uniqueness=`42`, DB uniqueness=`42` |
 
-Latest full-matrix evidence snapshot:
-- `api_smoke_20`: `200=20`, `409=0`, API uniqueness `20`
-- `api_100`: `200=56`, `502=32`, `ReadError=12`, API uniqueness `50`
-- `api_db_100`: `200=46`, `502=46`, `ReadError=8`, API uniqueness `46`, DB uniqueness `46`
+## Latest matrix output snapshot (2026-03-02)
+
+- `api_smoke_20`:
+  - `success(200|201) == 1 -> 20`
+  - `conflict(409) == 19 -> 0`
+  - `api_unique_name_count(...) == 1 -> 20`
+- `api_100`:
+  - `success(200|201) == 1 -> 49`
+  - `conflict(409) == 99 -> 0`
+  - `api_unique_name_count(...) == 1 -> 49`
+- `api_db_100`:
+  - `success(200|201) == 1 -> 42`
+  - `conflict(409) == 99 -> 0`
+  - `api_unique_name_count(...) == 1 -> 42`
+  - `db_unique_name_count(...) == 1 -> 42`
+
+Result: all 3 cases fail CONC-01 acceptance criteria for `/gateways`.
 
 ## Database proof (duplicates)
-Grouped duplicate count by run name:
+
 ```bash
 psql "postgresql://postgres:postgres@127.0.0.1:5432/concurrent_test" -c \
-"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC;"
+"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC LIMIT 5;"
 ```
 
-Sample observed output:
-- `conc-gw-api_smoke_20-1772112068765 | 20`
-- `conc-gw-api_smoke_20-1772107637078 | 20`
-- `conc-gw-api_smoke_20-1772107480373 | 20`
+Constraint-focused grouping:
 
-Constraint-focused check:
 ```bash
 psql "postgresql://postgres:postgres@127.0.0.1:5432/concurrent_test" -c \
-"SELECT team_id, owner_email, slug, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY team_id, owner_email, slug ORDER BY cnt DESC;"
+"SELECT team_id, owner_email, slug, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY team_id, owner_email, slug ORDER BY cnt DESC LIMIT 20;"
 ```
 
 Observed pattern:
-- `team_id` is `NULL` (blank in `psql` output)
-- same `owner_email` + same `slug` groups appear with `cnt=20`
+
+- `team_id` appears `NULL` (blank in `psql` output)
+- Same `owner_email + slug` groups can appear with high counts (for example `cnt=20`)
 
 ## Code references
+
 - Gateway schema/constraint:
   - `mcpgateway/db.py:4426` (`team_id` nullable)
   - `mcpgateway/db.py:4466` (`UniqueConstraint(team_id, owner_email, slug)`)
@@ -79,7 +146,9 @@ Observed pattern:
   - `mcpgateway/main.py:5477`
 
 ## Interpretation (non-fix)
-This test artifact captures reproducible evidence that current `/gateways` behavior does not meet CONC-01 acceptance in this setup:
+
+This artifact captures reproducible evidence that current `/gateways` behavior does not meet CONC-01 acceptance in this setup:
+
 - Expected conflict pattern (`1 success + N-1 conflicts`) is not observed.
 - Duplicate rows are persisted for same-name concurrent creates.
 

--- a/tests/manual/concurrency/conc_01_gateways_results.md
+++ b/tests/manual/concurrency/conc_01_gateways_results.md
@@ -1,289 +1,86 @@
-# CONC-01 Gateways Manual Results (Working Notes)
+# CONC-01 Gateway Parallel Create Results
 
-Date: 2026-02-25
-Scope:
-- Endpoint: `POST /gateways`
-- Goal: validate same-name parallel create behavior (`1 success`, `N-1 conflict`) and uniqueness
+Date: 2026-02-26
+Ticket scope: CONC-01 for gateway endpoint (`POST /gateways`)
+Out of scope: server endpoint results
+
+## Objective
+Validate CONC-01 acceptance for gateway create under concurrency:
+- 100 parallel creates with same name
+- Expected: exactly 1 success, 99 conflicts (`409`), no duplicates persisted
+
+## Test setup used
+- Gateway app: `http://127.0.0.1:8000`
+- Translate endpoint: `http://127.0.0.1:9000/sse`
+- DB/Cache: PostgreSQL + Redis
+- Runner: `make conc-01-gateways`
 - Script: `tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
-- Scope boundary: gateway endpoint only for CONC-01 (server endpoint results are out of scope for this artifact)
 
-Environment notes:
-- Local MCP translate endpoint running: `http://127.0.0.1:9000/sse`
-- SSRF localhost/private overrides enabled for local testing
-- Gateway app reachable at `http://127.0.0.1:8000`
-- DB modes exercised:
-  - SQLite (`mcp.db`) for early local runs
-  - PostgreSQL + Redis (`postgresql+psycopg://.../concurrent_test`, `redis://127.0.0.1:6379`) for parent-scope validation
+## Repro commands
+One-command matrix:
+```bash
+make conc-01-gateways
+```
 
-## Expected vs observed (gateway CONC-01)
+Focused smoke rerun:
+```bash
+CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 make conc-01-gateways
+```
+
+## Expected vs observed
 
 | Case | Expected | Observed |
 |------|----------|----------|
 | `api_smoke_20` | `1x 200/201`, `19x 409`, uniqueness=1 | `20x 200`, `0x 409`, uniqueness=20 |
 | `api_100` | `1x 200/201`, `99x 409`, uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, uniqueness > 1 |
-| `api_db_100` | same as `api_100` + DB uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, API/DB uniqueness > 1 |
+| `api_db_100` | same as above + DB uniqueness=1 | mixed (`200`, `500/502`, `ReadError`), `0x 409`, API/DB uniqueness > 1 |
 
-## Preflight checks
+Latest full-matrix evidence snapshot:
+- `api_smoke_20`: `200=20`, `409=0`, API uniqueness `20`
+- `api_100`: `200=56`, `502=32`, `ReadError=12`, API uniqueness `50`
+- `api_db_100`: `200=46`, `502=46`, `ReadError=8`, API uniqueness `46`, DB uniqueness `46`
 
-- `GET /health` -> `200`
-- Token regenerated and validated against read endpoint (`GET /servers?limit=1` -> `200`)
-
-## Manual gateway duplicate smoke (same payload twice)
-
-Payload:
-```json
-{
-  "name": "conc-gw-<ts>",
-  "url": "http://127.0.0.1:9000/sse",
-  "visibility": "public"
-}
-```
-
-Observed:
-- First create -> `200`
-- Second create (same payload) -> `409` (`{"message":"Gateway name already exists"}`)
-
-Verdict: baseline duplicate behavior works in sequential flow.
-
-## Gateway script run 1 (initial matrix)
-
-Command:
-```bash
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
-```
-
-Observed:
-- `api_smoke_20`: all `409` (no success)
-- `api_100`: all `409` (no success)
-- `api_db_100`: timeouts (`ConnectTimeout`/`ReadTimeout`)
-
-Interpretation:
-- URL-level duplicate checks likely collided with prior runs (fixed later by appending run-unique query param).
-
-## Gateway script run 2 (after run-unique URL fix)
-
-Command:
-```bash
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
-```
-
-Observed:
-- `api_smoke_20`: `API UNIQUENESS CHECK ERROR: ReadTimeout`
-- `api_100`: `API UNIQUENESS CHECK ERROR: ReadTimeout`
-- `api_db_100`: mostly `ConnectTimeout`/`ReadTimeout`
-
-Interpretation:
-- Under concurrency, gateway create path appears sensitive to upstream initialization latency/capacity.
-
-## Controlled single-case run (higher timeout)
-
-Command:
-```bash
-CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=300 \
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
-```
-
-Observed distribution:
-- `200`: `1`
-- `500`: `19`
-
-Assertions:
-- `success(200|201) == 1` -> pass
-- `conflict(409) == 19` -> fail (got `0`)
-- `api_unique_name_count(...) == 1` -> pass
-
-Verdict:
-- Concurrency acceptance (`1 success + N-1 conflict`) is **not met** for `/gateways` in current local setup.
-- Current behavior shows `500` responses under contention instead of `409`.
-
-## PostgreSQL + Redis validation run (parent-scope environment)
-
-Command:
-```bash
-CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 \
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
-```
-
-Observed distribution:
-- `200`: `20`
-- `409`: `0`
-
-Assertions:
-- `success(200|201) == 1` -> fail (`20`)
-- `conflict(409) == 19` -> fail (`0`)
-- `api_unique_name_count(conc-gw-api_smoke_20-1772041688506) == 1` -> fail (`20`)
-
-Interpretation:
-- Under concurrent same-name gateway create, all requests succeeded and duplicate records were created.
-- This does **not** satisfy CONC-01 acceptance criteria for `/gateways`.
-
-## Conclusion
-
-- CONC-01 appears **passing** for `/servers`.
-- CONC-01 appears **failing** for `/gateways` in parent-scope environment (Postgres+Redis):
-  - expected `1 success + N-1 conflict + no duplicates`
-  - observed `N successes + duplicates`
-
-## Possible technical reasoning
-
-1. `NULL` behavior in Postgres unique constraints
-
-- In SQL, `NULL` means "no value"/"unknown value" (not `''` and not `0`).
-- In `Gateway`, `team_id` is nullable (`nullable=True`) and uniqueness is defined as:
-  - `UniqueConstraint("team_id", "owner_email", "slug", name="uq_team_owner_slug_gateway")`
-- Postgres treats `NULL` values as distinct in unique checks.
-- Practical effect: rows with the same `owner_email + slug` can still coexist when `team_id` is `NULL` (global/public scope).
-- This matches our observed duplicate rows for `team_id` shown as blank (`NULL`) in `psql`.
-
-2. Concurrent gateway registration path adds instability under load
-
-- For higher-concurrency cases (`api_100`, `api_db_100`), responses included a mix of `200`, `502`, and `ReadError`.
-- This indicates create requests are not all resolving to conflict handling under contention and some requests fail along network/upstream initialization paths.
-- Even with those failures, duplicates are still persisted (API and DB uniqueness counts > 1).
-
-Verification query used:
-```sql
-SELECT team_id, owner_email, slug, COUNT(*) AS cnt
-FROM gateways
-WHERE name LIKE 'conc-gw-api_smoke_20-%'
-GROUP BY team_id, owner_email, slug
-ORDER BY cnt DESC;
-```
-
-## Code references supporting this hypothesis
-
-Gateway schema and constraints:
-- `mcpgateway/db.py:4355` → `Gateway` maps to `gateways`.
-- `mcpgateway/db.py:4357` → primary key on `id`.
-- `mcpgateway/db.py:4426` → `team_id` is nullable (`nullable=True`).
-- `mcpgateway/db.py:4427` → `owner_email` field used in tenant/user scoping.
-- `mcpgateway/db.py:4359` → `slug` field.
-- `mcpgateway/db.py:4466` → unique key is `("team_id", "owner_email", "slug")`.
-
-Slug identity path:
-- `mcpgateway/db.py:6179` / `mcpgateway/db.py:6189` → `before_insert` listener sets `slug = slugify(name)`.
-- `mcpgateway/services/gateway_service.py:728` → service computes `slug_name = slugify(gateway.name)` before create checks.
-
-Create path + conflict handling:
-- `mcpgateway/services/gateway_service.py:731`-`mcpgateway/services/gateway_service.py:735` → pre-check for existing public gateway by slug.
-- `mcpgateway/services/gateway_service.py:740`-`mcpgateway/services/gateway_service.py:744` → team-scoped pre-check by slug/team.
-- `mcpgateway/services/gateway_service.py:1065`-`mcpgateway/services/gateway_service.py:1091` → gateway insert model includes `team_id`, `owner_email`, `visibility`.
-- `mcpgateway/services/gateway_service.py:1100`-`mcpgateway/services/gateway_service.py:1102` → `db.add` + `db.flush`.
-- `mcpgateway/main.py:5469`-`mcpgateway/main.py:5472` → conflict exceptions map to `409`.
-- `mcpgateway/main.py:5477`-`mcpgateway/main.py:5478` → `IntegrityError` maps to `409`.
-
-Locking helper used by pre-check:
-- `mcpgateway/db.py:5473` (`get_for_update`) and `mcpgateway/db.py:5543` (`FOR UPDATE` on PostgreSQL).
-
-Migration intent (constraint shape):
-- `mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py:41` and `mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py:87`-`mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py:88` show the gateway unique constraint composed from `team_id`, `owner_email`, and `slug`.
-
-SSRF validation context (why localhost overrides were needed in local runs):
-- `mcpgateway/schemas.py:2607` calls URL validator for gateway create.
-- `mcpgateway/common/validators.py:1246`-`mcpgateway/common/validators.py:1248` localhost blocking logic.
-- `mcpgateway/common/validators.py:1251`-`mcpgateway/common/validators.py:1266` private-network blocking logic.
-- `mcpgateway/config.py:416` and `mcpgateway/config.py:422` configure `SSRF_ALLOW_LOCALHOST` and `SSRF_ALLOW_PRIVATE_NETWORKS`.
-
-## Repeatability proof (Postgres)
-
-DB query:
+## Database proof (duplicates)
+Grouped duplicate count by run name:
 ```bash
 psql "postgresql://postgres:postgres@127.0.0.1:5432/concurrent_test" -c \
-"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC LIMIT 2;"
+"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC;"
 ```
 
-Observed:
-- `conc-gw-api_smoke_20-1772042731271` -> `cnt=20`
-- `conc-gw-api_smoke_20-1772042640357` -> `cnt=20`
+Sample observed output:
+- `conc-gw-api_smoke_20-1772112068765 | 20`
+- `conc-gw-api_smoke_20-1772107637078 | 20`
+- `conc-gw-api_smoke_20-1772107480373 | 20`
 
-Interpretation:
-- Duplicate creation under concurrent same-name gateway create is reproducible across runs.
-
-## Postgres + Redis execution steps (what we ran)
-
-1. Started local container runtime (`colima`) and verified Docker was healthy.
-2. Started Postgres and Redis containers:
-   - `conc-postgres` on `:5432`
-   - `conc-redis` on `:6379`
-3. Switched gateway app runtime to Postgres + Redis:
-   - `DATABASE_URL=postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test`
-   - `REDIS_URL=redis://127.0.0.1:6379`
-4. Enabled local gateway URL testing for SSRF-protected validation:
-   - `SSRF_ALLOW_LOCALHOST=true`
-   - `SSRF_ALLOW_PRIVATE_NETWORKS=true`
-5. Installed Postgres driver in venv:
-   - `uv pip install "psycopg[binary]"`
-6. Restarted gateway with `make dev` and confirmed readiness via `GET /health -> 200`.
-7. Regenerated bearer token for the test shell.
-8. Ran controlled gateway concurrency case:
-   - `CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
-9. Observed API result:
-   - `200: 20`, `409: 0`, `api_unique_name_count(...)=20`
-10. Verified duplicates directly in Postgres via `psql`:
-   - `COUNT(*) = 20` for the same gateway name.
-11. Rechecked latest runs and again saw `cnt=20`, confirming repeatability.
-
-## Rerun steps (setup already running)
-
-Assumes:
-- Gateway app is already running via `make dev` with Postgres + Redis env.
-- MCP translate endpoint is already reachable at `http://127.0.0.1:9000/sse`.
-- Postgres/Redis containers are already up.
-
-Preferred one-command rerun:
-```bash
-make conc-01-gateways
-```
-
-Optional overrides for one-command rerun:
-```bash
-CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 make conc-01-gateways
-CONC_CASES=api_100 CONC_TIMEOUT_OVERRIDE=180 make conc-01-gateways
-CONC_REFRESH_TOKEN=1 make conc-01-gateways
-```
-
-What `make conc-01-gateways` automates:
-- sets default `DATABASE_URL`/`REDIS_URL` (if not already set)
-- generates `CONC_TOKEN` using `JWT_SECRET_KEY` (unless already set)
-- runs preflight checks (`/health`, auth check, translator TCP check)
-- runs `tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py`
-
-Manual equivalent:
-
-1. Open a fresh terminal, activate venv, and export test env:
-```bash
-cd /Users/pratik/Desktop/work/mcf/mcp-context-forge
-. /Users/pratik/.venv/mcpgateway/bin/activate
-export DATABASE_URL="postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test"
-export REDIS_URL="redis://127.0.0.1:6379"
-export CONC_TOKEN="$(
-  python -m mcpgateway.utils.create_jwt_token \
-    --username admin@example.com \
-    --exp 120 \
-    --secret "$JWT_SECRET_KEY"
-)"
-```
-
-2. Quick sanity checks:
-```bash
-curl -sS -i http://127.0.0.1:8000/health
-curl -sS -i "http://127.0.0.1:8000/servers?limit=1" -H "Authorization: Bearer $CONC_TOKEN"
-```
-
-3. Run controlled gateway concurrency case (smoke):
-```bash
-CONC_CASES=api_smoke_20 CONC_TIMEOUT_OVERRIDE=120 \
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
-```
-
-4. Verify duplicate counts in Postgres:
+Constraint-focused check:
 ```bash
 psql "postgresql://postgres:postgres@127.0.0.1:5432/concurrent_test" -c \
-"SELECT name, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY name ORDER BY name DESC LIMIT 3;"
+"SELECT team_id, owner_email, slug, COUNT(*) AS cnt FROM gateways WHERE name LIKE 'conc-gw-api_smoke_20-%' GROUP BY team_id, owner_email, slug ORDER BY cnt DESC;"
 ```
 
-5. Optional scale-up run:
-```bash
-CONC_CASES=api_100 CONC_TIMEOUT_OVERRIDE=180 \
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
-```
+Observed pattern:
+- `team_id` is `NULL` (blank in `psql` output)
+- same `owner_email` + same `slug` groups appear with `cnt=20`
+
+## Code references
+- Gateway schema/constraint:
+  - `mcpgateway/db.py:4426` (`team_id` nullable)
+  - `mcpgateway/db.py:4466` (`UniqueConstraint(team_id, owner_email, slug)`)
+- Slug derivation:
+  - `mcpgateway/db.py:6179`
+  - `mcpgateway/db.py:6189`
+- Gateway create path:
+  - `mcpgateway/services/gateway_service.py:728`
+  - `mcpgateway/services/gateway_service.py:731`
+  - `mcpgateway/services/gateway_service.py:1065`
+  - `mcpgateway/services/gateway_service.py:1100`
+- HTTP conflict mapping:
+  - `mcpgateway/main.py:5469`
+  - `mcpgateway/main.py:5477`
+
+## Interpretation (non-fix)
+This test artifact captures reproducible evidence that current `/gateways` behavior does not meet CONC-01 acceptance in this setup:
+- Expected conflict pattern (`1 success + N-1 conflicts`) is not observed.
+- Duplicate rows are persisted for same-name concurrent creates.
+
+This PR does not change gateway behavior; it adds reproducible CONC-01 gateway test coverage and evidence.

--- a/tests/manual/concurrency/conc_01_gateways_results.md
+++ b/tests/manual/concurrency/conc_01_gateways_results.md
@@ -81,8 +81,8 @@ make conc-01-gateways
 ### 5) Optional sanity checks
 
 ```bash
-curl -i -H "Authorization: Bearer $CONC_TOKEN" "http://127.0.0.1:8000/servers?limit=1"
-curl -i "http://127.0.0.1:8000/health"
+curl -sS --max-time 5 -o /dev/null -w "servers=%{http_code}\n" -H "Authorization: Bearer $CONC_TOKEN" "http://127.0.0.1:8000/servers?limit=1"
+curl -sS --max-time 5 -o /dev/null -w "health=%{http_code}\n" "http://127.0.0.1:8000/health"
 ```
 
 Expected: both return `200`.

--- a/tests/manual/concurrency/conc_01_gateways_results.md
+++ b/tests/manual/concurrency/conc_01_gateways_results.md
@@ -1,7 +1,7 @@
 # CONC-01 Gateway Parallel Create: Runbook + Results
 
-Date: 2026-03-02  
-Ticket scope: CONC-01 for gateway endpoint (`POST /gateways`)  
+Date: 2026-03-02
+Ticket scope: CONC-01 for gateway endpoint (`POST /gateways`)
 Out of scope: server endpoint results
 
 ## Objective

--- a/tests/manual/concurrency/conc_01_gateways_results.md
+++ b/tests/manual/concurrency/conc_01_gateways_results.md
@@ -25,7 +25,11 @@ Validate CONC-01 acceptance for gateway create under concurrency:
 
 ## Steps to run (copy/paste)
 
-### 1) Start Postgres + Redis in Docker (Colima runtime)
+Note for reviewers:
+- The commands below were executed on macOS with Colima.
+- On Linux, run equivalent Docker runtime/container startup commands for Postgres and Redis.
+
+### 1) Start Postgres + Redis in Docker
 
 ```bash
 colima start
@@ -47,7 +51,7 @@ docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | rg 'conc-postgr
 ### 2) Terminal A: start gateway (Postgres + Redis + local SSRF overrides)
 
 ```bash
-cd /Users/pratik/Desktop/work/new_mcf/mcp-context-forge
+cd <repo-root>
 pkill -f "mcpgateway.main|uvicorn" || true
 
 DATABASE_URL='postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test' \
@@ -62,14 +66,14 @@ make dev
 ### 3) Terminal B: start translator
 
 ```bash
-cd /Users/pratik/Desktop/work/new_mcf/mcp-context-forge
+cd <repo-root>
 python -m mcpgateway.translate --stdio "uvx mcp-server-git" --port 9000
 ```
 
 ### 4) Terminal C: generate token and run matrix
 
 ```bash
-cd /Users/pratik/Desktop/work/new_mcf/mcp-context-forge
+cd <repo-root>
 export CONC_TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 120 --secret my-test-key)"
 make conc-01-gateways
 ```

--- a/tests/manual/concurrency/run_conc_01_gateways.sh
+++ b/tests/manual/concurrency/run_conc_01_gateways.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+: "${CONC_BASE_URL:=http://127.0.0.1:8000}"
+: "${CONC_GATEWAY_URL:=http://127.0.0.1:9000/sse}"
+: "${DATABASE_URL:=postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test}"
+: "${REDIS_URL:=redis://127.0.0.1:6379}"
+: "${CONC_TOKEN_USER:=admin@example.com}"
+: "${CONC_TOKEN_EXP_MIN:=120}"
+
+export CONC_BASE_URL
+export CONC_GATEWAY_URL
+export DATABASE_URL
+export REDIS_URL
+
+if [[ -z "${CONC_TOKEN:-}" || "${CONC_REFRESH_TOKEN:-0}" == "1" ]]; then
+  if [[ -z "${JWT_SECRET_KEY:-}" ]]; then
+    echo "ERROR: JWT_SECRET_KEY is not set; cannot generate CONC_TOKEN." >&2
+    echo "Set JWT_SECRET_KEY (or provide CONC_TOKEN) and rerun." >&2
+    exit 2
+  fi
+  echo "Generating CONC_TOKEN (user=${CONC_TOKEN_USER}, exp=${CONC_TOKEN_EXP_MIN}m)..."
+  export CONC_TOKEN="$(
+    python -m mcpgateway.utils.create_jwt_token \
+      --username "${CONC_TOKEN_USER}" \
+      --exp "${CONC_TOKEN_EXP_MIN}" \
+      --secret "${JWT_SECRET_KEY}"
+  )"
+fi
+
+echo "Preflight: gateway health at ${CONC_BASE_URL}/health"
+curl -fsS "${CONC_BASE_URL}/health" >/dev/null
+
+echo "Preflight: auth token at ${CONC_BASE_URL}/servers?limit=1"
+curl -fsS \
+  -H "Authorization: Bearer ${CONC_TOKEN}" \
+  "${CONC_BASE_URL}/servers?limit=1" >/dev/null
+
+gateway_no_scheme="${CONC_GATEWAY_URL#*://}"
+host_port_path="${gateway_no_scheme%%/*}"
+gateway_host="${host_port_path%%:*}"
+gateway_port="${host_port_path##*:}"
+if [[ "${gateway_host}" == "${gateway_port}" ]]; then
+  gateway_port=80
+fi
+
+if command -v nc >/dev/null 2>&1; then
+  echo "Preflight: translator tcp check at ${gateway_host}:${gateway_port}"
+  nc -z "${gateway_host}" "${gateway_port}" >/dev/null
+else
+  echo "WARN: nc not found; skipping translator tcp preflight."
+fi
+
+echo "Running CONC-01 gateway matrix..."
+python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py

--- a/tests/manual/concurrency/run_conc_01_gateways.sh
+++ b/tests/manual/concurrency/run_conc_01_gateways.sh
@@ -11,48 +11,30 @@ cd "${ROOT_DIR}"
 : "${CONC_TOKEN_USER:=admin@example.com}"
 : "${CONC_TOKEN_EXP_MIN:=120}"
 
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "ERROR: python3/python not found in PATH." >&2
+    exit 2
+  fi
+fi
+
 export CONC_BASE_URL
 export CONC_GATEWAY_URL
 export DATABASE_URL
 export REDIS_URL
 
-if [[ -z "${CONC_TOKEN:-}" || "${CONC_REFRESH_TOKEN:-0}" == "1" ]]; then
-  if [[ -z "${JWT_SECRET_KEY:-}" ]]; then
-    echo "ERROR: JWT_SECRET_KEY is not set; cannot generate CONC_TOKEN." >&2
-    echo "Set JWT_SECRET_KEY (or provide CONC_TOKEN) and rerun." >&2
-    exit 2
-  fi
-  echo "Generating CONC_TOKEN (user=${CONC_TOKEN_USER}, exp=${CONC_TOKEN_EXP_MIN}m)..."
-  export CONC_TOKEN="$(
-    python -m mcpgateway.utils.create_jwt_token \
-      --username "${CONC_TOKEN_USER}" \
-      --exp "${CONC_TOKEN_EXP_MIN}" \
-      --secret "${JWT_SECRET_KEY}"
-  )"
-fi
-
-echo "Preflight: gateway health at ${CONC_BASE_URL}/health"
-curl -fsS "${CONC_BASE_URL}/health" >/dev/null
-
-echo "Preflight: auth token at ${CONC_BASE_URL}/servers?limit=1"
-curl -fsS \
-  -H "Authorization: Bearer ${CONC_TOKEN}" \
-  "${CONC_BASE_URL}/servers?limit=1" >/dev/null
-
-gateway_no_scheme="${CONC_GATEWAY_URL#*://}"
-host_port_path="${gateway_no_scheme%%/*}"
-gateway_host="${host_port_path%%:*}"
-gateway_port="${host_port_path##*:}"
-if [[ "${gateway_host}" == "${gateway_port}" ]]; then
-  gateway_port=80
-fi
-
-if command -v nc >/dev/null 2>&1; then
-  echo "Preflight: translator tcp check at ${gateway_host}:${gateway_port}"
-  nc -z "${gateway_host}" "${gateway_port}" >/dev/null
-else
-  echo "WARN: nc not found; skipping translator tcp preflight."
+if [[ -z "${CONC_TOKEN:-}" ]]; then
+  echo "ERROR: CONC_TOKEN is not set." >&2
+  echo "Generate and export it manually before running this script." >&2
+  echo "Example:" >&2
+  echo "  export CONC_TOKEN=\"\$(${PYTHON_BIN} -m mcpgateway.utils.create_jwt_token --username ${CONC_TOKEN_USER} --exp ${CONC_TOKEN_EXP_MIN} --secret <jwt-secret>)\"" >&2
+  exit 2
 fi
 
 echo "Running CONC-01 gateway matrix..."
-python tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py
+"${PYTHON_BIN}" tests/manual/concurrency/conc_01_gateways_parallel_create_pg_redis.py

--- a/tests/unit/test_conc_01_helpers.py
+++ b/tests/unit/test_conc_01_helpers.py
@@ -79,7 +79,7 @@ class TestBuildConfig:
         with patch.dict(os.environ, env, clear=True):
             cfg = _build_config()
             assert cfg["token"] == "tok123"
-            assert cfg["base_url"] == "http://localhost:8000"
+            assert cfg["base_url"] == "http://127.0.0.1:8000"
             assert cfg["name_prefix"] == "conc-gw"
             assert cfg["gateway_url"] == "http://127.0.0.1:9000/sse"
             assert cfg["db_check_default"] is True

--- a/tests/unit/test_conc_01_helpers.py
+++ b/tests/unit/test_conc_01_helpers.py
@@ -1,0 +1,213 @@
+"""Unit tests for CONC-01 gateway parallel-create helper functions."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+# Third-Party
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the manual test module by path (it has no __init__.py).
+# ---------------------------------------------------------------------------
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "tests" / "manual" / "concurrency" / "conc_01_gateways_parallel_create_pg_redis.py"
+_spec = importlib.util.spec_from_file_location("conc_01_gateways_parallel_create_pg_redis", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+
+_env_bool = _mod._env_bool
+_build_config = _mod._build_config
+_db_mode = _mod._db_mode
+_normalize_pg_dsn = _mod._normalize_pg_dsn
+_Case = _mod._Case
+DEFAULT_CASES = _mod.DEFAULT_CASES
+
+
+# ---------------------------------------------------------------------------
+# _env_bool
+# ---------------------------------------------------------------------------
+class TestEnvBool:
+    """Tests for _env_bool helper."""
+
+    def test_returns_default_when_env_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert _env_bool("CONC_MISSING_VAR", True) is True
+            assert _env_bool("CONC_MISSING_VAR", False) is False
+
+    def test_truthy_values(self):
+        for val in ("1", "true", "yes", "on", "TRUE", "Yes", "ON", " 1 ", " true "):
+            with patch.dict(os.environ, {"CONC_DB_CHECK": val}, clear=False):
+                assert _env_bool("CONC_DB_CHECK", False) is True, f"Expected True for {val!r}"
+
+    def test_falsy_values(self):
+        for val in ("0", "false", "no", "off", "", "random"):
+            with patch.dict(os.environ, {"CONC_DB_CHECK": val}, clear=False):
+                assert _env_bool("CONC_DB_CHECK", True) is False, f"Expected False for {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# _build_config
+# ---------------------------------------------------------------------------
+class TestBuildConfig:
+    """Tests for _build_config helper."""
+
+    def test_raises_when_token_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="CONC_TOKEN is required"):
+                _build_config()
+
+    def test_raises_when_token_empty(self):
+        with patch.dict(os.environ, {"CONC_TOKEN": ""}, clear=True):
+            with pytest.raises(ValueError, match="CONC_TOKEN is required"):
+                _build_config()
+
+    def test_raises_when_token_whitespace(self):
+        with patch.dict(os.environ, {"CONC_TOKEN": "   "}, clear=True):
+            with pytest.raises(ValueError, match="CONC_TOKEN is required"):
+                _build_config()
+
+    def test_returns_defaults_with_valid_token(self):
+        env = {"CONC_TOKEN": "tok123"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = _build_config()
+            assert cfg["token"] == "tok123"
+            assert cfg["base_url"] == "http://localhost:8000"
+            assert cfg["name_prefix"] == "conc-gw"
+            assert cfg["gateway_url"] == "http://127.0.0.1:9000/sse"
+            assert cfg["db_check_default"] is True
+            assert cfg["db_path"] == "mcp.db"
+            assert cfg["database_url"] == ""
+            assert cfg["cases_filter"] == ""
+            assert cfg["timeout_override"] == ""
+
+    def test_overrides_from_env(self):
+        env = {
+            "CONC_TOKEN": "tok",
+            "CONC_BASE_URL": "https://gw.example.com/",
+            "CONC_NAME_PREFIX": "my-gw",
+            "CONC_GATEWAY_URL": "https://backend.example.com/sse",
+            "CONC_DB_CHECK": "0",
+            "CONC_DB_PATH": "/tmp/test.db",
+            "DATABASE_URL": "postgresql+psycopg://user:pass@host/db",
+            "CONC_CASES": "api_smoke_20",
+            "CONC_TIMEOUT_OVERRIDE": "30",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            cfg = _build_config()
+            assert cfg["base_url"] == "https://gw.example.com"  # trailing slash stripped
+            assert cfg["name_prefix"] == "my-gw"
+            assert cfg["gateway_url"] == "https://backend.example.com/sse"
+            assert cfg["db_check_default"] is False
+            assert cfg["db_path"] == "/tmp/test.db"
+            assert cfg["database_url"] == "postgresql+psycopg://user:pass@host/db"
+            assert cfg["cases_filter"] == "api_smoke_20"
+            assert cfg["timeout_override"] == "30"
+
+    def test_empty_name_prefix_falls_back(self):
+        env = {"CONC_TOKEN": "tok", "CONC_NAME_PREFIX": "  "}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = _build_config()
+            assert cfg["name_prefix"] == "conc-gw"
+
+    def test_empty_db_path_falls_back(self):
+        env = {"CONC_TOKEN": "tok", "CONC_DB_PATH": "  "}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = _build_config()
+            assert cfg["db_path"] == "mcp.db"
+
+
+# ---------------------------------------------------------------------------
+# _db_mode
+# ---------------------------------------------------------------------------
+class TestDbMode:
+    """Tests for _db_mode helper."""
+
+    def test_postgresql_standard(self):
+        assert _db_mode("postgresql://user:pass@host/db") == "postgres"
+
+    def test_postgresql_psycopg(self):
+        assert _db_mode("postgresql+psycopg://user:pass@host/db") == "postgres"
+
+    def test_sqlite_empty(self):
+        assert _db_mode("") == "sqlite"
+
+    def test_sqlite_path(self):
+        assert _db_mode("sqlite:///./mcp.db") == "sqlite"
+
+    def test_sqlite_other(self):
+        assert _db_mode("mysql://user:pass@host/db") == "sqlite"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_pg_dsn
+# ---------------------------------------------------------------------------
+class TestNormalizePgDsn:
+    """Tests for _normalize_pg_dsn helper."""
+
+    def test_strips_psycopg_driver(self):
+        result = _normalize_pg_dsn("postgresql+psycopg://user:pass@host:5432/db")
+        assert result == "postgresql://user:pass@host:5432/db"
+
+    def test_preserves_standard_dsn(self):
+        dsn = "postgresql://user:pass@host:5432/db"
+        assert _normalize_pg_dsn(dsn) == dsn
+
+    def test_preserves_non_postgresql_dsn(self):
+        dsn = "sqlite:///./mcp.db"
+        assert _normalize_pg_dsn(dsn) == dsn
+
+
+# ---------------------------------------------------------------------------
+# _Case dataclass
+# ---------------------------------------------------------------------------
+class TestCaseDataclass:
+    """Tests for _Case frozen dataclass."""
+
+    def test_case_is_frozen(self):
+        case = _Case(name="test", n=10, timeout_sec=5, db_check=False)
+        with pytest.raises(AttributeError):
+            case.n = 20  # type: ignore[misc]
+
+    def test_case_fields(self):
+        case = _Case(name="api_smoke_20", n=20, timeout_sec=10, db_check=False)
+        assert case.name == "api_smoke_20"
+        assert case.n == 20
+        assert case.timeout_sec == 10
+        assert case.db_check is False
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_CASES
+# ---------------------------------------------------------------------------
+class TestDefaultCases:
+    """Tests for DEFAULT_CASES list."""
+
+    def test_has_three_cases(self):
+        assert len(DEFAULT_CASES) == 3
+
+    def test_case_names(self):
+        names = [c.name for c in DEFAULT_CASES]
+        assert names == ["api_smoke_20", "api_100", "api_db_100"]
+
+    def test_smoke_case(self):
+        case = DEFAULT_CASES[0]
+        assert case.n == 20
+        assert case.db_check is False
+
+    def test_api_100_case(self):
+        case = DEFAULT_CASES[1]
+        assert case.n == 100
+        assert case.db_check is False
+
+    def test_api_db_100_case(self):
+        case = DEFAULT_CASES[2]
+        assert case.n == 100
+        assert case.db_check is True


### PR DESCRIPTION
## 🔗 Related Issue
  Closes #3232

  ---
# Summary

This PR adds/updates CONC-01 manual concurrency test coverage for the `POST /gateways` endpoint and captures reproducible failure evidence in a parent-scope setup (Postgres + Redis).

The ticket acceptance for CONC-01 is:

- 100 parallel creates with same name
- Expected: exactly `1` success (`200/201`) + `N-1` conflicts (`409`)
- No duplicate rows persisted

Latest run on **March 2, 2026** still fails acceptance for `/gateways` under concurrency.

---

# Steps To Run This Test

## 1) Start Postgres + Redis in Docker (Colima runtime)

```bash
# Start runtime first if needed
colima start
docker context use colima

# Recreate clean containers
docker rm -f conc-postgres conc-redis 2>/dev/null || true

docker run -d --name conc-postgres -p 5432:5432 \
  -e POSTGRES_USER=postgres \
  -e POSTGRES_PASSWORD=postgres \
  -e POSTGRES_DB=concurrent_test \
  postgres:16

docker run -d --name conc-redis -p 6379:6379 redis:7

docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | rg 'conc-postgres|conc-redis'
```

## 2) Terminal A: start gateway (Postgres + Redis + local SSRF overrides)

```bash
export PROJECT_ROOT="<path-to-repo-root>"
cd "$PROJECT_ROOT"
pkill -f "mcpgateway.main|uvicorn" || true

DATABASE_URL='postgresql+psycopg://postgres:postgres@127.0.0.1:5432/concurrent_test' \
REDIS_URL='redis://127.0.0.1:6379/0' \
CACHE_TYPE='redis' \
JWT_SECRET_KEY='my-test-key' \
SSRF_ALLOW_LOCALHOST=true \
SSRF_ALLOW_PRIVATE_NETWORKS=true \
make dev
```

## 3) Terminal B: start translator

```bash
export PROJECT_ROOT="<path-to-repo-root>"
cd "$PROJECT_ROOT"
python -m mcpgateway.translate --stdio "uvx mcp-server-git" --port 9000
```

## 4) Terminal C: generate token and run matrix

```bash
export PROJECT_ROOT="<path-to-repo-root>"
cd "$PROJECT_ROOT"
export CONC_TOKEN="$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 120 --secret my-test-key)"
make conc-01-gateways
```

## 5) Optional token sanity check (before matrix)

```bash
curl -i -H "Authorization: Bearer $CONC_TOKEN" "http://127.0.0.1:8000/servers?limit=1"
```

Expected: `HTTP/1.1 200 OK`.

---

# Results Observed vs Expected

## Expected (CONC-01)

- `api_smoke_20`: `1x 200/201`, `19x 409`, uniqueness=1
- `api_100`: `1x 200/201`, `99x 409`, uniqueness=1
- `api_db_100`: same as above + DB uniqueness=1

## Observed (latest run)

- `api_smoke_20`: `200=20`, `409=0`, API uniqueness `20`
- `api_100`: `200=49`, `500=3`, `502=32`, `ReadError=16`, `409=0`, API uniqueness `49`
- `api_db_100`: `200=42`, `502=37`, `ReadError=21`, `409=0`, API uniqueness `42`, DB uniqueness `42`

## Outcome

CONC-01 acceptance is **NOT MET** for `/gateways` in this environment:

- Conflict pattern is not enforced under concurrency.
- Duplicate gateway rows are persisted for same-name create attempts.

---

# Scope

- In scope: manual concurrency test artifact and evidence for `/gateways`
- Out of scope: behavior fix for gateway concurrency race/uniqueness


## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [x] Other (Testing)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |  ✅ Passed (Pylint score: 10/10)      |
| Unit tests                | `make test`     | ✅ Passed (updated unit tests with the changes)        |
| Coverage ≥ 80%            | `make coverage` | ✅ Passed (100% for modified files, 99%+ overal        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._