### PR TITLE
Fix: Display OAuth 2.0 support and configuration in Server Administration UI

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2471,7 +2471,7 @@ async def admin_get_server(server_id: str, db: Session = Depends(get_db), user=D
     try:
         LOGGER.debug(f"User {get_user_email(user)} requested details for server ID {server_id}")
         server = await server_service.get_server(db, server_id)
-        return server.model_dump(by_alias=True)
+        return server.masked().model_dump(by_alias=True)
     except ServerNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -6975,6 +6975,111 @@ async function viewServer(serverId) {
 
             container.appendChild(associatedDiv);
 
+            // OAuth Configuration section
+            if (server.oauthEnabled) {
+                const oauthDiv = document.createElement("div");
+                oauthDiv.className = "mt-6 border-t pt-4";
+
+                const oauthTitle = document.createElement("strong");
+                oauthTitle.textContent = "OAuth 2.0 Configuration:";
+                oauthTitle.className =
+                    "block text-gray-900 dark:text-gray-100 mb-3";
+                oauthDiv.appendChild(oauthTitle);
+
+                // OAuth Config details
+                const oauthConfig = server.oauthConfig || server.oauth_config;
+                if (oauthConfig) {
+                    const oauthConfigDiv = document.createElement("div");
+                    oauthConfigDiv.className =
+                        "mt-3 space-y-2 bg-gray-50 dark:bg-gray-800 p-3 rounded-md";
+
+                    // Authorization Servers
+                    if (
+                        oauthConfig.authorization_servers &&
+                        oauthConfig.authorization_servers.length > 0
+                    ) {
+                        const authServersP = document.createElement("p");
+                        authServersP.className = "text-sm";
+                        const authServersStrong =
+                            document.createElement("strong");
+                        authServersStrong.textContent =
+                            "Authorization Servers: ";
+                        authServersStrong.className =
+                            "font-medium text-gray-700 dark:text-gray-300";
+                        authServersP.appendChild(authServersStrong);
+
+                        const serversList = document.createElement("ul");
+                        serversList.className =
+                            "mt-1 ml-4 list-disc list-inside";
+                        oauthConfig.authorization_servers.forEach(
+                            (serverUrl) => {
+                                const li = document.createElement("li");
+                                li.className =
+                                    "text-gray-600 dark:text-gray-400 text-sm";
+                                li.textContent = serverUrl;
+                                serversList.appendChild(li);
+                            },
+                        );
+                        authServersP.appendChild(serversList);
+                        oauthConfigDiv.appendChild(authServersP);
+                    }
+
+                    // Token Endpoint
+                    if (oauthConfig.token_endpoint) {
+                        const tokenEndpointP = document.createElement("p");
+                        tokenEndpointP.className = "text-sm";
+                        const tokenEndpointStrong =
+                            document.createElement("strong");
+                        tokenEndpointStrong.textContent = "Token Endpoint: ";
+                        tokenEndpointStrong.className =
+                            "font-medium text-gray-700 dark:text-gray-300";
+                        tokenEndpointP.appendChild(tokenEndpointStrong);
+
+                        const tokenEndpointSpan =
+                            document.createElement("span");
+                        tokenEndpointSpan.className =
+                            "text-gray-600 dark:text-gray-400 break-all";
+                        tokenEndpointSpan.textContent =
+                            oauthConfig.token_endpoint;
+                        tokenEndpointP.appendChild(tokenEndpointSpan);
+                        oauthConfigDiv.appendChild(tokenEndpointP);
+                    }
+
+                    // Scopes Supported
+                    if (
+                        oauthConfig.scopes_supported &&
+                        oauthConfig.scopes_supported.length > 0
+                    ) {
+                        const scopesP = document.createElement("p");
+                        scopesP.className = "text-sm";
+                        const scopesStrong = document.createElement("strong");
+                        scopesStrong.textContent = "Supported Scopes: ";
+                        scopesStrong.className =
+                            "font-medium text-gray-700 dark:text-gray-300";
+                        scopesP.appendChild(scopesStrong);
+
+                        const scopesSpan = document.createElement("span");
+                        scopesSpan.className =
+                            "text-gray-600 dark:text-gray-400";
+                        scopesSpan.textContent =
+                            oauthConfig.scopes_supported.join(", ");
+                        scopesP.appendChild(scopesSpan);
+                        oauthConfigDiv.appendChild(scopesP);
+                    }
+
+                    oauthDiv.appendChild(oauthConfigDiv);
+                } else {
+                    const noConfigP = document.createElement("p");
+                    noConfigP.className =
+                        "mt-2 text-sm text-gray-500 dark:text-gray-400";
+                    noConfigP.textContent =
+                        "OAuth is enabled but no configuration details are available.";
+                    oauthDiv.appendChild(noConfigP);
+                }
+
+                container.appendChild(oauthDiv);
+            }
+
             // Add metadata section
             const metadataDiv = document.createElement("div");
             metadataDiv.className = "mt-6 border-t pt-4";

--- a/mcpgateway/templates/servers_partial.html
+++ b/mcpgateway/templates/servers_partial.html
@@ -7,6 +7,7 @@
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">S. No.</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Server ID</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Auth</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Description</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Tools</th>
       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Resources</th>
@@ -20,7 +21,7 @@
   <tbody id="servers-table-body" data-testid="server-list" class="bg-white divide-y divide-gray-200 dark:bg-gray-900 dark:divide-gray-700">
   {% if data|length == 0 %}
   <tr data-testid="servers-empty-state">
-    <td colspan="13" class="px-6 py-8 text-center">
+    <td colspan="14" class="px-6 py-8 text-center">
       <p class="text-sm font-medium text-gray-700 dark:text-gray-300">
         {% if query_params is defined and query_params.get('team_id') %}
         No servers found in the selected team.
@@ -75,6 +76,13 @@
     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300">{{ (pagination.page - 1) * pagination.per_page + loop.index }}</td>
     <td class="px-6 py-4 whitespace-normal break-all text-sm font-medium text-gray-900 dark:text-gray-300 max-w-32">{{ server.id }}</td>
     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300">{{ server.name }}</td>
+    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-300">
+      {% if server.oauthEnabled %}
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200">OAuth</span>
+      {% else %}
+      <span class="text-gray-500 dark:text-gray-400 text-xs">—</span>
+      {% endif %}
+    </td>
     <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300">{{ server.description | decode_html }}</td>
     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-300">
       {% if server.associatedTools %}

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -469,11 +469,15 @@ class TestAdminServerRoutes:
         """Test getting server with edge cases."""
         # Test with non-string ID (should work)
         mock_server = MagicMock()
-        mock_server.model_dump.return_value = {"id": 123, "name": "Numeric ID Server"}
+        mock_masked = MagicMock()
+        mock_masked.model_dump.return_value = {"id": 123, "name": "Numeric ID Server"}
+        mock_server.masked.return_value = mock_masked
         mock_get_server.return_value = mock_server
 
         result = await admin_get_server(123, mock_db, user={"email": "test-user", "db": mock_db})
         assert result["id"] == 123
+        mock_server.masked.assert_called_once()
+        mock_masked.model_dump.assert_called_once_with(by_alias=True)
 
         # Test with generic exception
         mock_get_server.side_effect = RuntimeError("Database connection lost")

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -1565,7 +1565,9 @@ async def test_admin_list_servers_returns_paginated(monkeypatch):
 async def test_admin_get_server_success(monkeypatch):
     mock_db = MagicMock()
     mock_server = MagicMock()
-    mock_server.model_dump.return_value = {"id": "server-1"}
+    mock_masked = MagicMock()
+    mock_masked.model_dump.return_value = {"id": "server-1"}
+    mock_server.masked.return_value = mock_masked
 
     async def _fake_get_server(_db, _server_id):
         return mock_server
@@ -1574,6 +1576,8 @@ async def test_admin_get_server_success(monkeypatch):
 
     result = await admin.admin_get_server("server-1", db=mock_db, user={"email": "user@example.com"})
     assert result == {"id": "server-1"}
+    mock_server.masked.assert_called_once()
+    mock_masked.model_dump.assert_called_once_with(by_alias=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3572 and https://github.com/IBM/mcp-context-forge/issues/3575

## Summary
Fixes a bug where **OAuth 2.0 support and configuration details were not visible** in the Server Administration UI.  
This made it difficult for administrators to determine whether a server supports OAuth or to inspect its configuration.

## Changes

### Server List UI Enhancements
- Added a new **Auth** column in the servers table to indicate OAuth support.
- Displays an **OAuth badge** when OAuth is enabled.
- Displays a **dash (-)** when OAuth is not configured.
- Updated table row rendering and **empty-state colspan** to support the additional column.

### OAuth Configuration Display
- The **server details page** now includes a dedicated **OAuth 2.0 configuration section** when OAuth is enabled.
- The following OAuth metadata is displayed:
  - Authorization servers
  - Token endpoint
  - Supported scopes

### Backend Data Handling
- The `admin_get_server` endpoint now returns a **masked version of server data** using `.masked()` to ensure sensitive fields are not exposed.

### Test Updates
- Updated unit tests to align with the new `.masked()` behavior.
- Tests now mock and validate masked server responses.

---

## Files Updated

**Backend**
- `mcpgateway/admin.py` – Updated `admin_get_server` to return masked server data.

**Frontend**
- `mcpgateway/templates/servers_partial.html` – Added Auth column and updated empty-state rendering.
- `mcpgateway/static/admin.js` – Added OAuth configuration display in server details view.

**Tests**
- `tests/unit/mcpgateway/test_admin.py`
- `tests/unit/mcpgateway/test_admin_module.py`

Unit tests were updated to reflect the new `.masked()` method usage and expected response structure.