### PR TITLE
feat: MCP protocol load test and performance documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2173,6 +2173,67 @@ load-test-agentgateway-mcp-server-time:    ## Load test external MCP server (loc
 			--run-time=60s \
 			--class-picker'
 
+# --- MCP Streamable HTTP Protocol Load Test ---
+# help: load-test-mcp-protocol       - MCP-only protocol test (150 users, 2min) — measures pure MCP RPS
+# help: load-test-mcp-protocol-ui    - MCP-only protocol test with Locust Web UI (class picker)
+# help: load-test-mcp-protocol-heavy - MCP-only protocol heavy test (500 users, 5min)
+
+MCP_PROTOCOL_LOCUSTFILE ?= tests/loadtest/locustfile_mcp_protocol.py
+MCP_PROTOCOL_HOST ?= http://localhost:4444
+
+load-test-mcp-protocol:                    ## MCP Streamable HTTP protocol test (150 users, 2min)
+	@echo "🔬 Running MCP STREAMABLE HTTP protocol load test..."
+	@echo "   Host: $(MCP_PROTOCOL_HOST)"
+	@echo "   Users: 150, Spawn: 30/s, Duration: 2 minutes"
+	@echo "   📝 Tests ONLY MCP protocol path: /servers/{id}/mcp"
+	@echo "   💡 Requires: gateway + at least one MCP server connected"
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@mkdir -p reports
+	@/bin/bash -c 'source $(VENV_DIR)/bin/activate && \
+		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
+			--host=$(MCP_PROTOCOL_HOST) \
+			--users=150 \
+			--spawn-rate=30 \
+			--run-time=120s \
+			--headless \
+			--html=reports/loadtest_mcp_protocol.html \
+			--csv=reports/loadtest_mcp_protocol \
+			--processes=-1'
+
+load-test-mcp-protocol-ui:                 ## MCP Streamable HTTP protocol test with Web UI
+	@echo "🔬 Starting MCP STREAMABLE HTTP protocol load test Web UI..."
+	@echo "   🌐 Open http://localhost:8089 in your browser"
+	@echo "   🎯 Host: $(MCP_PROTOCOL_HOST)"
+	@echo "   👥 Defaults: 150 users, 30 spawn/s, 2 min"
+	@echo "   🎛️  Class picker enabled - select which MCP user types to run"
+	@echo "   📝 Tests ONLY MCP protocol path: /servers/{id}/mcp"
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@/bin/bash -c 'source $(VENV_DIR)/bin/activate && \
+		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
+			--host=$(MCP_PROTOCOL_HOST) \
+			--users=150 \
+			--spawn-rate=30 \
+			--run-time=120s \
+			--class-picker'
+
+load-test-mcp-protocol-heavy:              ## MCP Streamable HTTP protocol heavy test (500 users, 5min)
+	@echo "🔬 Running MCP STREAMABLE HTTP protocol HEAVY load test..."
+	@echo "   Host: $(MCP_PROTOCOL_HOST)"
+	@echo "   Users: 500, Spawn: 50/s, Duration: 5 minutes"
+	@echo "   ⚠️  This will generate sustained MCP protocol load"
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@mkdir -p reports
+	@/bin/bash -c 'source $(VENV_DIR)/bin/activate && \
+		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
+			--host=$(MCP_PROTOCOL_HOST) \
+			--users=500 \
+			--spawn-rate=50 \
+			--run-time=300s \
+			--headless \
+			--html=reports/loadtest_mcp_protocol_heavy.html \
+			--csv=reports/loadtest_mcp_protocol_heavy \
+			--processes=-1'
+
 # =============================================================================
 # 📊 JMETER PERFORMANCE TESTING
 # =============================================================================

--- a/docs/docs/architecture/performance-architecture.md
+++ b/docs/docs/architecture/performance-architecture.md
@@ -93,7 +93,7 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 │  │  │                              MULTI-LEVEL CACHING (80-95% DB reduction)                       │   ││
 │  │  │  ┌────────────────┐ ┌────────────────┐ ┌────────────────┐ ┌────────────────┐ ┌─────────────┐ │   ││
 │  │  │  │   JWT Cache    │ │  Auth Cache    │ │ Registry Cache │ │  Admin Stats   │ │ GlobalConfig│ │   ││
-│  │  │  │  TTL: 30s      │ │  TTL: 60s      │ │  TTL: 15-20s   │ │   TTL: 30-60s  │ │   TTL: 60s  │ │   ││
+│  │  │  │  TTL: 30s      │ │  TTL: 120-300s │ │  TTL: 20-300s  │ │   TTL: 30-120s │ │   TTL: 60s  │ │   ││
 │  │  │  │  <1ms auth     │ │  0-1 queries   │ │  95%+ hit rate │ │  Dashboard opt │ │  42K→0 qry  │ │   ││
 │  │  │  └────────────────┘ └────────────────┘ └────────────────┘ └────────────────┘ └─────────────┘ │   ││
 │  │  └──────────────────────────────────────────────────────────────────────────────────────────────┘   ││
