### PR TITLE
fix(tests): guard playwright import in e2e RBAC transport test

### DIFF
--- a/tests/e2e/test_mcp_rbac_transport.py
+++ b/tests/e2e/test_mcp_rbac_transport.py
@@ -34,8 +34,10 @@ from typing import Any, Generator
 import uuid
 
 # Third-Party
-from playwright.sync_api import APIRequestContext, Playwright
 import pytest
+
+pw = pytest.importorskip("playwright", reason="playwright is not installed – pip install playwright")
+from playwright.sync_api import APIRequestContext, Playwright
 
 # First-Party
 from mcpgateway.utils.create_jwt_token import _create_jwt_token


### PR DESCRIPTION
## 📌 Summary
CI fails during test collection on `tests/e2e/test_mcp_rbac_transport.py` because `playwright` is not installed in the standard CI runner, causing `ModuleNotFoundError` at import time.

## 🔁 Reproduction Steps
- Run `pytest` in a CI environment without playwright installed
- Test collection fails with `ModuleNotFoundError: No module named 'playwright'`

## 🐞 Root Cause
The `playwright.sync_api` import on line 37 is a bare top-level import with no guard. When playwright is absent, the entire test collection fails rather than gracefully skipping the module.

## 💡 Fix Description
Use `pytest.importorskip("playwright")` before the playwright import. This causes pytest to skip the entire module with a clear message when playwright is not installed, instead of failing collection.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | N/A - test-only change |
| Unit tests                            | `make test`          | No regression |
| Manual regression no longer fails     | CI collection passes | ✅     |

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed