### PR TITLE
fix(charts): fix TRANSPORT_TYPE validation and enable minikube testing profile

### DIFF
--- a/charts/mcp-stack/values-minikube.yaml
+++ b/charts/mcp-stack/values-minikube.yaml
@@ -99,3 +99,26 @@ redisCommander:
   enabled: false
 minio:
   enabled: false
+
+# Enable testing profile (fast-test-server + auto-registration)
+testing:
+  enabled: true
+  registration:
+    image:
+      repository: ghcr.io/ibm/mcp-context-forge
+      tag: "1.0.0-RC-2"
+      pullPolicy: Never
+    jwt:
+      secret: my-test-key
+  fastTime:
+    register:
+      enabled: true
+  fastTestServer:
+    enabled: true
+    image:
+      pullPolicy: Never
+  fastTest:
+    register:
+      enabled: true
+  a2aEchoAgent:
+    enabled: false

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -467,7 +467,7 @@ mcpContextForge:
     YIELD_BATCH_SIZE: "1000" # rows per batch when streaming rollup queries (100-10000)
 
     # ─ Transports ─
-    TRANSPORT_TYPE: http,sse          # comma-separated list: http, ws, sse, stdio, all
+    TRANSPORT_TYPE: all              # valid: http, sse, streamablehttp, all (WS/stdio gated by their own flags)
     MCPGATEWAY_WS_RELAY_ENABLED: "false" # /ws JSON-RPC relay (disabled)
     MCPGATEWAY_REVERSE_PROXY_ENABLED: "false" # /reverse-proxy/* endpoints (disabled)
     SSE_SEND_TIMEOUT: "30.0"         # ASGI send timeout (seconds), 0=disabled


### PR DESCRIPTION
## Summary

- Fix `TRANSPORT_TYPE: http,sse` → `all` — comma-separated values are not supported by the config validator and crash the gateway on startup
- Enable testing profile in `values-minikube.yaml` for local mcp-cli and Playwright testing

## Details

The `validate_transport()` method in `config.py` only accepts single values: `http`, `sse`, `streamablehttp`, or `all`. The comma-separated `http,sse` value introduced in #3550 causes a `ValueError` at startup, crashing both the migration job and the gateway pod.

Setting `TRANSPORT_TYPE: all` is safe because WS and stdio transports are independently gated by their own feature flags (`MCPGATEWAY_WS_RELAY_ENABLED=false`, `MCPGATEWAY_STDIO_TRANSPORT_ENABLED=false`).

The minikube overlay now includes the testing profile with fast-test-server and auto-registration of both gateways, enabling `make test-mcp-cli` against minikube deployments.

## Tested

- Fresh `helm install` on minikube — all pods healthy, no crashes
- `make test-mcp-cli`: **22 passed**
- Playwright (auth, API, admin UI, gateways, version): **70 passed, 3 skipped**