### PR TITLE
fix(ui): preserve pagination page after edit modal save

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -861,7 +861,26 @@ function _navigateAdmin(fragment, searchParams) {
         adminIdx >= 0
             ? window.location.origin + currentPath.slice(0, adminIdx)
             : window.ROOT_PATH || window.location.origin;
-    const qs = searchParams ? searchParams.toString() : "";
+
+    // Preserve namespaced pagination state (*_page, *_size, *_inactive, *_q, *_tags)
+    // from the current URL so that editing an item on page 3 returns to page 3.
+    if (!searchParams) {
+        searchParams = new URLSearchParams();
+    }
+    const currentUrlParams = new URLSearchParams(window.location.search);
+    currentUrlParams.forEach((value, key) => {
+        const isPaginationParam =
+            key.endsWith("_page") ||
+            key.endsWith("_size") ||
+            (key.endsWith("_inactive") && key !== "include_inactive") ||
+            key.endsWith("_q") ||
+            key.endsWith("_tags");
+        if (isPaginationParam && !searchParams.has(key)) {
+            searchParams.set(key, value);
+        }
+    });
+
+    const qs = searchParams.toString();
     const target = `${base}/admin${qs ? `?${qs}` : ""}#${fragment}`;
 
     // When the target URL is identical to the current URL (same path, query,

--- a/tests/js/admin-pagination.test.js
+++ b/tests/js/admin-pagination.test.js
@@ -75,7 +75,10 @@ beforeAll(() => {
                 }
 
                 if (
-                    !additionalParams.hasOwnProperty("include_inactive") &&
+                    !Object.prototype.hasOwnProperty.call(
+                        additionalParams,
+                        "include_inactive",
+                    ) &&
                     params.includeInactive !== null
                 ) {
                     url.searchParams.set(
@@ -846,5 +849,151 @@ describe("pagination loadPage swapStyle (#3396)", () => {
             createComponentWithAjaxSpy(defaultSwap);
         component.loadPage(2);
         expect(ajaxCalls[0].swap).toBe("innerHTML");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// _navigateAdmin: pagination state preservation (#3389)
+//
+// _navigateAdmin is the single function all edit/save/toggle handlers use to
+// redirect after a successful operation. The fix copies namespaced pagination
+// params (*_page, *_size, *_inactive, *_q, *_tags) from the current URL into
+// the outgoing searchParams so editing an item on page 3 returns to page 3.
+//
+// Testing strategy: the function mutates the passed URLSearchParams before
+// attempting navigation (which throws "Not implemented" in JSDOM). We inspect
+// the URLSearchParams object after catching the error to verify the mutation.
+// ---------------------------------------------------------------------------
+describe("_navigateAdmin pagination state preservation (#3389)", () => {
+    /**
+     * Call _navigateAdmin and swallow the JSDOM navigation error.
+     * Returns the searchParams object after mutation.
+     */
+    function callNavigateAdmin(fragment, searchParams) {
+        try {
+            win._navigateAdmin(fragment, searchParams);
+        } catch (_) {
+            // JSDOM throws "Not implemented: navigation" — expected
+        }
+        return searchParams;
+    }
+
+    test("preserves *_page and *_size params from current URL", () => {
+        win.history.replaceState({}, "", "/admin?tools_page=3&tools_size=25");
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.get("tools_page")).toBe("3");
+        expect(params.get("tools_size")).toBe("25");
+    });
+
+    test("preserves *_q and *_tags params from current URL", () => {
+        win.history.replaceState(
+            {},
+            "",
+            "/admin?tools_q=search&tools_tags=alpha,beta",
+        );
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.get("tools_q")).toBe("search");
+        expect(params.get("tools_tags")).toBe("alpha,beta");
+    });
+
+    test("preserves namespaced *_inactive params (e.g. tools_inactive)", () => {
+        win.history.replaceState({}, "", "/admin?tools_inactive=true");
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.get("tools_inactive")).toBe("true");
+    });
+
+    test("does NOT preserve bare include_inactive param", () => {
+        win.history.replaceState({}, "", "/admin?include_inactive=true");
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.has("include_inactive")).toBe(false);
+    });
+
+    test("does NOT preserve non-pagination params (e.g. team_id, random)", () => {
+        win.history.replaceState(
+            {},
+            "",
+            "/admin?team_id=abc&random=42&tools_page=2",
+        );
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.has("team_id")).toBe(false);
+        expect(params.has("random")).toBe(false);
+        expect(params.get("tools_page")).toBe("2");
+    });
+
+    test("caller-set params take precedence over URL params", () => {
+        win.history.replaceState({}, "", "/admin?tools_page=5&tools_size=50");
+        const params = new win.URLSearchParams();
+        params.set("tools_page", "1");
+        callNavigateAdmin("tools", params);
+        expect(params.get("tools_page")).toBe("1");
+        expect(params.get("tools_size")).toBe("50");
+    });
+
+    test("preserves params across multiple table namespaces", () => {
+        win.history.replaceState(
+            {},
+            "",
+            "/admin?tools_page=3&gateways_page=2&servers_size=50&agents_q=bot",
+        );
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.get("tools_page")).toBe("3");
+        expect(params.get("gateways_page")).toBe("2");
+        expect(params.get("servers_size")).toBe("50");
+        expect(params.get("agents_q")).toBe("bot");
+    });
+
+    test("handles null searchParams without TypeError", () => {
+        win.history.replaceState({}, "", "/admin?tools_page=4");
+        let typeError = false;
+        try {
+            win._navigateAdmin("tools", null);
+        } catch (e) {
+            if (e.message && e.message.includes("Cannot read properties")) {
+                typeError = true;
+            }
+        }
+        expect(typeError).toBe(false);
+    });
+
+    test("handles undefined searchParams without TypeError", () => {
+        win.history.replaceState({}, "", "/admin?tools_page=4");
+        let typeError = false;
+        try {
+            win._navigateAdmin("tools");
+        } catch (e) {
+            if (e.message && e.message.includes("Cannot read properties")) {
+                typeError = true;
+            }
+        }
+        expect(typeError).toBe(false);
+    });
+
+    test("preserves all five pagination suffixes simultaneously", () => {
+        win.history.replaceState(
+            {},
+            "",
+            "/admin?tools_page=3&tools_size=25&tools_inactive=true&tools_q=search&tools_tags=v1,v2",
+        );
+        const params = new win.URLSearchParams();
+        callNavigateAdmin("tools", params);
+        expect(params.get("tools_page")).toBe("3");
+        expect(params.get("tools_size")).toBe("25");
+        expect(params.get("tools_inactive")).toBe("true");
+        expect(params.get("tools_q")).toBe("search");
+        expect(params.get("tools_tags")).toBe("v1,v2");
+    });
+
+    test("does not overwrite caller include_inactive with URL's bare include_inactive", () => {
+        win.history.replaceState({}, "", "/admin?include_inactive=true");
+        const params = new win.URLSearchParams();
+        params.set("include_inactive", "false");
+        callNavigateAdmin("tools", params);
+        expect(params.get("include_inactive")).toBe("false");
     });
 });


### PR DESCRIPTION
## 📌 Summary
After saving any edit modal in the Admin UI (tools, gateways, resources, prompts, servers, A2A agents), the table reloads on page 1 instead of returning to the page the user was on. This forces users to re-navigate every time they edit an item on any page other than page 1, breaking the expected workflow.

## 🔗  Related Link
Closes #3388 

## 🐞 Root Cause
`_navigateAdmin()` in `mcpgateway/static/admin.js` is the single function all 15 edit/save/toggle handlers use to redirect after a successful operation. It rebuilt the destination URL from scratch, copying only `team_id` and `include_inactive`, and silently discarded the namespaced pagination params (`tools_page`, `tools_size`, `tools_q`, `tools_tags`, etc.) that `buildTableUrl()` depends on to restore the correct page on load.

The params were present in `window.location.search` — written there by `pagination_controls.html`'s `updateBrowserUrl()` on every page click — but `_navigateAdmin` never forwarded them.

## 💡 Fix Description
In `_navigateAdmin()`, before building the target URL, copy all params whose key ends with `_page`, `_size`, `_inactive`, `_q`, or `_tags` from `window.location.search` into the outgoing `searchParams` — but only when the caller has not already explicitly set that key (`!searchParams.has(key)` guard). This is a single-function change that fixes all 15 call sites at once without affecting any caller that intentionally overrides a param.

## 🧪 Verification

| Check | Command | Status |
|---------------------------------------|----------------------|--------|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 90 % | `make coverage` | |
| Manual: edit tool on page 3 → stays on page 3 | Browser — Tools tab, 55+ tools | |
| Manual: delete tool on page 3 → stays on page 3 | Browser — Deactivate/Delete row button | |
| Manual: add new tool while on page 3 → stays on page 3 | Browser — Add Tool form | |
| Manual: page state not shared between tables | Navigate Tools to pg 3, then edit a Gateway → Gateways table unaffected | |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed