### PR TITLE
[Fix][Observability]: Fix duplicate DB session in observability middleware

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3105,11 +3105,11 @@ def get_db(request: Request = None):
         'ResilientSession'
     """
     # Check if ObservabilityMiddleware already created a request-scoped session
-    # This eliminates duplicate session creation when observability is enabled
+    # This eliminates duplicate session creation when observability is enabled (Issue #3467)
     if request is not None and hasattr(request, "state") and hasattr(request.state, "db"):
         db = request.state.db
         if db is not None:
-            logger.info(f"[GET_DB] Reusing session from middleware: {id(db)}")
+            logger.debug(f"[GET_DB] Reusing session from middleware: {id(db)}")
             # Yield the middleware's session without closing it
             # The middleware will handle commit/rollback/close
             yield db
@@ -3117,7 +3117,7 @@ def get_db(request: Request = None):
 
     # Fallback: Create our own session (observability disabled or middleware didn't create one)
     db = SessionLocal()
-    logger.info(f"[GET_DB] DB session created: {id(db)}")
+    logger.debug(f"[GET_DB] DB session created: {id(db)}")
     try:
         yield db
         # Only commit if the transaction is still active.

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3058,9 +3058,14 @@ a2a_router = APIRouter(prefix="/a2a", tags=["A2A Agents"])
 
 
 # Database dependency
-def get_db():
+def get_db(request: Request = None):
     """
     Dependency function to provide a database session.
+
+    When observability is enabled, this reuses the session created by
+    ObservabilityMiddleware (stored in request.state.db) to avoid duplicate
+    session creation. When observability is disabled or the
+    middleware hasn't created a session, this creates its own session.
 
     Commits the transaction on successful completion to avoid implicit rollbacks
     for read-only operations. Rolls back explicitly on exception.
@@ -3070,6 +3075,9 @@ def get_db():
     network issues), the rollback will fail. In this case, we invalidate the
     session to ensure the broken connection is discarded from the pool rather
     than being returned in a bad state.
+
+    Args:
+        request: Optional FastAPI request object (injected automatically)
 
     Yields:
         Session: A SQLAlchemy session object for interacting with the database.
