### PR TITLE
feat(oauth): add client_credentials M2M config support (US2 of #3386)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11239,6 +11239,56 @@ async def admin_get_gateway(gateway_id: str, db: Session = Depends(get_db), user
         raise e
 
 
+@admin_router.post("/gateways/{gateway_id}/test-m2m")
+@require_permission("gateways.read", allow_admin_bypass=False)
+async def admin_test_m2m_gateway(gateway_id: str, db: Session = Depends(get_db), user=Depends(get_current_user_with_permissions)) -> JSONResponse:
+    """Test M2M token acquisition for a client_credentials gateway.
+
+    Attempts to acquire an OAuth 2.0 access token from the configured IDP
+    using the gateway's stored client credentials. Returns success or failure
+    without caching the token.
+
+    Args:
+        gateway_id: Gateway ID.
+        db: Database session.
+        user: Authenticated user.
+
+    Returns:
+        JSONResponse with success status and message.
+
+    Raises:
+        HTTPException: If the gateway is not found or not configured for client_credentials.
+
+    Examples:
+        >>> callable(admin_test_m2m_gateway)
+        True
+        >>> admin_test_m2m_gateway.__name__
+        'admin_test_m2m_gateway'
+    """
+    user_email = get_user_email(user)
+    LOGGER.debug(f"User {user_email} testing M2M token acquisition for gateway {gateway_id}")
+
+    try:
+        gateway = await gateway_service.get_gateway(db, gateway_id)
+    except GatewayNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    if not gateway.oauth_config:
+        raise HTTPException(status_code=400, detail="Gateway is not configured with OAuth")
+
+    grant_type = gateway.oauth_config.get("grant_type") if isinstance(gateway.oauth_config, dict) else None
+    if grant_type != "client_credentials":
+        raise HTTPException(status_code=400, detail=f"Gateway grant_type is '{grant_type}', not 'client_credentials'")
+
+    try:
+        oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=1)
+        await oauth_manager.get_access_token(gateway.oauth_config)
+        return JSONResponse(content={"success": True, "message": "Token acquired successfully"})
+    except Exception as e:
+        LOGGER.warning(f"M2M token test failed for gateway {gateway_id}: {e}")
+        return JSONResponse(content={"success": False, "message": str(e)})
+
+
 @admin_router.post("/gateways")
 @require_permission("gateways.create", allow_admin_bypass=False)
 async def admin_add_gateway(request: Request, db: Session = Depends(get_db), user: dict[str, Any] = Depends(get_current_user_with_permissions)) -> JSONResponse:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11316,9 +11316,10 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
             oauth_username = str(form.get("oauth_username", ""))
             oauth_password = str(form.get("oauth_password", ""))
             oauth_scopes_str = str(form.get("oauth_scopes", ""))
+            oauth_resource = str(form.get("oauth_resource", ""))
 
             # If any OAuth field is provided, assemble oauth_config
-            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
+            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id, oauth_resource]):
                 oauth_config = {}
 
                 if oauth_grant_type:
@@ -11337,6 +11338,8 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
                     # Encrypt the client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                if oauth_resource:
+                    oauth_config["resource"] = oauth_resource
 
                 # Add username and password for password grant type
                 if oauth_username:
@@ -11588,9 +11591,10 @@ async def admin_edit_gateway(
             oauth_username = str(form.get("oauth_username", ""))
             oauth_password = str(form.get("oauth_password", ""))
             oauth_scopes_str = str(form.get("oauth_scopes", ""))
+            oauth_resource = str(form.get("oauth_resource", ""))
 
             # If any OAuth field is provided, assemble oauth_config
-            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
+            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id, oauth_resource]):
                 oauth_config = {}
 
                 if oauth_grant_type:
@@ -11609,6 +11613,8 @@ async def admin_edit_gateway(
                     # Encrypt the client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                if oauth_resource:
+                    oauth_config["resource"] = oauth_resource
 
                 # Add username and password for password grant type
                 if oauth_username:
@@ -14506,9 +14512,10 @@ async def admin_add_a2a_agent(
             oauth_username = str(form.get("oauth_username", ""))
             oauth_password = str(form.get("oauth_password", ""))
             oauth_scopes_str = str(form.get("oauth_scopes", ""))
+            oauth_resource = str(form.get("oauth_resource", ""))
 
             # If any OAuth field is provided, assemble oauth_config
-            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
+            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id, oauth_resource]):
                 oauth_config = {}
 
                 if oauth_grant_type:
@@ -14527,6 +14534,8 @@ async def admin_add_a2a_agent(
                     # Encrypt the client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                if oauth_resource:
+                    oauth_config["resource"] = oauth_resource
 
                 # Add username and password for password grant type
                 if oauth_username:
@@ -14758,9 +14767,10 @@ async def admin_edit_a2a_agent(
             oauth_username = str(form.get("oauth_username", ""))
             oauth_password = str(form.get("oauth_password", ""))
             oauth_scopes_str = str(form.get("oauth_scopes", ""))
+            oauth_resource = str(form.get("oauth_resource", ""))
 
             # If any OAuth field is provided, assemble oauth_config
-            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
+            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id, oauth_resource]):
                 oauth_config = {}
 
                 if oauth_grant_type:
