### PR TITLE
[FIX][UI]: Make "+N more" badges clickable to expand full list in server details modal

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -6674,7 +6674,7 @@ async function viewServer(serverId) {
                     toolsList.appendChild(toolItem);
                 });
 
-                // If more than maxToShow, add a summary badge
+                // If more than maxToShow, add a summary badge (clickable to expand)
                 if (server.associatedTools.length > maxToShow) {
                     const moreItem = document.createElement("div");
                     moreItem.className = "flex items-center space-x-2";
@@ -6685,6 +6685,32 @@ async function viewServer(serverId) {
                     moreBadge.title = "Total tools associated";
                     const remaining = server.associatedTools.length - maxToShow;
                     moreBadge.textContent = `+${remaining} more`;
+
+                    // Expand inline to show full list when clicked
+                    moreBadge.addEventListener("click", () => {
+                        toolsList.innerHTML = "";
+                        (server.associatedTools || []).forEach((toolId) => {
+                            const toolItem = document.createElement("div");
+                            toolItem.className = "flex items-center space-x-2";
+
+                            const toolBadge = document.createElement("span");
+                            toolBadge.className =
+                                "inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full dark:bg-green-900 dark:text-green-200";
+                            toolBadge.textContent =
+                                window.toolMapping && window.toolMapping[toolId]
+                                    ? window.toolMapping[toolId]
+                                    : toolId;
+
+                            const toolIdSpan = document.createElement("span");
+                            toolIdSpan.className =
+                                "text-xs text-gray-500 dark:text-gray-400";
+                            toolIdSpan.textContent = `(${toolId})`;
+
+                            toolItem.appendChild(toolBadge);
+                            toolItem.appendChild(toolIdSpan);
+                            toolsList.appendChild(toolItem);
+                        });
+                    });
 
                     moreItem.appendChild(moreBadge);
                     toolsList.appendChild(moreItem);
@@ -6740,7 +6766,7 @@ async function viewServer(serverId) {
                     resourcesList.appendChild(resourceItem);
                 });
 
-                // If more than maxToShow, add a summary badge
+                // If more than maxToShow, add a summary badge (clickable to expand)
                 if (server.associatedResources.length > maxToShow) {
                     const moreItem = document.createElement("div");
                     moreItem.className = "flex items-center space-x-2";
@@ -6752,6 +6778,38 @@ async function viewServer(serverId) {
                     const remaining =
                         server.associatedResources.length - maxToShow;
                     moreBadge.textContent = `+${remaining} more`;
+
+                    moreBadge.addEventListener("click", () => {
+                        resourcesList.innerHTML = "";
+                        (server.associatedResources || []).forEach(
+                            (resourceId) => {
+                                const resourceItem =
+                                    document.createElement("div");
+                                resourceItem.className =
+                                    "flex items-center space-x-2";
+
+                                const resourceBadge =
+                                    document.createElement("span");
+                                resourceBadge.className =
+                                    "inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full dark:bg-blue-900 dark:text-blue-200";
+                                resourceBadge.textContent =
+                                    window.resourceMapping &&
+                                    window.resourceMapping[resourceId]
+                                        ? window.resourceMapping[resourceId]
+                                        : `Resource ${resourceId}`;
+
+                                const resourceIdSpan =
+                                    document.createElement("span");
+                                resourceIdSpan.className =
+                                    "text-xs text-gray-500 dark:text-gray-400";
+                                resourceIdSpan.textContent = `(${resourceId})`;
+
+                                resourceItem.appendChild(resourceBadge);
+                                resourceItem.appendChild(resourceIdSpan);
+                                resourcesList.appendChild(resourceItem);
+                            },
+                        );
+                    });
 
                     moreItem.appendChild(moreBadge);
                     resourcesList.appendChild(moreItem);
@@ -6806,7 +6864,7 @@ async function viewServer(serverId) {
                     promptsList.appendChild(promptItem);
                 });
 
-                // If more than maxToShow, add a summary badge
+                // If more than maxToShow, add a summary badge (clickable to expand)
                 if (server.associatedPrompts.length > maxToShow) {
                     const moreItem = document.createElement("div");
                     moreItem.className = "flex items-center space-x-2";
@@ -6818,6 +6876,33 @@ async function viewServer(serverId) {
                     const remaining =
                         server.associatedPrompts.length - maxToShow;
                     moreBadge.textContent = `+${remaining} more`;
+
+                    moreBadge.addEventListener("click", () => {
+                        promptsList.innerHTML = "";
+                        (server.associatedPrompts || []).forEach((promptId) => {
+                            const promptItem = document.createElement("div");
+                            promptItem.className =
+                                "flex items-center space-x-2";
+
+                            const promptBadge = document.createElement("span");
+                            promptBadge.className =
+                                "inline-block bg-purple-100 text-purple-800 text-xs px-2 py-1 rounded-full dark:bg-purple-900 dark:text-purple-200";
+                            promptBadge.textContent =
+                                window.promptMapping &&
+                                window.promptMapping[promptId]
+                                    ? window.promptMapping[promptId]
+                                    : `Prompt ${promptId}`;
+
+                            const promptIdSpan = document.createElement("span");
+                            promptIdSpan.className =
+                                "text-xs text-gray-500 dark:text-gray-400";
+                            promptIdSpan.textContent = `(${promptId})`;
+
+                            promptItem.appendChild(promptBadge);
+                            promptItem.appendChild(promptIdSpan);
+                            promptsList.appendChild(promptItem);
+                        });
+                    });
 
                     moreItem.appendChild(moreBadge);
                     promptsList.appendChild(moreItem);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "alpinejs": "^3.15.8"
+            },
             "devDependencies": {
                 "@biomejs/biome": "^2.4.4",
                 "@stylistic/eslint-plugin": "^5.9.0",
@@ -2782,6 +2785,21 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vue/reactivity": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.1.5"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+            "license": "MIT"
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2830,6 +2848,15 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/alpinejs": {
+            "version": "3.15.8",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.8.tgz",
+            "integrity": "sha512-zxIfCRTBGvF1CCLIOMQOxAyBuqibxSEwS6Jm1a3HGA9rgrJVcjEWlwLcQTVGAWGS8YhAsTRLVrtQ5a5QT9bSSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "~3.1.1"
             }
         },
         "node_modules/ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "overrides": {
         "keyv": "5.1.0",
         "minimatch": ">=10.2.1"
+    },
+    "dependencies": {
+        "alpinejs": "^3.15.8"
     }
 }