@@ -3096,7 +3104,20 @@ def get_db():
         ...         pass  # Expected - generator cleanup
         'ResilientSession'
     """
+    # Check if ObservabilityMiddleware already created a request-scoped session
+    # This eliminates duplicate session creation when observability is enabled
+    if request is not None and hasattr(request, "state") and hasattr(request.state, "db"):
+        db = request.state.db
+        if db is not None:
+            logger.info(f"[GET_DB] Reusing session from middleware: {id(db)}")
+            # Yield the middleware's session without closing it
+            # The middleware will handle commit/rollback/close
+            yield db
+            return
+
+    # Fallback: Create our own session (observability disabled or middleware didn't create one)
     db = SessionLocal()
+    logger.info(f"[GET_DB] DB session created: {id(db)}")
     try:
         yield db
         # Only commit if the transaction is still active.

--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -110,9 +110,9 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         try:
             # Create request-scoped database session and store in request.state
             # This session will be reused by route handlers via get_db() dependency,
-            # eliminating duplicate session creation
+            # eliminating duplicate session creation (Issue #3467)
             db = SessionLocal()
-            logger.info(f"[OBSERVABILITY] DB session created: {id(db)}")
+            logger.debug(f"[OBSERVABILITY] DB session created: {id(db)}")
             request.state.db = db
             session_owned_by_middleware = True
 
@@ -158,6 +158,14 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
             if db:
                 try:
                     db.rollback()  # Error path - rollback any partial transaction
+                except Exception as rollback_error:
+                    logger.debug(f"Failed to rollback during cleanup: {rollback_error}")
+                    # Connection is broken - invalidate to remove from pool
+                    try:
+                        db.invalidate()
+                    except Exception:
+                        pass  # Best effort cleanup
+                try:
                     db.close()
                 except Exception as close_error:
                     logger.debug(f"Failed to close database session during cleanup: {close_error}")
@@ -200,8 +208,11 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                     logger.warning(f"Failed to end trace {trace_id}: {end_trace_error}")
 
             # Commit the shared session (used by both observability and route handler)
-            # Only commit if the transaction is still active
-            if db.is_active:
+            # Note: Some route handlers may have already committed. The is_active check
+            # ensures we only commit if the transaction is still open. Services that
+            # explicitly commit will have already closed their transaction.
+            # Only commit if the transaction is still active AND has uncommitted changes
+            if db.is_active and db.in_transaction():
                 db.commit()
 
             return response
@@ -238,6 +249,13 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                 db.rollback()
             except Exception as rollback_error:
                 logger.warning(f"Failed to rollback database session: {rollback_error}")
+                # Connection is broken - invalidate to remove from pool
+                # This handles cases like PgBouncer query_wait_timeout where
+                # the connection is dead and rollback itself fails
+                try:
+                    db.invalidate()
+                except Exception:
+                    pass  # Best effort cleanup on connection failure
 
             # Re-raise the original exception
             raise

--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -105,10 +105,16 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         trace_id = None
         span_id = None
         start_time = time.time()
+        session_owned_by_middleware = False
 
         try:
-            # Create database session
+            # Create request-scoped database session and store in request.state
+            # This session will be reused by route handlers via get_db() dependency,
+            # eliminating duplicate session creation
             db = SessionLocal()
+            logger.info(f"[OBSERVABILITY] DB session created: {id(db)}")
+            request.state.db = db
+            session_owned_by_middleware = True
 
             # Start trace (use external trace_id if provided for distributed tracing)
             trace_id = self.service.start_trace(
@@ -155,10 +161,14 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                     db.close()
                 except Exception as close_error:
                     logger.debug(f"Failed to close database session during cleanup: {close_error}")
+                # Clean up request.state.db to prevent get_db() from reusing a closed session
+                if hasattr(request.state, "db"):
+                    delattr(request.state, "db")
             # Continue without tracing
             return await call_next(request)
 
         # Process request (trace is set up at this point)
+        # Route handlers will reuse request.state.db via get_db() dependency
         try:
             response = await call_next(request)
             status_code = response.status_code
@@ -189,6 +199,11 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                 except Exception as end_trace_error:
                     logger.warning(f"Failed to end trace {trace_id}: {end_trace_error}")
 
+            # Commit the shared session (used by both observability and route handler)
+            # Only commit if the transaction is still active
+            if db.is_active:
+                db.commit()
+
             return response
 
         except Exception as e:
@@ -218,15 +233,22 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                 except Exception as trace_error:
                     logger.warning(f"Failed to end trace: {trace_error}")
 
+            # Rollback the shared session on error
+            try:
+                db.rollback()
+            except Exception as rollback_error:
+                logger.warning(f"Failed to rollback database session: {rollback_error}")
+
             # Re-raise the original exception
             raise
 
         finally:
-            # Always close database session - observability service handles its own commits
-            if db:
+            # Always close database session and clean up request state
+            if db and session_owned_by_middleware:
                 try:
-                    if db.in_transaction():
-                        db.rollback()
                     db.close()
                 except Exception as close_error:
                     logger.warning(f"Failed to close database session: {close_error}")
+                # Clean up request.state.db to prevent stale references
+                if hasattr(request.state, "db"):
+                    delattr(request.state, "db")

--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -164,7 +164,7 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                     try:
                         db.invalidate()
                     except Exception:
-                        pass  # Best effort cleanup
+                        pass  # nosec B110
                 try:
                     db.close()
                 except Exception as close_error:
@@ -255,7 +255,7 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                 try:
                     db.invalidate()
                 except Exception:
-                    pass  # Best effort cleanup on connection failure
+                    pass  # nosec B110
 
             # Re-raise the original exception
             raise

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from starlette.requests import Request
 from starlette.responses import Response
 from mcpgateway.middleware.observability_middleware import ObservabilityMiddleware
+from mcpgateway.services.observability_service import ObservabilityService
 
 
 @pytest.fixture
@@ -58,13 +59,17 @@ async def test_dispatch_health_check_skipped(mock_request, mock_call_next):
 @pytest.mark.asyncio
 async def test_dispatch_trace_setup_success(mock_request, mock_call_next):
     middleware = ObservabilityMiddleware(app=None, enabled=True)
-    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=MagicMock()) as mock_session, \
+    mock_session = MagicMock()
+    mock_session.is_active = True
+    mock_session.in_transaction.return_value = False
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=mock_session), \
          patch.object(middleware.service, "start_trace", return_value="trace123") as mock_start_trace, \
          patch.object(middleware.service, "start_span", return_value="span123") as mock_start_span, \
          patch.object(middleware.service, "end_span") as mock_end_span, \
          patch.object(middleware.service, "end_trace") as mock_end_trace, \
          patch("mcpgateway.middleware.observability_middleware.attach_trace_to_session") as mock_attach, \
-         patch("mcpgateway.middleware.observability_middleware.parse_traceparent", return_value=("traceX", "spanY", "flags")):
+         patch("mcpgateway.middleware.observability_middleware.parse_traceparent", return_value=("traceX", "spanY", "flags")), \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
         mock_start_trace.assert_called_once()
@@ -89,12 +94,15 @@ async def test_dispatch_exception_during_request(mock_request):
 
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.in_transaction.return_value = False
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
          patch.object(middleware.service, "start_span", return_value="span123"), \
          patch.object(middleware.service, "end_span") as mock_end_span, \
          patch.object(middleware.service, "add_event") as mock_add_event, \
-         patch.object(middleware.service, "end_trace") as mock_end_trace:
+         patch.object(middleware.service, "end_trace") as mock_end_trace, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         with pytest.raises(RuntimeError):
             await middleware.dispatch(mock_request, failing_call_next)
         mock_end_span.assert_called()
@@ -106,12 +114,15 @@ async def test_dispatch_exception_during_request(mock_request):
 async def test_dispatch_close_db_failure(mock_request, mock_call_next):
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.in_transaction.return_value = False
     db_mock.close.side_effect = Exception("close fail")
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
          patch.object(middleware.service, "start_span", return_value="span123"), \
          patch.object(middleware.service, "end_span"), \
-         patch.object(middleware.service, "end_trace"):
+         patch.object(middleware.service, "end_trace"), \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
 
@@ -122,7 +133,8 @@ async def test_dispatch_trace_setup_failure_rolls_back_and_closes_db(mock_reques
     db_mock = MagicMock()
 
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
-         patch.object(middleware.service, "start_trace", side_effect=Exception("trace fail")):
+         patch.object(middleware.service, "start_trace", side_effect=Exception("trace fail")), \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
 
@@ -138,7 +150,8 @@ async def test_dispatch_trace_setup_cleanup_close_failure_logs_debug(mock_reques
 
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", side_effect=Exception("trace fail")), \
-         patch("mcpgateway.middleware.observability_middleware.logger.debug") as mock_debug:
+         patch("mcpgateway.middleware.observability_middleware.logger.debug") as mock_debug, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
         mock_debug.assert_called()
@@ -148,13 +161,16 @@ async def test_dispatch_trace_setup_cleanup_close_failure_logs_debug(mock_reques
 async def test_dispatch_end_span_failure_logs_warning(mock_request, mock_call_next):
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.in_transaction.return_value = False
 
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
          patch.object(middleware.service, "start_span", return_value="span123"), \
          patch.object(middleware.service, "end_span", side_effect=Exception("end span fail")), \
          patch.object(middleware.service, "end_trace"), \
-         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning:
+         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
         mock_warning.assert_called()
@@ -164,13 +180,16 @@ async def test_dispatch_end_span_failure_logs_warning(mock_request, mock_call_ne
 async def test_dispatch_end_trace_failure_logs_warning(mock_request, mock_call_next):
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.in_transaction.return_value = False
 
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
          patch.object(middleware.service, "start_span", return_value="span123"), \
          patch.object(middleware.service, "end_span"), \
          patch.object(middleware.service, "end_trace", side_effect=Exception("end trace fail")), \
-         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning:
+         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
         mock_warning.assert_called()
@@ -183,6 +202,8 @@ async def test_dispatch_exception_logging_failure_logs_warning(mock_request):
 
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.in_transaction.return_value = False
 
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
@@ -190,7 +211,8 @@ async def test_dispatch_exception_logging_failure_logs_warning(mock_request):
          patch.object(middleware.service, "end_span"), \
          patch.object(middleware.service, "add_event", side_effect=Exception("add event fail")), \
          patch.object(middleware.service, "end_trace"), \
-         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning:
+         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         with pytest.raises(RuntimeError):
             await middleware.dispatch(mock_request, failing_call_next)
         mock_warning.assert_called()
@@ -203,6 +225,8 @@ async def test_dispatch_end_trace_error_failure_logs_warning(mock_request):
 
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.in_transaction.return_value = False
 
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
@@ -210,7 +234,244 @@ async def test_dispatch_end_trace_error_failure_logs_warning(mock_request):
          patch.object(middleware.service, "end_span"), \
          patch.object(middleware.service, "add_event"), \
          patch.object(middleware.service, "end_trace", side_effect=Exception("end trace fail")), \
-         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning:
+         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         with pytest.raises(RuntimeError):
             await middleware.dispatch(mock_request, failing_call_next)
         mock_warning.assert_called()
+
+# ============================================================================
+# Session Reuse Tests
+# ============================================================================
+
+@pytest.fixture
+def mock_observability_service():
+    """Create a mock observability service."""
+    service = MagicMock(spec=ObservabilityService)
+    service.start_trace.return_value = "test-trace-id"
+    service.start_span.return_value = "test-span-id"
+    return service
+
+
+@pytest.fixture
+def mock_request():
+    """Create a mock request object."""
+    request = MagicMock(spec=Request)
+    request.method = "GET"
+    request.url.path = "/test"
+    request.url.query = ""
+    request.url = MagicMock()
+    request.url.__str__ = MagicMock(return_value="http://test.com/test")
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+    request.headers = {"user-agent": "test-agent"}
+    request.state = MagicMock()
+    return request
+
+
+@pytest.mark.asyncio
+async def test_observability_middleware_creates_request_scoped_session(mock_request, mock_observability_service):
+    """Test that observability middleware creates a session and stores it in request.state.db."""
+    
+    # Use /rpc path which is in the observability include list
+    mock_request.url.path = "/rpc"
+    
+    # Create middleware
+    app = MagicMock()
+    middleware = ObservabilityMiddleware(app, enabled=True, service=mock_observability_service)
+    
+    # Mock SessionLocal to track session creation
+    session_instances = []
+    
+    def mock_session_local():
+        session = MagicMock()
+        session.is_active = True
+        session.in_transaction.return_value = False
+        session_instances.append(session)
+        return session
+    
+    # Mock call_next to simulate route handler
+    async def mock_call_next(request):
+        # Verify session is stored in request.state.db
+        assert hasattr(request.state, "db"), "Session should be stored in request.state.db"
+        assert request.state.db is not None, "Session should not be None"
+        return Response(content="OK", status_code=200)
+    
+    # Patch SessionLocal and should_skip_observability
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", side_effect=mock_session_local):
+        with patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
+            response = await middleware.dispatch(mock_request, mock_call_next)
+    
+    # Verify only one session was created
+    assert len(session_instances) == 1, f"Expected 1 session, but {len(session_instances)} were created"
+    
+    # Verify session was committed and closed
+    session_instances[0].commit.assert_called_once()
+    session_instances[0].close.assert_called_once()
+    
+    # Verify response
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_observability_middleware_cleans_up_on_error(mock_request, mock_observability_service):
+    """Test that observability middleware properly cleans up session on error."""
+    
+    # Use /rpc path which is in the observability include list
+    mock_request.url.path = "/rpc"
+    
+    # Create middleware
+    app = MagicMock()
+    middleware = ObservabilityMiddleware(app, enabled=True, service=mock_observability_service)
+    
+    # Mock SessionLocal
+    session_instances = []
+    
+    def mock_session_local():
+        session = MagicMock()
+        session.is_active = True
+        session.in_transaction.return_value = False
+        session_instances.append(session)
+        return session
+    
+    # Mock call_next to raise an exception
+    async def mock_call_next(request):
+        raise ValueError("Test error")
+    
+    # Patch SessionLocal and should_skip_observability
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", side_effect=mock_session_local):
+        with patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
+            with pytest.raises(ValueError, match="Test error"):
+                await middleware.dispatch(mock_request, mock_call_next)
+    
+    # Verify session was rolled back and closed
+    assert len(session_instances) == 1, f"Expected 1 session, but {len(session_instances)} were created"
+    session_instances[0].rollback.assert_called_once()
+    session_instances[0].close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_db_reuses_middleware_session():
+    """Test that get_db() reuses the session from ObservabilityMiddleware."""
+    from mcpgateway.main import get_db
+    
+    # Create a mock request with a session in state
+    mock_request = MagicMock(spec=Request)
+    mock_session = MagicMock()
+    mock_request.state.db = mock_session
+    
+    # Call get_db with the request
+    db_generator = get_db(request=mock_request)
+    db = next(db_generator)
+    
+    # Verify it returns the same session
+    assert db is mock_session, "get_db should return the middleware's session"
+    
+    # Verify the session is NOT closed (middleware will handle that)
+    try:
+        next(db_generator)
+    except StopIteration:
+        pass
+    
+    mock_session.close.assert_not_called()
+    mock_session.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_db_creates_own_session_when_no_middleware_session():
+    """Test that get_db() creates its own session when middleware hasn't created one."""
+    from mcpgateway.main import get_db
+    
+    # Create a mock request without a session in state
+    mock_request = MagicMock(spec=Request)
+    mock_request.state = MagicMock(spec=[])  # No 'db' attribute
+    
+    # Mock SessionLocal
+    mock_session = MagicMock()
+    mock_session.is_active = True
+    
+    with patch("mcpgateway.main.SessionLocal", return_value=mock_session):
+        # Call get_db with the request
+        db_generator = get_db(request=mock_request)
+        db = next(db_generator)
+        
+        # Verify it creates a new session
+        assert db is mock_session
+        
+        # Complete the generator (simulating successful request)
+        try:
+            next(db_generator)
+        except StopIteration:
+            pass
+        
+        # Verify the session was committed and closed
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_single_session_per_request_integration():
+    """Integration test: Verify only one session is created per request with observability enabled."""
+    from mcpgateway.main import get_db
+    
+    # Track session creation
+    session_instances = []
+    
+    def mock_session_local():
+        session = MagicMock()
+        session.is_active = True
+        session.in_transaction.return_value = False
+        session_instances.append(session)
+        return session
+    
+    # Create mock request with /rpc path (traced by default)
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "GET"
+    mock_request.url.path = "/rpc"
+    mock_request.url.query = ""
+    mock_request.url = MagicMock()
+    mock_request.url.__str__ = MagicMock(return_value="http://test.com/rpc")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers = {"user-agent": "test-agent"}
+    mock_request.state = MagicMock()
+    
+    # Create middleware
+    app = MagicMock()
+    mock_service = MagicMock(spec=ObservabilityService)
+    mock_service.start_trace.return_value = "test-trace-id"
+    mock_service.start_span.return_value = "test-span-id"
+    middleware = ObservabilityMiddleware(app, enabled=True, service=mock_service)
+    
+    # Simulate route handler that uses get_db
+    async def mock_call_next(request):
+        # This simulates what happens in a real route handler
+        db_generator = get_db(request=request)
+        db = next(db_generator)
+        
+        # Verify we got a session
+        assert db is not None
+        
+        # Complete the generator
+        try:
+            next(db_generator)
+        except StopIteration:
+            pass
+        
+        return Response(content="OK", status_code=200)
+    
+    # Patch SessionLocal in both modules and should_skip_observability
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", side_effect=mock_session_local):
+        with patch("mcpgateway.main.SessionLocal", side_effect=mock_session_local):
+            with patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
+                response = await middleware.dispatch(mock_request, mock_call_next)
+    
+    # CRITICAL ASSERTION: Only ONE session should be created
+    assert len(session_instances) == 1, f"Expected 1 session, but {len(session_instances)} were created"
+    
+    # Verify the single session was properly managed
+    session_instances[0].commit.assert_called_once()
+    session_instances[0].close.assert_called_once()
+    
+    # Verify response
+    assert response.status_code == 200

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -476,6 +476,94 @@ async def test_single_session_per_request_integration():
     # Verify response
     assert response.status_code == 200
 
