### PR TITLE
[FIX][AUTH]: Cross-replica cache invalidation for auth caches

### DIFF
--- a/mcpgateway/cache/registry_cache.py
+++ b/mcpgateway/cache/registry_cache.py
@@ -824,7 +824,7 @@ class CacheInvalidationSubscriber:
         # First-Party
         from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
 
-        # Order matters: team_roles/teams must be checked before team
+        # Dispatch auth message to the correct handler
         if message.startswith("user:"):
             email = message[len("user:") :]
             with auth_cache._lock:  # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py
+++ b/tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py
@@ -866,8 +866,8 @@ class TestAuthCacheInvalidationSubscriber:
         assert "new-jti" in mock_auth._revoked_jtis
 
     @pytest.mark.asyncio
-    async def test_prefix_collision_teams_does_not_match_team(self):
-        """Regression: 'teams:' must not fall through to 'team:' handler."""
+    async def test_teams_message_dispatches_to_correct_handler(self):
+        """Verify 'teams:' is dispatched to teams handler, not 'team:' handler."""
         subscriber = CacheInvalidationSubscriber()
         mock_auth = create_mock_auth_cache(
             team_cache={"alice@test.com": "should-remain"},
@@ -884,8 +884,8 @@ class TestAuthCacheInvalidationSubscriber:
         assert "alice@test.com:jti1" in mock_auth._context_cache
 
     @pytest.mark.asyncio
-    async def test_prefix_collision_team_roles_does_not_match_team(self):
-        """Regression: 'team_roles:' must not fall through to 'team:' handler."""
+    async def test_team_roles_message_dispatches_to_correct_handler(self):
+        """Verify 'team_roles:' is dispatched to team_roles handler, not 'team:' handler."""
         subscriber = CacheInvalidationSubscriber()
         mock_auth = create_mock_auth_cache(
             team_cache={"alice@test.com": "should-remain"},


### PR DESCRIPTION
# 🐛 Bug-fix PR
---

## 📌 Summary

AuthCache published invalidation messages to `mcpgw:auth:invalidate`, but `CacheInvalidationSubscriber` only listened on `mcpgw:cache:invalidate`. In multi-replica deployments, when one replica invalidated auth data (e.g., after a role change or token revocation), other replicas never received the message and continued serving stale in-memory auth caches.

## 💡 Fix Description

1. Subscribe to both channels — Added `_channels` list containing both `mcpgw:cache:invalidate` and `mcpgw:auth:invalidate`. Updated `start()` to subscribe to all channels via await `self._pubsub.subscribe(*self._channels)` and `stop()` to unsubscribe from all.
2. Handle auth invalidation messages — Added 7 new message handlers in `_process_invalidation()`:
    - `user:{email}` — clears user cache, context cache, and team cache entries for the user
    - `revoke:{jti}` — adds JTI to revoked set, clears revocation cache and matching context cache entries
    - `team:{email}` — clears team cache and context cache for the user
    - `role:{email}:{team_id}` — clears specific role cache entry
    - `team_roles:{team_id}` — clears all role cache entries for a team
    - `teams:{email}` — clears teams list cache entries for the user
    - `membership:{email}` — clears team membership cache entries for the user

  The startswith check ordering ensures team_roles: and teams: are matched before team:.

###  Tests: `tests/unit/mcpgateway/cache/test_cache_invalidation_subscriber.py`

  - Updated `test_subscriber_initialization` to assert `_channels` includes both channels
  - Fixed `FakePubSub.subscribe/unsubscribe` signatures to accept `*_channels` (varargs)
  - Added `create_mock_auth_cache()` helper
  - Added `TestAuthCacheInvalidationSubscriber` class with 11 tests covering all auth invalidation message types, channel subscription verification, and an end-to-end regression test


## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |     ✅   |
| Coverage ≥ 80 %                       | `make coverage`      |   ✅     |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
