### PR TITLE
feat(security): add custom Semgrep rules for MCP patterns (#2237)

### DIFF
--- a/semgrep-rules/mcp/mcp-best-practices.yaml
+++ b/semgrep-rules/mcp/mcp-best-practices.yaml
@@ -1,0 +1,212 @@
+# Location: ./semgrep-rules/mcp/mcp-best-practices.yaml
+# Copyright 2026
+# SPDX-License-Identifier: Apache-2.0
+# Authors: Arnav Sanghi
+#
+# MCP-specific Semgrep rules used by the source scanner (#2217).
+# These rules detect security issues relevant to MCP servers.
+# ============================================================================
+# Purpose of these rules:
+# These rules detect cases where user input could be misused if best practices aren’t followed, such as:
+#
+# - Using arguments without type or value validation
+# - Constructing file paths unsafely → path traversal
+# - Making HTTP requests without validating URLs → SSRF
+# - Reading large files without limits → DoS
+# - Failing to handle errors → crashes or info leaks
+#
+# In short, they catch places where user input could indirectly cause unsafe behavior
+# or reliability/security issues, even if it’s not immediately critical.
+# ============================================================================
+
+rules:
+  # ============================================================================
+  # Input Validation - Foundation of secure MCP servers
+  # ============================================================================
+  - id: mcp-missing-input-validation
+    languages: [python]
+    message: >
+      Tool uses arguments without validation or type checking.
+      Always validate input: check types, formats, lengths, ranges, and allowed values.
+      Example: if not isinstance(args.get("count"), int) or args["count"] > 1000
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          def $FUNC(arguments):
+              ...
+      - pattern-either:
+          - pattern: $x = arguments[$KEY]
+          - pattern: $x = args[$KEY]
+    metadata:
+      category: input-validation
+      technology: mcp
+      cwe: CWE-20
+
+  - id: mcp-path-traversal-no-realpath-check
+    languages: [python]
+    message: >
+      File path from arguments used without realpath() or abspath() validation.
+      Always resolve to absolute path and verify it's within allowed base directory.
+      Use: secure_path = os.path.abspath(user_path); assert secure_path.startswith(BASE_DIR)
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern: os.path.join($BASEDIR, args[$KEY])
+          - pattern: f"{$BASEDIR}/{args[$KEY]}"
+    metadata:
+      category: path-traversal
+      technology: mcp
+      cwe: CWE-22
+
+  - id: mcp-url_protocol-not-validated
+    languages: [python]
+    message: >
+      HTTP request to user-provided URL without protocol validation.
+      Attacker could use file://, localhost, or internal IP addresses.
+      Validate URL starts with http:// or https:// before use.
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern: requests.get(f"...{args['endpoint']}...")
+          - pattern: urllib.request.urlopen(f"...{args['url']}...")
+    metadata:
+      category: ssrf
+      technology: mcp
+      cwe: CWE-918
+
+  - id: mcp-resource-limit-missing
+    languages: [python]
+    message: >
+      Tool reads entire file or data without size/resource limits.
+      Implement maximum size checks to prevent DoS via large file reads.
+      Example: if file_size > MAX_READ_SIZE: raise ValueError("File too large")
+    severity: WARNING
+    patterns:
+      - pattern: open($FILE).read()
+    metadata:
+      category: dos-prevention
+      technology: mcp
+      cwe: CWE-400
+
+  # ============================================================================
+  # Error Handling & Robustness
+  # ============================================================================
+  - id: mcp-missing-error-handling
+    languages: [python]
+    message: >
+      External call without exception handling. Unhandled exceptions can:
+      1. Leak sensitive information in tracebacks
+      2. Leave database/file connections open
+      3. Crash the tool handler
+      Wrap network, filesystem, and database calls in try-except.
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+      - pattern-either:
+          - pattern: requests.get(...)
+          - pattern: cursor.execute(...)
+          - pattern: file_path.open()
+    metadata:
+      category: error-handling
+      technology: mcp
+      cwe: CWE-248
+
+  - id: mcp-unvalidated-database-query
+    languages: [python]
+    message: >
+      Database query constructed without parameterization.
+      Always use parameterized queries (bind variables) for all user input.
+      Bad: cursor.execute("SELECT * FROM users WHERE id=" + user_id)
+      Good: cursor.execute("SELECT * FROM users WHERE id=?", (user_id,))
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: db.query("SELECT ... " + ...)
+          - pattern: cursor.execute("UPDATE ... " + ...)
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-89
+
+  # ============================================================================
+  # Shell Safety
+  # ============================================================================
+  - id: mcp-unsafe-shell-metacharacter-handling
+    languages: [python]
+    message: >
+      Shell metacharacters in command could be dangerous even with quoting.
+      Only use quoting as a last resort. Prefer safer approaches:
+      1. Use subprocess with list arguments (no shell=True)
+      2. Use purpose-built libraries instead of shell commands
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern: shlex.quote(args[$KEY])
+          - pattern: pipes.quote(args[$KEY])
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-78
+
+  # ============================================================================
+  # Code Quality & Maintainability
+  # ============================================================================
+  - id: mcp-missing-input-type-hints
+    languages: [python]
+    message: >
+      MCP tool function lacks type hints for arguments and return value.
+      Use type hints to document contract and enable static analysis:
+      def my_tool(arguments: Dict[str, str]) -> str:
+    severity: INFO
+    patterns:
+      - pattern: |
+          def $FUNC(arguments):
+              ...
+    metadata:
+      category: best-practices
+      technology: mcp
+      cwe: CWE-1287
+
+  - id: mcp-missing-function-docstring
+    languages: [python]
+    message: >
+      MCP tool function lacks docstring documentation.
+      Document tool purpose, parameters, and return value clearly for maintainability and security review:
+      """
+      Tool purpose.
+      Args: what parameters are expected
+      Returns: what the tool returns and any safety notes
+      """
+    severity: INFO
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              $BODY
+      - pattern-not: |
+          def $FUNC(...):
+              """..."""
+              ...
+    metadata:
+      category: best-practices
+      technology: mcp
+      cwe: CWE-1287
+
+  - id: mcp-overly-permissive-file-operations
+    languages: [python]
+    message: >
+      File operations may be overly permissive. Restrict file access:
+      1. Only allow reading from specific directories
+      2. Only allow writing to temp/output directories
+      3. Never allow deleting files from untrusted paths
+      4. Use restrictive file permissions (0o644 max)
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern: os.chmod(...)
+          - pattern: pathlib.Path(...).chmod(...)
+    metadata:
+      category: file-access
+      technology: mcp
+      cwe: CWE-73

--- a/semgrep-rules/mcp/mcp-response-security.yaml
+++ b/semgrep-rules/mcp/mcp-response-security.yaml
@@ -1,0 +1,187 @@
+# Location: ./semgrep-rules/mcp/mcp-response-security.yaml
+# Copyright 2026
+# SPDX-License-Identifier: Apache-2.0
+# Authors: Arnav Sanghi
+#
+# MCP-specific Semgrep rules used by the source scanner (#2217).
+# These rules detect security issues relevant to MCP servers.
+# ============================================================================
+# Purpose of these rules:
+# These rules detect cases where user input or internal data could be exposed or misused in responses, such as:
+#
+# - Returning user-controlled data directly → prompt or response injection
+# - Returning exceptions or stack traces → info leaks
+# - Logging or printing credentials → secret exposure
+# - Returning unescaped HTML/Markdown → injection
+# - Returning data in invalid formats → schema/protocol errors
+#
+# In short, they catch places where user input or sensitive info could leak or be misused
+# in tool outputs, protecting the system and downstream consumers.
+# ============================================================================
+
+rules:
+  # ============================================================================
+  # Response Validation & Output Safety
+  # ============================================================================
+  - id: mcp-unvalidated-response-content
+    languages: [python]
+    message: >
+      Tool response contains potentially unvalidated or user-controlled input.
+      Ensure all data in responses is validated/sanitized to prevent
+      prompt injection and context poisoning attacks.
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern: return {"text": $INPUT}
+          - pattern: return TextContent(text=$INPUT)
+          - pattern: return {..., "response": $INPUT, ...}
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-20
+
+  - id: mcp-sensitive-data-in_error_response
+    languages: [python]
+    message: >
+      Sensitive error details (stack trace, exception, server path) exposed in response.
+      Never return exception details or traceback to users.
+      Return generic error messages and log details securely server-side.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: return {"text": str($EXCEPTION)}
+          - pattern: return {"error": traceback.format_exc()}
+          - pattern: return {"response": $EXCEPTION}
+          - pattern: return ErrorContent(message=str($EXC))
+    metadata:
+      category: info-leak
+      technology: mcp
+      cwe: CWE-209
+
+  - id: mcp-credentials-in_logs_or_output
+    languages: [python]
+    message: >
+      Credentials or sensitive data logged or printed from tool arguments.
+      Never log API keys, passwords, tokens, or user PII.
+      Be especially careful with error paths and debug output.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: logger.debug(f"...{args['api_key']}...")
+          - pattern: logger.info(f"...{args['password']}...")
+          - pattern: print(f"...{args['token']}...")
+          - pattern: logger.error(f"...{args['secret']}...")
+          - pattern: logger.warning(f"...{arguments['bearer']}...")
+    metadata:
+      category: info-leak
+      technology: mcp
+      cwe: CWE-532
+
+  - id: mcp-unescaped_output
+    languages: [python]
+    message: >
+      Tool returns data without escaping HTML/markdown special characters.
+      If tool output can be rendered as markup, escape or sanitize content.
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern: return {"text": f"<{$X}>"}
+          - pattern: return {"text": "<script>"}
+          - pattern: return TextContent(text=f"...{{...}}...")
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-79
+
+  # ============================================================================
+  # Information Disclosure & Exception Handling
+  # ============================================================================
+  - id: mcp-exception-leaks_in_response
+    languages: [python]
+    message: >
+      Exception or exception message returned directly in tool response.
+      Catch exceptions, log securely, and return a generic user-facing message.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: return {"text": $EXCEPTION}
+          - pattern: return str($EXCEPTION)
+          - pattern: return repr($EXCEPTION)
+    metadata:
+      category: info-leak
+      technology: mcp
+      cwe: CWE-209
+
+  - id: mcp-missing-try-except-wrapper
+    languages: [python]
+    message: >
+      External call (network, file, database) without try-except error handling.
+      Always wrap I/O operations in exception handlers to prevent unhandled errors
+      from leaking sensitive information.
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+      - pattern-either:
+          - pattern: requests.get(...)
+          - pattern: open(...)
+          - pattern: cursor.execute(...)
+          - pattern: urllib.request.urlopen(...)
+    metadata:
+      category: error-handling
+      technology: mcp
+      cwe: CWE-248
+
+  # ============================================================================
+  # JSON & Schema Validation
+  # ============================================================================
+  - id: mcp-invalid_json_types_in_response
+    languages: [python]
+    message: >
+      Response contains non-JSON-serializable types (bytes, datetime, etc.).
+      Always ensure tool responses contain only JSON-compatible types
+      (str, int, float, bool, list, dict, None).
+    severity: WARNING
+    patterns:
+      - pattern: return {..., "data": bytes(...), ...}
+    metadata:
+      category: protocol-safety
+      technology: mcp
+      cwe: CWE-1287
+
+  - id: mcp-response_schema_mismatch
+    languages: [python]
+    message: >
+      Tool response structure may not match MCP response schema.
+      Validate response includes required fields (text, or result).
+    severity: INFO
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+              return $RESP
+      - pattern: return {"...": ..., "...": ...}
+    metadata:
+      category: protocol-safety
+      technology: mcp
+      cwe: CWE-1287
+
+  # ============================================================================
+  # Argument Validation in Responses
+  # ============================================================================
+  - id: mcp-unvalidated-subprocess-args
+    languages: [python]
+    message: >
+      Tool passes user arguments to subprocess without list formatting or validation.
+      Always convert arguments to a list and validate each element.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: subprocess.run(args[$KEY], shell=False)
+          - pattern: subprocess.Popen(args[$KEY])
+          - pattern: subprocess.call(args[$KEY])
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-78

--- a/semgrep-rules/mcp/mcp-security-critical.yaml
+++ b/semgrep-rules/mcp/mcp-security-critical.yaml
@@ -1,0 +1,267 @@
+# Location: ./semgrep-rules/mcp/mcp-security-critical.yaml
+# Copyright 2026
+# SPDX-License-Identifier: Apache-2.0
+# Authors: Arnav Sanghi
+#
+# MCP-specific Semgrep rules used by the source scanner (#2217).
+# These rules detect security issues relevant to MCP servers.
+# ============================================================================
+# Purpose of these rules:
+# These rules detect cases where user input can influence something powerful on the server, such as:
+#
+# - Executing commands → os.system(user_input)
+# - Querying databases → SQL injection
+# - Reading/writing files → path traversal (../../etc/passwd)
+# - Making server requests → SSRF (requests.get(user_url))
+# - Loading unsafe data → deserialization (pickle.loads)
+# - Returning unsafe data → response injection
+# - Exposing secrets → API keys, tokens, passwords
+#
+# In short, they detect places where user input could access, modify, execute,
+# or expose sensitive parts of the system.
+# ============================================================================
+
+rules:
+  # ============================================================================
+  # Command Injection - Multiple entry points
+  # ============================================================================
+  - id: mcp-command-injection-os-system
+    languages: [python]
+    message: >
+      Tool argument used directly in os.system() call.
+      This enables command injection. Use subprocess with shell=False,
+      validate arguments, and use proper escaping/quoting.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: os.system($ARG)
+          - pattern: os.system(f"...{$ARG}...")
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-78
+      references:
+        - https://owasp.org/www-community/attacks/Command_Injection
+
+  - id: mcp-command-injection-subprocess-shell-true
+    languages: [python]
+    message: >
+      subprocess.call/run with shell=True and unsanitized arguments
+      enables command injection. Use shell=False and validate arguments instead.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: subprocess.call($ARG, shell=True)
+          - pattern: subprocess.call(f"...{$ARG}...", shell=True)
+          - pattern: subprocess.run($ARG, shell=True)
+          - pattern: subprocess.run(f"...{$ARG}...", shell=True)
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-78
+
+  - id: mcp-command-injection-popen
+    languages: [python]
+    message: >
+      Popen with shell=True and unsanitized arguments enables command injection.
+      Use shell=False and pass arguments as a list, not a command string.
+    severity: ERROR
+    patterns:
+      - pattern: subprocess.Popen($ARG, shell=True)
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-78
+
+  # ============================================================================
+  # SQL Injection - Unparameterized queries
+  # ============================================================================
+  - id: mcp-sql-injection-dynamic-query
+    languages: [python]
+    message: >
+      SQL query constructed using string formatting with tool arguments.
+      This enables SQL injection. Use parameterized queries with bind variables.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: cursor.execute(f"SELECT ... {$ARG} ...")
+          - pattern: cursor.execute("SELECT ... " + $ARG)
+          - pattern: cursor.execute(f"DELETE ... WHERE id={$ARG}")
+          - pattern: cursor.execute("UPDATE ... %s ..." % ($ARG,))
+          - pattern: db.execute(f"UPDATE ... {$ARG}")
+          - pattern: db.query("SELECT ... " + $ARG)
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-89
+      references:
+        - https://owasp.org/www-community/attacks/SQL_Injection
+
+  # ============================================================================
+  # Path Traversal - Arbitrary file access
+  # ============================================================================
+  - id: mcp-path-traversal-arbitrary-read
+    languages: [python]
+    message: >
+      Tool accepts file paths from user arguments without validation.
+      Attacker could read arbitrary files via path traversal (e.g., ../../etc/passwd).
+      Use os.path.abspath() and verify path is within allowed base directory.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: open(args[$KEY])
+          - pattern: open(arguments["file"])
+          - pattern: open(arguments.get("path"))
+          - pattern: pathlib.Path(args[$KEY]).read_text()
+          - pattern: pathlib.Path(args[$KEY]).open()
+    metadata:
+      category: path-traversal
+      technology: mcp
+      cwe: CWE-22
+      references:
+        - https://owasp.org/www-community/attacks/Path_Traversal
+
+  - id: mcp-arbitrary-file-write
+    languages: [python]
+    message: >
+      Tool writes to file path from user arguments without validation.
+      Attacker could write to arbitrary locations (e.g., /etc files, code paths).
+      Validate paths are within allowed directory and restrict permissions.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: open(args[$KEY], "w").write(...)
+          - pattern: open(args["file"], "w")
+          - pattern: pathlib.Path(args[$KEY]).write_text(...)
+    metadata:
+      category: file-access
+      technology: mcp
+      cwe: CWE-73
+      references:
+        - https://owasp.org/www-community/attacks/Arbitrary_File_Write
+
+  # ============================================================================
+  # SSRF - Unvalidated URL requests to arbitrary hosts
+  # ============================================================================
+  - id: mcp-ssrf-unvalidated-url-request
+    languages: [python]
+    message: >
+      Unvalidated URL from tool arguments used in HTTP request.
+      Attacker could trigger requests to internal services (SSRF).
+      Whitelist domains, validate protocol (http/https only), and reject localhost/internal IPs.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: requests.get(args["url"])
+          - pattern: requests.post(args["url"])
+          - pattern: requests.get(args[$KEY])
+          - pattern: urllib.request.urlopen(args["url"])
+          - pattern: urllib.request.urlopen(arguments.get("endpoint"))
+    metadata:
+      category: ssrf
+      technology: mcp
+      cwe: CWE-918
+      references:
+        - https://owasp.org/www-community/attacks/Server-Side_Request_Forgery
+
+  # ============================================================================
+  # Credential/Secret Exposure - Never return secrets in responses
+  # ============================================================================
+  - id: mcp-credential-or-key-in-response
+    languages: [python]
+    message: >
+      API key, password, token, or secret exposed in tool response.
+      Never include credentials or sensitive data in tool outputs.
+      Use secure credential management and return only necessary data.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: return {..., "api_key": ..., ...}
+          - pattern: return {..., "apiKey": ..., ...}
+          - pattern: return {..., "password": ..., ...}
+          - pattern: return {..., "token": ..., ...}
+          - pattern: return {..., "secret": ..., ...}
+          - pattern: return {..., "access_token": ..., ...}
+          - pattern: return {"text": $X, "api_key": ..., ...}
+    metadata:
+      category: info-leak
+      technology: mcp
+      cwe: CWE-200
+      references:
+        - https://owasp.org/www-community/attacks/Sensitive_Data_Exposure
+
+  - id: mcp-hardcoded-secrets-in-code
+    languages: [python]
+    message: >
+      Hardcoded credential in MCP tool code.
+      Never hardcode API keys, passwords, or tokens.
+      Use environment variables and rotate credentials regularly.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: api_key = "sk_..."
+          - pattern: password = "......"
+          - pattern: APIKEY="..."
+          - pattern: SECRET_KEY = "..."
+          - pattern: token = "Bearer ..."
+    metadata:
+      category: hardcoded-secret
+      technology: mcp
+      cwe: CWE-798
+
+  # ============================================================================
+  # Deserialization - Arbitrary code execution via untrusted data
+  # ============================================================================
+  - id: mcp-insecure-deserialization
+    languages: [python]
+    message: >
+      Untrusted data deserialized with pickle.loads() or yaml.load().
+      These allow arbitrary code execution. Use json instead, or safe_load().
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: pickle.loads($ARG)
+          - pattern: pickle.load(...)
+          - pattern: yaml.load($ARG)
+    metadata:
+      category: deserialization
+      technology: mcp
+      cwe: CWE-502
+      references:
+        - https://owasp.org/www-community/attacks/Deserialization
+
+  # ============================================================================
+  # Response Injection - LLM prompt/output injection via tool responses
+  # ============================================================================
+  - id: mcp-response-injection-external-data
+    languages: [python]
+    message: >
+      External/user data returned in tool response without sanitization.
+      This could enable injection attacks through LLM context.
+      Sanitize, validate, or escape all external data before inclusion in response.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-inside: |
+                  def $FUNC(...):
+                      ...
+              - pattern: |
+                  $DATA = requests.get(...)
+                  ...
+                  return {"text": ...$DATA...}
+          - patterns:
+              - pattern-inside: |
+                  def $FUNC(...):
+                      ...
+              - pattern: |
+                  $RESP = requests.post(...)
+                  ...
+                  return {"text": $RESP.text}
+    metadata:
+      category: injection
+      technology: mcp
+      cwe: CWE-94
+      references:
+        - https://owasp.org/www-community/attacks/Content_Injection
+        - https://github.com/IBM/mcp-context-forge/issues/2237


### PR DESCRIPTION
**Issue**  
#2217  

📝 **Summary**  
This PR adds MCP-specific Semgrep rules to the Source Scanner plugin to improve detection of critical and best-practice security issues in MCP server code. It also includes response validation rules to catch unsafe or sensitive data being returned from tools.  

**Update/Fixes**  
- Added new Semgrep rulesets: `mcp-security-critical`, `mcp-security-best-practices`, `mcp-response-security`.  
- Each ruleset includes Python-specific patterns for:  
  - **Command injection** (`os.system`, `subprocess`)  
  - **SQL injection** (unparameterized queries)  
  - **Path traversal & arbitrary file access**  
  - **SSRF** (unvalidated URLs)  
  - **Deserialization & response injection**  
  - **Credential exposure & hardcoded secrets**  
  - **Input validation, DoS prevention, maintainability checks**  
  - **Response output validation and exception handling**  
- Updated existing Semgrep runner to integrate the new rulesets.  
- Minor fixes: logging instead of `print()`, copyright headers updated to 2026.  

**New Functionality**  
- Source Scanner now uses MCP-specific rules to detect security issues that are **critical**, **best-practice violations**, or **response/output risks**.  
- Rules are packaged so they can be extended with additional MCP server-specific patterns in the future.