--- a/plugins_rust/encoded_exfil_detection/python/encoded_exfil_detection_rust/__init__.pyi
+++ b/plugins_rust/encoded_exfil_detection/python/encoded_exfil_detection_rust/__init__.pyi
@@ -8,4 +8,3 @@ __all__ = [
 ]
 
 def py_scan_container(container: typing.Any, config: typing.Any) -> tuple[builtins.int, typing.Any, list]: ...
-

--- a/plugins_rust/pii_filter/python/pii_filter_rust/__init__.pyi
+++ b/plugins_rust/pii_filter/python/pii_filter_rust/__init__.pyi
@@ -11,18 +11,18 @@ __all__ = [
 class PIIDetectorRust:
     r"""
     Main PII detector exposed to Python
-    
+
     # Example (Python)
     ```python
     from pii_filter import PIIDetectorRust
-    
+
     config = {"detect_ssn": True, "detect_email": True}
     detector = PIIDetectorRust(config)
-    
+
     text = "My SSN is 123-45-6789 and email is john@example.com"
     detections = detector.detect(text)
     print(detections)  # {"ssn": [...], "email": [...]}
-    
+
     masked = detector.mask(text, detections)
     print(masked)  # "My SSN is [REDACTED] and email is [REDACTED]"
     ```
@@ -30,10 +30,10 @@ class PIIDetectorRust:
     def __new__(cls, config: typing.Any) -> PIIDetectorRust:
         r"""
         Create a new PII detector
-        
+
         # Arguments
         * `config` - Python dictionary or Pydantic model with configuration
-        
+
         # Configuration Keys
         * `detect_ssn` (bool): Detect Social Security Numbers
         * `detect_credit_card` (bool): Detect credit card numbers
@@ -55,10 +55,10 @@ class PIIDetectorRust:
     def detect(self, text: builtins.str) -> typing.Any:
         r"""
         Detect PII in text
-        
+
         # Arguments
         * `text` - Text to scan for PII
-        
+
         # Returns
         Dictionary mapping PII type to list of detections:
         ```python
@@ -75,23 +75,22 @@ class PIIDetectorRust:
     def mask(self, text: builtins.str, detections: typing.Any) -> builtins.str:
         r"""
         Mask detected PII in text
-        
+
         # Arguments
         * `text` - Original text
         * `detections` - Detection results from detect()
-        
+
         # Returns
         Masked text with PII replaced
         """
     def process_nested(self, data: typing.Any, path: builtins.str) -> tuple[builtins.bool, typing.Any, typing.Any]:
         r"""
         Process nested data structures (dicts, lists, strings)
-        
+
         # Arguments
         * `data` - Python object (dict, list, str, or other)
         * `path` - Current path in the structure (for logging)
-        
+
         # Returns
         Tuple of (modified: bool, new_data: Any, detections: dict)
         """
-

--- a/plugins_rust/secrets_detection/python/secrets_detection_rust/__init__.pyi
+++ b/plugins_rust/secrets_detection/python/secrets_detection_rust/__init__.pyi
@@ -11,4 +11,3 @@ def py_scan_container(container: typing.Any, config: typing.Any) -> tuple[builti
     r"""
     Scan Python container for secrets using optimized type dispatch
     """
-

--- a/tests/js/admin-server-detail-badges.test.js
+++ b/tests/js/admin-server-detail-badges.test.js
@@ -1,0 +1,522 @@
+/**
+ * Tests for the "+N more" badge click-to-expand functionality in the
+ * server details modal (viewServer).
+ *
+ * Covers:
+ *  - Tools "+N more" badge renders with cursor-pointer and correct count
+ *  - Clicking tools badge expands full list inline
+ *  - Resources "+N more" badge renders and expands on click
+ *  - Prompts "+N more" badge renders and expands on click
+ *  - Expanded list shows all items with correct display names and IDs
+ *  - Sections with <= maxToShow items do not render a "+N more" badge
+ *  - Window mapping lookups fall back to raw IDs when mappings are absent
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    vi,
+} from "vitest";
+import { loadAdminJs, cleanupAdminJs } from "./helpers/admin-env.js";
+
+let win;
+let doc;
+
+beforeAll(() => {
+    win = loadAdminJs();
+    doc = win.document;
+});
+
+afterAll(() => {
+    cleanupAdminJs();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeServerDetailsContainer() {
+    const div = doc.createElement("div");
+    div.id = "server-details";
+    doc.body.appendChild(div);
+    return div;
+}
+
+function makeServerModal() {
+    const modal = doc.createElement("div");
+    modal.id = "server-modal";
+    modal.classList.add("hidden");
+    doc.body.appendChild(modal);
+    return modal;
+}
+
+function mockFetch(serverData) {
+    const body = JSON.stringify(serverData);
+    const makeResponse = () => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {
+            get: (name) => {
+                if (name.toLowerCase() === "content-length") {
+                    return String(body.length);
+                }
+                return null;
+            },
+        },
+        json: () => Promise.resolve(serverData),
+        text: () => Promise.resolve(body),
+        clone: function () {
+            return makeResponse();
+        },
+    });
+    win.fetch = vi.fn().mockResolvedValue(makeResponse());
+}
+
+function buildServer(overrides = {}) {
+    return {
+        id: "srv-1",
+        name: "Test Server",
+        description: "A test server",
+        enabled: true,
+        visibility: "private",
+        tags: [],
+        associatedTools: [],
+        associatedResources: [],
+        associatedPrompts: [],
+        associatedA2aAgents: [],
+        ...overrides,
+    };
+}
+
+function findMoreBadge(container, colorClass) {
+    const badges = container.querySelectorAll("span");
+    for (const badge of badges) {
+        if (
+            badge.textContent.startsWith("+") &&
+            badge.textContent.includes("more") &&
+            badge.className.includes(colorClass)
+        ) {
+            return badge;
+        }
+    }
+    return null;
+}
+
+function getItemBadges(container, colorClass) {
+    const badges = container.querySelectorAll("span");
+    return Array.from(badges).filter(
+        (b) =>
+            b.className.includes(colorClass) &&
+            b.className.includes("inline-block") &&
+            !b.textContent.startsWith("+"),
+    );
+}
+
+beforeEach(() => {
+    doc.body.textContent = "";
+    win.ROOT_PATH = "";
+    win.toolMapping = undefined;
+    win.resourceMapping = undefined;
+    win.promptMapping = undefined;
+    // Reset modal state so openModal doesn't skip
+    if (win.AppState && win.AppState.activeModals) {
+        win.AppState.activeModals.clear();
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Tools: "+N more" badge click-to-expand
+// ---------------------------------------------------------------------------
+
+describe("viewServer — tools +N more badge", () => {
+    test("renders '+N more' badge when tools exceed maxToShow (3)", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4", "t5"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        expect(moreBadge).not.toBeNull();
+        expect(moreBadge.textContent).toBe("+2 more");
+    });
+
+    test("'+N more' badge has cursor-pointer class", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        expect(moreBadge.className).toContain("cursor-pointer");
+    });
+
+    test("clicking tools badge expands to show all tools", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4", "t5"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+
+        // Click the badge
+        moreBadge.click();
+
+        // After expansion, the "+N more" badge should be gone
+        const moreBadgeAfter = findMoreBadge(container, "bg-green");
+        expect(moreBadgeAfter).toBeNull();
+
+        // All 5 tool badges should be present
+        const toolBadges = getItemBadges(container, "bg-green");
+        expect(toolBadges.length).toBe(5);
+    });
+
+    test("expanded tools show IDs in parentheses", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        moreBadge.click();
+
+        // Check that ID spans are rendered
+        const idSpans = container.querySelectorAll(
+            "span.text-xs.text-gray-500",
+        );
+        const toolIdTexts = Array.from(idSpans)
+            .map((s) => s.textContent)
+            .filter((t) => t.match(/^\(t\d\)$/));
+        expect(toolIdTexts).toContain("(t1)");
+        expect(toolIdTexts).toContain("(t4)");
+    });
+
+    test("expanded tools use window.toolMapping for display names", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        win.toolMapping = { t1: "Tool Alpha", t4: "Tool Delta" };
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        moreBadge.click();
+
+        const toolBadges = getItemBadges(container, "bg-green");
+        const texts = toolBadges.map((b) => b.textContent);
+        expect(texts).toContain("Tool Alpha");
+        expect(texts).toContain("Tool Delta");
+        // t2 has no mapping, should fall back to raw ID
+        expect(texts).toContain("t2");
+    });
+
+    test("does not render badge when tools count equals maxToShow", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        expect(moreBadge).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Resources: "+N more" badge click-to-expand
+// ---------------------------------------------------------------------------
+
+describe("viewServer — resources +N more badge", () => {
+    test("renders '+N more' badge for resources exceeding maxToShow", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedResources: ["r1", "r2", "r3", "r4", "r5", "r6"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-blue");
+        expect(moreBadge).not.toBeNull();
+        expect(moreBadge.textContent).toBe("+3 more");
+    });
+
+    test("clicking resources badge expands to show all resources", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedResources: ["r1", "r2", "r3", "r4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-blue");
+        moreBadge.click();
+
+        const moreBadgeAfter = findMoreBadge(container, "bg-blue");
+        expect(moreBadgeAfter).toBeNull();
+
+        const resourceBadges = getItemBadges(container, "bg-blue");
+        // Note: tags also use bg-blue, so filter by the resource section
+        // Resources use "Resource {id}" as fallback text
+        const resourceTexts = resourceBadges
+            .map((b) => b.textContent)
+            .filter((t) => t.startsWith("Resource "));
+        expect(resourceTexts.length).toBe(4);
+    });
+
+    test("expanded resources use window.resourceMapping for display names", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        win.resourceMapping = { r1: "My Resource", r4: "Config File" };
+        const server = buildServer({
+            associatedResources: ["r1", "r2", "r3", "r4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-blue");
+        moreBadge.click();
+
+        const resourceBadges = getItemBadges(container, "bg-blue");
+        const texts = resourceBadges.map((b) => b.textContent);
+        expect(texts).toContain("My Resource");
+        expect(texts).toContain("Config File");
+        expect(texts).toContain("Resource r2");
+    });
+
+    test("resources '+N more' badge has cursor-pointer class", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedResources: ["r1", "r2", "r3", "r4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-blue");
+        expect(moreBadge.className).toContain("cursor-pointer");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Prompts: "+N more" badge click-to-expand
+// ---------------------------------------------------------------------------
+
+describe("viewServer — prompts +N more badge", () => {
+    test("renders '+N more' badge for prompts exceeding maxToShow", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedPrompts: ["p1", "p2", "p3", "p4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-purple");
+        expect(moreBadge).not.toBeNull();
+        expect(moreBadge.textContent).toBe("+1 more");
+    });
+
+    test("clicking prompts badge expands to show all prompts", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedPrompts: ["p1", "p2", "p3", "p4", "p5"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-purple");
+        moreBadge.click();
+
+        const moreBadgeAfter = findMoreBadge(container, "bg-purple");
+        expect(moreBadgeAfter).toBeNull();
+
+        const promptBadges = getItemBadges(container, "bg-purple");
+        expect(promptBadges.length).toBe(5);
+    });
+
+    test("expanded prompts use window.promptMapping for display names", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        win.promptMapping = { p1: "Welcome Prompt", p5: "Farewell Prompt" };
+        const server = buildServer({
+            associatedPrompts: ["p1", "p2", "p3", "p4", "p5"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-purple");
+        moreBadge.click();
+
+        const promptBadges = getItemBadges(container, "bg-purple");
+        const texts = promptBadges.map((b) => b.textContent);
+        expect(texts).toContain("Welcome Prompt");
+        expect(texts).toContain("Farewell Prompt");
+        expect(texts).toContain("Prompt p2");
+    });
+
+    test("prompts '+N more' badge has cursor-pointer class", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedPrompts: ["p1", "p2", "p3", "p4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-purple");
+        expect(moreBadge.className).toContain("cursor-pointer");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("viewServer — badge edge cases", () => {
+    test("no badges shown when all sections have <= 3 items", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2"],
+            associatedResources: ["r1"],
+            associatedPrompts: ["p1", "p2", "p3"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        expect(findMoreBadge(container, "bg-green")).toBeNull();
+        expect(findMoreBadge(container, "bg-purple")).toBeNull();
+    });
+
+    test("expanded tools list has correct green badge styling", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        moreBadge.click();
+
+        const toolBadges = getItemBadges(container, "bg-green");
+        for (const badge of toolBadges) {
+            expect(badge.className).toContain("bg-green-100");
+            expect(badge.className).toContain("text-green-800");
+            expect(badge.className).toContain("rounded-full");
+        }
+    });
+
+    test("badge shows correct count with exactly 4 items (maxToShow+1)", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const moreBadge = findMoreBadge(container, "bg-green");
+        expect(moreBadge.textContent).toBe("+1 more");
+    });
+
+    test("multiple sections can each have their own +N more badge", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4", "t5"],
+            associatedResources: ["r1", "r2", "r3", "r4"],
+            associatedPrompts: ["p1", "p2", "p3", "p4", "p5", "p6"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+        const toolsBadge = findMoreBadge(container, "bg-green");
+        const promptsBadge = findMoreBadge(container, "bg-purple");
+        expect(toolsBadge.textContent).toBe("+2 more");
+        expect(promptsBadge.textContent).toBe("+3 more");
+    });
+
+    test("clicking one section badge does not affect other sections", async () => {
+        makeServerDetailsContainer();
+        makeServerModal();
+        const server = buildServer({
+            associatedTools: ["t1", "t2", "t3", "t4"],
+            associatedPrompts: ["p1", "p2", "p3", "p4"],
+        });
+        mockFetch(server);
+
+        await win.viewServer("srv-1");
+
+        const container = doc.getElementById("server-details");
+
+        // Click only the tools badge
+        const toolsBadge = findMoreBadge(container, "bg-green");
+        toolsBadge.click();
+
+        // Tools badge should be gone
+        expect(findMoreBadge(container, "bg-green")).toBeNull();
+        // Prompts badge should still be present
+        expect(findMoreBadge(container, "bg-purple")).not.toBeNull();
+    });
+});

--- a/tests/manual/concurrency/conc_02_gateways_results.md
+++ b/tests/manual/concurrency/conc_02_gateways_results.md
@@ -1,7 +1,7 @@
 # CONC-02 Gateway Read-During-Write: Runbook + Results
 
-Date: 2026-03-02  
-Ticket scope: CONC-02 for gateway endpoint (`GET/PUT /gateways/{id}`)  
+Date: 2026-03-02
+Ticket scope: CONC-02 for gateway endpoint (`GET/PUT /gateways/{id}`)
 Out of scope: CONC-01 create race, cache/session/leader-election scenarios
 
 ## Objective

--- a/uv.lock
+++ b/uv.lock
@@ -891,6 +891,27 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/4fa79a57a8e69fe0d9763e98d1110320f9ecd7f1f362572e3aafd7417c9d/debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344", size = 3171493, upload-time = "2026-01-29T23:03:37.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/1e8f8affe51e12a26f3a8a8a4277d6e60aa89d0a66512f63b1e799d424a4/debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec", size = 5209240, upload-time = "2026-01-29T23:03:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/92/1cb532e88560cbee973396254b21bece8c5d7c2ece958a67afa08c9f10dc/debugpy-1.8.20-cp311-cp311-win_amd64.whl", hash = "sha256:1f7650546e0eded1902d0f6af28f787fa1f1dbdbc97ddabaf1cd963a405930cb", size = 5233481, upload-time = "2026-01-29T23:03:40.659Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2831,6 +2852,7 @@ dev = [
     { name = "cookiecutter" },
     { name = "coverage" },
     { name = "darglint" },
+    { name = "debugpy" },
     { name = "diff-cover" },
     { name = "dlint" },
     { name = "dodgy" },
@@ -2985,6 +3007,7 @@ dev = [
     { name = "cookiecutter", specifier = ">=2.6.0" },
     { name = "coverage", specifier = ">=7.10.7" },
     { name = "darglint", specifier = ">=1.8.1" },
+    { name = "debugpy", specifier = ">=1.8.20" },
     { name = "diff-cover", specifier = ">=9.0.0" },
     { name = "dlint", specifier = ">=0.16.0" },
     { name = "dodgy", specifier = ">=0.2.1" },


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #3509 
## 💡 Fix Description
implemented: made the “+N more” summary badges clickable; clicking expands the compact view and replaces it with the full inline list for that section.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |Pass    |
| Unit tests                            | `make test`          |Pass    |
## 📐 MCP Compliance (if relevant)
- [X] Matches current MCP spec
- [X] No breaking change to MCP clients

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
