### PR TITLE
feat(rust): add json_repair rust plugin and benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*.py,cover
 *,cover
 .hypothesis/
 .pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -7872,10 +7872,9 @@ upgrade-validate:                         ## Validate fresh + upgrade DB startup
 rust-ensure-deps:                       ## Ensure Rust toolchain, maturin, and all plugins are installed
 	@if ! command -v rustup > /dev/null 2>&1; then \
 		echo "🦀 Rust not found. Installing Rust toolchain..."; \
-		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt clippy; \
-		echo "✅ Rust installed successfully."; \
-		echo "⚠️  Please run 'source \"$$HOME/.cargo/env\"' or restart your shell, then run 'make' again."; \
-		exit 1; \
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt --component clippy; \
+		echo "🦀 Rust installed. Sourcing environment..."; \
+		. "$$HOME/.cargo/env"; \
 	fi
 	@if ! command -v cargo > /dev/null 2>&1; then \
 		echo "⚠️  cargo not in PATH. Please run 'source \"$$HOME/.cargo/env\"' or restart your shell."; \

--- a/plugins/json_repair/json_repair.py
+++ b/plugins/json_repair/json_repair.py
@@ -13,6 +13,7 @@ It is conservative: only applies transformations when confidently fixable.
 from __future__ import annotations
 
 # Standard
+import logging
 import re
 
 # Third-Party
@@ -26,6 +27,21 @@ from mcpgateway.plugins.framework import (
     ToolPostInvokePayload,
     ToolPostInvokeResult,
 )
+
+logger = logging.getLogger(__name__)
+
+# Try to import Rust-accelerated implemtation
+try:
+    from json_repair import JSONRepairPluginRust
+    _RUST_AVAILABLE = True
+except ImportError as e:
+    _RUST_AVAILABLE = False
+    JSONRepairPluginRust = None
+    logger.debug("Rust json_repair implementation is not available (using Python): %s", e)
+except Exception as e:
+    _RUST_AVAILABLE = False
+    JSONRepairPluginRust = None
+    logger.warning("Unexpected error importing Rust json_repair implementation (using Python): %s", e, exc_info=True)
 
 # Precompiled regex patterns for performance
 _JSON_BRACKETS_RE = re.compile(r"^[\[{].*[\]}]$", flags=re.S)
@@ -86,6 +102,12 @@ class JSONRepairPlugin(Plugin):
             config: Plugin configuration.
         """
         super().__init__(config)
+        self._rust_helper = None
+        if _RUST_AVAILABLE and JSONRepairPluginRust is not None:
+            try:
+                self._rust_helper = JSONRepairPluginRust()
+            except Exception as e:
+                logger.warning("Failed to initialize Rust JSON repair implementation (falling back to Python): %s", e, exc_info=True)
 
     async def tool_post_invoke(self, payload: ToolPostInvokePayload, context: PluginContext) -> ToolPostInvokeResult:
         """Repair JSON-like string results after tool invocation.
@@ -101,7 +123,15 @@ class JSONRepairPlugin(Plugin):
             text = payload.result
             if _try_parse(text):
                 return ToolPostInvokeResult(continue_processing=True)
-            repaired = _repair(text)
+            repaired = None
+            if self._rust_helper is not None:
+                try:
+                    repaired = self._rust_helper.repair(text)
+                except Exception as e:
+                    logger.warning("Rust json_repair failed; falling back to Python repair: %s", e)
+                    repaired = _repair(text)
+            else:
+                repaired = _repair(text)
             if repaired is not None:
                 return ToolPostInvokeResult(modified_payload=ToolPostInvokePayload(name=payload.name, result=repaired), metadata={"repaired": True})
         return ToolPostInvokeResult(continue_processing=True)

