### PR TITLE
feat(testing): add end-to-end wrapper test workflow for mcpgateway

### DIFF
--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,0 +1,355 @@
+name: Wrapper CI/CD
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+        types: [opened, synchronize, reopened]
+    workflow_dispatch:
+
+env:
+    CARGO_TERM_COLOR: never
+    RUST_BACKTRACE: 1
+
+jobs:
+    rust-checks:
+        name: Rust Checks
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v5
+              with:
+                  enable-cache: true
+
+            - name: Cache uv virtual environment
+              uses: actions/cache@v4
+              with:
+                  path: .venv
+                  key: venv-${{ runner.os }}-python-3.12-${{ hashFiles('uv.lock') }}
+                  restore-keys: |
+                      venv-${{ runner.os }}-python-3.12-
+                      venv-${{ runner.os }}-
+
+            - name: Setup Rust
+              if: true
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Rust Cache
+              if: true
+              uses: swatinem/rust-cache@v2
+              with:
+                  workspaces: tools_rust/wrapper
+                  cache-on-failure: true
+
+            - name: Compile
+              if: true
+              working-directory: tools_rust/wrapper
+              run: cargo build --release
+
+            - name: Secrets
+              run: |
+                  SECRET=$(openssl rand -base64 32)
+                  echo "DYNAMIC_JWT_SECRET=$SECRET" >> $GITHUB_ENV
+
+            - name: Run gateway
+              env:
+                  GUNICORN_WORKERS: 1
+                  MCPGATEWAY_UI_ENABLED: true
+                  MCPGATEWAY_ADMIN_API_ENABLED: true
+                  SSRF_PROTECTION_ENABLED: false
+                  JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
+                  ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: false
+                  PASSWORD_CHANGE_ENFORCEMENT_ENABLED: false
+
+              run: |
+
+                  make venv
+                  make install
+                  make stop-serve
+                  make serve &
+
+                  echo "Waiting for gateway to start..."
+                  for i in {1..60}; do
+                    if curl -s http://localhost:4444 >/dev/null 2>&1; then
+                      echo "Gateway is up!"
+                      break
+                    fi
+                    echo "Waiting for port 4444 to open... (attempt $i)"
+                    sleep 1
+                  done
+
+            - name: Generate JWT Token
+              id: generate_jwt
+              env:
+                  JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
+              run: |
+                  TOKEN=$(uv run --no-dev python -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret "$JWT_SECRET_KEY")
+                  echo "token=$TOKEN" >> $GITHUB_OUTPUT
+                  echo "JWT Token generated successfully"
+
+            - name: Fetch Version Info
+              run: |
+                  curl -v -X GET http://localhost:4444/version \
+                  -H "Authorization: Bearer ${{ steps.generate_jwt.outputs.token }}" \
+                  -H "Content-Type: application/json"
+
+            - name: Setup Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: "1.21"
+                  cache-dependency-path: mcp-servers/go/fast-time-server/go.sum
+                  cache: true
+
+            - name: Build fast-time-server
+              working-directory: mcp-servers/go/fast-time-server
+              run: |
+                  go build -o fast-time-server .
+                  chmod +x fast-time-server
+
+            - name: Start Fast Time Server as Background Service
+              run: |
+                  # Kill any existing fast-time-server processes (container reuse cleanup)
+                  echo "Cleaning up any existing fast-time-server processes..."
+                  pkill -9 -f "fast-time-server" 2>/dev/null || true
+                  sleep 1
+
+                  # Start fast-time-server as a background service using nohup
+                  echo "Starting fast-time-server as background service..."
+                  nohup mcp-servers/go/fast-time-server/fast-time-server \
+                    -transport=dual -listen=0.0.0.0 -port=8080 -log-level=info \
+                    > fast-time-server.log 2>&1 &
+                  echo $! > fast-time-server.pid
+
+                  # Wait for fast-time-server to be ready
+                  echo "Waiting for fast-time-server..."
+                  for i in {1..30}; do
+                    if curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                      echo "fast-time-server is up!"
+                      break
+                    fi
+                    echo "Waiting for fast-time-server... (attempt $i)"
+                    sleep 2
+                  done
+
+                  # Verify server is running
+                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                    echo "ERROR: fast-time-server failed to start"
+                    cat fast-time-server.log
+                    exit 1
+                  fi
+                  echo "fast-time-server PID: $(cat fast-time-server.pid)"
+
+            - name: Register Fast Time Gateway and Create Tools
+              run: |
+                  TOKEN="${{ steps.generate_jwt.outputs.token }}"
+
+                  # Verify fast-time-server is still running
+                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                    echo "ERROR: fast-time-server is not running"
+                    cat fast-time-server.log
+                    exit 1
+                  fi
+                  echo "fast-time-server is running (PID: $(cat fast-time-server.pid))"
+
+                  # Register gateway
+                  echo "Registering fast_time gateway..."
+                  GATEWAY_RESPONSE=$(curl -s -X POST http://localhost:4444/gateways \
+                    -H "Authorization: Bearer $TOKEN" \
+                    -H "Content-Type: application/json" \
+                    -d '{
+                      "name": "fast_time",
+                      "url": "http://localhost:8080/http",
+                      "transport": "STREAMABLEHTTP"
+                    }')
+                  echo "Gateway response: $GATEWAY_RESPONSE"
+
+                  # Extract gateway ID (handle existing gateway)
+                  if echo "$GATEWAY_RESPONSE" | grep -q "already exists"; then
+                    echo "Gateway already exists, fetching existing ID..."
+                    GATEWAYS=$(curl -s http://localhost:4444/gateways \
+                      -H "Authorization: Bearer $TOKEN")
+                    GATEWAY_ID=$(echo "$GATEWAYS" | jq -r '.[] | select(.name=="fast_time") | .id')
+                  else
+                    GATEWAY_ID=$(echo "$GATEWAY_RESPONSE" | jq -r '.id')
+                  fi
+                  echo "Gateway ID: $GATEWAY_ID"
+
+                  # Wait for tools to sync
+                  echo "Waiting for tools to sync..."
+                  for i in {1..30}; do
+                    TOOLS=$(curl -s http://localhost:4444/tools \
+                      -H "Authorization: Bearer $TOKEN")
+                    TOOL_COUNT=$(echo "$TOOLS" | jq --arg gid "$GATEWAY_ID" '[.[] | select(.gatewayId==$gid)] | length')
+                    if [ "$TOOL_COUNT" -gt 0 ]; then
+                      echo "Found $TOOL_COUNT tools from fast_time gateway"
+                      echo "$TOOLS" | jq --arg gid "$GATEWAY_ID" '[.[] | select(.gatewayId==$gid) | .name]'
+                      break
+                    fi
+                    echo "Waiting for tools to sync... (attempt $i)"
+                    sleep 2
+                  done
+
+                  # Get tool IDs
+                  TOOLS=$(curl -s http://localhost:4444/tools \
+                    -H "Authorization: Bearer $TOKEN")
+                  TOOL_IDS=$(echo "$TOOLS" | jq --arg gid "$GATEWAY_ID" -c '[.[] | select(.gatewayId==$gid) | .id]')
+                  echo "Tool IDs: $TOOL_IDS"
+
+                  # Create virtual server
+                  echo "Creating virtual server..."
+                  SERVER_RESPONSE=$(curl -s -X POST http://localhost:4444/servers \
+                    -H "Authorization: Bearer $TOKEN" \
+                    -H "Content-Type: application/json" \
+                    -d "{
+                      \"server\": {
+                        \"id\": \"9779b6698cbd4b4995ee04a4fab38737\",
+                        \"name\": \"Fast Time Server\",
+                        \"description\": \"Virtual server exposing Fast Time MCP tools\",
+                        \"associated_tools\": $TOOL_IDS,
+                        \"associated_resources\": [],
+                        \"associated_prompts\": []
+                      }
+                    }")
+                  echo "Server response: $SERVER_RESPONSE"
+
+                  # Keep server running for wrapper test - no cleanup needed (container is ephemeral)
+
+            - name: Verify Fast Time Server Before Test
+              run: |
+                  echo "Verifying fast-time-server is still running before wrapper test..."
+                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                    echo "ERROR: fast-time-server is not running!"
+                    echo "Server log:"
+                    cat fast-time-server.log
+                    echo "PID file content: $(cat fast-time-server.pid 2>/dev/null || echo 'not found')"
+                    ps aux | grep fast-time-server || echo "No fast-time-server process found"
+                    exit 1
+                  fi
+                  echo "✓ fast-time-server is running (PID: $(cat fast-time-server.pid))"
+                  echo "Health check response:"
+                  curl -s http://localhost:8080/health | head -20
+
+            - name: Test Wrapper with Fast Time Server
+              run: |
+                  TOKEN="${{ steps.generate_jwt.outputs.token }}"
+                  SERVER_ID="9779b6698cbd4b4995ee04a4fab38737"
+                  PORT="4444"
+                  URL="http://localhost:${PORT}/servers/${SERVER_ID}/mcp"
+                  AUTH="Bearer $TOKEN"
+
+                  # Debug: Verify fast-time-server is accessible
+                  echo "=== Debug: Fast-time-server status ==="
+                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                    echo "ERROR: fast-time-server is not accessible!"
+                    exit 1
+                  fi
+                  echo "fast-time-server health:"
+                  curl -s http://localhost:8080/health
+                  echo ""
+
+                  # Debug: Check virtual server configuration
+                  echo "=== Debug: Virtual server configuration ==="
+                  SERVER_INFO=$(curl -s http://localhost:${PORT}/servers/${SERVER_ID} \
+                    -H "Authorization: Bearer $TOKEN")
+                  echo "Server info: $SERVER_INFO" | head -50
+
+                  # Debug: Check tools associated with server
+                  echo "=== Debug: Tools on virtual server ==="
+                  TOOLS_ON_SERVER=$(curl -s "http://localhost:${PORT}/servers/${SERVER_ID}/tools" \
+                    -H "Authorization: Bearer $TOKEN")
+                  echo "Tools on server: $TOOLS_ON_SERVER"
+
+                  # Build the Rust wrapper
+                  echo "Building Rust wrapper..."
+                  cd tools_rust/wrapper
+                  cargo build --release
+                  WRAPPER_BIN="$(pwd)/target/release/mcp_stdio_wrapper"
+                  cd ../..
+
+                  # Define MCP messages
+                  INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}'
+                  NOTIFY='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+                  LIST='{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+                  CALL='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"fast-time-get-system-time","arguments":{"timezone":"UTC"}}}'
+
+                  # Run wrapper and capture output
+                  echo "Running wrapper test..."
+                  OUTPUT=$(
+                    {
+                      echo "$INIT"
+                      sleep 0.2
+                      echo "$NOTIFY"
+                      sleep 0.2
+                      echo "$LIST"
+                      sleep 0.2
+                      echo "$CALL"
+                      sleep 0.2
+                    } | "$WRAPPER_BIN" --url "$URL" --auth "$AUTH" --log-level debug --log-file wrapper_test.log
+                  )
+
+                  echo "Wrapper output:"
+                  echo "$OUTPUT"
+
+                  # Save output for debugging
+                  echo "$OUTPUT" > wrapper_output.json
+
+                  # Verify the response contains valid tool call result
+                  echo "Verifying wrapper response..."
+
+                  # Check for successful initialize response
+                  if ! echo "$OUTPUT" | grep -q '"result".*"protocolVersion"'; then
+                    echo "ERROR: Initialize response missing or invalid"
+                    exit 1
+                  fi
+                  echo "✓ Initialize response valid"
+
+                  # Check for tools/list response with fast-time tool
+                  if ! echo "$OUTPUT" | grep -q 'fast-time-get-system-time'; then
+                    echo "ERROR: Tool fast-time-get-system-time not found in tools/list"
+                    exit 1
+                  fi
+                  echo "✓ Tool list contains fast-time-get-system-time"
+
+                  # Check for successful tool call (should have result with time, not error)
+                  if echo "$OUTPUT" | grep -q '"error"'; then
+                    echo "ERROR: Tool call returned error"
+                    cat wrapper_test.log
+                    exit 1
+                  fi
+
+
+                  # Verify tool call has a result with time data
+                  # Check if ID 3 has a result and isError is false
+                  IS_SUCCESS=$(echo "$OUTPUT" | jq -r 'select(.id==3) | .result.isError == false')
+                  if [ "$IS_SUCCESS" != "true" ]; then
+                    echo "ERROR: Tool call failed or returned an error state"
+                    exit 1
+                  fi
+                  echo "✓ Tool call returned successful result"
+
+                  echo "All wrapper tests passed!"
+
+            - name: Upload Wrapper Test Artifacts
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: wrapper-test-logs
+                  path: |
+                      wrapper_output.json
+                      wrapper_test.log
+                  retention-days: 7
+
+            - name: Keep server running for debug - set true
+              if: false
+              run: |
+                  echo "Keeping server running for debugging..."
+                  sleep 3600
+                  echo "Debug period ended"

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -38,21 +38,32 @@ jobs:
                       venv-${{ runner.os }}-python-3.12-
                       venv-${{ runner.os }}-
 
+            - name: Install Rust Toolchain
+              run: |
+                uv tool install rustup
+                echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
             - name: Setup Rust
-              if: true
-              uses: dtolnay/rust-toolchain@stable
+              run: |
+                rustup toolchain install stable --profile minimal
+                rustup default stable
+                echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-            - name: Rust Cache
-              if: true
-              uses: swatinem/rust-cache@v2
+            - name: Check Rust version
+              run: rustc --version
+
+            - name: Cache Cargo & Rust
+              uses: actions/cache@v4
               with:
-                  workspaces: tools_rust/wrapper
-                  cache-on-failure: true
-
-            - name: Compile
-              if: true
-              working-directory: tools_rust/wrapper
-              run: cargo build --release
+                path: |
+                  ~/.cargo/bin/
+                  ~/.cargo/registry/index/
+                  ~/.cargo/registry/cache/
+                  ~/.cargo/git/db/
+                  tools_rust/wrapper/target/
+                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-cargo-
 
             - name: Secrets
               run: |

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -17,20 +17,20 @@ jobs:
         name: Rust Checks
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                   enable-cache: true
 
             - name: Cache uv virtual environment
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-python-3.12-${{ hashFiles('uv.lock') }}
@@ -39,7 +39,7 @@ jobs:
                       venv-${{ runner.os }}-
 
             - name: Cache Rust Toolchain
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: |
                       ~/.cargo/bin/
@@ -109,9 +109,9 @@ jobs:
                   -H "Content-Type: application/json"
 
             - name: Setup Go
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@v6
               with:
-                  go-version: "1.21"
+                  go-version: "1.23"
                   cache-dependency-path: mcp-servers/go/fast-time-server/go.sum
                   cache: true
 
@@ -249,7 +249,7 @@ jobs:
 
             - name: Upload Wrapper Test Artifacts
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: wrapper-test-logs
                   path: |

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -38,32 +38,12 @@ jobs:
                       venv-${{ runner.os }}-python-3.12-
                       venv-${{ runner.os }}-
 
-            - name: Install Rust Toolchain
-              run: |
-                uv tool install rustup
-                echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-            - name: Setup Rust
-              run: |
-                rustup toolchain install stable --profile minimal
-                rustup default stable
-                echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-            - name: Check Rust version
-              run: rustc --version
-
-            - name: Cache Cargo & Rust
-              uses: actions/cache@v4
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                path: |
-                  ~/.cargo/bin/
-                  ~/.cargo/registry/index/
-                  ~/.cargo/registry/cache/
-                  ~/.cargo/git/db/
-                  tools_rust/wrapper/target/
-                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-                restore-keys: |
-                  ${{ runner.os }}-cargo-
+                  toolchain: stable
+                  cache: true
+                  profile: minimal
+                  cache-workspaces: "tools_rust/wrapper -> target"
 
             - name: Secrets
               run: |
@@ -233,119 +213,22 @@ jobs:
 
                   # Keep server running for wrapper test - no cleanup needed (container is ephemeral)
 
-            - name: Verify Fast Time Server Before Test
-              run: |
-                  echo "Verifying fast-time-server is still running before wrapper test..."
-                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
-                    echo "ERROR: fast-time-server is not running!"
-                    echo "Server log:"
-                    cat fast-time-server.log
-                    echo "PID file content: $(cat fast-time-server.pid 2>/dev/null || echo 'not found')"
-                    ps aux | grep fast-time-server || echo "No fast-time-server process found"
-                    exit 1
-                  fi
-                  echo "✓ fast-time-server is running (PID: $(cat fast-time-server.pid))"
-                  echo "Health check response:"
-                  curl -s http://localhost:8080/health | head -20
-
             - name: Test Wrapper with Fast Time Server
               run: |
-                  TOKEN="${{ steps.generate_jwt.outputs.token }}"
-                  SERVER_ID="9779b6698cbd4b4995ee04a4fab38737"
-                  PORT="4444"
-                  URL="http://localhost:${PORT}/servers/${SERVER_ID}/mcp"
-                  AUTH="Bearer $TOKEN"
-
-                  # Debug: Verify fast-time-server is accessible
-                  echo "=== Debug: Fast-time-server status ==="
-                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
-                    echo "ERROR: fast-time-server is not accessible!"
-                    exit 1
-                  fi
-                  echo "fast-time-server health:"
-                  curl -s http://localhost:8080/health
-                  echo ""
-
-                  # Debug: Check virtual server configuration
-                  echo "=== Debug: Virtual server configuration ==="
-                  SERVER_INFO=$(curl -s http://localhost:${PORT}/servers/${SERVER_ID} \
-                    -H "Authorization: Bearer $TOKEN")
-                  echo "Server info: $SERVER_INFO" | head -50
-
-                  # Debug: Check tools associated with server
-                  echo "=== Debug: Tools on virtual server ==="
-                  TOOLS_ON_SERVER=$(curl -s "http://localhost:${PORT}/servers/${SERVER_ID}/tools" \
-                    -H "Authorization: Bearer $TOKEN")
-                  echo "Tools on server: $TOOLS_ON_SERVER"
-
-                  # Build the Rust wrapper
                   echo "Building Rust wrapper..."
                   cd tools_rust/wrapper
                   cargo build --release
-                  WRAPPER_BIN="$(pwd)/target/release/mcp_stdio_wrapper"
-                  cd ../..
-
-                  # Define MCP messages
-                  INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}'
-                  NOTIFY='{"jsonrpc":"2.0","method":"notifications/initialized"}'
-                  LIST='{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
-                  CALL='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"fast-time-get-system-time","arguments":{"timezone":"UTC"}}}'
-
-                  # Run wrapper and capture output
-                  echo "Running wrapper test..."
-                  OUTPUT=$(
-                    {
-                      echo "$INIT"
-                      sleep 0.2
-                      echo "$NOTIFY"
-                      sleep 0.2
-                      echo "$LIST"
-                      sleep 0.2
-                      echo "$CALL"
-                      sleep 0.2
-                    } | "$WRAPPER_BIN" --url "$URL" --auth "$AUTH" --log-level debug --log-file wrapper_test.log
-                  )
-
-                  echo "Wrapper output:"
-                  echo "$OUTPUT"
-
-                  # Save output for debugging
-                  echo "$OUTPUT" > wrapper_output.json
-
-                  # Verify the response contains valid tool call result
-                  echo "Verifying wrapper response..."
-
-                  # Check for successful initialize response
-                  if ! echo "$OUTPUT" | grep -q '"result".*"protocolVersion"'; then
-                    echo "ERROR: Initialize response missing or invalid"
-                    exit 1
-                  fi
-                  echo "✓ Initialize response valid"
-
-                  # Check for tools/list response with fast-time tool
-                  if ! echo "$OUTPUT" | grep -q 'fast-time-get-system-time'; then
-                    echo "ERROR: Tool fast-time-get-system-time not found in tools/list"
-                    exit 1
-                  fi
-                  echo "✓ Tool list contains fast-time-get-system-time"
-
-                  # Check for successful tool call (should have result with time, not error)
-                  if echo "$OUTPUT" | grep -q '"error"'; then
-                    echo "ERROR: Tool call returned error"
-                    cat wrapper_test.log
-                    exit 1
-                  fi
-
-
-                  # Verify tool call has a result with time data
-                  # Check if ID 3 has a result and isError is false
-                  IS_SUCCESS=$(echo "$OUTPUT" | jq -r 'select(.id==3) | .result.isError == false')
-                  if [ "$IS_SUCCESS" != "true" ]; then
-                    echo "ERROR: Tool call failed or returned an error state"
-                    exit 1
-                  fi
-                  echo "✓ Tool call returned successful result"
-
+                  cd -
+                  set -x
+                  pwd 
+                  stat ./tools_rust/wrapper/target/release/wrapper_integration
+                  TOKEN="${{ steps.generate_jwt.outputs.token }}"
+                  SERVER_ID="9779b6698cbd4b4995ee04a4fab38737"
+                  PORT="4444"
+                  URL="http://localhost:${PORT}/servers/${SERVER_ID}/mcp" 
+                  AUTH="Bearer $TOKEN" 
+                  WRAPPER_BIN="tools_rust/wrapper/target/release/mcp_stdio_wrapper"  
+                  URL="$URL" AUTH="$AUTH" WRAPPER_BIN="$WRAPPER_BIN" ./tools_rust/wrapper/target/release/wrapper_integration
                   echo "All wrapper tests passed!"
 
             - name: Upload Wrapper Test Artifacts
@@ -359,7 +242,7 @@ jobs:
                   retention-days: 7
 
             - name: Keep server running for debug - set true
-              if: false
+              if: true
               run: |
                   echo "Keeping server running for debugging..."
                   sleep 3600

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -38,12 +38,28 @@ jobs:
                       venv-${{ runner.os }}-python-3.12-
                       venv-${{ runner.os }}-
 
-            - uses: actions-rust-lang/setup-rust-toolchain@v1
+            - name: Cache Rust Toolchain
+              uses: actions/cache@v4
               with:
-                  toolchain: stable
-                  cache: true
-                  profile: minimal
-                  cache-workspaces: "tools_rust/wrapper -> target"
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                      ~/.rustup/
+                  key: ${{ runner.os }}-rust-stable-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-rust-stable-
+
+            - name: Install Rust Toolchain (Manual)
+              run: |
+                  if [ ! -f "$HOME/.cargo/bin/rustc" ]; then
+                    echo "Rustc not found, installing..."
+                    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+                  else
+                    echo "Rustc found in cache: $(rustc --version)"
+                  fi
+                  echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
             - name: Secrets
               run: |

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -258,7 +258,7 @@ jobs:
                   retention-days: 7
 
             - name: Keep server running for debug - set true
-              if: true
+              if: false
               run: |
                   echo "Keeping server running for debugging..."
                   sleep 3600

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,36 +1,54 @@
-name: Wrapper CI/CD
+name: Wrapper E2E
 
 on:
     push:
         branches: [main]
+        paths:
+            - "tools_rust/wrapper/**"
+            - "mcp-servers/go/fast-time-server/**"
+            - ".github/workflows/wrapper.yml"
     pull_request:
         branches: [main]
         types: [opened, synchronize, reopened]
+        paths:
+            - "tools_rust/wrapper/**"
+            - "mcp-servers/go/fast-time-server/**"
+            - ".github/workflows/wrapper.yml"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
-    CARGO_TERM_COLOR: never
+    CARGO_TERM_COLOR: always
     RUST_BACKTRACE: 1
 
 jobs:
-    rust-checks:
-        name: Rust Checks
+    wrapper-e2e:
+        if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+        name: Wrapper E2E
         runs-on: ubuntu-latest
+        timeout-minutes: 30
+
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v4
 
             - name: Setup Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.12"
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v5
               with:
                   enable-cache: true
 
             - name: Cache uv virtual environment
-              uses: actions/cache@v5
+              uses: actions/cache@v4
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-python-3.12-${{ hashFiles('uv.lock') }}
@@ -38,46 +56,38 @@ jobs:
                       venv-${{ runner.os }}-python-3.12-
                       venv-${{ runner.os }}-
 
-            - name: Cache Rust Toolchain
-              uses: actions/cache@v5
+            - name: Install Rust stable
+              run: |
+                  rustup toolchain install stable
+                  rustup default stable
+
+            - name: Cache Cargo
+              uses: actions/cache@v4
               with:
                   path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                      ~/.rustup/
