### PR TITLE
fix(ui): Team Selector dropdown fix

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -16751,6 +16751,59 @@ function refreshEditors() {
     }, 100);
 }
 
+/**
+ * Load teams into the team selector dropdown.
+ *
+ * Called from the Alpine.js x-data component when the dropdown opens.
+ * This logic lives here (not inline in x-data) because the innerHTML
+ * strings contain double-quote characters that break HTML attribute parsing
+ * when embedded inside an x-data="..." attribute.
+ */
+function loadTeamSelectorDropdown() {
+    const container = document.getElementById("team-selector-items");
+    if (!container || container.dataset.loaded) {
+        return;
+    }
+    container.innerHTML =
+        '<div class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">Loading teams\u2026</div>';
+    const rootPath = window.ROOT_PATH || "";
+    fetch(
+        rootPath + "/admin/teams/partial?page=1&per_page=10&render=selector",
+        { credentials: "same-origin" },
+    )
+        .then(function (resp) {
+            if (!resp.ok) {
+                throw new Error("HTTP " + resp.status);
+            }
+            return resp.text();
+        })
+        .then(function (html) {
+            container.innerHTML = html;
+            container.dataset.loaded = "true";
+            if (window.htmx) {
+                window.htmx.process(container);
+            }
+        })
+        .catch(function () {
+            delete container.dataset.loaded;
+            container.innerHTML =
+                '<div class="px-4 py-2 text-sm text-red-600 dark:text-red-400">' +
+                "Failed to load teams. Backend may be temporarily unavailable. " +
+                '<button type="button" data-action="retry-load-teams" ' +
+                'class="underline font-medium">Retry</button></div>';
+            const retryBtn = container.querySelector(
+                '[data-action="retry-load-teams"]',
+            );
+            if (retryBtn) {
+                retryBtn.addEventListener("click", function () {
+                    delete container.dataset.loaded;
+                    searchTeamSelector("");
+                });
+            }
+        });
+}
+window.loadTeamSelectorDropdown = loadTeamSelectorDropdown;
+
 // ===================================================================
 // GLOBAL ERROR HANDLERS
 // ===================================================================
@@ -33177,59 +33230,6 @@ window.filterTeams = filterTeams;
 window.searchTeamSelector = searchTeamSelector;
 window.selectTeamFromSelector = selectTeamFromSelector;
 window.getTeamsCurrentPaginationState = getTeamsCurrentPaginationState;
-
-/**
- * Load teams into the team selector dropdown.
- *
- * Called from the Alpine.js x-data component when the dropdown opens.
- * This logic lives here (not inline in x-data) because the innerHTML
- * strings contain double-quote characters that break HTML attribute parsing
- * when embedded inside an x-data="..." attribute.
- */
-function loadTeamSelectorDropdown() {
-    const container = document.getElementById("team-selector-items");
-    if (!container || container.dataset.loaded) {
-        return;
-    }
-    container.innerHTML =
-        '<div class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">Loading teams\u2026</div>';
-    const rootPath = window.ROOT_PATH || "";
-    fetch(
-        rootPath + "/admin/teams/partial?page=1&per_page=10&render=selector",
-        { credentials: "same-origin" },
-    )
-        .then(function (resp) {
-            if (!resp.ok) {
-                throw new Error("HTTP " + resp.status);
-            }
-            return resp.text();
-        })
-        .then(function (html) {
-            container.innerHTML = html;
-            container.dataset.loaded = "true";
-            if (window.htmx) {
-                window.htmx.process(container);
-            }
-        })
-        .catch(function () {
-            delete container.dataset.loaded;
-            container.innerHTML =
-                '<div class="px-4 py-2 text-sm text-red-600 dark:text-red-400">' +
-                "Failed to load teams. Backend may be temporarily unavailable. " +
-                '<button type="button" data-action="retry-load-teams" ' +
-                'class="underline font-medium">Retry</button></div>';
-            const retryBtn = container.querySelector(
-                '[data-action="retry-load-teams"]',
-            );
-            if (retryBtn) {
-                retryBtn.addEventListener("click", function () {
-                    delete container.dataset.loaded;
-                    searchTeamSelector("");
-                });
-            }
-        });
-}
-window.loadTeamSelectorDropdown = loadTeamSelectorDropdown;
 
 /**
  * Handle keydown event when Enter or Space key is pressed


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fix the team selector dropdown

https://github.com/user-attachments/assets/8358ad9d-66bc-4b1f-b49e-fd6c8509e585

Closes #3426

## 🔁 Reproduction Steps
1. Load the Admin UI
2. Click the teams dropdown

## 🐞 Root Cause
`window.loadTeamSelectorDropdown` was assigned at line ~33232, near the very end of `admin.js`. The global error handler (`window.addEventListener("error", ...)`) is registered at line `16758`. If any runtime error occurs in `admin.js` between those two points, execution halts and `window.loadTeamSelectorDropdown` is never set. When Alpine then calls `loadTeams()` (after user interaction or some init path), it throws because the function is undefined: caught and re-logged by the already-registered error handler as "Global error".

## 💡 Fix Description
Moved the `loadTeamSelectorDropdown` function and its window registration from line ~33189–33232 to just before the global error handler section.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     ✅    |
| Unit tests                            | `make test`          |     ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |     ✅    |
| Manual regression no longer fails     | steps / screenshots  |     ✅    |


## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
