### PR TITLE
[FIX][MCP]: add guard check for missing deps in MCPChatService

### DIFF
--- a/mcpgateway/services/mcp_client_chat_service.py
+++ b/mcpgateway/services/mcp_client_chat_service.py
@@ -2405,6 +2405,9 @@ class MCPChatService:
             logger.warning("Chat service already initialized")
             return
 
+        if not _LLMCHAT_AVAILABLE:
+            raise ImportError("LLM chat dependencies are missing. Install them with: pip install '.[llmchat]'")
+
         try:
             logger.info("Initializing chat service...")
 
@@ -2416,8 +2419,6 @@ class MCPChatService:
             llm = self.llm_provider.get_llm()
 
             # Create ReAct agent with tools
-            if create_react_agent is None:
-                raise RuntimeError("Some dependencies are missing. Install those with: pip install '.[llmchat]'")
             self._agent = create_react_agent(llm, self._tools)
 
             self._initialized = True
@@ -3065,13 +3066,14 @@ class MCPChatService:
         if not self._initialized:
             raise RuntimeError("Chat service not initialized")
 
+        if not _LLMCHAT_AVAILABLE:
+            raise ImportError("LLM chat dependencies are missing. Install them with: pip install '.[llmchat]'")
+
         try:
             logger.info("Reloading tools from MCP server...")
             tools = await self.mcp_client.get_tools(force_reload=True)
 
             # Recreate agent with new tools
-            if create_react_agent is None:
-                raise RuntimeError("Some dependencies are missing. Install those with: pip install '.[llmchat]'")
             llm = self.llm_provider.get_llm()
             self._agent = create_react_agent(llm, tools)
             self._tools = tools

--- a/tests/unit/mcpgateway/services/test_mcp_client_chat_service.py
+++ b/tests/unit/mcpgateway/services/test_mcp_client_chat_service.py
@@ -320,6 +320,7 @@ async def test_mcpchatservice_initialize_success_and_idempotent(monkeypatch, pat
         llm=svc.LLMConfig(provider="openai", config=svc.OpenAIConfig(api_key="k", model="gpt-4")),
     )
     service = svc.MCPChatService(cfg, user_id="u1")
+    monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
     monkeypatch.setattr(service.mcp_client, "connect", AsyncMock(return_value=None))
     monkeypatch.setattr(service.mcp_client, "get_tools", AsyncMock(return_value=["t1", "t2"]))
     service.llm_provider = MagicMock()
@@ -1422,6 +1423,7 @@ async def test_reload_tools_success(monkeypatch, patch_logger):
     )
     service = svc.MCPChatService(cfg)
     service._initialized = True
+    monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
     monkeypatch.setattr(service.mcp_client, "get_tools", AsyncMock(return_value=["t1", "t2"]))
     service.llm_provider = SimpleNamespace(get_llm=MagicMock(return_value=object()))
     agent_obj = object()
@@ -1442,6 +1444,7 @@ async def test_reload_tools_logs_and_raises_on_error(monkeypatch, patch_logger):
     )
     service = svc.MCPChatService(cfg)
     service._initialized = True
+    monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
     monkeypatch.setattr(service.mcp_client, "get_tools", AsyncMock(side_effect=RuntimeError("reload failed")))
 
     with pytest.raises(RuntimeError, match="reload failed"):
@@ -1451,40 +1454,36 @@ async def test_reload_tools_logs_and_raises_on_error(monkeypatch, patch_logger):
 
 
 # --------------------------------------------------------------------------- #
-# GUARD TESTS: create_react_agent is None (langgraph not installed)
+# GUARD TESTS: _LLMCHAT_AVAILABLE is False (langgraph not installed)
 # --------------------------------------------------------------------------- #
 
+
 @pytest.mark.asyncio
-async def test_initialize_raises_when_create_react_agent_is_none(monkeypatch, patch_logger):
-    """initialize() raises RuntimeError with install hint when some dependencies are missing."""
+async def test_initialize_raises_when_llmchat_unavailable(monkeypatch, patch_logger):
+    """initialize() raises ImportError with install hint when llmchat deps are missing."""
     cfg = svc.MCPClientConfig(
         mcp_server=svc.MCPServerConfig(url="https://srv", transport="sse"),
         llm=svc.LLMConfig(provider="openai", config=svc.OpenAIConfig(api_key="k", model="gpt-4")),
     )
     service = svc.MCPChatService(cfg, user_id="u1")
-    monkeypatch.setattr(service.mcp_client, "connect", AsyncMock(return_value=None))
-    monkeypatch.setattr(service.mcp_client, "get_tools", AsyncMock(return_value=["t1"]))
-    service.llm_provider = MagicMock()
-    service.llm_provider.get_llm.return_value = object()
-    monkeypatch.setattr(svc, "create_react_agent", None)
+    monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", False)
 
-    with pytest.raises(RuntimeError, match="Some dependencies are missing"):
+    with pytest.raises(ImportError, match="LLM chat dependencies are missing"):
         await service.initialize()
 
     assert service.is_initialized is False
 
 
 @pytest.mark.asyncio
-async def test_reload_tools_raises_when_create_react_agent_is_none(monkeypatch, patch_logger):
-    """reload_tools() raises RuntimeError with install hint when some dependencies are missing."""
+async def test_reload_tools_raises_when_llmchat_unavailable(monkeypatch, patch_logger):
+    """reload_tools() raises ImportError with install hint when llmchat deps are missing."""
     cfg = svc.MCPClientConfig(
         mcp_server=svc.MCPServerConfig(url="https://srv", transport="sse"),
         llm=svc.LLMConfig(provider="openai", config=svc.OpenAIConfig(api_key="k", model="gpt-4")),
     )
     service = svc.MCPChatService(cfg)
     service._initialized = True
-    monkeypatch.setattr(service.mcp_client, "get_tools", AsyncMock(return_value=["t1", "t2"]))
-    monkeypatch.setattr(svc, "create_react_agent", None)
+    monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", False)
 
-    with pytest.raises(RuntimeError, match="Some dependencies are missing"):
+    with pytest.raises(ImportError, match="LLM chat dependencies are missing"):
         await service.reload_tools()

--- a/tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py
@@ -696,6 +696,7 @@ async def test_chat_service_initialize_error(monkeypatch):
         llm=svc.LLMConfig(provider="openai", config=svc.OpenAIConfig(api_key="k", model="gpt-4")),
     )
     service = svc.MCPChatService(cfg)
+    monkeypatch.setattr(svc, "_LLMCHAT_AVAILABLE", True)
     monkeypatch.setattr(service.mcp_client, "connect", AsyncMock(side_effect=RuntimeError("boom")))
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes https://github.com/IBM/mcp-context-forge/issues/3233

---

## 📝 Summary

### Fix mcpgateway/services/mcp_client_chat_service.py

- Added `None` guard for `create_react_agent` in `MCPChatService.initialize()`
- Added `None` guard for `create_react_agent` in `MCPChatService.reload_tools()`
- Both raise `RuntimeError("Some dependencies are missing")` instead of the cryptic `TypeError: 'NoneType' object is not callable`

### Tests

- test_initialize_raises_when_create_react_agent_is_none — patches `create_react_agent` to None, asserts `RuntimeError` and that `is_initialized` remains False
- test_reload_tools_raises_when_create_react_agent_is_none — same guard verified for `reload_tools()`
---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