+@pytest.mark.asyncio
+async def test_dispatch_trace_setup_rollback_and_invalidate_failure():
+    """Test that trace setup handles both rollback and invalidate failures gracefully."""
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    
+    mock_request = MagicMock(spec=Request)
+    mock_request.url.path = "/rpc"
+    mock_request.url.query = ""
+    mock_request.url = MagicMock()
+    mock_request.url.__str__ = MagicMock(return_value="http://test.com/rpc")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers = {"user-agent": "test-agent"}
+    mock_request.state = MagicMock()
+    
+    # Mock SessionLocal to return a session that fails on both rollback and invalidate
+    db_mock = MagicMock()
+    db_mock.rollback.side_effect = Exception("rollback failed")
+    db_mock.invalidate.side_effect = Exception("invalidate failed")
+    db_mock.close.return_value = None
+    
+    async def mock_call_next(request):
+        return Response(content="OK", status_code=200)
+    
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
+         patch.object(middleware.service, "start_trace", side_effect=Exception("trace setup failed")), \
+         patch("mcpgateway.middleware.observability_middleware.logger.debug") as mock_debug, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
+        response = await middleware.dispatch(mock_request, mock_call_next)
+        
+        # Verify rollback was attempted
+        db_mock.rollback.assert_called_once()
+        
+        # Verify invalidate was attempted (even though it failed)
+        db_mock.invalidate.assert_called_once()
+        
+        # Verify debug log was called for rollback failure
+        mock_debug.assert_any_call("Failed to rollback during cleanup: rollback failed")
+        
+        # Verify response is still returned (graceful degradation)
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_dispatch_exception_handler_invalidate_failure():
+    """Test that main exception handler handles invalidate failure gracefully."""
+    async def failing_call_next(request):
+        raise RuntimeError("Request failed")
+    
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    
+    mock_request = MagicMock(spec=Request)
+    mock_request.url.path = "/rpc"
+    mock_request.url.query = ""
+    mock_request.url = MagicMock()
+    mock_request.url.__str__ = MagicMock(return_value="http://test.com/rpc")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers = {"user-agent": "test-agent"}
+    mock_request.state = MagicMock()
+    
+    # Mock SessionLocal to return a session that fails on both rollback and invalidate
+    db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.rollback.side_effect = Exception("rollback failed")
+    db_mock.invalidate.side_effect = Exception("invalidate failed")
+    
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
+         patch.object(middleware.service, "start_trace", return_value="trace123"), \
+         patch.object(middleware.service, "start_span", return_value="span123"), \
+         patch.object(middleware.service, "end_span"), \
+         patch.object(middleware.service, "add_event"), \
+         patch.object(middleware.service, "end_trace"), \
+         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
+        with pytest.raises(RuntimeError, match="Request failed"):
+            await middleware.dispatch(mock_request, failing_call_next)
+        
+        # Verify rollback was attempted
+        db_mock.rollback.assert_called_once()
+        
+        # Verify invalidate was attempted (even though it failed)
+        db_mock.invalidate.assert_called_once()
+        
+        # Verify warning log was called for rollback failure
+        mock_warning.assert_any_call("Failed to rollback database session: rollback failed")
+
+
 
 @pytest.mark.asyncio
 async def test_dispatch_rollback_failure_logs_warning(mock_request):

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -286,7 +286,7 @@ async def test_observability_middleware_creates_request_scoped_session(mock_requ
     def mock_session_local():
         session = MagicMock()
         session.is_active = True
-        session.in_transaction.return_value = False
+        session.in_transaction.return_value = True  # Session has uncommitted changes
         session_instances.append(session)
         return session
     
@@ -420,7 +420,7 @@ async def test_single_session_per_request_integration():
     def mock_session_local():
         session = MagicMock()
         session.is_active = True
-        session.in_transaction.return_value = False
+        session.in_transaction.return_value = True  # Session has uncommitted changes
         session_instances.append(session)
         return session
     

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -475,3 +475,28 @@ async def test_single_session_per_request_integration():
     
     # Verify response
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rollback_failure_logs_warning(mock_request):
+    """Test that rollback failure during exception handling logs a warning."""
+    async def failing_call_next(request):
+        raise RuntimeError("Request failed")
+
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    db_mock = MagicMock()
+    db_mock.is_active = True
+    db_mock.rollback.side_effect = Exception("rollback fail")  # Simulate rollback failure
+
+    with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
+         patch.object(middleware.service, "start_trace", return_value="trace123"), \
+         patch.object(middleware.service, "start_span", return_value="span123"), \
+         patch.object(middleware.service, "end_span"), \
+         patch.object(middleware.service, "add_event"), \
+         patch.object(middleware.service, "end_trace"), \
+         patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning, \
+         patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
+        with pytest.raises(RuntimeError):
+            await middleware.dispatch(mock_request, failing_call_next)
+        # Verify that the rollback failure was logged
+        mock_warning.assert_any_call("Failed to rollback database session: rollback fail")

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -255,43 +255,43 @@ def mock_observability_service():
 @pytest.mark.asyncio
 async def test_observability_middleware_creates_request_scoped_session(mock_request, mock_observability_service):
     """Test that observability middleware creates a session and stores it in request.state.db."""
-    
+
     # Use /rpc path which is in the observability include list
     mock_request.url.path = "/rpc"
-    
+
     # Create middleware
     app = MagicMock()
     middleware = ObservabilityMiddleware(app, enabled=True, service=mock_observability_service)
-    
+
     # Mock SessionLocal to track session creation
     session_instances = []
-    
+
     def mock_session_local():
         session = MagicMock()
         session.is_active = True
         session.in_transaction.return_value = True  # Session has uncommitted changes
         session_instances.append(session)
         return session
-    
+
     # Mock call_next to simulate route handler
     async def mock_call_next(request):
         # Verify session is stored in request.state.db
         assert hasattr(request.state, "db"), "Session should be stored in request.state.db"
         assert request.state.db is not None, "Session should not be None"
         return Response(content="OK", status_code=200)
-    
+
     # Patch SessionLocal and should_skip_observability
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", side_effect=mock_session_local):
         with patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
             response = await middleware.dispatch(mock_request, mock_call_next)
-    
+
     # Verify only one session was created
     assert len(session_instances) == 1, f"Expected 1 session, but {len(session_instances)} were created"
-    
+
     # Verify session was committed and closed
     session_instances[0].commit.assert_called_once()
     session_instances[0].close.assert_called_once()
-    
+
     # Verify response
     assert response.status_code == 200
 
@@ -299,34 +299,34 @@ async def test_observability_middleware_creates_request_scoped_session(mock_requ
 @pytest.mark.asyncio
 async def test_observability_middleware_cleans_up_on_error(mock_request, mock_observability_service):
     """Test that observability middleware properly cleans up session on error."""
-    
+
     # Use /rpc path which is in the observability include list
     mock_request.url.path = "/rpc"
-    
+
     # Create middleware
     app = MagicMock()
     middleware = ObservabilityMiddleware(app, enabled=True, service=mock_observability_service)
-    
+
     # Mock SessionLocal
     session_instances = []
-    
+
     def mock_session_local():
         session = MagicMock()
         session.is_active = True
         session.in_transaction.return_value = False
         session_instances.append(session)
         return session
-    
+
     # Mock call_next to raise an exception
     async def mock_call_next(request):
         raise ValueError("Test error")
-    
+
     # Patch SessionLocal and should_skip_observability
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", side_effect=mock_session_local):
         with patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
             with pytest.raises(ValueError, match="Test error"):
                 await middleware.dispatch(mock_request, mock_call_next)
-    
+
     # Verify session was rolled back and closed
     assert len(session_instances) == 1, f"Expected 1 session, but {len(session_instances)} were created"
     session_instances[0].rollback.assert_called_once()
@@ -337,25 +337,25 @@ async def test_observability_middleware_cleans_up_on_error(mock_request, mock_ob
 async def test_get_db_reuses_middleware_session():
     """Test that get_db() reuses the session from ObservabilityMiddleware."""
     from mcpgateway.main import get_db
-    
+
     # Create a mock request with a session in state
     mock_request = MagicMock(spec=Request)
     mock_session = MagicMock()
     mock_request.state.db = mock_session
-    
+
     # Call get_db with the request
     db_generator = get_db(request=mock_request)
     db = next(db_generator)
-    
+
     # Verify it returns the same session
     assert db is mock_session, "get_db should return the middleware's session"
-    
+
     # Verify the session is NOT closed (middleware will handle that)
     try:
         next(db_generator)
     except StopIteration:
         pass
-    
+
     mock_session.close.assert_not_called()
     mock_session.commit.assert_not_called()
 
@@ -364,29 +364,29 @@ async def test_get_db_reuses_middleware_session():
 async def test_get_db_creates_own_session_when_no_middleware_session():
     """Test that get_db() creates its own session when middleware hasn't created one."""
     from mcpgateway.main import get_db
-    
+
     # Create a mock request without a session in state
     mock_request = MagicMock(spec=Request)
     mock_request.state = MagicMock(spec=[])  # No 'db' attribute
-    
+
     # Mock SessionLocal
     mock_session = MagicMock()
     mock_session.is_active = True
-    
+
     with patch("mcpgateway.main.SessionLocal", return_value=mock_session):
         # Call get_db with the request
         db_generator = get_db(request=mock_request)
         db = next(db_generator)
-        
+
         # Verify it creates a new session
         assert db is mock_session
-        
+
         # Complete the generator (simulating successful request)
         try:
             next(db_generator)
         except StopIteration:
             pass
-        
+
         # Verify the session was committed and closed
         mock_session.commit.assert_called_once()
         mock_session.close.assert_called_once()
@@ -396,17 +396,17 @@ async def test_get_db_creates_own_session_when_no_middleware_session():
 async def test_single_session_per_request_integration():
     """Integration test: Verify only one session is created per request with observability enabled."""
     from mcpgateway.main import get_db
-    
+
     # Track session creation
     session_instances = []
-    
+
     def mock_session_local():
         session = MagicMock()
         session.is_active = True
         session.in_transaction.return_value = True  # Session has uncommitted changes
         session_instances.append(session)
         return session
-    
+
     # Create mock request with /rpc path (traced by default)
     mock_request = MagicMock(spec=Request)
     mock_request.method = "GET"
@@ -418,44 +418,44 @@ async def test_single_session_per_request_integration():
     mock_request.client.host = "127.0.0.1"
     mock_request.headers = {"user-agent": "test-agent"}
     mock_request.state = MagicMock()
-    
+
     # Create middleware
     app = MagicMock()
     mock_service = MagicMock(spec=ObservabilityService)
     mock_service.start_trace.return_value = "test-trace-id"
     mock_service.start_span.return_value = "test-span-id"
     middleware = ObservabilityMiddleware(app, enabled=True, service=mock_service)
-    
+
     # Simulate route handler that uses get_db
     async def mock_call_next(request):
         # This simulates what happens in a real route handler
         db_generator = get_db(request=request)
         db = next(db_generator)
-        
+
         # Verify we got a session
         assert db is not None
-        
+
         # Complete the generator
         try:
             next(db_generator)
         except StopIteration:
             pass
-        
+
         return Response(content="OK", status_code=200)
-    
+
     # Patch SessionLocal in both modules and should_skip_observability
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", side_effect=mock_session_local):
         with patch("mcpgateway.main.SessionLocal", side_effect=mock_session_local):
             with patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
                 response = await middleware.dispatch(mock_request, mock_call_next)
-    
+
     # CRITICAL ASSERTION: Only ONE session should be created
     assert len(session_instances) == 1, f"Expected 1 session, but {len(session_instances)} were created"
-    
+
     # Verify the single session was properly managed
     session_instances[0].commit.assert_called_once()
     session_instances[0].close.assert_called_once()
-    
+
     # Verify response
     assert response.status_code == 200
 
@@ -463,7 +463,7 @@ async def test_single_session_per_request_integration():
 async def test_dispatch_trace_setup_rollback_and_invalidate_failure():
     """Test that trace setup handles both rollback and invalidate failures gracefully."""
     middleware = ObservabilityMiddleware(app=None, enabled=True)
-    
+
     mock_request = MagicMock(spec=Request)
     mock_request.url.path = "/rpc"
     mock_request.url.query = ""
@@ -473,31 +473,31 @@ async def test_dispatch_trace_setup_rollback_and_invalidate_failure():
     mock_request.client.host = "127.0.0.1"
     mock_request.headers = {"user-agent": "test-agent"}
     mock_request.state = MagicMock()
-    
+
     # Mock SessionLocal to return a session that fails on both rollback and invalidate
     db_mock = MagicMock()
     db_mock.rollback.side_effect = Exception("rollback failed")
     db_mock.invalidate.side_effect = Exception("invalidate failed")
     db_mock.close.return_value = None
-    
+
     async def mock_call_next(request):
         return Response(content="OK", status_code=200)
-    
+
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", side_effect=Exception("trace setup failed")), \
          patch("mcpgateway.middleware.observability_middleware.logger.debug") as mock_debug, \
          patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         response = await middleware.dispatch(mock_request, mock_call_next)
-        
+
         # Verify rollback was attempted
         db_mock.rollback.assert_called_once()
-        
+
         # Verify invalidate was attempted (even though it failed)
         db_mock.invalidate.assert_called_once()
-        
+
         # Verify debug log was called for rollback failure
         mock_debug.assert_any_call("Failed to rollback during cleanup: rollback failed")
-        
+
         # Verify response is still returned (graceful degradation)
         assert response.status_code == 200
 
@@ -507,9 +507,9 @@ async def test_dispatch_exception_handler_invalidate_failure():
     """Test that main exception handler handles invalidate failure gracefully."""
     async def failing_call_next(request):
         raise RuntimeError("Request failed")
-    
+
     middleware = ObservabilityMiddleware(app=None, enabled=True)
-    
+
     mock_request = MagicMock(spec=Request)
     mock_request.url.path = "/rpc"
     mock_request.url.query = ""
@@ -519,13 +519,13 @@ async def test_dispatch_exception_handler_invalidate_failure():
     mock_request.client.host = "127.0.0.1"
     mock_request.headers = {"user-agent": "test-agent"}
     mock_request.state = MagicMock()
-    
+
     # Mock SessionLocal to return a session that fails on both rollback and invalidate
     db_mock = MagicMock()
     db_mock.is_active = True
     db_mock.rollback.side_effect = Exception("rollback failed")
     db_mock.invalidate.side_effect = Exception("invalidate failed")
-    
+
     with patch("mcpgateway.middleware.observability_middleware.SessionLocal", return_value=db_mock), \
          patch.object(middleware.service, "start_trace", return_value="trace123"), \
          patch.object(middleware.service, "start_span", return_value="span123"), \
@@ -536,13 +536,13 @@ async def test_dispatch_exception_handler_invalidate_failure():
          patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False):
         with pytest.raises(RuntimeError, match="Request failed"):
             await middleware.dispatch(mock_request, failing_call_next)
-        
+
         # Verify rollback was attempted
         db_mock.rollback.assert_called_once()
-        
+
         # Verify invalidate was attempted (even though it failed)
         db_mock.invalidate.assert_called_once()
-        
+
         # Verify warning log was called for rollback failure
         mock_warning.assert_any_call("Failed to rollback database session: rollback failed")
 

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -8,7 +8,6 @@ Unit tests for observability middleware.
 """
 
 import pytest
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from starlette.requests import Request
 from starlette.responses import Response
@@ -251,22 +250,6 @@ def mock_observability_service():
     service.start_trace.return_value = "test-trace-id"
     service.start_span.return_value = "test-span-id"
     return service
-
-
-@pytest.fixture
-def mock_request():
-    """Create a mock request object."""
-    request = MagicMock(spec=Request)
-    request.method = "GET"
-    request.url.path = "/test"
-    request.url.query = ""
-    request.url = MagicMock()
-    request.url.__str__ = MagicMock(return_value="http://test.com/test")
-    request.client = MagicMock()
-    request.client.host = "127.0.0.1"
-    request.headers = {"user-agent": "test-agent"}
-    request.state = MagicMock()
-    return request
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3467

---

## 📝 Summary
**What does this PR do?**
Eliminates duplicate database session creation in observability middleware by implementing request-scoped session sharing between middleware and route handlers.

**Why?**
- Reduces database connection usage by 50% for traced requests
- Prevents SQLite segfaults with StaticPool under concurrent load
- Improves performance by reducing session creation/destruction overhead
- Lowers connection pool pressure in production environments

**Technical Changes**:
1. `mcpgateway/middleware/observability_middleware.py`:
   - Creates request-scoped session and stores in `request.state.db`
   - Handles complete session lifecycle (commit/rollback/close)
   - Added session ownership tracking for proper cleanup

2. `mcpgateway/main.py` (`get_db()` function):
   - Checks for `request.state.db` and reuses if present
   - Falls back to creating own session if middleware didn't create one
   - Maintains backward compatibility for non-traced requests

3. `tests/unit/mcpgateway/middleware/test_observability_middleware.py`:
   - Updated 8 tests to mock `should_skip_observability` for proper coverage
   - Added verification for session reuse behavior

---

## 🏷️ Type of Change
- [X] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |     Pass   |
| Unit tests                | `make test`     |    Pass    |
| Coverage ≥ 80%            | `make coverage` |   Pass     |

---

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [X] No secrets or credentials committed

---

## 📓 Notes (optional)
**Manual Testing Results:**

**With OBSERVABILITY_ENABLED=true, single session ID confirmed:**
[OBSERVABILITY] DB session created: 139870311167472
[GET_DB] Reusing session from middleware: 139870311167472  ← Same ID ✅

**Before fix (two different session IDs):**
[OBSERVABILITY] DB session created: 4709458000
[GET_DB] DB session created: 4710405520  ← Different ID ❌