--- a/plugins_rust/json_repair/Cargo.toml
+++ b/plugins_rust/json_repair/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "json_repair"
+version = "1.0.0-BETA-2"
+edition = "2024"
+authors = ["MCP Gateway Contributors"]
+license = "Apache-2.0"
+repository = "https://github.com/IBM/mcp-context-forge"
+description = "JSON repair plugin"
+
+[lib]
+name = "json_repair"
+crate-type = ["rlib"]
+
+[dependencies]
+pyo3 = { version = "0.28", features = ["abi3-py311"] }
+regex = "1.12"
+serde_json = "1.0"
+
+[dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+
+[profile.bench]
+inherits = "release"
+debug = true
+
+[[bench]]
+name = "json_repair"
+harness = false

--- a/plugins_rust/json_repair/benches/json_repair.rs
+++ b/plugins_rust/json_repair/benches/json_repair.rs
@@ -1,0 +1,189 @@
+// Copyright 2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Criterion benchmarks for json_repair performance
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use json_repair::JSONRepairPluginRust;
+use std::hint::black_box;
+use std::time::Duration;
+
+fn create_plugin() -> JSONRepairPluginRust {
+    JSONRepairPluginRust::new().expect("json_repair plugin init")
+}
+
+fn create_valid_cases() -> Vec<&'static str> {
+    vec![
+        r#"{"a":1,"b":2}"#,
+        r#"{"user":{"id":42,"active":true},"tags":["x","y","z"]}"#,
+        r#"{"items":[{"k":"v"},{"k2":"v2"}],"count":2}"#,
+        r#"{"service":"gateway","status":"ok","latency_ms":12}"#,
+    ]
+}
+
+fn create_repairable_cases() -> Vec<&'static str> {
+    vec![
+        r#"{"a": 1, "b": 2,}"#, // trailing comma
+        "{'a': 1, 'b': 2}",     // single quotes
+        "{\n'a': 1,\n'b': 2\n}", // multiline single quotes
+        r#""a": 1, "b": 2"#,    // missing outer braces
+    ]
+}
+
+fn create_unrepairable_cases() -> Vec<&'static str> {
+    vec![
+        "not-json-at-all",
+        "just some plain text without colons",
+        "{ this is not valid json syntax",
+        "}",
+    ]
+}
+
+fn make_sized_object_kb(target_kb: usize, repairable: bool) -> String {
+    let mut parts = Vec::new();
+    let mut idx = 0usize;
+    while parts.join(",").len() < target_kb * 1024 {
+        if repairable {
+            parts.push(format!("'k{}': 'value_{}'", idx, idx));
+        } else {
+            parts.push(format!(r#""k{}":"value_{}""#, idx, idx));
+        }
+        idx += 1;
+    }
+    let body = parts.join(",");
+    if repairable {
+        format!("{{{},}}", body)
+    } else {
+        format!("{{{}}}", body)
+    }
+}
+
+fn bench_repair_cases(c: &mut Criterion) {
+    let plugin = create_plugin();
+
+    let mut group = c.benchmark_group("repair_cases");
+    group.measurement_time(Duration::from_millis(600));
+    group.warm_up_time(Duration::from_millis(100));
+    group.sample_size(50);
+
+    for (i, input) in create_valid_cases().iter().enumerate() {
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::new("valid", i), input, |b, text| {
+            b.iter(|| plugin.repair(black_box(text)));
+        });
+    }
+
+    for (i, input) in create_repairable_cases().iter().enumerate() {
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::new("repairable", i), input, |b, text| {
+            b.iter(|| plugin.repair(black_box(text)));
+        });
+    }
+
+    for (i, input) in create_unrepairable_cases().iter().enumerate() {
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::new("unrepairable", i), input, |b, text| {
+            b.iter(|| plugin.repair(black_box(text)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_batch_processing(c: &mut Criterion) {
+    let plugin = create_plugin();
+
+    let mut group = c.benchmark_group("batch_processing");
+    group.measurement_time(Duration::from_millis(600));
+    group.warm_up_time(Duration::from_millis(100));
+    group.sample_size(40);
+
+    let valid = create_valid_cases();
+    let repairable = create_repairable_cases();
+    let unrepairable = create_unrepairable_cases();
+
+    let mut mixed = Vec::new();
+    mixed.extend_from_slice(&valid);
+    mixed.extend_from_slice(&repairable);
+    mixed.extend_from_slice(&unrepairable);
+    let total_bytes: u64 = mixed.iter().map(|s| s.len() as u64).sum();
+
+    group.throughput(Throughput::Bytes(total_bytes));
+    group.bench_function("mixed_batch", |b| {
+        b.iter(|| {
+            for text in &mixed {
+                let _ = plugin.repair(black_box(text));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_text_sizes(c: &mut Criterion) {
+    let plugin = create_plugin();
+
+    let mut group = c.benchmark_group("text_sizes");
+    // Keep enough budget for 200KB repairable samples to avoid Criterion
+    // "Unable to complete N samples in target time" warnings.
+    group.measurement_time(Duration::from_millis(3000));
+    group.warm_up_time(Duration::from_millis(120));
+    group.sample_size(40);
+
+    // Representative size tiers used by compare_performance.py as well.
+    let sizes_kb = [1usize, 5, 50, 200];
+
+    for size in sizes_kb {
+        let valid = make_sized_object_kb(size, false);
+        let repairable = make_sized_object_kb(size, true);
+
+        group.throughput(Throughput::Bytes(valid.len() as u64));
+        group.bench_with_input(BenchmarkId::new("valid_kb", size), &valid, |b, text| {
+            b.iter(|| plugin.repair(black_box(text)));
+        });
+
+        group.throughput(Throughput::Bytes(repairable.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("repairable_kb", size),
+            &repairable,
+            |b, text| {
+                b.iter(|| plugin.repair(black_box(text)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_early_exit_vs_full_path(c: &mut Criterion) {
+    let plugin = create_plugin();
+
+    let mut group = c.benchmark_group("early_exit_vs_full_path");
+    group.measurement_time(Duration::from_millis(600));
+    group.warm_up_time(Duration::from_millis(100));
+    group.sample_size(50);
+
+    let valid = r#"{"a":1,"b":2,"c":[1,2,3],"d":{"ok":true}}"#;
+    let repairable = r#"{"a":1,"b":2,"c":[1,2,3],}"#;
+
+    group.throughput(Throughput::Bytes(valid.len() as u64));
+    group.bench_function("already_valid_early_exit", |b| {
+        b.iter(|| plugin.repair(black_box(valid)));
+    });
+
+    group.throughput(Throughput::Bytes(repairable.len() as u64));
+    group.bench_function("repairable_full_path", |b| {
+        b.iter(|| plugin.repair(black_box(repairable)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_repair_cases,
+    bench_batch_processing,
+    bench_text_sizes,
+    bench_early_exit_vs_full_path
+);
+criterion_main!(benches);

--- a/plugins_rust/json_repair/compare_performance.py
+++ b/plugins_rust/json_repair/compare_performance.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Performance comparison for json_repair (Python vs Rust).
+
+This benchmark compares:
+- Python implementation from ``plugins/json_repair/json_repair.py``
+- Rust implementation exposed via PyO3 module ``json_repair``
+
+Usage:
+    python compare_performance.py
+    python compare_performance.py --iterations 10000 --warmup 200
+"""
+
+from __future__ import annotations
+
+# Standard
+import argparse
+import importlib.util
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+# Third-Party
+import orjson
+
+
+def _load_python_impl():
+    """Load the Python json_repair implementation by file path.
+
+    Loaded by path to avoid a name conflict with the Rust extension module,
+    which is also imported as ``json_repair``.
+    """
+    py_file = Path(__file__).parent.parent.parent / "plugins" / "json_repair" / "json_repair.py"
+    spec = importlib.util.spec_from_file_location("python_json_repair_impl", py_file)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load Python implementation from {py_file}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PY_IMPL = _load_python_impl()
+
+# Try to import Rust implementation.
+try:
+    from json_repair import JSONRepairPluginRust
+
+    RUST_AVAILABLE = True
+except ImportError:
+    RUST_AVAILABLE = False
+    JSONRepairPluginRust = None  # type: ignore
+    print("WARNING: Rust implementation not available. Build it with:")
+    print("  cd plugins_rust/json_repair && maturin develop --release")
+    print()
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """Single benchmark scenario."""
+
+    name: str
+    payload: str
+
+
+def _make_object_json(target_kb: int, repairable: bool) -> str:
+    """Create deterministic object-like JSON-ish text around target size."""
+    parts = []
+    idx = 0
+    while len(",".join(parts)) < target_kb * 1024:
+        if repairable:
+            parts.append(f"'k{idx}': 'value_{idx}'")
+        else:
+            parts.append(f'"k{idx}": "value_{idx}"')
+        idx += 1
+
+    body = ",".join(parts)
+    if repairable:
+        return "{" + body + ",}"
+    return "{" + body + "}"
+
+
+def generate_scenarios() -> list[Scenario]:
+    """Build benchmark scenarios with realistic payload sizes."""
+    return [
+        Scenario("small_valid_1kb", _make_object_json(1, repairable=False)),
+        Scenario("small_repairable_1kb", _make_object_json(1, repairable=True)),
+        Scenario("medium_valid_5kb", _make_object_json(5, repairable=False)),
+        Scenario("medium_repairable_5kb", _make_object_json(5, repairable=True)),
+        Scenario("large_valid_50kb", _make_object_json(50, repairable=False)),
+        Scenario("large_repairable_50kb", _make_object_json(50, repairable=True)),
+        Scenario("xlarge_valid_500kb", _make_object_json(500, repairable=False)),
+        Scenario("xlarge_repairable_500kb", _make_object_json(500, repairable=True)),
+        Scenario("xxlarge_valid_1024kb", _make_object_json(1024, repairable=False)),
+        Scenario("xxlarge_repairable_1024kb", _make_object_json(1024, repairable=True)),
+        Scenario("unrepairable_text", "not-json-at-all " * 200),
+        Scenario("missing_braces", '"a": 1, "b": 2'),
+    ]
+
+
+def benchmark_python(payload: str, iterations: int, warmup: int) -> tuple[list[float], str | None]:
+    """Benchmark Python repair function."""
+    for _ in range(warmup):
+        PY_IMPL._repair(payload)
+
+    times: list[float] = []
+    output: str | None = None
+    for _ in range(iterations):
+        start = time.perf_counter()
+        output = PY_IMPL._repair(payload)
+        times.append(time.perf_counter() - start)
+    return times, output
+
+
+def benchmark_rust(payload: str, iterations: int, warmup: int, rust_repair: Callable[[str], str | None]) -> tuple[list[float], str | None]:
+    """Benchmark Rust repair function."""
+    for _ in range(warmup):
+        rust_repair(payload)
+
+    times: list[float] = []
+    output: str | None = None
+    for _ in range(iterations):
+        start = time.perf_counter()
+        output = rust_repair(payload)
+        times.append(time.perf_counter() - start)
+    return times, output
+
+
+def _summarize(times: list[float]) -> tuple[float, float, float]:
+    """Calculate mean, median, and standard deviation in milliseconds."""
+    mean_ms = statistics.mean(times) * 1000
+    median_ms = statistics.median(times) * 1000
+    stdev_ms = statistics.stdev(times) * 1000 if len(times) > 1 else 0.0
+    return mean_ms, median_ms, stdev_ms
+
+
+def _canonical_json(s: str | None):
+    """Parse JSON for semantic comparison, ignoring string formatting differences."""
+    if s is None:
+        return None
+    return orjson.loads(s)
+
+
+def run_scenario(scenario: Scenario, iterations: int, warmup: int, rust_repair: Callable[[str], str | None] | None) -> None:
+    """Run benchmark for one scenario and print results."""
+    print("\n" + "=" * 72)
+    print(f"Scenario: {scenario.name}")
+    print("=" * 72)
+
+    py_times, py_output = benchmark_python(scenario.payload, iterations, warmup)
+    py_mean, py_median, py_stdev = _summarize(py_times)
+    print(f"Python: {py_mean:.3f} ms ±{py_stdev:.3f} (median: {py_median:.3f})")
+
+    if rust_repair is None:
+        print("Rust: not available")
+        return
+
+    rust_times, rust_output = benchmark_rust(scenario.payload, iterations, warmup, rust_repair)
+    rust_mean, rust_median, rust_stdev = _summarize(rust_times)
+    speedup = py_mean / rust_mean if rust_mean > 0 else 0.0
+    print(f"Rust:   {rust_mean:.3f} ms ±{rust_stdev:.3f} (median: {rust_median:.3f})")
+    print(f"Speedup: {speedup:.2f}x")
+
+    py_norm = _canonical_json(py_output)
+    rust_norm = _canonical_json(rust_output)
+    if py_norm != rust_norm:
+        print("WARNING: output mismatch between Python and Rust implementations")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="json_repair Python vs Rust benchmark")
+    parser.add_argument("--iterations", type=int, default=10000, help="Iterations per scenario")
+    parser.add_argument("--warmup", type=int, default=100, help="Warmup iterations per scenario")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entrypoint."""
+    args = parse_args()
+
+    rust_repair = None
+    if RUST_AVAILABLE and JSONRepairPluginRust is not None:
+        try:
+            rust_repair = JSONRepairPluginRust().repair
+        except Exception as exc:
+            print(f"WARNING: Failed to initialize Rust helper: {exc}")
+
+    print("JSON Repair Performance Comparison")
+    print(f"Python: {sys.version.split()[0]}")
+    print(f"Rust available: {'yes' if rust_repair is not None else 'no'}")
+    print(f"Iterations: {args.iterations} (+{args.warmup} warmup)")
+
+    for scenario in generate_scenarios():
+        run_scenario(scenario, args.iterations, args.warmup, rust_repair)
+
+    print("\n" + "=" * 72)
+    print("Benchmark complete")
+    print("=" * 72)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins_rust/json_repair/src/lib.rs
+++ b/plugins_rust/json_repair/src/lib.rs
@@ -1,0 +1,139 @@
+// Copyright 2026
+// SPDX-License-Identifier: Apache-2.0
+
+use pyo3::prelude::*;
+use regex::Regex;
+
+/// Rust-backed JSON repair helper exposed to Python via PyO3.
+#[pyclass]
+pub struct JSONRepairPluginRust {
+    /// Matches JSON-ish bracketed text (`{...}` or `[...]`), including multiline.
+    json_brackets_re: Regex,
+    /// Matches commas that appear immediately before `}` or `]`.
+    trailing_comma_re: Regex,
+}
+
+#[pymethods]
+impl JSONRepairPluginRust {
+    /// Build a repair helper with precompiled patterns.
+    #[new]
+    pub fn new() -> PyResult<Self> {
+        let json_brackets_re = Regex::new(r"(?s)^[\[{].*[\]}]$").map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid regex pattern: {}", e))
+        })?;
+        let trailing_comma_re = Regex::new(r",(\s*[}\]])").map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid regex pattern: {}", e))
+        })?;
+
+        Ok(Self {
+            json_brackets_re,
+            trailing_comma_re,
+        })
+    }
+
+    /// Attempt conservative repair for near-JSON text.
+    ///
+    /// Returns `Some(repaired_json)` only when the repaired output parses as valid JSON.
+    /// Returns `None` if input is already valid JSON or no safe repair is found.
+    pub fn repair(&self, text: &str) -> Option<String> {
+        let t = text.trim();
+
+        if Self::try_parse(t) {
+            return None;
+        }
+
+        let mut base = t.to_string();
+
+        // Only normalize single quotes when input already looks like structured JSON.
+        if self.json_brackets_re.is_match(t) && t.contains('\'') && !t.contains('"') {
+            base = t.replace('\'', "\"");
+            if Self::try_parse(&base) {
+                return Some(base);
+            }
+        }
+
+        let repaired = self.trailing_comma_re.replace_all(&base, "$1").to_string();
+
+        if repaired != base && Self::try_parse(&repaired) {
+            return Some(repaired);
+        }
+
+        // Mirror Python plugin behavior: wrap object-like text missing outer braces.
+        if !t.starts_with('{') && t.contains(':') && !t.contains('{') && !t.contains('}') {
+            let wrapped = format!("{{{}}}", t);
+            if Self::try_parse(&wrapped) {
+                return Some(wrapped);
+            }
+        }
+        None
+    }
+}
+
+impl JSONRepairPluginRust {
+    /// Fast validity check used to gate conservative repairs.
+    fn try_parse(s: &str) -> bool {
+        serde_json::from_str::<serde_json::Value>(s).is_ok()
+    }
+}
+
+/// Python module entrypoint.
+#[pymodule]
+fn json_repair(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<JSONRepairPluginRust>()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JSONRepairPluginRust;
+
+    #[test]
+    fn already_valid_json_returns_none() {
+        let plugin = JSONRepairPluginRust::new().expect("plugin init");
+        let input = r#"{"a": 1, "b": 2}"#;
+        assert_eq!(plugin.repair(input), None);
+    }
+
+    #[test]
+    fn trailing_comma_repairs_to_valid_json() {
+        let plugin = JSONRepairPluginRust::new().expect("plugin init");
+        let input = r#"{"a": 1, "b": 2,}"#;
+        let repaired = plugin.repair(input).expect("expected a repair");
+        assert_eq!(repaired, r#"{"a": 1, "b": 2}"#);
+        assert!(JSONRepairPluginRust::try_parse(&repaired));
+    }
+
+    #[test]
+    fn single_quotes_repairs_when_jsonish_guard_matches() {
+        let plugin = JSONRepairPluginRust::new().expect("plugin init");
+        let input = "{'a': 1, 'b': 2}";
+        let repaired = plugin.repair(input).expect("expected a repair");
+        assert_eq!(repaired, r#"{"a": 1, "b": 2}"#);
+        assert!(JSONRepairPluginRust::try_parse(&repaired));
+    }
+
+    #[test]
+    fn unrepairable_input_returns_none() {
+        let plugin = JSONRepairPluginRust::new().expect("plugin init");
+        let input = "not-json-at-all";
+        assert_eq!(plugin.repair(input), None);
+    }
+
+    #[test]
+    fn wraps_object_like_text_without_outer_braces() {
+        let plugin = JSONRepairPluginRust::new().expect("plugin init");
+        let input = r#""a": 1, "b": 2"#;
+        let repaired = plugin.repair(input).expect("expected a repair");
+        assert_eq!(repaired, r#"{"a": 1, "b": 2}"#);
+        assert!(JSONRepairPluginRust::try_parse(&repaired));
+    }
+
+    #[test]
+    fn single_quotes_repair_works_for_multiline_jsonish_text() {
+        let plugin = JSONRepairPluginRust::new().expect("plugin init");
+        let input = "{\n'a': 1,\n'b': 2\n}";
+        let repaired = plugin.repair(input).expect("expected a repair");
+        assert_eq!(repaired, "{\n\"a\": 1,\n\"b\": 2\n}");
+        assert!(JSONRepairPluginRust::try_parse(&repaired));
+    }
+}

--- a/tests/unit/mcpgateway/plugins/plugins/json_repair/test_json_repair.py
+++ b/tests/unit/mcpgateway/plugins/plugins/json_repair/test_json_repair.py
@@ -8,6 +8,7 @@ Tests for JSONRepairPlugin.
 """
 
 import json
+
 import pytest
 
 from mcpgateway.plugins.framework import (
@@ -17,21 +18,74 @@ from mcpgateway.plugins.framework import (
     ToolHookType,
     ToolPostInvokePayload,
 )
-from plugins.json_repair.json_repair import JSONRepairPlugin
+from plugins.json_repair import json_repair as json_repair_module
+
+
+@pytest.fixture
+def plugin_config() -> PluginConfig:
+    return PluginConfig(
+        name="jsonr",
+        kind="plugins.json_repair.json_repair.JSONRepairPlugin",
+        hooks=[ToolHookType.TOOL_POST_INVOKE],
+    )
+
+
+@pytest.fixture
+def plugin_ctx() -> PluginContext:
+    return PluginContext(global_context=GlobalContext(request_id="r1"))
+
+
+@pytest.fixture(params=["normal", "python_fallback"])
+def mode(request):
+    """Fixture to run tests in both normal mode and Python fallback mode."""
+    return request.param
 
 
 @pytest.mark.asyncio
-async def test_repairs_trailing_commas_and_single_quotes():
-    plugin = JSONRepairPlugin(
-        PluginConfig(
-            name="jsonr",
-            kind="plugins.json_repair.json_repair.JSONRepairPlugin",
-            hooks=[ToolHookType.TOOL_POST_INVOKE],
-        )
-    )
-    ctx = PluginContext(global_context=GlobalContext(request_id="r1"))
-    broken = "{'a': 1, 'b': 2,}"
-    res = await plugin.tool_post_invoke(ToolPostInvokePayload(name="x", result=broken), ctx)
+@pytest.mark.parametrize(
+    "raw, expect_repaired",
+    [
+        ("{'a': 1, 'b': 2,}", True),  # Single quotes and trailing comma
+        ('{"a": 1, "b": 2,}', True),  # Double quotes but trailing comma
+        ('"a": 1, "b": 2', True),  # Missing outer braces
+        ('{"a": 1, "b": 2}', False),  # Valid JSON
+        ("not-json-at-all", False),  # Not JSON at all, unrepairable
+    ],
+)
+async def test_json_repair_parity(raw, expect_repaired, mode, plugin_config, plugin_ctx, monkeypatch):
+    """Test that JSON repair works correctly in both normal and Python fallback modes."""
+    if mode == "python_fallback":
+        monkeypatch.setattr(json_repair_module, "_RUST_AVAILABLE", False)
+        monkeypatch.setattr(json_repair_module, "JSONRepairPluginRust", None)
+
+    plugin = json_repair_module.JSONRepairPlugin(plugin_config)
+    res = await plugin.tool_post_invoke(ToolPostInvokePayload(name="x", result=raw), plugin_ctx)
+
+    # Check if repair was expected and validate results accordingly
+    if expect_repaired:
+        assert res.modified_payload is not None
+        assert res.metadata == {"repaired": True}
+        json.loads(res.modified_payload.result)  # Should not raise
+    else:
+        assert res.modified_payload is None  # No modification expected
+
+
+class _BoomRust:
+    def repair(self, _text):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_rust_exception_falls_back_to_python(monkeypatch, plugin_config, plugin_ctx):
+    """Test that if the Rust implementation raises an exception, the plugin falls back to the Python repair method."""
+
+    monkeypatch.setattr(json_repair_module, "_RUST_AVAILABLE", True)
+    monkeypatch.setattr(json_repair_module, "JSONRepairPluginRust", lambda: _BoomRust())
+
+    plugin = json_repair_module.JSONRepairPlugin(plugin_config)
+    raw = "{'a': 1, 'b': 2,}"
+    res = await plugin.tool_post_invoke(ToolPostInvokePayload(name="x", result=raw), plugin_ctx)
+
     assert res.modified_payload is not None
-    fixed = res.modified_payload.result
-    json.loads(fixed)
+    assert res.metadata == {"repaired": True}
+    json.loads(res.modified_payload.result)  # Should not raise


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #3080

---

## 📝 Summary

This PR adds a Rust implementation for `json_repair` and integrates it into the
existing plugin workflow while maintaining strict behavior parity with the
Python implementation.

### What's included

- Added new Rust crate: `plugins_rust/json_repair`
- Implemented repair logic with parity for:
  - trailing comma repair
  - single-quote JSON-ish repair
  - missing outer braces repair
  - multiline JSON-ish input handling
- Added Rust unit tests covering parity scenarios
- Added Criterion benchmarks for:
  - fixed repair cases
  - batch processing
  - text size scaling
  - early-exit vs full repair path
- Added and cleaned benchmark comparison script comments
  (`compare_performance.py`)

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

TBD


## Benchmarks

#### 📈 Performance Comparison
Run below commands:
- python plugins_rust/json_repair/compare_performance.py

<details>
<summary><strong>compare_performance.py results (Python vs Rust)</strong></summary>

### Environment
- Python: 3.13.12
- Rust available: yes
- Iterations: 10,000 (+100 warmup)

### High-level summary
- Python + `orjson` is consistently faster across all tested input sizes.
- Rust shows predictable scaling but has higher constant overhead, likely dominated by
  Python↔Rust (PyO3) boundary costs and repeated parse checks.
- Speedups are < 1.0× in all scenarios (i.e., Rust is slower end-to-end for this workload).

### Detailed results

```text
========================================================================
Scenario: small_valid_1kb
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.007 ms ±0.001 (median: 0.007)
Speedup: 0.17x

========================================================================
Scenario: small_repairable_1kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.004)
Rust:   0.016 ms ±0.001 (median: 0.016)
Speedup: 0.29x

========================================================================
Scenario: medium_valid_5kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.005)
Rust:   0.036 ms ±0.002 (median: 0.037)
Speedup: 0.13x

========================================================================
Scenario: medium_repairable_5kb
========================================================================
Python: 0.019 ms ±0.002 (median: 0.019)
Rust:   0.079 ms ±0.011 (median: 0.078)
Speedup: 0.24x

========================================================================
Scenario: large_valid_50kb
========================================================================
Python: 0.042 ms ±0.003 (median: 0.041)
Rust:   0.359 ms ±0.014 (median: 0.358)
Speedup: 0.12x

========================================================================
Scenario: large_repairable_50kb
========================================================================
Python: 0.227 ms ±0.015 (median: 0.226)
Rust:   0.777 ms ±0.029 (median: 0.776)
Speedup: 0.29x

========================================================================
Scenario: xlarge_valid_500kb
========================================================================
Python: 0.385 ms ±0.014 (median: 0.385)
Rust:   3.956 ms ±0.148 (median: 3.953)
Speedup: 0.10x

========================================================================
Scenario: xlarge_repairable_500kb
========================================================================
Python: 2.165 ms ±0.120 (median: 2.140)
Rust:   8.579 ms ±0.268 (median: 8.557)
Speedup: 0.25x

========================================================================
Scenario: xxlarge_valid_1024kb
========================================================================
Python: 0.811 ms ±0.028 (median: 0.808)
Rust:   8.840 ms ±0.294 (median: 8.828)
Speedup: 0.09x

========================================================================
Scenario: xxlarge_repairable_1024kb
========================================================================
Python: 4.241 ms ±0.177 (median: 4.209)
Rust:   18.558 ms ±0.592 (median: 18.511)
Speedup: 0.23x

========================================================================
Scenario: unrepairable_text
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.000 ms ±0.000 (median: 0.000)
Speedup: 2.60x

========================================================================
Scenario: missing_braces
========================================================================
Python: 0.000 ms ±0.000 (median: 0.000)
Rust:   0.000 ms ±0.000 (median: 0.000)
Speedup: 0.96x

========================================================================
Benchmark complete
========================================================================
```

Interpretation

The current Python path benefits from orjson (already Rust-backed) without crossing
an FFI boundary.

The Rust path is valuable for correctness parity, benchmarking, and future optimization,
but is not yet competitive as the default execution path.

These benchmarks support keeping Python + orjson as the default while continuing to
invest in Rust-side optimizations.

</details>


<details>
<summary><strong>Python vs Rust benchmark results</strong></summary>

### Environment
- Python: 3.13.12
- Rust available: yes
- Iterations: 10,000 (+100 warmup)
- Payload variants per scenario: 32

### Results

```text
========================================================================
Scenario: small_valid_1kb
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.005 ms ±0.001 (median: 0.005)
Speedup: 0.21x

========================================================================
Scenario: small_repairable_1kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.005)
Rust:   0.012 ms ±0.001 (median: 0.012)
Speedup: 0.43x

========================================================================
Scenario: medium_valid_5kb
========================================================================
Python: 0.004 ms ±0.000 (median: 0.004)
Rust:   0.029 ms ±0.002 (median: 0.028)
Speedup: 0.15x

========================================================================
Scenario: medium_repairable_5kb
========================================================================
Python: 0.021 ms ±0.001 (median: 0.021)
Rust:   0.062 ms ±0.003 (median: 0.062)
Speedup: 0.34x

========================================================================
Scenario: large_valid_50kb
========================================================================
Python: 0.038 ms ±0.003 (median: 0.037)
Rust:   0.308 ms ±0.018 (median: 0.301)
Speedup: 0.12x

========================================================================
Scenario: large_repairable_50kb
========================================================================
Python: 0.205 ms ±0.007 (median: 0.202)
Rust:   0.670 ms ±0.031 (median: 0.661)
Speedup: 0.31x

========================================================================
Scenario: xlarge_valid_500kb
========================================================================
Python: 0.356 ms ±0.012 (median: 0.353)
Rust:   3.361 ms ±0.211 (median: 3.311)
Speedup: 0.11x

========================================================================
Scenario: xlarge_repairable_500kb
========================================================================
Python: 1.906 ms ±0.089 (median: 1.887)
Rust:   7.134 ms ±0.424 (median: 7.005)
Speedup: 0.27x

========================================================================
Scenario: xxlarge_valid_1024kb
========================================================================
Python: 0.713 ms ±0.030 (median: 0.709)
Rust:   7.160 ms ±0.473 (median: 6.994)
Speedup: 0.10x

========================================================================
Scenario: xxlarge_repairable_1024kb
========================================================================
Python: 3.719 ms ±0.151 (median: 3.677)
Rust:   15.071 ms ±0.988 (median: 14.711)
Speedup: 0.25x

========================================================================
Scenario: unrepairable_text
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.000 ms ±0.000 (median: 0.001)
Speedup: 2.65x

========================================================================
Scenario: missing_braces
========================================================================
Python: 0.000 ms ±0.000 (median: 0.001)
Rust:   0.001 ms ±0.000 (median: 0.001)
Speedup: 0.99x

========================================================================
Benchmark complete
========================================================================
```

Notes

Python + orjson is faster for all valid and repairable JSON scenarios.

Rust shows a clear advantage only for early-exit unrepairable text.

Results reinforce keeping Python as the default path, with Rust retained for
parity, benchmarking, and future optimization work.

</details>


<details>
<summary><strong>Python vs Rust benchmark results, Iterations: 3,000 (+100 warmup), Payload variants per scenario: 32</strong></summary>

### Environment
- Python: 3.13.12
- Rust available: yes
- Iterations: 3,000 (+100 warmup)
- Payload variants per scenario: 32

### Results

```text
========================================================================
Scenario: small_valid_1kb
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.005 ms ±0.000 (median: 0.005)
Speedup: 0.21x

========================================================================
Scenario: small_repairable_1kb
========================================================================
Python: 0.005 ms ±0.000 (median: 0.005)
Rust:   0.012 ms ±0.001 (median: 0.012)
Speedup: 0.45x

========================================================================
Scenario: medium_valid_5kb
========================================================================
Python: 0.005 ms ±0.001 (median: 0.005)
Rust:   0.029 ms ±0.002 (median: 0.029)
Speedup: 0.16x

========================================================================
Scenario: medium_repairable_5kb
========================================================================
Python: 0.021 ms ±0.001 (median: 0.021)
Rust:   0.063 ms ±0.004 (median: 0.062)
Speedup: 0.34x

========================================================================
Scenario: large_valid_50kb
========================================================================
Python: 0.039 ms ±0.002 (median: 0.039)
Rust:   0.315 ms ±0.014 (median: 0.310)
Speedup: 0.12x

========================================================================
Scenario: large_repairable_50kb
========================================================================
Python: 0.204 ms ±0.006 (median: 0.202)
Rust:   0.677 ms ±0.074 (median: 0.670)
Speedup: 0.30x

========================================================================
Scenario: xlarge_valid_500kb
========================================================================
Python: 0.356 ms ±0.013 (median: 0.353)
Rust:   3.376 ms ±0.193 (median: 3.312)
Speedup: 0.11x

========================================================================
Scenario: xlarge_repairable_500kb
========================================================================
Python: 1.902 ms ±0.064 (median: 1.886)
Rust:   7.145 ms ±0.368 (median: 7.019)
Speedup: 0.27x

========================================================================
Scenario: xxlarge_valid_1024kb
========================================================================
Python: 0.720 ms ±0.022 (median: 0.715)
Rust:   7.168 ms ±0.435 (median: 7.002)
Speedup: 0.10x

========================================================================
Scenario: xxlarge_repairable_1024kb
========================================================================
Python: 3.730 ms ±0.142 (median: 3.688)
Rust:   15.075 ms ±0.958 (median: 14.746)
Speedup: 0.25x

========================================================================
Scenario: unrepairable_text
========================================================================
Python: 0.001 ms ±0.000 (median: 0.001)
Rust:   0.000 ms ±0.000 (median: 0.001)
Speedup: 2.59x

========================================================================
Scenario: missing_braces
========================================================================
Python: 0.000 ms ±0.000 (median: 0.001)
Rust:   0.001 ms ±0.000 (median: 0.001)
Speedup: 0.98x

========================================================================
Benchmark complete
========================================================================
```

Notes

Python + orjson remains faster for all valid and repairable JSON cases.

Rust shows a clear advantage only for early-exit unrepairable input.

Results support keeping Python as the default path, with Rust retained for
parity, benchmarking, and future optimization work.

</details>

#### 🧪 Rust Bench Results

Run below commands:
- cd plugins_rust/json_repair
- cargo bench --bench json_repair

<details>
<summary><strong>cargo bench --bench json_repair (Criterion output)</strong></summary>

### Environment
- Crate: `plugins_rust/json_repair`
- Command: `cargo bench --bench json_repair`
- Backend: Criterion (plotters fallback, gnuplot not found)
- Build: `bench` profile (optimized + debuginfo)

### High-level observations
- Benchmarks show **expected linear scaling** across input sizes.
- Valid-path throughput is consistently higher than repairable-path throughput.
- Several micro-benchmarks report minor regressions or improvements, largely within
  expected noise thresholds for Criterion.
- Early-exit path (already-valid JSON) shows **measurable improvement** over the
  full repair path.

### Raw Criterion output

```text
repair_cases/valid/0
time:   [111.45 ns 113.61 ns 116.01 ns]
thrpt:  [106.87 MiB/s 109.12 MiB/s 111.24 MiB/s]
No change in performance detected.

repair_cases/valid/1
time:   [388.35 ns 397.90 ns 408.58 ns]
thrpt:  [123.71 MiB/s 127.03 MiB/s 130.15 MiB/s]
No change in performance detected.

repair_cases/valid/2
time:   [389.11 ns 392.41 ns 395.69 ns]
thrpt:  [103.64 MiB/s 104.50 MiB/s 105.39 MiB/s]
Change within noise threshold.

repair_cases/valid/3
time:   [242.63 ns 243.83 ns 244.91 ns]
thrpt:  [198.59 MiB/s 199.47 MiB/s 200.46 MiB/s]
Performance has regressed.

repair_cases/repairable/0
time:   [536.83 ns 540.90 ns 544.88 ns]
thrpt:  [29.754 MiB/s 29.973 MiB/s 30.200 MiB/s]
Performance has regressed.

repair_cases/repairable/1
time:   [262.37 ns 267.04 ns 271.76 ns]
thrpt:  [56.148 MiB/s 57.140 MiB/s 58.157 MiB/s]
Performance has regressed.

repair_cases/repairable/2
time:   [278.67 ns 282.12 ns 285.22 ns]
thrpt:  [60.186 MiB/s 60.847 MiB/s 61.600 MiB/s]
Change within noise threshold.

repair_cases/repairable/3
time:   [440.10 ns 444.28 ns 447.90 ns]
thrpt:  [29.809 MiB/s 30.052 MiB/s 30.337 MiB/s]
Performance has regressed.

repair_cases/unrepairable/0
time:   [156.96 ns 158.75 ns 160.49 ns]
thrpt:  [89.135 MiB/s 90.109 MiB/s 91.138 MiB/s]
No change in performance detected.

repair_cases/unrepairable/1
time:   [126.39 ns 128.78 ns 131.42 ns]
thrpt:  [253.98 MiB/s 259.20 MiB/s 264.10 MiB/s]
Performance has regressed.

repair_cases/unrepairable/2
time:   [183.34 ns 184.72 ns 186.01 ns]
thrpt:  [158.93 MiB/s 160.05 MiB/s 161.26 MiB/s]
No change in performance detected.

repair_cases/unrepairable/3
time:   [132.25 ns 133.33 ns 134.15 ns]
thrpt:  [7.1091 MiB/s 7.1528 MiB/s 7.2113 MiB/s]
No change in performance detected.

batch_processing/mixed_batch
time:   [3.5575 µs 3.5967 µs 3.6375 µs]
thrpt:  [80.489 MiB/s 81.401 MiB/s 82.300 MiB/s]
No change in performance detected.

text_sizes/valid_kb/*
thrpt range: ~113–132 MiB/s

text_sizes/repairable_kb/*
thrpt range: ~56–63 MiB/s

early_exit_vs_full_path/already_valid_early_exit
thrpt: [107.17 MiB/s 108.53 MiB/s 110.35 MiB/s]
Performance has improved.

early_exit_vs_full_path/repairable_full_path
thrpt: [32.042 MiB/s 32.185 MiB/s 32.307 MiB/s]
Performance has improved.
```

**Interpretation**

Criterion results confirm stable behavior and predictable scaling.

Regressions/improvements are mostly small and consistent with micro-benchmark noise.

Early-exit optimization is effective and worth preserving.

These benches are useful for tracking Rust-side optimizations over time, even
though Rust is not yet the default execution path.

</details>

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Default path rationale (benchmark-driven)

- This PR follows the standard plugin pattern: Python as the default path,
  Rust as an optional accelerated path with safe fallback.
- Default behavior is driven by measured results, not assumptions.
- For `json_repair`, current benchmarks support Python + `orjson` as the
  default path.

### Why this is currently the best default

- Python already uses `orjson` (Rust-backed), providing a highly optimized
  baseline.
- The Rust extension introduces Python↔Rust (PyO3) boundary overhead and
  currently relies on `serde_json` for parse checks.
- End-to-end benchmarks show Rust is slower for valid and repairable inputs
  across tested sizes (1 KB to 1 MB), with only narrow wins for tiny
  unrepairable inputs.
- Therefore, Python + `orjson` remains the faster and lower-complexity
  production default at this time.

### Rust benchmark snapshot

- Criterion benchmarks show expected linear scaling.
- Valid-path throughput is consistently higher than repairable-path throughput.
- Observed throughput ranges in size benchmarks:
  - valid: ~115–128 MiB/s
  - repairable: ~57–63 MiB/s
- These results justify keeping Rust benchmarks for optimization tracking,
  while keeping default-path decisions evidence-based.

### Future optimization opportunities (Rust path)

1. Evaluate `simd-json` for parse-check workloads (with platform and complexity
   trade-offs).
2. Reduce parse attempts via cheap pre-parse byte-level guards.
3. Lower allocation overhead in transforms (single-pass scanners where feasible).
4. Amortize FFI overhead with batching APIs (repair multiple strings per call).

Any change to the default execution path should remain benchmark-driven.