### PR TITLE
fix(visibility): prevent auto-refresh from overriding tool/prompt/resource visibility

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2078,14 +2078,16 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         gateway.auth_value = None
                         gateway.oauth_config = None
 
-                    # Update tools using helper method
-                    tools_to_add = self._update_or_create_tools(db, tools, gateway, "update")
+                    # Update tools using helper method — only propagate visibility
+                    # when the user explicitly changed it in this request
+                    _vis_changed = gateway_update.visibility is not None
+                    tools_to_add = self._update_or_create_tools(db, tools, gateway, "update", update_visibility=_vis_changed)
 
                     # Update resources using helper method
-                    resources_to_add = self._update_or_create_resources(db, resources, gateway, "update")
+                    resources_to_add = self._update_or_create_resources(db, resources, gateway, "update", update_visibility=_vis_changed)
 
                     # Update prompts using helper method
-                    prompts_to_add = self._update_or_create_prompts(db, prompts, gateway, "update")
+                    prompts_to_add = self._update_or_create_prompts(db, prompts, gateway, "update", update_visibility=_vis_changed)
 
                     # Log newly added items
                     items_added = len(tools_to_add) + len(resources_to_add) + len(prompts_to_add)
@@ -4054,7 +4056,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             visibility=gateway.visibility,
         )
 
-    def _update_or_create_tools(self, db: Session, tools: List[Any], gateway: DbGateway, created_via: str) -> List[DbTool]:
+    def _update_or_create_tools(self, db: Session, tools: List[Any], gateway: DbGateway, created_via: str, update_visibility: bool = False) -> List[DbTool]:
         """Helper to handle update-or-create logic for tools from MCP server.
 
         Args:
@@ -4062,6 +4064,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             tools: List of tools from MCP server
             gateway: Gateway object
             created_via: String indicating creation source ("oauth", "update", etc.)
+            update_visibility: Whether to propagate gateway visibility to existing tools
 
         Returns:
             List of new tools to be added to the database
@@ -4124,8 +4127,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         gateway_tool_auth_value = encode_auth(gateway.auth_value) if isinstance(gateway.auth_value, dict) else gateway.auth_value
                         auth_value_changed = existing_tool.auth_value != gateway_tool_auth_value
 
-                    should_update_visibility = created_via == "update"
-                    auth_fields_changed = existing_tool.auth_type != gateway.auth_type or auth_value_changed or (should_update_visibility and existing_tool.visibility != gateway.visibility)
+                    auth_fields_changed = existing_tool.auth_type != gateway.auth_type or auth_value_changed or (update_visibility and existing_tool.visibility != gateway.visibility)
 
                     if basic_fields_changed or schema_fields_changed or auth_fields_changed:
                         fields_to_update = True
@@ -4144,7 +4146,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         existing_tool.jsonpath_filter = tool.jsonpath_filter
                         existing_tool.auth_type = gateway.auth_type
                         existing_tool.auth_value = encode_auth(gateway.auth_value) if isinstance(gateway.auth_value, dict) else gateway.auth_value
-                        if should_update_visibility:
+                        if update_visibility:
                             existing_tool.visibility = gateway.visibility
                         logger.debug(f"Updated existing tool: {tool.name}")
                 else:
@@ -4165,7 +4167,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         return tools_to_add
 
-    def _update_or_create_resources(self, db: Session, resources: List[Any], gateway: DbGateway, created_via: str) -> List[DbResource]:
+    def _update_or_create_resources(self, db: Session, resources: List[Any], gateway: DbGateway, created_via: str, update_visibility: bool = False) -> List[DbResource]:
         """Helper to handle update-or-create logic for resources from MCP server.
 
         Args:
@@ -4173,6 +4175,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             resources: List of resources from MCP server
             gateway: Gateway object
             created_via: String indicating creation source ("oauth", "update", etc.)
+            update_visibility: Whether to propagate gateway visibility to existing resources
 
         Returns:
             List of new resources to be added to the database
@@ -4203,14 +4206,13 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 if existing_resource:
                     # Update existing resource if there are changes
                     fields_to_update = False
-                    should_update_visibility = created_via == "update"
 
                     if (
                         existing_resource.name != resource.name
                         or existing_resource.description != resource.description
                         or existing_resource.mime_type != resource.mime_type
                         or existing_resource.uri_template != resource.uri_template
-                        or (should_update_visibility and existing_resource.visibility != gateway.visibility)
+                        or (update_visibility and existing_resource.visibility != gateway.visibility)
                     ):
                         fields_to_update = True
 
