### PR TITLE
refactor(makefile): parameterize target families and add deprecation framework

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: pr-review
+description: Use when a feature branch is ready for code review, needs rebasing onto main, or before creating/updating a pull request. Also use when asked to review changes, check code quality, or verify a branch is merge-ready.
+---
+
+# PR Review
+
+Review all changes between `main` and the current branch HEAD, plus any staged
+and unstaged working-tree changes.
+
+## Setup
+
+1. **Rebase** — Unless the user says otherwise, fetch `origin` and rebase onto
+   `origin/main`, resolving conflicts. If the branch has Alembic migrations,
+   run `alembic heads` after rebase — if multiple heads exist, update
+   `down_revision` to restore a single linear history.
+
+2. **Gather context** — If a PR exists (`gh pr view`):
+   - PR description, title, review comments (`gh pr view --comments`)
+   - Linked issues (`gh issue view N`) to understand requirements
+   If no PR exists, review from the diff alone.
+
+3. **Read project docs** — Check for `AGENTS.md`, `CONTRIBUTING.md`,
+   `CLAUDE.md`. These are authoritative for test commands, linter config, and
+   conventions — use their commands exactly, not generic substitutes.
+
+## Review checklist
+
+Review the diff in priority order. Fix blocking issues directly when
+straightforward; flag issues that need human judgment.
+
+| # | Category | Severity | Focus |
+|---|----------|----------|-------|
+| 1 | Security | Blocking | Injection, leaked secrets, auth gaps, OWASP top 10 |
+| 2 | Correctness | Blocking | Logic errors, edge cases, mismatch with linked issues |
+| 3 | Test coverage | Blocking | 100% differential coverage — verify changed code has tests |
+| 4 | Linter compliance | Blocking | Run project linters on touched files; resolve all findings |
+| 5 | Performance | High | N+1 queries, unnecessary allocations, bottlenecks |
+| 6 | Code quality | Medium | Redundancy, over-complexity, code smells |
+| 7 | Consistency | Medium | Follow documented conventions; suggest undocumented ones |
+| 8 | Alembic migrations | Conditional | Idempotence, reversibility, cross-DB compat, data safety, `batch_alter_table` for SQLite |
+
+## Second opinions
+
+After your own review, run available second-opinion tools in parallel as
+background tasks. If a tool is missing from `$PATH` or fails, skip it and note
+reduced coverage.
+
+- **Codex**: `codex exec review --base origin/main`
+- **Bob**: Pipe the diff inline — `git diff origin/main..HEAD | bob "Review this
+  diff for correctness, security, and code quality. Be specific about
+  line-level issues."` Tailor the prompt to the PR content.
+
+Attribute findings to their source (Claude/Codex/Bob) and resolve contradictions.
+
+## Output format
+
+```markdown
+# PR Review: [branch-name]
+
+## Summary
+[1-2 sentence overview: what changed, whether it meets PR/issue goals]
+
+## Findings
+| # | Severity | Category | File:Line | Issue | Source |
+|---|----------|----------|-----------|-------|--------|
+
+## Fixes Applied
+[Issues fixed directly, with commit refs]
+
+## Remaining Issues
+[Issues needing human decision or outside scope]
+
+## Recommendation
+- [ ] Ready to merge
+- [ ] Ready after fixing remaining issues
+- [ ] Needs significant rework
+```
+
+## Rules
+
+- Never mention Claude, Claude Code, or AI in commits or PR text.
+- Never push unless explicitly asked.
+- Sign commits with `git commit -s`. Verify Git author matches `gh auth status`.
+- Create new commits rather than amending existing ones when rebasing or fixing.
+- After fix-up commits, re-run linters and tests to confirm no regressions.

--- a/.claude/skills/pr-risk-scoring/SKILL.md
+++ b/.claude/skills/pr-risk-scoring/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pr-risk-scoring
+description: Score all open PRs by risk level and generate a CSV report. Use when asked to rescore, rate, or triage open PRs.
+---
+
+# PR Risk Scoring
+
+Score all open PRs against a 6-dimension risk rubric and produce a CSV at
+`todo/pr_risk_scores.csv`. The full rubric is in `review_rubric.md` in this
+skill directory.
+
+## Dimensions
+
+1. **Zone (0-10)** — which files are touched (auth core > transport > data model > business logic > UI > docs)
+2. **Size (0-5)** — lines changed and files changed
+3. **Structural (0-5)** — migrations, middleware ordering, new routers
+4. **Security (0-5)** — security invariant impact
+5. **Test Gap (0-5)** — penalty for missing tests with prod code changes
+6. **Performance (0-5)** — DB connection pressure, N+1 risks, cache bypasses
+
+**Tiers:** 1-Deep (20-35), 2-Standard (11-19), 3-Focused (5-10), 4-Quick (0-4)
+
+## Process
+
+### 1. Fetch PR metadata
+
+Use `gh pr list` with `--json number,title,url,additions,deletions,changedFiles,author,labels`
+and save to a temp file. The default limit is 30 — always use `--limit 500` or
+higher. Verify the count matches what GitHub reports.
+
+### 2. Fetch file lists and approvals
+
+For each PR, run `gh pr diff <number> --name-only` and save to a per-PR file.
+This makes one API call per PR (~2-3 min for 100+ PRs). Some PRs with empty
+diffs will fail — this is expected.
+
+Then fetch approval counts per PR using `gh pr view <number> --json reviews`
+and save as a two-column CSV (pr_number,approvals).
+
+### 3. Run the scoring script
+
+```bash
+SKILL_DIR="$(git rev-parse --show-toplevel)/.claude/skills/pr-risk-scoring"
+OUTPUT="$(git rev-parse --show-toplevel)/todo/pr_risk_scores.csv"
+mkdir -p "$(dirname "$OUTPUT")"
+python3 "$SKILL_DIR/score_prs.py" /tmp/all_prs.json /tmp/pr_files "$OUTPUT" /tmp/pr_approvals.csv
+```
+
+The script prints a tier distribution summary to stdout. Dimensions 3-6 use
+filename heuristics only — reviewers should apply the full rubric from
+`review_rubric.md` for Tier 1 and Tier 2 PRs.
+
+### 4. Present results
+
+After generating the CSV, present:
+
+1. **Tier distribution** — count of PRs per tier
+2. **Top 10 highest-risk PRs** — PR number, total score, tier, and title
+3. **Estimated review hours** — Tier 1: 4-8 hrs, Tier 2: 1-2 hrs, Tier 3: 30-60 min, Tier 4: 5-15 min
+4. **CSV location** — `todo/pr_risk_scores.csv`
+
+## Maintaining the rubric
+
+If zone mappings or scoring weights need to change, update both:
+- `score_prs.py` — source of truth for automated scoring
+- `review_rubric.md` — human-readable reference with full rubric detail