@@ -14779,6 +14789,8 @@ async def admin_edit_a2a_agent(
                     # Encrypt the client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                if oauth_resource:
+                    oauth_config["resource"] = oauth_resource
 
                 # Add username and password for password grant type
                 if oauth_username:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2894,6 +2894,35 @@ class GatewayCreate(BaseModel):
 
         return self
 
+    @model_validator(mode="after")
+    def validate_client_credentials_config(self) -> "GatewayCreate":
+        """Validate that client_credentials oauth_config has all required fields.
+
+        Returns:
+            GatewayCreate: The validated instance.
+
+        Raises:
+            ValueError: If required fields are missing for client_credentials grant.
+
+        Examples:
+            >>> from mcpgateway.schemas import GatewayCreate
+            >>> try:
+            ...     GatewayCreate(name="gw", url="http://example.com", oauth_config={"grant_type": "client_credentials"})
+            ... except Exception as e:
+            ...     "token_url" in str(e)
+            True
+        """
+        if not self.oauth_config:
+            return self
+        if self.oauth_config.get("grant_type") != "client_credentials":
+            return self
+
+        missing = [f for f in ("token_url", "client_id", "client_secret") if not self.oauth_config.get(f)]
+        if missing:
+            raise ValueError(f"oauth_config is missing required fields for client_credentials grant: {', '.join(missing)}")
+
+        return self
+
 
 class GatewayUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing federation gateway.
@@ -3176,6 +3205,38 @@ class GatewayUpdate(BaseModelWithConfigDict):
                 raise ValueError("auth_query_param_key is required when setting auth_type to 'query_param'")
             if not self.auth_query_param_value:
                 raise ValueError("auth_query_param_value is required when setting auth_type to 'query_param'")
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_client_credentials_config(self) -> "GatewayUpdate":
+        """Validate that client_credentials oauth_config has all required fields.
+
+        Only runs when oauth_config is explicitly provided in the update payload,
+        so partial updates that omit oauth_config are unaffected.
+
+        Returns:
+            GatewayUpdate: The validated instance.
+
+        Raises:
+            ValueError: If required fields are missing for client_credentials grant.
+
+        Examples:
+            >>> from mcpgateway.schemas import GatewayUpdate
+            >>> try:
+            ...     GatewayUpdate(oauth_config={"grant_type": "client_credentials", "client_id": "x"})
+            ... except Exception as e:
+            ...     "token_url" in str(e)
+            True
+        """
+        if not self.oauth_config:
+            return self
+        if self.oauth_config.get("grant_type") != "client_credentials":
+            return self
+
+        missing = [f for f in ("token_url", "client_id", "client_secret") if not self.oauth_config.get(f)]
+        if missing:
+            raise ValueError(f"oauth_config is missing required fields for client_credentials grant: {', '.join(missing)}")
 
         return self
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -18982,7 +18982,9 @@ function handleOAuthGrantTypeChange() {
 
     // Select the correct fields dynamically based on prefix
     const authCodeFields = safeGetElement(`oauth-auth-code-fields-${prefix}`);
-    const clientCredentialsFields = safeGetElement(`oauth-client-credentials-fields-${prefix}`);
+    const clientCredentialsFields = safeGetElement(
+        `oauth-client-credentials-fields-${prefix}`,
+    );
     const usernameField = safeGetElement(`oauth-username-field-${prefix}`);
     const passwordField = safeGetElement(`oauth-password-field-${prefix}`);
 
@@ -19011,7 +19013,8 @@ function handleOAuthGrantTypeChange() {
 
     // Handle Client Credentials flow
     if (clientCredentialsFields) {
-        clientCredentialsFields.style.display = grantType === "client_credentials" ? "block" : "none";
+        clientCredentialsFields.style.display =
+            grantType === "client_credentials" ? "block" : "none";
     }
 
     // Handle Password Grant flow
@@ -19055,7 +19058,9 @@ function handleEditOAuthGrantTypeChange() {
     const prefix = id.includes("a2a") ? "a2a-edit" : "gw-edit";
 
     const authCodeFields = safeGetElement(`oauth-auth-code-fields-${prefix}`);
-    const clientCredentialsFields = safeGetElement(`oauth-client-credentials-fields-${prefix}`);
+    const clientCredentialsFields = safeGetElement(
+        `oauth-client-credentials-fields-${prefix}`,
+    );
     const usernameField = safeGetElement(`oauth-username-field-${prefix}`);
     const passwordField = safeGetElement(`oauth-password-field-${prefix}`);
 
@@ -19076,7 +19081,8 @@ function handleEditOAuthGrantTypeChange() {
 
     // === Handle Client Credentials grant ===
     if (clientCredentialsFields) {
-        clientCredentialsFields.style.display = grantType === "client_credentials" ? "block" : "none";
+        clientCredentialsFields.style.display =
+            grantType === "client_credentials" ? "block" : "none";
     }
 
     // === Handle Password grant ===
@@ -20399,21 +20405,25 @@ window.updateAuthHeadersJSON = updateAuthHeadersJSON;
 window.loadAuthHeaders = loadAuthHeaders;
 
 /**
- * Fetch tools from MCP server after OAuth completion for Authorization Code flow
- * @param {string} gatewayId - ID of the gateway to fetch tools for
- * @param {string} gatewayName - Name of the gateway for display purposes
+ * Test M2M token acquisition for a client_credentials gateway.
+ * @param {string} gatewayId - ID of the gateway to test
+ * @param {HTMLElement} button - The button element that triggered the test
  */
-async function testM2MGateway(gatewayId, button) {
+window.testM2MGateway = async function testM2MGateway(gatewayId, button) {
     const originalText = button.textContent;
     button.disabled = true;
     button.textContent = "⏳ Testing...";
 
     try {
-        const response = await fetch(`${window.adminBasePath || ""}/admin/gateways/${gatewayId}/test-m2m`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "same-origin",
-        });
+        const base = window.adminBasePath || "";
+        const response = await fetch(
+            `${base}/admin/gateways/${gatewayId}/test-m2m`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                credentials: "same-origin",
+            },
+        );
         const data = await response.json();
 
         if (data.success) {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -20403,6 +20403,32 @@ window.loadAuthHeaders = loadAuthHeaders;
  * @param {string} gatewayId - ID of the gateway to fetch tools for
  * @param {string} gatewayName - Name of the gateway for display purposes
  */
+async function testM2MGateway(gatewayId, button) {
+    const originalText = button.textContent;
+    button.disabled = true;
+    button.textContent = "⏳ Testing...";
+
+    try {
+        const response = await fetch(`${window.adminBasePath || ""}/admin/gateways/${gatewayId}/test-m2m`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "same-origin",
+        });
+        const data = await response.json();
+
+        if (data.success) {
+            showToast("M2M token acquired successfully", "success");
+        } else {
+            showToast(`Token acquisition failed: ${data.message}`, "error");
+        }
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, "error");
+    } finally {
+        button.disabled = false;
+        button.textContent = originalText;
+    }
+}
+
 async function fetchToolsForGateway(gatewayId, gatewayName) {
     const button = document.getElementById(`fetch-tools-${gatewayId}`);
     if (!button) {

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -6258,8 +6258,12 @@ async function editGateway(gatewayId) {
             "oauth-redirect-uri-gw-edit",
         );
         const oauthScopesField = safeGetElement("oauth-scopes-gw-edit");
+        const oauthResourceField = safeGetElement("oauth-resource-gw-edit");
         const oauthAuthCodeFields = safeGetElement(
             "oauth-auth-code-fields-gw-edit",
+        );
+        const oauthClientCredentialsFields = safeGetElement(
+            "oauth-client-credentials-fields-gw-edit",
         );
 
         // Hide all auth sections first
@@ -6356,10 +6360,16 @@ async function editGateway(gatewayId) {
                     const config = gateway.oauthConfig;
                     if (oauthGrantTypeField && config.grant_type) {
                         oauthGrantTypeField.value = config.grant_type;
-                        // Show/hide authorization code fields based on grant type
+                        // Show/hide grant-type-specific fields
                         if (oauthAuthCodeFields) {
                             oauthAuthCodeFields.style.display =
                                 config.grant_type === "authorization_code"
+                                    ? "block"
+                                    : "none";
+                        }
+                        if (oauthClientCredentialsFields) {
+                            oauthClientCredentialsFields.style.display =
+                                config.grant_type === "client_credentials"
                                     ? "block"
                                     : "none";
                         }
@@ -6385,6 +6395,9 @@ async function editGateway(gatewayId) {
                         Array.isArray(config.scopes)
                     ) {
                         oauthScopesField.value = config.scopes.join(" ");
+                    }
+                    if (oauthResourceField && config.resource) {
+                        oauthResourceField.value = config.resource;
                     }
                 }
                 break;
@@ -18969,6 +18982,7 @@ function handleOAuthGrantTypeChange() {
 
     // Select the correct fields dynamically based on prefix
     const authCodeFields = safeGetElement(`oauth-auth-code-fields-${prefix}`);
+    const clientCredentialsFields = safeGetElement(`oauth-client-credentials-fields-${prefix}`);
     const usernameField = safeGetElement(`oauth-username-field-${prefix}`);
     const passwordField = safeGetElement(`oauth-password-field-${prefix}`);
 
@@ -18993,6 +19007,11 @@ function handleOAuthGrantTypeChange() {
                 authCodeFields.querySelectorAll('input[type="url"]');
             requiredFields.forEach((field) => (field.required = false));
         }
+    }
+
+    // Handle Client Credentials flow
+    if (clientCredentialsFields) {
+        clientCredentialsFields.style.display = grantType === "client_credentials" ? "block" : "none";
     }
 
     // Handle Password Grant flow
@@ -19036,6 +19055,7 @@ function handleEditOAuthGrantTypeChange() {
     const prefix = id.includes("a2a") ? "a2a-edit" : "gw-edit";
 
     const authCodeFields = safeGetElement(`oauth-auth-code-fields-${prefix}`);
+    const clientCredentialsFields = safeGetElement(`oauth-client-credentials-fields-${prefix}`);
     const usernameField = safeGetElement(`oauth-username-field-${prefix}`);
     const passwordField = safeGetElement(`oauth-password-field-${prefix}`);
 
@@ -19052,6 +19072,11 @@ function handleEditOAuthGrantTypeChange() {
             authCodeFields.style.display = "none";
             urlInputs.forEach((field) => (field.required = false));
         }
+    }
+
+    // === Handle Client Credentials grant ===
+    if (clientCredentialsFields) {
+        clientCredentialsFields.style.display = grantType === "client_credentials" ? "block" : "none";
     }
 
     // === Handle Password grant ===

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -20437,7 +20437,7 @@ window.testM2MGateway = async function testM2MGateway(gatewayId, button) {
         button.disabled = false;
         button.textContent = originalText;
     }
-}
+};
 
 async function fetchToolsForGateway(gatewayId, gatewayName) {
     const button = document.getElementById(`fetch-tools-${gatewayId}`);

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5967,6 +5967,26 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       read:user")
                     </p>
                   </div>
+
+                  <div id="oauth-client-credentials-fields-gw" style="display:none">
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                      >
+                        Resource (RFC 8707)
+                      </label>
+                      <input
+                        type="url"
+                        name="oauth_resource"
+                        id="oauth-resource-gw"
+                        class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        placeholder="https://upstream.example.com/mcp"
+                      />
+                      <p class="mt-1 text-sm text-gray-500">
+                        Upstream resource URL to scope the M2M token to (recommended)
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -10402,27 +10422,48 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             </p>
                           </div>
 
-                          <div>
-                            <label
-                              class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                            >
-                              Scopes
-                            </label>
-                            <input
-                              type="text"
-                              name="oauth_scopes"
-                              id="oauth-scopes-gw-edit"
-                              class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                              placeholder="repo read:user (space-separated)"
-                            />
-                            <p class="mt-1 text-sm text-gray-500">
-                              Space-separated list of OAuth scopes (e.g., "repo
-                              read:user")
-                            </p>
-                          </div>
                         </div>
                       </div>
                     </div>
+
+                    <div id="oauth-client-credentials-fields-gw-edit" style="display:none">
+                      <div>
+                        <label
+                          class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >
+                          Scopes
+                        </label>
+                        <input
+                          type="text"
+                          name="oauth_scopes"
+                          id="oauth-scopes-gw-edit"
+                          class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          placeholder="tools:read tools:execute (space-separated)"
+                        />
+                        <p class="mt-1 text-sm text-gray-500">
+                          Space-separated OAuth scopes requested from the token endpoint
+                        </p>
+                      </div>
+
+                      <div>
+                        <label
+                          class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >
+                          Resource (RFC 8707)
+                        </label>
+                        <input
+                          type="url"
+                          name="oauth_resource"
+                          id="oauth-resource-gw-edit"
+                          class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          placeholder="https://upstream.example.com/mcp"
+                        />
+                        <p class="mt-1 text-sm text-gray-500">
+                          Upstream resource URL to scope the M2M token to (recommended)
+                        </p>
+                      </div>
+                    </div>
+
                     <div class="mt-4">
                       <label class="flex items-center">
                         <input

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5287,6 +5287,15 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       >
                         🔐 Authorize
                       </a>
+                      {% if gateway.oauthConfig and gateway.oauthConfig.get('grant_type') == 'client_credentials' %}
+                      <button
+                        onclick="testM2MGateway({{ gateway.id|tojson_attr }}, this)"
+                        class="flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md text-teal-600 hover:text-teal-900 hover:bg-teal-50 dark:text-teal-400 dark:hover:bg-teal-900/20 transition-colors"
+                        x-tooltip="'🔑 Test M2M token acquisition from IDP'"
+                      >
+                        🔑 Test Token
+                      </button>
+                      {% endif %}
                       <button
                         onclick="fetchToolsForGateway({{ gateway.id|tojson_attr }}, {{ gateway.name|tojson_attr }})"
                         class="flex items-center justify-center px-1 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors"

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -14106,6 +14106,174 @@ async def test_admin_edit_a2a_agent_error_handlers(monkeypatch, mock_db):
         assert response.status_code == expected_status
 
 
+# ---------------------------------------------------------------------------
+# Tests for oauth_resource field coverage in add/edit gateway and A2A agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_add_gateway_oauth_resource_stored(monkeypatch, mock_request, mock_db):
+    """oauth_resource form field is stored in oauth_config['resource'] for add gateway."""
+    from mcpgateway.services.gateway_service import GatewayService
+
+    form_data = FakeForm(
+        {
+            "name": "M2M-GW",
+            "url": "https://api.example.com",
+            "auth_type": "oauth",
+            "oauth_grant_type": "client_credentials",
+            "oauth_token_url": "https://idp.example.com/token",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "secret",
+            "oauth_resource": "https://api.example.com/mcp",
+        }
+    )
+    mock_request.form = AsyncMock(return_value=form_data)
+
+    mock_svc = MagicMock()
+    mock_svc.register_gateway = AsyncMock()
+    monkeypatch.setattr("mcpgateway.admin.gateway_service", mock_svc)
+
+    team_service = MagicMock()
+    team_service.verify_team_for_user = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    encryptor = MagicMock()
+    encryptor.encrypt_secret_async = AsyncMock(return_value="enc-secret")
+    monkeypatch.setattr("mcpgateway.admin.get_encryption_service", lambda _s: encryptor)
+    monkeypatch.setattr(
+        "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+        lambda *_a, **_kw: {"created_by": "u", "created_from_ip": None, "created_via": "ui", "created_user_agent": None, "import_batch_id": None, "federation_source": None},
+    )
+
+    response = await admin_add_gateway(mock_request, mock_db, user={"email": "u@example.com", "db": mock_db})
+    assert response.status_code == 200
+    gw = mock_svc.register_gateway.call_args.args[1]
+    assert gw.oauth_config["resource"] == "https://api.example.com/mcp"
+
+
+@pytest.mark.asyncio
+async def test_admin_edit_gateway_oauth_resource_stored(monkeypatch, mock_request, mock_db):
+    """oauth_resource form field is stored in oauth_config['resource'] for edit gateway."""
+    form_data = FakeForm(
+        {
+            "name": "M2M-GW",
+            "url": "https://api.example.com",
+            "auth_type": "oauth",
+            "oauth_grant_type": "authorization_code",
+            "oauth_token_url": "https://idp.example.com/token",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "secret",
+            "oauth_resource": "https://api.example.com/mcp",
+        }
+    )
+    mock_request.form = AsyncMock(return_value=form_data)
+
+    mock_svc = MagicMock()
+    mock_svc.update_gateway = AsyncMock()
+    monkeypatch.setattr("mcpgateway.admin.gateway_service", mock_svc)
+
+    team_service = MagicMock()
+    team_service.verify_team_for_user = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    encryptor = MagicMock()
+    encryptor.encrypt_secret_async = AsyncMock(return_value="enc-secret")
+    monkeypatch.setattr("mcpgateway.admin.get_encryption_service", lambda _s: encryptor)
+    monkeypatch.setattr(
+        "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+        lambda *_a, **_kw: {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None},
+    )
+
+    response = await admin_edit_gateway("gw-1", mock_request, mock_db, user={"email": "u@example.com", "db": mock_db})
+    assert response.status_code == 200
+    gw = mock_svc.update_gateway.call_args.args[2]
+    assert gw.oauth_config["resource"] == "https://api.example.com/mcp"
+
+
+@pytest.mark.asyncio
+async def test_admin_add_a2a_agent_oauth_resource_stored(monkeypatch, mock_db):
+    """oauth_resource form field is stored in oauth_config['resource'] for add A2A agent."""
+    form_data = FakeForm(
+        {
+            "name": "M2M-Agent",
+            "endpoint_url": "http://agent.example.com",
+            "auth_type": "oauth",
+            "oauth_grant_type": "client_credentials",
+            "oauth_token_url": "https://idp.example.com/token",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "secret",
+            "oauth_resource": "http://agent.example.com/a2a",
+        }
+    )
+    request = MagicMock(spec=Request)
+    request.form = AsyncMock(return_value=form_data)
+    request.scope = {"root_path": ""}
+
+    service = MagicMock()
+    service.register_agent = AsyncMock()
+    monkeypatch.setattr("mcpgateway.admin.a2a_service", service)
+    monkeypatch.setattr(settings, "mcpgateway_a2a_enabled", True)
+
+    team_service = MagicMock()
+    team_service.verify_team_for_user = AsyncMock(return_value=str(uuid4()))
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    encryptor = MagicMock()
+    encryptor.encrypt_secret_async = AsyncMock(return_value="enc")
+    monkeypatch.setattr("mcpgateway.admin.get_encryption_service", lambda _s: encryptor)
+    monkeypatch.setattr(
+        "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+        lambda *_a, **_kw: {"created_by": "u", "created_from_ip": None, "created_via": "ui", "created_user_agent": None, "import_batch_id": None, "federation_source": None},
+    )
+
+    response = await admin_add_a2a_agent(request, mock_db, user={"email": "u@example.com"})
+    assert response.status_code == 200
+    agent = service.register_agent.call_args.args[1]
+    assert agent.oauth_config["resource"] == "http://agent.example.com/a2a"
+
+
+@pytest.mark.asyncio
+async def test_admin_edit_a2a_agent_oauth_resource_stored(monkeypatch, mock_db):
+    """oauth_resource form field is stored in oauth_config['resource'] for edit A2A agent."""
+    form_data = FakeForm(
+        {
+            "name": "M2M-Agent",
+            "endpoint_url": "http://agent.example.com",
+            "auth_type": "oauth",
+            "oauth_grant_type": "authorization_code",
+            "oauth_token_url": "https://idp.example.com/token",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "secret",
+            "oauth_resource": "http://agent.example.com/a2a",
+        }
+    )
+    request = MagicMock(spec=Request)
+    request.form = AsyncMock(return_value=form_data)
+    request.scope = {"root_path": ""}
+
+    service = MagicMock()
+    service.update_agent = AsyncMock()
+    monkeypatch.setattr("mcpgateway.admin.a2a_service", service)
+
+    team_service = MagicMock()
+    team_service.verify_team_for_user = AsyncMock(return_value=str(uuid4()))
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    encryptor = MagicMock()
+    encryptor.encrypt_secret_async = AsyncMock(return_value="enc")
+    monkeypatch.setattr("mcpgateway.admin.get_encryption_service", lambda _s: encryptor)
+    monkeypatch.setattr(
+        "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+        lambda *_a, **_kw: {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None},
+    )
+
+    response = await admin_edit_a2a_agent("agent-1", request, mock_db, user={"email": "u@example.com"})
+    assert response.status_code == 200
+    agent = service.update_agent.call_args.kwargs["agent_data"]
+    assert agent.oauth_config["resource"] == "http://agent.example.com/a2a"
+
+
 # ============================================================================ #
 #                 GROUP 1: Utility Functions                                    #
 # ============================================================================ #

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -166,6 +166,7 @@ from mcpgateway.admin import (  # admin_get_metrics,
     admin_teams_partial_html,
     admin_test_a2a_agent,
     admin_test_gateway,
+    admin_test_m2m_gateway,
     admin_test_resource,
     admin_tokens_partial_html,
     admin_tool_ops_partial,
@@ -20590,3 +20591,76 @@ class TestAdminPersonalTeamFiltering:
             call_kwargs = mock_team_service.list_teams.call_args[1]
             assert call_kwargs["search_query"] == "nomatch"
             assert call_kwargs["personal_owner_email"] == "admin@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Tests for admin_test_m2m_gateway
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_test_m2m_gateway_success(monkeypatch, mock_db):
+    """Token acquired successfully returns success=True JSON response."""
+    gateway = SimpleNamespace(id="gw-1", oauth_config={"grant_type": "client_credentials", "token_url": "https://idp.example.com/token", "client_id": "cid", "client_secret": "secret"})
+    monkeypatch.setattr("mcpgateway.admin.gateway_service.get_gateway", AsyncMock(return_value=gateway))
+
+    oauth_manager = MagicMock()
+    oauth_manager.get_access_token = AsyncMock(return_value="tok123")
+    monkeypatch.setattr("mcpgateway.admin.OAuthManager", lambda **_kwargs: oauth_manager)
+
+    response = await admin_test_m2m_gateway(gateway_id="gw-1", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert body["success"] is True
+    assert "successfully" in body["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_admin_test_m2m_gateway_not_found(monkeypatch, mock_db):
+    """Returns 404 when the gateway does not exist."""
+    monkeypatch.setattr("mcpgateway.admin.gateway_service.get_gateway", AsyncMock(side_effect=GatewayNotFoundError("not found")))
+
+    with pytest.raises(Exception) as exc_info:
+        await admin_test_m2m_gateway(gateway_id="missing", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_test_m2m_gateway_no_oauth_config(monkeypatch, mock_db):
+    """Returns 400 when the gateway has no OAuth config."""
+    gateway = SimpleNamespace(id="gw-2", oauth_config=None)
+    monkeypatch.setattr("mcpgateway.admin.gateway_service.get_gateway", AsyncMock(return_value=gateway))
+
+    with pytest.raises(Exception) as exc_info:
+        await admin_test_m2m_gateway(gateway_id="gw-2", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
+    assert exc_info.value.status_code == 400
+    assert "not configured with oauth" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_admin_test_m2m_gateway_wrong_grant_type(monkeypatch, mock_db):
+    """Returns 400 when grant_type is not client_credentials."""
+    gateway = SimpleNamespace(id="gw-3", oauth_config={"grant_type": "authorization_code"})
+    monkeypatch.setattr("mcpgateway.admin.gateway_service.get_gateway", AsyncMock(return_value=gateway))
+
+    with pytest.raises(Exception) as exc_info:
+        await admin_test_m2m_gateway(gateway_id="gw-3", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
+    assert exc_info.value.status_code == 400
+    assert "client_credentials" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_admin_test_m2m_gateway_idp_failure(monkeypatch, mock_db):
+    """IDP failure returns success=False with error message."""
+    gateway = SimpleNamespace(id="gw-4", oauth_config={"grant_type": "client_credentials", "token_url": "https://idp.example.com/token", "client_id": "cid", "client_secret": "secret"})
+    monkeypatch.setattr("mcpgateway.admin.gateway_service.get_gateway", AsyncMock(return_value=gateway))
+
+    oauth_manager = MagicMock()
+    oauth_manager.get_access_token = AsyncMock(side_effect=RuntimeError("IDP unreachable"))
+    monkeypatch.setattr("mcpgateway.admin.OAuthManager", lambda **_kwargs: oauth_manager)
+
+    response = await admin_test_m2m_gateway(gateway_id="gw-4", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert body["success"] is False
+    assert "IDP unreachable" in body["message"]

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -5009,18 +5009,21 @@ class TestOAuthFunctionality:
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_empty_client_secret(self, mock_update_gateway, mock_request, mock_db):
-        """Test editing gateway with empty OAuth client secret."""
-        oauth_config = {
-            "grant_type": "client_credentials",
-            "client_id": "edit-client-id",
-            "client_secret": "",  # Empty secret
-            "token_url": "https://auth.example.com/oauth/token",
-        }
-
-        form_data = FakeForm({"name": "Edited_Gateway", "url": "https://edited.example.com", "oauth_config": json.dumps(oauth_config)})
+        """Empty oauth_client_secret in form fields (Option 2) does not trigger encryption."""
+        # Uses authorization_code so the M2M required-fields validator does not run.
+        # The intent is to verify the `if oauth_client_secret:` branch skips encryption when empty.
+        form_data = FakeForm(
+            {
+                "name": "Edited_Gateway",
+                "url": "https://edited.example.com",
+                "oauth_grant_type": "authorization_code",
+                "oauth_client_id": "edit-client-id",
+                "oauth_client_secret": "",  # Empty — encryption must not be called
+                "oauth_token_url": "https://auth.example.com/oauth/token",
+            }
+        )
         mock_request.form = AsyncMock(return_value=form_data)
 
-        # Mock OAuth encryption - should not be called for empty secret
         with patch("mcpgateway.admin.get_encryption_service") as mock_get_encryption:
             mock_encryption = MagicMock()
             mock_encryption.encrypt_secret_async = AsyncMock()
@@ -5029,8 +5032,6 @@ class TestOAuthFunctionality:
             result = await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
-
-            # Verify OAuth encryption was not called for empty secret
             mock_encryption.encrypt_secret_async.assert_not_called()
             mock_update_gateway.assert_called_once()
 
@@ -5159,13 +5160,13 @@ class TestOAuthFunctionality:
 
     @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_oauth_scopes_parse_empty_and_missing_client_id(self, mock_register_gateway, mock_request, mock_db):
-        """Cover 'missing client_id' and 'empty scopes list' branches."""
+        """Cover 'missing client_id' and 'empty scopes list' branches (uses authorization_code to avoid M2M validator)."""
         form_data = FakeForm(
             {
                 "name": "OAuth_Scopes_Empty_Gateway",
                 "url": "https://example.com",
                 "auth_headers": "",
-                "oauth_grant_type": "client_credentials",
+                "oauth_grant_type": "authorization_code",
                 "oauth_client_id": "",  # Ensure the client_id branch is false
                 "oauth_scopes": ",",  # Truthy string but parses to empty list
             }
@@ -5193,11 +5194,11 @@ class TestOAuthFunctionality:
 
             gateway_create = mock_register_gateway.call_args.args[1]
             assert gateway_create.auth_type == "oauth"
-            assert gateway_create.oauth_config == {"grant_type": "client_credentials"}
+            assert gateway_create.oauth_config == {"grant_type": "authorization_code"}
 
     @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_oauth_config_without_client_secret(self, mock_register_gateway, mock_request, mock_db):
-        """Cover Option 1 parsing when oauth_config has no client_secret."""
+        """client_credentials config missing client_secret is rejected with 422."""
         oauth_config = {"grant_type": "client_credentials", "client_id": "cid"}
         form_data = FakeForm({"name": "OAuth_NoSecret_Gateway", "url": "https://example.com", "auth_headers": "", "oauth_config": json.dumps(oauth_config)})
         mock_request.form = AsyncMock(return_value=form_data)
@@ -5218,12 +5219,8 @@ class TestOAuthFunctionality:
             }
 
             result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
-            assert isinstance(result, JSONResponse)
-            assert result.status_code == 200
-
-            gateway_create = mock_register_gateway.call_args.args[1]
-            assert gateway_create.auth_type == "oauth"
-            assert gateway_create.oauth_config == oauth_config
+            assert result.status_code == 422
+            mock_register_gateway.assert_not_called()
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_assembled_from_form_fields(self, mock_update_gateway, mock_request, mock_db):
@@ -5268,14 +5265,14 @@ class TestOAuthFunctionality:
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_assembled_minimal_fields_covers_false_branches(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
-        """Cover false branches in admin_edit_gateway's OAuth field assembly."""
+        """Cover false branches in admin_edit_gateway's OAuth field assembly (uses authorization_code to avoid M2M validator)."""
         form_data = FakeForm(
             {
                 "name": "Edited_Gateway",
                 "url": "https://edited.example.com",
                 "auth_headers": "",
                 "passthrough_headers": "X-Req-Id, X-Trace",
-                "oauth_grant_type": "client_credentials",
+                "oauth_grant_type": "authorization_code",
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
@@ -5294,19 +5291,19 @@ class TestOAuthFunctionality:
 
         gateway_update = mock_update_gateway.call_args.args[2]
         assert gateway_update.auth_type == "oauth"
-        assert gateway_update.oauth_config == {"grant_type": "client_credentials"}
+        assert gateway_update.oauth_config == {"grant_type": "authorization_code"}
         assert gateway_update.passthrough_headers == ["X-Req-Id", "X-Trace"]
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_scopes_parse_empty(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
-        """Cover the empty-scopes (inner if) branch in admin_edit_gateway."""
+        """Cover the empty-scopes (inner if) branch in admin_edit_gateway (uses authorization_code to avoid M2M validator)."""
         form_data = FakeForm(
             {
                 "name": "Edited_Gateway",
                 "url": "https://edited.example.com",
                 "auth_headers": "",
                 "passthrough_headers": "",
-                "oauth_grant_type": "client_credentials",
+                "oauth_grant_type": "authorization_code",
                 "oauth_scopes": ",",
             }
         )
@@ -5325,7 +5322,7 @@ class TestOAuthFunctionality:
         assert result.status_code == 200
 
         gateway_update = mock_update_gateway.call_args.args[2]
-        assert gateway_update.oauth_config == {"grant_type": "client_credentials"}
+        assert gateway_update.oauth_config == {"grant_type": "authorization_code"}
 
     @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_ca_certificate_signed(self, mock_register_gateway, mock_request, mock_db, monkeypatch):

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1254,3 +1254,129 @@ class TestSchemaValidators:
             ResourceSubscription(uri="resource://one", subscriber_id=long_subscriber)
 
         assert "Subscriber ID exceeds maximum length" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# GatewayCreate / GatewayUpdate — client_credentials oauth_config validation
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayClientCredentialsValidation:
+    """Tests for the validate_client_credentials_config model validator."""
+
+    def test_create_rejects_missing_all_required_fields(self):
+        """GatewayCreate should reject client_credentials config with no required fields."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="gw",
+                url="http://example.com",
+                oauth_config={"grant_type": "client_credentials"},
+            )
+        error_str = str(exc_info.value)
+        assert "token_url" in error_str
+        assert "client_id" in error_str
+        assert "client_secret" in error_str
+
+    def test_create_rejects_missing_token_url(self):
+        """GatewayCreate should reject client_credentials config missing token_url."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="gw",
+                url="http://example.com",
+                oauth_config={"grant_type": "client_credentials", "client_id": "x", "client_secret": "s"},
+            )
+        assert "token_url" in str(exc_info.value)
+
+    def test_create_rejects_missing_client_id(self):
+        """GatewayCreate should reject client_credentials config missing client_id."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="gw",
+                url="http://example.com",
+                oauth_config={"grant_type": "client_credentials", "token_url": "http://idp/token", "client_secret": "s"},
+            )
+        assert "client_id" in str(exc_info.value)
+
+    def test_create_rejects_missing_client_secret(self):
+        """GatewayCreate should reject client_credentials config missing client_secret."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="gw",
+                url="http://example.com",
+                oauth_config={"grant_type": "client_credentials", "token_url": "http://idp/token", "client_id": "x"},
+            )
+        assert "client_secret" in str(exc_info.value)
+
+    def test_create_accepts_complete_client_credentials_config(self):
+        """GatewayCreate should accept client_credentials config with all required fields."""
+        from mcpgateway.schemas import GatewayCreate
+
+        gw = GatewayCreate(
+            name="gw",
+            url="http://example.com",
+            oauth_config={
+                "grant_type": "client_credentials",
+                "token_url": "http://idp/token",
+                "client_id": "my-client",
+                "client_secret": "my-secret",
+            },
+        )
+        assert gw.oauth_config["grant_type"] == "client_credentials"
+
+    def test_create_unaffected_for_authorization_code_grant(self):
+        """GatewayCreate should not validate required M2M fields for authorization_code grant."""
+        from mcpgateway.schemas import GatewayCreate
+
+        # authorization_code without token_url/client_id/client_secret should not raise
+        gw = GatewayCreate(
+            name="gw",
+            url="http://example.com",
+            oauth_config={"grant_type": "authorization_code"},
+        )
+        assert gw.oauth_config["grant_type"] == "authorization_code"
+
+    def test_create_unaffected_when_no_oauth_config(self):
+        """GatewayCreate without oauth_config should not trigger the validator."""
+        from mcpgateway.schemas import GatewayCreate
+
+        gw = GatewayCreate(name="gw", url="http://example.com")
+        assert gw.oauth_config is None
+
+    def test_update_rejects_incomplete_client_credentials_config(self):
+        """GatewayUpdate should reject client_credentials config missing required fields."""
+        from mcpgateway.schemas import GatewayUpdate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayUpdate(oauth_config={"grant_type": "client_credentials", "client_id": "x"})
+        error_str = str(exc_info.value)
+        assert "token_url" in error_str
+        assert "client_secret" in error_str
+
+    def test_update_accepts_complete_client_credentials_config(self):
+        """GatewayUpdate should accept a complete client_credentials config."""
+        from mcpgateway.schemas import GatewayUpdate
+
+        upd = GatewayUpdate(
+            oauth_config={
+                "grant_type": "client_credentials",
+                "token_url": "http://idp/token",
+                "client_id": "x",
+                "client_secret": "s",
+            }
+        )
+        assert upd.oauth_config["grant_type"] == "client_credentials"
+
+    def test_update_unaffected_when_oauth_config_omitted(self):
+        """GatewayUpdate with no oauth_config should pass validation cleanly."""
+        from mcpgateway.schemas import GatewayUpdate
+
+        upd = GatewayUpdate(name="renamed")
+        assert upd.oauth_config is None


### PR DESCRIPTION
## Summary

Implements User Story 2 of #3386 — admin configuration of OAuth 2.0 Client Credentials (M2M) for upstream gateways.

- `GatewayCreate` and `GatewayUpdate` now validate that `oauth_config` with `grant_type: client_credentials` includes all required fields (`token_url`, `client_id`, `client_secret`); missing fields return 422
- `oauth_resource` (RFC 8707 resource indicator) is handled in both the create and edit admin endpoints and stored in `oauth_config["resource"]`
- Gateway create/edit forms now show a dedicated **Client Credentials** section (scopes + resource URL) when `client_credentials` is selected as the grant type, and hide it for other grant types
- New `POST /admin/gateways/{id}/test-m2m` endpoint attempts a live token acquisition from the configured IDP and returns success/failure without caching the token
- **🔑 Test Token** button added to the gateway list for `client_credentials` gateways — calls the above endpoint and shows a toast notification in the UI

Closes part of #3386 (US2). US1 (token cache + fan-out wiring) and US3 (integration) will follow in separate PRs.

---

### Scenario 1 — Configure via Admin UI ✅

| Requirement | What we did |
|---|---|
| Show `token_endpoint`, `client_id`, `client_secret`, `scopes`, `resource` when **Client Credentials** selected | Added `oauth-client-credentials-fields-gw` / `oauth-client-credentials-fields-gw-edit` divs in HTML; updated `handleOAuthGrantTypeChange()` and `handleEditOAuthGrantTypeChange()` in JS to show/hide them |
| Hide user-specific fields (`authorization_url`, `redirect_uri`) | Already handled by `handleOAuthGrantTypeChange()` — those fields are inside the `oauth-auth-code-fields-gw` div which gets hidden |
| `client_secret` encrypted before storage | Already handled by existing `protect_oauth_config_for_storage()` — no change needed |
| Populate `resource` field when editing a gateway | Added `oauthResourceField` population in `editGateway()` in JS |

---

### Scenario 2 — Configure via API ✅

| Requirement | What we did |
|---|---|
| `POST /gateways` and `PATCH /gateways/{id}` accept `client_credentials` config | Already worked; added the `resource` field extraction in `admin_add_gateway` and `admin_edit_gateway` in `admin.py` |
| Validate required fields (`token_endpoint`, `client_id`, `client_secret`) | Added `validate_client_credentials_config` model validator to `GatewayCreate` and `GatewayUpdate` in `schemas.py` |
| `client_secret` encrypted | Existing path, no change needed |

---

### Scenario 3 — Test M2M connectivity from Admin UI ✅

| Requirement | What we did |
|---|---|
| **Test Connection** button for `client_credentials` gateways | Added **🔑 Test Token** button in gateway list (conditionally shown for `client_credentials` only) |
| ContextForge attempts token acquisition from IDP | Added new endpoint `POST /admin/gateways/{id}/test-m2m` that calls `OAuthManager.get_access_token()` |
| Displays success/failure in UI | Implemented `testM2MGateway()` JS function that calls the endpoint and shows `showToast` with success/error message |

---

## How to test

### API — reject incomplete config

```bash
export TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
  --username admin@example.com --exp 0 --secret <your-jwt-secret>)

# Should return 422 — missing client_id and client_secret
curl -s -X POST http://localhost:4444/admin/gateways \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "test-m2m",
    "url": "http://localhost:9000",
    "oauth_config": {"grant_type": "client_credentials", "token_url": "http://idp/token"}
  }' | jq .status_code
```

### API — accept complete config

```bash
curl -s -X POST http://localhost:4444/admin/gateways \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "test-m2m",
    "url": "http://localhost:9000",
    "oauth_config": {
      "grant_type": "client_credentials",
      "token_url": "http://idp/token",
      "client_id": "my-client",
      "client_secret": "<your-client-secret>",
      "resource": "http://localhost:9000/mcp"
    }
  }' | jq .
```

### Admin UI — configure Client Credentials

1. Open Admin UI → Gateways → **Add Gateway**
2. Set Auth Type to **OAuth**
3. Select Grant Type → **Client Credentials**
4. Verify: Scopes and Resource fields appear; Authorization URL and Redirect URI are hidden
5. Leave Token URL blank and submit — should show validation error
6. Fill all required fields and submit — gateway created successfully
7. Click **Edit** on the gateway — Resource field is pre-populated

### Admin UI — test M2M token acquisition

1. In the gateway list, find a gateway with Auth Type **OAuth / client_credentials**
2. Click the **🔑 Test Token** button
3. Button shows ⏳ Testing... while the request is in flight
4. On success: green toast — "M2M token acquired successfully"
5. On failure (wrong credentials, IDP unreachable): red toast with the error message from the IDP

---

<details>
<summary>Screenshots</summary>

_Add screenshots here_

</details>

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
