### PR TITLE
fix(infra): disable IPv6 listener in nginx config

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -220,7 +220,7 @@ http {
         # - backlog=4096: Kernel queue for pending connections (default 511)
         # - reuseport: Distribute connections across workers (reduces lock contention)
         listen 80 backlog=4096 reuseport;
-        listen [::]:80 backlog=4096 reuseport;
+        # listen [::]:80 backlog=4096 reuseport;
 
         # # HTTPS listener with SSL
         # listen 443 ssl backlog=4096 reuseport;


### PR DESCRIPTION
## Summary
- Comment out the IPv6 `listen [::]:80` directive in the nginx config to avoid binding failures in environments where IPv6 is not available or not configured.

## Test plan
- [ ] Deploy nginx with updated config and verify it starts without errors on IPv4-only hosts
- [ ] Confirm port 80 is still accessible over IPv4