### PR TITLE
fix(deps): dependency security hardening updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "mcp-context-forge",
             "dependencies": {
                 "alpinejs": "^3.15.8"
             },

--- a/plugin_templates/external/{{cookiecutter.plugin_slug}}/pyproject.toml
+++ b/plugin_templates/external/{{cookiecutter.plugin_slug}}/pyproject.toml
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------
 # Build system (PEP 517)
-#     - setuptools >= 77 gives SPDX licence support (PEP 639)
+#     - setuptools >= 78.1.1 gives SPDX licence support (PEP 639) and fixes CVE-2025-47273
 #     - wheel is needed by most build front-ends
 # ----------------------------------------------------------------
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 # ----------------------------------------------------------------

--- a/plugins/external/cedar/pyproject.toml
+++ b/plugins/external/cedar/pyproject.toml
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------
 # 💡 Build system (PEP 517)
-#     - setuptools ≥ 77 gives SPDX licence support (PEP 639)
+#     - setuptools ≥ 78.1.1 gives SPDX licence support (PEP 639) and fixes CVE-2025-47273
 #     - wheel is needed by most build front-ends
 # ----------------------------------------------------------------
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 # ----------------------------------------------------------------

--- a/plugins/external/llmguard/pyproject.toml
+++ b/plugins/external/llmguard/pyproject.toml
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------
 # 💡 Build system (PEP 517)
-#     - setuptools ≥ 77 gives SPDX licence support (PEP 639)
+#     - setuptools ≥ 78.1.1 gives SPDX licence support (PEP 639) and fixes CVE-2025-47273
 #     - wheel is needed by most build front-ends
 # ----------------------------------------------------------------
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 # ----------------------------------------------------------------

--- a/plugins/external/opa/pyproject.toml
+++ b/plugins/external/opa/pyproject.toml
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------
 # 💡 Build system (PEP 517)
-#     - setuptools ≥ 77 gives SPDX licence support (PEP 639)
+#     - setuptools ≥ 78.1.1 gives SPDX licence support (PEP 639) and fixes CVE-2025-47273
 #     - wheel is needed by most build front-ends
 # ----------------------------------------------------------------
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 # ----------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------
 # 💡 Build system (PEP 517)
-#     - setuptools ≥ 77 gives SPDX licence support (PEP 639)
+#     - setuptools ≥ 78.1.1 gives SPDX licence support (PEP 639) and fixes CVE-2025-47273
 #     - wheel is needed by most build front-ends
 # ----------------------------------------------------------------
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 # ----------------------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     # Install the package manually without dev extras
     -e .
     # Install core dependencies without problematic packages
-    aiohttp>=3.12.15
+    aiohttp>=3.13.3
     alembic>=1.16.5
     argon2-cffi>=25.1.0
     cookiecutter>=2.6.0


### PR DESCRIPTION
## Summary

Proactive security hardening: upgrade build and transitive dependencies to their latest patched versions and clean up dead code from a recently reverted login-page feature.

## Changes

### Python — build & runtime deps

| Package | From | To | Scope | Note |
|---------|------|----|-------|------|
| setuptools | `>=77` | `>=78.1.1` | build-system | Includes fix for CVE-2025-47273 |
| wheel | (unpinned) | `>=0.46.2` | build-system | Pin to current patched release |
| aiohttp | `>=3.12.15` | `>=3.13.3` | tox runtime | Latest patched release |

`setuptools` and `wheel` bumps applied consistently across all `pyproject.toml` files:
- Root `pyproject.toml`
- `plugins/external/cedar/`, `llmguard/`, `opa/`
- `plugin_templates/external/{{cookiecutter.plugin_slug}}/`

### Rust (lockfile-only)

| Package | From | To |
|---------|------|----|
| aws-lc-sys | 0.37.1 | 0.38.0 |
| aws-lc-rs | 1.16.0 | 1.16.1 |

Updated in `tools_rust/wrapper/Cargo.lock` and `mcp-servers/rust/filesystem-server/Cargo.lock`.

### Node.js (lockfile-only)

| Package | From | To |
|---------|------|----|
| minimatch | 10.2.2 | 10.2.4 |

## Impact

- **Security hardening only** — no new features, no API changes, no behavioral changes.
- Rust and Node.js changes are lockfile-only (no `Cargo.toml` or `package.json` source edits).