-                  key: ${{ runner.os }}-rust-stable-${{ hashFiles('**/Cargo.lock') }}
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      tools_rust/wrapper/target
+                  key: ${{ runner.os }}-cargo-wrapper-${{ hashFiles('tools_rust/wrapper/Cargo.lock') }}
                   restore-keys: |
-                      ${{ runner.os }}-rust-stable-
+                      ${{ runner.os }}-cargo-wrapper-
 
-            - name: Install Rust Toolchain (Manual)
-              run: |
-                  if [ ! -f "$HOME/.cargo/bin/rustc" ]; then
-                    echo "Rustc not found, installing..."
-                    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
-                  else
-                    echo "Rustc found in cache: $(rustc --version)"
-                  fi
-                  echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-            - name: Secrets
+            - name: Generate JWT secret
               run: |
                   SECRET=$(openssl rand -base64 32)
                   echo "DYNAMIC_JWT_SECRET=$SECRET" >> $GITHUB_ENV
 
-            - name: Run gateway
+            - name: Start gateway
               env:
                   GUNICORN_WORKERS: 1
                   MCPGATEWAY_UI_ENABLED: true
                   MCPGATEWAY_ADMIN_API_ENABLED: true
+                  # Disabled: localhost-only test, no external requests
                   SSRF_PROTECTION_ENABLED: false
                   JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
                   ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: false
                   PASSWORD_CHANGE_ENFORCEMENT_ENABLED: false