@@ -4219,7 +4221,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         existing_resource.description = resource.description
                         existing_resource.mime_type = resource.mime_type
                         existing_resource.uri_template = resource.uri_template
-                        if should_update_visibility:
+                        if update_visibility:
                             existing_resource.visibility = gateway.visibility
                         logger.debug(f"Updated existing resource: {resource.uri}")
                 else:
@@ -4243,7 +4245,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         return resources_to_add
 
-    def _update_or_create_prompts(self, db: Session, prompts: List[Any], gateway: DbGateway, created_via: str) -> List[DbPrompt]:
+    def _update_or_create_prompts(self, db: Session, prompts: List[Any], gateway: DbGateway, created_via: str, update_visibility: bool = False) -> List[DbPrompt]:
         """Helper to handle update-or-create logic for prompts from MCP server.
 
         Args:
@@ -4251,6 +4253,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             prompts: List of prompts from MCP server
             gateway: Gateway object
             created_via: String indicating creation source ("oauth", "update", etc.)
+            update_visibility: Whether to propagate gateway visibility to existing prompts
 
         Returns:
             List of new prompts to be added to the database
@@ -4281,19 +4284,18 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 if existing_prompt:
                     # Update existing prompt if there are changes
                     fields_to_update = False
-                    should_update_visibility = created_via == "update"
 
                     if (
                         existing_prompt.description != prompt.description
                         or existing_prompt.template != (prompt.template if hasattr(prompt, "template") else "")
-                        or (should_update_visibility and existing_prompt.visibility != gateway.visibility)
+                        or (update_visibility and existing_prompt.visibility != gateway.visibility)
                     ):
                         fields_to_update = True
 
                     if fields_to_update:
                         existing_prompt.description = prompt.description
                         existing_prompt.template = prompt.template if hasattr(prompt, "template") else ""
-                        if should_update_visibility:
+                        if update_visibility:
                             existing_prompt.visibility = gateway.visibility
                         logger.debug(f"Updated existing prompt: {prompt.name}")
                 else:

--- a/tests/unit/mcpgateway/services/test_gateway_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_extended.py
@@ -700,8 +700,8 @@ class TestGatewayServiceExtended:
         tools = [mock_tool]
         context = "update"
 
-        # Call the helper method
-        result = service._update_or_create_tools(mock_db, tools, mock_gateway, context)
+        # Call the helper method (with explicit visibility change)
+        result = service._update_or_create_tools(mock_db, tools, mock_gateway, context, update_visibility=True)
 
         # Should return empty list (no new tools, existing one updated)
         assert len(result) == 0
@@ -851,8 +851,8 @@ class TestGatewayServiceExtended:
         resources = [mock_resource]
         context = "update"
 
-        # Call method
-        result = service._update_or_create_resources(mock_db, resources, mock_gateway, context)
+        # Call method (with explicit visibility change)
+        result = service._update_or_create_resources(mock_db, resources, mock_gateway, context, update_visibility=True)
 
         # Should return empty list (no new resources)
         assert len(result) == 0
@@ -943,8 +943,8 @@ class TestGatewayServiceExtended:
         prompts = [mock_prompt]
         context = "update"
 
-        # Call the helper method
-        result = service._update_or_create_prompts(mock_db, prompts, mock_gateway, context)
+        # Call the helper method (with explicit visibility change)
+        result = service._update_or_create_prompts(mock_db, prompts, mock_gateway, context, update_visibility=True)
 
         # Should return empty list (no new prompts, existing one updated)
         assert len(result) == 0
@@ -1611,24 +1611,42 @@ class TestGatewayServiceExtended:
         service._update_or_create_prompts(mock_db, [prompt_from_server], mock_gateway, "rediscovery")
         assert existing_prompt.visibility == "private"
 
-        # --- Test 2: MANUAL UPDATE Context ---
+        # --- Test 2: MANUAL UPDATE with explicit visibility change ---
         mock_db.execute.side_effect = [
             create_mock_result(existing_tool),
         ]
-        service._update_or_create_tools(mock_db, [tool_from_server], mock_gateway, "update")
+        service._update_or_create_tools(mock_db, [tool_from_server], mock_gateway, "update", update_visibility=True)
         assert existing_tool.visibility == "public"
 
         mock_db.execute.side_effect = [
             create_mock_result(existing_res),
         ]
-        service._update_or_create_resources(mock_db, [res_from_server], mock_gateway, "update")
+        service._update_or_create_resources(mock_db, [res_from_server], mock_gateway, "update", update_visibility=True)
         assert existing_res.visibility == "public"
 
         mock_db.execute.side_effect = [
             create_mock_result(existing_prompt),
         ]
-        service._update_or_create_prompts(mock_db, [prompt_from_server], mock_gateway, "update")
+        service._update_or_create_prompts(mock_db, [prompt_from_server], mock_gateway, "update", update_visibility=True)
         assert existing_prompt.visibility == "public"
+
+        # --- Test 3: UPDATE without visibility change (e.g. description-only edit) ---
+        # Visibility must NOT be overwritten even though created_via is "update"
+        existing_tool.visibility = "private"
+        existing_res.visibility = "team"
+        existing_prompt.visibility = "private"
+
+        mock_db.execute.side_effect = [create_mock_result(existing_tool)]
+        service._update_or_create_tools(mock_db, [tool_from_server], mock_gateway, "update", update_visibility=False)
+        assert existing_tool.visibility == "private"
+
+        mock_db.execute.side_effect = [create_mock_result(existing_res)]
+        service._update_or_create_resources(mock_db, [res_from_server], mock_gateway, "update", update_visibility=False)
+        assert existing_res.visibility == "team"
+
+        mock_db.execute.side_effect = [create_mock_result(existing_prompt)]
+        service._update_or_create_prompts(mock_db, [prompt_from_server], mock_gateway, "update", update_visibility=False)
+        assert existing_prompt.visibility == "private"
 
     def test_create_db_tool_inherits_gateway_visibility(self):
         """New tools created via _create_db_tool inherit visibility from the gateway, not hardcoded 'public'."""


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #3530

## 📌 Summary
Fixed a bug where the `AUTO_REFRESH_SERVERS=true` configuration overrides the granular visibility settings of individual tools, resources, and prompts. Previously, during a server auto-refresh, any explicitly configured "Private" or "Team" items would automatically be changed to match the parent Gateway's visibility (e.g., "Public"). This fix ensures that background sync operations preserve existing visibility configurations while still allowing manual UI/API updates to propagate visibility changes correctly.

## 🔁 Reproduction Steps
1. Create and configure an MCP Gateway with "Public" visibility.
2. Allow the Gateway to perform its initial sync so that its tools default to "Public".
3. Manually update one of the synced tools to have "Private" visibility.
4. Trigger a background auto-refresh for the Gateway (e.g., via `AUTO_REFRESH_SERVERS=true` or a health check).
5. **Observed Bug:** The tool's visibility is changed back to "Public".
6. **Expected Behavior:** The tool remains "Private".

## 🐞 Root Cause
The `_update_or_create_tools`, `_update_or_create_resources`, and `_update_or_create_prompts` helper methods in `mcpgateway/services/gateway_service.py` contained logic that unconditionally applied `existing_item.visibility = gateway.visibility` during the synchronization process. The methods did not differentiate between an automatic background refresh and a manual update triggered by a user.

## 💡 Fix Description
The `_update_or_create_tools`, `_update_or_create_resources`, and `_update_or_create_prompts` helper methods in `mcpgateway/services/gateway_service.py` contained logic that unconditionally applied `existing_item.visibility = gateway.visibility` during the synchronization process. The methods did not differentiate between an automatic background refresh and a manual update triggered by a user.
## 💡 Fix Description
Updated the synchronization logic across tools, resources, and prompts to conditionally evaluate visibility changes based on the operation's context. 
- Introduced a `should_update_visibility = created_via == "update"` condition.
- The item's `visibility` attribute is now explicitly excluded from the `fields_to_update` conditions and field assignment blocks unless the sync is triggered by a manual update (`"update"`). 
- Added comprehensive unit tests `test_update_visibility_logic` and updated removal scenarios) in `test_gateway_service_extended.py` to assert that visibility correctly inherits during manual updates but is preserved during `auto_refresh`, `health_check`, and `rediscovery` contexts.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   ✅     |
| Unit tests                            | `make test`          |     ✅   |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed