### PR TITLE
fix: resolve JS syntax error in pagination and login redirect loop

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -105,6 +105,7 @@ recursive-include plugins_rust *.py
 recursive-include plugins_rust *.pyi
 recursive-include plugins_rust *.lock
 recursive-include plugins_rust Makefile
+exclude plugins_rust/Cargo.lock
 prune plugins_rust/target
 
 # 5️⃣  (Optional) include MKDocs-based docs in the sdist

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -437,9 +437,21 @@ The `/tools` endpoint supports several query parameters for filtering and pagina
 curl -s -H "Authorization: Bearer $TOKEN" \
   "$BASE_URL/tools?gateway_id=<gateway-id>" | jq '.'
 
+# Get tools not associated with any gateway (REST tools, A2A agents, etc.)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/tools?gateway_id=null" | jq '.'
+
+# Filter by visibility
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/tools?visibility=public" | jq '.'
+
 # Filter by tags (paginated)
 curl -s -H "Authorization: Bearer $TOKEN" \
   "$BASE_URL/tools?tags=api,data" | jq '.'
+
+# Combine filters: all public tools from a specific gateway
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/tools?gateway_id=<gateway-id>&visibility=public&limit=0" | jq '.'
 
 # Get up to 100 tools per page
 curl -s -H "Authorization: Bearer $TOKEN" \
@@ -761,6 +773,36 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "$BASE_URL/resources?include_pagination=false" | jq '.'
 ```
 
+#### Filtering and Pagination
+
+The `/resources` endpoint supports several query parameters for filtering and pagination:
+
+| Parameter | Description |
+|-----------|-------------|
+| `tags` | Comma-separated list of tags to filter by (matches any). |
+| `visibility` | Filter by visibility: `private`, `team`, or `public`. |
+| `team_id` | Filter by team ID. |
+| `include_inactive` | Include disabled resources (default: `false`). |
+| `limit` | Maximum resources to return. Use `0` for all resources (no limit). Default: 50. |
+| `cursor` | Pagination cursor for fetching the next page. |
+| `include_pagination` | Return paginated format with cursor (default: `true`). Set to `false` for array only. |
+
+**Examples:**
+
+```bash
+# Filter by visibility
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/resources?visibility=public" | jq '.'
+
+# Filter by tags
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/resources?tags=config,database" | jq '.'
+
+# Get ALL resources (no pagination - returns all as array)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/resources?limit=0&include_pagination=false" | jq '.'
+```
+
 ### Register a Resource
 
 ```bash
@@ -888,6 +930,36 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" \
   "$BASE_URL/prompts?include_pagination=false" | jq '.'