-
               run: |
-
                   make venv
                   make install
                   make stop-serve
@@ -93,23 +103,29 @@ jobs:
                     sleep 1
                   done
 
-            - name: Generate JWT Token
+                  if ! curl -s http://localhost:4444 >/dev/null 2>&1; then
+                    echo "ERROR: gateway failed to start"
+                    exit 1
+                  fi
+
+            - name: Generate JWT token
               id: generate_jwt
               env:
                   JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
               run: |
                   TOKEN=$(uv run --no-dev python -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret "$JWT_SECRET_KEY")
+                  echo "::add-mask::$TOKEN"
                   echo "token=$TOKEN" >> $GITHUB_OUTPUT
-                  echo "JWT Token generated successfully"
+                  echo "JWT token generated successfully"
 
-            - name: Fetch Version Info
+            - name: Verify gateway is responding
               run: |
-                  curl -v -X GET http://localhost:4444/version \
-                  -H "Authorization: Bearer ${{ steps.generate_jwt.outputs.token }}" \
-                  -H "Content-Type: application/json"
+                  curl -sf -X GET http://localhost:4444/version \
+                    -H "Authorization: Bearer ${{ steps.generate_jwt.outputs.token }}" \
+                    -H "Content-Type: application/json"
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@v5
               with:
                   go-version: "1.23"
                   cache-dependency-path: mcp-servers/go/fast-time-server/go.sum
