### PR TITLE
feat(security): container image scanner - earlier iteration (#2216)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -15688,6 +15688,27 @@ async def get_plugins_partial(request: Request, db: Session = Depends(get_db), u
         return HTMLResponse(content=error_html, status_code=500)
 
 
+@admin_router.get("/container-scanner/partial", response_class=HTMLResponse)
+async def container_scanner_partial(
+    request: Request,
+    _user=Depends(get_current_user_with_permissions),
+) -> Any:
+    """Render the container scanner scan results partial."""
+    try:
+        # First-Party
+        from plugins.container_scanner.storage.repository import container_scan_repo  # pylint: disable=import-outside-toplevel
+
+        results = container_scan_repo.list_recent()
+    except Exception:
+        results = []
+    root_path = request.scope.get("root_path", "")
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "container_scanner_partial.html",
+        {"request": request, "results": results, "root_path": root_path},
+    )
+
+
 @admin_router.get("/plugins", response_model=PluginListResponse)
 @require_permission("admin.plugins", allow_admin_bypass=False)
 async def list_plugins(

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -7711,6 +7711,17 @@ app.include_router(metrics_router)
 app.include_router(tag_router)
 app.include_router(export_import_router)
 
+# Include container scanner router if plugins are enabled
+if _PLUGINS_ENABLED:
+    try:
+        # First-Party
+        from mcpgateway.routers.container_scanner_router import container_scanner_router  # pylint: disable=import-outside-toplevel
+
+        app.include_router(container_scanner_router)
+        logger.info("Container scanner router included")
+    except ImportError as e:
+        logger.warning(f"Failed to import container scanner router: {e}")
+
 # Include log search router if structured logging is enabled
 if getattr(settings, "structured_logging_enabled", True):
     try:

--- a/mcpgateway/plugins/framework/__init__.py
+++ b/mcpgateway/plugins/framework/__init__.py
@@ -61,6 +61,7 @@ from mcpgateway.plugins.framework.models import (
     PluginResult,
     PluginViolation,
 )
+from mcpgateway.plugins.framework.hooks.gateway import GatewayHookType, ServerPreRegisterPayload, ServerPreRegisterResult, RuntimePreDeployPayload, RuntimePreDeployResult
 from mcpgateway.plugins.framework.utils import get_attr
 
 # Plugin manager singleton (lazy initialization)
@@ -115,6 +116,7 @@ __all__ = [
     "get_attr",
     "get_hook_registry",
     "get_plugin_manager",
+    "GatewayHookType",
     "GlobalContext",
     "HookRegistry",
     "HttpAuthCheckPermissionPayload",
@@ -154,6 +156,10 @@ __all__ = [
     "ResourcePostFetchResult",
     "ResourcePreFetchPayload",
     "ResourcePreFetchResult",
+    "RuntimePreDeployPayload",
+    "RuntimePreDeployResult",
+    "ServerPreRegisterPayload",
+    "ServerPreRegisterResult",
     "ToolHookType",
     "ToolPostInvokePayload",
     "ToolPostInvokeResult",

--- a/mcpgateway/plugins/framework/hooks/gateway.py
+++ b/mcpgateway/plugins/framework/hooks/gateway.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/plugins/hooks/gateway.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Gateway lifecycle hook definitions for the plugin framework.
+
+Defines the two hook points at which plugins can intercept container
+image assessments before a server is registered or deployed:
+
+- ``server_pre_register`` — fired when a new MCP server is being registered
+  with the gateway.  Plugins can inspect the image and block registration.
+- ``runtime_pre_deploy`` — fired at runtime just before an image is activated.
+  Plugins can re-evaluate policy and block deployment.
+
+Both hooks share the same payload shape (:class:`ServerPreRegisterPayload` /
+:class:`RuntimePreDeployPayload`) and are registered into the global hook
+registry on module import via :func:`_register_plugin_hooks`.
+"""
+
+# Standard
+from enum import Enum
+from typing import Optional
+
+# Third-Party
+from pydantic import Field
+
+# First-Party
+from mcpgateway.plugins.framework.models import PluginPayload, PluginResult
+
+
+class GatewayHookType(str, Enum):
+    """Enumeration of gateway lifecycle hook identifiers.
+
+    Values are used as keys when registering and dispatching hooks through
+    the :class:`~mcpgateway.plugins.framework.hooks.registry.HookRegistry`.
+
+    Attributes:
+        SERVER_PRE_REGISTER: Hook fired before a new MCP server is registered.
+        RUNTIME_PRE_DEPLOY: Hook fired before an image is activated at runtime.
+    """
+
+    SERVER_PRE_REGISTER = "server_pre_register"
+    RUNTIME_PRE_DEPLOY = "runtime_pre_deploy"
+
+
+class ServerPreRegisterPayload(PluginPayload):
+    """Payload delivered to plugins at the ``server_pre_register`` hook point.
+
+    Carries the identity of the container image being registered so that
+    plugins (e.g. :class:`~plugins.container_scanner.ContainerScannerPlugin`)
+    can inspect it and decide whether to allow or block registration.
+
+    Attributes:
+        assessment_id: Unique identifier for this assessment request (UUID).
+        image_ref: Full OCI image reference, e.g. ``"ghcr.io/org/app:v1"``.
+        image_digest: Optional SHA-256 digest, e.g.
+            ``"sha256:abc123..."``.  When provided, enables digest-keyed
+            caching in scanner plugins.
+    """
+
+    assessment_id: str
+    image_ref: str
+    image_digest: Optional[str] = Field(default=None)
+
+
+class RuntimePreDeployPayload(PluginPayload):
+    """Payload delivered to plugins at the ``runtime_pre_deploy`` hook point.
+
+    Identical in structure to :class:`ServerPreRegisterPayload` but fired
+    at a later lifecycle stage — when the gateway is about to activate an
+    already-registered image.  This allows plugins to re-evaluate policy
+    (e.g. after a CVE database update) without waiting for re-registration.
+
+    Attributes:
+        assessment_id: Unique identifier for this assessment request (UUID).
+        image_ref: Full OCI image reference, e.g. ``"ghcr.io/org/app:v1"``.
+        image_digest: Optional SHA-256 digest used for cache lookup.
+    """
+
+    assessment_id: str
+    image_ref: str
+    image_digest: Optional[str] = Field(default=None)
+
+
+ServerPreRegisterResult = PluginResult[ServerPreRegisterPayload]
+"""Concrete result type for the ``server_pre_register`` hook.
+
+A ``continue_processing=False`` result with a populated ``violation`` field
+will cause the gateway to reject the registration request.
+"""
+
+RuntimePreDeployResult = PluginResult[RuntimePreDeployPayload]
+"""Concrete result type for the ``runtime_pre_deploy`` hook.
+
+A ``continue_processing=False`` result with a populated ``violation`` field
+will cause the gateway to block deployment of the image.
+"""
+
+
+def _register_plugin_hooks() -> None:
+    """Register gateway hook types into the global hook registry.
+
+    Called once on module import.  Uses an idempotency guard
+    (``is_registered``) so that repeated imports in tests do not
+    register duplicate handlers.
+    """
+    # First-Party
+    from mcpgateway.plugins.framework.hooks.registry import get_hook_registry  # pylint: disable=import-outside-toplevel
+
+    registry = get_hook_registry()
+    if not registry.is_registered(GatewayHookType.SERVER_PRE_REGISTER):
+        registry.register_hook(GatewayHookType.SERVER_PRE_REGISTER, ServerPreRegisterPayload, ServerPreRegisterResult)
+        registry.register_hook(GatewayHookType.RUNTIME_PRE_DEPLOY, RuntimePreDeployPayload, RuntimePreDeployResult)
+
+
+_register_plugin_hooks()

--- a/mcpgateway/routers/container_scanner_router.py
+++ b/mcpgateway/routers/container_scanner_router.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/container_scanner_router.py
+
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+FastAPI Router for Container Scanner Results API.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any, Dict, List, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+# First-Party
+from mcpgateway.auth import get_current_user
+
+container_scanner_router = APIRouter(
+    prefix="/container-scanner",
+    tags=["Container Scanner"],
+    dependencies=[Depends(get_current_user)],
+)
+
+
+class SummaryResponse(BaseModel):
+    """CVE severity counts for a single scan result."""
+
+    critical_count: int
+    high_count: int
+    medium_count: int
+    low_count: int
+
+
+class VulnerabilityResponse(BaseModel):
+    """API representation of a single CVE finding."""
+
+    cve_id: str
+    severity: str
+    package_name: str
+    installed_version: str
+    fixed_version: Optional[str]
+    description: Optional[str]
+
+
+class ScanResultResponse(BaseModel):
+    """API representation of one container scan result."""
+
+    image_ref: str
+    image_digest: Optional[str]
+    scanners: str
+    scan_time: str
+    duration_ms: int
+    blocked: bool
+    reason: Optional[str]
+    scan_error: Optional[str]
+    summary: SummaryResponse
+    vulnerability_count: int
+    vulnerabilities: List[VulnerabilityResponse]
+
+
+def _to_response(result: Any) -> ScanResultResponse:
+    """Convert a ScanResult domain object to the API response model."""
+    scan_time = result.scan_time
+    if hasattr(scan_time, "isoformat"):
+        scan_time_str = scan_time.isoformat()
+    else:
+        scan_time_str = str(scan_time)
+
+    return ScanResultResponse(
+        image_ref=result.image_ref,
+        image_digest=result.image_digest,
+        scanners=result.scanners,
+        scan_time=scan_time_str,
+        duration_ms=result.duration_ms,
+        blocked=result.blocked,
+        reason=result.reason,
+        scan_error=result.scan_error,
+        summary=SummaryResponse(
+            critical_count=result.summary.critical_count,
+            high_count=result.summary.high_count,
+            medium_count=result.summary.medium_count,
+            low_count=result.summary.low_count,
+        ),
+        vulnerability_count=len(result.vulnerabilities),
+        vulnerabilities=[
+            VulnerabilityResponse(
+                cve_id=v.cve_id,
+                severity=v.severity,
+                package_name=v.package_name,
+                installed_version=v.installed_version,
+                fixed_version=v.fixed_version,
+                description=v.description,
+            )
+            for v in result.vulnerabilities
+        ],
+    )
+
+
+@container_scanner_router.get("/scans", response_model=List[ScanResultResponse])
+async def list_scans(
+    current_user: Dict[str, Any] = Depends(get_current_user),
+) -> List[ScanResultResponse]:
+    """Return all recent container scan results, most recent first."""
+    # First-Party
+    from plugins.container_scanner.storage.repository import container_scan_repo  # pylint: disable=import-outside-toplevel
+
+    return [_to_response(r) for r in container_scan_repo.list_recent()]
+
+
+@container_scanner_router.get("/scans/{image_ref:path}", response_model=ScanResultResponse)
+async def get_scan(
+    image_ref: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+) -> ScanResultResponse:
+    """Return the scan result for a specific image reference or digest."""
+    # First-Party
+    from plugins.container_scanner.storage.repository import container_scan_repo  # pylint: disable=import-outside-toplevel
+
+    result = container_scan_repo.get(image_ref)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"No scan result found for '{image_ref}'")
+    return _to_response(result)
+
+
+@container_scanner_router.get("/health")
+async def health(
+    current_user: Dict[str, Any] = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Return liveness status and current result count."""
+    # First-Party
+    from plugins.container_scanner.storage.repository import container_scan_repo  # pylint: disable=import-outside-toplevel
+
+    return {"status": "ok", "count": len(container_scan_repo)}

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -35,6 +35,8 @@ from mcpgateway.db import Resource as DbResource
 from mcpgateway.db import Server as DbServer
 from mcpgateway.db import ServerMetric, ServerMetricsHourly
 from mcpgateway.db import Tool as DbTool
+from mcpgateway.plugins.framework import get_plugin_manager, GlobalContext, PluginManager
+from mcpgateway.plugins.framework.hooks.gateway import GatewayHookType, RuntimePreDeployPayload, ServerPreRegisterPayload
 from mcpgateway.schemas import ServerCreate, ServerMetrics, ServerRead, ServerUpdate, TopPerformer
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
@@ -210,6 +212,7 @@ class ServerService(BaseService):
         self._structured_logger = get_structured_logger("server_service")
         self._audit_trail = get_audit_trail_service()
         self._performance_tracker = get_performance_tracker()
+        self._plugin_manager: PluginManager | None = get_plugin_manager()
 
     async def initialize(self) -> None:
         """Initialize the server service."""
@@ -556,6 +559,27 @@ class ServerService(BaseService):
             existing_server = get_for_update(db, DbServer, where=and_(*conditions))
             if existing_server:
                 raise ServerNameConflictError(server_in.name, enabled=existing_server.enabled, server_id=existing_server.id, visibility=existing_server.visibility)
+
+            if self._plugin_manager and self._plugin_manager.has_hooks_for(GatewayHookType.SERVER_PRE_REGISTER):
+                image_ref = getattr(server_in, "image_ref", "") or ""
+                image_digest = getattr(server_in, "image_digest", None)
+                global_context = GlobalContext(
+                    request_id=str(db_server.id),
+                    user=created_by or "",
+                    server_id=None,
+                    tenant_id=None,
+                )
+                await self._plugin_manager.invoke_hook(
+                    GatewayHookType.SERVER_PRE_REGISTER,
+                    payload=ServerPreRegisterPayload(
+                        assessment_id=str(db_server.id),
+                        image_ref=image_ref,
+                        image_digest=image_digest,
+                    ),
+                    global_context=global_context,
+                    violations_as_exceptions=True,
+                )
+
             # Set custom UUID if provided
             if server_in.id:
                 logger.info(f"Setting custom UUID for server: {server_in.id}")
@@ -1465,6 +1489,26 @@ class ServerService(BaseService):
                 permission_service = PermissionService(db)
                 if not await permission_service.check_resource_ownership(user_email, server):
                     raise PermissionError("Only the owner can activate the Server" if activate else "Only the owner can deactivate the Server")
+
+                if activate and self._plugin_manager and self._plugin_manager.has_hooks_for(GatewayHookType.RUNTIME_PRE_DEPLOY):
+                    image_ref = getattr(server, "image_ref", "") or ""
+                    image_digest = getattr(server, "image_digest", None)
+                    global_context = GlobalContext(
+                        request_id=str(server.id),
+                        user=user_email or "",
+                        server_id=str(server.id),
+                        tenant_id=None,
+                    )
+                    await self._plugin_manager.invoke_hook(
+                        GatewayHookType.RUNTIME_PRE_DEPLOY,
+                        payload=RuntimePreDeployPayload(
+                            assessment_id=str(server.id),
+                            image_ref=image_ref,
+                            image_digest=image_digest,
+                        ),
+                        global_context=global_context,
+                        violations_as_exceptions=True,
+                    )
 
             if server.enabled != activate:
                 server.enabled = activate

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -670,6 +670,13 @@
               <span class="sidebar-icon text-lg" :class="{ 'mr-3': !sidebarCollapsed }">🧩</span>
               <span x-show="!sidebarCollapsed">Plugins</span>
             </a>
+            <a href="#container-scanner" id="tab-container-scanner" data-testid="container-scanner-tab"
+               class="sidebar-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors"
+               :class="{ 'justify-center': sidebarCollapsed }"
+               onclick="showTab('container-scanner')">
+              <span class="sidebar-icon text-lg" :class="{ 'mr-3': !sidebarCollapsed }">🔒</span>
+              <span x-show="!sidebarCollapsed">Container Scanner</span>
+            </a>
             {% endif %}
           </div>
           {% endif %}
@@ -1665,6 +1672,21 @@
       {% if is_admin and 'plugins' not in hidden_sections %}
       <!-- Plugins Panel -->
       <div id="plugins-panel" class="tab-panel hidden"></div>
+      {% endif %}
+
+      {% if is_admin %}
+      <div id="container-scanner-panel" class="tab-panel hidden"
+           hx-get="{{ root_path }}/admin/container-scanner/partial"
+           hx-trigger="revealed once"
+           hx-swap="innerHTML">
+        <div class="flex justify-center items-center py-8">
+          <svg class="animate-spin h-8 w-8 text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+          </svg>
+          <span class="ml-3 text-gray-600 dark:text-gray-400">Loading container scanner results...</span>
+        </div>
+      </div>
       {% endif %}
 
       <!-- Performance Panel -->

--- a/mcpgateway/templates/container_scanner_partial.html
+++ b/mcpgateway/templates/container_scanner_partial.html
@@ -1,0 +1,170 @@
+<!-- Container Scanner Partial Template -->
+<div class="p-6">
+    <div class="mb-6">
+      <h2 class="text-2xl font-bold text-gray-900 dark:text-white">Container Scanner</h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Recent container image scan results from the CVE scanner pipeline.</p>
+    </div>
+  
+    {% if results %}
+    <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-6"></th>
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Scan Time</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Image</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Scanner</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+            <th class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Critical</th>
+            <th class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">High</th>
+            <th class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Medium</th>
+            <th class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Low</th>
+            <th class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Duration</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+          {% for result in results %}
+          <tbody x-data="{ open: false }" class="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            <!-- Summary row -->
+            <tr class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer" @click="open = !open">
+              <td class="px-4 py-3 text-gray-400 text-xs select-none">
+                <span x-text="open ? '▾' : '▸'"></span>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                {{ result.scan_time.strftime('%Y-%m-%d %H:%M:%S') if result.scan_time else '—' }}
+              </td>
+              <td class="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white max-w-xs truncate" title="{{ result.image_ref }}">
+                {{ result.image_ref }}
+                {% if result.image_digest and result.image_digest != result.image_ref %}
+                <div class="text-xs text-gray-400 truncate" title="{{ result.image_digest }}">{{ result.image_digest }}</div>
+                {% endif %}
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                {{ result.scanners }}
+              </td>
+              <td class="px-4 py-3 whitespace-nowrap">
+                {% if result.scan_error %}
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+                  Error
+                </span>
+                {% elif result.blocked %}
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
+                  Blocked
+                </span>
+                {% else %}
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                  Allowed
+                </span>
+                {% endif %}
+                {% if result.reason %}
+                <div class="text-xs text-gray-400 mt-0.5" title="{{ result.reason }}">{{ result.reason | truncate(40) }}</div>
+                {% endif %}
+              </td>
+              <td class="px-4 py-3 text-center text-sm font-semibold">
+                {% if result.summary.critical_count > 0 %}
+                <span class="text-red-600 dark:text-red-400">{{ result.summary.critical_count }}</span>
+                {% else %}
+                <span class="text-gray-400">0</span>
+                {% endif %}
+              </td>
+              <td class="px-4 py-3 text-center text-sm font-semibold">
+                {% if result.summary.high_count > 0 %}
+                <span class="text-orange-500 dark:text-orange-400">{{ result.summary.high_count }}</span>
+                {% else %}
+                <span class="text-gray-400">0</span>
+                {% endif %}
+              </td>
+              <td class="px-4 py-3 text-center text-sm font-semibold">
+                {% if result.summary.medium_count > 0 %}
+                <span class="text-yellow-500 dark:text-yellow-400">{{ result.summary.medium_count }}</span>
+                {% else %}
+                <span class="text-gray-400">0</span>
+                {% endif %}
+              </td>
+              <td class="px-4 py-3 text-center text-sm text-gray-600 dark:text-gray-300">
+                {{ result.summary.low_count }}
+              </td>
+              <td class="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                {{ result.duration_ms }} ms
+              </td>
+            </tr>
+  
+            <!-- Vulnerability detail row -->
+            <tr x-show="open" x-cloak>
+              <td colspan="10" class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
+                {% if result.scan_error %}
+                <p class="text-sm text-yellow-700 dark:text-yellow-300">
+                  <span class="font-semibold">Scan error:</span> {{ result.scan_error }}
+                </p>
+                {% elif result.vulnerabilities %}
+                <table class="min-w-full text-xs divide-y divide-gray-200 dark:divide-gray-700">
+                  <thead>
+                    <tr class="text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      <th class="py-2 pr-4 text-left font-semibold">CVE</th>
+                      <th class="py-2 pr-4 text-left font-semibold">Severity</th>
+                      <th class="py-2 pr-4 text-left font-semibold">Package</th>
+                      <th class="py-2 pr-4 text-left font-semibold">Installed</th>
+                      <th class="py-2 pr-4 text-left font-semibold">Fixed Version</th>
+                      <th class="py-2 text-left font-semibold">Description</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+                    {% for v in result.vulnerabilities %}
+                    <tr class="hover:bg-gray-100 dark:hover:bg-gray-700">
+                      <td class="py-1.5 pr-4 font-mono text-blue-600 dark:text-blue-400 whitespace-nowrap">{{ v.cve_id }}</td>
+                      <td class="py-1.5 pr-4 whitespace-nowrap">
+                        {% if v.severity == 'CRITICAL' %}
+                        <span class="font-semibold text-red-600 dark:text-red-400">CRITICAL</span>
+                        {% elif v.severity == 'HIGH' %}
+                        <span class="font-semibold text-orange-500 dark:text-orange-400">HIGH</span>
+                        {% elif v.severity == 'MEDIUM' %}
+                        <span class="font-semibold text-yellow-500 dark:text-yellow-400">MEDIUM</span>
+                        {% elif v.severity == 'LOW' %}
+                        <span class="text-gray-500 dark:text-gray-400">LOW</span>
+                        {% else %}
+                        <span class="text-gray-400">{{ v.severity }}</span>
+                        {% endif %}
+                      </td>
+                      <td class="py-1.5 pr-4 font-mono whitespace-nowrap">{{ v.package_name }}</td>
+                      <td class="py-1.5 pr-4 font-mono whitespace-nowrap text-gray-600 dark:text-gray-300">{{ v.installed_version }}</td>
+                      <td class="py-1.5 pr-4 font-mono whitespace-nowrap">
+                        {% if v.fixed_version %}
+                        <span class="text-green-600 dark:text-green-400">{{ v.fixed_version }}</span>
+                        {% else %}
+                        <span class="text-gray-400 italic">no fix available</span>
+                        {% endif %}
+                      </td>
+                      <td class="py-1.5 text-gray-600 dark:text-gray-300 max-w-sm truncate" title="{{ v.description or '' }}">
+                        {{ v.description or '—' }}
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+                {% else %}
+                <p class="text-sm text-gray-500 dark:text-gray-400 italic">No vulnerabilities found.</p>
+                {% endif %}
+              </td>
+            </tr>
+          </tbody>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <p class="mt-3 text-xs text-gray-400">Showing {{ results | length }} result(s). Results are stored in memory and reset on gateway restart.</p>
+  
+    {% else %}
+    <div class="flex flex-col items-center justify-center py-16 text-center">
+      <div class="text-5xl mb-4">🔒</div>
+      <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">No scan results yet</h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md">
+        Container scan results will appear here after images are scanned.
+        Register a server with a container image reference to trigger a scan.
+      </p>
+      <p class="mt-4 text-xs text-gray-400 dark:text-gray-500">
+        Ensure <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">PLUGINS_ENABLED=true</code> and the container scanner plugin is configured.
+      </p>
+    </div>
+    {% endif %}
+  </div>
+  

--- a/mcpgateway/utils/exec.py
+++ b/mcpgateway/utils/exec.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/exec.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Xinyi, Ayo
+
+Subprocess wrapper with timeout, stdout/stderr capture, and return code handling.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+from typing import List, Optional
+
+
+class ExecResult:
+    """Result of subprocess execution.
+
+    Attributes:
+        returncode: Exit code of the process.
+        stdout: Standard output as string.
+        stderr: Standard error as string.
+        timed_out: Whether the process timed out.
+    """
+
+    def __init__(
+        self,
+        returncode: int,
+        stdout: str,
+        stderr: str,
+        timed_out: bool = False,
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.timed_out = timed_out
+
+    def __repr__(self) -> str:
+        return f"ExecResult(returncode={self.returncode}, " f"timed_out={self.timed_out}, " f"stdout_len={len(self.stdout)}, " f"stderr_len={len(self.stderr)})"
+
+
+async def run_command(
+    cmd: List[str],
+    timeout_seconds: Optional[int] = None,
+    cwd: Optional[str] = None,
+    env: Optional[dict[str, str]] = None,
+) -> ExecResult:
+    """Execute a command with optional timeout.
+
+    Notes:
+        This utility never raises on timeout; it returns ExecResult(timed_out=True)
+        and captures any partial stdout/stderr where possible. Callers decide how
+        to map failures into domain-specific exceptions.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+    )
+
+    try:
+        if timeout_seconds is not None:
+            stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout_seconds)
+        else:
+            stdout_b, stderr_b = await proc.communicate()
+
+        stdout = (stdout_b or b"").decode("utf-8", errors="replace")
+        stderr = (stderr_b or b"").decode("utf-8", errors="replace")
+        return ExecResult(returncode=proc.returncode or 0, stdout=stdout, stderr=stderr, timed_out=False)
+
+    except asyncio.TimeoutError:
+        # Mark timeout and ensure process is terminated
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+        # Best-effort: wait shortly for pipes to flush
+        stdout = ""
+        stderr = ""
+        try:
+            stdout_b, stderr_b = await proc.communicate()
+            stdout = (stdout_b or b"").decode("utf-8", errors="replace")
+            stderr = (stderr_b or b"").decode("utf-8", errors="replace")
+        except Exception:
+            # If communicate fails after kill, return empty outputs
+            pass
+
+        return ExecResult(
+            returncode=proc.returncode if proc.returncode is not None else -1,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=True,
+        )

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -1062,3 +1062,26 @@ plugins:
     conditions: []
     config:
       context_key: jwt_claims
+
+# Container Scanner - scan images for CVEs before registration and deployment
+  - name: "ContainerScannerPlugin"
+    kind: "plugins.container_scanner.container_scanner.ContainerScannerPlugin"
+    description: "Scans container images for CVEs before gateway registration and runtime activation"
+    version: "0.1.0"
+    author: "Agnetha"
+    hooks: ["server_pre_register", "runtime_pre_deploy"]
+    tags: ["security", "container", "scanning", "cve"]
+    mode: "enforce"        # enforce | audit | disabled
+    priority: 5            # Run before all other security plugins
+    conditions: []
+    config:
+      scanner: "trivy"               # trivy | grype
+      severity_threshold: "HIGH"     # CRITICAL | HIGH | MEDIUM | LOW
+      fail_on_unfixed: false
+      ignore_cves: []
+      timeout_seconds: 300
+      mode: "enforce"                # enforce | audit | disabled
+      cache_enabled: true
+      cache_ttl_hours: 24
+      registries: []                 # Add per-registry auth here as needed
+      on_scan_error: "fail_closed"   # fail_closed | fail_open

--- a/plugins/container_scanner/Design_Doc.md
+++ b/plugins/container_scanner/Design_Doc.md
@@ -1,0 +1,610 @@
+# **Design Document**
+
+## **1\. Purpose**
+
+The `ContainerScannerPlugin` provides pre-deployment container security validation.
+
+It scans container images using Trivy or Grype before:
+
+* `server_pre_register`  
+* `runtime_pre_deploy`
+
+The plugin enforces configurable security policies and may block deployment when violations are detected.
+
+---
+
+## **2\. Flow**
+
+### **2.1 Flow**
+
+Gateway
+
+* **Hook Trigger**
+
+   The gateway invokes the ContainerScannerPlugin during:
+
+  * `server_pre_register`  
+  * `runtime_pre_deploy`
+
+---
+
+ContainerScannerPlugin
+
+* **Image Extraction**
+
+   Extract `image_ref` from payload.
+
+   Resolve `image_digest` if available (preferred for caching).
+
+---
+
+ContainerScannerPlugin
+
+* **Cache Check**
+
+   If caching is enabled:
+
+  * Lookup scan result by `image_digest`  
+  * If valid (TTL not expired) → reuse cached result  
+  * Otherwise → continue to scanning
+
+---
+
+ContainerScannerPlugin
+
+* **Registry Authentication Resolution**
+
+   Determine if the image registry requires authentication.
+
+  * If public → continue  
+  * If private → resolve credentials from configuration and environment variables
+
+---
+
+ContainerScannerPlugin → ScannerRunner
+
+* **Scanner Execution**  
+  * If `scanner = trivy` → execute `TrivyRunner`  
+  * If `scanner = grype` → execute `GrypeRunner`  
+  * Enforce `timeout_seconds`  
+  * Require JSON output
+
+---
+
+ScannerRunner → ContainerScannerPlugin
+
+* **Result Collection**  
+  * Collect raw JSON output  
+  * Parse into unified `Vulnerability[]`
+
+---
+
+ContainerScannerPlugin
+
+* **Policy Evaluation**  
+  * Apply `severity_threshold`  
+  * Remove `ignore_cves`  
+  * Apply `fail_on_unfixed`  
+  * Determine block/allow decision  
+  * Distinguish scan failure vs policy violation
+
+---
+
+ContainerScannerPlugin
+
+* **Result Persistence**  
+  * Store scan results  
+  * Store decision metadata  
+  * Store scan\_error (if any)
+
+---
+
+ContainerScannerPlugin → Gateway
+
+* **Result Propagation**  
+  * Return `ScanResult`  
+  * If enforce mode and violation → block workflow  
+  * Otherwise → allow continuation
+
+---
+
+### **2.2 Call Flow**
+
+```py
+Gateway
+  → ContainerScannerPlugin
+      →extract_image(payload) → image_ref
+      →resolve_digest(image_ref) → image_digest        #If image_digest not provided in context, scanner may resolve it internally and return it in result.
+      → CacheManager.lookup(image_digest)
+            → if valid →use cached_result
+            → else continue
+      → AuthResolver.resolve(image_ref)
+      → ScannerRunner.run(image_ref, config, timeout)
+            → raw_json
+      → ParserNormalizer.normalize(raw_json) → vulnerabilities[]
+      → PolicyEvaluator.evaluate(vulnerabilities, config) → decision
+      → StorageLayer.save(scan_result)                #Always persist raw scan result first, Then persist decision metadata
+      → return ScanResult
+```
+
+---
+
+## **3\. Hook Integration**
+
+### **Trigger Points**
+
+* `server_pre_register`  
+* `runtime_pre_deploy`
+
+Both hooks use the same internal scan workflow.
+
+---
+
+## **4\. Core Responsibilities**
+
+### **4.1 ContainerScannerPlugin (Orchestrator)**
+
+Responsibilities:
+
+* Extract image reference from payload  
+* Handle cache lookup  
+* Resolve registry authentication  
+* Select scanner implementation  
+* Normalize results  
+* Apply policy evaluation  
+* Persist scan results  
+* Return allow/block decision
+
+Talks to:
+
+* `ScannerRunner`  
+* `CacheManager`  
+* `PolicyEvaluator`  
+* `StorageLayer`
+
+---
+
+### **4.2 ScannerRunner (Interface)**
+
+Abstract interface:
+
+```py
+run(image_ref: str,config:object,timeout_s:int) -> Vulnerability[]
+```
+
+Implementations:
+
+* `TrivyRunner`  
+* `GrypeRunner`
+
+Responsibilities:
+
+* Execute CLI  
+* Enforce timeout  
+* Parse JSON  
+* Return normalized vulnerability objects
+
+---
+
+### **4.3 CacheManager**
+
+Keyed by:
+
+```py
+image_digest
+```
+
+Responsibilities:
+
+* Lookup cached results  
+* Validate TTL  
+* Store scan results
+
+If cache is disabled → skip entirely.
+
+---
+
+### **4.4 PolicyEvaluator**
+
+**Input:**
+
+* vulnerabilities  
+* severity\_threshold  
+* ignore\_cves  
+* fail\_on\_unfixed  
+* mode (audit/enforce)
+
+**Output:**
+
+```py
+{
+  blocked:bool,
+  reason?:str
+}
+```
+
+**Logic**:
+
+* Filter vulnerabilities ≥ threshold  
+* Remove ignored CVEs  
+* Apply fail\_on\_unfixed rule  
+* If mode \= enforce and violation exists → blocked \= true
+
+---
+
+## **5\. Data Contracts**
+
+### **5.1 Vulnerability (Unified Schema)**
+
+```py
+- scanner:"trivy" |"grype"
+- cve_id:string
+- severity:"CRITICAL" |"HIGH" |"MEDIUM" |"LOW"
+- package_name:string
+- installed_version:string
+- fixed_version?:string
+- description?:string
+```
+
+All scanners must normalize their output into this format.
+
+---
+
+### **5.2 ScanResult**
+
+```py
+-image_ref:string
+-image_digest?:string
+-scanners:string[]
+-scan_time: datetime
+-duration_ms:number
+-vulnerabilities:Vulnerability[]
+-summary:
+    -critical_count:number
+    -high_count:number
+    -medium_count:number
+    -low_count:number
+-blocked:boolean
+-reason?:string
+-scan_error?:string
+```
+
+Important:
+
+* `scan_error` distinguishes execution failure from policy violation.
+
+---
+
+## **6\. Configuration**
+
+Example:
+
+```py
+scanner: trivy | grype
+severity_threshold: CRITICAL | HIGH | MEDIUM | LOW
+fail_on_unfixed:boolean
+ignore_cves:string[]
+timeout_seconds: number
+mode: enforce | audit
+cache_enabled:boolean
+cache_ttl_hours: number
+registries:
+  - url:string
+    auth_type: token | basic
+    token_env?:string
+    username_env?:string
+    password_env?:string
+```
+
+---
+
+## **7\. Failure Handling Strategy**
+
+### **7.1 Scan Execution Failure**
+
+Examples:
+
+* CLI crash  
+* Authentication failure  
+* Timeout  
+* Image not found
+
+Recommended default:
+
+```py
+fail-closed (block deployment)            # This behavior applies only in enforce mode
+```
+
+Optional configuration:
+
+```
+on_scan_error: fail_closed | fail_open
+```
+
+---
+
+### **7.2 Policy Violation**
+
+Occurs when vulnerabilities meet configured threshold.
+
+Handling:
+
+* If mode \= enforce → block  
+* If mode \= audit → allow but record
+
+---
+
+## **8\. Cache Strategy**
+
+* Cache key: `image_digest`  
+* Tag-based caching is NOT allowed, if image\_digest is unavailable, caching MUST be skipped.  
+* TTL required due to CVE database updates  
+* Cache optional but recommended
+
+---
+
+## **9\. Design Principles**
+
+* Scanner-agnostic (Trivy/Grype interchangeable)  
+* Digest-based identity  
+* Clear separation:  
+  * Execution errors  
+  * Policy violations  
+* Single orchestration layer  
+* All scanner outputs normalized
+
+---
+
+## **10\. Suggest Structure**
+
+Path: `plugins/container_scanner`
+
+Structure:
+
+```py
+container_scanner/
+│
+├── __init__.py
+│
+├── container_scanner.py        # Plugin entry (hook integration)
+├── config.py                   # Config model
+├── types.py                    # Unified data models (Vulnerability, ScanResult)
+│
+├── cache/
+│   ├── __init__.py
+│   └── cache_manager.py        # Digest-based cache logic
+│
+├── auth/
+│   ├── __init__.py
+│   └── auth_resolver.py        # Registry auth resolution
+│
+├── scanners/
+│   ├── __init__.py
+│   ├── base.py                 # ScannerRunner interface
+│   ├── trivy_runner.py
+│   └── grype_runner.py
+│
+├── policy/
+│   ├── __init__.py
+│   └── policy_evaluator.py
+│
+└── storage/
+    ├── __init__.py
+    └── repository.py           # DB integration (if needed)
+```
+
+---
+
+## **11\. Suggest Plan**
+
+### **Week 1: Core Scanning Capabilities**
+
+**Phase 1: Infrastructure (2-3 days)**
+
+* Project structure setup (`container_scanner/` directory)  
+* Config models & Types (Vulnerability, ScanResult)  
+* Database schema
+
+**Phase 2: Scanner Implementation (2-3 days)**
+
+* ScannerRunner interface  
+* TrivyRunner (CLI wrapper, JSON parsing)  
+* GrypeRunner  
+* Timeout & error handling
+
+### **Week 2: Integration & Policies**
+
+**Phase 3: Peripheral Components (2-3 days)**
+
+* AuthResolver (registry authentication)  
+* CacheManager (digest-based caching)  
+* PolicyEvaluator (severity filtering, ignore list)
+
+**Phase 4: Plugin Integration (2-3 days)**
+
+* ContainerScannerPlugin main class  
+* Hook integration (server\_pre\_register, runtime\_pre\_deploy)  
+* Result persistence
+
+**Phase 5: Testing & Polish (1-2 days)**
+
+* Integration tests (real image scanning)  
+* Admin UI (scan results display)  
+* Documentation
+
+---
+
+### **Main Order**
+
+\<aside\> 📝
+
+Types/Config → TrivyRunner → PolicyEvaluator → Plugin ↓ CacheManager \+ AuthResolver
+
+\</aside\>
+
+# **Plugin Interface Alignment Document**
+
+## **1\. Assessment Context Structure**
+
+All plugins receive a standardized context from the Gateway:
+
+```py
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class AssessmentContext:
+    """Context passed from Gateway to plugins"""
+    assessment_id: str          # UUID generated by Gateway
+    image_ref: str              # Full image reference
+    image_digest: Optional[str] # Image digest (SHA256), if available
+    # Extensible for future fields
+```
+
+**Example:**
+
+```py
+context = AssessmentContext(
+    assessment_id="550e8400-e29b-41d4-a716-446655440000",
+    image_ref="ghcr.io/myorg/myapp:v1.0.0",
+    image_digest="sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+)
+```
+
+---
+
+## **2\. Image Reference Format**
+
+### **2.1 image\_ref Format**
+
+**Standard OCI format:**
+
+`<registry>/<repository>:<tag>`
+
+**Examples:**
+
+* `ghcr.io/myorg/myapp:v1.0.0`  
+* `docker.io/library/nginx:latest`  
+* `gcr.io/my-project/service:main`
+
+**Rules:**
+
+* Must include registry (use `docker.io` for Docker Hub)  
+* Repository can contain `/` (e.g., `library/nginx`, `org/team/app`)  
+* Tag is required (default to `latest` if parsing user input)
+
+### **2.2 image\_digest Format**
+
+**Standard format:**
+
+`sha256:<64-character-hex-string>`
+
+**Example:**
+
+`sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef`
+
+**Validation:**
+
+* Must start with `sha256:`  
+* Total length: 71 characters (7 \+ 1 \+ 64\)  
+* Hex characters only after colon
+
+---
+
+## **3\. Plugin Base Class**
+
+All plugins must extend the base `Plugin` class:
+
+```py
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+@dataclass
+class PluginResult:
+    """Result returned by plugin to Gateway"""
+    blocked: bool                       # Whether to block deployment
+    reason: Optional[str] = None        # Block reason (required if blocked=True)
+    metadata: Optional[Dict[str, Any]] = None  # Additional data for logging/UI
+
+class Plugin(ABC):
+    """Base class for all security assessment plugins"""
+    
+    @abstractmethod
+    def execute(self, context: AssessmentContext) -> PluginResult:
+        """
+        Execute plugin logic
+        
+        Args:
+            context: Assessment context from Gateway
+            
+        Returns:
+            PluginResult with block decision and metadata
+        """
+        pass
+```
+
+**Usage Example:**
+
+```py
+class ContainerScannerPlugin(Plugin):
+    def execute(self, context: AssessmentContext) -> PluginResult:
+        vulnerabilities = self.scan(context.image_ref)
+        
+        if self.has_critical_vulnerabilities(vulnerabilities):
+            return PluginResult(
+                blocked=True,
+                reason="Found 3 CRITICAL vulnerabilities",
+                metadata={"critical_count": 3, "high_count": 5}
+            )
+        
+        return PluginResult(blocked=False)
+```
+
+---
+
+## **4\. Configuration Standards**
+
+### **4.1 Naming Conventions**
+
+| Field Type | Convention | Example |
+| ----- | ----- | ----- |
+| Mode | `mode` | `"enforce"`, `"audit"`, `"disabled"` |
+| Timeout | `timeout_seconds` | `300` |
+| Environment Variable | `xxx_env` | `"GITHUB_TOKEN"` |
+| Boolean Flag | `xxx_enabled` | `true`, `false` |
+
+### **4.2 Standard Configuration Structure**
+
+```py
+plugins:
+  - name: "PluginName"
+    kind: "plugins.module.ClassName"
+    hooks:
+      - hook_name
+    mode: "enforce"        # enforce | audit | disabled
+    priority: 10           # Lower executes first
+    
+    config:
+      # Timeout (always in seconds)
+      timeout_seconds: 300
+      
+      # Environment variables (always _env suffix)
+      token_env: "GITHUB_TOKEN"
+      username_env: "DOCKER_USER"
+      password_env: "DOCKER_PASS"
+      
+      # Boolean flags (always _enabled suffix)
+      cache_enabled: true
+      offline_enabled: false
+      
+      # Plugin-specific config
+      # ...
+```
+
+**4.3 Mode Definitions**
+
+* **`enforce`**: Block deployment if policy violated  
+* **`audit`**: Log violations but allow deployment  
+* **`disabled`**: Skip plugin execution
+

--- a/plugins/container_scanner/README.md
+++ b/plugins/container_scanner/README.md
@@ -1,0 +1,191 @@
+# Container Scanner Plugin
+
+Scans container images for CVEs before gateway registration and runtime deployment using [Trivy](https://github.com/aquasecurity/trivy) or [Grype](https://github.com/anchore/grype).
+
+## Overview
+
+The plugin intercepts two gateway lifecycle hooks:
+
+- **`server_pre_register`** — blocks registration of a new MCP server if its image fails policy
+- **`runtime_pre_deploy`** — blocks deployment at runtime if the image fails policy
+
+Both hooks run the same pipeline: cache check → auth resolution → scanner execution → policy evaluation → result persistence.
+
+## Pipeline
+
+```
+Hook trigger
+  └── CacheManager.lookup(image_digest)       # skip scan if result is fresh
+        └── AuthResolver.resolve(image_ref)   # inject registry credentials
+              └── TrivyRunner / GrypeRunner   # run scanner CLI, parse JSON
+                    └── PolicyEvaluator       # filter by threshold, CVE ignore list
+                          └── ScanResultRepository.save()   # persist result
+                                └── return allow / block decision
+```
+
+Scan errors (CLI crash, timeout, image not found) are handled separately from policy violations — see `scan_error` vs `reason` in the result.
+
+## Directory Structure
+
+```
+plugins/container_scanner/
+├── container_scanner.py        # Plugin entry point, hook handlers
+├── config.py                   # ScannerConfig and RegistryConfig models
+├── types.py                    # Vulnerability, Summary, ScanResult schemas
+├── auth/
+│   └── auth_resolver.py        # Resolves registry credentials from env vars
+├── cache/
+│   └── cache_manager.py        # Digest-keyed TTL cache
+├── policy/
+│   └── policy_evaluator.py     # Severity filtering and block/audit decision
+├── scanners/
+│   ├── base.py                 # ScannerRunner interface
+│   ├── trivy_runner.py
+│   └── grype_runner.py
+└── storage/
+    └── repository.py           # In-memory result store + shared singleton
+```
+
+## Configuration
+
+Add to `plugins/config.yaml`:
+
+```yaml
+- name: "ContainerScannerPlugin"
+  kind: "plugins.container_scanner.container_scanner.ContainerScannerPlugin"
+  hooks: ["server_pre_register", "runtime_pre_deploy"]
+  mode: "enforce"       # enforce | audit | disabled
+  priority: 5
+  config:
+    scanner: "trivy"              # trivy | grype
+    severity_threshold: "HIGH"   # CRITICAL | HIGH | MEDIUM | LOW
+    fail_on_unfixed: false        # if false, vulns with no fix are ignored
+    ignore_cves: []               # list of CVE IDs to suppress
+    timeout_seconds: 300
+    mode: "enforce"
+    cache_enabled: true
+    cache_ttl_hours: 24
+    on_scan_error: "fail_closed"  # fail_closed | fail_open
+    registries: []                # per-registry auth (see below)
+```
+
+### Registry Authentication
+
+```yaml
+registries:
+  - url: "ghcr.io"
+    auth_type: "token"
+    token_env: "GHCR_TOKEN"          # env var name, not the token value
+
+  - url: "registry.example.com"
+    auth_type: "basic"
+    username_env: "REG_USER"
+    password_env: "REG_PASS"
+```
+
+Credentials are read from environment variables at scan time — never stored in config.
+
+### Mode Reference
+
+| Mode | Effect |
+|------|--------|
+| `enforce` | Blocks deployment when policy is violated |
+| `audit` | Allows deployment but records the violation |
+| `disabled` | Skips scanning entirely |
+
+### `on_scan_error` Reference
+
+| Value | Effect |
+|-------|--------|
+| `fail_closed` | Block deployment if the scanner CLI fails (safe default) |
+| `fail_open` | Allow deployment but record the error in `scan_error` |
+
+## REST API
+
+Scan results are accessible via the admin API (requires authentication):
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /container-scanner/health` | Liveness check and result count |
+| `GET /container-scanner/scans` | All results, most recent first |
+| `GET /container-scanner/scans/{image_ref}` | Result for a specific image ref or digest |
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/container-scanner/scans/ghcr.io/org/app:v1
+```
+
+## Admin UI
+
+When `PLUGINS_ENABLED=true` and the plugin is configured, scan results appear in the gateway Admin UI under the **Container Scanner** tab.
+
+### Summary table
+
+The table shows one row per scanned image, most recent first. Click the `▸` arrow on any row to expand it.
+
+| Column | Description |
+|--------|-------------|
+| Scan Time | UTC timestamp of when the scan ran |
+| Image | `image_ref` (digest shown on a second line if available) |
+| Scanner | `trivy` or `grype` |
+| Status | **Allowed** (green), **Blocked** (red), or **Error** (yellow) with the policy reason truncated below |
+| Critical / High / Medium / Low | CVE counts by severity, coloured red → orange → yellow → grey |
+| Duration | Scanner subprocess wall time in ms |
+
+### Vulnerability detail (expandable)
+
+Clicking a row expands an inline panel showing every individual CVE finding:
+
+| Column | Description |
+|--------|-------------|
+| CVE | CVE identifier (e.g. `CVE-2023-0001`) |
+| Severity | Colour-coded: **CRITICAL** (red), **HIGH** (orange), **MEDIUM** (yellow), **LOW** (grey) |
+| Package | Vulnerable package name |
+| Installed | Currently installed version |
+| Fixed Version | Remediation target in green, or *"no fix available"* if none exists |
+| Description | Full CVE description (truncated; hover for full text) |
+
+If the scanner encountered an error, the expanded panel shows the raw error message instead of a CVE table.
+
+If no results are present, the UI shows a prompt to register a server with a container image reference to trigger the first scan.
+
+> Results are held in memory and reset when the gateway restarts. Use the REST API to export them before restarting if persistence is needed.
+
+## Policy Evaluation
+
+Vulnerabilities are filtered in order:
+
+1. **Severity threshold** — drop vulns below `severity_threshold`
+2. **CVE ignore list** — drop CVE IDs in `ignore_cves`
+3. **Unfixed filter** — if `fail_on_unfixed: false`, drop vulns with no `fixed_version`
+4. **Mode decision** — `enforce` blocks if any violations remain; `audit` records but allows
+
+## Caching
+
+The cache is keyed by `image_digest` (not by tag). Tag-based caching is not supported — if no digest is available, the cache is skipped entirely. Cached vulnerability lists are re-evaluated against the current policy on every hit, so changing `severity_threshold` takes effect without re-scanning.
+
+## Prerequisites
+
+At least one scanner must be installed and on `PATH`:
+
+```bash
+# Trivy (recommended)
+brew install aquasecurity/trivy/trivy   # macOS
+# or: https://github.com/aquasecurity/trivy/releases
+
+# Grype (alternative)
+brew install anchore/grype/grype
+# or: https://github.com/anchore/grype/releases
+```
+
+## Running Tests
+
+```bash
+# Unit tests
+pytest tests/unit/plugins/test_container_scanner/ -v
+
+# Integration tests (hook → API end-to-end)
+pytest tests/integration/test_container_scanner/ -v
+```

--- a/plugins/container_scanner/__init__.py
+++ b/plugins/container_scanner/__init__.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Public API for the container_scanner plugin.
+"""
+
+from __future__ import annotations
+
+from .config import RegistryConfig, ScannerConfig
+from .types import ScanResult, Vulnerability
+
+__all__ = [
+    "Vulnerability",
+    "ScanResult",
+    "ScannerConfig",
+    "RegistryConfig",
+]

--- a/plugins/container_scanner/auth/__init__.py
+++ b/plugins/container_scanner/auth/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/auth/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Public API for the auth subpackage.
+"""
+
+from __future__ import annotations

--- a/plugins/container_scanner/auth/auth_resolver.py
+++ b/plugins/container_scanner/auth/auth_resolver.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/auth/auth_resolver.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Resolves registry credentials from environment variables and returns
+scanner-compatible environment variable dicts for subprocess injection.
+
+The resolver is intentionally stateless after construction — it reads
+os.environ on every call so that credential rotation is picked up
+without restarting the gateway.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+
+# Local
+from plugins.container_scanner.config import ScannerConfig
+
+
+class AuthResolver:
+    """Translates RegistryConfig env-var-name fields into scanner credentials.
+
+    Usage::
+
+        resolver = AuthResolver(config)
+        env_vars = resolver.resolve("ghcr.io/org/app:v1")
+        # env_vars is injected into the scanner subprocess environment
+
+    Args:
+        config: Top-level scanner configuration containing the registries list.
+    """
+
+    _config : ScannerConfig
+
+    def __init__(self, config: ScannerConfig) -> None:
+        self._config = config
+
+
+    def _resolve_env(self, var_name: str, registry_url: str) -> str:
+        """Look up a required environment variable by name.
+
+        Args:
+            var_name: Name of the environment variable (e.g., "GHCR_TOKEN").
+            registry_url: Registry URL used in the error message for clarity.
+
+        Returns:
+            The value of the environment variable.
+
+        Raises:
+            EnvironmentError: If the variable is not set in os.environ.
+        """
+        resolved_value = os.environ.get(var_name)
+        if not resolved_value:
+            raise EnvironmentError(f"Registry {registry_url}: required env var {var_name} is not set")
+
+        return resolved_value
+
+
+    def resolve(self, image_ref: str) -> dict[str, str]:
+        """Return scanner env vars for the registry that owns *image_ref*.
+
+        Injects credentials for both Trivy and Grype so that the runner
+        does not need to know which scanner CLI is in use.
+
+        Args:
+            image_ref: Full image reference (e.g., "ghcr.io/org/app:v1").
+
+        Returns:
+            A dict of environment variable names → values to merge into the
+            scanner subprocess environment.  Returns ``{}`` for public
+            registries that have no matching entry in the config.
+
+        Raises:
+            EnvironmentError: If a required credential env var is not set.
+        """
+        reg = self._config.registry_for(image_ref)
+        if not reg:
+            return {}
+        if reg.auth_type == "token":
+            username = ""
+            password = self._resolve_env(reg.token_env, reg.url)
+        else:
+            username = self._resolve_env(reg.username_env, reg.url)
+            password = self._resolve_env(reg.password_env, reg.url)
+        return {
+            "TRIVY_USERNAME": username,
+            "TRIVY_PASSWORD": password,
+            "GRYPE_REGISTRY_AUTH_USERNAME": username,
+            "GRYPE_REGISTRY_AUTH_PASSWORD": password,
+        }
+

--- a/plugins/container_scanner/cache/__init__.py
+++ b/plugins/container_scanner/cache/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/cache/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Public API for the cache subpackage.
+"""
+
+from __future__ import annotations
+
+from .cache_manager import CacheManager
+
+__all__ = ["CacheManager"]

--- a/plugins/container_scanner/cache/cache_manager.py
+++ b/plugins/container_scanner/cache/cache_manager.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/cache/cache_manager.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Cache manager for container scan results. """
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+# Local
+from ..types import Vulnerability
+
+logger = logging.getLogger(__name__)
+
+
+class CacheManager:
+    """Manages caching of raw vulnerability lists by image digest.
+
+    Stores only the scanner output (List[Vulnerability]), not policy decisions.
+    Policy evaluation is always re-run on a cache hit so that config changes
+    (threshold, ignore_cves, fail_on_unfixed) take effect immediately without
+    requiring a fresh scan.
+    """
+
+    def __init__(self, ttl_hours: int = 24, enabled: bool = True):
+        """Initialize cache manager.
+
+        Args:
+            ttl_hours: Cache time-to-live in hours (default 24h).
+            enabled: Whether caching is enabled (disable for testing).
+        """
+        self._cache: Dict[str, tuple[List[Vulnerability], datetime]] = {}
+        self._ttl_hours = ttl_hours
+        self._enabled = enabled
+        self._hits = 0
+        self._misses = 0
+
+        logger.info(
+            "CacheManager initialized",
+            extra={
+                "ttl_hours": ttl_hours,
+                "enabled": enabled,
+            },
+        )
+
+    def lookup(self, image_digest: Optional[str]) -> Optional[List[Vulnerability]]:
+        """Lookup cached vulnerability list by image digest.
+
+        Args:
+            image_digest: SHA256 digest of the image (e.g., "sha256:abc123...").
+
+        Returns:
+            Cached List[Vulnerability] if valid, None otherwise.
+            Policy decisions are NOT cached — callers must re-evaluate.
+        """
+        # Fast path: return immediately if caching disabled or no digest
+        if not self._enabled or not image_digest:
+            self._misses += 1
+            return None
+
+        # Lookup in cache
+        cached_entry = self._cache.get(image_digest)
+        if not cached_entry:
+            self._misses += 1
+            logger.debug("Cache miss", extra={"image_digest": image_digest})
+            return None
+
+        # Unpack tuple and validate TTL
+        scan_result, cached_at = cached_entry
+        entry_age = datetime.now(timezone.utc) - cached_at
+
+        if entry_age > timedelta(hours=self._ttl_hours):
+            # Expired - lazy deletion (green computing!)
+            del self._cache[image_digest]
+            self._misses += 1
+            logger.info(
+                "Cache expired",
+                extra={
+                    "image_digest": image_digest,
+                    "age_hours": entry_age.total_seconds() / 3600,
+                },
+            )
+            return None
+
+        # Valid cache hit - major compute savings!
+        self._hits += 1
+        logger.info(
+            "Cache HIT - scan avoided",
+            extra={
+                "image_digest": image_digest,
+                "age_hours": entry_age.total_seconds() / 3600,
+                "compute_saved": "~2-5 minutes",
+            },
+        )
+        return scan_result
+
+    def store(self, image_digest: Optional[str], vulnerabilities: List[Vulnerability]) -> None:
+        """Store raw vulnerability list in cache.
+
+        Args:
+            image_digest: SHA256 digest of the image.
+            vulnerabilities: Raw scanner output to cache (policy decisions excluded).
+        """
+        # Skip if caching disabled or no digest
+        if not self._enabled or not image_digest:
+            return
+
+        self._cache[image_digest] = (vulnerabilities, datetime.now(timezone.utc))
+        logger.debug(
+            "Cache stored",
+            extra={
+                "image_digest": image_digest,
+                "ttl_hours": self._ttl_hours,
+            },
+        )
+
+    def invalidate(self, image_digest: str) -> None:
+        """Manually invalidate a cached entry.
+
+        Args:
+            image_digest: SHA256 digest to invalidate.
+        """
+        if image_digest in self._cache:
+            del self._cache[image_digest]
+            logger.debug("Cache invalidated", extra={"image_digest": image_digest})
+
+    def clear(self) -> None:
+        """Clear entire cache."""
+        self._cache.clear()
+        self._hits = 0
+        self._misses = 0
+        logger.info("Cache cleared")
+
+    def get_stats(self) -> Dict[str, float]:
+        """Get cache statistics.
+
+        Returns:
+            Dictionary with hits, misses, size, and hit rate.
+        """
+        total = self._hits + self._misses
+        hit_rate = (self._hits / total * 100) if total > 0 else 0.0
+
+        return {
+            "hits": float(self._hits),
+            "misses": float(self._misses),
+            "size": float(len(self._cache)),
+            "hit_rate_percent": round(hit_rate, 2),
+        }

--- a/plugins/container_scanner/config.py
+++ b/plugins/container_scanner/config.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/config.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Configuration models for the ContainerScannerPlugin.
+
+All values are loaded from the gateway plugin config dict, not from environment
+variables directly. Registry credentials are referenced by env-var name and
+resolved at runtime by auth_resolver.py.
+
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import List, Literal, Optional
+
+# Third-Party
+from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_registry_host(ref: str) -> str:
+    """Extract the registry host from a Docker image reference or registry URL.
+
+    A segment is treated as a registry host when it contains a dot, is "localhost",
+    or has a colon followed only by digits (a port number).  A colon followed by
+    non-digits is a tag separator on an implicit docker.io image (e.g. "python:3.12-slim").
+
+    Args:
+        ref: An image reference (e.g., "ghcr.io/org/app:v1") or registry URL
+            (e.g., "gcr.io/my-project"). Path components beyond the host are ignored.
+
+    Returns:
+        The registry hostname (and optional port), e.g. "ghcr.io" or "registry:5000".
+        Returns "docker.io" when no explicit registry host is present.
+    """
+    first = ref.split("/")[0]
+    # Strip tag/port to isolate the bare hostname for dot and localhost checks
+    # e.g. "python:3.12-slim" → hostname_part="python"; "localhost:5000" → "localhost"
+    hostname_part = first.split(":")[0]
+    if "." in hostname_part or hostname_part == "localhost":
+        return first
+    # Colon is a port only when followed exclusively by digits (e.g. "registry:5000")
+    colon_idx = first.find(":")
+    if colon_idx != -1 and first[colon_idx + 1 :].isdigit():
+        return first
+    return "docker.io"
+
+
+class RegistryConfig(BaseModel):
+    """Per-registry authentication configuration.
+
+    Credentials are stored as the *names* of environment variables,
+    not the secret values themselves. auth_resolver.py resolves them
+    at scan time via os.environ.
+
+    Attributes:
+        url: Registry URL prefix (e.g., "ghcr.io", "gcr.io/my-project").
+        auth_type: Authentication mechanism — "token" or "basic".
+        token_env: Env var name holding a bearer/token credential (token auth).
+        username_env: Env var name holding the username (basic auth).
+        password_env: Env var name holding the password (basic auth).
+    """
+
+    url: str
+    auth_type: Literal["token", "basic"]
+    token_env: Optional[str] = None
+    username_env: Optional[str] = None
+    password_env: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_auth_fields(self) -> "RegistryConfig":
+        if self.auth_type == "token":
+            if not self.token_env:
+                raise ValueError(f"Registry '{self.url}': auth_type 'token' requires token_env.")
+            unused = [name for name, val in [("username_env", self.username_env), ("password_env", self.password_env)] if val]
+            if unused:
+                logger.warning(f"Registry '{self.url}': auth_type 'token' ignores {' and '.join(unused)}.")
+        elif self.auth_type == "basic":
+            missing = [name for name, val in [("username_env", self.username_env), ("password_env", self.password_env)] if not val]
+            if missing:
+                raise ValueError(f"Registry '{self.url}': auth_type 'basic' requires {' and '.join(missing)}.")
+            if self.token_env:
+                logger.warning(f"Registry '{self.url}': auth_type 'basic' ignores token_env.")
+        return self
+
+
+class ScannerConfig(BaseModel):
+    """Top-level configuration for the ContainerScannerPlugin.
+
+    Attributes:
+        scanner: Which scanner CLI to use.
+        severity_threshold: Minimum severity level that triggers a finding.
+            Vulnerabilities below this threshold are silently dropped.
+        fail_on_unfixed: If True, unfixed vulnerabilities still count as violations.
+        ignore_cves: CVE IDs to suppress regardless of severity.
+        timeout_seconds: Hard timeout for the scanner subprocess.
+        mode: Plugin enforcement mode — "enforce" blocks deployment,
+            "audit" logs but allows, "disabled" skips the plugin entirely.
+        cache_enabled: Whether digest-based result caching is active.
+        cache_ttl_hours: How long cached results are considered valid.
+        registries: Per-registry authentication configuration.
+        on_scan_error: Behaviour when the scanner subprocess fails.
+            "fail_closed" blocks deployment (safe default);
+            "fail_open" allows deployment and records the error.
+    """
+
+    scanner: Literal["trivy", "grype"] = "trivy"
+    severity_threshold: Literal["CRITICAL", "HIGH", "MEDIUM", "LOW"] = "HIGH"
+    fail_on_unfixed: bool = False
+    ignore_cves: List[str] = Field(default_factory=list)
+    timeout_seconds: int = Field(default=300, gt=0)
+    mode: Literal["enforce", "audit", "disabled"] = "enforce"
+    cache_enabled: bool = True
+    cache_ttl_hours: int = Field(default=24, gt=0)
+    registries: List[RegistryConfig] = Field(default_factory=list)
+    on_scan_error: Literal["fail_closed", "fail_open"] = "fail_closed"
+
+    def registry_for(self, image_ref: str) -> Optional[RegistryConfig]:
+        """Return the first registry config whose host matches the image reference.
+
+        Args:
+            image_ref: Full image reference (e.g., "ghcr.io/org/app:v1").
+
+        Returns:
+            Matching RegistryConfig, or None if the registry is public / unconfigured.
+        """
+        image_host = _parse_registry_host(image_ref)
+        for reg in self.registries:
+            if image_host == _parse_registry_host(reg.url):
+                return reg
+        return None

--- a/plugins/container_scanner/container_scanner.py
+++ b/plugins/container_scanner/container_scanner.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/container_scanner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+ContainerScannerPlugin — orchestrates the full scan pipeline:
+  cache lookup → auth resolution → scanner execution →
+  policy evaluation → result construction → cache store.
+
+Plugin hooks (server_pre_register, runtime_pre_deploy) are not yet wired;
+use scan() directly for now.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import datetime
+import logging
+from typing import List
+from collections import Counter
+
+# First-Party
+from mcpgateway.plugins.framework import Plugin, PluginConfig
+
+# Local
+from plugins.container_scanner.auth.auth_resolver import AuthResolver
+from plugins.container_scanner.cache.cache_manager import CacheManager
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.policy.policy_evaluator import PolicyEvaluator
+from plugins.container_scanner.scanners.grype_runner import GrypeRunner
+from plugins.container_scanner.scanners.trivy_runner import TrivyRunner
+from plugins.container_scanner.types import ScanResult, Summary, Vulnerability
+from plugins.container_scanner.storage.repository import ScanResultRepository
+
+logger = logging.getLogger(__name__)
+
+
+class ContainerScannerPlugin(Plugin):
+    """Gateway plugin that scans container images for CVEs before deployment.
+
+    Orchestrates: cache → auth → scanner CLI → policy → result.
+    Hooks (server_pre_register, runtime_pre_deploy) are added separately.
+
+    Args:
+        config: Framework-level plugin configuration.  Scanner-specific
+            settings are read from ``config.config`` and validated into
+            a :class:`ScannerConfig`.
+    """
+    _scanner_config : ScannerConfig
+    _cache : CacheManager
+    _auth : AuthResolver
+    _runner : TrivyRunner | GrypeRunner
+    _policy : PolicyEvaluator
+    _repo : ScanResultRepository
+
+    def __init__(self, config: PluginConfig) -> None:
+        super().__init__(config)
+        self._scanner_config = ScannerConfig(**(config.config or {}))
+        self._cache = CacheManager(ttl_hours=self._scanner_config.cache_ttl_hours, enabled=self._scanner_config.cache_enabled)
+        self._auth = AuthResolver(self._scanner_config)
+        if self._scanner_config.scanner == "trivy":
+            self._runner = TrivyRunner(self._scanner_config)
+        else:
+            self._runner = GrypeRunner(self._scanner_config)
+        self._policy = PolicyEvaluator()
+        self._repo = ScanResultRepository()
+
+    # ------------------------------------------------------------------
+    # Core scan pipeline
+    # ------------------------------------------------------------------
+
+    async def scan(self, image_ref: str, image_digest: str) -> ScanResult:
+        """Run the full scan pipeline for *image_digest*.
+
+        Args:
+            image_digest: Full image reference (e.g., ``"ghcr.io/org/app:v1"``).
+
+        Returns:
+            :class:`ScanResult` with vulnerabilities, policy decision, and
+            timing metadata.  Never raises — scanner errors are captured into
+            ``scan_error`` and resolved via ``on_scan_error`` policy.
+        """
+        cfg = self._scanner_config
+        start = datetime.datetime.now(datetime.timezone.utc)
+
+        if cfg.mode == "disabled":
+            return self._build_result(image_ref=image_ref, image_digest=image_digest, vulnerabilities=[], blocked=False, reason = "scan skipped", start=start)
+
+        cached_vulns = self._cache.lookup(image_digest)
+        if cached_vulns is not None:
+            logger.info("Cache hit for %s — re-evaluating policy against current config", image_digest)
+            decision = self._policy.evaluate(cached_vulns, cfg)
+            return self._build_result(image_ref, image_digest, cached_vulns, blocked=decision.blocked, reason=decision.reason, start=start)
+
+        auth_env = self._auth.resolve(image_ref)
+        logger.debug("Auth resolved for %s: %d env vars", image_ref, len(auth_env))
+
+        vulnerabilities: List[Vulnerability] = []
+        scan_error = None
+        try:
+            vulnerabilities = await self._runner.run(image_ref, auth_env)
+        except Exception as exc:
+            scan_error = str(exc)
+            logger.warning("Scan failed with error: %s", scan_error)
+            if cfg.on_scan_error == "fail_closed":
+                return self._build_result(image_ref=image_ref, image_digest=image_digest, vulnerabilities=vulnerabilities, blocked=True, scan_error=scan_error, start=start)
+            else:
+                logger.info("Scan error for %s (fail_open): allowing deployment, error recorded", image_digest)
+                return self._build_result(image_ref=image_ref, image_digest=image_digest, vulnerabilities=vulnerabilities, blocked=False, scan_error=scan_error, start=start)
+
+        decision = self._policy.evaluate(vulnerabilities, cfg)
+        result = self._build_result(image_ref=image_ref, image_digest=image_digest, vulnerabilities=vulnerabilities, blocked=decision.blocked, reason=decision.reason, scan_error=scan_error, start=start)
+        self._cache.store(image_digest, vulnerabilities)
+        self._repo.save(result)
+        return result
+
+
+
+    def _build_result(
+        self,
+        image_ref:str,
+        image_digest: str,
+        vulnerabilities: List[Vulnerability],
+        *,
+        blocked: bool,
+        reason: str | None = None,
+        scan_error: str | None = None,
+        start: datetime.datetime | None = None,
+    ) -> ScanResult:
+        """Construct a ScanResult from raw findings and a policy decision.
+
+        Args:
+            image_ref: Image reference that was scanned.
+            vulnerabilities: Normalized vulnerability list from the scanner.
+            blocked: Whether the policy decision blocks deployment.
+            reason: Human-readable policy violation summary, if any.
+            scan_error: Error message if the scanner subprocess failed.
+            start: Scan start timestamp; defaults to now if omitted.
+
+        Returns:
+            Fully populated :class:`ScanResult`.
+        """
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if start is None:
+            start = now
+        duration_ms = int((now - start).total_seconds() * 1000)
+
+        counts: Counter[str] = Counter(v.severity for v in vulnerabilities)
+        summary = Summary(
+            critical_count=counts["CRITICAL"],
+            high_count=counts["HIGH"],
+            medium_count=counts["MEDIUM"],
+            low_count=counts["LOW"],
+        )
+
+        return ScanResult(
+            image_ref=image_ref,
+            image_digest=image_digest,
+            scanners=self._scanner_config.scanner,
+            scan_time=start,
+            duration_ms=duration_ms,
+            vulnerabilities=vulnerabilities,
+            summary=summary,
+            blocked=blocked,
+            reason=reason,
+            scan_error=scan_error,
+        )

--- a/plugins/container_scanner/container_scanner.py
+++ b/plugins/container_scanner/container_scanner.py
@@ -23,7 +23,8 @@ from typing import List
 from collections import Counter
 
 # First-Party
-from mcpgateway.plugins.framework import Plugin, PluginConfig
+from mcpgateway.plugins.framework import Plugin, PluginConfig, PluginContext
+from mcpgateway.plugins.framework.models import PluginViolation
 
 # Local
 from plugins.container_scanner.auth.auth_resolver import AuthResolver
@@ -33,7 +34,8 @@ from plugins.container_scanner.policy.policy_evaluator import PolicyEvaluator
 from plugins.container_scanner.scanners.grype_runner import GrypeRunner
 from plugins.container_scanner.scanners.trivy_runner import TrivyRunner
 from plugins.container_scanner.types import ScanResult, Summary, Vulnerability
-from plugins.container_scanner.storage.repository import ScanResultRepository
+from plugins.container_scanner.storage.repository import ScanResultRepository, container_scan_repo
+from mcpgateway.plugins.framework.hooks.gateway import ServerPreRegisterPayload, ServerPreRegisterResult, RuntimePreDeployPayload, RuntimePreDeployResult
 
 logger = logging.getLogger(__name__)
 
@@ -66,13 +68,21 @@ class ContainerScannerPlugin(Plugin):
         else:
             self._runner = GrypeRunner(self._scanner_config)
         self._policy = PolicyEvaluator()
-        self._repo = ScanResultRepository()
+        self._repo = container_scan_repo
 
-    # ------------------------------------------------------------------
+
+    async def server_pre_register(self, payload: ServerPreRegisterPayload, context: PluginContext) -> ServerPreRegisterResult:
+        result = await self.scan(payload.image_ref, payload.image_digest)
+        violation = PluginViolation(reason=result.reason or "", description=result.reason or "", code="CVE_POLICY_VIOLATION") if result.blocked else None
+        return ServerPreRegisterResult(payload=payload, continue_processing=not result.blocked, violation=violation)
+
+    async def runtime_pre_deploy(self, payload: RuntimePreDeployPayload, context: PluginContext) -> RuntimePreDeployResult:
+        result = await self.scan(payload.image_ref, payload.image_digest)
+        violation = PluginViolation(reason=result.reason or "", description=result.reason or "", code="CVE_POLICY_VIOLATION") if result.blocked else None
+        return RuntimePreDeployResult(payload=payload, continue_processing=not result.blocked, violation=violation)
+
     # Core scan pipeline
-    # ------------------------------------------------------------------
-
-    async def scan(self, image_ref: str, image_digest: str) -> ScanResult:
+    async def scan(self, image_ref: str, image_digest: str | None) -> ScanResult:
         """Run the full scan pipeline for *image_digest*.
 
         Args:
@@ -122,7 +132,7 @@ class ContainerScannerPlugin(Plugin):
     def _build_result(
         self,
         image_ref:str,
-        image_digest: str,
+        image_digest: str | None,
         vulnerabilities: List[Vulnerability],
         *,
         blocked: bool,

--- a/plugins/container_scanner/policy/__init__.py
+++ b/plugins/container_scanner/policy/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/policy/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Public API for the policy subpackage.
+"""
+
+from __future__ import annotations

--- a/plugins/container_scanner/policy/policy_evaluator.py
+++ b/plugins/container_scanner/policy/policy_evaluator.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/policy/policy_evaluator.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Evaluates a list of Vulnerability objects against a ScannerConfig and returns
+a PolicyDecision indicating whether deployment should be blocked.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass, field
+from typing import List, Optional
+from collections import Counter
+
+# Local
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.types import Vulnerability
+
+_SEVERITY_ORDER: dict[str, int] = {
+    "CRITICAL": 4,
+    "HIGH": 3,
+    "MEDIUM": 2,
+    "LOW": 1,
+    "UNKNOWN": 0,
+}
+
+
+@dataclass
+class PolicyDecision:
+    """Result of a policy evaluation pass.
+
+    Attributes:
+        blocked: Whether deployment should be blocked.
+        reason: Human-readable explanation (set even in audit mode).
+        violations: Filtered vulnerabilities that triggered the decision.
+    """
+
+    blocked: bool
+    reason: Optional[str] = None
+    violations: List[Vulnerability] = field(default_factory=list)
+
+
+class PolicyEvaluator:
+    """Applies configured policy rules to a list of vulnerabilities."""
+
+    def _format_reason(self, violations: List[Vulnerability], threshold: str, blocked: bool) -> str:
+        """Build a human-readable summary of policy violations.
+
+        Args:
+            violations: The filtered list of violating vulnerabilities.
+            threshold: The configured severity threshold label.
+            blocked: Whether the decision is a hard block.
+
+        Returns:
+            A string like "Blocked: 2 CRITICAL, 3 HIGH vulnerabilities exceed threshold HIGH"
+            or the equivalent prefixed with "Audit:" when not blocking.
+        """
+        counts: Counter[str] = Counter(v.severity for v in violations)
+        severity_parts = [
+            f"{counts[sev]} {sev}"
+            for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")
+            if counts[sev]
+        ]
+        prefix = "Blocked" if blocked else "Audit"
+        return f"{prefix}: {', '.join(severity_parts)} vulnerabilities exceed threshold {threshold}"
+
+    def evaluate(self, vulnerabilities: List[Vulnerability], config: ScannerConfig) -> PolicyDecision:
+        """Evaluate vulnerabilities against policy and return a decision.
+        1. Severity filter  — drop vulns below config.severity_threshold
+        2. Ignore list      — drop vulns in config.ignore_cves
+        3. Unfixed filter   — when fail_on_unfixed=False, drop unfixed vulns
+        4. Mode decision    — enforce → block if violations exist; audit → allow but surface
+
+        Args:
+            vulnerabilities: Normalized list from the scanner adapter.
+            config: Active ScannerConfig for this evaluation.
+
+        Returns:
+            PolicyDecision with blocked flag, optional reason, and violation list.
+        """
+        threshold_rank = _SEVERITY_ORDER[config.severity_threshold]
+        violations = [v for v in vulnerabilities if _SEVERITY_ORDER.get(v.severity, 0) >= threshold_rank]
+        ignore_set = set(config.ignore_cves)
+        violations = [v for v in violations if v.cve_id not in ignore_set]
+        if not config.fail_on_unfixed:
+            violations = [v for v in violations if v.fixed_version is not None]
+        if config.mode == "disabled":
+            return PolicyDecision(blocked=False, reason="scan skipped")
+        elif config.mode == "enforce":
+            blocked = bool(violations)
+            reason = self._format_reason(violations, config.severity_threshold, blocked=True) if blocked else None
+            return PolicyDecision(blocked=blocked, reason=reason, violations=violations)
+        else:  # "audit"
+            reason = self._format_reason(violations, config.severity_threshold, blocked=False) if violations else None
+            return PolicyDecision(blocked=False, reason=reason, violations=violations)

--- a/plugins/container_scanner/scanners/__init__.py
+++ b/plugins/container_scanner/scanners/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/scanners/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Public API for the scanners subpackage.
+"""
+
+from __future__ import annotations
+
+from .base import ScannerRunner
+from .grype_runner import GrypeRunner
+from .trivy_runner import TrivyRunner
+
+__all__ = ["ScannerRunner", "GrypeRunner", "TrivyRunner"]

--- a/plugins/container_scanner/scanners/base.py
+++ b/plugins/container_scanner/scanners/base.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/scanners/base.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Abstract base class for container scanner runners.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+from plugins.container_scanner.types import Vulnerability
+
+
+class ScannerRunner(ABC):
+    @abstractmethod
+    async def run(self, image_ref: str, auth_env: Dict[str, str]) -> List[Vulnerability]:
+        pass

--- a/plugins/container_scanner/scanners/grype_runner.py
+++ b/plugins/container_scanner/scanners/grype_runner.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/scanners/grype_runner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Grype scanner runner — executes the Grype CLI and normalizes its JSON output
+into the unified Vulnerability schema.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+# Local
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.scanners.base import ScannerRunner
+from plugins.container_scanner.types import Vulnerability
+from mcpgateway.utils.exec import run_command
+
+_SEVERITY_MAP = {"CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"}
+
+
+class GrypeRunner(ScannerRunner):
+    def __init__(self, config: ScannerConfig) -> None:
+        super().__init__()
+        self.enabled = config.mode != "disabled"
+        self.timeout_s = config.timeout_seconds
+        self.mode = config.mode
+
+    def _extract_fixed_version(self, fix: dict[str, Any]) -> Optional[str]:
+        if fix.get("state") == "fixed":
+            versions = fix.get("versions") or []
+            return versions[0] if versions else None
+        return None
+
+    def _parse_grype_result(self, scan_output: dict[str, Any]) -> List[Vulnerability]:
+        """Parse Grype JSON output into unified Vulnerability objects.
+
+        Grype's top-level structure:
+            {"matches": [{"vulnerability": {...}, "artifact": {...}}, ...]}
+
+        Each match pairs one CVE record with one affected package.
+        """
+        findings: List[Vulnerability] = []
+
+        for match in scan_output.get("matches") or []:
+            vuln = match.get("vulnerability") or {}
+            artifact = match.get("artifact") or {}
+
+            cve_id: str = vuln.get("id") or ""
+            if not cve_id:
+                continue
+
+            raw_severity: str = (vuln.get("severity") or "").upper()
+            if raw_severity not in _SEVERITY_MAP:
+                continue
+
+            fix_info: dict[str, Any] = vuln.get("fix") or {}
+            fixed_version = self._extract_fixed_version(fix_info)
+
+            findings.append(
+                Vulnerability(
+                    scanner="grype",
+                    cve_id=cve_id,
+                    severity=raw_severity,
+                    package_name=artifact.get("name") or "",
+                    installed_version=artifact.get("version") or "",
+                    fixed_version=fixed_version,
+                    description=vuln.get("description"),
+                )
+            )
+
+        return findings
+
+    async def run(self, image_ref: str, auth_env: Dict[str, str]) -> List[Vulnerability]:
+        # -o json — machine-readable output
+        # -q     — suppress progress bars / status lines so stdout is pure JSON
+        commands = ["grype", image_ref, "-o", "json", "-q"]
+
+        # Merge auth credentials into the subprocess environment.
+        # auth_env is {} for public images so this is a no-op in the common case.
+        env = {**os.environ, **auth_env}
+        result = await run_command(cmd=commands, timeout_seconds=self.timeout_s, cwd=None, env=env)
+
+        if result.timed_out:
+            raise TimeoutError(f"Grype scan timed out after {self.timeout_s}s for '{image_ref}'")
+        if result.returncode != 0:
+            raise RuntimeError(f"Grype exited {result.returncode} for '{image_ref}'. stderr: {result.stderr.strip()}")
+
+        data: dict[str, Any] = json.loads(result.stdout) if result.stdout else {}
+        return self._parse_grype_result(data)

--- a/plugins/container_scanner/scanners/trivy_runner.py
+++ b/plugins/container_scanner/scanners/trivy_runner.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/scanners/trivy_runner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Trivy scanner runner — executes the Trivy CLI and normalizes its JSON output
+into the unified Vulnerability schema.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import json
+import os
+from typing import Any, Dict, List
+
+# Local
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.scanners.base import ScannerRunner
+from plugins.container_scanner.types import Vulnerability
+from mcpgateway.utils.exec import run_command
+
+# UNKNOWN is included: Trivy emits it when no CVSS score exists (common in
+# Alpine/Debian vendor advisories). Dropping UNKNOWN silently would hide real CVEs.
+_SEVERITY_MAP = {"CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"}
+
+
+class TrivyRunner(ScannerRunner):
+    def __init__(self, config: ScannerConfig) -> None:
+        super().__init__()
+        self.enabled = config.mode != "disabled"
+        self.timeout_s = config.timeout_seconds
+        self.mode = config.mode
+
+    def _parse_trivy_result(self, scan_output: dict[str, Any]) -> List[Vulnerability]:
+        findings: List[Vulnerability] = []
+        results = scan_output.get("Results", [])
+
+        for result in results:
+            # Trivy omits "Vulnerabilities" entirely when a target has none — use `or []`
+            for vuln in result.get("Vulnerabilities") or []:
+                if vuln.get("Severity") not in _SEVERITY_MAP:
+                    continue
+                findings.append(
+                    Vulnerability(
+                        scanner="trivy",
+                        cve_id=vuln.get("VulnerabilityID"),
+                        severity=vuln.get("Severity"),
+                        package_name=vuln.get("PkgName"),
+                        installed_version=vuln.get("InstalledVersion"),
+                        fixed_version=vuln.get("FixedVersion"),
+                        description=vuln.get("Description"),
+                    )
+                )
+
+        return findings
+
+    async def run(self, image_ref: str, auth_env: Dict[str, str]) -> List[Vulnerability]:
+        commands = ["trivy", "image", "--format", "json", "--quiet", "--timeout", f"{self.timeout_s}s", image_ref]
+
+        # Merge auth credentials into the subprocess environment.
+        # auth_env is {} for public images so this is a no-op in the common case.
+        env = {**os.environ, **auth_env}
+        result = await run_command(cmd=commands, timeout_seconds=self.timeout_s, cwd=None, env=env)
+
+        if result.timed_out:
+            raise TimeoutError(f"Trivy scan timed out after {self.timeout_s}s for '{image_ref}'")
+        if result.returncode != 0:
+            raise RuntimeError(f"Trivy exited {result.returncode} for '{image_ref}'. stderr: {result.stderr.strip()}")
+
+        data: dict[str, Any] = json.loads(result.stdout) if result.stdout else {}
+        return self._parse_trivy_result(data)

--- a/plugins/container_scanner/storage/__init__.py
+++ b/plugins/container_scanner/storage/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/storage/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Public API for the storage subpackage.
+"""
+
+from __future__ import annotations

--- a/plugins/container_scanner/storage/repository.py
+++ b/plugins/container_scanner/storage/repository.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/storage/repository.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+In-memory repository for container scan results.
+
+Stores the most recent ScanResult per image_digest and supports listing
+recent scans in reverse-chronological order.  Bounded by max_entries
+to keep memory predictable; oldest entries are evicted when full.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import Dict, List, Optional
+
+# Local
+from plugins.container_scanner.types import ScanResult
+
+logger = logging.getLogger(__name__)
+
+
+class ScanResultRepository:
+    """Bounded in-memory store for container scan results.
+
+    Usage::
+
+        repo = ScanResultRepository(max_entries=500)
+        repo.save(scan_result)
+        result = repo.get("ghcr.io/org/app:v1")
+
+    Args:
+        max_entries: Maximum number of results to retain.
+            When the limit is reached, the oldest entry is evicted
+            before inserting the new one.
+    """
+    _max_entries : int
+    _store : Dict[str, ScanResult]
+    _insertion_order : List[str]
+
+    def __init__(self, max_entries: int = 1000) -> None:
+        if max_entries < 1:
+            raise ValueError("Maximum number of entries must be a positive number")
+        self._max_entries = max_entries
+        self._store = {}
+        self._insertion_order = []
+
+
+    def save(self, result: ScanResult) -> None:
+        """Persist a scan result, replacing any prior result for the same image.
+
+        If the repository is at capacity and the image_digest is new, the oldest
+        entry is evicted to make room.
+
+        Args:
+            result: Completed scan result to store.
+        """
+        if result.image_digest in self._store:
+            self._insertion_order.remove(result.image_digest)
+        if len(self._store) == self._max_entries:
+            oldest = self._insertion_order.pop(0)
+            self._store.pop(oldest)
+            logger.info("Repository at capacity (%d), evicted oldest entry: %s", self._max_entries, oldest)
+        if result.image_digest:
+            self._store[result.image_digest] = result
+            self._insertion_order.append(result.image_digest)
+        else:
+            self._store[result.image_ref] = result
+            self._insertion_order.append(result.image_ref)
+
+
+
+    def get(self, image_digest: str) -> Optional[ScanResult]:
+        """Return the most recent scan result for *image_digest*, or None.
+
+        Args:
+            image_digest: Full image reference (e.g., ``"ghcr.io/org/app:v1"``).
+
+        Returns:
+            Stored :class:`ScanResult`, or ``None`` if not found.
+        """
+        return self._store.get(image_digest)
+
+
+
+    def clear(self) -> None:
+        """Remove all stored results."""
+        self._store.clear()
+        self._insertion_order.clear()
+        logger.info("ScanResultRepository cleared")
+
+    def __len__(self) -> int:
+        """Return the number of stored results."""
+        return len(self._store)

--- a/plugins/container_scanner/storage/repository.py
+++ b/plugins/container_scanner/storage/repository.py
@@ -60,18 +60,18 @@ class ScanResultRepository:
         Args:
             result: Completed scan result to store.
         """
-        if result.image_digest in self._store:
-            self._insertion_order.remove(result.image_digest)
-        if len(self._store) == self._max_entries:
-            oldest = self._insertion_order.pop(0)
-            self._store.pop(oldest)
-            logger.info("Repository at capacity (%d), evicted oldest entry: %s", self._max_entries, oldest)
-        if result.image_digest:
-            self._store[result.image_digest] = result
-            self._insertion_order.append(result.image_digest)
+        key = result.image_digest if result.image_digest else result.image_ref
+        if key in self._store:
+            # Update existing entry — move to end of order, no eviction needed
+            self._insertion_order.remove(key)
         else:
-            self._store[result.image_ref] = result
-            self._insertion_order.append(result.image_ref)
+            # New entry — evict oldest if at capacity
+            if len(self._store) == self._max_entries:
+                oldest = self._insertion_order.pop(0)
+                self._store.pop(oldest)
+                logger.info("Repository at capacity (%d), evicted oldest entry: %s", self._max_entries, oldest)
+        self._store[key] = result
+        self._insertion_order.append(key)
 
 
 
@@ -94,6 +94,14 @@ class ScanResultRepository:
         self._insertion_order.clear()
         logger.info("ScanResultRepository cleared")
 
+    def list_recent(self) -> List[ScanResult]:
+        """Return all stored results, most recent first."""
+        return [self._store[key] for key in reversed(self._insertion_order) if key in self._store]
+
     def __len__(self) -> int:
         """Return the number of stored results."""
         return len(self._store)
+
+
+# Shared singleton — used by ContainerScannerPlugin and the admin/API routers
+container_scan_repo = ScanResultRepository()

--- a/plugins/container_scanner/types.py
+++ b/plugins/container_scanner/types.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/container_scanner/types.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Data schemas for findings and scan results.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import datetime
+from typing import List, Literal, Optional
+
+# Third-Party
+from pydantic import BaseModel
+
+class Vulnerability(BaseModel):
+    """Unified vulnerability schema from any scanner.
+
+    Attributes:
+        scanner: Scanner tool name (e.g., "trivy", "grype").
+        cve_id: CVE identifier (e.g., "CVE-2023-12345").
+        severity: Normalized severity level (CRITICAL|HIGH|MEDIUM|LOW).
+        package_name: Name of the vulnerable package.
+        installed_version: Currently installed version.
+        fixed_version: Version that fixes the vulnerability, if available.
+        description: Human-readable description of the vulnerability.
+    """
+
+    scanner: Literal["trivy", "grype"]
+    cve_id: str
+    severity: Literal["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+    package_name: str
+    installed_version: str
+    fixed_version: Optional[str] = None
+    description: Optional[str] = None
+
+class Summary(BaseModel):
+    critical_count: int
+    high_count: int
+    medium_count: int
+    low_count: int
+
+
+class ScanResult(BaseModel):
+    """Complete scan result contract.
+
+    Attributes:
+        image_ref:
+        image_digest:
+        scanners:
+        scan_time:
+        duration_ms:
+        vulnerabilities:
+        summary:
+        blocked:
+        reason:
+        scan_error:
+    """
+
+    image_ref : str
+    image_digest : Optional[str] = None
+    scanners: Literal["trivy", "grype"]
+    scan_time: datetime.datetime
+    duration_ms: int
+    vulnerabilities: List[Vulnerability]
+    summary: Summary
+    blocked:bool
+    reason : Optional[str] = None
+    scan_error : Optional[str] = None

--- a/tests/integration/test_container_scanner/conftest.py
+++ b/tests/integration/test_container_scanner/conftest.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_container_scanner/conftest.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Shared fixtures for container scanner integration tests.
+"""
+
+from __future__ import annotations
+
+# Third-Party
+import pytest
+from fastapi.testclient import TestClient
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.main import app
+from mcpgateway.routers.container_scanner_router import container_scanner_router
+from plugins.container_scanner.storage.repository import container_scan_repo
+
+# Register the router if plugins were disabled at startup (e.g. in CI without config)
+if not any(getattr(r, "path", "").startswith("/container-scanner") for r in app.routes):
+    app.include_router(container_scanner_router)
+
+
+@pytest.fixture
+def clean_repo():
+    """Clear the shared singleton before and after each test."""
+    container_scan_repo.clear()
+    yield container_scan_repo
+    container_scan_repo.clear()
+
+
+@pytest.fixture
+def client(clean_repo):
+    """TestClient with auth dependency overridden."""
+    app.dependency_overrides[get_current_user] = lambda: {"email": "test@example.com", "is_admin": True}
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_current_user, None)

--- a/tests/integration/test_container_scanner/test_api.py
+++ b/tests/integration/test_container_scanner/test_api.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_container_scanner/test_api.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Integration tests for container scanner REST API endpoints.
+Verifies that the router reads from the shared singleton repository.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# Third-Party
+import pytest
+
+# Local
+from plugins.container_scanner.types import ScanResult, Summary
+
+
+def make_scan_result(image_ref: str = "ghcr.io/org/app:v1", blocked: bool = False, image_digest: str | None = None) -> ScanResult:
+    return ScanResult(
+        image_ref=image_ref,
+        image_digest=image_digest,
+        scanners="trivy",
+        scan_time=datetime.now(timezone.utc),
+        duration_ms=100,
+        vulnerabilities=[],
+        summary=Summary(critical_count=0, high_count=0, medium_count=0, low_count=0),
+        blocked=blocked,
+        reason=None,
+        scan_error=None,
+    )
+
+
+class TestHealthEndpoint:
+    def test_health_empty(self, client, clean_repo):
+        response = client.get("/container-scanner/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["count"] == 0
+
+    def test_health_with_results(self, client, clean_repo):
+        clean_repo.save(make_scan_result())
+        response = client.get("/container-scanner/health")
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+
+
+class TestListScansEndpoint:
+    def test_list_scans_empty(self, client):
+        response = client.get("/container-scanner/scans")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_scans_with_result(self, client, clean_repo):
+        clean_repo.save(make_scan_result("ghcr.io/org/app:v1"))
+        response = client.get("/container-scanner/scans")
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["image_ref"] == "ghcr.io/org/app:v1"
+        assert results[0]["blocked"] is False
+        assert "scan_time" in results[0]
+        assert "summary" in results[0]
+
+    def test_list_scans_most_recent_first(self, client, clean_repo):
+        clean_repo.save(make_scan_result("ghcr.io/org/app:v1"))
+        clean_repo.save(make_scan_result("ghcr.io/org/app:v2"))
+        response = client.get("/container-scanner/scans")
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 2
+        assert results[0]["image_ref"] == "ghcr.io/org/app:v2"
+        assert results[1]["image_ref"] == "ghcr.io/org/app:v1"
+
+
+class TestGetScanEndpoint:
+    def test_get_scan_not_found(self, client, clean_repo):
+        response = client.get("/container-scanner/scans/unknown:tag")
+        assert response.status_code == 404
+
+    def test_get_scan_by_image_ref(self, client, clean_repo):
+        clean_repo.save(make_scan_result("ghcr.io/org/app:v1"))
+        response = client.get("/container-scanner/scans/ghcr.io/org/app:v1")
+        assert response.status_code == 200
+        assert response.json()["image_ref"] == "ghcr.io/org/app:v1"
+
+    def test_get_scan_by_digest(self, client, clean_repo):
+        digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        clean_repo.save(make_scan_result("ghcr.io/org/app:v1", image_digest=digest))
+        response = client.get(f"/container-scanner/scans/{digest}")
+        assert response.status_code == 200
+        assert response.json()["image_digest"] == digest
+
+    def test_get_scan_blocked_result(self, client, clean_repo):
+        clean_repo.save(make_scan_result("ghcr.io/org/app:bad", blocked=True))
+        response = client.get("/container-scanner/scans/ghcr.io/org/app:bad")
+        assert response.status_code == 200
+        assert response.json()["blocked"] is True
+
+
+class TestAuthentication:
+    def test_unauthenticated_returns_401(self, clean_repo):
+        """Requests without auth override are rejected."""
+        from fastapi.testclient import TestClient
+        from mcpgateway.main import app
+
+        unauthenticated_client = TestClient(app, raise_server_exceptions=False)
+        response = unauthenticated_client.get("/container-scanner/health")
+        assert response.status_code in (401, 403)

--- a/tests/integration/test_container_scanner/test_hook_pipeline.py
+++ b/tests/integration/test_container_scanner/test_hook_pipeline.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_container_scanner/test_hook_pipeline.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+End-to-end integration tests: plugin hook fires → result stored in singleton → retrievable via API.
+Proves the wiring between ContainerScannerPlugin and the REST router is correct.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.plugins.framework import PluginConfig
+from mcpgateway.plugins.framework.models import GlobalContext, PluginContext
+from plugins.container_scanner.container_scanner import ContainerScannerPlugin
+from plugins.container_scanner.scanners.trivy_runner import TrivyRunner
+from plugins.container_scanner.types import Vulnerability
+from mcpgateway.plugins.framework.hooks.gateway import ServerPreRegisterPayload, RuntimePreDeployPayload
+
+
+IMAGE_REF = "ghcr.io/org/app:v1"
+DIGEST = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def make_plugin_config(**kwargs) -> PluginConfig:
+    defaults = dict(scanner="trivy", mode="enforce", cache_enabled=False)
+    defaults.update(kwargs)
+    return PluginConfig(
+        name="container_scanner",
+        kind="plugins.container_scanner.container_scanner.ContainerScannerPlugin",
+        priority=100,
+        config=defaults,
+    )
+
+
+def make_plugin_context() -> PluginContext:
+    return PluginContext(global_context=GlobalContext(request_id="req-test-001"))
+
+
+def make_vuln(**kwargs: Any) -> Vulnerability:
+    defaults: Dict[str, Any] =  dict(
+        scanner="trivy",
+        cve_id="CVE-2023-0001",
+        severity="CRITICAL",
+        package_name="libfoo",
+        installed_version="1.0.0",
+        fixed_version="2.0.0",  # required: policy drops unfixed vulns by default
+    )
+    defaults.update(kwargs)
+    return Vulnerability(**defaults)
+
+
+class TestServerPreRegisterHook:
+    @pytest.mark.asyncio
+    async def test_server_pre_register_stores_result(self, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config())
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = []
+            payload = ServerPreRegisterPayload(assessment_id="assess-001", image_ref=IMAGE_REF, image_digest=DIGEST)
+            await plugin.server_pre_register(payload, make_plugin_context())
+
+        assert clean_repo.get(DIGEST) is not None
+        assert clean_repo.get(DIGEST).image_ref == IMAGE_REF
+
+    @pytest.mark.asyncio
+    async def test_server_pre_register_blocked_result(self, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config(severity_threshold="HIGH"))
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = [make_vuln(severity="CRITICAL")]
+            payload = ServerPreRegisterPayload(assessment_id="assess-002", image_ref=IMAGE_REF, image_digest=DIGEST)
+            hook_result = await plugin.server_pre_register(payload, make_plugin_context())
+
+        assert hook_result.continue_processing is False
+        assert hook_result.violation is not None
+
+    @pytest.mark.asyncio
+    async def test_server_pre_register_unblocked_result(self, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config(severity_threshold="CRITICAL"))
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = [make_vuln(severity="LOW")]
+            payload = ServerPreRegisterPayload(assessment_id="assess-003", image_ref=IMAGE_REF, image_digest=DIGEST)
+            hook_result = await plugin.server_pre_register(payload, make_plugin_context())
+
+        assert hook_result.continue_processing is True
+
+
+class TestRuntimePreDeployHook:
+    @pytest.mark.asyncio
+    async def test_runtime_pre_deploy_stores_result(self, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config())
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = []
+            payload = RuntimePreDeployPayload(assessment_id="assess-101", image_ref=IMAGE_REF, image_digest=DIGEST)
+            await plugin.runtime_pre_deploy(payload, make_plugin_context())
+
+        assert clean_repo.get(DIGEST) is not None
+
+    @pytest.mark.asyncio
+    async def test_runtime_pre_deploy_blocked_result(self, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config(severity_threshold="HIGH"))
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = [make_vuln(severity="CRITICAL")]
+            payload = RuntimePreDeployPayload(assessment_id="assess-102", image_ref=IMAGE_REF, image_digest=DIGEST)
+            hook_result = await plugin.runtime_pre_deploy(payload, make_plugin_context())
+
+        assert hook_result.continue_processing is False
+
+
+class TestHookResultVisibleViaAPI:
+    @pytest.mark.asyncio
+    async def test_hook_result_visible_via_api(self, client, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config())
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = []
+            payload = ServerPreRegisterPayload(assessment_id="assess-201", image_ref=IMAGE_REF, image_digest=None)
+            await plugin.server_pre_register(payload, make_plugin_context())
+
+        response = client.get("/container-scanner/scans")
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["image_ref"] == IMAGE_REF
+
+    @pytest.mark.asyncio
+    async def test_hook_blocked_result_visible_via_api(self, client, clean_repo):
+        plugin = ContainerScannerPlugin(make_plugin_config(severity_threshold="HIGH"))
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = [make_vuln(severity="CRITICAL")]
+            payload = ServerPreRegisterPayload(assessment_id="assess-202", image_ref=IMAGE_REF, image_digest=None)
+            await plugin.server_pre_register(payload, make_plugin_context())
+
+        response = client.get(f"/container-scanner/scans/{IMAGE_REF}")
+        assert response.status_code == 200
+        assert response.json()["blocked"] is True
+
+    @pytest.mark.asyncio
+    async def test_disabled_mode_skips_scan(self, clean_repo):
+        """Mode=disabled stores a result with reason='scan skipped', runner not invoked."""
+        plugin = ContainerScannerPlugin(make_plugin_config(mode="disabled"))
+        plugin._repo = clean_repo
+
+        with patch.object(TrivyRunner, "run", new_callable=AsyncMock) as mock_run:
+            payload = ServerPreRegisterPayload(assessment_id="assess-203", image_ref=IMAGE_REF, image_digest=None)
+            await plugin.server_pre_register(payload, make_plugin_context())
+            mock_run.assert_not_called()
+
+        # disabled mode returns early without saving to repo
+        assert len(clean_repo) == 0

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_auth_resolver.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_auth_resolver.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_auth_resolver.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for AuthResolver.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.container_scanner.auth.auth_resolver import AuthResolver
+from plugins.container_scanner.config import RegistryConfig, ScannerConfig
+
+
+def make_config(registries=None) -> ScannerConfig:
+    return ScannerConfig(registries=registries or [])
+
+
+class TestAuthResolverPublicRegistry:
+    def test_public_image_returns_empty_dict(self):
+        resolver = AuthResolver(make_config())
+        result = resolver.resolve("python:3.12-slim")
+        assert result == {}
+
+    def test_no_matching_registry_returns_empty_dict(self):
+        reg = RegistryConfig(url="ghcr.io", auth_type="token", token_env="GHCR_TOKEN")
+        resolver = AuthResolver(make_config(registries=[reg]))
+        # gcr.io doesn't match ghcr.io
+        result = resolver.resolve("gcr.io/myproject/app:latest")
+        assert result == {}
+
+
+class TestAuthResolverTokenAuth:
+    def test_token_auth_sets_all_scanner_vars(self, monkeypatch):
+        monkeypatch.setenv("GHCR_TOKEN", "secret-token")
+        reg = RegistryConfig(url="ghcr.io", auth_type="token", token_env="GHCR_TOKEN")
+        resolver = AuthResolver(make_config(registries=[reg]))
+        result = resolver.resolve("ghcr.io/org/app:v1")
+        assert result["TRIVY_USERNAME"] == ""
+        assert result["TRIVY_PASSWORD"] == "secret-token"
+        assert result["GRYPE_REGISTRY_AUTH_USERNAME"] == ""
+        assert result["GRYPE_REGISTRY_AUTH_PASSWORD"] == "secret-token"
+
+    def test_token_auth_raises_when_env_missing(self, monkeypatch):
+        monkeypatch.delenv("GHCR_TOKEN", raising=False)
+        reg = RegistryConfig(url="ghcr.io", auth_type="token", token_env="GHCR_TOKEN")
+        resolver = AuthResolver(make_config(registries=[reg]))
+        with pytest.raises(EnvironmentError, match="GHCR_TOKEN"):
+            resolver.resolve("ghcr.io/org/app:v1")
+
+
+class TestAuthResolverBasicAuth:
+    def test_basic_auth_sets_credentials(self, monkeypatch):
+        monkeypatch.setenv("REG_USER", "myuser")
+        monkeypatch.setenv("REG_PASS", "mypass")
+        reg = RegistryConfig(url="registry.example.com", auth_type="basic", username_env="REG_USER", password_env="REG_PASS")
+        resolver = AuthResolver(make_config(registries=[reg]))
+        result = resolver.resolve("registry.example.com/app:latest")
+        assert result["TRIVY_USERNAME"] == "myuser"
+        assert result["TRIVY_PASSWORD"] == "mypass"
+        assert result["GRYPE_REGISTRY_AUTH_USERNAME"] == "myuser"
+        assert result["GRYPE_REGISTRY_AUTH_PASSWORD"] == "mypass"
+
+    def test_basic_auth_raises_when_username_missing(self, monkeypatch):
+        monkeypatch.delenv("REG_USER", raising=False)
+        monkeypatch.setenv("REG_PASS", "mypass")
+        reg = RegistryConfig(url="registry.example.com", auth_type="basic", username_env="REG_USER", password_env="REG_PASS")
+        resolver = AuthResolver(make_config(registries=[reg]))
+        with pytest.raises(EnvironmentError, match="REG_USER"):
+            resolver.resolve("registry.example.com/app:latest")
+
+    def test_basic_auth_raises_when_password_missing(self, monkeypatch):
+        monkeypatch.setenv("REG_USER", "myuser")
+        monkeypatch.delenv("REG_PASS", raising=False)
+        reg = RegistryConfig(url="registry.example.com", auth_type="basic", username_env="REG_USER", password_env="REG_PASS")
+        resolver = AuthResolver(make_config(registries=[reg]))
+        with pytest.raises(EnvironmentError, match="REG_PASS"):
+            resolver.resolve("registry.example.com/app:latest")
+
+
+class TestAuthResolverMatchingLogic:
+    def test_first_matching_registry_wins(self, monkeypatch):
+        monkeypatch.setenv("TOKEN_A", "tokenA")
+        reg_a = RegistryConfig(url="ghcr.io", auth_type="token", token_env="TOKEN_A")
+        monkeypatch.setenv("TOKEN_B", "tokenB")
+        reg_b = RegistryConfig(url="ghcr.io", auth_type="token", token_env="TOKEN_B")
+        resolver = AuthResolver(make_config(registries=[reg_a, reg_b]))
+        result = resolver.resolve("ghcr.io/org/app:v1")
+        assert result["TRIVY_PASSWORD"] == "tokenA"

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_cache_manager.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_cache_manager.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_cache_manager.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for CacheManager.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from plugins.container_scanner.cache.cache_manager import CacheManager
+from plugins.container_scanner.types import Vulnerability
+
+
+def make_vuln(**kwargs) -> Vulnerability:
+    defaults = dict(
+        scanner="trivy",
+        cve_id="CVE-2023-0001",
+        severity="HIGH",
+        package_name="libfoo",
+        installed_version="1.0.0",
+        fixed_version="1.0.1",
+    )
+    defaults.update(kwargs)
+    return Vulnerability(**defaults)
+
+
+class TestCacheManagerLookup:
+    def test_miss_when_disabled(self):
+        cache = CacheManager(enabled=False)
+        cache.store("sha256:abc", [make_vuln()])
+        assert cache.lookup("sha256:abc") is None
+
+    def test_miss_on_none_digest(self):
+        cache = CacheManager()
+        assert cache.lookup(None) is None
+
+    def test_miss_on_empty_string_digest(self):
+        cache = CacheManager()
+        assert cache.lookup("") is None
+
+    def test_miss_when_not_stored(self):
+        cache = CacheManager()
+        assert cache.lookup("sha256:unknown") is None
+
+    def test_hit_returns_stored_vulns(self):
+        cache = CacheManager()
+        vulns = [make_vuln()]
+        cache.store("sha256:abc", vulns)
+        result = cache.lookup("sha256:abc")
+        assert result == vulns
+
+    def test_miss_when_expired(self):
+        cache = CacheManager(ttl_hours=1)
+        vulns = [make_vuln()]
+        cache.store("sha256:abc", vulns)
+        # Backdate the cached_at timestamp to simulate expiry
+        two_hours_ago = datetime.now(timezone.utc) - timedelta(hours=2)
+        cache._cache["sha256:abc"] = (vulns, two_hours_ago)
+        assert cache.lookup("sha256:abc") is None
+        # Expired entry should be lazily evicted
+        assert "sha256:abc" not in cache._cache
+
+    def test_hit_within_ttl(self):
+        cache = CacheManager(ttl_hours=24)
+        vulns = [make_vuln()]
+        cache.store("sha256:abc", vulns)
+        assert cache.lookup("sha256:abc") is not None
+
+
+class TestCacheManagerStore:
+    def test_store_is_noop_when_disabled(self):
+        cache = CacheManager(enabled=False)
+        cache.store("sha256:abc", [make_vuln()])
+        assert len(cache._cache) == 0
+
+    def test_store_is_noop_on_none_digest(self):
+        cache = CacheManager()
+        cache.store(None, [make_vuln()])
+        assert len(cache._cache) == 0
+
+    def test_store_overwrites_previous_entry(self):
+        cache = CacheManager()
+        v1 = [make_vuln(cve_id="CVE-2023-0001")]
+        v2 = [make_vuln(cve_id="CVE-2023-0002")]
+        cache.store("sha256:abc", v1)
+        cache.store("sha256:abc", v2)
+        assert cache.lookup("sha256:abc") == v2
+
+
+class TestCacheManagerInvalidateAndClear:
+    def test_invalidate_removes_entry(self):
+        cache = CacheManager()
+        cache.store("sha256:abc", [make_vuln()])
+        cache.invalidate("sha256:abc")
+        assert cache.lookup("sha256:abc") is None
+
+    def test_invalidate_nonexistent_is_safe(self):
+        cache = CacheManager()
+        cache.invalidate("sha256:nonexistent")  # should not raise
+
+    def test_clear_empties_cache(self):
+        cache = CacheManager()
+        cache.store("sha256:abc", [make_vuln()])
+        cache.store("sha256:def", [make_vuln(cve_id="CVE-2023-0002")])
+        cache.clear()
+        assert cache.lookup("sha256:abc") is None
+        assert cache.lookup("sha256:def") is None
+
+    def test_clear_resets_stats(self):
+        cache = CacheManager()
+        cache.store("sha256:abc", [make_vuln()])
+        cache.lookup("sha256:abc")  # hit
+        cache.lookup("sha256:miss")  # miss
+        cache.clear()
+        stats = cache.get_stats()
+        assert stats["hits"] == 0.0
+        assert stats["misses"] == 0.0
+
+
+class TestCacheManagerStats:
+    def test_initial_stats_are_zero(self):
+        cache = CacheManager()
+        stats = cache.get_stats()
+        assert stats["hits"] == 0.0
+        assert stats["misses"] == 0.0
+        assert stats["size"] == 0.0
+        assert stats["hit_rate_percent"] == 0.0
+
+    def test_hit_rate_calculation(self):
+        cache = CacheManager()
+        cache.store("sha256:abc", [make_vuln()])
+        cache.lookup("sha256:abc")  # hit
+        cache.lookup("sha256:abc")  # hit
+        cache.lookup("sha256:miss")  # miss
+        stats = cache.get_stats()
+        assert stats["hits"] == 2.0
+        assert stats["misses"] == 1.0
+        assert stats["hit_rate_percent"] == pytest.approx(66.67, abs=0.01)
+
+    def test_size_reflects_stored_entries(self):
+        cache = CacheManager()
+        cache.store("sha256:a", [make_vuln()])
+        cache.store("sha256:b", [make_vuln(cve_id="CVE-2023-0002")])
+        assert cache.get_stats()["size"] == 2.0

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_config.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_config.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_config.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for ScannerConfig, RegistryConfig, and _parse_registry_host.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from plugins.container_scanner.config import RegistryConfig, ScannerConfig, _parse_registry_host
+
+
+class TestParseRegistryHost:
+    def test_docker_hub_image(self):
+        assert _parse_registry_host("python:3.12-slim") == "docker.io"
+
+    def test_ghcr_image(self):
+        assert _parse_registry_host("ghcr.io/org/app:v1") == "ghcr.io"
+
+    def test_gcr_image(self):
+        assert _parse_registry_host("gcr.io/myproject/app:latest") == "gcr.io"
+
+    def test_localhost_registry(self):
+        assert _parse_registry_host("localhost:5000/app:v1") == "localhost:5000"
+
+    def test_registry_with_port(self):
+        assert _parse_registry_host("registry.example.com:443/app:v1") == "registry.example.com:443"
+
+
+class TestRegistryConfigValidation:
+    def test_token_auth_requires_token_env(self):
+        with pytest.raises(ValidationError, match="token_env"):
+            RegistryConfig(url="ghcr.io", auth_type="token")
+
+    def test_token_auth_valid(self):
+        reg = RegistryConfig(url="ghcr.io", auth_type="token", token_env="GHCR_TOKEN")
+        assert reg.token_env == "GHCR_TOKEN"
+
+    def test_basic_auth_requires_username_and_password(self):
+        with pytest.raises(ValidationError):
+            RegistryConfig(url="registry.example.com", auth_type="basic", username_env="USER")
+
+    def test_basic_auth_missing_username(self):
+        with pytest.raises(ValidationError):
+            RegistryConfig(url="registry.example.com", auth_type="basic", password_env="PASS")
+
+    def test_basic_auth_valid(self):
+        reg = RegistryConfig(url="registry.example.com", auth_type="basic", username_env="USER", password_env="PASS")
+        assert reg.username_env == "USER"
+        assert reg.password_env == "PASS"
+
+
+class TestScannerConfigDefaults:
+    def test_default_scanner_is_trivy(self):
+        cfg = ScannerConfig()
+        assert cfg.scanner == "trivy"
+
+    def test_default_mode_is_enforce(self):
+        cfg = ScannerConfig()
+        assert cfg.mode == "enforce"
+
+    def test_default_severity_threshold_is_high(self):
+        cfg = ScannerConfig()
+        assert cfg.severity_threshold == "HIGH"
+
+    def test_default_fail_on_unfixed_is_false(self):
+        cfg = ScannerConfig()
+        assert cfg.fail_on_unfixed is False
+
+    def test_default_cache_enabled_is_true(self):
+        cfg = ScannerConfig()
+        assert cfg.cache_enabled is True
+
+    def test_default_on_scan_error_is_fail_closed(self):
+        cfg = ScannerConfig()
+        assert cfg.on_scan_error == "fail_closed"
+
+    def test_timeout_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            ScannerConfig(timeout_seconds=0)
+
+
+class TestScannerConfigRegistryFor:
+    def test_returns_matching_registry(self):
+        reg = RegistryConfig(url="ghcr.io", auth_type="token", token_env="GHCR_TOKEN")
+        cfg = ScannerConfig(registries=[reg])
+        assert cfg.registry_for("ghcr.io/org/app:v1") is reg
+
+    def test_returns_none_for_unmatched_registry(self):
+        reg = RegistryConfig(url="ghcr.io", auth_type="token", token_env="GHCR_TOKEN")
+        cfg = ScannerConfig(registries=[reg])
+        assert cfg.registry_for("gcr.io/project/app:latest") is None
+
+    def test_returns_none_for_public_image(self):
+        cfg = ScannerConfig()
+        assert cfg.registry_for("python:3.12") is None

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_container_scanner.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_container_scanner.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_container_scanner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for ContainerScannerPlugin.scan() pipeline.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mcpgateway.plugins.framework import PluginConfig
+from plugins.container_scanner.container_scanner import ContainerScannerPlugin
+from plugins.container_scanner.types import Vulnerability
+
+DIGEST_V1 = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+DIGEST_V2 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+DIGEST_V3 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+DIGEST_UNKNOWN = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+def make_plugin_config(**scanner_config_kwargs) -> PluginConfig:
+    """Build a minimal PluginConfig with scanner config overrides."""
+    defaults = dict(scanner="trivy", mode="enforce", cache_enabled=False)
+    defaults.update(scanner_config_kwargs)
+    return PluginConfig(
+        name="container_scanner",
+        kind="plugins.container_scanner.container_scanner.ContainerScannerPlugin",
+        priority=100,
+        config=defaults,
+    )
+
+
+def make_vuln(**kwargs) -> Vulnerability:
+    defaults = dict(
+        scanner="trivy",
+        cve_id="CVE-2023-0001",
+        severity="HIGH",
+        package_name="libfoo",
+        installed_version="1.0.0",
+        fixed_version="1.0.1",
+    )
+    defaults.update(kwargs)
+    return Vulnerability(**defaults)
+
+
+class TestScanDisabledMode:
+    @pytest.mark.asyncio
+    async def test_scan_disabled_mode_returns_unblocked(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(mode="disabled"))
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert result.blocked is False
+        assert result.image_ref == "ghcr.io/org/app:v1"
+
+    @pytest.mark.asyncio
+    async def test_scan_disabled_skips_runner(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(mode="disabled"))
+        plugin._runner.run = AsyncMock()
+        await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        plugin._runner.run.assert_not_called()
+
+
+class TestScanCacheHit:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_runner(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(cache_enabled=True))
+        cached_vulns = [make_vuln(severity="LOW")]
+        plugin._cache.lookup = MagicMock(return_value=cached_vulns)
+        plugin._runner.run = AsyncMock()
+        await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        plugin._runner.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_re_evaluates_policy(self):
+        """Cache returns vulns but policy is always re-evaluated (not cached)."""
+        plugin = ContainerScannerPlugin(make_plugin_config(cache_enabled=True, severity_threshold="CRITICAL"))
+        # Only a HIGH vuln cached — CRITICAL threshold means no block
+        cached_vulns = [make_vuln(severity="HIGH")]
+        plugin._cache.lookup = MagicMock(return_value=cached_vulns)
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert result.blocked is False
+
+
+class TestScanCacheMiss:
+    @pytest.mark.asyncio
+    async def test_scan_cache_miss_runs_scanner(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(cache_enabled=True))
+        plugin._cache.lookup = MagicMock(return_value=None)
+        plugin._runner.run = AsyncMock(return_value=[])
+        plugin._cache.store = MagicMock()
+        plugin._repo.save = MagicMock()
+        await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        plugin._runner.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_scan_stores_result_after_scan(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(cache_enabled=True))
+        plugin._cache.lookup = MagicMock(return_value=None)
+        plugin._runner.run = AsyncMock(return_value=[])
+        plugin._cache.store = MagicMock()
+        plugin._repo.save = MagicMock()
+        await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        plugin._cache.store.assert_called_once()
+        plugin._repo.save.assert_called_once()
+
+
+
+
+
+class TestScanErrorHandling:
+    @pytest.mark.asyncio
+    async def test_fail_closed_blocks_on_scanner_error(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(on_scan_error="fail_closed"))
+        plugin._runner.run = AsyncMock(side_effect=RuntimeError("trivy not found"))
+        plugin._cache.lookup = MagicMock(return_value=None)
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert result.blocked is True
+        assert result.scan_error is not None
+
+    @pytest.mark.asyncio
+    async def test_fail_open_allows_on_scanner_error(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(on_scan_error="fail_open"))
+        plugin._runner.run = AsyncMock(side_effect=RuntimeError("trivy not found"))
+        plugin._cache.lookup = MagicMock(return_value=None)
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert result.blocked is False
+        assert result.scan_error is not None
+
+    @pytest.mark.asyncio
+    async def test_scan_error_is_recorded_in_result(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(on_scan_error="fail_open"))
+        plugin._runner.run = AsyncMock(side_effect=RuntimeError("connection timeout"))
+        plugin._cache.lookup = MagicMock(return_value=None)
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert "connection timeout" in result.scan_error
+
+
+class TestScanResultStructure:
+    @pytest.mark.asyncio
+    async def test_result_summary_counts_severities(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(mode="audit"))
+        vulns = [
+            make_vuln(severity="CRITICAL", cve_id="CVE-1"),
+            make_vuln(severity="HIGH", cve_id="CVE-2"),
+            make_vuln(severity="HIGH", cve_id="CVE-3"),
+            make_vuln(severity="MEDIUM", cve_id="CVE-4"),
+        ]
+        plugin._runner.run = AsyncMock(return_value=vulns)
+        plugin._cache.lookup = MagicMock(return_value=None)
+        plugin._cache.store = MagicMock()
+        plugin._repo.save = MagicMock()
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert result.summary.critical_count == 1
+        assert result.summary.high_count == 2
+        assert result.summary.medium_count == 1
+        assert result.summary.low_count == 0
+
+    @pytest.mark.asyncio
+    async def test_result_image_ref_matches_input(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(mode="audit"))
+        plugin._runner.run = AsyncMock(return_value=[])
+        plugin._cache.lookup = MagicMock(return_value=None)
+        plugin._cache.store = MagicMock()
+        plugin._repo.save = MagicMock()
+        result = await plugin.scan("ghcr.io/org/app:latest", DIGEST_V1)
+        assert result.image_ref == "ghcr.io/org/app:latest"
+
+    @pytest.mark.asyncio
+    async def test_result_duration_ms_is_non_negative(self):
+        plugin = ContainerScannerPlugin(make_plugin_config(mode="audit"))
+        plugin._runner.run = AsyncMock(return_value=[])
+        plugin._cache.lookup = MagicMock(return_value=None)
+        plugin._cache.store = MagicMock()
+        plugin._repo.save = MagicMock()
+        result = await plugin.scan("ghcr.io/org/app:v1", DIGEST_V1)
+        assert result.duration_ms >= 0

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_container_scanner.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_container_scanner.py
@@ -10,6 +10,7 @@ Unit tests for ContainerScannerPlugin.scan() pipeline.
 
 from __future__ import annotations
 
+from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -35,8 +36,8 @@ def make_plugin_config(**scanner_config_kwargs) -> PluginConfig:
     )
 
 
-def make_vuln(**kwargs) -> Vulnerability:
-    defaults = dict(
+def make_vuln(**kwargs: Any) -> Vulnerability:
+    defaults: Dict[str, Any] = dict(
         scanner="trivy",
         cve_id="CVE-2023-0001",
         severity="HIGH",

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_grype_runner.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_grype_runner.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_grype_runner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for GrypeRunner._parse_grype_result and async run().
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.scanners.grype_runner import GrypeRunner
+
+
+def make_config(**kwargs: Any) -> ScannerConfig:
+    defaults: Dict[str, Any] = dict(scanner="grype", mode="enforce")
+    defaults.update(kwargs)
+    return ScannerConfig(**defaults)
+
+
+GRYPE_OUTPUT = {
+    "matches": [
+        {
+            "vulnerability": {
+                "id": "CVE-2023-0001",
+                "severity": "HIGH",
+                "description": "OpenSSL vulnerability",
+                "fix": {"state": "fixed", "versions": ["1.1.1u-r0"]},
+            },
+            "artifact": {"name": "libssl", "version": "1.1.1t-r0"},
+        },
+        {
+            "vulnerability": {
+                "id": "CVE-2023-0002",
+                "severity": "CRITICAL",
+                "description": None,
+                "fix": {"state": "not-fixed", "versions": []},
+            },
+            "artifact": {"name": "libcrypto", "version": "1.1.1t-r0"},
+        },
+    ]
+}
+
+
+class TestGrypeRunnerParseResult:
+    runner = GrypeRunner(make_config())
+
+    def test_parses_high_severity(self):
+        findings = self.runner._parse_grype_result(GRYPE_OUTPUT)
+        high = [f for f in findings if f.cve_id == "CVE-2023-0001"]
+        assert len(high) == 1
+        assert high[0].severity == "HIGH"
+        assert high[0].package_name == "libssl"
+        assert high[0].installed_version == "1.1.1t-r0"
+        assert high[0].scanner == "grype"
+
+    def test_parses_fixed_version(self):
+        findings = self.runner._parse_grype_result(GRYPE_OUTPUT)
+        high = [f for f in findings if f.cve_id == "CVE-2023-0001"]
+        assert high[0].fixed_version == "1.1.1u-r0"
+
+    def test_not_fixed_state_returns_none(self):
+        findings = self.runner._parse_grype_result(GRYPE_OUTPUT)
+        critical = [f for f in findings if f.cve_id == "CVE-2023-0002"]
+        assert len(critical) == 1
+        assert critical[0].fixed_version is None
+
+    def test_empty_matches_returns_empty_list(self):
+        assert self.runner._parse_grype_result({}) == []
+        assert self.runner._parse_grype_result({"matches": []}) == []
+
+    def test_match_missing_cve_id_is_skipped(self):
+        data = {
+            "matches": [
+                {
+                    "vulnerability": {"id": "", "severity": "HIGH", "fix": {}},
+                    "artifact": {"name": "libfoo", "version": "1.0"},
+                }
+            ]
+        }
+        assert self.runner._parse_grype_result(data) == []
+
+    def test_unknown_severity_is_included(self):
+        data = {
+            "matches": [
+                {
+                    "vulnerability": {"id": "CVE-2023-X", "severity": "UNKNOWN", "fix": {}},
+                    "artifact": {"name": "libfoo", "version": "1.0"},
+                }
+            ]
+        }
+        findings = self.runner._parse_grype_result(data)
+        assert len(findings) == 1
+        assert findings[0].severity == "UNKNOWN"
+
+    def test_invalid_severity_is_skipped(self):
+        data = {
+            "matches": [
+                {
+                    "vulnerability": {"id": "CVE-2023-Y", "severity": "BOGUS", "fix": {}},
+                    "artifact": {"name": "libfoo", "version": "1.0"},
+                }
+            ]
+        }
+        assert self.runner._parse_grype_result(data) == []
+
+    def test_fix_state_fixed_but_no_versions_returns_none(self):
+        data = {
+            "matches": [
+                {
+                    "vulnerability": {
+                        "id": "CVE-2023-Z",
+                        "severity": "LOW",
+                        "fix": {"state": "fixed", "versions": []},
+                    },
+                    "artifact": {"name": "pkg", "version": "1.0"},
+                }
+            ]
+        }
+        findings = self.runner._parse_grype_result(data)
+        assert findings[0].fixed_version is None
+
+    def test_description_is_passed_through(self):
+        findings = self.runner._parse_grype_result(GRYPE_OUTPUT)
+        high = [f for f in findings if f.cve_id == "CVE-2023-0001"]
+        assert high[0].description == "OpenSSL vulnerability"
+
+    def test_fix_state_fixed_with_missing_versions_key_returns_none(self):
+        data = {
+            "matches": [
+                {
+                    "vulnerability": {
+                        "id": "CVE-2023-B",
+                        "severity": "HIGH",
+                        "fix": {"state": "fixed"},  # no "versions" key at all
+                    },
+                    "artifact": {"name": "pkg", "version": "1.0"},
+                }
+            ]
+        }
+        findings = self.runner._parse_grype_result(data)
+        assert findings[0].fixed_version is None
+
+    def test_severity_is_uppercased(self):
+        data = {
+            "matches": [
+                {
+                    "vulnerability": {"id": "CVE-2023-A", "severity": "high", "fix": {}},
+                    "artifact": {"name": "pkg", "version": "1.0"},
+                }
+            ]
+        }
+        findings = self.runner._parse_grype_result(data)
+        assert findings[0].severity == "HIGH"
+
+
+class TestGrypeRunnerRun:
+    @pytest.mark.asyncio
+    async def test_run_raises_timeout_error(self):
+        runner = GrypeRunner(make_config(timeout_seconds=30))
+        mock_result = MagicMock(timed_out=True, returncode=0, stdout="", stderr="")
+        with patch("plugins.container_scanner.scanners.grype_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            with pytest.raises(TimeoutError, match="timed out"):
+                await runner.run("ghcr.io/org/app:v1", {})
+
+    @pytest.mark.asyncio
+    async def test_run_raises_runtime_error_on_nonzero_exit(self):
+        runner = GrypeRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=1, stdout="", stderr="grype: image not found")
+        with patch("plugins.container_scanner.scanners.grype_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            with pytest.raises(RuntimeError, match="Grype exited 1"):
+                await runner.run("ghcr.io/org/app:v1", {})
+
+    @pytest.mark.asyncio
+    async def test_run_returns_parsed_vulnerabilities(self):
+        runner = GrypeRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=0, stdout=json.dumps(GRYPE_OUTPUT), stderr="")
+        with patch("plugins.container_scanner.scanners.grype_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            vulns = await runner.run("ghcr.io/org/app:v1", {})
+        assert len(vulns) == 2
+
+    @pytest.mark.asyncio
+    async def test_run_passes_auth_env_to_command(self):
+        runner = GrypeRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=0, stdout=json.dumps({}), stderr="")
+        auth_env = {"GRYPE_REGISTRY_AUTH_TOKEN": "mytoken"}
+        with patch("plugins.container_scanner.scanners.grype_runner.run_command", new=AsyncMock(return_value=mock_result)) as mock_cmd:
+            await runner.run("ghcr.io/org/app:v1", auth_env)
+            called_env = mock_cmd.call_args.kwargs["env"]
+            assert called_env["GRYPE_REGISTRY_AUTH_TOKEN"] == "mytoken"
+
+    @pytest.mark.asyncio
+    async def test_run_handles_empty_stdout(self):
+        runner = GrypeRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=0, stdout="", stderr="")
+        with patch("plugins.container_scanner.scanners.grype_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            vulns = await runner.run("ghcr.io/org/app:v1", {})
+        assert vulns == []

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_policy_evaluator.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_policy_evaluator.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_policy_evaluator.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for PolicyEvaluator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.policy.policy_evaluator import PolicyDecision, PolicyEvaluator
+from plugins.container_scanner.types import Vulnerability
+
+
+def make_vuln(severity="HIGH", cve_id="CVE-2023-0001", fixed_version="1.0.1") -> Vulnerability:
+    return Vulnerability(
+        scanner="trivy",
+        cve_id=cve_id,
+        severity=severity,
+        package_name="libfoo",
+        installed_version="1.0.0",
+        fixed_version=fixed_version,
+    )
+
+
+def make_config(**kwargs) -> ScannerConfig:
+    defaults = dict(scanner="trivy", mode="enforce", severity_threshold="HIGH", fail_on_unfixed=False)
+    defaults.update(kwargs)
+    return ScannerConfig(**defaults)
+
+
+class TestPolicyEvaluatorEnforceMode:
+    evaluator = PolicyEvaluator()
+
+    def test_no_violations_not_blocked(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH")
+        # LOW vuln is below HIGH threshold
+        vulns = [make_vuln(severity="LOW")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.blocked is False
+        assert decision.reason is None
+
+    def test_violations_cause_block(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH")
+        vulns = [make_vuln(severity="CRITICAL"), make_vuln(severity="HIGH", cve_id="CVE-2023-0002")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.blocked is True
+        assert decision.reason is not None
+        assert "Blocked" in decision.reason
+
+    def test_violations_list_populated(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH")
+        vulns = [make_vuln(severity="HIGH")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert len(decision.violations) == 1
+
+    def test_empty_vulns_not_blocked(self):
+        cfg = make_config(mode="enforce")
+        decision = self.evaluator.evaluate([], cfg)
+        assert decision.blocked is False
+
+    def test_critical_threshold_blocks_only_critical(self):
+        cfg = make_config(mode="enforce", severity_threshold="CRITICAL")
+        vulns = [make_vuln(severity="HIGH"), make_vuln(severity="CRITICAL", cve_id="CVE-2023-X")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        # Only CRITICAL triggers block, HIGH is below threshold
+        assert decision.blocked is True
+        assert len(decision.violations) == 1
+        assert decision.violations[0].severity == "CRITICAL"
+
+
+class TestPolicyEvaluatorAuditMode:
+    evaluator = PolicyEvaluator()
+
+    def test_violations_not_blocked_in_audit(self):
+        cfg = make_config(mode="audit", severity_threshold="HIGH")
+        vulns = [make_vuln(severity="CRITICAL")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.blocked is False
+
+    def test_audit_sets_reason_when_violations(self):
+        cfg = make_config(mode="audit", severity_threshold="HIGH")
+        vulns = [make_vuln(severity="HIGH")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.reason is not None
+        assert "Audit" in decision.reason
+
+    def test_audit_no_reason_when_no_violations(self):
+        cfg = make_config(mode="audit", severity_threshold="HIGH")
+        vulns = [make_vuln(severity="LOW")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.reason is None
+
+
+class TestPolicyEvaluatorDisabledMode:
+    evaluator = PolicyEvaluator()
+
+    def test_disabled_never_blocks(self):
+        cfg = make_config(mode="disabled")
+        vulns = [make_vuln(severity="CRITICAL")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.blocked is False
+        assert decision.reason == 'scan skipped'
+
+
+class TestPolicyEvaluatorFilters:
+    evaluator = PolicyEvaluator()
+
+    def test_ignore_cves_drops_matching(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH", ignore_cves=["CVE-2023-0001"])
+        vulns = [make_vuln(severity="CRITICAL", cve_id="CVE-2023-0001")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.blocked is False
+
+    def test_ignore_cves_does_not_drop_others(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH", ignore_cves=["CVE-2023-0001"])
+        vulns = [make_vuln(severity="HIGH", cve_id="CVE-2023-9999")]
+        decision = self.evaluator.evaluate(vulns, cfg)
+        assert decision.blocked is True
+
+    def test_fail_on_unfixed_false_drops_unfixed(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH", fail_on_unfixed=False)
+        # Vuln with no fix available (fixed_version=None)
+        unfixed = make_vuln(severity="CRITICAL", fixed_version=None)
+        decision = self.evaluator.evaluate([unfixed], cfg)
+        assert decision.blocked is False
+
+    def test_fail_on_unfixed_true_keeps_unfixed(self):
+        cfg = make_config(mode="enforce", severity_threshold="HIGH", fail_on_unfixed=True)
+        unfixed = make_vuln(severity="HIGH", fixed_version=None)
+        decision = self.evaluator.evaluate([unfixed], cfg)
+        assert decision.blocked is True
+
+
+class TestFormatReason:
+    evaluator = PolicyEvaluator()
+
+    def test_blocked_prefix(self):
+        vulns = [make_vuln(severity="HIGH")]
+        reason = self.evaluator._format_reason(vulns, "HIGH", blocked=True)
+        assert reason.startswith("Blocked:")
+
+    def test_audit_prefix(self):
+        vulns = [make_vuln(severity="CRITICAL")]
+        reason = self.evaluator._format_reason(vulns, "HIGH", blocked=False)
+        assert reason.startswith("Audit:")
+
+    def test_counts_by_severity(self):
+        vulns = [
+            make_vuln(severity="CRITICAL", cve_id="CVE-1"),
+            make_vuln(severity="CRITICAL", cve_id="CVE-2"),
+            make_vuln(severity="HIGH", cve_id="CVE-3"),
+        ]
+        reason = self.evaluator._format_reason(vulns, "HIGH", blocked=True)
+        assert "2 CRITICAL" in reason
+        assert "1 HIGH" in reason

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_repository.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_repository.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_repository.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for ScanResultRepository.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from plugins.container_scanner.storage.repository import ScanResultRepository
+from plugins.container_scanner.types import ScanResult, Summary
+
+
+DIGEST_V1 = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+DIGEST_V2 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+DIGEST_V3 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+DIGEST_UNKNOWN = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+
+def make_result(image_digest: str = DIGEST_V1, image_ref: str = "ghcr.io/org/app:v1") -> ScanResult:
+    return ScanResult(
+        image_ref=image_ref,
+        image_digest=image_digest,
+        scanners="trivy",
+        scan_time=datetime.datetime.now(datetime.timezone.utc),
+        duration_ms=100,
+        vulnerabilities=[],
+        summary=Summary(critical_count=0, high_count=0, medium_count=0, low_count=0),
+        blocked=False,
+    )
+
+
+class TestScanResultRepositorySaveAndGet:
+    def test_save_and_get_round_trip(self):
+        repo = ScanResultRepository()
+        result = make_result(DIGEST_V1)
+        repo.save(result)
+        assert repo.get(DIGEST_V1) is result
+
+    def test_get_unknown_digest_returns_none(self):
+        repo = ScanResultRepository()
+        assert repo.get(DIGEST_UNKNOWN) is None
+
+    def test_save_overwrites_previous_result(self):
+        repo = ScanResultRepository()
+        first = make_result(DIGEST_V1)
+        second = make_result(DIGEST_V1)
+        repo.save(first)
+        repo.save(second)
+        assert repo.get(DIGEST_V1) is second
+
+    def test_update_does_not_grow_store(self):
+        repo = ScanResultRepository()
+        repo.save(make_result(DIGEST_V1))
+        repo.save(make_result(DIGEST_V1))
+        assert len(repo) == 1
+
+
+class TestScanResultRepositoryEviction:
+    def test_evicts_oldest_when_at_capacity(self):
+        repo = ScanResultRepository(max_entries=2)
+        repo.save(make_result(DIGEST_V1))
+        repo.save(make_result(DIGEST_V2))
+        repo.save(make_result(DIGEST_V3))  # triggers eviction of DIGEST_V1
+        assert repo.get(DIGEST_V1) is None
+        assert repo.get(DIGEST_V2) is not None
+        assert repo.get(DIGEST_V3) is not None
+
+    def test_len_does_not_exceed_max(self):
+        repo = ScanResultRepository(max_entries=3)
+        for i in range(10):
+            digest = f"sha256:{i:064x}"
+            repo.save(make_result(digest))
+        assert len(repo) == 3
+
+    def test_update_existing_does_not_evict(self):
+        repo = ScanResultRepository(max_entries=3)
+        repo.save(make_result(DIGEST_V1))
+        repo.save(make_result(DIGEST_V2))
+        # Update existing — should not evict
+        repo.save(make_result(DIGEST_V1))
+        assert repo.get(DIGEST_V2) is not None
+        assert repo.get(DIGEST_V1) is not None
+        assert len(repo) == 2
+
+
+class TestScanResultRepositoryClear:
+    def test_clear_removes_all_entries(self):
+        repo = ScanResultRepository()
+        repo.save(make_result(DIGEST_V1))
+        repo.save(make_result(DIGEST_V2))
+        repo.clear()
+        assert len(repo) == 0
+        assert repo.get(DIGEST_V1) is None
+
+    def test_len_after_clear_is_zero(self):
+        repo = ScanResultRepository()
+        repo.save(make_result(DIGEST_V1))
+        repo.clear()
+        assert len(repo) == 0

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_repository.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_repository.py
@@ -81,7 +81,7 @@ class TestScanResultRepositoryEviction:
         assert len(repo) == 3
 
     def test_update_existing_does_not_evict(self):
-        repo = ScanResultRepository(max_entries=3)
+        repo = ScanResultRepository(max_entries=2)
         repo.save(make_result(DIGEST_V1))
         repo.save(make_result(DIGEST_V2))
         # Update existing — should not evict

--- a/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_trivy_runner.py
+++ b/tests/unit/mcpgateway/plugins/plugins/test_container_scanner/test_trivy_runner.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_container_scanner/test_trivy_runner.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Agnetha
+
+Unit tests for TrivyRunner._parse_trivy_result and async run().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plugins.container_scanner.config import ScannerConfig
+from plugins.container_scanner.scanners.trivy_runner import TrivyRunner
+
+
+def make_config(**kwargs) -> ScannerConfig:
+    defaults = dict(scanner="trivy", mode="enforce")
+    defaults.update(kwargs)
+    return ScannerConfig(**defaults)
+
+
+TRIVY_OUTPUT = {
+    "Results": [
+        {
+            "Target": "app:latest (alpine 3.18)",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2023-0001",
+                    "Severity": "HIGH",
+                    "PkgName": "libssl",
+                    "InstalledVersion": "1.1.1t-r0",
+                    "FixedVersion": "1.1.1u-r0",
+                    "Description": "OpenSSL vulnerability",
+                },
+                {
+                    "VulnerabilityID": "CVE-2023-0002",
+                    "Severity": "CRITICAL",
+                    "PkgName": "libcrypto",
+                    "InstalledVersion": "1.1.1t-r0",
+                    "FixedVersion": None,
+                    "Description": None,
+                },
+            ],
+        },
+        {
+            # Target with no vulnerabilities key — common in Trivy output
+            "Target": "app:latest (config)",
+        },
+    ]
+}
+
+
+class TestTrivyRunnerParseResult:
+    runner = TrivyRunner(make_config())
+
+    def test_parses_high_severity(self):
+        findings = self.runner._parse_trivy_result(TRIVY_OUTPUT)
+        high = [f for f in findings if f.cve_id == "CVE-2023-0001"]
+        assert len(high) == 1
+        assert high[0].severity == "HIGH"
+        assert high[0].package_name == "libssl"
+        assert high[0].fixed_version == "1.1.1u-r0"
+        assert high[0].scanner == "trivy"
+
+    def test_parses_critical_with_no_fix(self):
+        findings = self.runner._parse_trivy_result(TRIVY_OUTPUT)
+        critical = [f for f in findings if f.cve_id == "CVE-2023-0002"]
+        assert len(critical) == 1
+        assert critical[0].fixed_version is None
+
+    def test_target_with_no_vulnerabilities_key_is_skipped(self):
+        # No "Vulnerabilities" key in the second target — should not raise
+        findings = self.runner._parse_trivy_result(TRIVY_OUTPUT)
+        assert len(findings) == 2  # only 2 vulns from the first target
+
+    def test_empty_results(self):
+        findings = self.runner._parse_trivy_result({})
+        assert findings == []
+
+    def test_empty_vulnerabilities_list(self):
+        data = {"Results": [{"Target": "scratch", "Vulnerabilities": []}]}
+        findings = self.runner._parse_trivy_result(data)
+        assert findings == []
+
+    def test_unknown_severity_is_included(self):
+        data = {
+            "Results": [
+                {
+                    "Target": "app:latest",
+                    "Vulnerabilities": [
+                        {
+                            "VulnerabilityID": "CVE-2023-X",
+                            "Severity": "UNKNOWN",
+                            "PkgName": "libfoo",
+                            "InstalledVersion": "1.0",
+                        }
+                    ],
+                }
+            ]
+        }
+        findings = self.runner._parse_trivy_result(data)
+        assert len(findings) == 1
+        assert findings[0].severity == "UNKNOWN"
+
+
+class TestTrivyRunnerRun:
+    @pytest.mark.asyncio
+    async def test_run_raises_timeout_error(self):
+        runner = TrivyRunner(make_config(timeout_seconds=30))
+        mock_result = MagicMock(timed_out=True, returncode=0, stdout="", stderr="")
+        with patch("plugins.container_scanner.scanners.trivy_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            with pytest.raises(TimeoutError, match="timed out"):
+                await runner.run("ghcr.io/org/app:v1", {})
+
+    @pytest.mark.asyncio
+    async def test_run_raises_runtime_error_on_nonzero_exit(self):
+        runner = TrivyRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=1, stdout="", stderr="trivy: image not found")
+        with patch("plugins.container_scanner.scanners.trivy_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            with pytest.raises(RuntimeError, match="Trivy exited 1"):
+                await runner.run("ghcr.io/org/app:v1", {})
+
+    @pytest.mark.asyncio
+    async def test_run_returns_parsed_vulnerabilities(self):
+        import json
+
+        runner = TrivyRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=0, stdout=json.dumps(TRIVY_OUTPUT), stderr="")
+        with patch("plugins.container_scanner.scanners.trivy_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            vulns = await runner.run("ghcr.io/org/app:v1", {})
+        assert len(vulns) == 2
+
+    @pytest.mark.asyncio
+    async def test_run_passes_auth_env_to_command(self):
+        import json
+
+        runner = TrivyRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=0, stdout=json.dumps({}), stderr="")
+        auth_env = {"TRIVY_USERNAME": "", "TRIVY_PASSWORD": "mytoken"}
+        with patch("plugins.container_scanner.scanners.trivy_runner.run_command", new=AsyncMock(return_value=mock_result)) as mock_cmd:
+            await runner.run("ghcr.io/org/app:v1", auth_env)
+            called_env = mock_cmd.call_args.kwargs["env"]
+            assert called_env["TRIVY_PASSWORD"] == "mytoken"
+
+    @pytest.mark.asyncio
+    async def test_run_handles_empty_stdout(self):
+        runner = TrivyRunner(make_config())
+        mock_result = MagicMock(timed_out=False, returncode=0, stdout="", stderr="")
+        with patch("plugins.container_scanner.scanners.trivy_runner.run_command", new=AsyncMock(return_value=mock_result)):
+            vulns = await runner.run("ghcr.io/org/app:v1", {})
+        assert vulns == []


### PR DESCRIPTION
## 🔗 Related Issue
Partial PR for #2216 

---

## 📝 Summary
 Implements a container image vulnerability scanning plugin for ContextForge. Before a container image is
  registered or deployed through the gateway, the plugin runs Trivy or Grype against it, filters findings
  against a configurable policy, and returns a block/allow decision.

  Scan pipeline:
  1. Check in-memory cache by image digest (skip re-scanning identical images)
  2. Resolve registry credentials from environment variables
  3. Execute Trivy or Grype CLI and parse JSON output into a unified Vulnerability schema
  4. Apply policy filters: severity threshold, CVE ignore list, unfixed-only flag
  5. Enforce mode decision: enforce (block), audit (log only), or disabled (skip)
  6. Persist result in a bounded in-memory repository (evicts oldest when full)

Included: Trivy/Grype scanners, policy evaluation, authorisation resolver, cache manager, storage, unit tests

Upcoming: hook integration, integration tests, AdminUI, full documentation. These will be addressed in following PRs.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |   pass     |
| Coverage ≥ 80%            | `make coverage` |    99%    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

