### PR TITLE
test-clear-filters-htmx-race-condition

### DIFF
--- a/tests/playwright/pages/mcp_registry_page.py
+++ b/tests/playwright/pages/mcp_registry_page.py
@@ -242,6 +242,25 @@ class MCPRegistryPage(BasePage):
         self.page.wait_for_selector("#server-grid", state="attached", timeout=30000)
         self.search_input.fill("")
         self.page.wait_for_selector("#server-grid", state="attached", timeout=30000)
+
+        # Wait until the server grid count stabilizes (no change between two polls).
+        # This guards against HTMX partials that may reattach the grid multiple
+        # times and avoids races where the DOM is attached but not fully updated.
+        self.page.wait_for_function(
+            """() => {
+                const grid = document.querySelector('#server-grid');
+                if (!grid) return false;
+                const cnt = grid.querySelectorAll('.server-card').length;
+                if (window.__last_server_count_for_tests === cnt) {
+                    window.__last_server_count_for_tests = undefined;
+                    return true;
+                }
+                window.__last_server_count_for_tests = cnt;
+                return false;
+            }""",
+            timeout=30000,
+        )
+
         self.page.wait_for_timeout(1000)
 
     def click_category_badge(self, category: str) -> None:


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #3423 
## 💡 Fix Description

Fixes an intermittent failure in test_clear_filters_functionality caused by an HTMX race condition when clearing filters. Added wait_for_selector("#server-grid") after each filter reset to ensure HTMX swaps complete before the next action. Also added a stabilization check to wait until the server grid count stops changing. Verified by running the test multiple times to confirm the failure no longer occurs.
## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |Pass    |
| Unit tests                            | `make test`          |Pass    |
## 📐 MCP Compliance (if relevant)
- [X] Matches current MCP spec
- [X] No breaking change to MCP clients

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
