### PR TITLE
fix: SSE resource subscribe endpoint yielding raw dicts instead of SSE-formatted strings

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4878,10 +4878,10 @@ async def subscribe_resource(request: Request, user=Depends(get_current_user_wit
     user_email, token_teams = _get_scoped_resource_access_context(request, user)
 
     async def sse_generator():
-        """Yield resource events formatted as SSE 'data: {...}\\n\\n' strings.
+        """Generate SSE-formatted events from resource subscription changes.
 
         Yields:
-            str: SSE-formatted event string.
+            str: SSE-formatted event data.
         """
         async for event in resource_service.subscribe_events(user_email=user_email, token_teams=token_teams):
             yield f"data: {orjson.dumps(event).decode()}\n\n"

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -21,6 +21,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 import jwt
+import orjson
 from pydantic import BaseModel, SecretStr, ValidationError
 import pytest
 import sqlalchemy as sa
@@ -31,6 +32,7 @@ from starlette.websockets import WebSocketDisconnect
 from mcpgateway.common.models import InitializeResult, ResourceContent, ServerCapabilities
 from mcpgateway.config import settings
 import mcpgateway.db as db_mod
+from mcpgateway.plugins.framework.constants import PLUGIN_VIOLATION_CODE_MAPPING
 from mcpgateway.schemas import (
     A2AAgentAggregateMetrics,
     GatewayRead,
@@ -43,8 +45,6 @@ from mcpgateway.schemas import (
     ToolMetrics,
     ToolRead,
 )
-from mcpgateway.plugins.framework.constants import PLUGIN_VIOLATION_CODE_MAPPING
-
 
 # --------------------------------------------------------------------------- #
 # Constants                                                                   #
@@ -1211,11 +1211,9 @@ class TestResourceEndpoints:
         assert len(lines) == 2
 
         # Verify each line is valid SSE with JSON payload
-        import orjson
-
         for line in lines:
             assert line.startswith("data: ")
-            payload = orjson.loads(line[len("data: "):])
+            payload = orjson.loads(line[len("data: ") :])
             assert "type" in payload
             assert "data" in payload
 
@@ -3517,12 +3515,7 @@ class TestPluginExceptionHandlers:
         from mcpgateway.plugins.framework.errors import PluginViolationError
         from mcpgateway.plugins.framework.models import PluginViolation
 
-        violation = PluginViolation(
-            reason="Invalid status",
-            description="Status code above valid range",
-            code="RATE_LIMIT",  # Has mapping to 429
-            http_status_code=512  # Invalid: above 511
-        )
+        violation = PluginViolation(reason="Invalid status", description="Status code above valid range", code="RATE_LIMIT", http_status_code=512)  # Has mapping to 429  # Invalid: above 511
         exc = PluginViolationError(message="Invalid status", violation=violation)
 
         result = asyncio.run(plugin_violation_exception_handler(None, exc))


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Found this bug while executing manual tests on Resources https://github.com/IBM/mcp-context-forge/issues/2419

The POST /resources/subscribe SSE endpoint at main.py:4864 passes resource_service.subscribe_events() directly to StreamingResponse. However, subscribe_events() yields raw Python dicts, while StreamingResponse expects an async generator of strings or bytes.

This causes the SSE connection to remain open (HTTP 200) but no events are ever written to the stream. Clients stay connected but never receive resource change notifications (resource_updated, resource_added, resource_deleted, etc.) over SSE.

## 🔁 Reproduction Steps

1. Terminal 1 — open SSE stream (should stay open now):
```bash
curl -N -X POST "http://localhost:8080/resources/subscribe" \
      -H "Authorization: Bearer $TOKEN" \
      -H "Accept: text/event-stream"
```

2.  Terminal 2 — update the resource to trigger a notification:
```bash
curl -s -X PUT "http://localhost:8080/resources/$RESOURCE_ID" \
      -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
      -d '{
        "resource": {
          "uri": "file:///config/settings.json",
          "name": "config-file",
          "description": "Updated settings",
          "mimeType": "application/json",
          "content": "{\"theme\": \"light\", \"lang\": \"fr\"}"
        },
        "visibility": "public"
      }' | jq .
```

3. Terminal 1 should now show (but does not show):
```bash
data: {"type":"resource_updated","data":{"id":"...","uri":"file:///config/settings.json",...},"timestamp":"..."}
```

## 🐞 Root Cause

The `EventService` already has a correct `event_generator()` method that formats events as `data: {...}\n\n`, but it was not being used by this endpoint.

## 💡 Fix Description

Wrap the async generator in an SSE formatter that serializes each event dict to the standard SSE `data: {...}\n\n` format before yielding to StreamingResponse:

```bash
  async def sse_generator():
      async for event in resource_service.subscribe_events(user_email=user_email, token_teams=token_teams):
          yield f"data: {orjson.dumps(event).decode()}\n\n"

  return StreamingResponse(sse_generator(), media_type="text/event-stream")
```

This aligns with the pattern used by `EventService.event_generator()` and the SSE specification (each event prefixed with `data:` and terminated with `\n\n`).

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |   ✅     |
| Unit tests                            | `make test`          |   ✅     |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