@@ -121,21 +137,16 @@ jobs:
                   go build -o fast-time-server .
                   chmod +x fast-time-server
 
-            - name: Start Fast Time Server as Background Service
+            - name: Start fast-time-server
               run: |
-                  # Kill any existing fast-time-server processes (container reuse cleanup)
-                  echo "Cleaning up any existing fast-time-server processes..."
                   pkill -9 -f "fast-time-server" 2>/dev/null || true
                   sleep 1
 
-                  # Start fast-time-server as a background service using nohup
-                  echo "Starting fast-time-server as background service..."
                   nohup mcp-servers/go/fast-time-server/fast-time-server \
                     -transport=dual -listen=0.0.0.0 -port=8080 -log-level=info \
                     > fast-time-server.log 2>&1 &
                   echo $! > fast-time-server.pid
 
-                  # Wait for fast-time-server to be ready
                   echo "Waiting for fast-time-server..."
                   for i in {1..30}; do
                     if curl -s http://localhost:8080/health >/dev/null 2>&1; then
@@ -146,7 +157,6 @@ jobs:
                     sleep 2
                   done
 
-                  # Verify server is running
                   if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
                     echo "ERROR: fast-time-server failed to start"
                     cat fast-time-server.log
@@ -154,17 +164,15 @@ jobs:
                   fi
                   echo "fast-time-server PID: $(cat fast-time-server.pid)"
 
-            - name: Register Fast Time Gateway and Create Tools
+            - name: Register gateway and create virtual server
               run: |
                   TOKEN="${{ steps.generate_jwt.outputs.token }}"
 
-                  # Verify fast-time-server is still running
                   if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
                     echo "ERROR: fast-time-server is not running"
                     cat fast-time-server.log
                     exit 1
                   fi
-                  echo "fast-time-server is running (PID: $(cat fast-time-server.pid))"
 
                   # Register gateway
                   echo "Registering fast_time gateway..."
@@ -204,11 +212,15 @@ jobs:
                     sleep 2
                   done
 
-                  # Get tool IDs
                   TOOLS=$(curl -s http://localhost:4444/tools \
                     -H "Authorization: Bearer $TOKEN")
                   TOOL_IDS=$(echo "$TOOLS" | jq --arg gid "$GATEWAY_ID" -c '[.[] | select(.gatewayId==$gid) | .id]')
                   echo "Tool IDs: $TOOL_IDS"
+
+                  if [ "$TOOL_IDS" = "[]" ] || [ -z "$TOOL_IDS" ]; then
+                    echo "ERROR: no tools synced from gateway"
+                    exit 1
+                  fi
 
                   # Create virtual server
                   echo "Creating virtual server..."
@@ -227,39 +239,30 @@ jobs:
                     }")
                   echo "Server response: $SERVER_RESPONSE"
 
-                  # Keep server running for wrapper test - no cleanup needed (container is ephemeral)
-
-            - name: Test Wrapper with Fast Time Server
+            - name: Build and test wrapper
               run: |
-                  echo "Building Rust wrapper..."
                   cd tools_rust/wrapper
-                  cargo build --release
+                  cargo build --release --features integration-test
                   cd -
-                  set -x
-                  pwd 
-                  stat ./tools_rust/wrapper/target/release/wrapper_integration
+
                   TOKEN="${{ steps.generate_jwt.outputs.token }}"
                   SERVER_ID="9779b6698cbd4b4995ee04a4fab38737"