--- a/.claude/skills/pr-risk-scoring/review_rubric.md
+++ b/.claude/skills/pr-risk-scoring/review_rubric.md
@@ -1,0 +1,187 @@
+# PR Risk Scoring Rubric for ContextForge
+
+## Context
+
+With 50 open PRs spanning trivial UI fixes (+5 lines) to massive security features (+15K lines), the team needs a systematic way to allocate review effort. The goal: spend 2-4 hours on PRs that could break auth, and 5 minutes on CODEOWNERS updates.
+
+## Risk Score: 6 Dimensions, 0-35 Points
+
+### Dimension 1: Zone Score (0-10 pts)
+
+Each file touched maps to a risk zone. Sum the per-file zone scores, cap at 10.
+
+| Zone | Pts/file | Files |
+|------|----------|-------|
+| **Z4 - Auth core** | 4 | `auth.py`, `middleware/token_scoping.py`, `middleware/rbac.py`, `middleware/auth_middleware.py`, `middleware/http_auth_middleware.py`, `services/permission_service.py`, `routers/auth.py`, `routers/oauth_router.py`, `routers/tokens.py`, `routers/sso.py`, `services/sso_service.py`, `common/oauth.py` |
+| **Z3 - Transport/session** | 3 | `transports/*.py`, `services/mcp_session_pool.py`, `cache/session_registry.py`, middleware ordering section of `main.py` |
+| **Z3 - Data model / connections** | 3 | `db.py` (ORM models, pool config, `ResilientSession`, `SessionLocal`, engine creation), `schemas.py`, `alembic/versions/*.py` |
+| **Z3 - Config/flags** | 3 | `config.py` (includes DB pool sizing, Redis pool limits, worker counts, cache TTLs) |
+| **Z3 - Per-request middleware** | 3 | `middleware/rbac.py`, `middleware/token_usage_middleware.py` (both acquire DB sessions on every request) |
+| **Z2 - Plugin framework** | 2 | `plugins/framework/**/*.py` |
+| **Z2 - Cache / pooling** | 2 | `cache/auth_cache.py` (2-tier L1/L2), `cache/registry_cache.py`, `cache/resource_cache.py`, `cache/tool_lookup_cache.py`, `cache/global_config_cache.py` |
+| **Z2 - Business logic** | 2 | Other `services/*.py`, `routers/*.py`, `main.py` (non-middleware) |
+| **Z1 - Admin UI** | 1 | `admin.py`, `templates/*.html`, `static/*.js` |
+| **Z0 - Docs/CI/meta** | 0 | `docs/`, `.github/`, `README.md`, `Makefile`, `charts/`, `llms/` |
+| **Z0 - Tests only** | 0 | `tests/**` (when no prod code changes) |
+
+### Dimension 2: Size Score (0-5 pts)
+
+| Lines changed (add+del) | Files | Score |
+|--------------------------|-------|-------|
+| <= 50 | <= 3 | 0 |
+| 51-200 | <= 6 | 1 |
+| 201-500 | <= 10 | 2 |
+| 501-1500 | <= 15 | 3 |
+| 1501-4000 | <= 30 | 4 |
+| > 4000 OR > 30 files | any | 5 |
+
+Use the higher of the two bracket scores.
+
+### Dimension 3: Structural Impact (0-5 pts, additive)
+
+| Condition | Pts |
+|-----------|-----|
+| New Alembic migration | +2 |
+| New/modified DB table in `db.py` | +2 |
+| Modifies middleware ordering in `main.py` | +3 |
+| Changes `normalize_token_teams()` or `get_current_user()` | +3 |
+| Changes security feature flags in `config.py` | +2 |
+| Modifies transport endpoint auth logic | +2 |
+| Adds new router/endpoint | +1 |
+| Pure rename/move refactor (no logic change) | -1 |
+
+### Dimension 4: Security Invariant Impact (0-5 pts, additive)
+
+| Condition | Pts |
+|-----------|-----|
+| Modifies two-layer model (token scoping + RBAC interaction) | +3 |
+| Changes `oauth_enabled` enforcement | +3 |
+| New bypass/exception to AUTH_REQUIRED | +3 |
+| Token team interpretation outside `normalize_token_teams()` | +4 |
+| Auth tokens via URL query parameters | +5 |
+| Changes plugin auth hook execution | +2 |
+| External contributor touching Z3/Z4 files | +1 |
+
+### Dimension 5: Test Adequacy (0-5 pts, penalty)
+
+| Condition | Pts |
+|-----------|-----|
+| Zero test files in diff (with prod code changes) | +3 |
+| Security code changes without deny-path tests | +2 |
+| New endpoints without integration tests | +1 |
+| Test-only PR | -5 (floor at 0 total) |
+
+### Dimension 6: Performance Impact (0-5 pts, additive)
+
+**Background:** The application runs behind Gunicorn with up to 16 workers. Each worker holds a SQLAlchemy connection pool (default `pool_size=200`, `max_overflow=10`; SQLite capped at 50). Total possible DB connections = `pool_size * workers` (up to 3,200 for PostgreSQL). Synchronous SQLAlchemy sessions run inside async FastAPI handlers (intentional design). Redis connections are pooled at 50/worker. Per-request middleware (`rbac.py`, `token_usage_middleware.py`) acquires a DB session on every request via `fresh_db_session()`.
+
+| Condition | Pts | What to look for |
+|-----------|-----|------------------|
+| Adds DB queries to per-request middleware path | +3 | New `fresh_db_session()` or `SessionLocal()` calls in middleware. At 1K req/s with 16 workers, each added query multiplies connection pressure by request volume. |
+| Introduces N+1 query pattern (loop with per-iteration DB call) | +3 | `for item in items: db.query(...)` without `selectinload`/`joinedload`. Existing services explicitly annotate N+1 prevention (Issue #1892). |
+| Modifies connection pool config or session lifecycle | +3 | Changes to `pool_size`, `max_overflow`, `pool_timeout`, `pool_recycle` in `db.py` or `config.py`. Changes to `ResilientSession`, `SessionLocal`, `get_db()`, `fresh_db_session()`, or engine event listeners. |
+| Bypasses or weakens caching layer | +2 | Removes or reduces TTLs on `auth_cache` (L1/L2), `registry_cache`, `global_config_cache`, or `tool_lookup_cache`. These caches reduce auth queries from 3-4/request to ~0-1/TTL. |
+| Adds bulk/unbounded DB operations without batching | +2 | `db.query(Model).all()` without `LIMIT`, or inserts without `bulk_insert`/`executemany`. Existing pattern: `metrics_buffer_service`, `audit_trail_service` batch writes. |
+| Modifies Gunicorn worker config or preload behavior | +2 | Changes to `run-gunicorn.sh` (worker count formula, `max_requests`, preload, post-fork hooks). Post-fork hook resets Redis clients per worker; breaking this causes cross-worker connection sharing. |
+| Changes Redis connection pooling or fallback behavior | +2 | Modifications to `redis_max_connections`, Redis health check intervals, or the graceful fallback from Redis to in-memory cache. Silent Redis failures could cascade to DB overload. |
+| Holds DB session across `await` boundaries | +2 | Sync `SessionLocal()` opened before an `await` and used after. Blocks the connection pool slot for the entire async wait duration. |
+
+## Automatic Overrides
+
+These override the numeric score:
+
+- **Auto Tier 1:** Modifies `normalize_token_teams()`, introduces query-param auth, changes middleware ordering in `main.py`
+- **Auto Tier 2 min:** New Alembic migration, or external contributor touching Z3/Z4
+- **Auto Tier 2 min:** Changes to `db.py` engine/pool/session creation, `run-gunicorn.sh` worker config, or `ResilientSession`
+- **`do-not-merge` label:** Blocks merge regardless of score
+
+## Review Tiers
+
+### Tier 1: Deep Review (20-35 pts) -- Red
+
+**Examples from current PRs:** #3248 (CSRF, 29 files), #3292 (JIT access, new DB table + router)
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Reviewers** | 2 core maintainers, at least 1 with security expertise |
+| **Time budget** | 2-4 hours per reviewer |
+| **Activities** | Full line-by-line diff of all prod files |
+| | Threat model walkthrough: unauth, wrong-team, expired-token, feature-disabled |
+| | Migration verification: single head, idempotent guards |
+| | Middleware ordering audit if `main.py` touched |
+| | Deny-path test review (401/403 for all new paths) |
+| | `normalize_token_teams` consistency check |
+| | Config impact: `.env.example` updated, secure defaults |
+| | **Connection budget analysis:** Trace new DB session acquisitions per request path. Verify sessions use `fresh_db_session()` context manager (not `Depends(get_db)` in middleware). Estimate worst-case pool pressure = (new queries/request) * (peak RPS) * (avg query duration). |
+| | **Cache dependency audit:** If new code bypasses caching, estimate the DB query amplification factor (auth_cache prevents ~3-4 queries/request). |
+
+### Tier 2: Standard Review (11-19 pts) -- Orange
+
+**Examples:** #3344 (protocol hardening), #3449 (rate limiter), #3414 (mgmt-plane isolation), #3432 (streamable-http public access)
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Reviewers** | 1 core maintainer with domain knowledge |
+| **Time budget** | 1-2 hours |
+| **Activities** | Line-by-line review of Z3/Z4 files; skim Z0/Z1 |
+| | Auth boundary check on new/modified endpoints |
+| | Migration review if present |
+| | Test adequacy: happy-path + error-path tests present |
+| | Cache invalidation review if cache layer touched |
+| | **N+1 query check:** Verify new service code uses `selectinload`/`joinedload` for relationship traversals. Look for DB queries inside loops. |
+| | **Session lifecycle check:** Confirm DB sessions are scoped to context managers, not held across `await` calls or leaked through early returns. |
+
+### Tier 3: Focused Review (5-10 pts) -- Yellow
+
+**Examples:** #3309 (cache invalidation), #3239 (metrics), #3337 (extract util), #3263 (configurable patterns)
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Reviewers** | 1 maintainer (any) |
+| **Time budget** | 30-60 minutes |
+| **Activities** | Targeted review of core change logic |
+| | Pattern consistency check (follows existing conventions?) |
+| | Test presence check |
+| | CI green confirmation |
+| | **Spot-check for unbounded queries:** Look for `.all()` without `LIMIT` or bulk operations without batching. |
+
+### Tier 4: Quick Review (0-4 pts) -- Green
+
+**Examples:** #3436 (CODEOWNERS), #3402 (1-file UI fix), #3396 (pagination), #3265 (Ollama defaults), #3330 (UI CRUD)
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Reviewers** | 1 maintainer (quick approval) |
+| **Time budget** | 5-15 minutes |
+| **Activities** | Spot check: change matches title, no secrets, no unrelated files |
+| | CI green confirmation |
+
+## Quick Heuristic (30-second version)
+
+For a maintainer scanning a new PR without computing the full score:
+
+1. **Does it touch Z4 files (auth, middleware, tokens)?** At least Tier 2. Over 500 lines? Tier 1.
+2. **Does it add a migration or new DB table?** At least Tier 2.
+3. **Does it touch `db.py` (pool/session), `run-gunicorn.sh`, or per-request middleware?** At least Tier 2.
+4. **Only Z0/Z1 files and under 200 lines?** Tier 4.
+5. **Everything else?** Tier 3.
+
+## Operational Labels
+
+Add these GitHub labels to PRs after scoring:
+
+- `review:deep` (red) -- Tier 1
+- `review:standard` (orange) -- Tier 2
+- `review:focused` (yellow) -- Tier 3
+- `review:quick` (green) -- Tier 4
+
+## Implementation (optional automation)
+
+This rubric can be partially automated via a GitHub Action that:
+1. Reads the file list from the PR diff
+2. Maps files to zones
+3. Computes Zone + Size scores (dimensions 1 & 2)
+4. Detects presence of `alembic/versions/`, `db.py`, `run-gunicorn.sh` for structural/perf flags
+5. Applies automatic override rules
+6. Applies the appropriate `review:*` label
+7. Dimensions 3-6 require human judgment but could be assisted by an LLM reviewing the diff; Dimension 6 (Performance) can be partially automated by grepping for `SessionLocal()`, `fresh_db_session()`, `.all()`, and loop-nested DB access patterns in the diff

--- a/.claude/skills/pr-risk-scoring/score_prs.py
+++ b/.claude/skills/pr-risk-scoring/score_prs.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Score all open PRs against the ContextForge risk rubric and output CSV.
+
+Usage:
+    python3 score_prs.py <pr_json> <file_list_dir> <output_csv> [approvals_csv]
+
+Arguments:
+    pr_json        Path to JSON file from `gh pr list --json ...`
+    file_list_dir  Directory containing per-PR file lists (<number>.txt)
+    output_csv     Path to write the scored CSV
+    approvals_csv  Optional CSV with columns: pr_number,approvals
+"""
+
+import csv
+import json
+import os
+import re
+import sys
+
+# ── Zone mapping ──────────────────────────────────────────────────────────────
+# Each pattern maps to (zone_name, score). First match wins per file.
+ZONE_RULES = [
+    # Z4 - Auth core (4 pts)
+    (re.compile(r"mcpgateway/auth\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/middleware/token_scoping\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/middleware/rbac\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/middleware/auth_middleware\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/middleware/http_auth_middleware\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/services/permission_service\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/routers/auth\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/routers/oauth_router\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/routers/tokens\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/routers/sso\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/services/sso_service\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/common/oauth\.py"), "Z4-Auth", 4),
+    (re.compile(r"mcpgateway/services/email_auth_service\.py"), "Z4-Auth", 4),
+    # Z3 - Transport/session (3 pts)
+    (re.compile(r"mcpgateway/transports/"), "Z3-Transport", 3),
+    (re.compile(r"mcpgateway/services/mcp_session_pool\.py"), "Z3-Transport", 3),
+    (re.compile(r"mcpgateway/cache/session_registry\.py"), "Z3-Transport", 3),
+    # Z3 - Data model / connections (3 pts)
+    (re.compile(r"mcpgateway/db\.py"), "Z3-Data", 3),
+    (re.compile(r"mcpgateway/schemas\.py"), "Z3-Data", 3),
+    (re.compile(r"mcpgateway/alembic/versions/"), "Z3-Data", 3),
+    # Z3 - Config/flags (3 pts)
+    (re.compile(r"mcpgateway/config\.py"), "Z3-Config", 3),
+    # Z3 - Per-request middleware (3 pts)
+    (re.compile(r"mcpgateway/middleware/token_usage_middleware\.py"), "Z3-Middleware", 3),
+    # Z2 - Plugin framework (2 pts)
+    (re.compile(r"mcpgateway/plugins/framework/"), "Z2-Plugin", 2),
+    # Z2 - Cache / pooling (2 pts)
+    (re.compile(r"mcpgateway/cache/"), "Z2-Cache", 2),
+    # Z2 - Business logic (2 pts)
+    (re.compile(r"mcpgateway/services/"), "Z2-Business", 2),
+    (re.compile(r"mcpgateway/routers/"), "Z2-Business", 2),
+    (re.compile(r"mcpgateway/main\.py"), "Z2-Business", 2),
+    (re.compile(r"mcpgateway/middleware/"), "Z2-Business", 2),
+    # Z1 - Admin UI (1 pt) — must precede the mcpgateway/ catch-all
+    (re.compile(r"mcpgateway/admin\.py"), "Z1-UI", 1),
+    (re.compile(r"mcpgateway/templates/"), "Z1-UI", 1),
+    (re.compile(r"mcpgateway/static/"), "Z1-UI", 1),
+    # Z2 - Other mcpgateway code (catch-all — keep last among mcpgateway/ rules)
+    (re.compile(r"mcpgateway/"), "Z2-Business", 2),
+    # Z2 - Plugin implementations
+    (re.compile(r"plugins/"), "Z2-Plugin", 2),
+    # Z0 - Everything else
+    (re.compile(r"tests/"), "Z0-Tests", 0),
+    (re.compile(r"docs/"), "Z0-Docs", 0),
+    (re.compile(r"\.github/"), "Z0-CI", 0),
+    (re.compile(r"charts/"), "Z0-Charts", 0),
+    (re.compile(r"llms/"), "Z0-Docs", 0),
+    (re.compile(r"infra/"), "Z0-Infra", 0),
+    (re.compile(r"run-gunicorn\.sh"), "Z0-Infra", 0),
+]
+
+
+def classify_file(path):
+    """Return (zone_name, score) for a file path."""
+    for pattern, name, score in ZONE_RULES:
+        if pattern.search(path):
+            return name, score
+    return "Z0-Other", 0
+
+
+def compute_zone_score(files):
+    """Dimension 1: sum per-file zone scores, cap at 10."""
+    total = sum(classify_file(f)[1] for f in files)
+    return min(total, 10)
+
+
+def compute_size_score(additions, deletions, changed_files):
+    """Dimension 2: size bracket scoring."""
+    lines = additions + deletions
+    if lines > 4000:
+        lines_score = 5
+    elif lines > 1500:
+        lines_score = 4
+    elif lines > 500:
+        lines_score = 3
+    elif lines > 200:
+        lines_score = 2
+    elif lines > 50:
+        lines_score = 1
+    else:
+        lines_score = 0
+    if changed_files > 30:
+        files_score = 5
+    elif changed_files > 15:
+        files_score = 4
+    elif changed_files > 10:
+        files_score = 3
+    elif changed_files > 6:
+        files_score = 2
+    elif changed_files > 3:
+        files_score = 1
+    else:
+        files_score = 0
+    return max(lines_score, files_score)
+
+
+def compute_structural_score(files):
+    """Dimension 3: structural impact, additive, cap at 5."""
+    score = 0
+    has_migration = any("alembic/versions/" in f for f in files)
+    has_db_model = any(f.endswith("mcpgateway/db.py") or f == "mcpgateway/db.py" for f in files)
+    has_main = any(f.endswith("mcpgateway/main.py") or f == "mcpgateway/main.py" for f in files)
+    has_config_flags = any(f.endswith("mcpgateway/config.py") or f == "mcpgateway/config.py" for f in files)
+    has_transport_auth = any("mcpgateway/transports/" in f for f in files)
+    has_new_router = any("mcpgateway/routers/" in f for f in files)
+
+    if has_migration:
+        score += 2
+    if has_db_model:
+        score += 2
+    if has_main:
+        score += 1
+    if has_config_flags:
+        score += 1
+    if has_transport_auth:
+        score += 2
+    if has_new_router:
+        score += 1
+    return min(score, 5)
+
+
+def compute_security_score(files, labels):
+    """Dimension 4: security invariant impact, additive, cap at 5."""
+    score = 0
+    label_names = {lbl["name"] for lbl in labels}
+
+    has_token_scoping = any("token_scoping.py" in f for f in files)
+    has_rbac = any("middleware/rbac.py" in f for f in files)
+    has_auth_core = any(f.endswith("mcpgateway/auth.py") or f == "mcpgateway/auth.py" for f in files)
+    has_oauth = any("oauth_router.py" in f or "oauth.py" in f for f in files)
+    has_tokens = any("routers/tokens.py" in f for f in files)
+
+    if has_token_scoping and has_rbac:
+        score += 3
+    if has_auth_core:
+        score += 2
+    if has_oauth:
+        score += 1
+    if has_tokens:
+        score += 1
+    if "security" in label_names:
+        score += 1
+    return min(score, 5)
+
+
+PROD_PREFIXES = ("mcpgateway/", "plugins/", "plugins_rust/", "a2a-agents/", "mcp-servers/", "tools_rust/")
+
+
+def compute_test_score(files):
+    """Dimension 5: test adequacy penalty, cap at 5."""
+    prod_files = [f for f in files if any(f.startswith(p) for p in PROD_PREFIXES)]
+    test_files = [f for f in files if f.startswith("tests/")]
+
+    if not prod_files:
+        return 0
+    if not test_files:
+        return 3
+    return 0
+
+
+def compute_perf_score(files):
+    """Dimension 6: performance impact, additive, cap at 5."""
+    score = 0
+    has_db_engine = any(f.endswith("mcpgateway/db.py") or f == "mcpgateway/db.py" for f in files)
+    has_per_request_mw = any("middleware/rbac.py" in f or "middleware/token_usage_middleware.py" in f or "middleware/auth_middleware.py" in f for f in files)
+    has_cache = any("mcpgateway/cache/" in f for f in files)
+    has_gunicorn = any("run-gunicorn" in f for f in files)
+    has_services = any("mcpgateway/services/" in f for f in files)
+
+    if has_db_engine:
+        score += 3
+    if has_per_request_mw:
+        score += 2
+    if has_cache:
+        score += 2
+    if has_gunicorn:
+        score += 2
+    if has_services and not has_db_engine and not has_per_request_mw:
+        score += 1
+    return min(score, 5)
+
+
+def assign_tier(total):
+    """Map total score to tier."""
+    if total >= 20:
+        return "1-Deep"
+    elif total >= 11:
+        return "2-Standard"
+    elif total >= 5:
+        return "3-Focused"
+    else:
+        return "4-Quick"
+
+
+def main():
+    """Score open PRs and write results to CSV."""
+    if len(sys.argv) < 4 or len(sys.argv) > 5:
+        print(f"Usage: {sys.argv[0]} <pr_json> <file_list_dir> <output_csv> [approvals_csv]", file=sys.stderr)
+        sys.exit(1)
+
+    pr_json_path, file_list_dir, output_csv = sys.argv[1], sys.argv[2], sys.argv[3]
+    approvals_csv = sys.argv[4] if len(sys.argv) == 5 else None
+
+    with open(pr_json_path, encoding="utf-8") as f:
+        prs = json.load(f)
+
+    # Load approvals if provided (CSV: pr_number,approvals)
+    approvals_map = {}
+    if approvals_csv:
+        with open(approvals_csv, encoding="utf-8") as af:
+            for line in af:
+                line = line.strip()
+                if not line or line.startswith("pr_number"):
+                    continue
+                parts = line.split(",", 1)
+                if len(parts) == 2:
+                    approvals_map[int(parts[0])] = int(parts[1])
+
+    rows = []
+    for pr in sorted(prs, key=lambda x: x["number"]):
+        num = pr["number"]
+        files_path = os.path.join(file_list_dir, f"{num}.txt")
+        if os.path.exists(files_path):
+            with open(files_path, encoding="utf-8") as ff:
+                files = [line.strip() for line in ff if line.strip()]
+        else:
+            files = []
+
+        zone = compute_zone_score(files)
+        size = compute_size_score(pr["additions"], pr["deletions"], pr["changedFiles"])
+        struct = compute_structural_score(files)
+        sec = compute_security_score(files, pr.get("labels", []))
+        test = compute_test_score(files)
+        perf = compute_perf_score(files)
+        total = zone + size + struct + sec + test + perf
+        tier = assign_tier(total)
+
+        label_names = ", ".join(lbl["name"] for lbl in pr.get("labels", []))
+        author = pr.get("author", {}).get("login", "unknown")
+        title = pr["title"][:80]
+
+        url = pr.get("url", f"https://github.com/IBM/mcp-context-forge/pull/{num}")
+
+        rows.append(
+            {
+                "PR": num,
+                "URL": url,
+                "Title": title,
+                "Author": author,
+                "Approvals": approvals_map.get(num, 0),
+                "Files": pr["changedFiles"],
+                "Additions": pr["additions"],
+                "Deletions": pr["deletions"],
+                "Zone": zone,
+                "Size": size,
+                "Structural": struct,
+                "Security": sec,
+                "TestGap": test,
+                "Perf": perf,
+                "Total": total,
+                "Tier": tier,
+                "Labels": label_names,
+            }
+        )
+
+    fieldnames = ["PR", "URL", "Title", "Author", "Approvals", "Files", "Additions", "Deletions", "Zone", "Size", "Structural", "Security", "TestGap", "Perf", "Total", "Tier", "Labels"]
+    with open(output_csv, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    tier_counts = {}
+    for r in rows:
+        tier_counts[r["Tier"]] = tier_counts.get(r["Tier"], 0) + 1
+
+    print(f"Scored {len(rows)} PRs -> {output_csv}")
+    print()
+    for tier in sorted(tier_counts.keys()):
+        print(f"  {tier}: {tier_counts[tier]} PRs")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: sprint-plan
+description: Based on the current contents of the project issues, plan a series of sprints to address the issues.
+---
+# Sprint Planning Regeneration Guide
+
+Instructions for Claude Code to regenerate the sprint planning worksheets in this directory.
+This process is expected to run roughly monthly.
+
+## Prerequisites
+
+- `gh` CLI authenticated with access to IBM/mcp-context-forge
+- Python 3.11+ available
+- Access to the full open issue list (currently ~661 issues)
+
+## Overview
+
+The process produces four artifacts:
+
+1. **sprint-plan.csv** — Master issue inventory with sprint assignments and effort estimates
+2. **epic-categories.csv** — Epic inventory with child issue rollup
+3. **label-fixes.csv** — Label/title consistency audit
+4. **milestone-sprint-matrix.csv** — Milestone vs sprint cross-reference
+
+## Step-by-Step Process
+
+### Step 1: Fetch All Open Issues
+
+```bash
+gh issue list --repo IBM/mcp-context-forge --state open --limit 1000 \
+  --json number,title,labels,milestone \
+  > /tmp/all_issues.json
+```
+
+Important: The default limit is 30. Always set `--limit` high enough to capture all open issues. Verify the count matches what GitHub reports.
+
+### Step 2: Fetch Milestones
+
+```bash
+gh api repos/IBM/mcp-context-forge/milestones --paginate \
+  --jq '.[] | [.number, .title, .open_issues, .closed_issues] | @tsv'
+```
+
+Note: The `!=` operator in jq requires escaping in zsh. Use Python to filter null milestones from JSON rather than jq `select()` with negation.
+
+### Step 3: Classify Each Issue
+
+#### 3a. Issue Type (from title tags)
+
+| Title Pattern | Type |
+|---------------|------|
+| `[EPIC]` in title OR `epic` label | Epic |
+| `[BUG]` in title OR `bug` label | Bug |
+| `[FEATURE]` or `[ENHANCEMENT]` in title | Feature |
+| `[PERFORMANCE]` in title | Performance |
+| `[TESTING]` or `[CHORE][TESTING]` in title | Testing |
+| `[CHORE]` in title | Chore |
+| `[DOCS]` or `[README]` or `[QUICK-START]` in title | Docs |
+| Default | Feature |
+
+Priority: Epic > Bug > Performance > Testing > Chore > Docs > Feature.
+If multiple tags match, use the highest priority type.
+
+#### 3b. MoSCoW Priority (from labels)
+
+Look for these exact label strings: `MUST`, `SHOULD`, `COULD`, `WOULD`.
+If none found, mark as empty/unset.
+
+#### 3c. Epic Category
+
+Assign each issue to exactly one of these 12 categories based on title tags and labels:
+
+| # | Category | Matching signals |
+|---|----------|-----------------|
+| 1 | Security & Auth | `[AUTH]`, `[SECURITY]`, `[SSO]`, `[RBAC]`, `[COMPLIANCE]`, `security` label |
+| 2 | Admin UI & Frontend | `[UI]`, `[CATALOG]`, `frontend` label, `ui` label |
+| 3 | Protocol & Transport | `[PROTOCOL]`, `[API]`, `[A2A]`, `[RUNTIME]`, `[INTEGRATION]`, `mcp-protocol` label |
+| 4 | Performance & Database | `[PERFORMANCE]`, `[DB]`, `[DATABASE]`, `[RUST]`, `performance` label, `database` label |
+| 5 | Plugins & Extensions | `[PLUGIN]`, `[PLUGINS]`, `plugins` label |
+| 6 | DevOps & Infrastructure | `[HELM]`, `[DOCKER]`, `[CICD]`, `[K8S]`, `[DEPLOYMENT]`, `devops` label |
+| 7 | Observability & Monitoring | `[OBSERVABILITY]`, `[LOGGING]`, `observability` label |
+| 8 | SaaS Readiness | `[COMPLIANCE]` (when SaaS-specific), SaaS-related billing/metering |
+| 9 | Client Integration | `wxo` label, `client-*` labels, `ica` label |
+| 10 | Testing & QA | `[TESTING]`, `testing` label, `manual-testing` label |
+| 11 | Documentation & Samples | `[DOCS]`, `[README]`, `[QUICK-START]`, `documentation` label |
+| 12 | AI & Discovery | `[AI]`, `[SEARCH]`, AI/ML/semantic keywords |
+
+Priority order when multiple match: Client Integration (9) > Security (1) > Protocol (3) > Performance (4) > Plugins (5) > UI (2) > Observability (7) > SaaS (8) > Testing (10) > DevOps (6) > Docs (11) > AI (12).
+
+### Step 4: Sprint Priority Assignment
+
+| Priority | Criteria |
+|----------|----------|
+| P0 | Has `wxo` label, or any `client-*` label, or `ica` label |
+| P1 | SaaS enablement: security hardening, compliance, auth, billing, multi-tenancy |
+| P2 | A2A/LLM gateway: protocol compliance, transport, A2A features |
+| P3 | Platform quality: performance, database, observability, bug fixes |
+| P4 | Developer experience: DevOps, testing infrastructure, documentation, CI/CD |
+| P5 | Nice-to-have: COULD/WOULD items without higher priority signals |
+
+### Step 5: Sprint Assignment
+
+| Sprint | Rule |
+|--------|------|
+| Sprint 1 | P0 + MUST |
+| Sprint 2 | P0 remaining + P1 MUST |
+| Sprint 3 | P1 SHOULD + P2 MUST (theme: Protocol & Compliance) |
+| Sprint 4 | P2 SHOULD + P3 MUST (theme: Performance, DB, Testing & UI Infrastructure) |
+| Sprint 5A | P3 SHOULD bugs + performance items |
+| Sprint 5B | P3 SHOULD testing items |
+| Sprint 5C | P3 SHOULD features + epics (theme: Security Hardening) |
+| Sprint 6 | P4 SHOULD (theme: DevOps, Docs & Polish) |
+| Backlog | Everything else (COULD, WOULD, P5) |
+
+Target capacity per sprint: ~200-270 SP. If any sprint exceeds ~300 SP, rebalance by:
+1. Moving items to the next sprint that fits thematically
+2. Pushing aspirational items (AI & Discovery, speculative epics) to Backlog
+
+### Step 6: Effort Estimation
+
+Apply effort estimates to sprint-assigned issues only (not Backlog).
+
+#### Story Point Scale (Fibonacci)
+
+| SP | Person-Days | Typical Use |
+|----|-------------|-------------|
+| 1 | 0.5 | Trivial config change, typo fix |
+| 2 | 1 | Small bug fix, minor feature, single-file change |
+| 3 | 1.5-2 | Standard feature, moderate bug, 2-3 file change |
+| 5 | 3-4 | Multi-file feature, complex bug, new endpoint |
+| 8 | 5-7 | Large feature, significant refactor, new service |
+| 13 | 8-12 | Epic-sized, multi-component, new subsystem |
+| 21 | 13-20 | Major epic, cross-cutting architectural change |
+
+#### Estimation Heuristics
+
+- **Epics**: 13 SP (Medium/Large) or 21 SP (XL). Always Low confidence.
+- **Bugs**: 1-2 SP (simple), 3-5 SP (complex/multi-file), 8 SP (architectural).
+- **Features**: 3 SP (standard), 5 SP (multi-component), 8 SP (large/new service).
+- **Testing manual test plans**: 3 SP each (write + first-pass execution).
+- **Performance**: 2-3 SP (config/index), 5 SP (refactor), 8+ SP (architectural).
+- **Chores**: 2 SP (simple), 3-5 SP (moderate), 8 SP (large restructure).
+- **Docs**: 2 SP (standard), 5-8 SP (comprehensive framework adoption).
+
+Confidence levels:
+- **High**: Well-scoped, clear requirements, similar past work.
+- **Medium**: Reasonable scope but some unknowns.
+- **Low**: Epics, architectural changes, first-of-kind work.
+
+### Step 7: Epic-to-Issue Mapping
+
+For non-epic issues, identify a parent epic by matching:
+
+1. **Explicit title/label overlap**: Issue title tags match epic title tags (e.g., `[AUTH]` issue under `[EPIC][AUTH]`).
+2. **Functional domain**: Issue addresses a story within the epic's scope.
+3. **Label intersection**: Shared labels like `security`, `plugins`, `ui`.
+
+Record the parent epic number and a brief justification. These mappings are **proposals** — always get approval before creating GitHub sub-issue links.
+
+### Step 8: Label Consistency Audit
+
+Check every issue for mismatches between title tags and labels:
+
+| Title Tag | Expected Label |
+|-----------|---------------|
+| `[EPIC]` | `epic` |
+| `[BUG]` | `bug` |
+| `[FEATURE]` or `[ENHANCEMENT]` | `enhancement` |
+| `[CHORE]` | `chore` |
+| `[UI]` | `ui` |
+| `[SECURITY]` or `[AUTH]` or `[COMPLIANCE]` | `security` |
+| `[PLUGIN]` or `[PLUGINS]` | `plugins` |
+| `[PERFORMANCE]` | `performance` |
+| `[DB]` or `[DATABASE]` | `database` |
+| `[OBSERVABILITY]` | `observability` |
+| `[PROTOCOL]` | `mcp-protocol` |
+
+Also flag the reverse: labels present without matching title tags. And flag issues with no labels at all.
+
+### Step 9: Milestone-Sprint Matrix
+
+Cross-reference GitHub milestone assignments against sprint assignments. Produce two matrices:
+- **Story Points matrix**: Milestone (rows) x Sprint (columns), cell = total SP.
+- **Issue Count matrix**: Same structure, cell = number of issues.
+
+Include a `(No milestone)` row and `TOTAL` row/column.
+
+### Step 10: Generate README.md
+
+Update the README.md in this directory with:
+- File listing and descriptions
+- Column definitions for each CSV
+- Sprint summary table with themes and SP totals
+- Key observations for each worksheet
+- Milestone summary
+
+## Known Pitfalls
+
+1. **`gh issue list` default limit is 30.** Always use `--limit 1000` or higher.
+2. **jq `!=` requires escaping in zsh.** Use Python for null filtering instead of `select(.field != null)`.
+3. **Large JSON output may exceed tool limits.** Use TSV or process with Python scripts instead of trying to read raw JSON.
+4. **Backlog items should not have effort estimates.** Clear SP/Person-Days/Confidence/Notes when moving items to Backlog.
+5. **Epic detection is dual-source.** Check both `[EPIC]` in title AND `epic` label — some epics only have one or the other (which is itself a label-fix finding).
+6. **Sprint 5 splitting.** If any sprint exceeds ~300 SP after initial assignment, split by type: bugs+performance (A), testing (B), features+epics (C).
+7. **Thematic coherence matters.** When rebalancing, keep sprint themes intact rather than just leveling SP counts. Ask the user for theme preferences.
+
+## Verification Checklist
+
+After regeneration, verify:
+
+- [ ] Total issue count matches `gh issue list --state open` count
+- [ ] All sprint SP totals are in the 150-280 SP range (except Sprint 1 which may be smaller)
+- [ ] No Backlog items have story point values
+- [ ] Every epic appears in epic-categories.csv
+- [ ] Milestone matrix row totals match milestone open issue counts
+- [ ] Label fixes CSV has no duplicate rows (same issue + same fix)
+- [ ] README.md sprint summary table matches actual CSV data

--- a/.gitignore
+++ b/.gitignore
@@ -191,7 +191,8 @@ packages.json
 .aider*
 aider*
 .ai*
-.claude
+.claude/*
+!.claude/skills/
 CLAUDE.local.md
 .continue
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -271,11 +271,12 @@ volumes:
 
 ```bash
 # Format code
-make black              # Python formatter
-make isort              # Import sorter
+make black              # Python formatter (CHECK=1 for dry-run)
+make isort              # Import sorter (CHECK=1 for dry-run)
 make autoflake          # Remove unused imports
 
 # Lint code
+make ruff               # Ruff linter (RUFF_MODE=check|fix|format)
 make flake8             # Style checker
 make pylint             # Advanced linting
 make mypy               # Type checking

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,12 @@ XARGS_FLAGS := $(shell [ "$$(uname)" = "Darwin" ] && echo "" || echo "-r")
 .PHONY: help
 help:
 	@grep "^# help\:" Makefile | grep -v grep | sed 's/\# help\: //' | sed 's/\# help\://'
+	@if grep -q "^# deprecated:" Makefile; then \
+		printf '\n\033[33m⚠️  DEPRECATED TARGETS (still work, will be removed in stated version)\033[0m\n'; \
+		grep "^# deprecated:" Makefile | sed 's/^# deprecated: //' | while IFS= read -r line; do \
+			printf '  \033[2;33m%s\033[0m\n' "$$line"; \
+		done; \
+	fi
 
 # -----------------------------------------------------------------------------
 # 🔧 SYSTEM-LEVEL DEPENDENCIES
@@ -120,6 +126,18 @@ os-deps: $(OS_DEPS_SCRIPT)
 # -----------------------------------------------------------------------------
 # 🔧 HELPER SCRIPTS
 # -----------------------------------------------------------------------------
+
+# Boolean normalizer: returns non-empty only for explicit truth values.
+# Usage: $(if $(call is_true,$(VAR)),yes-branch,no-branch)
+is_true = $(filter 1 true yes,$(1))
+
+# Deprecation warning for aliased targets.
+# Usage: $(call deprecated_target,old-name,replacement invocation,removal-version)
+define deprecated_target
+	@printf '\n  ⚠️  WARNING: "%s" is deprecated. Use "%s" instead.\n' '$(1)' '$(2)'
+	@printf '     This alias will be removed in v%s.\n\n' '$(3)'
+endef
+
 # Helper to ensure a Python package is installed in venv (uses uv to avoid pip corruption)
 define ensure_pip_package
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
@@ -630,6 +648,15 @@ clean:
 
 .PHONY: smoketest test-mcp-cli test-mcp-rbac test test-verbose test-profile coverage test-docs pytest-examples test-curl htmlcov doctest doctest-verbose doctest-coverage doctest-check test-db-perf test-db-perf-verbose 2025-11-25 2025-11-25-core 2025-11-25-tasks 2025-11-25-auth 2025-11-25-report dev-query-log query-log-tail query-log-analyze query-log-clear load-test load-test-ui load-test-light load-test-heavy load-test-sustained load-test-stress load-test-report load-test-compose load-test-timeserver load-test-fasttime load-test-1000 load-test-summary load-test-baseline load-test-baseline-ui load-test-baseline-stress load-test-agentgateway-mcp-server-time
 
+# Dirs/files always excluded from standard pytest runs
+PYTEST_IGNORE := tests/fuzz tests/manual test.py \
+    tests/e2e/test_entra_id_integration.py \
+    tests/e2e/test_mcp_cli_protocol.py \
+    tests/e2e/test_mcp_rbac_transport.py
+
+# Expand to --ignore=<path> flags for pytest CLI
+PYTEST_IGNORE_FLAGS := $(foreach p,$(PYTEST_IGNORE),--ignore=$(p))
+
 ## --- Automated checks --------------------------------------------------------
 smoketest:
 	@echo "🚀 Running smoketest..."
@@ -665,9 +692,7 @@ test:
 		export ARGON2ID_TIME_COST=1 && \
 		export ARGON2ID_MEMORY_COST=1024 && \
 		uv run --active pytest -n auto --maxfail=0 -v --durations=5 \
-			--ignore=tests/fuzz --ignore=tests/e2e/test_entra_id_integration.py \
-			--ignore=tests/e2e/test_mcp_cli_protocol.py \
-			--ignore=tests/e2e/test_mcp_rbac_transport.py"
+			$(PYTEST_IGNORE_FLAGS)"
 
 test-verbose:
 	@echo "🧪 Running tests (verbose, sequential)..."
@@ -677,7 +702,7 @@ test-verbose:
 		export TEST_DATABASE_URL='sqlite:///:memory:' && \
 		export ARGON2ID_TIME_COST=1 && \
 		export ARGON2ID_MEMORY_COST=1024 && \
-		uv run --active pytest --maxfail=0 -v --tb=short --instafail --ignore=tests/fuzz"
+		uv run --active pytest --maxfail=0 -v --tb=short --instafail $(PYTEST_IGNORE_FLAGS)"
 
 test-profile:
 	@echo "🧪 Running tests with profiling (showing slowest tests)..."
@@ -687,7 +712,7 @@ test-profile:
 		export TEST_DATABASE_URL='sqlite:///:memory:' && \
 		export ARGON2ID_TIME_COST=1 && \
 		export ARGON2ID_MEMORY_COST=1024 && \
-		uv run --active pytest -n 16 --durations=20 --durations-min=1.0 --disable-warnings -v --ignore=tests/fuzz"
+		uv run --active pytest -n 16 --durations=20 --durations-min=1.0 --disable-warnings -v $(PYTEST_IGNORE_FLAGS)"
 
 .PHONY: coverage-pytest
 coverage-pytest: install-dev
@@ -704,8 +729,7 @@ coverage-pytest: install-dev
 		python3 -m pytest -p pytest_cov --reruns=1 --reruns-delay 30 \
 			--dist loadgroup -n auto -rA --cov-append --capture=fd -v \
 			--durations=120 --cov-report=term --cov=mcpgateway \
-			--ignore=tests/fuzz --ignore=tests/manual --ignore=test.py tests/ \
-			--ignore=tests/e2e/test_entra_id_integration.py || true"
+			$(PYTEST_IGNORE_FLAGS) tests/ || true"
 
 coverage: coverage-pytest install-dev
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
@@ -750,7 +774,7 @@ test-docs:
 			--md-report --md-report-output=$(DOCS_DIR)/docs/test/unittest.md \
 			--dist loadgroup -n 8 -rA --cov-append --capture=fd -v \
 			--durations=120 --cov-report=term --cov=mcpgateway \
-			--ignore=tests/fuzz --ignore=tests/manual --ignore=test.py tests/ || true"
+			$(PYTEST_IGNORE_FLAGS) tests/ || true"
 	@printf '\n## Coverage report\n\n' >> $(DOCS_DIR)/docs/test/unittest.md
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
 		coverage report --format=markdown -m --no-skip-covered \
@@ -2803,9 +2827,9 @@ images:
 # help:   make lint-fix myfile.py      - Auto-fix formatting issues
 # help:   make lint-changed            - Lint only git-changed files
 # help: lint                 - Run the full linting suite (see targets below)
-# help: black                - Reformat code with black
+# help: black                - Reformat code with black (CHECK=1 for dry-run)
 # help: autoflake            - Remove unused imports / variables with autoflake
-# help: isort                - Organise & sort imports with isort
+# help: isort                - Organise & sort imports with isort (CHECK=1 for dry-run)
 # help: flake8               - PEP-8 style & logical errors
 # help: pylint               - Pylint static analysis
 # help: markdownlint         - Lint Markdown files with markdownlint (requires markdownlint-cli)
@@ -2814,7 +2838,7 @@ images:
 # help: pydocstyle           - Docstring style checker
 # help: pycodestyle          - Simple PEP-8 checker
 # help: pre-commit           - Run all configured pre-commit hooks
-# help: ruff                 - Ruff linter + (eventually) formatter
+# help: ruff                 - Ruff linter (RUFF_MODE=check|fix|format, RUFF_SELECT=rules)
 # help: ty                   - Ty type checker from astral
 # help: pyright              - Static type-checking with Pyright
 # help: radon                - Code complexity & maintainability metrics
@@ -2880,7 +2904,7 @@ LINTERS := isort flake8 pylint mypy bandit pydocstyle pycodestyle \
 FILE_AWARE_LINTERS := isort black flake8 pylint mypy bandit pydocstyle \
 	pycodestyle ruff pyright vulture unimport markdownlint
 
-.PHONY: lint $(LINTERS) black autoflake lint-py lint-yaml lint-json lint-md lint-strict \
+.PHONY: lint $(LINTERS) black black-check isort-check ruff-check ruff-fix ruff-format autoflake lint-py lint-yaml lint-json lint-md lint-strict \
 	lint-count-errors lint-report lint-changed lint-staged lint-commit \
 	lint-pre-commit lint-pre-push lint-parallel lint-cache-clear lint-stats \
 	lint-complexity lint-watch lint-watch-quick \
@@ -2956,9 +2980,9 @@ lint-quick:
 		actual_target="$(TARGET)"; \
 	fi; \
 	echo "⚡ Quick lint of $$actual_target (ruff + black + isort)..."; \
-	$(MAKE) --no-print-directory ruff-check TARGET="$$actual_target"; \
-	$(MAKE) --no-print-directory black-check TARGET="$$actual_target"; \
-	$(MAKE) --no-print-directory isort-check TARGET="$$actual_target"
+	$(MAKE) --no-print-directory ruff RUFF_MODE=check TARGET="$$actual_target"; \
+	$(MAKE) --no-print-directory black CHECK=1 TARGET="$$actual_target"; \
+	$(MAKE) --no-print-directory isort CHECK=1 TARGET="$$actual_target"
 
 # Fix formatting issues
 .PHONY: lint-fix
@@ -2979,7 +3003,7 @@ lint-fix:
 	echo "🔧 Fixing lint issues in $$actual_target..."; \
 	$(MAKE) --no-print-directory black TARGET="$$actual_target"; \
 	$(MAKE) --no-print-directory isort TARGET="$$actual_target"; \
-	$(MAKE) --no-print-directory ruff-fix TARGET="$$actual_target"
+	$(MAKE) --no-print-directory ruff RUFF_MODE=fix TARGET="$$actual_target"
 
 # Smart linting based on file extension
 .PHONY: lint-smart
@@ -3318,29 +3342,39 @@ autoflake:                          ## 🧹  Strip unused imports / vars
 	@$(VENV_DIR)/bin/autoflake --in-place --remove-all-unused-imports \
 		--remove-unused-variables -r $(TARGET)
 
-black:                              ## 🎨  Reformat code with black
-	@echo "🎨  black $(TARGET)..." && $(VENV_DIR)/bin/black -l 200 $(TARGET)
+CHECK ?=
 
-# Black check mode (separate target)
+black: uv                           ## 🎨  Reformat code with black (CHECK=1 for dry-run)
+	@if [ -n "$(call is_true,$(CHECK))" ]; then \
+		echo "🎨  black --check $(TARGET)..." && uv run black -l 200 --check --diff $(TARGET); \
+	else \
+		echo "🎨  black $(TARGET)..." && uv run black -l 200 $(TARGET); \
+	fi
+
+isort: uv                           ## 🔀  Sort imports (CHECK=1 for dry-run)
+	@if [ -n "$(call is_true,$(CHECK))" ]; then \
+		echo "🔀  isort --check $(TARGET)..." && uv run isort --check-only --diff $(TARGET); \
+	else \
+		echo "🔀  isort $(TARGET)..." && uv run isort $(TARGET); \
+	fi
+
+# --- Deprecated aliases (use CHECK=1 instead) ---
+# deprecated: black-check       - Use "make black CHECK=1" instead (v1.2.0)
+# deprecated: isort-check       - Use "make isort CHECK=1" instead (v1.2.0)
 black-check:
-	@echo "🎨  black --check $(TARGET)..." && $(VENV_DIR)/bin/black -l 200 --check --diff $(TARGET)
+	$(call deprecated_target,black-check,make black CHECK=1,1.2.0)
+	@$(MAKE) --no-print-directory black CHECK=1 TARGET="$(TARGET)"
 
-isort:                              ## 🔀  Sort imports
-	@echo "🔀  isort $(TARGET)..." && $(VENV_DIR)/bin/isort $(TARGET)
-
-# Isort check mode (separate target)
 isort-check:
-	@echo "🔀  isort --check $(TARGET)..." && $(VENV_DIR)/bin/isort --check-only --diff $(TARGET)
+	$(call deprecated_target,isort-check,make isort CHECK=1,1.2.0)
+	@$(MAKE) --no-print-directory isort CHECK=1 TARGET="$(TARGET)"
 
 flake8:                             ## 🐍  flake8 checks
 	@echo "🐍 flake8 $(TARGET)..." && $(VENV_DIR)/bin/flake8 $(TARGET)
 
 pylint: uv                             ## 🐛  pylint checks
 	@echo "🐛 pylint $(TARGET) (parallel)..."
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		PYLINTHOME=\"$(CURDIR)/.pylint-cache\" UV_CACHE_DIR=\"$(CURDIR)/.uv-cache\" \
-		uv run --active pylint -j 0 --fail-on E --fail-under 10 $(TARGET)"
+	@uv run pylint -j 0 --fail-on E --fail-under 10 $(TARGET)
 
 markdownlint:					    ## 📖  Markdown linting
 	@# Install markdownlint-cli2 if not present
@@ -3416,20 +3450,46 @@ pre-commit: uv                     ## 🪄  Run pre-commit tool
 		GOCACHE='$(CURDIR)/.cache/go-build' \
 		$(VENV_DIR)/bin/pre-commit run --config .pre-commit-lite.yaml --all-files --show-diff-on-failure"
 
-ruff:                               ## ⚡  Ruff lint + (eventually) format
-	@echo "⚡ ruff $(TARGET)..." && $(VENV_DIR)/bin/ruff check $(TARGET)
-	#                   && $(VENV_DIR)/bin/ruff format $(TARGET)
+RUFF_MODE   ?= check
+RUFF_SELECT ?=
 
-# Separate ruff targets for different modes
+ruff: uv                            ## ⚡  Ruff linter (RUFF_MODE=check|fix|format, RUFF_SELECT=rules)
+	@ruff_cmd=""; \
+	case "$(RUFF_MODE)" in \
+		check)  ruff_cmd="check" ;; \
+		fix)    ruff_cmd="check --fix" ;; \
+		format) ruff_cmd="format" ;; \
+		*)      printf 'ERROR: RUFF_MODE must be check, fix, or format (got "%s")\n' '$(RUFF_MODE)'; exit 1 ;; \
+	esac; \
+	select_flag=""; \
+	if [ -n "$(RUFF_SELECT)" ]; then select_flag="--select $(RUFF_SELECT)"; fi; \
+	echo "⚡ ruff $$ruff_cmd $$select_flag $(TARGET)..."; \
+	uv run ruff $$ruff_cmd $$select_flag $(TARGET)
+
+# --- Deprecated aliases (use RUFF_MODE= instead) ---
+# deprecated: ruff-check        - Use "make ruff RUFF_MODE=check" instead (v1.2.0)
+# deprecated: ruff-fix          - Use "make ruff RUFF_MODE=fix" instead (v1.2.0)
+# deprecated: ruff-format       - Use "make ruff RUFF_MODE=format" instead (v1.2.0)
 ruff-check:
-	@echo "⚡ ruff check $(TARGET)..." && $(VENV_DIR)/bin/ruff check $(TARGET)
+	$(call deprecated_target,ruff-check,make ruff RUFF_MODE=check,1.2.0)
+	@$(MAKE) --no-print-directory ruff RUFF_MODE=check TARGET="$(TARGET)"
 
 ruff-fix:
-	@echo "⚡ ruff check --fix $(TARGET)..." && $(VENV_DIR)/bin/ruff check --fix $(TARGET)
+	$(call deprecated_target,ruff-fix,make ruff RUFF_MODE=fix,1.2.0)
+	@$(MAKE) --no-print-directory ruff RUFF_MODE=fix TARGET="$(TARGET)"
 
-#  Nothing depends on this target yet, but kept for future and ad hoc use
 ruff-format:
-	@echo "⚡ ruff format $(TARGET)..." && $(VENV_DIR)/bin/ruff format $(TARGET)
+	$(call deprecated_target,ruff-format,make ruff RUFF_MODE=format,1.2.0)
+	@$(MAKE) --no-print-directory ruff RUFF_MODE=format TARGET="$(TARGET)"
+
+future-proof-ruff: uv               ## ⚡  Ruff G+BLE rules on files diverged from main
+	@changed=$$(git diff --name-only --diff-filter=ACM main -- '*.py' 2>/dev/null || true); \
+	if [ -z "$$changed" ]; then \
+		echo "ℹ️  No Python files diverged from main"; \
+	else \
+		echo "⚡ ruff check --select G,BLE on $$(echo $$changed | wc -w | tr -d ' ') file(s)..."; \
+		uv run ruff check --select G,BLE $$changed; \
+	fi
 
 ty:                                 ## ⚡  Ty type checker
 	@echo "⚡ ty $(TARGET)..." && $(VENV_DIR)/bin/ty check $(TARGET)
@@ -3590,63 +3650,41 @@ shell-lint-file:                    ## 🐚  Lint shell script
 # -----------------------------------------------------------------------------
 # 🔍 LINT CHANGED FILES (GIT INTEGRATION)
 # -----------------------------------------------------------------------------
-# help: lint-changed         - Lint only git-changed files
-# help: lint-staged          - Lint only git-staged files
-# help: lint-commit          - Lint files in specific commit (use COMMIT=hash)
+# help: lint-changed         - Lint only git-changed files (uses lint-smart per file)
+# help: lint-staged          - Lint only git-staged files (uses lint-smart per file)
+# help: lint-commit          - Lint files in specific commit (COMMIT=hash)
 .PHONY: lint-changed lint-staged lint-commit
 
-lint-changed:							## 🔍 Lint only changed files (git)
-	@echo "🔍 Linting changed files..."
-	@changed_files=$$(git diff --name-only --diff-filter=ACM HEAD 2>/dev/null || true); \
-	if [ -z "$$changed_files" ]; then \
-		echo "ℹ️  No changed files to lint"; \
+# Generic "lint files from a git command" macro.
+# $(1) = human label (e.g., "changed", "staged", "in commit abc123")
+# $(2) = shell command that produces a newline-delimited file list
+define lint_git_files
+	@echo "🔍 Linting $(1) files..."; \
+	file_list=$$($(2) 2>/dev/null || true); \
+	if [ -z "$$file_list" ]; then \
+		echo "ℹ️  No $(1) files to lint"; \
 	else \
-		echo "Changed files:"; \
-		echo "$$changed_files" | sed 's/^/  - /'; \
+		echo "$(1) files:"; \
+		printf '  - %s\n' $$file_list; \
 		echo ""; \
-		for file in $$changed_files; do \
+		for file in $$file_list; do \
 			if [ -e "$$file" ]; then \
 				echo "🎯 Linting: $$file"; \
 				$(MAKE) --no-print-directory lint-smart "$$file"; \
 			fi; \
 		done; \
 	fi
+endef
+
+lint-changed:							## 🔍 Lint only changed files (git)
+	$(call lint_git_files,changed,git diff --name-only --diff-filter=ACM HEAD)
 
 lint-staged:							## 🔍 Lint only staged files (git)
-	@echo "🔍 Linting staged files..."
-	@staged_files=$$(git diff --name-only --cached --diff-filter=ACM 2>/dev/null || true); \
-	if [ -z "$$staged_files" ]; then \
-		echo "ℹ️  No staged files to lint"; \
-	else \
-		echo "Staged files:"; \
-		echo "$$staged_files" | sed 's/^/  - /'; \
-		echo ""; \
-		for file in $$staged_files; do \
-			if [ -e "$$file" ]; then \
-				echo "🎯 Linting: $$file"; \
-				$(MAKE) --no-print-directory lint-smart "$$file"; \
-			fi; \
-		done; \
-	fi
+	$(call lint_git_files,staged,git diff --name-only --cached --diff-filter=ACM)
 
-# Lint files in specific commit (use COMMIT=hash)
 COMMIT ?= HEAD
-lint-commit:							## 🔍 Lint files changed in commit
-	@echo "🔍 Linting files changed in commit $(COMMIT)..."
-	@commit_files=$$(git diff-tree --no-commit-id --name-only -r $(COMMIT) 2>/dev/null || true); \
-	if [ -z "$$commit_files" ]; then \
-		echo "ℹ️  No files found in commit $(COMMIT)"; \
-	else \
-		echo "Files in commit $(COMMIT):"; \
-		echo "$$commit_files" | sed 's/^/  - /'; \
-		echo ""; \
-		for file in $$commit_files; do \
-			if [ -e "$$file" ]; then \
-				echo "🎯 Linting: $$file"; \
-				$(MAKE) --no-print-directory lint-smart "$$file"; \
-			fi; \
-		done; \
-	fi
+lint-commit:							## 🔍 Lint files changed in commit (COMMIT=hash)
+	$(call lint_git_files,in commit $(COMMIT),git diff-tree --no-commit-id --name-only -r $(COMMIT))
 
 # -----------------------------------------------------------------------------
 # 👁️ WATCH MODE - LINT ON FILE CHANGES
@@ -3888,9 +3926,9 @@ lint-parallel:							## 🚀 Run linters in parallel
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
 		uv pip install -q pytest-xdist"
 	@# Run fast linters in parallel
-	@$(MAKE) --no-print-directory ruff-check TARGET="$(TARGET)" & \
-	$(MAKE) --no-print-directory black-check TARGET="$(TARGET)" & \
-	$(MAKE) --no-print-directory isort-check TARGET="$(TARGET)" & \
+	@$(MAKE) --no-print-directory ruff RUFF_MODE=check TARGET="$(TARGET)" & \
+	$(MAKE) --no-print-directory black CHECK=1 TARGET="$(TARGET)" & \
+	$(MAKE) --no-print-directory isort CHECK=1 TARGET="$(TARGET)" & \
 	wait
 	@echo "✅ Parallel linting completed!"
 
@@ -4518,11 +4556,7 @@ endef
 # help: container-build-rust - Build image WITH Rust plugins (ENABLE_RUST_BUILD=1)
 # help: container-build-rust-lite - Build lite image WITH Rust plugins
 # help: container-rust       - Build with Rust and run container (all-in-one)
-# help: container-run        - Run container using detected runtime
-# help: container-run-host   - Run container using detected runtime with host networking
-# help: container-run-ssl    - Run container with TLS using detected runtime
-# help: container-run-ssl-host - Run container with TLS and host networking
-# help: container-run-ssl-jwt - Run container with TLS and JWT asymmetric keys
+# help: container-run        - Run container (CONTAINER_SSL=1 CONTAINER_HOST_NET=1 CONTAINER_JWT=1 CONTAINER_HTTP_SERVER=granian|gunicorn)
 # help: container-push       - Push image (handles localhost/ prefix)
 # help: container-stop       - Stop & remove the container
 # help: container-logs       - Stream container logs
@@ -4531,6 +4565,7 @@ endef
 # help: container-health     - Check container health status
 # help: image-list           - List all matching container images
 # help: image-clean          - Remove all project images
+# help: docker-nuke          - Remove ALL containers, images, volumes, networks, and build cache (destructive!)
 # help: image-retag          - Fix image naming consistency issues
 # help: use-docker           - Switch to Docker runtime
 # help: use-podman           - Switch to Podman runtime
@@ -4606,195 +4641,89 @@ container-rust: container-build-rust
 	@echo "🦀 Building and running container with Rust plugins..."
 	$(MAKE) container-run
 
+CONTAINER_SSL        ?=
+CONTAINER_HOST_NET   ?=
+CONTAINER_JWT        ?=
+CONTAINER_HTTP_SERVER ?=
+
 .PHONY: container-run
-container-run: container-check-image
-	@echo "🚀 Running with $(CONTAINER_RUNTIME)..."
+container-run: container-check-image  ## Run container (CONTAINER_SSL=1 CONTAINER_HOST_NET=1 CONTAINER_JWT=1 CONTAINER_HTTP_SERVER=granian|gunicorn)
+	$(if $(call is_true,$(CONTAINER_SSL)),@test -d certs || $(MAKE) --no-print-directory certs,)
+	$(if $(call is_true,$(CONTAINER_JWT)),@test -d certs/jwt || $(MAKE) --no-print-directory certs-jwt,)
+	@printf '🚀 Running with %s%s%s%s%s...\n' \
+		'$(CONTAINER_RUNTIME)' \
+		'$(if $(call is_true,$(CONTAINER_SSL)), (TLS),)' \
+		'$(if $(call is_true,$(CONTAINER_HOST_NET)), (host network),)' \
+		'$(if $(call is_true,$(CONTAINER_JWT)), (JWT asymmetric),)' \
+		'$(if $(CONTAINER_HTTP_SERVER), + $(CONTAINER_HTTP_SERVER),)'
 	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
 	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
 	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
+		$(if $(or $(call is_true,$(CONTAINER_SSL)),$(call is_true,$(CONTAINER_JWT))),--user $(shell id -u):$(shell id -g),) \
+		$(if $(call is_true,$(CONTAINER_HOST_NET)),--network=host,) \
 		--env-file=.env \
+		$(if $(CONTAINER_HTTP_SERVER),-e HTTP_SERVER=$(CONTAINER_HTTP_SERVER),) \
+		$(if $(call is_true,$(CONTAINER_SSL)),-e SSL=true -e CERT_FILE=certs/cert.pem -e KEY_FILE=certs/key.pem,) \
+		$(if $(call is_true,$(CONTAINER_JWT)),-e JWT_ALGORITHM=RS256 -e JWT_PUBLIC_KEY_PATH=/app/certs/jwt/public.pem -e JWT_PRIVATE_KEY_PATH=/app/certs/jwt/private.pem,) \
+		$(if $(or $(call is_true,$(CONTAINER_SSL)),$(call is_true,$(CONTAINER_JWT))),-v $(PWD)/certs:/app/certs:ro$(if $(filter podman,$(CONTAINER_RUNTIME)),$(COMMA)Z,),) \
 		-p 4444:4444 \
 		--restart=always \
 		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl --fail http://localhost:4444/health || exit 1" \
+		--health-cmd="curl $(if $(call is_true,$(CONTAINER_SSL)),-k,) --fail $(if $(call is_true,$(CONTAINER_SSL)),https,http)://localhost:4444/health || exit 1" \
 		--health-interval=1m --health-retries=3 \
 		--health-start-period=30s --health-timeout=10s \
 		-d $(call get_image_name)
 	@sleep 2
-	@echo "✅ Container started"
-	@echo "🔍 Health check status:"
-	@$(CONTAINER_RUNTIME) inspect $(PROJECT_NAME) --format='{{.State.Health.Status}}' 2>/dev/null || echo "No health check configured"
+	@printf '✅ Container started%s%s%s\n' \
+		'$(if $(call is_true,$(CONTAINER_SSL)), with TLS,)' \
+		'$(if $(call is_true,$(CONTAINER_JWT)), + JWT asymmetric,)' \
+		'$(if $(CONTAINER_HTTP_SERVER), ($(CONTAINER_HTTP_SERVER)),)'
+	$(if $(call is_true,$(CONTAINER_JWT)),@echo "🔐 JWT Algorithm: RS256",)
+	$(if $(call is_true,$(CONTAINER_JWT)),@echo "📁 Keys mounted: /app/certs/jwt/{private$(COMMA)public}.pem",)
 
-.PHONY: container-run-host
+# --- Deprecated container-run aliases ---
+# deprecated: container-run-host        - Use "make container-run CONTAINER_HOST_NET=1" instead (v1.2.0)
+# deprecated: container-run-ssl         - Use "make container-run CONTAINER_SSL=1" instead (v1.2.0)
+# deprecated: container-run-ssl-host    - Use "make container-run CONTAINER_SSL=1 CONTAINER_HOST_NET=1" instead (v1.2.0)
+# deprecated: container-run-ssl-jwt     - Use "make container-run CONTAINER_SSL=1 CONTAINER_JWT=1" instead (v1.2.0)
+# deprecated: container-run-granian     - Use "make container-run CONTAINER_HTTP_SERVER=granian" instead (v1.2.0)
+# deprecated: container-run-gunicorn    - Use "make container-run CONTAINER_HTTP_SERVER=gunicorn" instead (v1.2.0)
+# deprecated: container-run-granian-ssl - Use "make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=granian" instead (v1.2.0)
+# deprecated: container-run-gunicorn-ssl - Use "make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=gunicorn" instead (v1.2.0)
+.PHONY: container-run-host container-run-ssl container-run-ssl-host container-run-ssl-jwt \
+	container-run-granian container-run-gunicorn container-run-granian-ssl container-run-gunicorn-ssl
+
 container-run-host: container-check-image
-	@echo "🚀 Running with $(CONTAINER_RUNTIME)..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--env-file=.env \
-		--network=host \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl --fail http://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started"
-	@echo "🔍 Health check status:"
-	@$(CONTAINER_RUNTIME) inspect $(PROJECT_NAME) --format='{{.State.Health.Status}}' 2>/dev/null || echo "No health check configured"
+	$(call deprecated_target,container-run-host,make container-run CONTAINER_HOST_NET=1,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_HOST_NET=1
 
+container-run-ssl: container-check-image
+	$(call deprecated_target,container-run-ssl,make container-run CONTAINER_SSL=1,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_SSL=1
 
-.PHONY: container-run-ssl
-container-run-ssl: certs container-check-image
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) (TLS)..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--user $(shell id -u):$(shell id -g) \
-		--env-file=.env \
-		-e SSL=true \
-		-e CERT_FILE=certs/cert.pem \
-		-e KEY_FILE=certs/key.pem \
-		-v $(PWD)/certs:/app/certs:ro$(if $(filter podman,$(CONTAINER_RUNTIME)),$(COMMA)Z,) \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl -k --fail https://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with TLS"
+container-run-ssl-host: container-check-image
+	$(call deprecated_target,container-run-ssl-host,make container-run CONTAINER_SSL=1 CONTAINER_HOST_NET=1,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_SSL=1 CONTAINER_HOST_NET=1
 
-.PHONY: container-run-ssl-host
-container-run-ssl-host: certs container-check-image
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) (TLS, host network)..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--user $(shell id -u):$(shell id -g) \
-		--network=host \
-		--env-file=.env \
-		-e SSL=true \
-		-e CERT_FILE=certs/cert.pem \
-		-e KEY_FILE=certs/key.pem \
-		-v $(PWD)/certs:/app/certs:ro$(if $(filter podman,$(CONTAINER_RUNTIME)),$(COMMA)Z,) \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl -k --fail https://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with TLS (host networking)"
+container-run-ssl-jwt: container-check-image
+	$(call deprecated_target,container-run-ssl-jwt,make container-run CONTAINER_SSL=1 CONTAINER_JWT=1,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_SSL=1 CONTAINER_JWT=1
 
-.PHONY: container-run-ssl-jwt
-container-run-ssl-jwt: certs certs-jwt container-check-image
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) (TLS + JWT asymmetric)..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--user $(shell id -u):$(shell id -g) \
-		--env-file=.env \
-		-e SSL=true \
-		-e CERT_FILE=certs/cert.pem \
-		-e KEY_FILE=certs/key.pem \
-		-e JWT_ALGORITHM=RS256 \
-		-e JWT_PUBLIC_KEY_PATH=/app/certs/jwt/public.pem \
-		-e JWT_PRIVATE_KEY_PATH=/app/certs/jwt/private.pem \
-		-v $(PWD)/certs:/app/certs:ro$(if $(filter podman,$(CONTAINER_RUNTIME)),$(COMMA)Z,) \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl -k --fail https://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with TLS + JWT asymmetric authentication"
-	@echo "🔐 JWT Algorithm: RS256"
-	@echo "📁 Keys mounted: /app/certs/jwt/{private,public}.pem"
+container-run-granian: container-check-image
+	$(call deprecated_target,container-run-granian,make container-run CONTAINER_HTTP_SERVER=granian,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_HTTP_SERVER=granian
 
-# HTTP Server selection targets
-container-run-granian: container-check-image  ## Run container with Granian (Rust-based HTTP server)
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) + Granian..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--env-file=.env \
-		-e HTTP_SERVER=granian \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl --fail http://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with Granian"
+container-run-gunicorn: container-check-image
+	$(call deprecated_target,container-run-gunicorn,make container-run CONTAINER_HTTP_SERVER=gunicorn,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_HTTP_SERVER=gunicorn
 
-container-run-gunicorn: container-check-image  ## Run container with Gunicorn + Uvicorn
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) + Gunicorn..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--env-file=.env \
-		-e HTTP_SERVER=gunicorn \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl --fail http://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with Gunicorn"
+container-run-granian-ssl: container-check-image
+	$(call deprecated_target,container-run-granian-ssl,make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=granian,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=granian
 
-container-run-granian-ssl: certs container-check-image  ## Run container with Granian + TLS
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) + Granian (TLS)..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--user $(shell id -u):$(shell id -g) \
-		--env-file=.env \
-		-e HTTP_SERVER=granian \
-		-e SSL=true \
-		-e CERT_FILE=certs/cert.pem \
-		-e KEY_FILE=certs/key.pem \
-		-v $(PWD)/certs:/app/certs:ro$(if $(filter podman,$(CONTAINER_RUNTIME)),$(COMMA)Z,) \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl -k --fail https://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with Granian + TLS"
-
-container-run-gunicorn-ssl: certs container-check-image  ## Run container with Gunicorn + TLS
-	@echo "🚀 Running with $(CONTAINER_RUNTIME) + Gunicorn (TLS)..."
-	-$(CONTAINER_RUNTIME) stop $(PROJECT_NAME) 2>/dev/null || true
-	-$(CONTAINER_RUNTIME) rm $(PROJECT_NAME) 2>/dev/null || true
-	$(CONTAINER_RUNTIME) run --name $(PROJECT_NAME) \
-		--user $(shell id -u):$(shell id -g) \
-		--env-file=.env \
-		-e HTTP_SERVER=gunicorn \
-		-e SSL=true \
-		-e CERT_FILE=certs/cert.pem \
-		-e KEY_FILE=certs/key.pem \
-		-v $(PWD)/certs:/app/certs:ro$(if $(filter podman,$(CONTAINER_RUNTIME)),$(COMMA)Z,) \
-		-p 4444:4444 \
-		--restart=always \
-		--memory=$(CONTAINER_MEMORY) --cpus=$(CONTAINER_CPUS) \
-		--health-cmd="curl -k --fail https://localhost:4444/health || exit 1" \
-		--health-interval=1m --health-retries=3 \
-		--health-start-period=30s --health-timeout=10s \
-		-d $(call get_image_name)
-	@sleep 2
-	@echo "✅ Container started with Gunicorn + TLS"
+container-run-gunicorn-ssl: container-check-image
+	$(call deprecated_target,container-run-gunicorn-ssl,make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=gunicorn,1.2.0)
+	@$(MAKE) --no-print-directory container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=gunicorn
 
 .PHONY: container-push
 container-push: container-check-image
@@ -4931,6 +4860,29 @@ image-clean:
 		grep -E "(localhost/)?$(IMAGE_BASE)" | \
 		xargs $(XARGS_FLAGS) $(CONTAINER_RUNTIME) rmi -f 2>/dev/null
 	@echo "✅ Images cleaned"
+
+.PHONY: docker-nuke
+docker-nuke:
+	@echo "⚠️  This will remove ALL containers, images, volumes, networks, and build cache."
+	@echo "    Runtime: $(CONTAINER_RUNTIME)"
+	@printf "    Continue? [y/N] "; read ans; \
+	if [ "$$ans" = "y" ] || [ "$$ans" = "Y" ]; then \
+		echo "🛑 Stopping and removing all containers..."; \
+		$(CONTAINER_RUNTIME) ps -qa | xargs $(XARGS_FLAGS) $(CONTAINER_RUNTIME) rm -f 2>/dev/null || true; \
+		echo "🗑️  Removing all images..."; \
+		$(CONTAINER_RUNTIME) images -q | xargs $(XARGS_FLAGS) $(CONTAINER_RUNTIME) rmi -f 2>/dev/null || true; \
+		echo "💾 Removing all volumes..."; \
+		$(CONTAINER_RUNTIME) volume ls -q | xargs $(XARGS_FLAGS) $(CONTAINER_RUNTIME) volume rm -f 2>/dev/null || true; \
+		echo "🌐 Pruning networks..."; \
+		$(CONTAINER_RUNTIME) network prune -f 2>/dev/null || true; \
+		echo "🏗️  Pruning build cache..."; \
+		$(CONTAINER_RUNTIME) builder prune -af 2>/dev/null || true; \
+		echo "🧹 Running system prune..."; \
+		$(CONTAINER_RUNTIME) system prune -af 2>/dev/null || true; \
+		echo "✅ Docker environment nuked."; \
+	else \
+		echo "❌ Cancelled"; \
+	fi
 
 # Fix image naming issues
 .PHONY: image-retag
@@ -6778,135 +6730,91 @@ playwright-preflight:
 		exit 1; \
 	fi
 
-## --- UI Test Execution ------------------------------------------------------
-test-ui: playwright-install
-	@echo "🎭 Running Playwright UI tests with visible browser..."
+## --- Playwright test macro ---------------------------------------------------
+# Run a Playwright test variant.
+# $(1) = label (e.g., "headed", "headless parallel")
+# $(2) = directories to mkdir -p (space-separated, or empty for none)
+# $(3) = extra pip packages (space-separated, or empty)
+# $(4) = env var exports before pytest (e.g., "PWDEBUG=1", or empty)
+# $(5) = pytest arguments (variant-specific part)
+# $(6) = fail behavior: "fail" or "continue" (|| true)
+define run_playwright_test
+	@echo "🎭 Running Playwright UI tests ($(1))..."
 	@$(MAKE) --no-print-directory playwright-preflight
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS)
+	$(if $(strip $(2)),@mkdir -p $(2),)
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
+		$(if $(strip $(3)),uv pip install -q $(3) &&,) \
+		$(if $(strip $(4)),export $(4) &&,) \
 		export TEST_BASE_URL='$(TEST_BASE_URL)' && \
-		python -m pytest ${PLAYWRIGHT_TEST_TARGET} -v --headed --screenshot=only-on-failure \
-		--browser chromium || { echo '❌ UI tests failed!'; exit 1; }"
+		pytest $(5) \
+		--browser chromium \
+		$(if $(filter fail,$(6)),|| { echo '❌ UI tests failed!'; exit 1; },|| true)"
+endef
+
+## --- UI Test Execution ------------------------------------------------------
+test-ui: playwright-install
+	$(call run_playwright_test,headed,$(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS),,,\
+		$(PLAYWRIGHT_TEST_TARGET) -v --headed --screenshot=only-on-failure,fail)
 	@echo "✅ UI tests completed!"
 
 test-ui-headless: playwright-install
-	@echo "🎭 Running Playwright UI tests in headless mode..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		export TEST_BASE_URL='$(TEST_BASE_URL)' && \
-		pytest ${PLAYWRIGHT_TEST_TARGET} -v --screenshot=only-on-failure \
-		--browser chromium || { echo '❌ UI tests failed!'; exit 1; }"
+	$(call run_playwright_test,headless,$(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS),,,\
+		$(PLAYWRIGHT_TEST_TARGET) -v --screenshot=only-on-failure,fail)
 	@echo "✅ UI tests completed!"
 
 test-ui-headless-parallel: playwright-install
-	@echo "🎭 Running Playwright UI tests headless in parallel..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		uv pip install -q pytest-xdist && \
-		export TEST_BASE_URL='$(TEST_BASE_URL)' && \
-		pytest ${PLAYWRIGHT_TEST_TARGET} -v -n auto --dist loadscope \
-		--screenshot=only-on-failure \
-		--browser chromium || { echo '❌ UI tests failed!'; exit 1; }"
+	$(call run_playwright_test,headless parallel,$(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS),pytest-xdist,,\
+		$(PLAYWRIGHT_TEST_TARGET) -v -n auto --dist loadscope --screenshot=only-on-failure,fail)
 	@echo "✅ UI parallel tests completed!"
 
 test-ui-debug: playwright-install
-	@echo "🎭 Running Playwright UI tests with Playwright Inspector..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		PWDEBUG=1 TEST_BASE_URL='$(TEST_BASE_URL)' pytest ${PLAYWRIGHT_TEST_TARGET} -v -s --headed \
-		--browser chromium"
+	$(call run_playwright_test,debug,$(PLAYWRIGHT_SCREENSHOTS) $(PLAYWRIGHT_REPORTS),,PWDEBUG=1,\
+		$(PLAYWRIGHT_TEST_TARGET) -v -s --headed,fail)
 
 test-ui-smoke: playwright-install
-	@echo "🎭 Running Playwright UI smoke tests..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v -m smoke --headed \
-		--browser chromium || { echo '❌ UI smoke tests failed!'; exit 1; }"
+	$(call run_playwright_test,smoke,,,,\
+		$(PLAYWRIGHT_DIR)/ -v -m smoke --headed,fail)
 	@echo "✅ UI smoke tests passed!"
 
 test-ui-ci-smoke: playwright-install
-	@echo "🎭 Running Playwright CI smoke tests (headless subset)..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest -v --screenshot=only-on-failure \
-		--browser chromium $(PLAYWRIGHT_CI_SMOKE_TESTS) || { echo '❌ UI CI smoke tests failed!'; exit 1; }"
+	$(call run_playwright_test,CI smoke,$(PLAYWRIGHT_REPORTS),,,\
+		-v --screenshot=only-on-failure $(PLAYWRIGHT_CI_SMOKE_TESTS),fail)
 	@echo "✅ UI CI smoke tests passed!"
 
 test-ui-parallel: playwright-install
-	@echo "🎭 Running Playwright UI tests in parallel..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		uv pip install -q pytest-xdist && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v -n auto --dist loadscope \
-		--browser chromium || { echo '❌ UI tests failed!'; exit 1; }"
+	$(call run_playwright_test,parallel,,pytest-xdist,,\
+		$(PLAYWRIGHT_DIR)/ -v -n auto --dist loadscope,fail)
 	@echo "✅ UI parallel tests completed!"
 
 ## --- UI Test Reporting ------------------------------------------------------
 test-ui-report: playwright-install
-	@echo "🎭 Running Playwright UI tests with HTML report..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		uv pip install -q pytest-html && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v --screenshot=only-on-failure \
-		--html=$(PLAYWRIGHT_REPORTS)/report.html --self-contained-html \
-		--browser chromium || true"
+	$(call run_playwright_test,report,$(PLAYWRIGHT_REPORTS),pytest-html,,\
+		$(PLAYWRIGHT_DIR)/ -v --screenshot=only-on-failure --html=$(PLAYWRIGHT_REPORTS)/report.html --self-contained-html,continue)
 	@echo "✅ UI test report generated: $(PLAYWRIGHT_REPORTS)/report.html"
 	@echo "   Open with: open $(PLAYWRIGHT_REPORTS)/report.html"
 
 test-ui-coverage: playwright-install
-	@echo "🎭 Running Playwright UI tests with coverage..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v --cov=mcpgateway.admin \
-		--cov-report=html:$(PLAYWRIGHT_REPORTS)/coverage \
-		--cov-report=term --browser chromium || true"
+	$(call run_playwright_test,coverage,$(PLAYWRIGHT_REPORTS),,,\
+		$(PLAYWRIGHT_DIR)/ -v --cov=mcpgateway.admin --cov-report=html:$(PLAYWRIGHT_REPORTS)/coverage --cov-report=term,continue)
 	@echo "✅ UI coverage report: $(PLAYWRIGHT_REPORTS)/coverage/index.html"
 
 test-ui-screenshots: playwright-install
-	@echo "🎭 Running Playwright UI tests with always-on screenshots..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_REPORTS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v --screenshot=on \
-		--browser chromium || { echo '❌ UI tests failed!'; exit 1; }"
+	$(call run_playwright_test,screenshots,$(PLAYWRIGHT_REPORTS),,,\
+		$(PLAYWRIGHT_DIR)/ -v --screenshot=on,fail)
 	@echo "✅ Playwright screenshots captured"
 	@echo "📁 Artifacts saved to: test-results/"
 
 test-ui-record: playwright-install
-	@echo "🎭 Running Playwright UI tests with video recording + screenshots..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@mkdir -p $(PLAYWRIGHT_VIDEOS)
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v --video=on --screenshot=on --slowmo $(PLAYWRIGHT_SLOWMO) \
-		--browser chromium || { echo '❌ UI tests failed!'; exit 1; }"
+	$(call run_playwright_test,record,$(PLAYWRIGHT_VIDEOS),,,\
+		$(PLAYWRIGHT_DIR)/ -v --video=on --screenshot=on --slowmo $(PLAYWRIGHT_SLOWMO),fail)
 	@echo "✅ Playwright videos + screenshots saved"
 	@echo "📁 Artifacts saved to: test-results/"
 
 ## --- UI Test Utilities ------------------------------------------------------
 test-ui-update-snapshots: playwright-install
-	@echo "🎭 Updating Playwright visual regression snapshots..."
-	@$(MAKE) --no-print-directory playwright-preflight
-	@test -d "$(VENV_DIR)" || $(MAKE) venv
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
-		TEST_BASE_URL='$(TEST_BASE_URL)' pytest $(PLAYWRIGHT_DIR)/ -v --update-snapshots \
-		--browser chromium"
+	$(call run_playwright_test,update-snapshots,,,,\
+		$(PLAYWRIGHT_DIR)/ -v --update-snapshots,fail)
 	@echo "✅ Snapshots updated!"
 
 test-ui-clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       - SSRF_DNS_FAIL_CLOSED=${SSRF_DNS_FAIL_CLOSED:-false}
       # Database connection: Via PgBouncer (default) or direct PostgreSQL
       # PgBouncer provides connection pooling for better performance under high concurrency
-      - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@pgbouncer:6432/mcp
+      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@pgbouncer:6432/mcp}
       # Direct PostgreSQL connection (bypass PgBouncer - increase DB_POOL_SIZE if using):
       # - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp
       # SQLAlchemy query logging (useful for N+1 detection; noisy under load)
@@ -422,7 +422,7 @@ services:
       # ═══════════════════════════════════════════════════════════════════════════
       # Gunicorn Configuration (used when HTTP_SERVER=gunicorn)
       # ═══════════════════════════════════════════════════════════════════════════
-      - GUNICORN_WORKERS=24                    # Worker processes (match CPU cores)
+      - GUNICORN_WORKERS=${GUNICORN_WORKERS:-24}  # Worker processes per replica
       - GUNICORN_TIMEOUT=120                   # Worker timeout in seconds
       - GUNICORN_GRACEFUL_TIMEOUT=60           # Grace period for worker shutdown
       - GUNICORN_KEEP_ALIVE=30                 # Keep-alive timeout (matches SSE keepalive)
@@ -471,7 +471,7 @@ services:
       # Session pooling for MCP ClientSessions reduces per-request overhead from
       # ~20ms to ~1-2ms (10-20x improvement). Sessions are isolated per user/tenant
       # via identity hashing to prevent cross-user session sharing.
-      - MCP_SESSION_POOL_ENABLED=true              # Enable session pooling (default: false, enabled for docker-compose)
+      - MCP_SESSION_POOL_ENABLED=${MCP_SESSION_POOL_ENABLED:-true}  # Session pooling (broken sessions are now evicted on error)
       - MCP_SESSION_POOL_MAX_PER_KEY=200           # Max sessions per (URL, identity, transport) - increased from 150 for 4000+ users
       - MCP_SESSION_POOL_TTL=300.0                 # Session TTL in seconds (default: 300)
       - MCP_SESSION_POOL_HEALTH_CHECK_INTERVAL=60.0  # Idle time before health check (default: 60)
@@ -484,8 +484,7 @@ services:
       - MCP_SESSION_POOL_EXPLICIT_HEALTH_RPC=false  # Force RPC on health checks (default: false)
       # Configurable health check chain - ordered list of methods to try (JSON array)
       # Options: ping, list_tools, list_prompts, list_resources, skip
-      # - MCP_SESSION_POOL_HEALTH_CHECK_METHODS=["ping", "skip"]  # Try ping, skip if unsupported
-      - MCP_SESSION_POOL_HEALTH_CHECK_METHODS=["skip"]  # skip, highest performance
+      - MCP_SESSION_POOL_HEALTH_CHECK_METHODS=["ping", "skip"]  # Try ping, fall back to skip if unsupported
       - MCP_SESSION_POOL_HEALTH_CHECK_TIMEOUT=5.0               # Timeout per health check attempt
       # ═══════════════════════════════════════════════════════════════════════════
       # CPU Spin Loop Mitigation (Issue #2360, anyio#695)
@@ -611,14 +610,14 @@ services:
 
     deploy:
       mode: replicated
-      replicas: 3
+      replicas: ${GATEWAY_REPLICAS:-3}
       resources:
         limits:
-          cpus: '8'
-          memory: 8G
+          cpus: '${GATEWAY_CPU_LIMIT:-8}'
+          memory: ${GATEWAY_MEM_LIMIT:-8G}
         reservations:
-          cpus: '4'
-          memory: 4G
+          cpus: '${GATEWAY_CPU_RESERVATION:-4}'
+          memory: ${GATEWAY_MEM_RESERVATION:-4G}
 
     # ──────────────────────────────────────────────────────────────────────
     # Volume Mounts
@@ -626,6 +625,7 @@ services:
     # Mount catalog configuration and SSL certificates
     volumes:
       - ./mcp-catalog.yml:/app/mcp-catalog.yml:ro # mount catalog configuration
+      - ${PLUGINS_DIR:-./plugins}:/app/plugins:ro # override the plugins directory
       # - ./certs:/app/certs:ro   # mount certs folder read-only (includes both SSL and JWT keys)
     #
     # SSL/TLS Certificate Setup:
@@ -1847,6 +1847,15 @@ services:
         except Exception as e:
             print(f'Note: {e}')
 
+        VIRTUAL_SERVER_ID = 'b8e3f1a2c4d5e6f7a1b2c3d4e5f6a7b8'
+
+        # Delete existing virtual server if present
+        try:
+            api_request('DELETE', f'/servers/{VIRTUAL_SERVER_ID}')
+            print(f'Deleted existing virtual server {VIRTUAL_SERVER_ID}')
+        except Exception as e:
+            print(f'Note: No existing virtual server to delete (or error: {e})')
+
         # Register the gateway
         try:
             result = api_request('POST', '/gateways', {
@@ -1854,9 +1863,54 @@ services:
                 'url': 'http://fast_test_server:8880/mcp',
                 'transport': 'STREAMABLEHTTP'
             })
-            print(f'✅ Registered fast_test_server: {result.get(\"id\", \"unknown\")}')
+            gateway_id = result.get('id', '')
+            print(f'✅ Registered fast_test_server (gateway_id: {gateway_id})')
         except Exception as e:
             print(f'❌ Registration failed: {e}')
+            exit(1)
+
+        # Wait for tools to sync from the gateway
+        print('Waiting for tools to sync...')
+        for i in range(30):
+            time.sleep(1)
+            try:
+                tools = api_request('GET', '/tools')
+                fast_test_tools = [t for t in tools if t.get('gatewayId') == gateway_id]
+                if fast_test_tools:
+                    print(f'Found {len(fast_test_tools)} tools from fast_test gateway')
+                    break
+            except Exception:
+                pass
+            print(f'Waiting for sync... ({i+1}/30)')
+        else:
+            print('Warning: No tools synced, continuing anyway...')
+
+        # Collect tool IDs from the fast_test gateway
+        tool_ids = []
+        try:
+            tools = api_request('GET', '/tools')
+            tool_ids = [t['id'] for t in tools if t.get('gatewayId') == gateway_id]
+            print(f'Tools: {[t[\"name\"] for t in tools if t.get(\"gatewayId\") == gateway_id]}')
+        except Exception as e:
+            print(f'Failed to fetch tools: {e}')
+
+        # Create virtual server
+        print('Creating virtual server...')
+        try:
+            server_payload = {
+                'server': {
+                    'id': VIRTUAL_SERVER_ID,
+                    'name': 'Fast Test Server',
+                    'description': 'Virtual server exposing Fast Test MCP tools (echo, time, stats)',
+                    'associated_tools': tool_ids,
+                    'associated_resources': [],
+                    'associated_prompts': []
+                }
+            }
+            result = api_request('POST', '/servers', server_payload)
+            print(f'✅ Virtual server created: {VIRTUAL_SERVER_ID} with {len(tool_ids)} tools')
+        except Exception as e:
+            print(f'❌ Failed to create virtual server: {e}')
             exit(1)
         "
         echo "✅ Registration complete!"
@@ -2023,7 +2077,7 @@ services:
         export MCPGATEWAY_BEARER_TOKEN="$$(cat /tokens/gateway.jwt)"
         MODE="$${LOCUST_MODE:-master}"
         if [ "$$MODE" = "headless" ]; then
-          exec locust -f /mnt/locust/locustfile.py \
+          exec locust -f /mnt/locust/$${LOCUST_LOCUSTFILE:-locustfile.py} \
             --host=http://nginx:80 \
             --users="$${LOCUST_USERS:-100}" \
             --spawn-rate="$${LOCUST_SPAWN_RATE:-10}" \
@@ -2034,7 +2088,7 @@ services:
             --only-summary
         fi
 
-        exec locust -f /mnt/locust/locustfile.py \
+        exec locust -f /mnt/locust/$${LOCUST_LOCUSTFILE:-locustfile.py} \
           --host=http://nginx:80 \
           --web-host=0.0.0.0 --web-port=8089 \
           --master --expect-workers="$${LOCUST_EXPECT_WORKERS:-1}" \
@@ -2043,6 +2097,7 @@ services:
       - HOME=/tmp
       - LOCUST_EXPECT_WORKERS=${LOCUST_EXPECT_WORKERS:-1}
       - LOCUST_MODE=${LOCUST_MODE:-master}          # master (default) or headless
+      - LOCUST_LOCUSTFILE=${LOCUST_LOCUSTFILE:-locustfile.py}
       - LOCUST_USERS=${LOCUST_USERS:-100}
       - LOCUST_SPAWN_RATE=${LOCUST_SPAWN_RATE:-10}
       - LOCUST_RUN_TIME=${LOCUST_RUN_TIME:-5m}
@@ -2076,11 +2131,12 @@ services:
         set -eu
         while [ ! -s /tokens/gateway.jwt ]; do echo "Waiting for gateway JWT..."; sleep 0.5; done
         export MCPGATEWAY_BEARER_TOKEN="$$(cat /tokens/gateway.jwt)"
-        exec locust -f /mnt/locust/locustfile.py \
+        exec locust -f /mnt/locust/$${LOCUST_LOCUSTFILE:-locustfile.py} \
           --host=http://nginx:80 \
           --worker --master-host=locust
     environment:
       - HOME=/tmp
+      - LOCUST_LOCUSTFILE=${LOCUST_LOCUSTFILE:-locustfile.py}
     deploy:
       resources:
         limits:

--- a/docs/docs/architecture/adr/025-granian-http-server.md
+++ b/docs/docs/architecture/adr/025-granian-http-server.md
@@ -180,12 +180,12 @@ services:
 ```bash
 # Run container with Gunicorn (default)
 make container-run
-make container-run-gunicorn
-make container-run-gunicorn-ssl
+make container-run CONTAINER_HTTP_SERVER=gunicorn
+make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=gunicorn
 
 # Run container with Granian (alternative)
-make container-run-granian
-make container-run-granian-ssl
+make container-run CONTAINER_HTTP_SERVER=granian
+make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=granian
 
 # Or pass HTTP_SERVER directly
 docker run mcpgateway/mcpgateway                         # Gunicorn (default)

--- a/docs/docs/manage/tuning.md
+++ b/docs/docs/manage/tuning.md
@@ -123,11 +123,11 @@ make serve-granian-http2      # Granian with HTTP/2 + TLS
 
 # Container with Gunicorn (default)
 make container-run
-make container-run-gunicorn-ssl
+make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=gunicorn
 
 # Container with Granian (alternative)
-make container-run-granian
-make container-run-granian-ssl
+make container-run CONTAINER_HTTP_SERVER=granian
+make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=granian
 
 # Docker Compose (default uses Gunicorn)
 docker compose up

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -154,6 +154,7 @@ Full runbook, environment variable reference, and results template: [`tests/manu
 
 ## 🔍 Additional Testing
 
+- [Load Testing Hints](load-testing-hints.md) - environment variables and workflows for containerized load tests
 - [Acceptance Testing](acceptance.md) - formal acceptance criteria
 - [Fuzzing](fuzzing.md) - fuzz testing for edge cases
 

--- a/docs/docs/testing/load-testing-hints.md
+++ b/docs/docs/testing/load-testing-hints.md
@@ -1,0 +1,183 @@
+# Load Testing Hints
+
+Quick reference for running containerized load tests with `docker compose` and Locust.
+
+---
+
+## Starting the Testing Stack
+
+```bash
+# Default: starts gateway, nginx, fast_test_server, Locust (web UI at :8089)
+make testing-up
+```
+
+All load testing services run inside Docker on the `mcpnet` network. Locust targets `http://nginx:80` by default.
+
+---
+
+## Environment Variable Reference
+
+### Locust Configuration
+
+Override these when calling `make testing-up` or `docker compose --profile testing up`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOCUST_LOCUSTFILE` | `locustfile.py` | Which locustfile to run (any file in `tests/loadtest/`) |
+| `LOCUST_MODE` | `master` | `master` for web UI, `headless` for CLI-only |
+| `LOCUST_USERS` | `100` | Number of concurrent simulated users |
+| `LOCUST_SPAWN_RATE` | `10` | Users spawned per second during ramp-up |
+| `LOCUST_RUN_TIME` | `5m` | Test duration (headless mode only), e.g. `30s`, `5m`, `1h` |
+| `LOCUST_EXPECT_WORKERS` | `1` | Number of distributed workers the master expects |
+
+**Examples:**
+
+```bash
+# Run the echo delay locustfile with web UI
+LOCUST_LOCUSTFILE=locustfile_echo_delay.py make testing-up
+
+# Headless run with 500 users for 2 minutes
+LOCUST_LOCUSTFILE=locustfile_echo_delay.py LOCUST_MODE=headless \
+  LOCUST_USERS=500 LOCUST_SPAWN_RATE=50 LOCUST_RUN_TIME=120s \
+  make testing-up
+
+# Use the high-throughput locustfile
+LOCUST_LOCUSTFILE=locustfile_highthroughput.py make testing-up
+
+# Scale to 4 Locust workers for higher concurrency
+TESTING_LOCUST_WORKERS=4 make testing-up
+```
+
+### Gateway Scaling
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GATEWAY_REPLICAS` | `3` | Number of gateway container instances |
+| `GATEWAY_CPU_LIMIT` | `8` | CPU limit per replica |
+| `GATEWAY_MEM_LIMIT` | `8G` | Memory limit per replica |
+| `GATEWAY_CPU_RESERVATION` | `4` | CPU reservation per replica |
+| `GATEWAY_MEM_RESERVATION` | `4G` | Memory reservation per replica |
+| `GUNICORN_WORKERS` | `24` | Gunicorn worker processes per replica |
+
+**Examples:**
+
+```bash
+# 6 small replicas with 5 workers each (30 total workers)
+GATEWAY_REPLICAS=6 GATEWAY_CPU_LIMIT=1 GATEWAY_MEM_LIMIT=2G \
+  GATEWAY_CPU_RESERVATION=0.5 GATEWAY_MEM_RESERVATION=1G \
+  GUNICORN_WORKERS=5 make testing-up
+
+# Single large replica for debugging
+GATEWAY_REPLICAS=1 GUNICORN_WORKERS=4 make testing-up
+```
+
+### Gateway Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `postgresql+psycopg://...@pgbouncer:6432/mcp` | Database connection string |
+| `POSTGRES_PASSWORD` | `mysecretpassword` | PostgreSQL password (used in default `DATABASE_URL`) |
+| `MCP_SESSION_POOL_ENABLED` | `true` | Enable MCP client session pooling |
+
+**Examples:**
+
+```bash
+# Bypass PgBouncer and connect directly to PostgreSQL
+DATABASE_URL='postgresql+psycopg://postgres:mysecretpassword@postgres:5432/mcp' make testing-up
+
+# Disable session pooling (uses fresh connection per tool call — slower but more reliable)
+MCP_SESSION_POOL_ENABLED=false make testing-up
+
+# Combine: small replicas + direct Postgres + echo delay test + no pool
+GATEWAY_REPLICAS=6 GUNICORN_WORKERS=5 MCP_SESSION_POOL_ENABLED=false \
+  DATABASE_URL='postgresql+psycopg://postgres:mysecretpassword@postgres:5432/mcp' \
+  LOCUST_LOCUSTFILE=locustfile_echo_delay.py \
+  make testing-up
+```
+
+### Echo Delay Test Configuration
+
+These are read by `locustfile_echo_delay.py` inside the Locust container:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECHO_DELAY_MS` | `500` | Milliseconds the echo tool waits before responding |
+| `ECHO_DELAY_SERVER_ID` | *(fixed UUID)* | Virtual server ID to target (matches `register_fast_test`) |
+
+The echo delay test sends MCP `tools/call` requests through the gateway's Streamable HTTP endpoint (`/servers/{id}/mcp`), measuring how efficiently the gateway handles I/O-bound backends.
+
+---
+
+## Available Locustfiles
+
+| File | Description |
+|------|-------------|
+| `locustfile.py` | Main comprehensive test with 20+ user classes |
+| `locustfile_echo_delay.py` | Streamable HTTP echo with configurable delay |
+| `locustfile_baseline.py` | Component baselines (REST, MCP, PostgreSQL, Redis) |
+| `locustfile_highthroughput.py` | Optimized for maximum RPS |
+| `locustfile_slow_time_server.py` | Resilience testing against slow backends |
+| `locustfile_spin_detector.py` | CPU spin loop detection (spike/drop pattern) |
+| `locustfile_agentgateway_mcp_server_time.py` | External MCP server testing |
+
+---
+
+## Typical Workflows
+
+### Measure gateway overhead
+
+Compare direct server performance vs. going through the gateway:
+
+```bash
+# 1. Baseline: hit the fast_test_server REST API directly
+hey -n 10000 -c 200 -m POST -T 'application/json' \
+    -d '{"message":"hello"}' http://localhost:8880/api/echo
+
+# 2. Through gateway: Streamable HTTP MCP path
+LOCUST_LOCUSTFILE=locustfile_echo_delay.py ECHO_DELAY_MS=0 make testing-up
+```
+
+### Measure throughput with slow backends
+
+```bash
+# 500ms backend delay — theoretical max with 200 users is ~400 RPS
+LOCUST_LOCUSTFILE=locustfile_echo_delay.py make testing-up
+# Open http://localhost:8089, set 200 users, observe actual RPS
+```
+
+### Stress test with many replicas
+
+```bash
+LOCUST_LOCUSTFILE=locustfile_echo_delay.py \
+  LOCUST_USERS=2000 LOCUST_SPAWN_RATE=100 \
+  TESTING_LOCUST_WORKERS=4 \
+  GATEWAY_REPLICAS=6 GUNICORN_WORKERS=5 \
+  make testing-up
+```
+
+### Headless CI run
+
+```bash
+LOCUST_LOCUSTFILE=locustfile_echo_delay.py \
+  LOCUST_MODE=headless LOCUST_USERS=100 LOCUST_RUN_TIME=60s \
+  make testing-up
+# Reports saved to reports/locust_report.html and reports/locust_*.csv
+```
+
+---
+
+## Stopping the Stack
+
+```bash
+make testing-down
+```
+
+---
+
+## Host Tuning
+
+For 500+ concurrent users, tune the host OS first. See [Performance Testing](performance.md#host-tcp-tuning-for-load-testing) for TCP, file descriptor, and memory settings, or run:
+
+```bash
+sudo scripts/tune-loadtest.sh
+```

--- a/mcp-servers/rust/fast-test-server/Cargo.toml
+++ b/mcp-servers/rust/fast-test-server/Cargo.toml
@@ -29,6 +29,10 @@ serde_json = "1.0"
 # Schema generation (re-exported via rmcp with server feature)
 schemars = "0.8"
 
+# Random number generation (normal distribution for delay jitter)
+rand = "0.8"
+rand_distr = "0.4"
+
 # Error handling
 anyhow = "1.0"
 

--- a/mcp-servers/rust/fast-test-server/src/main.rs
+++ b/mcp-servers/rust/fast-test-server/src/main.rs
@@ -27,6 +27,8 @@ use rmcp::{
         session::local::LocalSessionManager,
     },
 };
+use rand::Rng;
+use rand_distr::Normal;
 use serde_json::json;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -44,6 +46,12 @@ const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct EchoRequest {
     /// The message to echo back
     pub message: String,
+    /// Optional delay in milliseconds before responding (default 0)
+    #[serde(default)]
+    pub delay: Option<u64>,
+    /// Optional standard deviation in milliseconds for a normal distribution around the delay mean (default 0 = no randomness)
+    #[serde(default)]
+    pub delay_stddev: Option<f64>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -73,13 +81,23 @@ impl FastTestServer {
     }
 
     /// Echo back whatever message is sent
-    #[tool(description = "Echo back the provided message. Useful for testing connectivity and latency.")]
+    #[tool(description = "Echo back the provided message. Useful for testing connectivity and
+        latency. Optionally delay the response by a specified number of milliseconds. If
+        delay_stddev is provided (and gt 0), the actual delay is sampled from a normal distribution
+        with mean=delay and the given standard deviation, clamped to  0.")]
     async fn echo(
         &self,
         rmcp::handler::server::wrapper::Parameters(req): rmcp::handler::server::wrapper::Parameters<EchoRequest>,
     ) -> Result<CallToolResult, McpError> {
         let mut count = self.request_count.lock().await;
         *count += 1;
+
+        if let Some(ms) = req.delay {
+            if ms > 0 {
+                let actual_ms = compute_delay(ms, req.delay_stddev);
+                tokio::time::sleep(std::time::Duration::from_millis(actual_ms)).await;
+            }
+        }
 
         Ok(CallToolResult::success(vec![Content::text(&req.message)]))
     }
@@ -154,6 +172,24 @@ impl ServerHandler for FastTestServer {
     ) -> Result<InitializeResult, McpError> {
         info!("Client connected to {}", APP_NAME);
         Ok(self.get_info())
+    }
+}
+
+// ============================================================================
+// Delay Helpers
+// ============================================================================
+
+/// Compute the actual delay in ms, optionally sampling from a normal distribution.
+/// Returns the mean unchanged when stddev is None, zero, or negative.
+fn compute_delay(mean_ms: u64, stddev: Option<f64>) -> u64 {
+    match stddev {
+        Some(sd) if sd > 0.0 => {
+            let dist = Normal::new(mean_ms as f64, sd).unwrap_or_else(|_| Normal::new(mean_ms as f64, 0.0).unwrap());
+            let sample = rand::thread_rng().sample(dist);
+            // Clamp to >= 0 (negative delays make no sense)
+            sample.round().max(0.0) as u64
+        }
+        _ => mean_ms,
     }
 }
 
@@ -347,6 +383,10 @@ async fn version_handler() -> axum::Json<serde_json::Value> {
 #[derive(Debug, serde::Deserialize)]
 struct RestEchoRequest {
     message: String,
+    #[serde(default)]
+    delay: Option<u64>,
+    #[serde(default)]
+    delay_stddev: Option<f64>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -359,6 +399,12 @@ struct RestTimeQuery {
 async fn rest_echo_handler(
     axum::Json(req): axum::Json<RestEchoRequest>,
 ) -> axum::Json<serde_json::Value> {
+    if let Some(ms) = req.delay {
+        if ms > 0 {
+            let actual_ms = compute_delay(ms, req.delay_stddev);
+            tokio::time::sleep(std::time::Duration::from_millis(actual_ms)).await;
+        }
+    }
     axum::Json(json!({
         "message": req.message
     }))

--- a/mcpgateway/services/mcp_session_pool.py
+++ b/mcpgateway/services/mcp_session_pool.py
@@ -838,12 +838,16 @@ class MCPSessionPool:  # pylint: disable=too-many-instance-attributes
                 logger.warning(f"Failed to create session for {sanitize_url_for_logging(url)}: {e}")
             raise
 
-    async def release(self, pooled: PooledSession) -> None:
+    async def release(self, pooled: PooledSession, *, discard: bool = False) -> None:
         """
-        Return a session to the pool for reuse.
+        Return a session to the pool for reuse, or discard it.
 
         Args:
             pooled: The session to release.
+            discard: If True, close the session instead of returning it to the
+                pool.  Used when the caller detected a transport error
+                (e.g. ``ClosedResourceError``) to prevent recycling a
+                broken session.
         """
         if pooled.is_closed:
             logger.warning("Attempted to release already-closed session")
@@ -867,6 +871,15 @@ class MCPSessionPool:  # pylint: disable=too-many-instance-attributes
             # eviction sees recent activity.
             self._pool_last_used[pool_key] = time.time()
             self._active.get(pool_key, set()).discard(pooled)
+
+        # Discard broken sessions instead of recycling them
+        if discard:
+            logger.debug(f"Discarding broken session for {sanitize_url_for_logging(pooled.url)}")
+            await self._close_session(pooled)
+            if pool_key in self._semaphores:
+                self._semaphores[pool_key].release()
+            self._evictions += 1
+            return
 
         # Check if session should be returned to pool
         if self._closed or pooled.age_seconds > self._session_ttl:
@@ -1864,10 +1877,16 @@ class MCPSessionPool:  # pylint: disable=too-many-instance-attributes
             PooledSession ready for use.
         """
         pooled = await self.acquire(url, headers, transport_type, httpx_client_factory, timeout, user_identity, gateway_id)
+        failed = False
         try:
             yield pooled
+        except BaseException:
+            # Session encountered an error (e.g. ClosedResourceError) — evict it
+            # instead of returning a broken session to the pool.
+            failed = True
+            raise
         finally:
-            await self.release(pooled)
+            await self.release(pooled, discard=failed)
 
 
 # Global pool instance - initialized by FastAPI lifespan

--- a/tests/loadtest/locustfile_echo_delay.py
+++ b/tests/loadtest/locustfile_echo_delay.py
@@ -1,0 +1,468 @@
+# -*- coding: utf-8 -*-
+"""Streamable HTTP echo-with-delay load test for ContextForge.
+
+Measures gateway throughput when the backend MCP tool has an artificial delay,
+exercising the full Streamable HTTP path: /servers/{server_id}/mcp.
+
+Each Locust user establishes one MCP session (initialize + Mcp-Session-Id) and
+then repeatedly calls fast-test-echo with a configurable delay (default 500ms).
+
+Usage (containerized — recommended):
+    make load-test-echo-delay          # headless, 200 users, 3min
+    make load-test-echo-delay-ui       # web UI at http://localhost:8089
+
+Usage (local):
+    cd tests/loadtest
+    locust -f locustfile_echo_delay.py --host=http://localhost:4444 \\
+           --users=200 --spawn-rate=20 --run-time=180s --headless
+
+Environment Variables:
+    MCPGATEWAY_BEARER_TOKEN:   JWT token (auto-loaded from /tokens/gateway.jwt in container)
+    ECHO_DELAY_MS:             Delay in milliseconds for each echo call (default: 500)
+    ECHO_DELAY_SERVER_ID:      Virtual server ID (default: matches register_fast_test in docker-compose)
+    JWT_SECRET_KEY:            Secret for auto-generating JWT if token not provided (default: my-test-key)
+
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import logging
+import os
+import random
+import time
+from pathlib import Path
+
+from locust import User, between, events, tag, task
+from locust.runners import MasterRunner, WorkerRunner
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+def _load_env_file() -> dict[str, str]:
+    """Load environment variables from .env file."""
+    env_vars: dict[str, str] = {}
+    search_paths = [
+        Path.cwd() / ".env",
+        Path.cwd().parent / ".env",
+        Path.cwd().parent.parent / ".env",
+        Path(__file__).parent.parent.parent / ".env",
+    ]
+    for path in search_paths:
+        if path.exists():
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line or line.startswith("#"):
+                            continue
+                        if "=" in line:
+                            key, _, value = line.partition("=")
+                            key = key.strip()
+                            value = value.strip()
+                            if value and value[0] in ('"', "'") and value[-1] == value[0]:
+                                value = value[1:-1]
+                            env_vars[key] = value
+            except Exception as e:
+                logger.warning(f"Error reading .env file: {e}")
+            break
+    return env_vars
+
+
+_ENV_FILE_VARS = _load_env_file()
+
+
+def _cfg(key: str, default: str = "") -> str:
+    return os.environ.get(key) or _ENV_FILE_VARS.get(key, default)
+
+
+# Auth
+BEARER_TOKEN = _cfg("MCPGATEWAY_BEARER_TOKEN", "")
+JWT_SECRET = _cfg("JWT_SECRET_KEY", "my-test-key")
+
+# Echo delay settings
+ECHO_DELAY_MS = int(_cfg("ECHO_DELAY_MS", "500"))
+
+# Virtual server ID — matches the fixed ID created by register_fast_test in docker-compose
+# Override via ECHO_DELAY_SERVER_ID to target a different virtual server
+FAST_TEST_SERVER_ID = _cfg("ECHO_DELAY_SERVER_ID", "b8e3f1a2c4d5e6f7a1b2c3d4e5f6a7b8")
+
+# Direct URL to the fast_test_server REST API (bypasses gateway entirely).
+# Used as a baseline to isolate whether errors originate in the gateway or the backend.
+# In docker-compose this is the container hostname; override for local testing.
+FAST_TEST_DIRECT_URL = _cfg("FAST_TEST_DIRECT_URL", "http://fast_test_server:8880")
+
+# MCP protocol version (must match gateway config)
+MCP_PROTOCOL_VERSION = "2025-11-25"
+
+logger.info(f"Echo delay: {ECHO_DELAY_MS}ms")
+logger.info(f"Virtual server ID: {FAST_TEST_SERVER_ID}")
+
+
+# =============================================================================
+# JWT generation
+# =============================================================================
+
+
+def _generate_jwt_token() -> str | None:
+    """Generate a JWT token for gateway authentication."""
+    now = int(time.time())
+    payload = {
+        "username": "admin@example.com",
+        "iat": now,
+        "iss": "mcpgateway",
+        "aud": "mcpgateway-api",
+        "sub": "admin@example.com",
+        "exp": now + 86400,
+    }
+    try:
+        import jwt  # noqa: E402  # pylint: disable=import-outside-toplevel
+
+        return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+    except ImportError:
+        pass
+
+    # Manual fallback
+    import base64  # pylint: disable=import-outside-toplevel
+    import hashlib  # pylint: disable=import-outside-toplevel
+    import hmac  # pylint: disable=import-outside-toplevel
+    import json as json_mod  # pylint: disable=import-outside-toplevel
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header = b64url(json_mod.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = b64url(json_mod.dumps(payload, separators=(",", ":")).encode())
+    sig = b64url(hmac.new(JWT_SECRET.encode(), f"{header}.{body}".encode(), hashlib.sha256).digest())
+    return f"{header}.{body}.{sig}"
+
+
+_CACHED_TOKEN: str | None = None
+
+
+def _get_auth_token() -> str:
+    """Get a bearer token, preferring env var, then auto-generation."""
+    global _CACHED_TOKEN  # pylint: disable=global-statement
+    if BEARER_TOKEN:
+        return BEARER_TOKEN
+    if _CACHED_TOKEN is None:
+        _CACHED_TOKEN = _generate_jwt_token()
+    if not _CACHED_TOKEN:
+        raise RuntimeError("No bearer token available. Set MCPGATEWAY_BEARER_TOKEN or install PyJWT.")
+    return _CACHED_TOKEN
+
+
+# =============================================================================
+# Default parameters for Web UI
+# =============================================================================
+
+
+@events.init_command_line_parser.add_listener
+def set_defaults(parser):
+    parser.set_defaults(
+        users=200,
+        spawn_rate=20,
+        run_time="180s",
+    )
+
+
+# =============================================================================
+# Event handlers
+# =============================================================================
+
+
+@events.test_start.add_listener
+def on_test_start(environment, **_kwargs):
+    """Log test configuration at start."""
+    if isinstance(environment.runner, WorkerRunner):
+        return
+
+    host = environment.host or "http://localhost:4444"
+
+    logger.info("=" * 60)
+    logger.info("ECHO DELAY STREAMABLE HTTP LOAD TEST")
+    logger.info("=" * 60)
+    logger.info(f"  Gateway:    {host}")
+    logger.info(f"  Echo delay: {ECHO_DELAY_MS}ms")
+    logger.info(f"  MCP path:   /servers/{FAST_TEST_SERVER_ID}/mcp")
+    logger.info("=" * 60)
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **_kwargs):
+    """Print throughput summary."""
+    if isinstance(environment.runner, MasterRunner):
+        return
+
+    stats = environment.stats
+    total = stats.total.num_requests
+    failures = stats.total.num_failures
+    fail_rate = (failures / total * 100) if total > 0 else 0
+
+    print("\n" + "=" * 80)
+    print("ECHO DELAY LOAD TEST SUMMARY")
+    print("=" * 80)
+    print(f"\n  Echo delay:         {ECHO_DELAY_MS}ms")
+    print(f"  Total Requests:     {total:,}")
+    print(f"  Total Failures:     {failures:,} ({fail_rate:.2f}%)")
+    print(f"  Requests/sec (RPS): {stats.total.total_rps:.2f}")
+    print(f"\n  Response Times (ms):")
+    print(f"    Average:          {stats.total.avg_response_time:.2f}")
+    print(f"    Min:              {stats.total.min_response_time:.2f}")
+    print(f"    Max:              {stats.total.max_response_time:.2f}")
+    if total > 0:
+        print(f"    Median (p50):     {stats.total.get_response_time_percentile(0.5):.2f}")
+        print(f"    p90:              {stats.total.get_response_time_percentile(0.9):.2f}")
+        print(f"    p95:              {stats.total.get_response_time_percentile(0.95):.2f}")
+        print(f"    p99:              {stats.total.get_response_time_percentile(0.99):.2f}")
+
+    # Theoretical max: users / (delay_s + overhead)
+    print(f"\n  Theoretical max RPS at {ECHO_DELAY_MS}ms delay:")
+    print(f"    (users / {ECHO_DELAY_MS/1000:.1f}s) = ~{environment.runner.user_count / (ECHO_DELAY_MS / 1000):.0f} RPS")
+    print("=" * 80)
+
+
+# =============================================================================
+# User class
+# =============================================================================
+
+
+class EchoDelayUser(User):
+    """Streamable HTTP MCP user that calls fast-test-echo with a delay.
+
+    Each user:
+    1. Establishes an MCP session via initialize
+    2. Repeatedly calls fast-test-echo with the configured delay
+    3. Reports metrics via Locust event system
+    """
+
+    weight = 1
+    wait_time = between(0.0, 0.1)  # Minimal wait — the delay is server-side
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        import requests  # pylint: disable=import-outside-toplevel
+
+        self._session = requests.Session()
+        self._request_id = 0
+        self._mcp_session_id = None
+        self._initialized = False
+        self._token = _get_auth_token()
+        self._mcp_url = None
+        self._sample_logged = False
+
+        # Echo messages to rotate through
+        self._messages = [
+            "load-test-echo",
+            "performance-benchmark",
+            "throughput-measurement",
+            "delay-test-payload",
+            "streamable-http-test",
+        ]
+
+    def on_start(self):
+        """Build the MCP URL targeting the fast_test virtual server."""
+        host = self.host or "http://localhost:4444"
+        self._mcp_url = f"{host}/servers/{FAST_TEST_SERVER_ID}/mcp"
+
+    def on_stop(self):
+        if self._session:
+            self._session.close()
+
+    def _next_id(self) -> int:
+        self._request_id += 1
+        return self._request_id
+
+    def _headers(self) -> dict[str, str]:
+        h = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "Authorization": f"Bearer {self._token}",
+            "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+        }
+        if self._mcp_session_id:
+            h["Mcp-Session-Id"] = self._mcp_session_id
+        return h
+
+    def _mcp_post(self, method: str, params: dict | None, name: str) -> dict | None:
+        """POST a JSON-RPC request to the MCP endpoint and report to Locust."""
+        if not self._mcp_url:
+            events.request.fire(
+                request_type="MCP",
+                name=name,
+                response_time=0,
+                response_length=0,
+                exception=Exception("No MCP URL — server ID discovery failed"),
+            )
+            return None
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": method,
+        }
+        if params is not None:
+            payload["params"] = params
+
+        start = time.perf_counter()
+        try:
+            resp = self._session.post(self._mcp_url, json=payload, headers=self._headers(), timeout=30)
+            elapsed_ms = (time.perf_counter() - start) * 1000
+
+            # Capture session ID
+            sid = resp.headers.get("Mcp-Session-Id")
+            if sid:
+                self._mcp_session_id = sid
+
+            if resp.status_code != 200:
+                # Include body snippet for diagnosis (auth errors, backpressure, etc.)
+                body_preview = resp.text[:200] if resp.text else ""
+                events.request.fire(
+                    request_type="MCP",
+                    name=name,
+                    response_time=elapsed_ms,
+                    response_length=len(resp.content),
+                    exception=Exception(f"HTTP {resp.status_code}: {body_preview}"),
+                )
+                return None
+
+            body = resp.json()
+            if "error" in body:
+                events.request.fire(
+                    request_type="MCP",
+                    name=name,
+                    response_time=elapsed_ms,
+                    response_length=len(resp.content),
+                    exception=Exception(f"JSON-RPC error {body['error'].get('code', '?')}: {body['error'].get('message', '?')}"),
+                )
+                return None
+
+            result = body.get("result")
+
+            # Check for MCP tool-level errors (isError=true in the result)
+            if isinstance(result, dict) and result.get("isError"):
+                content = result.get("content", [])
+                err_text = ""
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        err_text = item.get("text", "")
+                        break
+                events.request.fire(
+                    request_type="MCP",
+                    name=name,
+                    response_time=elapsed_ms,
+                    response_length=len(resp.content),
+                    exception=Exception(f"MCP tool error: {err_text[:200]}"),
+                )
+                return None
+
+            events.request.fire(
+                request_type="MCP",
+                name=name,
+                response_time=elapsed_ms,
+                response_length=len(resp.content),
+            )
+            return result
+
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            events.request.fire(
+                request_type="MCP",
+                name=name,
+                response_time=elapsed_ms,
+                response_length=0,
+                exception=e,
+            )
+            return None
+
+    def _ensure_initialized(self):
+        """Initialize the MCP session if not already done."""
+        if self._initialized:
+            return
+        result = self._mcp_post(
+            "initialize",
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "locust-echo-delay", "version": "1.0"},
+            },
+            "initialize",
+        )
+        if result is not None:
+            self._initialized = True
+
+    @task(10)
+    @tag("mcp", "echo", "delay")
+    def call_echo_with_delay(self):
+        """Call fast-test-echo with the configured delay."""
+        self._ensure_initialized()
+        message = random.choice(self._messages)
+        result = self._mcp_post(
+            "tools/call",
+            {
+                "name": "fast-test-echo",
+                "arguments": {"message": message, "delay": ECHO_DELAY_MS},
+            },
+            f"echo (delay={ECHO_DELAY_MS}ms)",
+        )
+        # Log one sample response for debugging
+        if result is not None and not self._sample_logged:
+            logger.info(f"Sample echo response: {result}")
+            self._sample_logged = True
+
+    @task(1)
+    @tag("mcp", "list")
+    def list_tools(self):
+        """List tools as a lightweight heartbeat."""
+        self._ensure_initialized()
+        self._mcp_post("tools/list", {}, "tools/list")
+
+    # Uncomment to enable direct baseline (bypasses gateway, useful for isolating bottlenecks)
+    # @task(2)
+    # @tag("direct", "baseline")
+    def direct_echo_baseline(self):
+        """Call the fast_test_server REST API directly, bypassing the gateway.
+
+        Reported as request_type="DIRECT" so it appears separately in Locust stats.
+        If this succeeds while MCP tasks fail, the problem is in the gateway layer.
+        If this also fails, the fast_test_server itself is overloaded.
+        """
+        message = random.choice(self._messages)
+        payload = {"message": message, "delay": ECHO_DELAY_MS}
+        start = time.perf_counter()
+        try:
+            resp = self._session.post(
+                f"{FAST_TEST_DIRECT_URL}/api/echo",
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            if resp.status_code == 200:
+                events.request.fire(
+                    request_type="DIRECT",
+                    name=f"direct echo (delay={ECHO_DELAY_MS}ms)",
+                    response_time=elapsed_ms,
+                    response_length=len(resp.content),
+                )
+            else:
+                events.request.fire(
+                    request_type="DIRECT",
+                    name=f"direct echo (delay={ECHO_DELAY_MS}ms)",
+                    response_time=elapsed_ms,
+                    response_length=len(resp.content),
+                    exception=Exception(f"HTTP {resp.status_code}"),
+                )
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            events.request.fire(
+                request_type="DIRECT",
+                name=f"direct echo (delay={ECHO_DELAY_MS}ms)",
+                response_time=elapsed_ms,
+                response_length=0,
+                exception=e,
+            )

--- a/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
+++ b/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
@@ -570,6 +570,79 @@ class TestReleaseEdgeCases:
         mock_close.assert_awaited_once()
         assert pool_key not in pool._semaphores
 
+    @pytest.mark.asyncio
+    async def test_release_discard_closes_session_and_releases_semaphore(self):
+        """release(discard=True) should close the session, release semaphore, and increment evictions."""
+        pool = MCPSessionPool()
+        url = "http://test:8080"
+        pool_key = ("anonymous", url, "anonymous", "streamablehttp", "")
+        await pool._get_or_create_pool(pool_key)
+
+        pooled = PooledSession(
+            session=MagicMock(),
+            transport_context=MagicMock(),
+            url=url,
+            identity_key="anonymous",
+            transport_type=TransportType.STREAMABLE_HTTP,
+            headers={},
+        )
+
+        evictions_before = pool._evictions
+
+        with patch.object(pool, "_close_session", new_callable=AsyncMock) as mock_close:
+            await pool.release(pooled, discard=True)
+
+        mock_close.assert_awaited_once_with(pooled)
+        assert pool._evictions == evictions_before + 1
+
+    @pytest.mark.asyncio
+    async def test_release_discard_handles_missing_semaphore(self):
+        """release(discard=True) should not crash when semaphore was already evicted."""
+        pool = MCPSessionPool()
+        url = "http://test:8080"
+        pool_key = ("anonymous", url, "anonymous", "streamablehttp", "")
+        await pool._get_or_create_pool(pool_key)
+
+        pooled = PooledSession(
+            session=MagicMock(),
+            transport_context=MagicMock(),
+            url=url,
+            identity_key="anonymous",
+            transport_type=TransportType.STREAMABLE_HTTP,
+            headers={},
+        )
+
+        # Remove semaphore to simulate concurrent eviction
+        pool._semaphores.pop(pool_key, None)
+
+        with patch.object(pool, "_close_session", new_callable=AsyncMock) as mock_close:
+            await pool.release(pooled, discard=True)
+
+        mock_close.assert_awaited_once_with(pooled)
+        assert pool._evictions == 1
+
+    @pytest.mark.asyncio
+    async def test_release_discard_does_not_return_session_to_pool(self):
+        """release(discard=True) should NOT put session back in the pool queue."""
+        pool = MCPSessionPool()
+        url = "http://test:8080"
+        pool_key = ("anonymous", url, "anonymous", "streamablehttp", "")
+        queue = await pool._get_or_create_pool(pool_key)
+
+        pooled = PooledSession(
+            session=MagicMock(),
+            transport_context=MagicMock(),
+            url=url,
+            identity_key="anonymous",
+            transport_type=TransportType.STREAMABLE_HTTP,
+            headers={},
+        )
+
+        with patch.object(pool, "_close_session", new_callable=AsyncMock):
+            await pool.release(pooled, discard=True)
+
+        assert queue.empty(), "Discarded session should not be in pool queue"
+
 
 # ---------------------------------------------------------------------------
 # Lines 910, 935, 937->925, 946->939, 950-953, 956->925: _maybe_evict_idle_pool_keys
@@ -2078,7 +2151,7 @@ class TestSessionContextManagerEdgeCases:
 
     @pytest.mark.asyncio
     async def test_session_context_manager_releases_on_exception(self):
-        """Session should be released even if body raises."""
+        """Session should be released with discard=True when body raises."""
         pool = MCPSessionPool()
 
         mock_session = PooledSession(
@@ -2093,7 +2166,26 @@ class TestSessionContextManagerEdgeCases:
                     async with pool.session("http://test:8080") as pooled:
                         raise ValueError("test error")
 
-        mock_release.assert_awaited_once_with(mock_session)
+        mock_release.assert_awaited_once_with(mock_session, discard=True)
+        await pool.close_all()
+
+    @pytest.mark.asyncio
+    async def test_session_context_manager_releases_without_discard_on_success(self):
+        """Session should be released with discard=False on normal exit."""
+        pool = MCPSessionPool()
+
+        mock_session = PooledSession(
+            session=MagicMock(), transport_context=MagicMock(),
+            url="http://test:8080", identity_key="anonymous",
+            transport_type=TransportType.STREAMABLE_HTTP, headers={},
+        )
+
+        with patch.object(pool, "_create_session", new_callable=AsyncMock, return_value=mock_session):
+            with patch.object(pool, "release", new_callable=AsyncMock) as mock_release:
+                async with pool.session("http://test:8080") as pooled:
+                    pass  # no error
+
+        mock_release.assert_awaited_once_with(mock_session, discard=False)
         await pool.close_all()
 
 


### PR DESCRIPTION
## Summary

- Consolidate near-duplicate Makefile target families into parameterized versions with variables, reducing ~120 lines of boilerplate
- Add `is_true` and `deprecated_target` helper macros with per-target removal version (`v1.2.0`)
- Introduce `# deprecated:` tag system that `make help` renders as a highlighted section (dim yellow) at the end of help output
- Convert impacted targets (`black`, `isort`, `ruff`, `pylint`, `future-proof-ruff`) from `$(VENV_DIR)/bin/<tool>` to `uv run`
- Update documentation (tuning.md, ADR-025, DEVELOPING.md) to reference new parameterized invocations
- Add `docker-nuke` target for full container environment cleanup (stops all containers, removes images, volumes, networks, and build cache)
- Add Claude Code skills for pr-review, pr-risk-scoring, and sprint-plan
- Update `.gitignore` to track `.claude/skills/` directory

### Targets consolidated

| Family | Before | After | Mechanism |
|--------|--------|-------|-----------| 
| black / isort | 4 targets | 2 parameterized + 2 deprecated stubs | `CHECK=1` variable |
| ruff | 4 targets | 1 parameterized + 3 deprecated stubs | `RUFF_MODE=check\|fix\|format` |
| lint-changed/staged/commit | 3 near-identical targets | 3 thin call sites via `lint_git_files` macro | `define/endef` |
| test-ui-* | 12 targets with repeated boilerplate | 12 thin call sites via `run_playwright_test` macro | `define/endef` |
| container-run-* | 9 targets | 1 parameterized + 8 deprecated stubs | `CONTAINER_SSL`, `CONTAINER_HOST_NET`, `CONTAINER_JWT`, `CONTAINER_HTTP_SERVER` |

### Deprecated aliases

All old target names still work but emit a warning with the removal version:
```
  ⚠️  WARNING: "container-run-ssl" is deprecated. Use "make container-run CONTAINER_SSL=1" instead.
     This alias will be removed in v1.2.0.
```

`make help` now shows a dedicated deprecated targets section at the bottom.

### New target: `docker-nuke`

Destructive cleanup target that removes ALL containers, images, volumes, networks, and build cache. Includes an interactive confirmation prompt before proceeding.

### Claude Code skills

Added three reusable skills under `.claude/skills/`:
- **pr-review** — structured code review for feature branches with rebase, security/correctness checks
- **pr-risk-scoring** — score open PRs by risk level and generate CSV reports
- **sprint-plan** — plan sprints based on current project issues

## Test plan

- [ ] `make help` displays deprecated section with yellow highlighting
- [ ] `make black CHECK=1 TARGET=mcpgateway/` runs dry-run check
- [ ] `make ruff RUFF_MODE=fix TARGET=mcpgateway/` runs ruff fix
- [ ] `make black-check` shows deprecation warning then runs correctly
- [ ] `make ruff-fix` shows deprecation warning then runs correctly
- [ ] `make lint-quick` works end-to-end (calls parameterized targets internally)
- [ ] `make lint-fix` works end-to-end
- [ ] `make container-run-ssl` shows deprecation warning then delegates
- [ ] `make pylint TARGET=mcpgateway/` runs via `uv run` without venv activation
- [ ] `make docker-nuke` prompts for confirmation and cleans up when confirmed