+```
+
+#### Filtering and Pagination
+
+The `/prompts` endpoint supports several query parameters for filtering and pagination:
+
+| Parameter | Description |
+|-----------|-------------|
+| `tags` | Comma-separated list of tags to filter by (matches any). |
+| `visibility` | Filter by visibility: `private`, `team`, or `public`. |
+| `team_id` | Filter by team ID. |
+| `include_inactive` | Include disabled prompts (default: `false`). |
+| `limit` | Maximum prompts to return. Use `0` for all prompts (no limit). Default: 50. |
+| `cursor` | Pagination cursor for fetching the next page. |
+| `include_pagination` | Return paginated format with cursor (default: `true`). Set to `false` for array only. |
+
+**Examples:**
+
+```bash
+# Filter by visibility
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/prompts?visibility=public" | jq '.'
+
+# Filter by tags
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/prompts?tags=template,greeting" | jq '.'
+
+# Get ALL prompts (no pagination - returns all as array)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/prompts?limit=0&include_pagination=false" | jq '.'
 ```
 
 ### Register a Prompt

--- a/llms/api.md
+++ b/llms/api.md
@@ -154,6 +154,8 @@ PY
 - `tags` (comma‑separated or repeated): filter by tag.
 - `team_id` (str): team scoping.
 - `visibility` (str): `private|team|public`.
+- `gateway_id` (str): filter by physical gateway ID (`/tools` only). Use `null` for tools without a gateway.
+- `limit` (int): max items to return. Use `0` for all (no limit). Default: 50.
 
 **Auth & Errors**
 - 401 Unauthorized when the bearer token is missing/invalid.

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -3769,17 +3769,23 @@ async def admin_login_page(request: Request) -> Response:
     root_path = settings.app_root_path
 
     # Check if user is already authenticated via JWT cookie
-    jwt_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
-    if jwt_token:
-        try:
-            # Verify the token is valid
-            payload = await verify_jwt_token_cached(jwt_token, request)
-            if payload:
-                # User is authenticated, redirect to dashboard
-                return RedirectResponse(url=f"{root_path}/admin", status_code=303)
-        except (HTTPException, jwt.PyJWTError):
-            # Token is invalid or expired, continue to show login page
-            pass
+    # Skip redirect when an error param is present — the user was sent here
+    # intentionally (e.g. admin_required, account_disabled).
+    if not request.query_params.get("error"):
+        jwt_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
+        if jwt_token:
+            try:
+                payload = await verify_jwt_token_cached(jwt_token, request)
+                if payload:
+                    # Only redirect if the token indicates admin privileges;
+                    # otherwise the middleware will reject and redirect back here,
+                    # creating an infinite redirect loop.
+                    is_admin = payload.get("is_admin", False) or payload.get("user", {}).get("is_admin", False)
+                    if is_admin:
+                        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+            except (HTTPException, jwt.PyJWTError):
+                # Token is invalid or expired, continue to show login page
+                pass
 
     # Only show secure cookie warning if there's a login error AND problematic config
     secure_cookie_warning = None

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2505,7 +2505,8 @@
             'total_items': total_items,
             'total_pages': total_pages,
             'has_prev': has_prev,
-            'has_next': has_next
+            'has_next': has_next,
+            'page_items': None
           } %}
 
           {# build the refresh URL for controls #}
@@ -3497,7 +3498,8 @@
             'total_items': total_items,
             'total_pages': total_pages,
             'has_prev': has_prev,
-            'has_next': has_next
+            'has_next': has_next,
+            'page_items': None
           } %}
 
           {# build the refresh URL for controls #}
@@ -5044,7 +5046,8 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
             'total_items': total_items,
             'total_pages': total_pages,
             'has_prev': has_prev,
-            'has_next': has_next
+            'has_next': has_next,
+            'page_items': None
           } %}
 
           {# build the refresh URL for controls #}
@@ -6701,7 +6704,8 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
               'total_items': total_items,
               'total_pages': total_pages,
               'has_prev': has_prev,
-              'has_next': has_next
+              'has_next': has_next,
+              'page_items': None
             } %}
 
             {# build the refresh URL for controls #}
@@ -6847,7 +6851,8 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
               'total_items': total_items,
               'total_pages': total_pages,
               'has_prev': has_prev,
-              'has_next': has_next
+              'has_next': has_next,
+              'page_items': None
             } %}
 
             {# build the refresh URL for controls #}


### PR DESCRIPTION
## Summary

- **Pagination JS error**: `pagination_controls.html` references `pagination.page_items` but the 5 inline pagination dicts in `admin.html` didn't include it. Jinja2 rendered `Undefined` as empty string producing invalid JS (`pageItems: ,`). Added `'page_items': None` to all inline pagination dicts. Regression from #3238.
- **Login redirect loop**: `admin_login_page()` redirected any authenticated user to `/admin` without checking admin privileges, causing `ERR_TOO_MANY_REDIRECTS` for non-admin users. Now checks `is_admin` in JWT payload and skips redirect when `error` query params are present. Regression from #3461.
- **MANIFEST.in**: Excluded gitignored `plugins_rust/Cargo.lock` that was matched by `recursive-include *.lock`, fixing `make verify`.
- **Docs**: Added filtering/pagination docs for `/resources` and `/prompts` endpoints, and `gateway_id`/`limit` params to `llms/api.md`.

## Test plan
- [x] All 9 previously failing Playwright tests now pass
- [x] `make verify` passes
- [x] `make test` passes (14,301 tests)