-                  PORT="4444"
-                  URL="http://localhost:${PORT}/servers/${SERVER_ID}/mcp" 
-                  AUTH="Bearer $TOKEN" 
-                  WRAPPER_BIN="tools_rust/wrapper/target/release/mcp_stdio_wrapper"  
-                  URL="$URL" AUTH="$AUTH" WRAPPER_BIN="$WRAPPER_BIN" ./tools_rust/wrapper/target/release/wrapper_integration
+                  URL="http://localhost:4444/servers/${SERVER_ID}/mcp"
+                  AUTH="Bearer $TOKEN"
+                  WRAPPER_BIN="tools_rust/wrapper/target/release/mcp_stdio_wrapper"
+
+                  URL="$URL" AUTH="$AUTH" WRAPPER_BIN="$WRAPPER_BIN" \
+                    ./tools_rust/wrapper/target/release/wrapper_integration
+
                   echo "All wrapper tests passed!"
 
-            - name: Upload Wrapper Test Artifacts
+            - name: Upload logs on failure
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@v4
               with:
                   name: wrapper-test-logs
                   path: |
+                      fast-time-server.log
                       wrapper_output.json
                       wrapper_test.log
                   retention-days: 7
-
-            - name: Keep server running for debug - set true
-              if: false
-              run: |
-                  echo "Keeping server running for debugging..."
-                  sleep 3600
-                  echo "Debug period ended"

