### PR TITLE
fix(api): query raw DbGateway in admin_test_gateway to avoid decode_auth crash on masked auth_value

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12945,7 +12945,7 @@ async def admin_test_gateway(
     # (get_first_gateway_by_url returns a masked GatewayRead where
     # auth_value="*****", which cannot be decoded).
     try:
-        query = select(DbGateway).where(DbGateway.url == validated_base_url)
+        query = select(DbGateway).where(DbGateway.url == validated_base_url, DbGateway.enabled)
         if team_id:
             query = query.where(DbGateway.team_id == team_id)
         gateway = db.execute(query).scalars().first()

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -12892,6 +12892,102 @@ async def test_admin_test_gateway_no_auth_skips_decode(monkeypatch, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_admin_test_gateway_preserves_caller_headers(monkeypatch, mock_db):
+    """Stored gateway auth merges with (and overrides) caller-supplied headers."""
+
+    class MockResponse:
+        status_code = 200
+
+        def json(self):
+            return {"message": "ok"}
+
+        @property
+        def text(self):
+            return "ok"
+
+    captured: dict = {}
+
+    class MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def request(self, **kwargs):
+            captured.update(kwargs)
+            return MockResponse()
+
+    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+
+    gateway = SimpleNamespace(
+        id="gw-4", name="GW4", auth_type="bearer", auth_value={"Authorization": "Bearer stored-token"}, oauth_config=None
+    )
+    mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
+
+    request = GatewayTestRequest(
+        base_url="https://api.example.com", path="/test", method="GET",
+        headers={"X-Custom": "keep-me", "Authorization": "Bearer caller-token"}, body=None,
+    )
+    response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
+    assert response.status_code == 200
+    # Caller custom header is preserved
+    assert captured["headers"]["X-Custom"] == "keep-me"
+    # Stored gateway auth takes precedence over caller-supplied Authorization
+    assert captured["headers"]["Authorization"] == "Bearer stored-token"
+
+
+@pytest.mark.asyncio
+async def test_admin_test_gateway_skips_disabled_gateway(monkeypatch, mock_db):
+    """Disabled gateways should not be matched; the enabled filter must be applied."""
+
+    class MockResponse:
+        status_code = 200
+
+        def json(self):
+            return {"message": "ok"}
+
+        @property
+        def text(self):
+            return "ok"
+
+    class MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def request(self, **kwargs):
+            return MockResponse()
+
+    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    mock_db.execute.return_value.scalars.return_value.first.return_value = None
+
+    request = GatewayTestRequest(base_url="https://api.example.com", path="/test", method="GET", headers={}, body=None)
+    await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
+
+    # Verify the query was executed with arguments that include the enabled filter.
+    # The select() call produces a SQL WHERE clause; inspect the compiled query args.
+    execute_call = mock_db.execute.call_args
+    query = execute_call[0][0]
+    # Compile the query to verify enabled filter is present
+    compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+    assert "enabled" in compiled.lower(), f"Query should filter by enabled column, got: {compiled}"
+
+    # Also verify team_id filter is applied when provided.
+    mock_db.reset_mock()
+    mock_db.execute.return_value.scalars.return_value.first.return_value = None
+    await admin_test_gateway(request, "team-123", user={"email": "user@example.com", "db": mock_db}, db=mock_db)
+    execute_call = mock_db.execute.call_args
+    query = execute_call[0][0]
+    compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+    assert "team_id" in compiled.lower(), f"Query should filter by team_id, got: {compiled}"
+
+
+@pytest.mark.asyncio
 async def test_admin_list_tags(monkeypatch, mock_db):
     stats = SimpleNamespace(tools=1, resources=2, prompts=3, servers=4, gateways=5, total=15)
     entity = SimpleNamespace(id="tool-1", name="Tool", type="tool", description="desc")


### PR DESCRIPTION
  ## 🔗 Related Issue                                                                                                      Closes #3539
                                                                                                                         
  ---

  ## 📝 Summary
  `admin_test_gateway` crashed with `ValueError: Nonce must be between 8 and 128 bytes` because it called `decode_auth()`
   on a masked `auth_value` (`"*****"`) returned by `get_first_gateway_by_url()`. This PR queries the raw `DbGateway` ORM
   object directly and guards the `decode_auth` call with an explicit `auth_type` check, fixing the crash for all        
  gateways (with and without auth).

  ---

  ## 🏷️ Type of Change
  - [x] Bug fix
  - [ ] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)
  - [ ] Other (describe below)

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | ✅ No new issues (pre-existing black/ruff warnings on upstream main) | 
  | Unit tests                | `make test`     | ✅ 1001 passed, 4 pre-existing failures (TestPaginationSwapStyle) |    
  | Coverage ≥ 80%            | `make coverage` | ✅ 97% on mcpgateway/admin.py |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [x] Tests added/updated for changes
  - [ ] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  **Root cause:** `get_first_gateway_by_url()` returns a `GatewayRead.masked()` where `auth_value="*****"`. Passing that 
  to `decode_auth()` base64-decodes it to a 3-byte payload, then AES-GCM fails extracting a 12-byte nonce.

  **Fix:**
  1. Replace `gateway_service.get_first_gateway_by_url()` with a direct `select(DbGateway)` query to get the unmasked    
  auth value
  2. Replace the catch-all `else` with `elif gateway.auth_type in ("basic", "bearer", "authheaders")` so gateways with no
   auth skip decryption entirely
  3. Handle both `dict` and `str` `auth_value` formats from the raw DB object

  The 4 `TestPaginationSwapStyle` failures are pre-existing on upstream main and unrelated to this change.