### PR TITLE
feat(cicd): auto-generate requirements.txt from pyproject.toml

### DIFF
--- a/.github/workflows/check-requirements.yml
+++ b/.github/workflows/check-requirements.yml
@@ -1,0 +1,56 @@
+# ===============================================================
+# Check requirements.txt - Sync Verification
+# ===============================================================
+#
+#   Verifies that requirements.txt is in sync with pyproject.toml.
+#   Fails with actionable instructions if the file is stale.
+# ---------------------------------------------------------------
+
+name: Check requirements.txt
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - "requirements.txt"
+      - "scripts/generate_requirements.py"
+      - ".github/workflows/check-requirements.yml"
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - "requirements.txt"
+      - "scripts/generate_requirements.py"
+      - ".github/workflows/check-requirements.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-requirements:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Verify requirements.txt
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify requirements.txt is in sync
+        run: python3 scripts/generate_requirements.py --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -526,6 +526,20 @@ repos:
   #       types: [python]
 
   # -----------------------------------------------------------------------------
+  # 📦 Auto-generate requirements.txt from pyproject.toml
+  # -----------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: generate-requirements
+        name: 📦 Generate requirements.txt
+        description: Regenerates requirements.txt from pyproject.toml [project].dependencies.
+        entry: python3 scripts/generate_requirements.py
+        language: system
+        files: ^pyproject\.toml$
+        pass_filenames: false
+        stages: [pre-commit, pre-push, manual]
+
+  # -----------------------------------------------------------------------------
   #  Interrogate
   # -----------------------------------------------------------------------------
   - repo: https://github.com/econchick/interrogate

--- a/Makefile
+++ b/Makefile
@@ -2849,6 +2849,8 @@ images:
 # help: wily                 - Maintainability report
 # help: pyre                 - Static analysis with Facebook Pyre
 # help: pyrefly              - Static analysis with Facebook Pyrefly
+# help: requirements          - Generate requirements.txt from pyproject.toml (MODE=uv for full tree)
+# help: check-requirements    - Verify requirements.txt is in sync with pyproject.toml
 # help: depend               - List dependencies in ≈requirements format
 # help: snakeviz             - Profile & visualise with snakeviz
 # help: pstats               - Generate PNG call-graph from cProfile stats
@@ -3533,6 +3535,15 @@ pyre:                               ## 🧠  Facebook Pyre analysis
 
 pyrefly:                            ## 🧠  Facebook Pyrefly analysis (faster, rust)
 	@echo "🧠 pyrefly $(TARGET)..." && $(VENV_DIR)/bin/pyrefly check $(TARGET)
+
+MODE ?= direct
+.PHONY: requirements
+requirements:                       ## 📦  Generate requirements.txt from pyproject.toml (MODE=uv for full tree)
+	@python3 scripts/generate_requirements.py --mode $(MODE)
+
+.PHONY: check-requirements
+check-requirements:                 ## ✅  Verify requirements.txt is in sync with pyproject.toml
+	@python3 scripts/generate_requirements.py --check --mode $(MODE)
 
 .PHONY: depend
 depend:                             ## 📦  List dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,36 @@
+# Auto-generated from pyproject.toml [project].dependencies
+# Direct dependencies only (no transitive deps)
+# DO NOT EDIT — regenerate with: make requirements
+alembic>=1.18.4
+argon2-cffi>=25.1.0
+cryptography>=46.0.5
+fastapi>=0.135.1
+filelock>=3.25.0
+gunicorn>=25.1.0
+httpx>=0.28.1
+httpx[http2]>=0.28.1
+jinja2>=3.1.6
+jq>=1.11.0
+jsonpath-ng>=1.8.0
+jsonschema>=4.26.0
+mcp>=1.26.0
+orjson>=3.11.7
+parse>=1.21.1
+prometheus_client>=0.24.1
+prometheus-fastapi-instrumentator>=7.1.0
+psutil>=7.2.2
+pydantic>=2.12.5
+pydantic[email]>=2.12.5
+pydantic-settings>=2.13.1
+pyjwt>=2.11.0
+python-json-logger>=4.0.0
+python-multipart>=0.0.22
+PyYAML>=6.0.3
+requests-oauthlib>=2.0.0
+sqlalchemy>=2.0.48
+sse-starlette>=3.3.2
+starlette>=0.52.1
+starlette-compress>=1.7.0
+typer>=0.24.1
+urllib3>=2.6.3
+uvicorn[standard]>=0.41.0

--- a/scripts/generate_requirements.py
+++ b/scripts/generate_requirements.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Generate requirements.txt from pyproject.toml runtime dependencies.
+
+Copyright 2025 Mihai Criveti
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Extracts [project].dependencies from pyproject.toml (excluding dev and
+optional extras) and writes a sorted requirements.txt for compatibility
+with legacy security scanners and CI pipelines.
+
+Usage:
+    python scripts/generate_requirements.py                     # generate
+    python scripts/generate_requirements.py --check             # verify in sync
+    python scripts/generate_requirements.py --dry-run           # preview
+    python scripts/generate_requirements.py --mode uv           # full resolved tree via uv export
+    python scripts/generate_requirements.py --mode direct       # direct deps only (default)
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+HEADER_DIRECT = """\
+# Auto-generated from pyproject.toml [project].dependencies
+# Direct dependencies only (no transitive deps)
+# DO NOT EDIT — regenerate with: make requirements
+"""
+
+HEADER_UV = """\
+# Auto-generated via uv export (full resolved dependency tree)
+# DO NOT EDIT — regenerate with: make requirements MODE=uv
+"""
+
+
+def normalize_name(name: str) -> str:
+    """Normalize package name per PEP 503 (lowercase, hyphens to hyphens)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def extract_direct_deps(pyproject_path: Path) -> list[str]:
+    """Extract and sort [project].dependencies from pyproject.toml."""
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    deps = data.get("project", {}).get("dependencies", [])
+    if not deps:
+        print("Warning: No dependencies found in pyproject.toml", file=sys.stderr)
+        return []
+
+    return sorted(deps, key=lambda d: normalize_name(d.split("[")[0].split(">")[0].split("<")[0].split("=")[0].split("!")[0].split("~")[0]))
+
+
+def generate_direct(pyproject_path: Path) -> str:
+    """Generate requirements.txt content from direct dependencies."""
+    deps = extract_direct_deps(pyproject_path)
+    return HEADER_DIRECT + "\n".join(deps) + "\n"
+
+
+def generate_uv(pyproject_path: Path) -> str:
+    """Generate requirements.txt content via uv export (full resolved tree)."""
+    result = subprocess.run(
+        ["uv", "export", "--no-dev", "--no-hashes", "--no-emit-project"],
+        capture_output=True,
+        text=True,
+        cwd=pyproject_path.parent,
+    )
+    if result.returncode != 0:
+        print(f"Error: uv export failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # uv export includes its own header comments; replace with ours
+    lines = [line for line in result.stdout.splitlines() if not line.startswith("#")]
+    return HEADER_UV + "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate requirements.txt from pyproject.toml")
+    parser.add_argument("-i", "--input", default="pyproject.toml", help="Path to pyproject.toml (default: pyproject.toml)")
+    parser.add_argument("-o", "--output", default="requirements.txt", help="Output path (default: requirements.txt)")
+    parser.add_argument("--mode", choices=["direct", "uv"], default="direct", help="Generation mode: 'direct' extracts declared deps, 'uv' resolves full tree (default: direct)")
+    parser.add_argument("--check", action="store_true", help="Verify requirements.txt is in sync (exit 1 if not)")
+    parser.add_argument("--dry-run", action="store_true", help="Print generated content without writing")
+    args = parser.parse_args()
+
+    pyproject_path = Path(args.input)
+    output_path = Path(args.output)
+
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found", file=sys.stderr)
+        return 1
+
+    # Generate content
+    if args.mode == "uv":
+        content = generate_uv(pyproject_path)
+    else:
+        content = generate_direct(pyproject_path)
+
+    # Dry-run: just print
+    if args.dry_run:
+        print(content, end="")
+        return 0
+
+    # Check mode: compare with existing file
+    if args.check:
+        if not output_path.exists():
+            print(f"Error: {output_path} does not exist. Run 'make requirements' to generate it.", file=sys.stderr)
+            return 1
+
+        existing = output_path.read_text()
+        if existing == content:
+            print(f"{output_path} is up to date.")
+            return 0
+        else:
+            print(f"Error: {output_path} is out of sync with {pyproject_path}.", file=sys.stderr)
+            print(f"Run 'make requirements' to regenerate it.", file=sys.stderr)
+            return 1
+
+    # Write mode
+    output_path.write_text(content)
+    dep_count = len([line for line in content.splitlines() if line and not line.startswith("#")])
+    print(f"Generated {output_path} with {dep_count} dependencies (mode: {args.mode}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `scripts/generate_requirements.py` to extract `[project].dependencies` from `pyproject.toml` (supports `--mode direct` and `--mode uv` for full resolved tree)
- Add `make requirements` and `make check-requirements` Makefile targets
- Add pre-commit hook that regenerates `requirements.txt` on `pyproject.toml` changes
- Add `.github/workflows/check-requirements.yml` CI gate to fail PRs with stale `requirements.txt`
- Commit the generated `requirements.txt` (33 direct runtime dependencies)

Closes #2652