### PR TITLE
fix(plugins): add enforce_ignore_error to plugins admin dropdown

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -25887,7 +25887,8 @@ function initializePluginFunctions() {
                             <h4 class="font-medium text-gray-700 dark:text-gray-300">Mode</h4>
                             <p class="mt-1">
                                 <span class="px-2 py-1 text-xs rounded-full ${
-                                    plugin.mode === "enforce"
+                                    plugin.mode === "enforce" ||
+                                    plugin.mode === "enforce_ignore_error"
                                         ? "bg-red-100 text-red-800"
                                         : plugin.mode === "permissive"
                                           ? "bg-yellow-100 text-yellow-800"

--- a/mcpgateway/templates/plugins_partial.html
+++ b/mcpgateway/templates/plugins_partial.html
@@ -213,6 +213,7 @@
         >
           <option value="">All Modes</option>
           <option value="enforce">Enforce</option>
+          <option value="enforce_ignore_error">Enforce Ignore Error</option>
           <option value="permissive">Permissive</option>
           <option value="disabled">Disabled</option>
         </select>
@@ -305,6 +306,12 @@
           class="px-2 py-1 bg-red-100 text-red-800 text-xs font-medium rounded dark:bg-red-900 dark:text-red-200"
         >
           Enforce
+        </span>
+        {% elif plugin.mode == 'enforce_ignore_error' %}
+        <span
+          class="px-2 py-1 bg-red-100 text-red-800 text-xs font-medium rounded dark:bg-red-900 dark:text-red-200"
+        >
+          Enforce Ignore Error
         </span>
         {% elif plugin.mode == 'permissive' %}
         <span

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -64,7 +64,7 @@ plugins:
     author: "Mihai Criveti"
     hooks: ["prompt_pre_fetch", "prompt_post_fetch", "tool_pre_invoke", "tool_post_invoke"]
     tags: ["security", "pii", "compliance", "filter", "gdpr", "hipaa"]
-    mode: "disabled"  # enforce | permissive | disabled
+    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 50  # Lower number = higher priority (runs first)
     conditions:
       - prompts: []  # Empty list = apply to all prompts
@@ -99,7 +99,7 @@ plugins:
     author: "Mihai Criveti"
     hooks: ["prompt_pre_fetch", "prompt_post_fetch", "tool_pre_invoke", "tool_post_invoke"]
     tags: ["plugin", "transformer", "regex", "search-and-replace", "pre-post"]
-    mode: "disabled"  # enforce | permissive | disabled
+    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 150
     conditions:
       # Apply to specific tools/servers
@@ -121,7 +121,7 @@ plugins:
     author: "Mihai Criveti"
     hooks: ["prompt_pre_fetch"]
     tags: ["plugin", "filter", "denylist", "pre-post"]
-    mode: "disabled"  # enforce | permissive | disabled
+    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 100
     conditions:
       # Apply to specific tools/servers
@@ -820,7 +820,7 @@ plugins:
     author: "Adrian Popa"
     hooks: ["tool_pre_invoke"]
     tags: ["security", "vault", "OAUTH2"]
-    mode: "disabled"  # enforce | permissive | disabled
+    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 10
     conditions:
       - prompts: []
@@ -943,7 +943,7 @@ plugins:
     author: "Jason Tsay"
     hooks: ["tool_post_invoke"]
     tags: ["plugin"]
-    mode: "disabled"  # enforce | permissive | disabled
+    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 150
     conditions:
       # Apply to specific tools/servers
@@ -973,7 +973,7 @@ plugins:
     author: "Bar Haim"
     hooks: ["tool_pre_invoke", "tool_post_invoke"]
     tags: ["telemetry", "observability", "opentelemetry", "monitoring"]
-    mode: "disabled" # enforce | permissive | disabled
+    mode: "disabled" # enforce | enforce_ignore_error | permissive | disabled
     priority: 200  # Run late to capture all context
     conditions: []  # Apply to all tools
     config:
@@ -988,7 +988,7 @@ plugins:
     author: "Joe Stein"
     hooks: ["tool_post_invoke"]
     tags: ["optimization", "tokens", "encoding", "toon", "llm"]
-    mode: "disabled"  # enforce | permissive | disabled
+    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 900  # Run very late, after all other post-processing
     conditions: []  # Apply to all tools
     config:

--- a/tests/js/admin-plugin-filters.test.js
+++ b/tests/js/admin-plugin-filters.test.js
@@ -191,6 +191,21 @@ function buildPluginsDOM() {
     card2.appendChild(viewBtn2);
     grid.appendChild(card2);
 
+    const card3 = doc.createElement("div");
+    card3.className = "plugin-card";
+    card3.dataset.name = "http-header-filter";
+    card3.dataset.description = "filter sensitive http headers";
+    card3.dataset.author = "ibm";
+    card3.dataset.mode = "enforce_ignore_error";
+    card3.dataset.status = "enabled";
+    card3.dataset.hooks = "request_hook,response_hook";
+    card3.dataset.tags = "security,headers";
+    const viewBtn3 = doc.createElement("button");
+    viewBtn3.dataset.showPlugin = "http-header-filter";
+    viewBtn3.textContent = "View Details";
+    card3.appendChild(viewBtn3);
+    grid.appendChild(card3);
+
     partial.append(
         hookBadgeAll,
         hookBadgeRequest,
@@ -220,6 +235,7 @@ function buildPluginsDOM() {
         authorBadgeIbm,
         card1,
         card2,
+        card3,
         viewBtn1,
         viewBtn2,
         modal,
@@ -269,19 +285,20 @@ describe("A. initializePluginFunctions() sets up listeners", () => {
 
 describe("B. filterPlugins search filtering", () => {
     test("searching for 'header' hides card that does not match", () => {
-        const { searchInput, card1, card2 } = buildPluginsDOM();
+        const { searchInput, card1, card2, card3 } = buildPluginsDOM();
         win.initializePluginFunctions();
 
         searchInput.value = "header";
         searchInput.dispatchEvent(new win.Event("input", { bubbles: true }));
 
-        // card1 name/desc contains "header", card2 does not
+        // card1 and card3 name/desc contain "header", card2 does not
         expect(card1.style.display).not.toBe("none");
         expect(card2.style.display).toBe("none");
+        expect(card3.style.display).not.toBe("none");
     });
 
     test("clearing search shows all cards", () => {
-        const { searchInput, card1, card2 } = buildPluginsDOM();
+        const { searchInput, card1, card2, card3 } = buildPluginsDOM();
         win.initializePluginFunctions();
 
         // First filter
@@ -294,10 +311,11 @@ describe("B. filterPlugins search filtering", () => {
         searchInput.dispatchEvent(new win.Event("input", { bubbles: true }));
         expect(card1.style.display).toBe("block");
         expect(card2.style.display).toBe("block");
+        expect(card3.style.display).toBe("block");
     });
 
     test("mode filter hides cards with different mode", () => {
-        const { modeFilter, card1, card2 } = buildPluginsDOM();
+        const { modeFilter, card1, card2, card3 } = buildPluginsDOM();
         win.initializePluginFunctions();
 
         // Add the option so the select value can actually be set
@@ -309,9 +327,28 @@ describe("B. filterPlugins search filtering", () => {
         modeFilter.dispatchEvent(new win.Event("change", { bubbles: true }));
 
         // card1 mode=enforce, card2 mode=permissive
-        expect(card1.style.display).not.toBe("none");
+        expect(card1.style.display).toBe("block");
         expect(card2.style.display).toBe("none");
+        expect(card3.style.display).toBe("none");
     });
+    test("mode filter select enforce_ignore_error card", () => {
+        const { modeFilter, card1, card2, card3 } = buildPluginsDOM();
+        win.initializePluginFunctions();
+
+        // Add the option so the select value can actually be set
+        const enforceOpt = doc.createElement("option");
+        enforceOpt.value = "enforce_ignore_error";
+        modeFilter.appendChild(enforceOpt);
+
+        modeFilter.value = "enforce_ignore_error";
+        modeFilter.dispatchEvent(new win.Event("change", { bubbles: true }));
+
+        // card1 mode=enforce, card2 mode=permissive. card3 mode=enforce_ignore_error
+        expect(card1.style.display).toBe("none");
+        expect(card2.style.display).toBe("none");
+        expect(card3.style.display).toBe("block");
+    });
+
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🔗 Related Issue
Closes #3119

---

## 📝 Summary

The `enforce_ignore_error` plugin mode existed in the backend but was missing from the Admin UI. This caused the mode filter dropdown to not include it, mode badges to render incorrectly, and the plugin config comments to be outdated.

- Added `enforce_ignore_error` option to the mode filter dropdown in the plugins admin panel
- Added a styled badge for `enforce_ignore_error` in the server-rendered plugin list (red, matching `enforce`)
- Updated `admin.js` dynamic badge logic so `enforce_ignore_error` also renders red
- Updated inline comments in `plugins/config.yaml` to document all four valid mode values
- Added JS unit tests covering filter and badge rendering for `enforce_ignore_error`

---

## 🏷️ Type of Change
- [x] Bug fix

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅     |
| Unit tests                | `make test`     | ✅     |
| Coverage ≥ 80%            | `make coverage` | ✅     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed
