### PR TITLE
fix(charts): fix ingress template YAML rendering for gateway and fast-time

### DIFF
--- a/charts/mcp-stack/templates/ingress.yaml
+++ b/charts/mcp-stack/templates/ingress.yaml
@@ -17,7 +17,8 @@ Ingress
 {{- range $key, $value := ($gatewayIngress.annotations | default dict) -}}
 {{- $_ := set $gatewayAnnotations $key (toString $value) -}}
 {{- end -}}
-{{- $gatewayTlsSecretName := $gatewayIngress.tls.secretName | default (printf "%s-ingress-tls" $fullName) -}}
+{{- $gatewayTlsSecretName := $gatewayIngress.tls.secretName | default (printf "%s-ingress-tls" $fullName) }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -47,9 +48,8 @@ spec:
                 name: {{ $fullName }}-mcpgateway
                 port:
                   number: {{ .Values.mcpContextForge.service.port }}
-{{- end }}
-
-{{- if and .Values.mcpFastTimeServer.enabled .Values.mcpFastTimeServer.ingress.enabled }}
+{{ end -}}
+{{ if and .Values.mcpFastTimeServer.enabled .Values.mcpFastTimeServer.ingress.enabled }}
 {{- $fastTimeIngress := .Values.mcpFastTimeServer.ingress -}}
 {{- $fastTimeClassName := lower ($fastTimeIngress.className | default "") -}}
 {{- $fastTimeAnnotations := dict -}}
@@ -63,7 +63,7 @@ spec:
 {{- range $key, $value := ($fastTimeIngress.annotations | default dict) -}}
 {{- $_ := set $fastTimeAnnotations $key (toString $value) -}}
 {{- end -}}
-{{- $fastTimeTlsSecretName := $fastTimeIngress.tls.secretName | default (printf "%s-fast-time-ingress-tls" $fullName) -}}
+{{- $fastTimeTlsSecretName := $fastTimeIngress.tls.secretName | default (printf "%s-fast-time-ingress-tls" $fullName) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/mcp-stack/values-minikube.yaml
+++ b/charts/mcp-stack/values-minikube.yaml
@@ -58,6 +58,12 @@ mcpContextForge:
     PASSWORD_REQUIRE_SPECIAL: "false"
     REQUIRE_STRONG_SECRETS: "false"
 
+# Disable TLS on fast-time-server ingress for minikube
+mcpFastTimeServer:
+  ingress:
+    tls:
+      enabled: false
+
 # Infrastructure — minikube-sized
 postgres:
   enabled: true


### PR DESCRIPTION
## Summary

Fix a pre-existing bug where the gateway ingress (`mcp-stack-ingress`) was never created in the cluster, and disable TLS on the fast-time ingress for minikube.

## Root Cause

The `ingress.yaml` Helm template had whitespace control bugs (`{{-` / `-}}`) that ate newlines around the YAML document separator (`---`), causing:

1. **Gateway ingress missing**: `number: 80---` rendered on one line — Kubernetes silently rejected the malformed YAML, so `mcp-stack-ingress` was never created despite being in the Helm manifest.

2. **Fast-time ingress only**: `mcp-stack-fast-time-ingress` worked because it was the second document and its `apiVersion` line wasn't affected.

## Fix

- `{{- end }}` → `{{ end -}}` — preserve the newline before `---` so the gateway document ends cleanly
- `{{- if ...` → `{{ if ...` — preserve whitespace between the two ingress documents
- `{{- $fastTimeTlsSecretName ... -}}` → remove trailing `-` — preserve newline before `---`
- Disable `mcpFastTimeServer.ingress.tls` in `values-minikube.yaml` to prevent 308 redirects

## Tested

```
$ kubectl get ingress -n mcp-private
NAME                          CLASS   HOSTS           ADDRESS        PORTS   AGE
mcp-stack-fast-time-ingress   nginx   gateway.local   192.168.49.2   80      46s
mcp-stack-ingress             nginx   gateway.local   192.168.49.2   80      46s

$ curl -s -H "Host: gateway.local" http://192.168.49.2/health
{"status":"healthy"}

$ curl -s -o /dev/null -w "%{http_code}" -H "Host: gateway.local" http://192.168.49.2/tools
401

$ # Tool invocation via ingress
$ curl -s -X POST http://192.168.49.2/rpc ...
  get-system-time: 2026-03-09T13:18:21Z  isError=False

$ # SSE transport via ingress
  SSE endpoint event: received
```

Both production (TLS enabled) and minikube (TLS disabled) template rendering verified via `helm template`.