### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,11 @@
 # All files in the repo
 * @crivetimihai
 
+# Plugin framework
+/mcpgateway/plugins @araujof @terylt @jonpspri
+
 # Ownership for all tests
 /tests/ @crivetimihai @kevalmahajan @madhav165
+
+# Tests for plugin framework
+/tests/unit/mcpgateway/plugins @araujof @terylt @jonpspri


### PR DESCRIPTION
This PR updates CODEOWNERS for files related to the Plugin Framework. 

This is to ensure that we can review and monitor changes made in the the gateway while we complete the migration and release of the [standalone package](https://github.com/contextforge-org/contextforge-plugins-framework).

Related #2100 