--- a/tools_rust/wrapper/Cargo.lock
+++ b/tools_rust/wrapper/Cargo.lock
@@ -23,6 +23,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +107,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +177,26 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -245,6 +285,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +343,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -639,6 +719,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +828,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -895,6 +1005,7 @@ dependencies = [
  "mockito",
  "nom",
  "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "tempfile",
@@ -980,6 +1091,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1096,6 +1219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1292,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1362,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1305,6 +1468,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1572,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1656,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,10 +2372,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2172,6 +2504,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/tools_rust/wrapper/Cargo.toml
+++ b/tools_rust/wrapper/Cargo.toml
@@ -35,6 +35,7 @@ base64 = "0.22.1"
 arc-swap = "1.8.1"
 mimalloc = "0.1.48"
 time = "0.3.47"
+rmcp = { version = "1.2.0", features = ["client", "transport-child-process"] }
 
 [dev-dependencies]
 mockito = "1.7.1"

--- a/tools_rust/wrapper/Cargo.toml
+++ b/tools_rust/wrapper/Cargo.toml
@@ -35,7 +35,15 @@ base64 = "0.22.1"
 arc-swap = "1.8.1"
 mimalloc = "0.1.48"
 time = "0.3.47"
-rmcp = { version = "1.2.0", features = ["client", "transport-child-process"] }
+rmcp = { version = "1.2.0", features = ["client", "transport-child-process"], optional = true }
+
+[features]
+integration-test = ["rmcp"]
+
+[[bin]]
+name = "wrapper_integration"
+path = "src/bin/wrapper_integration.rs"
+required-features = ["integration-test"]
 
 [dev-dependencies]
 mockito = "1.7.1"

--- a/tools_rust/wrapper/src/bin/wrapper_integration.rs
+++ b/tools_rust/wrapper/src/bin/wrapper_integration.rs
@@ -1,0 +1,65 @@
+use rmcp::{
+    ClientHandler, ServiceExt,
+    model::*,
+    transport::{ConfigureCommandExt, TokioChildProcess},
+};
+use std::env;
+use tokio::process::Command;
+
+#[derive(Clone, Debug, Default)]
+pub struct IntegrationClient;
+
+impl ClientHandler for IntegrationClient {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    check_fast_time_server().await?;
+    for (key, value) in env::vars() {
+        println!("ENV: {key} = {value}");
+    }
+    let client = IntegrationClient
+        .serve(TokioChildProcess::new(
+            Command::new(env::var("WRAPPER_BIN")?).configure(|cmd| {
+                cmd.args([
+                    "--url",
+                    &env::var("URL").unwrap(),
+                    "--auth",
+                    &env::var("AUTH").unwrap(),
+                    "--log-level",
+                    "debug",
+                ]);
+            }),
+        )?)
+        .await?;
+
+    let tools = client.list_all_tools().await?;
+    println!("{tools:?}");
+    if !tools.iter().any(|t| t.name == "fast-time-get-system-time") {
+        panic!("Tool not found");
+    }
+
+    let args = rmcp::object!({ "timezone": "UTC" });
+
+    let out = client
+        .call_tool(
+            CallToolRequestParams::new("fast-time-get-system-time").with_arguments(args), // Consumes the object
+        )
+        .await?;
+
+    println!("{out:?}");
+
+    client.cancel().await?;
+    Ok(())
+}
+
+async fn check_fast_time_server() -> Result<(), reqwest::Error> {
+    let body = reqwest::Client::new()
+        .get("http://localhost:8080/health")
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    println!("{}", body);
+    Ok(())
+}

--- a/tools_rust/wrapper/src/bin/wrapper_integration.rs
+++ b/tools_rust/wrapper/src/bin/wrapper_integration.rs
@@ -1,6 +1,6 @@
 use rmcp::{
     ClientHandler, ServiceExt,
-    model::*,
+    model::CallToolRequestParams,
     transport::{ConfigureCommandExt, TokioChildProcess},
 };
 use std::env;
@@ -34,22 +34,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let tools = client.list_all_tools().await?;
     println!("{tools:?}");
-    if !tools.iter().any(|t| t.name == "fast-time-get-system-time") {
-        panic!("Tool not found");
-    }
+    assert!(
+        tools.iter().any(|t| t.name == "fast-time-get-system-time"),
+        "Tool not found"
+    );
 
     let args = rmcp::object!({ "timezone": "UTC" });
 
-    let out = client
-        .call_tool(
-            CallToolRequestParams::new("fast-time-get-system-time").with_arguments(args), // Consumes the object
-        )
-        .await?;
+    for _ in 0..42 {
+        let out = client
+            .call_tool(
+                CallToolRequestParams::new("fast-time-get-system-time")
+                    .with_arguments(args.clone()),
+            )
+            .await?;
 
-    println!("{out:?}");
-
-    client.cancel().await?;
-    Ok(())
+        println!("{out:?}");
+        if !out.is_error.unwrap() {
+            client.cancel().await?;
+            return Ok(());
+        }
+    }
+    panic!("Fail");
 }
 
 async fn check_fast_time_server() -> Result<(), reqwest::Error> {
@@ -60,6 +66,6 @@ async fn check_fast_time_server() -> Result<(), reqwest::Error> {
         .text()
         .await?;
 
-    println!("{}", body);
+    println!("{body}");
     Ok(())
 }

--- a/tools_rust/wrapper/src/bin/wrapper_integration.rs
+++ b/tools_rust/wrapper/src/bin/wrapper_integration.rs
@@ -14,34 +14,36 @@ impl ClientHandler for IntegrationClient {}
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     check_fast_time_server().await?;
-    for (key, value) in env::vars() {
-        println!("ENV: {key} = {value}");
-    }
+
     let client = IntegrationClient
         .serve(TokioChildProcess::new(
-            Command::new(env::var("WRAPPER_BIN")?).configure(|cmd| {
-                cmd.args([
-                    "--url",
-                    &env::var("URL").unwrap(),
-                    "--auth",
-                    &env::var("AUTH").unwrap(),
-                    "--log-level",
-                    "debug",
-                ]);
-            }),
+            Command::new(env::var("WRAPPER_BIN").expect("WRAPPER_BIN env var required")).configure(
+                |cmd| {
+                    cmd.args([
+                        "--url",
+                        &env::var("URL").expect("URL env var required"),
+                        "--auth",
+                        &env::var("AUTH").expect("AUTH env var required"),
+                        "--log-level",
+                        "debug",
+                    ]);
+                },
+            ),
         )?)
         .await?;
 
     let tools = client.list_all_tools().await?;
-    println!("{tools:?}");
+    println!("Discovered {} tools", tools.len());
     assert!(
         tools.iter().any(|t| t.name == "fast-time-get-system-time"),
-        "Tool not found"
+        "Tool 'fast-time-get-system-time' not found in: {:?}",
+        tools.iter().map(|t| &t.name).collect::<Vec<_>>()
     );
 
     let args = rmcp::object!({ "timezone": "UTC" });
 
-    for _ in 0..42 {
+    // Retry up to 10 times to allow the wrapper to establish its upstream connection
+    for attempt in 1..=10 {
         let out = client
             .call_tool(
                 CallToolRequestParams::new("fast-time-get-system-time")
@@ -49,13 +51,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )
             .await?;
 
-        println!("{out:?}");
-        if !out.is_error.unwrap() {
+        if !out.is_error.unwrap_or(false) {
+            println!("Tool call succeeded on attempt {attempt}");
             client.cancel().await?;
             return Ok(());
         }
+        eprintln!("Tool call returned error on attempt {attempt}, retrying...");
     }
-    panic!("Fail");
+
+    client.cancel().await?;
+    panic!("Tool call failed after 10 attempts");
 }
 
 async fn check_fast_time_server() -> Result<(), reqwest::Error> {
@@ -66,6 +71,6 @@ async fn check_fast_time_server() -> Result<(), reqwest::Error> {
         .text()
         .await?;
 
-    println!("{body}");
+    println!("fast-time-server health: {body}");
     Ok(())
 }


### PR DESCRIPTION
Added workflow to test wrapper with running mcpgateway with fast time server tool.

<!--
For specialized templates, append to your PR URL:
  ?template=feature.md   - New features
Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
https://github.com/IBM/mcp-context-forge/issues/1618
Closes #1618 

---

## 📝 Summary

*    Chores
        Added a CI/CD workflow to automate multi-language environment setup, build, service orchestration, and test execution with robust readiness checks and retries.
        Uploads artifacts on failure and supports optional debugging modes to keep services running.

 *   Tests
        Added scripts to run wrapper integration tests (including service health checks and authenticated calls) locally or in CI.

* Adds comprehensive GitHub Actions CI/CD workflow for Rust wrapper testing
* Implement automated testing with gateway, fast-time server, and wrapper integration
* It is possible to run workflow locally with act tool
* JWT token generation with random salt, not dependent on any hard coded values
---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests               | `make test`     |        |
| Coverage ≥ 80%  | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
The act may be used for local workflow execution, if the act tool usage is plausible.
```
act --pull=false -W .github/workflows/wrapper.yml
```
The --pull=false means that no docker images should be pulled by act, and this means that no docker hub login is required, but on other hand the images for local workflow execution should be pulled beforehand.
```
docker pull catthehacker/ubuntu:act-latest
```
Currently this feature is not part of the PR, but the comands are simple and they are in this comment.
The workflow starts mcpgateway, compiles fast time server, starts fast time server, creates tools and virutal servers with curl, compiles wrapper and runs the integration test with validation of results.