### PR TITLE
fix(tests): auto-install pytest-playwright for test-mcp-rbac target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -640,6 +640,8 @@ test-mcp-rbac:  ## RBAC + multi-transport MCP protocol tests (needs live gateway
 	@echo "🔐 Running RBAC + multi-transport MCP protocol tests against $${MCP_CLI_BASE_URL:-http://localhost:8080}..."
 	@echo "   Requires: docker-compose stack with SSE gateway registered"
 	@/bin/bash -c 'source $(VENV_DIR)/bin/activate && \
+		uv pip show pytest-playwright >/dev/null 2>&1 || \
+			{ echo "📦 Installing playwright dependencies..."; uv pip install -q ".[playwright]" && playwright install --with-deps chromium; } && \
 		uv run --active pytest tests/e2e/test_mcp_rbac_transport.py -v -s --tb=short \
 			|| { echo "❌ MCP RBAC transport tests failed!"; exit 1; }; \
 		echo "✅ MCP RBAC transport tests passed!"'


### PR DESCRIPTION
## Summary
- `make test-mcp-rbac` failed because `pytest-playwright` (optional `[playwright]` dependency group) was not installed in the venv
- The Makefile target now auto-detects missing `pytest-playwright` and installs `.[playwright]` + Chromium browser binaries before running tests

## Test plan
- [x] `make test-mcp-rbac` passes (40/40 tests) on a fresh venv with only `make install-dev`