### PR TITLE
feat: wire OAuth endpoint discovery into gateway UI and service (#1435)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-09T13:03:11Z",
+  "generated_at": "2026-05-09T15:00:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4246,7 +4246,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15218,
+        "line_number": 15307,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7436,7 +7436,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 454,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7444,7 +7444,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 655,
+        "line_number": 700,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7452,7 +7452,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 790,
+        "line_number": 835,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8604,7 +8604,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1602,
+        "line_number": 1603,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8612,7 +8612,7 @@
         "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1774,
+        "line_number": 1775,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8620,7 +8620,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2774,
+        "line_number": 2775,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8628,7 +8628,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5171,
+        "line_number": 5248,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8636,7 +8636,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5824,
+        "line_number": 5901,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8644,7 +8644,7 @@
         "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5888,
+        "line_number": 5965,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8652,7 +8652,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6140,
+        "line_number": 6217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8660,7 +8660,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9123,
+        "line_number": 9200,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8668,7 +8668,7 @@
         "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9172,
+        "line_number": 9249,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8676,7 +8676,7 @@
         "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9211,
+        "line_number": 9288,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8684,7 +8684,7 @@
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9268,
+        "line_number": 9345,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8692,7 +8692,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14343,
+        "line_number": 14420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8700,7 +8700,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17100,
+        "line_number": 17177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8708,7 +8708,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17119,
+        "line_number": 17196,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-09T15:00:46Z",
+  "generated_at": "2026-05-09T16:19:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8628,7 +8628,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5248,
+        "line_number": 5273,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8636,7 +8636,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5901,
+        "line_number": 5926,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8644,7 +8644,7 @@
         "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5965,
+        "line_number": 5990,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8652,7 +8652,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6217,
+        "line_number": 6242,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8660,7 +8660,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9200,
+        "line_number": 9225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8668,7 +8668,7 @@
         "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9249,
+        "line_number": 9274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8676,7 +8676,7 @@
         "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9288,
+        "line_number": 9313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8684,7 +8684,7 @@
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9345,
+        "line_number": 9370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8692,7 +8692,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14420,
+        "line_number": 14445,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8700,7 +8700,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17177,
+        "line_number": 17202,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8708,7 +8708,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17196,
+        "line_number": 17221,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12042,12 +12042,14 @@ async def admin_get_gateway(gateway_id: str, request: Request, db: Session = Dep
 
 @admin_router.post("/gateways/discover-oauth")
 @require_permission("gateways.create", allow_admin_bypass=False)
-async def admin_discover_oauth(request: Request, db: Session = Depends(get_db), user: dict[str, Any] = Depends(get_current_user_with_permissions)) -> JSONResponse:  # pylint: disable=unused-argument
+async def admin_discover_oauth(
+    request: Request,
+    user: dict[str, Any] = Depends(get_current_user_with_permissions),
+) -> JSONResponse:
     """Discover OAuth/OIDC endpoints from an issuer URL (RFC 8414 / OIDC discovery).
 
     Args:
         request: FastAPI request containing JSON body with 'issuer' field.
-        db: Database session.
         user: Authenticated user.
 
     Returns:
@@ -12057,15 +12059,36 @@ async def admin_discover_oauth(request: Request, db: Session = Depends(get_db), 
         >>> callable(admin_discover_oauth)
         True
     """
+    # First-Party
+    from mcpgateway.common.validators import SecurityValidator  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.utils.url_auth import sanitize_exception_message  # pylint: disable=import-outside-toplevel
+
     try:
         body = await request.json()
-        issuer = body.get("issuer", "").strip()
-        if not issuer:
-            return JSONResponse({"success": False, "error": "issuer is required"}, status_code=400)
+    except Exception as _e:
+        LOGGER.warning("OAuth discovery failed: invalid JSON body")
+        return JSONResponse(
+            {"success": False, "error": "Invalid JSON body"},
+            status_code=400,
+        )
 
-        # First-Party
-        from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
+    issuer = body.get("issuer", "").strip()
+    if not issuer:
+        return JSONResponse(
+            {"success": False, "error": "issuer is required"},
+            status_code=400,
+        )
 
+    try:
+        SecurityValidator.validate_url(issuer, "OAuth issuer URL")
+    except ValueError as _e:
+        return JSONResponse(
+            {"success": False, "error": f"Invalid issuer URL: {_e}"},
+            status_code=400,
+        )
+
+    try:
         dcr = DcrService()
         metadata = await dcr.discover_as_metadata(issuer)
 
@@ -12080,12 +12103,16 @@ async def admin_discover_oauth(request: Request, db: Session = Depends(get_db), 
             "grant_types_supported": metadata.get("grant_types_supported", []),
         })
     except Exception as e:
-        LOGGER.warning(f"OAuth discovery failed: {e}")
-        return JSONResponse({
-            "success": False,
-            "error": str(e),
-            "message": "Discovery failed. Please configure token and authorization endpoints manually.",
-        }, status_code=200)
+        LOGGER.warning("OAuth discovery failed: %s", e)
+        sanitized = sanitize_exception_message(str(e))
+        return JSONResponse(
+            {
+                "success": False,
+                "error": sanitized,
+                "message": "Discovery failed. Please configure token and authorization endpoints manually.",
+            },
+            status_code=502,
+        )
 
 
 @admin_router.post("/gateways")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12044,7 +12044,7 @@ async def admin_get_gateway(gateway_id: str, request: Request, db: Session = Dep
 @require_permission("gateways.create", allow_admin_bypass=False)
 async def admin_discover_oauth(
     request: Request,
-    user: dict[str, Any] = Depends(get_current_user_with_permissions),
+    user: dict[str, Any] = Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> JSONResponse:
     """Discover OAuth/OIDC endpoints from an issuer URL (RFC 8414 / OIDC discovery).
 
@@ -12060,7 +12060,6 @@ async def admin_discover_oauth(
         True
     """
     # First-Party
-    from mcpgateway.common.validators import SecurityValidator  # pylint: disable=import-outside-toplevel
     from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
     from mcpgateway.utils.url_auth import sanitize_exception_message  # pylint: disable=import-outside-toplevel
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12098,12 +12098,21 @@ async def admin_discover_oauth(
         dcr = DcrService()
         metadata = await dcr.discover_as_metadata(issuer)
 
+        def _safe_endpoint(raw: str | None, name: str) -> str | None:
+            if not raw:
+                return None
+            try:
+                SecurityValidator.validate_url(raw, name)
+                return raw
+            except ValueError:
+                return None
+
         return JSONResponse({
             "success": True,
-            "token_endpoint": metadata.get("token_endpoint"),
-            "authorization_endpoint": metadata.get("authorization_endpoint"),
-            "jwks_uri": metadata.get("jwks_uri"),
-            "registration_endpoint": metadata.get("registration_endpoint"),
+            "token_endpoint": _safe_endpoint(metadata.get("token_endpoint"), "token_endpoint"),
+            "authorization_endpoint": _safe_endpoint(metadata.get("authorization_endpoint"), "authorization_endpoint"),
+            "jwks_uri": _safe_endpoint(metadata.get("jwks_uri"), "jwks_uri"),
+            "registration_endpoint": _safe_endpoint(metadata.get("registration_endpoint"), "registration_endpoint"),
             "dcr_available": bool(metadata.get("registration_endpoint")),
             "scopes_supported": metadata.get("scopes_supported", []),
             "grant_types_supported": metadata.get("grant_types_supported", []),

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12073,6 +12073,12 @@ async def admin_discover_oauth(
             status_code=400,
         )
 
+    if not isinstance(body, dict):
+        return JSONResponse(
+            {"success": False, "error": "Request body must be a JSON object"},
+            status_code=400,
+        )
+
     issuer = body.get("issuer", "").strip()
     if not issuer:
         return JSONResponse(

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12040,6 +12040,54 @@ async def admin_get_gateway(gateway_id: str, request: Request, db: Session = Dep
         raise e
 
 
+@admin_router.post("/gateways/discover-oauth")
+@require_permission("gateways.create", allow_admin_bypass=False)
+async def admin_discover_oauth(request: Request, db: Session = Depends(get_db), user: dict[str, Any] = Depends(get_current_user_with_permissions)) -> JSONResponse:  # pylint: disable=unused-argument
+    """Discover OAuth/OIDC endpoints from an issuer URL (RFC 8414 / OIDC discovery).
+
+    Args:
+        request: FastAPI request containing JSON body with 'issuer' field.
+        db: Database session.
+        user: Authenticated user.
+
+    Returns:
+        JSONResponse with discovered endpoints or error message.
+
+    Examples:
+        >>> callable(admin_discover_oauth)
+        True
+    """
+    try:
+        body = await request.json()
+        issuer = body.get("issuer", "").strip()
+        if not issuer:
+            return JSONResponse({"success": False, "error": "issuer is required"}, status_code=400)
+
+        # First-Party
+        from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
+
+        dcr = DcrService()
+        metadata = await dcr.discover_as_metadata(issuer)
+
+        return JSONResponse({
+            "success": True,
+            "token_endpoint": metadata.get("token_endpoint"),
+            "authorization_endpoint": metadata.get("authorization_endpoint"),
+            "jwks_uri": metadata.get("jwks_uri"),
+            "registration_endpoint": metadata.get("registration_endpoint"),
+            "dcr_available": bool(metadata.get("registration_endpoint")),
+            "scopes_supported": metadata.get("scopes_supported", []),
+            "grant_types_supported": metadata.get("grant_types_supported", []),
+        })
+    except Exception as e:
+        LOGGER.warning(f"OAuth discovery failed: {e}")
+        return JSONResponse({
+            "success": False,
+            "error": str(e),
+            "message": "Discovery failed. Please configure token and authorization endpoints manually.",
+        }, status_code=200)
+
+
 @admin_router.post("/gateways")
 @require_permission("gateways.create", allow_admin_bypass=False)
 async def admin_add_gateway(request: Request, db: Session = Depends(get_db), user: dict[str, Any] = Depends(get_current_user_with_permissions)) -> JSONResponse:

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -105,7 +105,7 @@ class DcrService:
 
         try:
             client = await self._get_client()
-            response = await client.get(rfc8414_url, timeout=self._get_timeout())
+            response = await client.get(rfc8414_url, timeout=self._get_timeout(), follow_redirects=False)
             if response.status_code == 200:
                 metadata = response.json()
 
@@ -127,7 +127,7 @@ class DcrService:
 
         try:
             client = await self._get_client()
-            response = await client.get(oidc_url, timeout=self._get_timeout())
+            response = await client.get(oidc_url, timeout=self._get_timeout(), follow_redirects=False)
             if response.status_code == 200:
                 metadata = response.json()
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -626,15 +626,26 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             logger.warning("OAuth endpoint discovery skipped for issuer %s: %s", issuer, _e)
             return raw_oauth_config
 
+        def _validate_discovered(url: str, name: str) -> bool:
+            try:
+                SecurityValidator.validate_url(url, name)
+                return True
+            except ValueError as _e:
+                logger.warning("Discovered %s rejected for issuer %s: %s", name, issuer, _e)
+                return False
+
         try:
             _dcr = DcrService()
             _metadata = await _dcr.discover_as_metadata(issuer)
-            if _metadata.get("token_endpoint") and not raw_oauth_config.get("token_url"):
-                raw_oauth_config["token_url"] = _metadata["token_endpoint"]
-            if _metadata.get("authorization_endpoint") and not raw_oauth_config.get("authorization_url"):
-                raw_oauth_config["authorization_url"] = _metadata["authorization_endpoint"]
-            if _metadata.get("jwks_uri") and not raw_oauth_config.get("jwks_uri"):
-                raw_oauth_config["jwks_uri"] = _metadata["jwks_uri"]
+            token_endpoint = _metadata.get("token_endpoint")
+            if token_endpoint and not raw_oauth_config.get("token_url") and _validate_discovered(token_endpoint, "token_endpoint"):
+                raw_oauth_config["token_url"] = token_endpoint
+            authz_endpoint = _metadata.get("authorization_endpoint")
+            if authz_endpoint and not raw_oauth_config.get("authorization_url") and _validate_discovered(authz_endpoint, "authorization_endpoint"):
+                raw_oauth_config["authorization_url"] = authz_endpoint
+            jwks_uri = _metadata.get("jwks_uri")
+            if jwks_uri and not raw_oauth_config.get("jwks_uri") and _validate_discovered(jwks_uri, "jwks_uri"):
+                raw_oauth_config["jwks_uri"] = jwks_uri
             raw_oauth_config["dcr_available"] = bool(_metadata.get("registration_endpoint"))
             raw_oauth_config["endpoints_discovered"] = True
             logger.info("Auto-discovered OAuth endpoints for issuer %s", issuer)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -617,7 +617,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             return raw_oauth_config
 
         # First-Party
-        from mcpgateway.common.validators import SecurityValidator  # pylint: disable=import-outside-toplevel
         from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
 
         try:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -567,6 +567,37 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         self.oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=int(os.getenv("OAUTH_MAX_RETRIES", "3")))
         self._event_service = EventService(channel_name="mcpgateway:gateway_events")
 
+        # Per-gateway refresh locks to prevent concurrent refreshes for the same gateway
+        self._refresh_locks: Dict[str, asyncio.Lock] = {}
+
+        # For health checks, we determine the leader instance.
+        self.redis_url = settings.redis_url if settings.cache_type == "redis" else None
+
+        # Initialize optional Redis client holder (set in initialize())
+        self._redis_client: Optional[Any] = None
+
+        # Leader election settings from config
+        if self.redis_url and REDIS_AVAILABLE:
+            self._instance_id = str(uuid.uuid4())  # Unique ID for this process
+            self._leader_key = settings.redis_leader_key
+            self._leader_ttl = settings.redis_leader_ttl
+            self._leader_heartbeat_interval = settings.redis_leader_heartbeat_interval
+            self._leader_heartbeat_task: Optional[asyncio.Task] = None
+            self._follower_election_task: Optional[asyncio.Task] = None
+
+            # Log instance mapping for debugging
+            logger.info(f"Instance started: instance_id={self._instance_id}, port={settings.port}, pid={os.getpid()}")
+
+        # Always initialize file lock as fallback (used if Redis connection fails at runtime)
+        if settings.cache_type != "none":
+            temp_dir = tempfile.gettempdir()
+            user_path = os.path.normpath(settings.filelock_name)
+            if os.path.isabs(user_path):
+                user_path = os.path.relpath(user_path, start=os.path.splitdrive(user_path)[0] + os.sep)
+            full_path = os.path.join(temp_dir, user_path)
+            self._lock_path = full_path.replace("\\", "/")
+            self._file_lock = FileLock(self._lock_path)
+
     @staticmethod
     async def _auto_discover_oauth_endpoints(raw_oauth_config: dict) -> dict:
         """Auto-discover OAuth endpoints from issuer metadata if needed.
@@ -610,37 +641,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         except Exception as _e:  # pylint: disable=broad-except
             logger.warning("OAuth endpoint discovery failed for issuer %s: %s", issuer, _e)
         return raw_oauth_config
-
-        # Per-gateway refresh locks to prevent concurrent refreshes for the same gateway
-        self._refresh_locks: Dict[str, asyncio.Lock] = {}
-
-        # For health checks, we determine the leader instance.
-        self.redis_url = settings.redis_url if settings.cache_type == "redis" else None
-
-        # Initialize optional Redis client holder (set in initialize())
-        self._redis_client: Optional[Any] = None
-
-        # Leader election settings from config
-        if self.redis_url and REDIS_AVAILABLE:
-            self._instance_id = str(uuid.uuid4())  # Unique ID for this process
-            self._leader_key = settings.redis_leader_key
-            self._leader_ttl = settings.redis_leader_ttl
-            self._leader_heartbeat_interval = settings.redis_leader_heartbeat_interval
-            self._leader_heartbeat_task: Optional[asyncio.Task] = None
-            self._follower_election_task: Optional[asyncio.Task] = None
-
-            # Log instance mapping for debugging
-            logger.info(f"Instance started: instance_id={self._instance_id}, port={settings.port}, pid={os.getpid()}")
-
-        # Always initialize file lock as fallback (used if Redis connection fails at runtime)
-        if settings.cache_type != "none":
-            temp_dir = tempfile.gettempdir()
-            user_path = os.path.normpath(settings.filelock_name)
-            if os.path.isabs(user_path):
-                user_path = os.path.relpath(user_path, start=os.path.splitdrive(user_path)[0] + os.sep)
-            full_path = os.path.join(temp_dir, user_path)
-            self._lock_path = full_path.replace("\\", "/")
-            self._file_lock = FileLock(self._lock_path)
 
     @staticmethod
     def normalize_url(url: str) -> str:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -567,6 +567,50 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         self.oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=int(os.getenv("OAUTH_MAX_RETRIES", "3")))
         self._event_service = EventService(channel_name="mcpgateway:gateway_events")
 
+    @staticmethod
+    async def _auto_discover_oauth_endpoints(raw_oauth_config: dict) -> dict:
+        """Auto-discover OAuth endpoints from issuer metadata if needed.
+
+        Args:
+            raw_oauth_config: The raw OAuth config dict with potential 'issuer' key.
+
+        Returns:
+            The (possibly mutated) raw_oauth_config dict.
+        """
+        if not raw_oauth_config:
+            return raw_oauth_config
+        issuer = raw_oauth_config.get("issuer")
+        has_token_url = raw_oauth_config.get("token_url")
+        has_authz_url = raw_oauth_config.get("authorization_url")
+        if not issuer or (has_token_url and has_authz_url):
+            return raw_oauth_config
+
+        # First-Party
+        from mcpgateway.common.validators import SecurityValidator  # pylint: disable=import-outside-toplevel
+        from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
+
+        try:
+            SecurityValidator.validate_url(issuer, "OAuth issuer URL")
+        except ValueError as _e:
+            logger.warning("OAuth endpoint discovery skipped for issuer %s: %s", issuer, _e)
+            return raw_oauth_config
+
+        try:
+            _dcr = DcrService()
+            _metadata = await _dcr.discover_as_metadata(issuer)
+            if _metadata.get("token_endpoint") and not raw_oauth_config.get("token_url"):
+                raw_oauth_config["token_url"] = _metadata["token_endpoint"]
+            if _metadata.get("authorization_endpoint") and not raw_oauth_config.get("authorization_url"):
+                raw_oauth_config["authorization_url"] = _metadata["authorization_endpoint"]
+            if _metadata.get("jwks_uri") and not raw_oauth_config.get("jwks_uri"):
+                raw_oauth_config["jwks_uri"] = _metadata["jwks_uri"]
+            raw_oauth_config["dcr_available"] = bool(_metadata.get("registration_endpoint"))
+            raw_oauth_config["endpoints_discovered"] = True
+            logger.info("Auto-discovered OAuth endpoints for issuer %s", issuer)
+        except Exception as _e:  # pylint: disable=broad-except
+            logger.warning("OAuth endpoint discovery failed for issuer %s: %s", issuer, _e)
+        return raw_oauth_config
+
         # Per-gateway refresh locks to prevent concurrent refreshes for the same gateway
         self._refresh_locks: Dict[str, asyncio.Lock] = {}
 
@@ -1034,23 +1078,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 authentication_headers = None
 
             raw_oauth_config = getattr(gateway, "oauth_config", None)
-            if raw_oauth_config and raw_oauth_config.get("issuer") and not raw_oauth_config.get("token_url") and not raw_oauth_config.get("authorization_url"):
-                try:
-                    # First-Party
-                    from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
-                    _dcr = DcrService()
-                    _metadata = await _dcr.discover_as_metadata(raw_oauth_config["issuer"])
-                    if _metadata.get("token_endpoint") and not raw_oauth_config.get("token_url"):
-                        raw_oauth_config["token_url"] = _metadata["token_endpoint"]
-                    if _metadata.get("authorization_endpoint") and not raw_oauth_config.get("authorization_url"):
-                        raw_oauth_config["authorization_url"] = _metadata["authorization_endpoint"]
-                    if _metadata.get("jwks_uri") and not raw_oauth_config.get("jwks_uri"):
-                        raw_oauth_config["jwks_uri"] = _metadata["jwks_uri"]
-                    raw_oauth_config["dcr_available"] = bool(_metadata.get("registration_endpoint"))
-                    raw_oauth_config["endpoints_discovered"] = True
-                    logger.info(f"Auto-discovered OAuth endpoints for issuer {raw_oauth_config['issuer']}")
-                except Exception as _e:
-                    logger.warning(f"OAuth endpoint discovery failed for issuer {raw_oauth_config.get('issuer')}: {_e}")
+            raw_oauth_config = await self._auto_discover_oauth_endpoints(raw_oauth_config)
             oauth_config = await protect_oauth_config_for_storage(raw_oauth_config)
             ca_certificate = getattr(gateway, "ca_certificate", None)
             init_client_cert = getattr(gateway, "client_cert", None)
@@ -2272,23 +2300,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 # Handle OAuth configuration updates
                 if gateway_update.oauth_config is not None:
                     raw_oauth_update = dict(gateway_update.oauth_config)
-                    if raw_oauth_update.get("issuer") and not raw_oauth_update.get("token_url") and not raw_oauth_update.get("authorization_url"):
-                        try:
-                            # First-Party
-                            from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
-                            _dcr = DcrService()
-                            _metadata = await _dcr.discover_as_metadata(raw_oauth_update["issuer"])
-                            if _metadata.get("token_endpoint") and not raw_oauth_update.get("token_url"):
-                                raw_oauth_update["token_url"] = _metadata["token_endpoint"]
-                            if _metadata.get("authorization_endpoint") and not raw_oauth_update.get("authorization_url"):
-                                raw_oauth_update["authorization_url"] = _metadata["authorization_endpoint"]
-                            if _metadata.get("jwks_uri") and not raw_oauth_update.get("jwks_uri"):
-                                raw_oauth_update["jwks_uri"] = _metadata["jwks_uri"]
-                            raw_oauth_update["dcr_available"] = bool(_metadata.get("registration_endpoint"))
-                            raw_oauth_update["endpoints_discovered"] = True
-                            logger.info(f"Auto-discovered OAuth endpoints for issuer {raw_oauth_update['issuer']}")
-                        except Exception as _e:
-                            logger.warning(f"OAuth endpoint discovery failed for issuer {raw_oauth_update.get('issuer')}: {_e}")
+                    raw_oauth_update = await self._auto_discover_oauth_endpoints(raw_oauth_update)
                     gateway.oauth_config = await protect_oauth_config_for_storage(raw_oauth_update, existing_oauth_config=gateway.oauth_config)
 
                 # Handle auth_value updates (both existing and new auth values)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1033,7 +1033,25 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             else:
                 authentication_headers = None
 
-            oauth_config = await protect_oauth_config_for_storage(getattr(gateway, "oauth_config", None))
+            raw_oauth_config = getattr(gateway, "oauth_config", None)
+            if raw_oauth_config and raw_oauth_config.get("issuer") and not raw_oauth_config.get("token_url") and not raw_oauth_config.get("authorization_url"):
+                try:
+                    # First-Party
+                    from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
+                    _dcr = DcrService()
+                    _metadata = await _dcr.discover_as_metadata(raw_oauth_config["issuer"])
+                    if _metadata.get("token_endpoint") and not raw_oauth_config.get("token_url"):
+                        raw_oauth_config["token_url"] = _metadata["token_endpoint"]
+                    if _metadata.get("authorization_endpoint") and not raw_oauth_config.get("authorization_url"):
+                        raw_oauth_config["authorization_url"] = _metadata["authorization_endpoint"]
+                    if _metadata.get("jwks_uri") and not raw_oauth_config.get("jwks_uri"):
+                        raw_oauth_config["jwks_uri"] = _metadata["jwks_uri"]
+                    raw_oauth_config["dcr_available"] = bool(_metadata.get("registration_endpoint"))
+                    raw_oauth_config["endpoints_discovered"] = True
+                    logger.info(f"Auto-discovered OAuth endpoints for issuer {raw_oauth_config['issuer']}")
+                except Exception as _e:
+                    logger.warning(f"OAuth endpoint discovery failed for issuer {raw_oauth_config.get('issuer')}: {_e}")
+            oauth_config = await protect_oauth_config_for_storage(raw_oauth_config)
             ca_certificate = getattr(gateway, "ca_certificate", None)
             init_client_cert = getattr(gateway, "client_cert", None)
             init_client_key = getattr(gateway, "client_key", None)
@@ -2253,7 +2271,25 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     # if auth_type is not None and only then check auth_value
                 # Handle OAuth configuration updates
                 if gateway_update.oauth_config is not None:
-                    gateway.oauth_config = await protect_oauth_config_for_storage(gateway_update.oauth_config, existing_oauth_config=gateway.oauth_config)
+                    raw_oauth_update = dict(gateway_update.oauth_config)
+                    if raw_oauth_update.get("issuer") and not raw_oauth_update.get("token_url") and not raw_oauth_update.get("authorization_url"):
+                        try:
+                            # First-Party
+                            from mcpgateway.services.dcr_service import DcrService  # pylint: disable=import-outside-toplevel
+                            _dcr = DcrService()
+                            _metadata = await _dcr.discover_as_metadata(raw_oauth_update["issuer"])
+                            if _metadata.get("token_endpoint") and not raw_oauth_update.get("token_url"):
+                                raw_oauth_update["token_url"] = _metadata["token_endpoint"]
+                            if _metadata.get("authorization_endpoint") and not raw_oauth_update.get("authorization_url"):
+                                raw_oauth_update["authorization_url"] = _metadata["authorization_endpoint"]
+                            if _metadata.get("jwks_uri") and not raw_oauth_update.get("jwks_uri"):
+                                raw_oauth_update["jwks_uri"] = _metadata["jwks_uri"]
+                            raw_oauth_update["dcr_available"] = bool(_metadata.get("registration_endpoint"))
+                            raw_oauth_update["endpoints_discovered"] = True
+                            logger.info(f"Auto-discovered OAuth endpoints for issuer {raw_oauth_update['issuer']}")
+                        except Exception as _e:
+                            logger.warning(f"OAuth endpoint discovery failed for issuer {raw_oauth_update.get('issuer')}: {_e}")
+                    gateway.oauth_config = await protect_oauth_config_for_storage(raw_oauth_update, existing_oauth_config=gateway.oauth_config)
 
                 # Handle auth_value updates (both existing and new auth values)
                 token = gateway_update.auth_token

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5720,15 +5720,24 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     >
                       Issuer URL
                     </label>
-                    <input
-                      type="url"
-                      name="oauth_issuer"
-                      class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                      placeholder="http://localhost:3003 or https://oauth.example.com"
-                    />
+                    <div class="mt-1 flex gap-2">
+                      <input
+                        type="url"
+                        name="oauth_issuer"
+                        class="px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        placeholder="http://localhost:3003 or https://oauth.example.com"
+                      />
+                      <button
+                        type="button"
+                        onclick="discoverOAuthEndpoints(this)"
+                        class="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md border border-indigo-500 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition-colors"
+                        title="Auto-discover token &amp; authorization endpoints from issuer metadata"
+                      >🔍 Discover</button>
+                    </div>
                     <p class="mt-1 text-sm text-gray-500">
                       The OAuth Authorization Server issuer URL. Required for DCR (Dynamic Client Registration).
                     </p>
+                  <div class="oauth-discover-status mt-1 hidden"></div>
                   </div>
 
                   <div>
@@ -7150,15 +7159,24 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                     >
                       Issuer URL
                     </label>
-                    <input
-                      type="url"
-                      name="oauth_issuer"
-                      class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                      placeholder="http://localhost:3003 or https://oauth.example.com"
-                    />
+                    <div class="mt-1 flex gap-2">
+                      <input
+                        type="url"
+                        name="oauth_issuer"
+                        class="px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        placeholder="http://localhost:3003 or https://oauth.example.com"
+                      />
+                      <button
+                        type="button"
+                        onclick="discoverOAuthEndpoints(this)"
+                        class="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md border border-indigo-500 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition-colors"
+                        title="Auto-discover token &amp; authorization endpoints from issuer metadata"
+                      >🔍 Discover</button>
+                    </div>
                     <p class="mt-1 text-sm text-gray-500">
                       The OAuth Authorization Server issuer URL. Required for DCR (Dynamic Client Registration).
                     </p>
+                  <div class="oauth-discover-status mt-1 hidden"></div>
                   </div>
 
                   <div>
@@ -10185,16 +10203,25 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           >
                             Issuer URL
                           </label>
-                          <input
-                            type="url"
-                            name="oauth_issuer"
-                            id="oauth-issuer-gw-edit"
-                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                            placeholder="http://localhost:3003 or https://oauth.example.com"
-                          />
+                          <div class="mt-1 flex gap-2">
+                            <input
+                              type="url"
+                              name="oauth_issuer"
+                              id="oauth-issuer-gw-edit"
+                              class="px-1.5 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                              placeholder="http://localhost:3003 or https://oauth.example.com"
+                            />
+                            <button
+                              type="button"
+                              onclick="discoverOAuthEndpoints(this)"
+                              class="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md border border-indigo-500 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition-colors"
+                              title="Auto-discover token &amp; authorization endpoints from issuer metadata"
+                            >🔍 Discover</button>
+                          </div>
                           <p class="mt-1 text-sm text-gray-500">
                             The OAuth Authorization Server issuer URL. Required for DCR.
                           </p>
+                        <div class="oauth-discover-status mt-1 hidden"></div>
                         </div>
 
                         <div>
@@ -10648,18 +10675,27 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           >
                             Issuer URL
                           </label>
-                          <input
-                            type="url"
-                            name="oauth_issuer"
-                            id="oauth-issuer-a2a-edit"
-                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                            placeholder="http://localhost:3003 or https://oauth.example.com"
-                          />
+                          <div class="mt-1 flex gap-2">
+                            <input
+                              type="url"
+                              name="oauth_issuer"
+                              id="oauth-issuer-a2a-edit"
+                              class="px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                              placeholder="http://localhost:3003 or https://oauth.example.com"
+                            />
+                            <button
+                              type="button"
+                              onclick="discoverOAuthEndpoints(this)"
+                              class="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md border border-indigo-500 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900 transition-colors"
+                              title="Auto-discover token &amp; authorization endpoints from issuer metadata"
+                            >🔍 Discover</button>
+                          </div>
 
                           <!--
                           <p class="mt-1 text-sm text-gray-500">
                             The OAuth Authorization Server issuer URL. Required for DCR (Dynamic Client Registration).
                           </p>
+                          <div class="oauth-discover-status mt-1 hidden"></div>
                           -->
 
                           </div>
@@ -14856,6 +14892,110 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+      }
+
+      // ---------------------------------------------------------------------------
+      // OAuth endpoint discovery (RFC 8414 / OIDC Discovery)
+      // Called by the 🔍 Discover buttons next to each Issuer URL field.
+      // ---------------------------------------------------------------------------
+      async function discoverOAuthEndpoints(btn) {
+        // DOM layout:
+        //   <div>                                  ← grandparent (section wrapper)
+        //     <label>Issuer URL</label>
+        //     <div class="mt-1 flex gap-2">        ← btn.parentElement
+        //       <input name="oauth_issuer" />
+        //       <button onclick="discoverOAuthEndpoints(this)">
+        //     </div>
+        //     <p>...</p>
+        //     <div class="oauth-discover-status">  ← status target
+        //   </div>
+        const section   = btn.parentElement.parentElement;
+        const statusEl  = section.querySelector('.oauth-discover-status');
+        const form      = btn.closest('form');
+
+        const issuerInput = form
+          ? form.querySelector('input[name="oauth_issuer"]')
+          : section.querySelector('input[name="oauth_issuer"]');
+        const issuer = issuerInput?.value?.trim();
+
+        if (!issuer) {
+          _oauthDiscoverStatus(statusEl, 'error', 'Please enter an Issuer URL first.');
+          return;
+        }
+
+        btn.disabled    = true;
+        btn.textContent = '⏳ Discovering…';
+        _oauthDiscoverStatus(statusEl, 'info', 'Contacting issuer metadata endpoint…');
+
+        try {
+          const resp = await fetch(
+            `${window.ROOT_PATH}/admin/gateways/discover-oauth`,
+            {
+              method:  'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body:    JSON.stringify({ issuer }),
+            }
+          );
+          const data = await resp.json();
+
+          if (!data.success) {
+            _oauthDiscoverStatus(statusEl, 'error',
+              `Discovery failed: ${data.error || data.message || 'Unknown error'}. ` +
+              'Please configure Token URL and Authorization URL manually.');
+            return;
+          }
+
+          // Map discovered values → form field names
+          const discovered = {
+            oauth_token_url:         data.token_endpoint,
+            oauth_authorization_url: data.authorization_endpoint,
+          };
+
+          let populated = 0;
+          for (const [name, value] of Object.entries(discovered)) {
+            if (!value) continue;
+            const el = form
+              ? form.querySelector(`input[name="${name}"]`)
+              : document.querySelector(`input[name="${name}"]`);
+            if (!el) continue;
+            el.value              = value;
+            el.dataset.discovered = 'true';
+            el.readOnly           = true;
+            el.title              = 'Auto-discovered — clear the Issuer URL field to edit manually';
+            el.classList.add('bg-gray-50', 'text-gray-500', 'cursor-not-allowed');
+            populated++;
+          }
+
+          const dcrBadge = data.dcr_available
+            ? '<span class="ml-2 inline-flex items-center px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 rounded">DCR available</span>'
+            : '<span class="ml-2 inline-flex items-center px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-500 rounded">No DCR</span>';
+
+          _oauthDiscoverStatus(statusEl, 'success',
+            `✅ Discovered ${populated} endpoint${populated !== 1 ? 's' : ''} from ` +
+            `<code class="font-mono text-xs">${_escHtml(issuer)}</code>${dcrBadge}`);
+
+        } catch (err) {
+          _oauthDiscoverStatus(statusEl, 'error', `Network error: ${_escHtml(err.message)}`);
+        } finally {
+          btn.disabled    = false;
+          btn.textContent = '🔍 Discover';
+        }
+      }
+
+      function _oauthDiscoverStatus(el, type, html) {
+        if (!el) return;
+        const colours = { info: 'text-blue-600', success: 'text-green-600', error: 'text-red-600' };
+        el.className = `oauth-discover-status mt-1 text-sm ${colours[type] || ''}`;
+        el.innerHTML = html;
+        el.classList.remove('hidden');
+      }
+
+      function _escHtml(str) {
+        return String(str)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
       }
     </script>
         </main>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -14932,7 +14932,10 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
             `${window.ROOT_PATH}/admin/gateways/discover-oauth`,
             {
               method:  'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': getCookie('mcpgateway_csrf_token') || '',
+              },
               body:    JSON.stringify({ issuer }),
             }
           );
@@ -14940,7 +14943,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 
           if (!data.success) {
             _oauthDiscoverStatus(statusEl, 'error',
-              `Discovery failed: ${data.error || data.message || 'Unknown error'}. ` +
+              `Discovery failed: ${_escHtml(data.error || data.message || 'Unknown error')}. ` +
               'Please configure Token URL and Authorization URL manually.');
             return;
           }

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -393,6 +393,51 @@ class TestDiscoverASMetadata:
             # OIDC: appended to issuer
             assert calls[1][0][0] == "https://as.example.com/tenant1/.well-known/openid-configuration"
 
+    @pytest.mark.asyncio
+    async def test_discover_as_metadata_does_not_follow_redirects_rfc8414(self):
+        """RFC 8414 discovery must not follow redirects (SSRF protection)."""
+        dcr_service = DcrService()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(dcr_service, "_get_client", return_value=mock_client):
+            with pytest.raises(DcrError):
+                await dcr_service.discover_as_metadata("https://as.example.com")
+
+            # Verify follow_redirects=False was passed
+            call_kwargs = mock_client.get.call_args[1]
+            assert call_kwargs.get("follow_redirects") is False
+
+    @pytest.mark.asyncio
+    async def test_discover_as_metadata_does_not_follow_redirects_oidc(self):
+        """OIDC fallback discovery must not follow redirects (SSRF protection)."""
+        dcr_service = DcrService()
+
+        # First request (RFC 8414) returns 404
+        not_found = MagicMock()
+        not_found.status_code = 404
+
+        # Second request (OIDC) returns redirect
+        redirect = MagicMock()
+        redirect.status_code = 307
+        redirect.headers = {"location": "http://localhost:8080/internal"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[not_found, redirect])
+
+        with patch.object(dcr_service, "_get_client", return_value=mock_client):
+            with pytest.raises(DcrError):
+                await dcr_service.discover_as_metadata("https://as.example.com")
+
+            calls = mock_client.get.call_args_list
+            assert len(calls) == 2
+            assert calls[1][1].get("follow_redirects") is False
+
 
 class TestRegisterClient:
     """Test client registration (RFC 7591)."""

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -8126,3 +8126,75 @@ class TestToolReachabilityRestoration:
         assert mock_existing_tool.reachable is True, "Tool should be marked reachable on successful fetch"
         # Critical security invariant: refresh must NOT re-enable admin-disabled tools
         assert mock_existing_tool.enabled is False, "Admin-disabled tool must remain disabled after refresh"
+
+
+class TestGatewayServiceOAuthAutoDiscovery:
+    """Tests for GatewayService._auto_discover_oauth_endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_auto_discover_returns_none_for_none_config(self):
+        """Passing None config returns None immediately."""
+        result = await GatewayService._auto_discover_oauth_endpoints(None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_auto_discover_skips_when_no_issuer(self):
+        """Config without issuer is returned unchanged."""
+        config = {"token_url": "https://example.com/token"}
+        result = await GatewayService._auto_discover_oauth_endpoints(config)
+        assert result == config
+        assert "endpoints_discovered" not in result
+
+    @pytest.mark.asyncio
+    async def test_auto_discover_skips_when_already_has_endpoints(self):
+        """Config with both token_url and authorization_url is returned unchanged."""
+        config = {
+            "issuer": "https://example.com",
+            "token_url": "https://example.com/token",
+            "authorization_url": "https://example.com/authorize",
+        }
+        result = await GatewayService._auto_discover_oauth_endpoints(config)
+        assert result == config
+        assert "endpoints_discovered" not in result
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.gateway_service.SecurityValidator")
+    async def test_auto_discover_skips_invalid_issuer(self, mock_validator_cls):
+        """Invalid issuer URL does not trigger outbound request."""
+        mock_validator_cls.validate_url.side_effect = ValueError("bad scheme")
+        config = {"issuer": "ftp://evil.com"}
+        result = await GatewayService._auto_discover_oauth_endpoints(config)
+        assert result == config
+        assert "endpoints_discovered" not in result
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.dcr_service.DcrService")
+    async def test_auto_discover_populates_endpoints(self, mock_dcr_service_cls):
+        """Valid issuer triggers discovery and populates endpoints."""
+        mock_dcr = AsyncMock()
+        mock_dcr.discover_as_metadata.return_value = {
+            "token_endpoint": "https://as.example.com/token",
+            "authorization_endpoint": "https://as.example.com/authorize",
+            "jwks_uri": "https://as.example.com/jwks",
+            "registration_endpoint": "https://as.example.com/register",
+        }
+        mock_dcr_service_cls.return_value = mock_dcr
+        config = {"issuer": "https://as.example.com"}
+        result = await GatewayService._auto_discover_oauth_endpoints(config)
+        assert result["token_url"] == "https://as.example.com/token"
+        assert result["authorization_url"] == "https://as.example.com/authorize"
+        assert result["jwks_uri"] == "https://as.example.com/jwks"
+        assert result["dcr_available"] is True
+        assert result["endpoints_discovered"] is True
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.dcr_service.DcrService")
+    async def test_auto_discover_graceful_on_failure(self, mock_dcr_service_cls):
+        """Discovery failure is logged but does not raise."""
+        mock_dcr = AsyncMock()
+        mock_dcr.discover_as_metadata.side_effect = RuntimeError("timeout")
+        mock_dcr_service_cls.return_value = mock_dcr
+        config = {"issuer": "https://as.example.com"}
+        result = await GatewayService._auto_discover_oauth_endpoints(config)
+        assert result == config
+        assert "endpoints_discovered" not in result

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -8189,6 +8189,31 @@ class TestGatewayServiceOAuthAutoDiscovery:
 
     @pytest.mark.asyncio
     @patch("mcpgateway.services.dcr_service.DcrService")
+    @patch("mcpgateway.services.gateway_service.SecurityValidator")
+    async def test_auto_discover_filters_invalid_endpoints(self, mock_validator_cls, mock_dcr_service_cls):
+        """Discovered endpoints that fail URL validation are rejected but discovery continues."""
+
+        def _validate_side_effect(url, _name):
+            if "evil" in url:
+                raise ValueError("bad host")
+
+        mock_validator_cls.validate_url.side_effect = _validate_side_effect
+        mock_dcr = AsyncMock()
+        mock_dcr.discover_as_metadata.return_value = {
+            "token_endpoint": "https://evil.com/token",  # invalid - rejected
+            "authorization_endpoint": "https://as.example.com/authorize",  # valid
+            "jwks_uri": "https://as.example.com/jwks",  # valid
+        }
+        mock_dcr_service_cls.return_value = mock_dcr
+        config = {"issuer": "https://as.example.com"}
+        result = await GatewayService._auto_discover_oauth_endpoints(config)
+        assert "token_url" not in result  # rejected by _validate_discovered
+        assert result["authorization_url"] == "https://as.example.com/authorize"
+        assert result["jwks_uri"] == "https://as.example.com/jwks"
+        assert result["endpoints_discovered"] is True
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.dcr_service.DcrService")
     async def test_auto_discover_graceful_on_failure(self, mock_dcr_service_cls):
         """Discovery failure is logged but does not raise."""
         mock_dcr = AsyncMock()

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3400,6 +3400,31 @@ class TestAdminGatewayRoutes:
         assert body["authorization_endpoint"] == "https://example.com/authorize"
         assert body["dcr_available"] is True
 
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.dcr_service.DcrService")
+    async def test_admin_discover_oauth_invalid_endpoint_urls_filtered(self, mock_dcr_service_cls, mock_request):
+        """Invalid discovered endpoint URLs are filtered out (returned as None)."""
+        mock_dcr = AsyncMock()
+        mock_dcr.discover_as_metadata.return_value = {
+            "token_endpoint": "ftp://evil.com/token",
+            "authorization_endpoint": None,
+            "jwks_uri": "https://example.com/jwks",
+            "registration_endpoint": "",
+            "scopes_supported": [],
+            "grant_types_supported": [],
+        }
+        mock_dcr_service_cls.return_value = mock_dcr
+        mock_request.json = AsyncMock(return_value={"issuer": "https://example.com"})
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["success"] is True
+        assert body["token_endpoint"] is None  # invalid URL filtered
+        assert body["authorization_endpoint"] is None  # None input filtered
+        assert body["jwks_uri"] == "https://example.com/jwks"  # valid kept
+        assert body["registration_endpoint"] is None  # empty string filtered
+
 
 class TestAdminRootRoutes:
     """Test admin routes for root management with enhanced coverage."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -77,6 +77,7 @@ from mcpgateway.admin import (  # admin_get_metrics,
     admin_delete_a2a_agent,
     admin_delete_gateway,
     admin_delete_grpc_service,
+    admin_discover_oauth,
     admin_delete_prompt,
     admin_delete_resource,
     admin_delete_root,
@@ -3322,6 +3323,82 @@ class TestAdminGatewayRoutes:
         response = await admin_set_gateway_state("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert "include_inactive=true" in response.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_admin_discover_oauth_missing_issuer(self, mock_request):
+        """Test that missing issuer returns 400."""
+        mock_request.json = AsyncMock(return_value={})
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+        assert not response.body or b"issuer is required" in response.body
+
+    @pytest.mark.asyncio
+    async def test_admin_discover_oauth_invalid_json_body(self, mock_request):
+        """Test that invalid JSON body returns 400."""
+        mock_request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "", 0))
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+        assert b"Invalid JSON body" in response.body
+
+    @pytest.mark.asyncio
+    async def test_admin_discover_oauth_non_object_json(self, mock_request):
+        """Test that non-object JSON body returns 400."""
+        mock_request.json = AsyncMock(return_value=["not", "an", "object"])
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+        assert b"JSON object" in response.body
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.admin.SecurityValidator")
+    async def test_admin_discover_oauth_invalid_issuer_url(self, mock_validator_cls, mock_request):
+        """Test that invalid issuer URL returns 400 without making outbound request."""
+        mock_validator_cls.validate_url.side_effect = ValueError("Invalid scheme")
+        mock_request.json = AsyncMock(return_value={"issuer": "ftp://evil.com"})
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+        assert b"Invalid issuer URL" in response.body
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.dcr_service.DcrService")
+    async def test_admin_discover_oauth_discovery_failure(self, mock_dcr_service_cls, mock_request):
+        """Test that upstream discovery failure returns 502."""
+        mock_dcr = AsyncMock()
+        mock_dcr.discover_as_metadata.side_effect = RuntimeError("Network timeout")
+        mock_dcr_service_cls.return_value = mock_dcr
+        mock_request.json = AsyncMock(return_value={"issuer": "https://example.com"})
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 502
+        body = json.loads(response.body)
+        assert body["success"] is False
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.dcr_service.DcrService")
+    async def test_admin_discover_oauth_success(self, mock_dcr_service_cls, mock_request):
+        """Test successful OAuth endpoint discovery."""
+        mock_dcr = AsyncMock()
+        mock_dcr.discover_as_metadata.return_value = {
+            "token_endpoint": "https://example.com/token",
+            "authorization_endpoint": "https://example.com/authorize",
+            "jwks_uri": "https://example.com/jwks",
+            "registration_endpoint": "https://example.com/register",
+            "scopes_supported": ["openid", "profile"],
+            "grant_types_supported": ["authorization_code"],
+        }
+        mock_dcr_service_cls.return_value = mock_dcr
+        mock_request.json = AsyncMock(return_value={"issuer": "https://example.com"})
+        response = await admin_discover_oauth(mock_request, user={"email": "test-user"})
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["success"] is True
+        assert body["token_endpoint"] == "https://example.com/token"
+        assert body["authorization_endpoint"] == "https://example.com/authorize"
+        assert body["dcr_available"] is True
 
 
 class TestAdminRootRoutes:


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #1435

---

## 📝 Summary
Wires the OAuth endpoint discovery feature from #1435 end-to-end.

---

## 🏷️ Type of Change
- `admin.py`: Add `POST /admin/gateways/discover-oauth` endpoint that calls `DcrService.discover_as_metadata()` and returns discovered endpoints
- `gateway_service.py`: Auto-trigger discovery on gateway create/update when `issuer` is set but `token_url`/`authorization_url` are missing
- `admin.html`: Add `discoverOAuthEndpoints()` JS function for the existing Discover buttons — populates fields, marks them read-only, shows DCR badge and success/error status

---

## 🧪 Verification

- Tested with mock OAuth server at `http://localhost:3003`
- Discover button successfully populates Token URL and Authorization URL
- DCR available badge shows correctly
- Error case shows clear message prompting manual configuration
- Passed Make lint and Make test
---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