@@ -169,6 +169,95 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 └─────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+## MCP Streamable HTTP Request Path
+
+Every MCP request to `/servers/{server_id}/mcp` passes through these layers:
+
+```
+Client Request (JSON-RPC over HTTP POST)
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  NGINX (Edge/Proxy)                         │
+│  • least_conn load balancing                │
+│  • keepalive 512 per worker                 │
+│  • No caching for /mcp (POST requests)      │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  GATEWAY MIDDLEWARE STACK                    │
+│  1. SecurityHeaders, CORS                   │
+│  2. MCPPathRewrite + Auth                   │
+│     • JWT verification (HMAC)               │
+│     • Token revocation check (DB/cache)     │
+│     • User lookup (DB/cache)                │
+│     • Team resolution (DB/cache)            │
+│  3. Token scoping (Layer 1 auth)            │
+│  4. Request logging                         │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  MCP SDK SessionManager                     │
+│  • JSON-RPC envelope parsing                │
+│  • Session tracking (stateless by default)  │
+│  • Context variable propagation             │
+│  • Handler method routing                   │
+└─────────────────────────────────────────────┘
+    │
+    ├── tools/list ─────┐
+    ├── tools/call ─────┤
+    ├── resources/list ─┤
+    ├── prompts/list ───┤
+    └── ping ───────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  MCP HANDLER                                │
+│  • RBAC permission check (Layer 2 auth)     │
+│  • Server/tool lookup (DB query)            │
+│  • For tools/call: upstream proxy           │
+│    via MCP Session Pool (if enabled)        │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  UPSTREAM MCP SERVER                        │
+│  (fast_test_server, fast_time, plugins)     │
+│  • Executes tool logic                      │
+│  • Returns JSON-RPC result                  │
+└─────────────────────────────────────────────┘
+```
+
+### Performance Characteristics by Layer
+
+| Layer | Typical Latency | Scaling Bottleneck | Key Tunable |
+|-------|----------------|-------------------|-------------|
+| nginx | <1ms | Not a bottleneck | `keepalive`, `worker_connections` |
+| Middleware + Auth | 5-15ms | Auth DB queries | `AUTH_CACHE_*_TTL`, `AUTH_CACHE_BATCH_QUERIES` |
+| MCP SDK SessionManager | 2-5ms | JSON-RPC parsing, context vars | `JSON_RESPONSE_ENABLED` |
+| RBAC check | 1-5ms | Permission DB queries | Role cache TTL (5 min internal) |
+| tools/list (DB) | 5-10ms | Sequential table scans | `REGISTRY_CACHE_TOOLS_TTL` |
+| tools/call (upstream) | 10-200ms | Upstream server + network | `MCP_SESSION_POOL_ENABLED` |
+
+### Feature Flags and Middleware Overhead
+
+Every enabled feature registers middleware, routers, or background tasks that consume resources even when not actively used. ContextForge has ~90 feature flags; each disabled feature removes its middleware and background tasks from the request path.
+
+The most impactful features to disable when not needed are: admin UI, A2A protocol, LLM chat, catalog, observability, audit trail, and database-backed structured logging. See the [disable unused features](../manage/tuning.md#10---disable-unused-features) section in the tuning guide for deployment profiles.
+
+### Key Architectural Insight
+
+The `/rpc` endpoint and the `/servers/{id}/mcp` endpoint serve the same logical operations (tools/list, tools/call) but follow different code paths:
+
+- **`/rpc`**: Uses Redis-backed caching (registry cache, tool lookup cache) for most lookups. Under load, Redis handles the read pressure, keeping PgBouncer/PostgreSQL near idle.
+- **`/mcp`**: Routes through the MCP SDK session manager, which executes its own handler functions. These handlers query the database via SQLAlchemy for server resolution, tool lookup, and RBAC checks. The auth cache (Redis-backed, TTL up to 300s) mitigates some of this, but RBAC and server/tool lookups still hit the database.
+
+This means that scaling MCP throughput depends heavily on reducing per-request database queries in the MCP transport handlers.
+
+---
+
 ## Component Performance Impact Summary
 
 ### Rust-Powered Components (GIL Bypass)
@@ -192,12 +281,13 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 
 ### Caching Performance
 
-| Cache Layer | Hit Rate | Latency Reduction | DB Query Reduction |
+| Cache Layer | Hit Rate | TTL (Configurable) | DB Query Reduction |
 |-------------|----------|-------------------|---------------------|
-| **JWT Cache** | >80% | 5-12ms → <1ms | Per-request auth overhead |
-| **Auth Cache** | >90% | 8-15ms → 1-3ms | 3-4 → 0-1 queries/request |
-| **Registry Cache** | 95%+ | Variable | 50-200 → 0-1 queries |
-| **GlobalConfig Cache** | 99%+ | 1ms → 0.00001ms | 42K+ queries eliminated |
+| **JWT Cache** | >80% | 30s | Per-request HMAC verification cached |
+| **Auth Cache** | >90% | 120-300s (max) | 3-4 → 0-1 queries/request (user, team, role, revocation) |
+| **Registry Cache** | 95%+ | 20-300s | 50-200 → 0-1 queries (tools, servers, prompts, resources) |
+| **GlobalConfig Cache** | 99%+ | 60s | 42K+ queries eliminated (passthrough header config) |
+| **MCP Session Pool** | Varies | 300s pool TTL | 10-20x latency improvement for repeated upstream calls |
 
 ### Compression & Bandwidth
 
@@ -209,12 +299,15 @@ This diagram showcases the performance-optimized architecture of ContextForge, h
 
 ### Scaling Capacity
 
-| Configuration | Capacity |
-|---------------|----------|
-| Single pod (16 workers) | ~1,600 RPS |
-| 3 pods (default) | ~4,800 RPS |
-| 10 pods (HPA scaled) | ~16,000 RPS |
-| 50 pods (max) | ~80,000 RPS |
+Capacity varies by workload type. MCP Streamable HTTP requests are more resource-intensive per request than REST API calls due to additional middleware, auth, and upstream proxy overhead.
+
+| Configuration | REST API (`/rpc`) | MCP Streamable HTTP (`/mcp`) |
+|---------------|-------------------|------------------------------|
+| Single pod (16-24 workers) | ~1,600 RPS | ~250-400 RPS |
+| 3 pods (default) | ~4,800 RPS | ~750-800 RPS |
+| 10 pods (HPA scaled) | ~16,000 RPS | ~2,500-3,000 RPS |
+
+MCP throughput is lower because each request includes auth/RBAC database queries that the `/rpc` endpoint caches in Redis. With session pool enabled (`MCP_SESSION_POOL_ENABLED=true`), upstream MCP server latency is amortized across pooled connections, providing ~10% throughput improvement.
 
 ## Key Performance Features by Issue
 
@@ -323,6 +416,12 @@ Future Architecture (Python 3.14+):
 │  Performance: Near-linear scaling with CPU cores            │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+## See Also
+
+- [Gateway Tuning Guide](../manage/tuning.md) - Environment variables, MCP transport settings, session pool, connection pool tuning
+- [Performance Profiling Guide](../development/profiling.md) - py-spy, memray, PostgreSQL profiling, MCP bottleneck triage
+- [Database Performance Guide](../development/db-performance.md) - N+1 detection, query logging, DB vs transport bottleneck triage
 
 ## Quick Reference Commands
 

--- a/docs/docs/development/db-performance.md
+++ b/docs/docs/development/db-performance.md
@@ -628,8 +628,49 @@ Priority files based on typical N+1 patterns:
 
 ---
 
+## Database vs Transport vs Runtime Bottlenecks
+
+Database tuning is one layer in end-to-end MCP performance. Before investing heavily in query optimization, determine whether the database is actually the bottleneck.
+
+### When to Stay in DB Profiling
+
+- `pg_stat_user_tables` shows high `seq_tup_read` counts growing under load
+- PgBouncer CPU is above 50%
+- PostgreSQL CPU is above 50%
+- `idle in transaction` connections are growing
+- N+1 patterns detected in query logs
+
+### When to Investigate Transport/Session Issues Instead
+
+- Gateway CPU is the highest resource consumer (>300% per replica)
+- Redis is idle during load (MCP transport may be bypassing cache)
+- Tool response times are dominated by upstream MCP server latency
+- Per-request latency is high but database query time is low
+- Session pool metrics show high miss rate or circuit breaker trips
+
+### When to Investigate Runtime Issues
+
+- py-spy flamegraph shows CPU time in middleware, JSON parsing, or Pydantic validation
+- Memory is growing during load (possible leak in template rendering or response buffering)
+- Thread pool workers are all blocked (check `py-spy dump` for thread stacks)
+
+### Triage Decision Table
+
+| Symptom | Check First | Then Check |
+|---------|------------|------------|
+| High latency, low RPS | DB queries per request (`pg_stat_user_tables`) | Gateway CPU (py-spy) |
+| High RPS, high latency | Upstream MCP server response time | Session pool hit rate |
+| PgBouncer at capacity | Auth cache TTLs, batch queries | Connection pool sizing |
+| Redis idle during MCP load | MCP transport cache path | Compare `/rpc` vs `/mcp` resource usage |
+| Errors under load (401, 500) | Connection pool limits, timeouts | Auth cache, token revocation |
+
+---
+
 ## Related Documentation
 
+- [Performance Profiling Guide](profiling.md) - py-spy, memray, container monitoring, MCP bottleneck triage
+- [Gateway Tuning Guide](../manage/tuning.md) - Environment variables, MCP transport settings, session pool tuning
+- [Performance Architecture](../architecture/performance-architecture.md) - MCP request path, caching layers
 - [SQLAlchemy Eager Loading](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#relationship-loading-techniques)
 - Existing instrumentation: `mcpgateway/instrumentation/sqlalchemy.py`
 - Performance strategy: `tests/performance/PERFORMANCE_STRATEGY.md`

--- a/docs/docs/development/profiling.md
+++ b/docs/docs/development/profiling.md
@@ -539,6 +539,71 @@ ORDER BY seq_tup_read DESC LIMIT 10;
 
 ---
 
+## MCP Protocol Profiling
+
+The MCP Streamable HTTP transport (`/servers/{id}/mcp`) has a different performance profile from the REST API (`/rpc`). Use the dedicated MCP load test to isolate protocol overhead.
+
+### MCP vs REST: Quick Comparison
+
+```bash
+# Run MCP-only load test
+make load-test-mcp-protocol
+
+# Compare with general load test (includes REST + admin)
+make load-test-cli
+```
+
+The MCP path processes requests through the MCP SDK session manager, which adds JSON-RPC parsing, context variable management, and per-request auth/RBAC database queries. The `/rpc` endpoint uses Redis-backed caching for tool lookups and auth, which the MCP transport path does not fully leverage. Under load, this manifests as significantly higher PgBouncer and PostgreSQL CPU on MCP workloads vs REST workloads for the same RPS.
+
+### Bottleneck Triage Table
+
+Use this table to identify which layer is the bottleneck:
+
+| Symptom | Bottleneck Layer | Investigation |
+|---------|-----------------|---------------|
+| Gateway CPU >300% per replica | Gateway compute (middleware, MCP SDK) | py-spy flamegraph on a gateway worker |
+| PgBouncer CPU >80% | Database connection pressure | Check `pg_stat_activity`, reduce DB queries per request |
+| PostgreSQL CPU >100% | Query overhead (seq scans, RBAC lookups) | `pg_stat_user_tables` for seq scan counts |
+| Redis CPU <1% during MCP load | MCP path not using Redis cache | Compare with `/rpc` which does use Redis |
+| Upstream MCP server CPU high | Tool execution overhead | Profile the upstream MCP server separately |
+| nginx CPU >30% | Proxy overhead (unlikely) | Check keepalive, connection reuse |
+| High p99 but low p50 | Tail latency from GC or lock contention | py-spy dump to check for blocked threads |
+
+### MCP Profiling Session
+
+```bash
+# 1. Reset DB stats
+docker exec mcp-context-forge-postgres-1 psql -U postgres -d mcp -c "SELECT pg_stat_reset();"
+
+# 2. Start MCP-specific load test in background
+make load-test-mcp-protocol &
+
+# 3. Capture container stats during load
+docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}" \
+  | grep -E "gateway|postgres|redis|pgbouncer|nginx"
+
+# 4. py-spy flamegraph on a gateway worker
+WORKER_PID=$(docker top mcp-context-forge-gateway-1 | grep worker | head -1 | awk '{print $2}')
+sudo py-spy record -o mcp_flamegraph.svg --pid $WORKER_PID -d 15 --subprocesses
+
+# 5. Check which DB tables are hammered
+docker exec mcp-context-forge-postgres-1 psql -U postgres -d mcp -c "
+SELECT relname, seq_scan, seq_tup_read, idx_scan
+FROM pg_stat_user_tables WHERE seq_tup_read > 0
+ORDER BY seq_tup_read DESC LIMIT 10;"
+
+# 6. Check Redis cache utilization
+docker exec mcp-context-forge-redis-1 redis-cli info stats | grep -E "hits|misses"
+```
+
+**What to look for:**
+
+- If PgBouncer/PostgreSQL CPU is high but Redis is idle, the MCP path is bypassing the cache layer.
+- If gateway CPU is the constraint, look at middleware overhead (auth, RBAC, validation) in the flamegraph.
+- If upstream MCP server CPU is the constraint, the bottleneck is in tool execution, not the gateway.
+
+---
+
 ## Common Performance Issues
 
 ### Issue: High Sequential Scan Count
@@ -690,21 +755,26 @@ except Exception as e:
 
 **Causes:**
 
-- Template rendering overhead
+- Template rendering overhead (admin UI)
 - JSON serialization of large responses
 - Pydantic validation overhead
+- Middleware overhead from enabled-but-unused features
+- Too many gunicorn workers causing context switching
 
 **Solutions:**
 
 - Enable response caching
 - Paginate large result sets
 - Use orjson for serialization (enabled by default)
+- Disable unused features (A2A, catalog, LLM chat, admin UI) — see [disable unused features](../manage/tuning.md#10---disable-unused-features) in the tuning guide
+- Tune `GUNICORN_WORKERS` to match CPU cores (not exceed them)
 
 ---
 
 ## See Also
 
+- [Gateway Tuning Guide](../manage/tuning.md) - Environment variables, session pool, connection pool tuning
 - [Database Performance Guide](db-performance.md) - N+1 detection and query logging
+- [Performance Architecture](../architecture/performance-architecture.md) - MCP request path, caching layers, scaling capacity
 - [Performance Testing](../testing/performance.md) - Load testing with hey
 - [Scaling Guide](../manage/scale.md) - Production scaling configuration
-- [Issue #1906](https://github.com/IBM/mcp-context-forge/issues/1906) - Metrics cache optimization

--- a/docs/docs/manage/tuning.md
+++ b/docs/docs/manage/tuning.md
@@ -851,10 +851,213 @@ environment:
 
 ---
 
-## 9 - Security tips while tuning
+## 9 - MCP Streamable HTTP Transport Tuning
+
+The MCP Streamable HTTP endpoint (`/servers/{id}/mcp`) has its own performance characteristics distinct from the REST API (`/rpc`). This section covers settings that specifically affect MCP protocol performance.
+
+### Critical Settings
+
+These settings have the largest measured impact on MCP throughput:
+
+| Setting | Recommended | Impact | Notes |
+|---------|-------------|--------|-------|
+| `MCP_SESSION_POOL_ENABLED` | `true` | ~10% RPS improvement | Reuses upstream MCP server connections |
+| `JSON_RESPONSE_ENABLED` | `true` | **Required** — disabling breaks JSON clients | Returns JSON instead of SSE framing |
+| `USE_STATEFUL_SESSIONS` | `false` | **Required** for multi-replica | Stateful sessions are per-process |
+| `DB_POOL_CLASS` | `queue` | **Required** — `null` causes ~55% RPS loss | QueuePool with PgBouncer |
+| `AUTH_CACHE_ENABLED` | `true` | Significant — reduces per-request DB queries | Caches user/team/role lookups |
+| `CACHE_TYPE` | `redis` | Significant — shared cache across workers | Enables cross-worker caching |
+
+### Settings with Negligible Impact
+
+These settings were tested and found to have less than ~3% effect on MCP throughput. Tune them for correctness, not performance:
+
+| Setting | Why Negligible |
+|---------|---------------|
+| `VALIDATION_MIDDLEWARE_ENABLED` | MCP requests bypass most validation |
+| `DB_METRICS_RECORDING_ENABLED` | Writes are buffered, minimal per-request overhead |
+| `REGISTRY_CACHE_ENABLED` | MCP handlers use their own DB queries, not the registry cache |
+| `PERFORMANCE_TRACKING_ENABLED` | Lightweight in-memory tracking |
+| `TOKEN_USAGE_LOGGING_ENABLED` | Rate-limited to one DB write per 5 minutes per token |
+| `CORRELATION_ID_ENABLED` | Adds/reads one header per request |
+
+### MCP SDK / FastMCP Tunables
+
+When running MCP servers behind the gateway:
+
+| Setting | Recommendation | Why |
+|---------|---------------|-----|
+| `MCP_SESSION_POOL_HEALTH_CHECK_METHODS` | `["skip"]` for max throughput | Skips health checks on pooled sessions |
+| `MCP_SESSION_POOL_CLEANUP_TIMEOUT` | `0.5` | Fast cleanup of stale sessions |
+| Upstream `stateless_http` | `true` for multi-replica servers | Avoids session affinity requirements |
+| Upstream `json_response` | `true` for unary tool calls | Removes SSE framing overhead |
+| `terminate_on_close` | `false` for pooled sessions | Prevents session teardown on reuse |
+| Streamable HTTP over SSE | Prefer Streamable HTTP | Recommended production transport |
+
+### MCP Worker Tuning
+
+The gateway worker count (`GUNICORN_WORKERS`) directly affects MCP throughput:
+
+- Too few workers: CPU underutilized, low RPS
+- Too many workers: Excessive context switching, DB connection pressure
+- **Rule of thumb:** Match `GUNICORN_WORKERS` to the available CPU cores per container. 24 workers per 8-CPU container is well-tuned for MCP workloads.
+
+### Auth Cache TTL Guidance
+
+The auth cache prevents repeated database lookups for the same JWT token. Higher TTLs reduce DB pressure but delay permission changes:
+
+| Setting | Max Allowed | Recommendation |
+|---------|-------------|---------------|
+| `AUTH_CACHE_USER_TTL` | 300s | 300s (max) for performance |
+| `AUTH_CACHE_TEAM_TTL` | 300s | 300s (max) for performance |
+| `AUTH_CACHE_ROLE_TTL` | 300s | 300s (max) for performance |
+| `AUTH_CACHE_REVOCATION_TTL` | 120s | 120s (max) — security-sensitive |
+| `AUTH_CACHE_BATCH_QUERIES` | — | `true` — batches three queries into one |
+
+---
+
+## 10 - Disable unused features
+
+ContextForge has many optional features that are enabled by default for completeness but consume CPU, memory, or database I/O even when not used. Disabling features you do not need is a free performance win that does not require additional resources.
+
+### High-impact features to disable
+
+These features have measurable per-request or background overhead. Disable any you are not actively using:
+
+| Feature | Setting | Default | Overhead When Enabled |
+|---------|---------|---------|----------------------|
+| **Admin UI** | `MCPGATEWAY_UI_ENABLED` | `false` | Template rendering CPU, admin middleware checks on every request |
+| **Admin API** | `MCPGATEWAY_ADMIN_API_ENABLED` | `false` | Exposes additional endpoints, admin auth middleware |
+| **A2A protocol** | `MCPGATEWAY_A2A_ENABLED` | `true` | A2A router registration, agent discovery, metrics tracking |
+| **A2A metrics** | `MCPGATEWAY_A2A_METRICS_ENABLED` | `true` | DB writes per A2A invocation |
+| **LLM chat** | `LLMCHAT_ENABLED` | `true` | Session management, Redis locks, chat routing middleware |
+| **Catalog** | `MCPGATEWAY_CATALOG_ENABLED` | `true` | Catalog server sync, background health checks |
+| **Plugins** | `PLUGINS_ENABLED` | `false` | Plugin discovery, hook dispatch on every request |
+| **DB metrics recording** | `DB_METRICS_RECORDING_ENABLED` | `true` | One buffered DB write per tool/resource/prompt execution |
+| **Token usage logging** | `TOKEN_USAGE_LOGGING_ENABLED` | `true` | DB write per unique token per 5-minute window |
+| **Structured logging (DB)** | `STRUCTURED_LOGGING_DATABASE_ENABLED` | `false` | DB writes per log entry (high overhead) |
+| **Audit trail** | `AUDIT_TRAIL_ENABLED` | `false` | DB write per mutating request (high overhead) |
+| **Security logging** | `SECURITY_LOGGING_ENABLED` | `false` | DB writes for auth events |
+| **Observability** | `OBSERVABILITY_ENABLED` | `false` | Span creation, trace storage, request instrumentation |
+| **Prometheus** | `ENABLE_METRICS` | `false` | Per-request histogram updates, `/metrics` endpoint |
+| **Net connections count** | `MCPGATEWAY_PERFORMANCE_NET_CONNECTIONS_ENABLED` | `true` | `psutil.net_connections()` call in performance stats |
+
+### Medium-impact features
+
+These add some overhead but are useful in most deployments. Disable only if you are certain you do not need them:
+
+| Feature | Setting | Default | When to Disable |
+|---------|---------|---------|-----------------|
+| **Correlation ID** | `CORRELATION_ID_ENABLED` | `true` | If your external proxy already handles trace IDs |
+| **Performance tracking** | `PERFORMANCE_TRACKING_ENABLED` | `true` | If using external APM (Datadog, New Relic, etc.) |
+| **Metrics aggregation** | `METRICS_AGGREGATION_ENABLED` | `true` | If using external metrics (Prometheus, Grafana) |
+| **Metrics rollup** | `METRICS_ROLLUP_ENABLED` | `true` | If raw metrics are exported externally |
+| **Metrics cleanup** | `METRICS_CLEANUP_ENABLED` | `true` | Only disable if you manage retention externally |
+| **Elicitation** | `MCPGATEWAY_ELICITATION_ENABLED` | `true` | If no MCP clients use elicitation |
+| **Tool cancellation** | `MCPGATEWAY_TOOL_CANCELLATION_ENABLED` | `true` | If clients do not cancel in-flight tool calls |
+| **SSE keepalive** | `SSE_KEEPALIVE_ENABLED` | `true` | If not using SSE transport |
+| **Dynamic client registration** | `DCR_ENABLED` | `true` | If not using OAuth DCR flow |
+| **OAuth discovery** | `OAUTH_DISCOVERY_ENABLED` | `true` | If not using OAuth |
+
+### Low-impact features (safe to leave enabled)
+
+These have negligible runtime cost and are generally worth keeping:
+
+| Feature | Setting | Default | Notes |
+|---------|---------|---------|-------|
+| Security headers | `SECURITY_HEADERS_ENABLED` | `true` | Adds static headers, near-zero CPU |
+| CORS | `CORS_ENABLED` | `true` | Standard cross-origin handling |
+| SSRF protection | `SSRF_PROTECTION_ENABLED` | `true` | URL validation on registration only |
+| Password policy | `PASSWORD_POLICY_ENABLED` | `true` | Checked only during password set/change |
+| Well-known endpoints | `WELL_KNOWN_ENABLED` | `true` | Rarely hit, cached responses |
+| Auth cache | `AUTH_CACHE_ENABLED` | `true` | **Improves** performance; do not disable |
+| Registry cache | `REGISTRY_CACHE_ENABLED` | `true` | **Improves** performance; do not disable |
+| Tool lookup cache | `TOOL_LOOKUP_CACHE_ENABLED` | `true` | **Improves** performance; do not disable |
+
+### Deployment profiles
+
+**MCP-only deployment** (maximum MCP protocol throughput):
+
+```bash
+# Disable everything not needed for MCP tool serving
+MCPGATEWAY_UI_ENABLED=false
+MCPGATEWAY_ADMIN_API_ENABLED=false
+MCPGATEWAY_A2A_ENABLED=false
+MCPGATEWAY_CATALOG_ENABLED=false
+LLMCHAT_ENABLED=false
+PLUGINS_ENABLED=false
+OBSERVABILITY_ENABLED=false
+ENABLE_METRICS=false
+AUDIT_TRAIL_ENABLED=false
+SECURITY_LOGGING_ENABLED=false
+STRUCTURED_LOGGING_DATABASE_ENABLED=false
+CORRELATION_ID_ENABLED=false
+DB_METRICS_RECORDING_ENABLED=false
+MCPGATEWAY_PERFORMANCE_NET_CONNECTIONS_ENABLED=false
+COMPRESSION_ENABLED=false          # Let nginx handle compression
+DISABLE_ACCESS_LOG=true
+
+# Keep these enabled
+AUTH_CACHE_ENABLED=true
+REGISTRY_CACHE_ENABLED=true
+MCP_SESSION_POOL_ENABLED=true
+CACHE_TYPE=redis
+```
+
+**Full-featured production** (all features, tuned for performance):
+
+```bash
+# Features enabled
+MCPGATEWAY_UI_ENABLED=true
+MCPGATEWAY_ADMIN_API_ENABLED=true
+MCPGATEWAY_A2A_ENABLED=true
+PLUGINS_ENABLED=true
+
+# Expensive features disabled unless needed
+OBSERVABILITY_ENABLED=false         # Enable only when tracing needed
+ENABLE_METRICS=false                # Enable with Prometheus
+AUDIT_TRAIL_ENABLED=false           # Enable for compliance
+STRUCTURED_LOGGING_DATABASE_ENABLED=false
+SECURITY_LOGGING_ENABLED=false
+DB_METRICS_RECORDING_ENABLED=true   # Keep for built-in analytics
+
+# Caching maximized
+AUTH_CACHE_ENABLED=true
+AUTH_CACHE_BATCH_QUERIES=true
+REGISTRY_CACHE_ENABLED=true
+MCP_SESSION_POOL_ENABLED=true
+CACHE_TYPE=redis
+```
+
+**Development / debugging** (full observability, relaxed performance):
+
+```bash
+# Everything on for debugging
+MCPGATEWAY_UI_ENABLED=true
+MCPGATEWAY_ADMIN_API_ENABLED=true
+OBSERVABILITY_ENABLED=true
+ENABLE_METRICS=true
+DB_METRICS_RECORDING_ENABLED=true
+DB_QUERY_LOG_ENABLED=true           # N+1 detection
+STRUCTURED_LOGGING_DATABASE_ENABLED=true
+LOG_LEVEL=INFO
+CORRELATION_ID_ENABLED=true
+PERFORMANCE_TRACKING_ENABLED=true
+```
+
+---
+
+## 11 - Security tips while tuning
 
 * Never commit real `JWT_SECRET_KEY`, DB passwords, or tokens-use `.env.example` as a template.
 * Prefer platform secrets (K8s Secrets, Code Engine secrets) over baking creds into the image.
 * If you enable `gevent`/`eventlet`, pin their versions and run **bandit** or **trivy** scans.
 
 ---
+
+## See Also
+
+- [Performance Profiling Guide](../development/profiling.md) - py-spy, memray, PostgreSQL profiling, MCP bottleneck triage
+- [Database Performance Guide](../development/db-performance.md) - N+1 detection, query logging, query counting
+- [Performance Architecture](../architecture/performance-architecture.md) - MCP request path, caching layers, scaling capacity
+- [Scaling Guide](scale.md) - Production scaling configuration

--- a/docs/docs/testing/performance.md
+++ b/docs/docs/testing/performance.md
@@ -282,21 +282,46 @@ ContextForge includes [Locust](https://locust.io/) for comprehensive load testin
 ### Quick Start
 
 ```bash
-# Start Locust Web UI (default: 4000 users, 200 spawn/s)
+# Interactive Web UI — configure users, spawn rate, duration in browser
 make load-test-ui
+# Open http://localhost:8089, pick user classes, click Start
 
-# Open http://localhost:8089 in your browser
+# Headless CLI — runs to completion, prints live stats, generates reports
+make load-test-cli
+# Reports saved to reports/loadtest.html and reports/loadtest_*.csv
 ```
+
+Both targets use the same locustfile (`tests/loadtest/locustfile.py`) with all user classes. The Web UI (`load-test-ui`) lets you pick which user types to run interactively; the CLI (`load-test-cli`) runs all types at their configured weights.
 
 ### Available Targets
 
+**General load tests** (all endpoints — REST, admin, MCP JSON-RPC, tools):
+
+| Target | Users | Duration | Mode | Description |
+|--------|-------|----------|------|-------------|
+| `make load-test-ui` | 4000 | 5 min | Web UI | Interactive with class picker at `http://localhost:8089` |
+| `make load-test-cli` | 4000 | 5 min | Headless | Live CLI stats + HTML/CSV reports |
+| `make load-test-light` | 10 | 30s | Headless | Quick smoke test |
+| `make load-test-heavy` | 200 | 120s | Headless | Sustained moderate load |
+| `make load-test-sustained` | 25 | 300s | Headless | 5-minute endurance test |
+| `make load-test-stress` | 500 | 60s | Headless | Stress test (confirmation prompt) |
+| `make load-test-1000` | 1000 | 120s | Headless | High-load ~1000 RPS |
+
+**MCP protocol only** (Streamable HTTP `/servers/{id}/mcp` endpoint):
+
+| Target | Users | Duration | Mode | Description |
+|--------|-------|----------|------|-------------|
+| `make load-test-mcp-protocol` | 150 | 2 min | Headless | MCP-only with reports |
+| `make load-test-mcp-protocol-ui` | 150 | 2 min | Web UI | MCP-only with class picker |
+| `make load-test-mcp-protocol-heavy` | 500 | 5 min | Headless | Heavy MCP sustained load |
+
+**Component baselines** (individual servers, database, cache):
+
 | Target | Description |
 |--------|-------------|
-| `make load-test-ui` | Web UI with class picker (4000 users default) |
-| `make load-test` | Headless test with HTML/CSV reports |
-| `make load-test-light` | Light test (10 users, 30s) |
-| `make load-test-heavy` | Heavy test (200 users, 120s) |
-| `make load-test-stress` | Stress test (500 users, 60s) |
+| `make load-test-baseline` | Fast Time Server REST API (1000 users, 3 min) |
+| `make load-test-baseline-ui` | Baseline with class picker |
+| `make load-test-fasttime` | Fast Time MCP tools (50 users, 60s) |
 
 ### Configuration
 
@@ -306,11 +331,14 @@ Override defaults via environment variables:
 # Custom user count and spawn rate
 LOADTEST_USERS=2000 LOADTEST_SPAWN_RATE=100 make load-test-ui
 
-# Custom host
-LOADTEST_HOST=http://localhost:4444 make load-test-ui
+# Custom host (default: http://localhost:8080 via nginx)
+LOADTEST_HOST=http://localhost:4444 make load-test-cli
 
 # Limit worker processes (default: auto-detect CPUs)
 LOADTEST_PROCESSES=4 make load-test-ui
+
+# Custom run time
+LOADTEST_RUN_TIME=10m make load-test-cli
 ```
 
 ### User Classes
@@ -360,9 +388,12 @@ For testing with 4000+ concurrent users:
 
 | File | Purpose |
 |------|---------|
-| `tests/loadtest/locustfile.py` | Main locustfile with all user classes |
-| `tests/loadtest/locustfile_highthroughput.py` | Optimized for maximum RPS |
-| `tests/loadtest/locustfile_baseline.py` | Component baseline testing |
+| `tests/loadtest/locustfile.py` | Main locustfile — all endpoints, 20+ user classes |
+| `tests/loadtest/locustfile_mcp_protocol.py` | MCP Streamable HTTP protocol only — 6 user classes |
+| `tests/loadtest/locustfile_highthroughput.py` | Fast endpoints only — optimized for maximum RPS |
+| `tests/loadtest/locustfile_baseline.py` | Component baselines — REST, MCP direct, PostgreSQL, Redis |
+| `tests/loadtest/locustfile_spin_detector.py` | CPU spin loop detection (escalating waves) |
+| `tests/loadtest/locustfile_slow_time_server.py` | Timeout / circuit breaker testing |
 
 ### Performance Tips
 
@@ -372,6 +403,117 @@ For testing with 4000+ concurrent users:
 - **Check p95/p99**: Tail latency matters more than average
 - **Use `constant_throughput`**: For predictable RPS instead of random waits
 - **Nginx caching**: Admin pages use 5s TTL caching by default (see [Nginx Tuning](../manage/tuning.md#7-nginx-reverse-proxy-tuning))
+
+---
+
+## 📦 Test Data Generation
+
+Before running load tests against a realistic dataset, populate the database with synthetic data. The `tests/load/` framework generates production-scale data across 29 entity types (users, teams, tools, servers, metrics, sessions, etc.).
+
+### Quick Start
+
+```bash
+# Generate small dataset (100 users, ~74K records, <1 minute)
+make generate-small
+
+# Generate medium dataset (10K users, ~70M records, ~10 min, needs PostgreSQL)
+make generate-medium
+
+# View generated data report
+make generate-report
+```
+
+### Profiles
+
+| Profile | Users | Records | Time | Database | Command |
+|---------|-------|---------|------|----------|---------|
+| Small | 100 | ~74K | <1 min | SQLite OK | `make generate-small` |
+| Medium | 10K | ~70M | ~10 min | PostgreSQL | `make generate-medium` |
+| Large | 100K | ~700M | ~1-2 hrs | PostgreSQL | `make generate-large` |
+| Massive | 1M | ~7B | ~10-20 hrs | PostgreSQL + high-end | `make generate-massive` |
+
+**Why it matters for load testing:** Many performance bottlenecks (N+1 queries, sequential scans, pagination overhead) only manifest with realistic data volumes. Testing with an empty database hides these issues.
+
+For full documentation, configuration options, and custom profiles, see [`tests/load/README.md`](https://github.com/IBM/mcp-context-forge/blob/main/tests/load/README.md).
+
+---
+
+## 🔌 MCP Protocol Load Testing
+
+The MCP Streamable HTTP endpoint (`/servers/{id}/mcp`) has different performance characteristics than the REST API. A dedicated load test isolates MCP protocol overhead from other endpoints.
+
+### Quick Start
+
+```bash
+# MCP protocol test (150 users, 2 min, headless with reports)
+make load-test-mcp-protocol
+
+# MCP protocol test with Web UI (class picker to select user types)
+make load-test-mcp-protocol-ui
+
+# Heavy MCP test (500 users, 5 min)
+make load-test-mcp-protocol-heavy
+```
+
+### What It Tests
+
+The MCP protocol load test (`locustfile_mcp_protocol.py`) sends JSON-RPC requests exclusively to `/servers/{server_id}/mcp`. It auto-detects a virtual server with the most tools and discovers available tools, resources, and prompts via MCP protocol at startup.
+
+**User Classes (selectable via `--class-picker` in Web UI):**
+
+| User Class | Weight | Simulates |
+|------------|--------|-----------|
+| `MCPAgentUser` | 10 | Realistic AI agent with up to 6 tools — init, discover, call 1-3 tools per turn |
+| `MCPToolCallerUser` | 5 | Heavy `tools/call` in tight loop |
+| `MCPDiscoveryUser` | 3 | Discovery-heavy — `tools/list`, `resources/list`, `prompts/list`, templates |
+| `MCPSessionChurnUser` | 2 | New MCP session every cycle (serverless worst-case) |
+| `MCPStressUser` | 1 | `constant_throughput(5)` for predictable sustained load |
+| `RESTBaselineUser` | 0 | `/rpc` + REST comparison baseline (opt-in via class picker) |
+
+### Comparing MCP vs REST Performance
+
+To compare MCP Streamable HTTP overhead against the REST `/rpc` path:
+
+1. Open the Web UI: `make load-test-mcp-protocol-ui`
+2. In the class picker, enable **both** MCP user classes and `RESTBaselineUser`
+3. Run the test and compare per-endpoint RPS and latency in the statistics table
+
+The MCP path includes additional middleware (MCPPathRewrite, MCP SDK session manager, per-request auth/RBAC database queries) that the `/rpc` endpoint avoids via Redis-backed caching. Under load, this difference is significant — see the [Performance Profiling Guide](../development/profiling.md#mcp-protocol-profiling) for investigation steps.
+
+### Configuration
+
+```bash
+# Override the target server
+MCP_SERVER_ID=<uuid> make load-test-mcp-protocol
+
+# Override tool names (comma-separated)
+MCP_TOOL_NAMES=my-tool-1,my-tool-2 make load-test-mcp-protocol
+
+# Override target host
+MCP_PROTOCOL_HOST=http://my-gateway:8080 make load-test-mcp-protocol
+```
+
+### What to Look For
+
+- **RPS plateau**: MCP throughput saturates at a lower RPS than REST due to heavier per-request processing
+- **PgBouncer/PostgreSQL CPU**: If these are high during MCP load but low during REST load, the MCP path is doing more DB queries per request
+- **Redis utilization**: Low Redis CPU during MCP load indicates the MCP path is not leveraging the cache layer
+- **Session pool metrics**: Check `/admin/mcp-pool/metrics` to verify upstream connection reuse
+- **p99 latency**: Tail latency often reveals contention in the auth/RBAC path or upstream proxy
+
+### Prerequisites
+
+The test requires:
+
+- At least one virtual server registered with associated tools (`POST /servers`)
+- At least one MCP gateway connected (`POST /gateways`)
+- Authentication configured (JWT auto-generated from `.env`)
+
+Start the full testing stack with:
+
+```bash
+make testing-up      # Starts fast_test_server + locust + MCP inspector
+```
 
 ---
 
@@ -624,46 +766,38 @@ Based on benchmark results, orjson provides:
 
 ## 📈 JMeter Performance Testing
 
-ContextForge includes [Apache JMeter](https://jmeter.apache.org/) test plans for industry-standard performance baseline measurements and CI/CD integration.
+ContextForge includes [Apache JMeter](https://jmeter.apache.org/) test plans for industry-standard performance baseline measurements and CI/CD integration. JMeter is best suited for reproducible benchmarks and CI/CD gating; use Locust for interactive testing with complex user behavior.
 
-### Prerequisites
+### Install & Run
 
-**Recommended: Use the Makefile target** (installs JMeter 5.6.3 locally):
 ```bash
+# Install JMeter (one-time, downloads 5.6.3 locally)
 make jmeter-install
-make jmeter-check   # Verify installation (requires JMeter 5.x+)
-```
 
-**Alternative: Manual installation**
-```bash
-# macOS
-brew install jmeter
-
-# Linux
-wget https://dlcdn.apache.org/jmeter/binaries/apache-jmeter-5.6.3.tgz
-tar -xzf apache-jmeter-5.6.3.tgz
-export PATH=$PATH:$(pwd)/apache-jmeter-5.6.3/bin
-```
-
-### Quick Start
-
-```bash
-# Set up authentication token
+# Set up authentication
 export MCPGATEWAY_BEARER_TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
   --username admin@example.com --exp 10080 --secret $JWT_SECRET_KEY)
 
-# Launch JMeter GUI for interactive editing
+# Run key baselines
+make jmeter-rest-baseline                                    # REST API — 1,000 RPS, 10 min
+make jmeter-mcp-baseline JMETER_SERVER_ID=<server-id>       # MCP JSON-RPC — 1,000 RPS, 15 min
+make jmeter-load JMETER_SERVER_ID=<server-id>               # Production load — 4,000 RPS, 30 min
+
+# Interactive GUI for editing test plans
 make jmeter-ui
-
-# Run REST API baseline
-make jmeter-rest-baseline
-
-# Run MCP JSON-RPC baseline (requires server ID)
-make jmeter-mcp-baseline JMETER_SERVER_ID=<your-server-id>
-
-# Run production load test
-make jmeter-load JMETER_SERVER_ID=<your-server-id>
 ```
+
+### When to Use JMeter vs Locust
+
+| Criterion | JMeter | Locust |
+|-----------|--------|--------|
+| Best for | CI/CD baselines, threshold gating | Interactive exploration, complex behavior |
+| Protocol | HTTP, WebSocket, JDBC, gRPC | HTTP primarily |
+| Config | XML test plans | Python code |
+| Output | JTL files, HTML reports | HTML reports, CSV |
+| Scaling | Distributed (controller/agent) | `--processes` multi-worker |
+
+Use both: JMeter for repeatable CI checks, Locust for ad-hoc investigation and MCP protocol profiling.
 
 ### Available Test Plans
 
@@ -798,3 +932,10 @@ For maximum performance, combine multiple optimizations:
 These optimizations are complementary and provide cumulative benefits.
 
 ---
+
+## See Also
+
+- [Performance Profiling Guide](../development/profiling.md) - py-spy, memray, PostgreSQL profiling, MCP bottleneck triage
+- [Gateway Tuning Guide](../manage/tuning.md) - Environment variables, MCP transport settings, session pool tuning, disable unused features
+- [Database Performance Guide](../development/db-performance.md) - N+1 detection, query logging, DB vs transport bottleneck triage
+- [Performance Architecture](../architecture/performance-architecture.md) - MCP request path, caching layers, scaling capacity

--- a/tests/loadtest/locustfile_mcp_protocol.py
+++ b/tests/loadtest/locustfile_mcp_protocol.py
@@ -1,0 +1,863 @@
+# -*- coding: utf-8 -*-
+"""MCP Streamable HTTP protocol load test — pure MCP protocol RPS measurement.
+
+This locustfile tests ONLY the MCP Streamable HTTP transport path through the
+gateway virtual server endpoint: /servers/{server_id}/mcp
+
+It exists to isolate MCP protocol overhead from REST API / admin UI / other
+endpoints so we can get a clean RPS number for just the MCP path.
+
+Test scenarios (selectable via --class-picker):
+  MCPAgentUser        (weight 10) - Realistic agent: init once, then call 6 tools
+  MCPToolCallerUser   (weight  5) - Heavy tool caller: tools/call in a tight loop
+  MCPDiscoveryUser    (weight  3) - Discovery heavy: tools/list, resources/list, prompts/list
+  MCPSessionChurnUser (weight  2) - Session churn: new session per request cycle
+  MCPStressUser       (weight  1) - Max-throughput: constant_throughput, minimal overhead
+
+Usage:
+    # Quick headless (150 users, 2 min)
+    make load-test-mcp-protocol
+
+    # Web UI with class picker
+    make load-test-mcp-protocol-ui
+
+    # High-load (500 users, 5 min)
+    make load-test-mcp-protocol-heavy
+
+    # Direct invocation
+    locust -f tests/loadtest/locustfile_mcp_protocol.py \
+        --host=http://localhost:4444 --users=150 --spawn-rate=30 --run-time=120s --headless
+
+Environment Variables:
+    LOADTEST_HOST:             Gateway URL           (default: http://localhost:4444)
+    MCP_SERVER_ID:             Virtual server UUID   (auto-detected from /servers if empty)
+    MCP_TOOL_NAMES:            Comma-sep tool names  (auto-detected from tools/list if empty)
+    JWT_SECRET_KEY:            JWT signing secret     (default: my-test-key)
+    JWT_ALGORITHM:             JWT algorithm          (default: HS256)
+    JWT_AUDIENCE:              JWT audience           (default: mcpgateway-api)
+    JWT_ISSUER:                JWT issuer             (default: mcpgateway)
+    PLATFORM_ADMIN_EMAIL:      Admin email            (default: admin@example.com)
+    MCPGATEWAY_BEARER_TOKEN:   Pre-generated token    (optional, overrides JWT generation)
+
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+import json
+import logging
+import os
+from pathlib import Path
+import random
+from typing import Any
+import uuid
+
+# Third-Party
+from locust import between, constant_throughput, events, tag, task
+from locust.contrib.fasthttp import FastHttpUser
+from locust.runners import MasterRunner, WorkerRunner
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+def _load_env_file() -> dict[str, str]:
+    """Load .env file from project root."""
+    env_vars: dict[str, str] = {}
+    search_paths = [
+        Path.cwd() / ".env",
+        Path.cwd().parent / ".env",
+        Path.cwd().parent.parent / ".env",
+        Path(__file__).parent.parent.parent / ".env",
+    ]
+    for path in search_paths:
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if "=" in line:
+                        key, _, value = line.partition("=")
+                        env_vars[key.strip()] = value.strip().strip("\"'")
+            break
+    return env_vars
+
+
+_ENV = _load_env_file()
+
+
+def _cfg(key: str, default: str = "") -> str:
+    return os.environ.get(key) or _ENV.get(key) or default
+
+
+# JWT / Auth
+JWT_SECRET_KEY = _cfg("JWT_SECRET_KEY", "my-test-key")
+JWT_ALGORITHM = _cfg("JWT_ALGORITHM", "HS256")
+JWT_AUDIENCE = _cfg("JWT_AUDIENCE", "mcpgateway-api")
+JWT_ISSUER = _cfg("JWT_ISSUER", "mcpgateway")
+JWT_USERNAME = _cfg("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+BEARER_TOKEN = _cfg("MCPGATEWAY_BEARER_TOKEN", "")
+
+# MCP target
+MCP_SERVER_ID = _cfg("MCP_SERVER_ID", "")
+MCP_TOOL_NAMES_STR = _cfg("MCP_TOOL_NAMES", "")
+
+# Shared state (populated on test_start)
+_server_id: str = ""
+_tool_names: list[str] = []
+_resource_uris: list[str] = []
+_prompt_names: list[str] = []
+_jwt_token: str | None = None
+
+# Timezones for realistic args
+TIMEZONES = [
+    "UTC",
+    "America/New_York",
+    "America/Los_Angeles",
+    "Europe/London",
+    "Europe/Paris",
+    "Asia/Tokyo",
+    "Asia/Shanghai",
+    "Australia/Sydney",
+    "America/Chicago",
+    "Europe/Dublin",
+    "Europe/Berlin",
+    "Asia/Singapore",
+]
+
+
+# =============================================================================
+# JWT Token Generation
+# =============================================================================
+
+
+def _generate_jwt_token() -> str:
+    """Generate a JWT token matching gateway expectations."""
+    try:
+        # Third-Party
+        import jwt  # pylint: disable=import-outside-toplevel
+
+        jti = str(uuid.uuid4())
+        payload = {
+            "sub": JWT_USERNAME,
+            "exp": datetime.now(timezone.utc) + timedelta(hours=8760),
+            "iat": datetime.now(timezone.utc),
+            "aud": JWT_AUDIENCE,
+            "iss": JWT_ISSUER,
+            "jti": jti,
+            "token_use": "session",
+            "user": {
+                "email": JWT_USERNAME,
+                "full_name": "MCP Protocol Load Test",
+                "is_admin": True,
+                "auth_provider": "local",
+            },
+        }
+        token = jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+        logger.info("Generated JWT for %s (jti=%s...)", JWT_USERNAME, jti[:8])
+        return token
+    except Exception as e:
+        logger.warning("JWT generation failed: %s", e)
+        return ""
+
+
+def _get_token() -> str:
+    global _jwt_token  # pylint: disable=global-statement
+    if BEARER_TOKEN:
+        return BEARER_TOKEN
+    if _jwt_token is None:
+        _jwt_token = _generate_jwt_token()
+    return _jwt_token
+
+
+# =============================================================================
+# Auto-Detection: Server ID, Tool Names
+# =============================================================================
+
+
+def _auto_detect(host: str) -> None:
+    """Discover server_id and tool_names from the gateway REST API."""
+    global _server_id, _tool_names, _resource_uris, _prompt_names  # pylint: disable=global-statement
+
+    # Third-Party
+    import requests  # pylint: disable=import-outside-toplevel
+
+    token = _get_token()
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+    # --- Server ID (prefer server with the most associated tools) ---
+    if MCP_SERVER_ID:
+        _server_id = MCP_SERVER_ID
+    else:
+        try:
+            resp = requests.get(f"{host}/servers", headers=headers, timeout=10)
+            resp.raise_for_status()
+            servers = resp.json()
+            if isinstance(servers, dict):
+                servers = servers.get("items", servers.get("servers", []))
+            if isinstance(servers, list) and servers:
+                # Pick enabled server with the most tools
+                enabled = [s for s in servers if s.get("enabled", True)]
+                if enabled:
+                    best = max(enabled, key=lambda s: len(s.get("associatedTools", [])))
+                    _server_id = best.get("id", "")
+                    logger.info(
+                        "Selected server %r (%s) with %d tools",
+                        best.get("name"),
+                        _server_id,
+                        len(best.get("associatedTools", [])),
+                    )
+                else:
+                    _server_id = servers[0].get("id", "")
+        except Exception as e:
+            logger.warning("Failed to auto-detect server_id: %s", e)
+
+    if not _server_id:
+        logger.error("No MCP_SERVER_ID set and auto-detection failed. Set MCP_SERVER_ID env var.")
+        return
+
+    logger.info("Using server_id: %s", _server_id)
+
+    # --- Discover tools/resources/prompts via MCP protocol ---
+    mcp_url = f"{host}/servers/{_server_id}/mcp"
+    mcp_headers = {**headers, "Content-Type": "application/json"}
+    session_id = None
+
+    def _mcp_call(method: str, params: dict | None = None) -> dict | None:
+        nonlocal session_id
+        payload = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method}
+        if params:
+            payload["params"] = params
+        hdrs = dict(mcp_headers)
+        if session_id:
+            hdrs["Mcp-Session-Id"] = session_id
+        try:
+            resp = requests.post(mcp_url, json=payload, headers=hdrs, timeout=15)
+            if "Mcp-Session-Id" in resp.headers:
+                session_id = resp.headers["Mcp-Session-Id"]
+            resp.raise_for_status()
+            data = resp.json()
+            if "error" in data:
+                logger.warning("MCP error for %s: %s", method, data["error"])
+                return None
+            return data.get("result")
+        except Exception as e:
+            logger.warning("MCP %s failed: %s", method, e)
+            return None
+
+    # Initialize session
+    _mcp_call(
+        "initialize",
+        {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "locust-mcp-discovery", "version": "1.0"},
+        },
+    )
+
+    # Tool names
+    if MCP_TOOL_NAMES_STR:
+        _tool_names = [t.strip() for t in MCP_TOOL_NAMES_STR.split(",") if t.strip()]
+    else:
+        result = _mcp_call("tools/list")
+        if result:
+            _tool_names = [t["name"] for t in result.get("tools", []) if "name" in t]
+
+    # Resources
+    result = _mcp_call("resources/list")
+    if result:
+        _resource_uris = [r["uri"] for r in result.get("resources", []) if "uri" in r]
+
+    # Prompts
+    result = _mcp_call("prompts/list")
+    if result:
+        _prompt_names = [p["name"] for p in result.get("prompts", []) if "name" in p]
+
+    logger.info("Discovered %d tools, %d resources, %d prompts", len(_tool_names), len(_resource_uris), len(_prompt_names))
+    if _tool_names:
+        logger.info("Tools: %s", ", ".join(_tool_names[:20]))
+
+
+# =============================================================================
+# Event Handlers
+# =============================================================================
+
+
+_detect_lock_done = False
+
+
+def _ensure_detected(host: str) -> None:
+    """Run auto-detection once per process (safe for --processes mode)."""
+    global _detect_lock_done  # pylint: disable=global-statement
+    if _detect_lock_done:
+        return
+    _detect_lock_done = True
+    _auto_detect(host)
+
+
+@events.init_command_line_parser.add_listener
+def set_defaults(parser):
+    parser.set_defaults(users=150, spawn_rate=30, run_time="120s")
+
+
+@events.test_start.add_listener
+def on_test_start(environment, **kwargs):
+    host = environment.host or "http://localhost:4444"
+    # Run auto-detect in every process (master, workers, standalone)
+    # This ensures _server_id / _tool_names are populated in each worker
+    _ensure_detected(host)
+    # Only log banner from master / standalone
+    if not isinstance(environment.runner, WorkerRunner):
+        logger.info("=" * 70)
+        logger.info("MCP STREAMABLE HTTP PROTOCOL LOAD TEST")
+        logger.info("=" * 70)
+        logger.info("  Host: %s", host)
+        if _server_id:
+            logger.info("  MCP endpoint: %s/servers/%s/mcp", host, _server_id)
+        logger.info("  Tools: %s", ", ".join(_tool_names[:10]) if _tool_names else "(none)")
+        logger.info("=" * 70)
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    if isinstance(environment.runner, MasterRunner):
+        return
+    stats = environment.stats
+    total = stats.total.num_requests
+    fails = stats.total.num_failures
+    fail_pct = (fails / total * 100) if total > 0 else 0
+
+    print("\n" + "=" * 90)
+    print("MCP STREAMABLE HTTP PROTOCOL — RESULTS")
+    print("=" * 90)
+    print(f"\n  {'OVERALL':^86}")
+    print("  " + "-" * 86)
+    print(f"  Total Requests:     {total:>12,}")
+    print(f"  Total Failures:     {fails:>12,} ({fail_pct:.2f}%)")
+    print(f"  Requests/sec (RPS): {stats.total.total_rps:>12.2f}")
+    if total > 0:
+        print("\n  Response Times (ms):")
+        print(f"    Average:  {stats.total.avg_response_time:>10.2f}")
+        print(f"    Min:      {stats.total.min_response_time:>10.2f}")
+        print(f"    Max:      {stats.total.max_response_time:>10.2f}")
+        print(f"    p50:      {stats.total.get_response_time_percentile(0.50):>10.2f}")
+        print(f"    p90:      {stats.total.get_response_time_percentile(0.90):>10.2f}")
+        print(f"    p95:      {stats.total.get_response_time_percentile(0.95):>10.2f}")
+        print(f"    p99:      {stats.total.get_response_time_percentile(0.99):>10.2f}")
+
+    # Per-endpoint breakdown
+    entries = sorted(stats.entries.values(), key=lambda e: e.num_requests, reverse=True)
+    if entries:
+        print(f"\n  {'ENDPOINT BREAKDOWN':^86}")
+        print("  " + "-" * 86)
+        print(f"  {'Name':<45} {'Reqs':>8} {'Fails':>8} {'RPS':>8} {'Avg(ms)':>8} {'p99(ms)':>8}")
+        print("  " + "-" * 86)
+        for entry in entries[:20]:
+            p99 = entry.get_response_time_percentile(0.99) if entry.num_requests > 0 else 0
+            print(f"  {entry.name:<45} {entry.num_requests:>8,} {entry.num_failures:>8,} " f"{entry.total_rps:>8.1f} {entry.avg_response_time:>8.1f} {p99:>8.1f}")
+
+    print("\n" + "=" * 90 + "\n")
+
+
+# =============================================================================
+# Helper: JSON-RPC
+# =============================================================================
+
+
+def _jsonrpc(method: str, params: dict | None = None) -> dict:
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method}
+    if params is not None:
+        payload["params"] = params
+    return payload
+
+
+# =============================================================================
+# Base MCP User — handles session init, auth, and request mechanics
+# =============================================================================
+
+
+class BaseMCPUser(FastHttpUser):
+    """Base for all MCP Streamable HTTP user classes.
+
+    Uses FastHttpUser for gevent-based high concurrency.
+    Each user maintains its own MCP session via Mcp-Session-Id header.
+    """
+
+    abstract = True
+    connection_timeout = 30.0
+    network_timeout = 30.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mcp_session_id: str | None = None
+        self._initialized = False
+        self._token = _get_token()
+
+    def _mcp_path(self) -> str:
+        return f"/servers/{_server_id}/mcp"
+
+    def _mcp_headers(self) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self._token}",
+        }
+        if self._mcp_session_id:
+            headers["Mcp-Session-Id"] = self._mcp_session_id
+        return headers
+
+    def _mcp_request(self, method: str, params: dict | None, name: str) -> dict | None:
+        """Send MCP JSON-RPC request and validate the response.
+
+        Returns the 'result' field on success, None on error.
+        """
+        payload = _jsonrpc(method, params)
+        with self.client.post(
+            self._mcp_path(),
+            data=json.dumps(payload),
+            headers=self._mcp_headers(),
+            name=name,
+            catch_response=True,
+        ) as response:
+            # Capture session ID
+            sid = response.headers.get("Mcp-Session-Id")
+            if sid:
+                self._mcp_session_id = sid
+
+            if response.status_code in (502, 503, 504):
+                response.failure(f"Infrastructure error: {response.status_code}")
+                return None
+
+            if response.status_code != 200:
+                response.failure(f"HTTP {response.status_code}")
+                return None
+
+            try:
+                data = response.json()
+            except Exception as e:
+                response.failure(f"Invalid JSON: {e}")
+                return None
+
+            if data is None:
+                response.failure("Null JSON response")
+                return None
+
+            if "error" in data:
+                err = data["error"]
+                response.failure(f"JSON-RPC error {err.get('code', '?')}: {err.get('message', '?')}")
+                return None
+
+            response.success()
+            return data.get("result")
+
+    def _ensure_initialized(self):
+        """Initialize the MCP session (once per user lifecycle)."""
+        if self._initialized:
+            return
+        result = self._mcp_request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
+                "clientInfo": {"name": "locust-mcp-protocol", "version": "1.0.0"},
+            },
+            "MCP initialize",
+        )
+        if result is not None:
+            self._initialized = True
+
+    def on_start(self):
+        self._ensure_initialized()
+
+
+# =============================================================================
+# User 1: MCPAgentUser — Realistic agent with 6 tools (customer scenario)
+# =============================================================================
+
+
+class MCPAgentUser(BaseMCPUser):
+    """Simulates a realistic AI agent that uses 6 MCP tools.
+
+    Matches the customer scenario: an agent with 6 tools at 150 RPS target.
+    Each "turn" the agent:
+      1. Calls tools/list (periodic discovery)
+      2. Calls 1-3 tools per turn (random selection from available tools)
+      3. Occasionally lists resources/prompts
+
+    Weight: 10 (dominant — this is the primary scenario to measure)
+    """
+
+    weight = 10
+    wait_time = between(0.05, 0.3)
+
+    def _pick_tools(self, n: int = 1) -> list[str]:
+        """Pick n random tools from the discovered set (cap at 6 like the customer)."""
+        pool = _tool_names[:6] if len(_tool_names) > 6 else _tool_names
+        if not pool:
+            return []
+        return random.sample(pool, min(n, len(pool)))
+
+    def _build_tool_args(self, tool_name: str) -> dict:
+        """Build plausible arguments for a tool based on its name."""
+        name_lower = tool_name.lower()
+        if "time" in name_lower or "timezone" in name_lower:
+            return {"timezone": random.choice(TIMEZONES)}
+        if "echo" in name_lower:
+            return {"message": f"load-test-{random.randint(1, 10000)}"}
+        if "convert" in name_lower:
+            src = random.choice(TIMEZONES)
+            dst = random.choice([t for t in TIMEZONES if t != src])
+            return {"time": "2025-06-15T14:30:00Z", "source_timezone": src, "target_timezone": dst}
+        # Generic: many tools accept empty args or have defaults
+        return {}
+
+    @task(15)
+    @tag("agent", "tools", "call")
+    def agent_call_tool(self):
+        """Agent calls a tool — the core workload."""
+        tools = self._pick_tools(1)
+        if not tools:
+            return
+        tool = tools[0]
+        args = self._build_tool_args(tool)
+        self._mcp_request("tools/call", {"name": tool, "arguments": args}, f"MCP tools/call [{tool}]")
+
+    @task(8)
+    @tag("agent", "tools", "call")
+    def agent_multi_tool_turn(self):
+        """Agent calls 2-3 tools in sequence (multi-step reasoning)."""
+        tools = self._pick_tools(random.randint(2, 3))
+        for tool in tools:
+            args = self._build_tool_args(tool)
+            self._mcp_request("tools/call", {"name": tool, "arguments": args}, f"MCP tools/call [{tool}]")
+
+    @task(5)
+    @tag("agent", "tools", "list")
+    def agent_list_tools(self):
+        """Agent discovers available tools."""
+        self._mcp_request("tools/list", {}, "MCP tools/list")
+
+    @task(2)
+    @tag("agent", "resources")
+    def agent_list_resources(self):
+        """Agent lists resources."""
+        self._mcp_request("resources/list", {}, "MCP resources/list")
+
+    @task(2)
+    @tag("agent", "prompts")
+    def agent_list_prompts(self):
+        """Agent lists prompts."""
+        self._mcp_request("prompts/list", {}, "MCP prompts/list")
+
+    @task(1)
+    @tag("agent", "resources")
+    def agent_read_resource(self):
+        """Agent reads a resource."""
+        if _resource_uris:
+            uri = random.choice(_resource_uris)
+            self._mcp_request("resources/read", {"uri": uri}, "MCP resources/read")
+
+    @task(1)
+    @tag("agent", "prompts")
+    def agent_get_prompt(self):
+        """Agent gets a prompt."""
+        if _prompt_names:
+            name = random.choice(_prompt_names)
+            self._mcp_request("prompts/get", {"name": name}, "MCP prompts/get")
+
+    @task(1)
+    @tag("agent", "ping")
+    def agent_ping(self):
+        """Agent sends ping (keepalive)."""
+        self._mcp_request("ping", None, "MCP ping")
+
+
+# =============================================================================
+# User 2: MCPToolCallerUser — Heavy tool/call in tight loop
+# =============================================================================
+
+
+class MCPToolCallerUser(BaseMCPUser):
+    """Hammers tools/call as fast as possible to find the ceiling.
+
+    Weight: 5
+    """
+
+    weight = 5
+    wait_time = between(0.02, 0.1)
+
+    @task(20)
+    @tag("toolcall", "call")
+    def call_tool(self):
+        """Call a random tool rapidly."""
+        if not _tool_names:
+            return
+        tool = random.choice(_tool_names[:6] if len(_tool_names) > 6 else _tool_names)
+        name_lower = tool.lower()
+        if "time" in name_lower:
+            args = {"timezone": random.choice(TIMEZONES)}
+        elif "echo" in name_lower:
+            args = {"message": "perf-test"}
+        elif "convert" in name_lower:
+            args = {"time": "2025-01-01T00:00:00Z", "source_timezone": "UTC", "target_timezone": "Europe/London"}
+        else:
+            args = {}
+        self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [rapid]")
+
+    @task(1)
+    @tag("toolcall", "list")
+    def list_tools(self):
+        """Occasional tools/list."""
+        self._mcp_request("tools/list", {}, "MCP tools/list [rapid]")
+
+
+# =============================================================================
+# User 3: MCPDiscoveryUser — Discovery-heavy (tools/list, resources, prompts)
+# =============================================================================
+
+
+class MCPDiscoveryUser(BaseMCPUser):
+    """Exercises discovery endpoints heavily.
+
+    Weight: 3
+    """
+
+    weight = 3
+    wait_time = between(0.05, 0.2)
+
+    @task(10)
+    @tag("discovery", "tools")
+    def list_tools(self):
+        self._mcp_request("tools/list", {}, "MCP tools/list")
+
+    @task(8)
+    @tag("discovery", "resources")
+    def list_resources(self):
+        self._mcp_request("resources/list", {}, "MCP resources/list")
+
+    @task(8)
+    @tag("discovery", "prompts")
+    def list_prompts(self):
+        self._mcp_request("prompts/list", {}, "MCP prompts/list")
+
+    @task(5)
+    @tag("discovery", "resources")
+    def list_resource_templates(self):
+        self._mcp_request("resources/templates/list", {}, "MCP resources/templates/list")
+
+    @task(3)
+    @tag("discovery", "resources")
+    def read_resource(self):
+        if _resource_uris:
+            uri = random.choice(_resource_uris)
+            self._mcp_request("resources/read", {"uri": uri}, "MCP resources/read")
+
+    @task(3)
+    @tag("discovery", "prompts")
+    def get_prompt(self):
+        if _prompt_names:
+            name = random.choice(_prompt_names)
+            self._mcp_request("prompts/get", {"name": name}, "MCP prompts/get")
+
+
+# =============================================================================
+# User 4: MCPSessionChurnUser — New session per cycle (worst case)
+# =============================================================================
+
+
+class MCPSessionChurnUser(BaseMCPUser):
+    """Creates a new MCP session for every request cycle.
+
+    This simulates the worst case where clients don't reuse sessions
+    (e.g. serverless functions, short-lived containers).
+
+    Weight: 2
+    """
+
+    weight = 2
+    wait_time = between(0.1, 0.3)
+
+    def on_start(self):
+        # Do NOT call _ensure_initialized — each task cycle initializes fresh
+        pass
+
+    @task(10)
+    @tag("churn", "lifecycle")
+    def full_lifecycle(self):
+        """Full init -> tools/list -> tools/call -> end."""
+        # Reset session
+        self._mcp_session_id = None
+        self._initialized = False
+
+        # Initialize
+        self._mcp_request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "locust-churn", "version": "1.0.0"},
+            },
+            "MCP initialize [churn]",
+        )
+
+        # List tools
+        self._mcp_request("tools/list", {}, "MCP tools/list [churn]")
+
+        # Call a tool
+        if _tool_names:
+            tool = random.choice(_tool_names[:6] if len(_tool_names) > 6 else _tool_names)
+            name_lower = tool.lower()
+            if "time" in name_lower:
+                args = {"timezone": random.choice(TIMEZONES)}
+            elif "echo" in name_lower:
+                args = {"message": "churn-test"}
+            else:
+                args = {}
+            self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [churn]")
+
+
+# =============================================================================
+# User 5: MCPStressUser — Maximum throughput with constant_throughput
+# =============================================================================
+
+
+class MCPStressUser(BaseMCPUser):
+    """Constant-throughput stress test: 5 req/s per user.
+
+    With 100 users = 500 RPS target.
+
+    Weight: 1 (opt-in via class picker for stress runs)
+    """
+
+    weight = 1
+    wait_time = constant_throughput(5)
+
+    @task(10)
+    @tag("stress", "call")
+    def stress_call_tool(self):
+        if not _tool_names:
+            return
+        tool = random.choice(_tool_names[:6] if len(_tool_names) > 6 else _tool_names)
+        name_lower = tool.lower()
+        if "time" in name_lower:
+            args = {"timezone": "UTC"}
+        elif "echo" in name_lower:
+            args = {"message": "stress"}
+        else:
+            args = {}
+        self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [stress]")
+
+    @task(3)
+    @tag("stress", "list")
+    def stress_list_tools(self):
+        self._mcp_request("tools/list", {}, "MCP tools/list [stress]")
+
+    @task(1)
+    @tag("stress", "ping")
+    def stress_ping(self):
+        self._mcp_request("ping", None, "MCP ping [stress]")
+
+
+# =============================================================================
+# User 6: RESTBaselineUser — /rpc + REST API comparison baseline
+# =============================================================================
+
+
+class RESTBaselineUser(FastHttpUser):
+    """REST API baseline for direct comparison with MCP streamable HTTP.
+
+    Runs the same logical operations (tools/list, tools/call) via the /rpc
+    endpoint and REST API, so we can measure the overhead that the MCP
+    streamable HTTP transport adds.
+
+    Weight: 0 (opt-in via class picker — not included in default runs)
+    """
+
+    weight = 0
+    wait_time = between(0.05, 0.2)
+    connection_timeout = 30.0
+    network_timeout = 30.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._token = _get_token()
+        self._auth_headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    @task(10)
+    @tag("baseline", "rpc", "list")
+    def rpc_list_tools(self):
+        """tools/list via /rpc (REST JSON-RPC)."""
+        payload = _jsonrpc("tools/list", {})
+        with self.client.post(
+            "/rpc",
+            data=json.dumps(payload),
+            headers=self._auth_headers,
+            name="REST /rpc tools/list",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                resp.success()
+            else:
+                resp.failure(f"HTTP {resp.status_code}")
+
+    @task(10)
+    @tag("baseline", "rpc", "call")
+    def rpc_call_tool(self):
+        """tools/call via /rpc (REST JSON-RPC)."""
+        if not _tool_names:
+            return
+        tool = random.choice(_tool_names[:6] if len(_tool_names) > 6 else _tool_names)
+        name_lower = tool.lower()
+        if "echo" in name_lower:
+            args = {"message": "baseline"}
+        elif "time" in name_lower:
+            args = {"timezone": "UTC"}
+        else:
+            args = {}
+        payload = _jsonrpc("tools/call", {"name": tool, "arguments": args})
+        with self.client.post(
+            "/rpc",
+            data=json.dumps(payload),
+            headers=self._auth_headers,
+            name="REST /rpc tools/call",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                resp.success()
+            else:
+                resp.failure(f"HTTP {resp.status_code}")
+
+    @task(5)
+    @tag("baseline", "rest", "list")
+    def rest_list_tools(self):
+        """/tools via REST API."""
+        with self.client.get(
+            "/tools",
+            headers=self._auth_headers,
+            name="REST /tools",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                resp.success()
+            else:
+                resp.failure(f"HTTP {resp.status_code}")
+
+    @task(3)
+    @tag("baseline", "health")
+    def health_check(self):
+        """/health (no auth, minimal middleware)."""
+        with self.client.get("/health", name="REST /health", catch_response=True) as resp:
+            if resp.status_code == 200:
+                resp.success()
+            else:
+                resp.failure(f"HTTP {resp.status_code}")


### PR DESCRIPTION
## Summary

- Add dedicated MCP Streamable HTTP protocol load test (`locustfile_mcp_protocol.py`) with 6 user classes and 3 Makefile targets
- Update 5 performance docs with MCP-specific profiling, tuning, and bottleneck triage guidance
- Add disable-unused-features guide with deployment profiles

## Changes

### New: `tests/loadtest/locustfile_mcp_protocol.py`
Dedicated Locust load test exercising ONLY the MCP Streamable HTTP transport (`/servers/{id}/mcp`). User classes:
- `MCPAgentUser` (weight 10) — realistic agent with up to 6 tools
- `MCPToolCallerUser` (weight 5) — heavy tools/call loop
- `MCPDiscoveryUser` (weight 3) — tools/list, resources/list, prompts/list
- `MCPSessionChurnUser` (weight 2) — new session per cycle
- `MCPStressUser` (weight 1) — constant_throughput for sustained load
- `RESTBaselineUser` (weight 0) — /rpc comparison (opt-in via class picker)

Auto-detects server ID (picks server with most tools), discovers tools/resources/prompts via MCP protocol, works with `--processes` multi-worker mode.

### New Makefile targets
- `make load-test-mcp-protocol` — 150 users, 2 min, headless with reports
- `make load-test-mcp-protocol-ui` — Web UI with class picker
- `make load-test-mcp-protocol-heavy` — 500 users, 5 min

### Documentation updates

**`docs/docs/development/profiling.md`**
- MCP bottleneck triage table (symptom → layer → investigation)
- MCP profiling session workflow (DB stats + py-spy + container stats)

**`docs/docs/manage/tuning.md`**
- MCP transport tuning: critical settings, negligible settings, SDK tunables
- Disable-unused-features guide: high/medium/low impact features with 3 deployment profiles (MCP-only, full-prod, dev)
- Auth cache TTL guidance

**`docs/docs/development/db-performance.md`**
- DB vs transport vs runtime bottleneck triage section

**`docs/docs/architecture/performance-architecture.md`**
- MCP request path diagram (client → nginx → middleware → SDK → handler → upstream)
- Per-layer latency and tunable table
- Feature flag overhead note
- Updated cache TTLs, separate MCP vs REST scaling capacity

**`docs/docs/testing/performance.md`**
- Expanded Locust section: `load-test-ui`/`load-test-cli` docs, grouped target tables
- MCP protocol load testing section with user classes and configuration
- Test data generation section linking to `tests/load/README.md`
- JMeter quick-start with `make jmeter-install` / `make jmeter-load`
- Cross-links between all 5 performance docs

## Test plan

- [x] `locustfile_mcp_protocol.py` passes `black`, `isort`, `ruff` checks
- [x] Tested with 5–300 concurrent users against Docker Compose stack
- [x] All Makefile targets verified functional
- [x] All cross-links between docs verified to point to existing files