### PR TITLE
[FIX][UI]: Fix message animation being incorrect in LLM Chat

### DIFF
--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -632,14 +632,13 @@
 
 /* Welcome Message Animations */
 #chat-welcome-message {
-    animation: fade-in 0.5s ease-in;
+   animation: fade-in-welcome 0.5s ease-in;
 }
 
-@keyframes fade-in {
+@keyframes fade-in-welcome {
     from {
         opacity: 0;
     }
-
     to {
         opacity: 1;
     }

--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -639,6 +639,7 @@
     from {
         opacity: 0;
     }
+    
     to {
         opacity: 1;
     }

--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -632,14 +632,14 @@
 
 /* Welcome Message Animations */
 #chat-welcome-message {
-   animation: fade-in-welcome 0.5s ease-in;
+    animation: fade-in-welcome 0.5s ease-in;
 }
 
 @keyframes fade-in-welcome {
     from {
         opacity: 0;
     }
-    
+
     to {
         opacity: 1;
     }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -1936,7 +1936,7 @@
               class="bg-white dark:bg-gray-800 shadow-xl rounded-xl border border-gray-200 dark:border-gray-700 flex flex-col overflow-hidden h-[calc(100vh-12rem)]">
               <!-- Chat Messages Area -->
               <div id="chat-messages-container"
-                class="flex-1 overflow-y-auto p-5 bg-gray-50 dark:bg-gray-900 space-y-4">
+                class="flex flex-col flex-1 overflow-y-auto p-5 bg-gray-50 dark:bg-gray-900 space-y-4">
                 <div id="chat-welcome-message" class="flex items-center justify-center h-full">
                   <div class="text-center max-w-md">
                     <div


### PR DESCRIPTION
Signed-off-by: Claudia Gray [[claudiag082004@gmail.com](mailto:claudiag082004@gmail.com)](mailto:claudiag082004@gmail.com)

<!--
For specialized templates, append to your PR URL:
?template=bug_fix.md   - Bug fixes
?[[template=feature.md](http://template=feature.md/)](http://template=feature.md/)   - New features
?[[template=docs.md](http://template=docs.md/)](http://template=docs.md/)      - Documentation
?[[template=plugin.md](http://template=plugin.md/)](http://template=plugin.md/)    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes https://github.com/IBM/mcp-context-forge/issues/3627

---

## 📝 Summary

This PR fixes the animation for the welcome message when initially opening LLM Chat by stopping it from loading on the left before moving to centre. Shows before and after in Videos section below.

---

## 🏷️ Type of Change

- [x]  Bug fix
- [ ]  Feature / Enhancement
- [ ]  Documentation
- [ ]  Refactor
- [ ]  Chore (deps, CI, tooling)
- [ ]  Other (describe below)

---

## Fixed By

In admin.css line ~633 -> 645
Rename "fade-in" to "fade-in-welcome" in two places as "fade-in" animation for tooltip was overwriting the one needed for welcome message.

admin.html line ~1939
Add "flex flex-col" so the h-full on line 1940 works for vertical centering.

## 🧪 Verification

Passed all tests ran by file here on slack: https://ibm-cloud.slack.com/archives/C0A71H6HMAN/p1772704889538949
They are:
**Format** - autoflake · isort · black  
**Unit Test** - flake8 · bandit · interrogate · doctest · test · lint-web · pylint · verify 
**Coverage** - make coverage results in 99%


---

## 📓 Videos

### Video of original issue from https://github.com/IBM/mcp-context-forge/issues/3627 :

https://github.com/user-attachments/assets/ee187b6c-e703-468a-8263-444c981273d3

### Video of fixed version:

https://github.com/user-attachments/assets/64bcc2f9-b1a1-4e9a-923f-9eb2b93656eb