### PR TITLE
fix: handle ResourceNotFoundError when the resource is not found

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -6343,7 +6343,7 @@ async def handle_rpc(request: Request, db: Session = Depends(get_db), user=Depen
                     result = {"contents": [result.model_dump(by_alias=True, exclude_none=True)]}
                 else:
                     result = {"contents": [result]}
-            except ValueError:
+            except (ValueError, ResourceNotFoundError):
                 # Resource not found in the gateway
                 logger.error(f"Resource not found: {uri}")
                 raise JSONRPCError(-32002, f"Resource not found: {uri}", {"uri": uri})

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1998,6 +1998,28 @@ class TestRPCEndpoints:
         assert body["error"]["code"] == -32002
         assert "Resource not found" in body["error"]["message"]
 
+    @patch("mcpgateway.main.resource_service.read_resource", new_callable=AsyncMock)
+    def test_rpc_resources_read_not_found_error(self, mock_read, test_client, auth_headers):
+        """Test resources/read returns -32002 when ResourceNotFoundError is raised."""
+        from mcpgateway.services.resource_service import ResourceNotFoundError
+
+        mock_read.side_effect = ResourceNotFoundError("Resource template not found for 'file:///nonexistent/bad-resource'")
+
+        req = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "method": "resources/read",
+            "params": {"uri": "file:///nonexistent/bad-resource"},
+        }
+        response = test_client.post("/rpc/", json=req, headers=auth_headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "error" in body
+        assert body["error"]["code"] == -32002
+        assert "Resource not found" in body["error"]["message"]
+        assert body["error"]["message"] != "Internal error"
+
     @patch("mcpgateway.main.get_user_email", return_value="user_1")
     @patch("mcpgateway.main.resource_service.subscribe_resource", new_callable=AsyncMock)
     @patch("mcpgateway.main.resource_service.unsubscribe_resource", new_callable=AsyncMock)


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

The bug was found during manual testing of the issue https://github.com/IBM/mcp-context-forge/issues/2419

The except `ValueError` on line 6329 never catches the actual exception thrown by resource_service.read_resource(), which is `ResourceNotFoundError` (inherits from `ResourceError` → `Exception`, not `ValueError`). So the exception falls through to the generic catch-all at line ~6763, which returns:

```bash
{"code": -32000, "message": "Internal error", "data": "Resource template not found for '...'"}
```

## 🔁 Reproduction Steps

1. Make a request to 
```bash
curl -s -X POST http://localhost:8080/rpc \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $TOKEN" \
    -d '{
      "jsonrpc": "2.0",
      "method": "resources/read",
      "params": {
        "uri": "file:///nonexistent/bad-resource"
      },
      "id": 1
    }' | python -m json.tool
```

2. Returns

**BEFORE**
```bash
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32000,
        "message": "Internal error",
        "data": "Resource template not found for 'file:///nonexistent/bad-resource'"
    },
    "id": 1
}
```

**AFTER**
```bash
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32002,
        "message": "Resource not found: file:///nonexistent/bad-resource",
        "data": {
            "uri": "file:///nonexistent/bad-resource"
        }
    },
    "id": 1
}
```


## 💡 Fix Description

Changed except `ValueError` → `except (ValueError, ResourceNotFoundError)` so the handler now properly catches the service-layer exception and returns the clear error:
```bash
  {"code": -32002, "message": "Resource not found: file:///nonexistent/bad-resource", "data": {"uri": "file:///nonexistent/bad-resource"}}
```

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅     |
| Unit tests                            | `make test`          |    ✅     |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅     |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
