### PR TITLE
fix: resolve MAX_MEMBERS_PER_TEAM not applying to existing teams

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|Cargo.lock|^.secrets.baseline$|scripts/sign_image.sh|scripts/zap|sonar-project.properties|^/Users/brian/dev/github.ibm.com/contextforge-org/sps-pipeline-config/.secrets.baseline$|^./.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-03-27T15:57:24Z",
+  "generated_at": "2026-03-27T19:28:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 467,
+        "line_number": 482,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -250,7 +250,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 555,
+        "line_number": 570,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 905,
+        "line_number": 920,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2271,
+        "line_number": 2286,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2362,
+        "line_number": 2377,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2405,
+        "line_number": 2420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2410,
+        "line_number": 2425,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2415,
+        "line_number": 2430,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5102,7 +5102,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14821,
+        "line_number": 14866,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6224,7 +6224,7 @@
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33880,
+        "line_number": 33882,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9434,7 +9434,7 @@
         "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1467,
+        "line_number": 1470,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9442,7 +9442,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4828,
+        "line_number": 4833,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9450,7 +9450,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4833,
+        "line_number": 4838,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9458,7 +9458,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6370,
+        "line_number": 6375,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9466,7 +9466,7 @@
         "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6967,
+        "line_number": 6972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9474,7 +9474,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6986,
+        "line_number": 6991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9482,7 +9482,7 @@
         "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7192,
+        "line_number": 7197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9490,7 +9490,7 @@
         "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7211,
+        "line_number": 7216,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -10260,7 +10260,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1599,
+        "line_number": 1600,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10268,7 +10268,7 @@
         "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1771,
+        "line_number": 1772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10276,7 +10276,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2735,
+        "line_number": 2736,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -10284,7 +10284,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4939,
+        "line_number": 4940,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10292,7 +10292,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5586,
+        "line_number": 5587,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10300,7 +10300,7 @@
         "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5650,
+        "line_number": 5651,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10308,7 +10308,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5902,
+        "line_number": 5903,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10316,7 +10316,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8795,
+        "line_number": 8878,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10324,7 +10324,7 @@
         "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8844,
+        "line_number": 8927,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10332,7 +10332,7 @@
         "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8883,
+        "line_number": 8966,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10340,7 +10340,7 @@
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8940,
+        "line_number": 9023,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10348,7 +10348,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13710,
+        "line_number": 13793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10356,7 +10356,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16467,
+        "line_number": 16550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10364,7 +10364,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16486,
+        "line_number": 16569,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10372,7 +10372,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20038,
+        "line_number": 20121,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@
 
 ### ⚠️ Breaking Changes
 
+#### **👥 `MAX_MEMBERS_PER_TEAM` No Longer Baked Into Team Rows** ([#3682](https://github.com/IBM/mcp-context-forge/pull/3682), [#3588](https://github.com/IBM/mcp-context-forge/issues/3588))
+
+**Action Required**: New teams now store `NULL` for `max_members` and resolve the limit at check time from the `MAX_MEMBERS_PER_TEAM` environment variable. Existing teams created before this change still have the old default baked into the DB and will **not** automatically pick up env var changes.
+
+To apply the new behavior to existing teams, set each team's `max_members` to `null` via the API:
+
+```bash
+curl -X PUT "http://localhost:8080/teams/<team_id>" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"max_members": null}'
+```
+
+Teams with an explicit non-null `max_members` value will continue to use that value, ignoring the global setting.
+
 #### **🗄️ MySQL/MariaDB/MongoDB Support Removed** ([#3684](https://github.com/IBM/mcp-context-forge/pull/3684), [#1688](https://github.com/IBM/mcp-context-forge/issues/1688))
 
 **Action Required**: MySQL, MariaDB, and MongoDB database backends are no longer supported.

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1311,7 +1311,7 @@
     },
     "max_members_per_team": {
       "default": 100,
-      "description": "Maximum number of members per team",
+      "description": "Default maximum members per team, resolved at check time. Teams without an explicit per-team override use this value.",
       "title": "Max Members Per Team",
       "type": "integer"
     },

--- a/docs/docs/architecture/multitenancy.md
+++ b/docs/docs/architecture/multitenancy.md
@@ -1126,7 +1126,7 @@ sequenceDiagram
 AUTO_CREATE_PERSONAL_TEAMS=true
 # PERSONAL_TEAM_PREFIX=personal  # optional: set to get collision-safe email-based slugs
 MAX_TEAMS_PER_USER=50
-MAX_MEMBERS_PER_TEAM=100        # platform admins are exempt from this cap
+MAX_MEMBERS_PER_TEAM=100        # default limit resolved at check time; platform admins are exempt
 
 # Team Invitation Settings
 INVITATION_EXPIRY_DAYS=7

--- a/docs/docs/config.schema.json
+++ b/docs/docs/config.schema.json
@@ -1346,7 +1346,7 @@
     },
     "max_members_per_team": {
       "default": 100,
-      "description": "Maximum number of members per team",
+      "description": "Default maximum members per team, resolved at check time. Teams without an explicit per-team override use this value.",
       "title": "Max Members Per Team",
       "type": "integer"
     },

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -525,7 +525,7 @@ ContextForge implements **OAuth 2.0 Dynamic Client Registration (RFC 7591)** and
 | `AUTO_CREATE_PERSONAL_TEAMS`             | Enable automatic personal team creation for new users | `true`   | bool    |
 | `PERSONAL_TEAM_PREFIX`                   | Personal team naming prefix (empty = derive from display name) | `""` | string  |
 | `MAX_TEAMS_PER_USER`                     | Maximum number of teams a user can belong to    | `50`       | int > 0 |
-| `MAX_MEMBERS_PER_TEAM`                   | Maximum number of members per team (platform admins are exempt from this limit) | `100`      | int > 0 |
+| `MAX_MEMBERS_PER_TEAM`                   | Default maximum members per team, resolved at check time. Teams without an explicit per-team override use this value. Platform admins are exempt from this limit. | `100`      | int > 0 |
 | `INVITATION_EXPIRY_DAYS`                 | Number of days before team invitations expire   | `7`        | int > 0 |
 | `REQUIRE_EMAIL_VERIFICATION_FOR_INVITES` | Require email verification for team invitations | `true`     | bool    |
 | `ALLOW_TEAM_CREATION`                    | Allow users to create organizational teams (admins always can) | `true`  | bool    |

--- a/docs/docs/manage/troubleshooting.md
+++ b/docs/docs/manage/troubleshooting.md
@@ -163,24 +163,33 @@ The `+psycopg` suffix tells SQLAlchemy to use the psycopg 3 dialect instead of t
 
 If you see an error such as `"Team has reached maximum member limit of 100"` when adding members or sending invitations, the team has hit its membership cap.
 
-Each team has a `max_members` value that defaults to the global `MAX_MEMBERS_PER_TEAM` setting (default: **100**). The limit applies to active members plus pending invitations.
+Each team has a `max_members` value. When `max_members` is `null` (the default for new teams), the global `MAX_MEMBERS_PER_TEAM` setting is used at check time (default: **100**). The limit applies to active members plus pending invitations.
 
 ### Fix
 
-Increase the global default by setting `MAX_MEMBERS_PER_TEAM` in your environment:
+Increase the global default by setting `MAX_MEMBERS_PER_TEAM` in your environment. This takes effect immediately for all teams that do not have an explicit per-team override:
 
 ```bash
 # .env
 MAX_MEMBERS_PER_TEAM=500
 ```
 
-Alternatively, update the limit on a specific team via the Admin API:
+Alternatively, set an explicit per-team limit via the Admin API:
 
 ```bash
-curl -X PATCH http://localhost:4444/api/v1/teams/{team_id} \
+curl -X PUT http://localhost:4444/teams/{team_id} \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"max_members": 500}'
+```
+
+To revert a team to the global default, clear its per-team override:
+
+```bash
+curl -X PUT http://localhost:4444/teams/{team_id} \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"max_members": null}'
 ```
 
 See the [Configuration Reference](./configuration.md) for all team-related settings.

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -145,7 +145,7 @@ from mcpgateway.services.root_service import RootService, RootServiceError, Root
 from mcpgateway.services.server_service import ServerError, ServerLockConflictError, ServerNameConflictError, ServerNotFoundError, ServerService
 from mcpgateway.services.structured_logger import get_structured_logger
 from mcpgateway.services.tag_service import TagService
-from mcpgateway.services.team_management_service import TeamManagementService
+from mcpgateway.services.team_management_service import TeamManagementService, UNSET
 from mcpgateway.services.token_catalog_service import TokenCatalogService
 from mcpgateway.services.tool_service import ToolError, ToolLockConflictError, ToolNameConflictError, ToolNotFoundError, ToolService
 from mcpgateway.utils.create_jwt_token import create_jwt_token, get_jwt_token
@@ -3980,7 +3980,7 @@ async def admin_ui(
             # Token policy flags
             "require_token_expiration": getattr(settings, "require_token_expiration", True),
             "sri_hashes": load_sri_hashes(),
-            "max_members_per_team": getattr(settings, "max_members_per_team", 100),
+            "max_members_per_team": settings.max_members_per_team,
         },
     )
 
@@ -5576,6 +5576,26 @@ async def admin_list_teams(
         return HTMLResponse(content=f'<div class="text-center py-8"><p class="text-red-500">Error loading teams: {html.escape(str(e))}</p></div>', status_code=200)
 
 
+def _parse_form_max_members(raw: object) -> Optional[int]:
+    """Parse and validate a max_members value from a form field.
+
+    Args:
+        raw: The raw form value (typically a string or None).
+
+    Returns:
+        The parsed integer, or ``None`` when the field is blank or non-numeric.
+
+    Raises:
+        ValueError: When the parsed integer is less than 1.
+    """
+    if raw and str(raw).strip().isdigit():
+        parsed = int(str(raw).strip())
+        if parsed < 1:
+            raise ValueError("Maximum members must be at least 1")
+        return parsed
+    return None
+
+
 @admin_router.post("/teams")
 @require_permission("teams.create", allow_admin_bypass=False)
 async def admin_create_team(
@@ -5610,10 +5630,7 @@ async def admin_create_team(
         slug = form.get("slug") or None
         description = form.get("description") or None
         visibility = form.get("visibility", "private")
-        max_members_val = form.get("max_members")
-        max_members: Optional[int] = None
-        if max_members_val and str(max_members_val).strip().isdigit():
-            max_members = int(str(max_members_val).strip()) or None
+        max_members = _parse_form_max_members(form.get("max_members"))
 
         if not name:
             response = HTMLResponse(
@@ -5657,6 +5674,12 @@ async def admin_create_team(
             status_code=400,
         )
         return response
+    except ValueError as e:
+        LOGGER.warning(f"Validation error creating team: {e}")
+        return HTMLResponse(
+            content=f'<div class="text-red-500 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">{html.escape(str(e))}</div>',
+            status_code=400,
+        )
     except IntegrityError as e:
         LOGGER.error(f"Error creating team for admin {user}: {e}")
         if "UNIQUE constraint failed: email_teams.slug" in str(e):
@@ -6011,21 +6034,27 @@ async def admin_get_team_edit(
         safe_team_name = html.escape(team.name, quote=True)
         safe_description = html.escape(team.description or "")
         is_admin_edit = isinstance(_user, dict) and _user.get("is_admin")
-        max_members_limit = getattr(settings, "max_members_per_team", 100)
-        current_exceeds_limit = bool(team.max_members and team.max_members > max_members_limit)
+        max_members_limit = settings.max_members_per_team
+        current_exceeds_limit = bool(team.max_members is not None and team.max_members > max_members_limit)
         max_attr = "" if is_admin_edit else f'max="{max_members_limit}"'
+        use_default_checked = "checked" if team.max_members is None else ""
+        max_members_disabled = "disabled" if team.max_members is None else ""
         # When the existing value exceeds the configured limit for a non-admin,
         # show an empty field to avoid browser validation blocking form submission.
         # Submitting empty preserves the current value server-side.
-        if is_admin_edit:
-            max_members_value = team.max_members if team.max_members else ""
-            max_members_hint = "Admins can set any limit. Leave empty to keep current value."
+        max_members_value: Union[str, int] = ""
+        if team.max_members is None:
+            max_members_value = ""
+            max_members_hint = f"Currently using global default ({max_members_limit})."
+        elif is_admin_edit:
+            max_members_value = team.max_members
+            max_members_hint = "Admins can set any limit."
         elif current_exceeds_limit:
             max_members_value = ""
             max_members_hint = f"Current: {team.max_members} (above max {max_members_limit}). Leave empty to keep, or set a new value \u2264 {max_members_limit}."
         else:
-            max_members_value = team.max_members if team.max_members else ""
-            max_members_hint = f"Max {max_members_limit}. Leave empty to keep current value."
+            max_members_value = team.max_members
+            max_members_hint = f"Max {max_members_limit}."
         edit_form = rf"""
         <div class="space-y-4">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Edit Team</h3>
@@ -6058,7 +6087,13 @@ async def admin_get_team_edit(
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Maximum Members</label>
-                    <input type="number" name="max_members" min="1" {max_attr} value="{max_members_value}"
+                    <div class="flex items-center mt-1 mb-2">
+                        <input type="checkbox" name="use_default_max_members" id="use-default-max-members" {use_default_checked}
+                               onchange="var mi = this.closest('div').parentElement.querySelector('input[name=max_members]'); mi.disabled = this.checked; if(this.checked) mi.value = '';"
+                               class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded">
+                        <label for="use-default-max-members" class="ml-2 text-sm text-gray-700 dark:text-gray-300">Use global default ({max_members_limit})</label>
+                    </div>
+                    <input type="number" name="max_members" min="1" {max_attr} value="{max_members_value}" {max_members_disabled}
                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 text-gray-900 dark:text-white">
                     <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{max_members_hint}</p>
                 </div>
@@ -6114,14 +6149,12 @@ async def admin_update_team(
         name_val = form.get("name")
         desc_val = form.get("description")
         vis_val = form.get("visibility", "private")
-        max_members_val = form.get("max_members")
+        use_default_max_members = form.get("use_default_max_members")
         # Trim before presence check for consistent error messages
         name = name_val.strip() if isinstance(name_val, str) else None
         description = desc_val.strip() if isinstance(desc_val, str) and desc_val.strip() != "" else None
         visibility = vis_val if isinstance(vis_val, str) else "private"
-        max_members: Optional[int] = None
-        if max_members_val and str(max_members_val).strip().isdigit():
-            max_members = int(str(max_members_val).strip()) or None
+        max_members = _parse_form_max_members(form.get("max_members"))
 
         if not name:
             is_htmx = request.headers.get("HX-Request") == "true"
@@ -6174,7 +6207,19 @@ async def admin_update_team(
         # Update team
         user_email = getattr(user, "email", None) or str(user)
         is_admin = isinstance(user, dict) and user.get("is_admin")
-        updated = await team_service.update_team(team_id=team_id, name=name, description=description, visibility=visibility, max_members=max_members, updated_by=user_email, skip_limits=bool(is_admin))
+        # Three-way max_members resolution:
+        #   checkbox checked  → None  (clear per-team override, revert to global default)
+        #   number provided   → int   (set explicit per-team limit)
+        #   neither           → UNSET (leave current value unchanged)
+        if use_default_max_members:
+            max_members_kwarg = None
+        elif max_members is not None:
+            max_members_kwarg = max_members
+        else:
+            max_members_kwarg = UNSET
+        updated = await team_service.update_team(
+            team_id=team_id, name=name, description=description, visibility=visibility, max_members=max_members_kwarg, updated_by=user_email, skip_limits=bool(is_admin)
+        )
 
         if not updated:
             is_htmx = request.headers.get("HX-Request") == "true"

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -101,15 +101,6 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
         if not settings.allow_team_creation and not is_admin:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Team creation is currently disabled")
 
-        # Enforce max_members_per_team limit for non-admin users
-        if not is_admin and request.max_members is not None:
-            limit = getattr(settings, "max_members_per_team", 100)
-            if request.max_members > limit:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"max_members cannot exceed {limit} for non-admin users",
-                )
-
         service = TeamManagementService(db)
         team = await service.create_team(
             name=request.name,
@@ -378,16 +369,13 @@ async def update_team(team_id: str, request: TeamUpdateRequest, current_user: di
         if role != "owner":
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_MSG)
 
-        # Enforce max_members_per_team limit for non-admin users
-        if not is_admin and request.max_members is not None:
-            limit = getattr(settings, "max_members_per_team", 100)
-            if request.max_members > limit:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"max_members cannot exceed {limit} for non-admin users",
-                )
-
-        success = await service.update_team(team_id=team_id, name=request.name, description=request.description, visibility=request.visibility, max_members=request.max_members, skip_limits=is_admin)
+        # Only pass max_members when explicitly provided in the request body
+        # (including explicit null) so update_team can distinguish "not provided"
+        # from "clear the per-team override".
+        update_kwargs: dict[str, Any] = dict(team_id=team_id, name=request.name, description=request.description, visibility=request.visibility, skip_limits=is_admin)
+        if "max_members" in request.model_fields_set:
+            update_kwargs["max_members"] = request.max_members
+        success = await service.update_team(**update_kwargs)
 
         if not success:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found or update failed")
@@ -747,7 +735,7 @@ async def invite_team_member(team_id: str, request: TeamInviteRequest, current_u
         )
     except HTTPException:
         raise
-    except ValueError as e:
+    except (ValueError, TeamMemberLimitExceededError) as e:
         logger.error(f"Team invitation failed: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
@@ -842,7 +830,7 @@ async def accept_team_invitation(token: str, current_user: dict = Depends(get_cu
         return TeamMemberResponse.model_validate(member)
     except HTTPException:
         raise
-    except ValueError as e:
+    except (ValueError, TeamMemberLimitExceededError) as e:
         logger.error(f"Invitation acceptance failed: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
@@ -1133,7 +1121,7 @@ async def approve_join_request(
             invited_by=member.invited_by,
             is_active=member.is_active,
         )
-    except ValueError as e:
+    except (ValueError, TeamMemberLimitExceededError) as e:
         # Handle validation errors with 400 Bad Request
         error_msg = str(e)
         if "maximum team limit" in error_msg:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5873,7 +5873,7 @@ class TeamCreateRequest(BaseModel):
     slug: Optional[str] = Field(None, min_length=2, max_length=255, pattern="^[a-z0-9-]+$", description="URL-friendly team identifier")
     description: Optional[str] = Field(None, max_length=1000, description="Team description")
     visibility: Literal["private", "public"] = Field("private", description="Team visibility level")
-    max_members: Optional[int] = Field(default=None, description="Maximum number of team members")
+    max_members: Optional[int] = Field(default=None, ge=1, description="Maximum number of team members. If omitted, the team inherits the global MAX_MEMBERS_PER_TEAM setting at check time.")
 
     @field_validator("name")
     @classmethod
@@ -5968,7 +5968,9 @@ class TeamUpdateRequest(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=255, description="Team display name")
     description: Optional[str] = Field(None, max_length=1000, description="Team description")
     visibility: Optional[Literal["private", "public"]] = Field(None, description="Team visibility level")
-    max_members: Optional[int] = Field(default=None, description="Maximum number of team members")
+    max_members: Optional[int] = Field(
+        default=None, ge=1, description="Maximum number of team members. Set to null to clear a per-team override and revert to the global MAX_MEMBERS_PER_TEAM setting."
+    )
 
     @field_validator("name")
     @classmethod
@@ -6061,7 +6063,7 @@ class TeamResponse(BaseModel):
     created_by: str = Field(..., description="Email of team creator")
     is_personal: bool = Field(..., description="Whether this is a personal team")
     visibility: Optional[Literal["private", "public"]] = Field(..., description="Team visibility level")
-    max_members: Optional[int] = Field(None, description="Maximum number of members allowed")
+    max_members: Optional[int] = Field(None, description="Per-team member limit override. Null means the team uses the global MAX_MEMBERS_PER_TEAM setting.")
     member_count: int = Field(..., description="Current number of team members")
     created_at: datetime = Field(..., description="Team creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -29,10 +29,9 @@ from sqlalchemy.orm import Session
 from mcpgateway.cache.auth_cache import auth_cache
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
-from mcpgateway.services.team_management_service import get_effective_max_members
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailUser, utc_now
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.team_management_service import get_user_team_count
+from mcpgateway.services.team_management_service import check_team_member_capacity, get_user_team_count
 
 # Initialize logging
 logging_service = LoggingService()
@@ -230,16 +229,10 @@ class TeamInvitationService:
                 logger.warning(f"Active invitation already exists for {SecurityValidator.sanitize_log_message(email)} to team {SecurityValidator.sanitize_log_message(team_id)}")
                 raise ValueError(f"An active invitation already exists for {email}")
 
-            # Check team member limit (explicit per-team value or global default)
-            effective_max = get_effective_max_members(team)
-            if effective_max:
-                current_member_count = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.is_active.is_(True)).count()
-
-                pending_invitation_count = self.db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == team_id, EmailTeamInvitation.is_active.is_(True)).count()
-
-                if (current_member_count + pending_invitation_count) >= effective_max:
-                    logger.warning(f"Team {SecurityValidator.sanitize_log_message(team_id)} has reached maximum member limit")
-                    raise ValueError(f"Team has reached maximum member limit of {effective_max}")
+            # Check team member limit (explicit per-team value or global default).
+            # Reserve slots for pending invitations too, so we don't over-invite.
+            pending_count = self.db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == team_id, EmailTeamInvitation.is_active.is_(True)).count()
+            check_team_member_capacity(self.db, team, extra_count=pending_count)
 
             # Deactivate any existing invitations for this email/team combination
             if existing_invitation:
@@ -359,12 +352,7 @@ class TeamInvitationService:
                 raise ValueError(f"User has reached the maximum team limit of {max_teams}")
 
             # Check team member limit (explicit per-team value or global default)
-            effective_max = get_effective_max_members(team)
-            if effective_max:
-                current_member_count = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.is_active.is_(True)).count()
-                if current_member_count >= effective_max:
-                    logger.warning(f"Team {invitation.team_id} has reached maximum member limit")
-                    raise ValueError(f"Team has reached maximum member limit of {effective_max}")
+            check_team_member_capacity(self.db, team)
 
             # Create team membership
             membership = EmailTeamMember(team_id=invitation.team_id, user_email=invitation.email, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True)

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -141,7 +141,22 @@ class TeamMemberAddError(TeamManagementError):
     """
 
 
-def get_effective_max_members(team: "EmailTeam") -> Optional[int]:
+class _Unset:
+    """Sentinel type: distinguishes 'caller omitted the argument' from 'caller passed None'."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = _Unset()
+
+
+def get_effective_max_members(team: "EmailTeam") -> int:
     """Return the effective member limit for a team.
 
     If the team has an explicit ``max_members`` value stored in the DB, that
@@ -149,12 +164,34 @@ def get_effective_max_members(team: "EmailTeam") -> Optional[int]:
     returned so that changing the environment variable takes effect for all
     teams that have not been individually overridden.
 
-    Returns ``None`` only when neither the team nor the global setting
-    specifies a limit (no cap enforced).
+    Args:
+        team: The team whose effective member limit should be resolved.
+
+    Returns:
+        The member limit (always an int; 0 means unlimited).
     """
     if team.max_members is not None:
         return team.max_members
-    return getattr(settings, "max_members_per_team", 100)
+    return settings.max_members_per_team
+
+
+def check_team_member_capacity(db: "Session", team: "EmailTeam", *, extra_count: int = 0) -> None:
+    """Raise if the team is at or over its member capacity.
+
+    Args:
+        db: Database session for querying active member count.
+        team: The team to check.
+        extra_count: Additional slots to reserve (e.g. pending invitations).
+
+    Raises:
+        TeamMemberLimitExceededError: If the team is at capacity.
+    """
+    effective_max = get_effective_max_members(team)
+    if effective_max <= 0:
+        return
+    member_count = db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id, EmailTeamMember.is_active.is_(True)).count()
+    if (member_count + extra_count) >= effective_max:
+        raise TeamMemberLimitExceededError(f"Team has reached maximum member limit of {effective_max}")
 
 
 class TeamManagementService:
@@ -262,11 +299,6 @@ class TeamManagementService:
                 close()
             raise
 
-    @staticmethod
-    def _get_effective_max_members(team: "EmailTeam") -> Optional[int]:
-        """Return the effective member limit for a team. Delegates to module-level helper."""
-        return get_effective_max_members(team)
-
     def _log_team_member_action(self, team_member_id: str, team_id: str, user_email: str, role: str, action: str, action_by: Optional[str]):
         """
         Log a team member action to EmailTeamMemberHistory.
@@ -370,7 +402,7 @@ class TeamManagementService:
 
             # Enforce max_members cap for non-admins (only when explicitly provided)
             if not skip_limits and max_members is not None:
-                max_limit = getattr(settings, "max_members_per_team", 100)
+                max_limit = settings.max_members_per_team
                 if max_members > max_limit:
                     raise ValueError(f"max_members cannot exceed the configured limit of {max_limit}")
 
@@ -501,7 +533,7 @@ class TeamManagementService:
         name: Optional[str] = None,
         description: Optional[str] = None,
         visibility: Optional[str] = None,
-        max_members: Optional[int] = None,
+        max_members: Union[int, None, _Unset] = UNSET,
         updated_by: Optional[str] = None,
         skip_limits: bool = False,
     ) -> bool:
@@ -512,7 +544,9 @@ class TeamManagementService:
             name: New team name
             description: New team description
             visibility: New visibility setting
-            max_members: New maximum member limit
+            max_members: New maximum member limit. Pass ``None`` to clear an
+                explicit per-team override (reverts to global default).  Omit
+                (or pass ``UNSET``) to leave the current value unchanged.
             updated_by: Email of user making the update
             skip_limits: Skip the max_members_per_team cap check (platform admins only)
 
@@ -554,9 +588,12 @@ class TeamManagementService:
                     raise ValueError(f"Invalid visibility. Must be one of: {', '.join(valid_visibilities)}")
                 team.visibility = visibility
 
-            if max_members is not None:
-                if not skip_limits:
-                    max_limit = getattr(settings, "max_members_per_team", 100)
+            # UNSET means "not provided" — leave unchanged.
+            # None means "explicitly clear the per-team override" — store NULL.
+            # An int means "set an explicit per-team limit".
+            if max_members is not UNSET:
+                if max_members is not None and not skip_limits:
+                    max_limit = settings.max_members_per_team
                     if max_members > max_limit:
                         raise ValueError(f"max_members cannot exceed the configured limit of {max_limit}")
                 team.max_members = max_members
@@ -706,13 +743,7 @@ class TeamManagementService:
             raise MemberAlreadyExistsError("User is already a member of this team")
 
         # Check team member limit (explicit per-team value or global default)
-        effective_max = self._get_effective_max_members(team)
-        if effective_max:
-            current_member_count = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.is_active.is_(True)).count()
-
-            if current_member_count >= effective_max:
-                logger.warning(f"Team {SecurityValidator.sanitize_log_message(team_id)} has reached maximum member limit of {effective_max}")
-                raise TeamMemberLimitExceededError(f"Team has reached maximum member limit of {effective_max}")
+        check_team_member_capacity(self.db, team)
 
         # Add or reactivate membership
         try:
@@ -1664,12 +1695,9 @@ class TeamManagementService:
 
             # Check team member limit
             team = await self.get_team_by_id(join_request.team_id)
-            if team:
-                effective_max = self._get_effective_max_members(team)
-                if effective_max:
-                    current_count = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == join_request.team_id, EmailTeamMember.is_active.is_(True)).count()
-                    if current_count >= effective_max:
-                        raise ValueError(f"Team has reached maximum member limit of {effective_max}")
+            if not team:
+                raise ValueError(f"Team {join_request.team_id} not found or inactive")
+            check_team_member_capacity(self.db, team)
 
             # Add user to team
             member = EmailTeamMember(team_id=join_request.team_id, user_email=join_request.user_email, role="member", invited_by=approved_by, joined_at=utc_now())  # New joiners are always members

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -23548,6 +23548,8 @@ async function showTeamEditModal(teamId) {
 
 function hideTeamEditModal() {
     document.getElementById("team-edit-modal").classList.add("hidden");
+    var content = document.getElementById("team-edit-modal-content");
+    if (content) content.innerHTML = "";
 }
 
 // Expose team modal functions to global scope

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -14646,14 +14646,13 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                     id="team-max-members"
                     min="1"
                     {% if not is_admin %}max="{{ max_members_per_team }}"{% endif %}
-                    value="{{ [50, max_members_per_team] | min }}"
                     class="block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                   />
                   <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                     {% if is_admin %}
-                    Optional. Admins can set any limit.
+                    Optional. Leave empty to use global default ({{ max_members_per_team }}). Admins can set any limit.
                     {% else %}
-                    Optional, defaults to {{ [50, max_members_per_team] | min }}.
+                    Optional. Leave empty to use global default ({{ max_members_per_team }}).
                     {% endif %}
                   </p>
                 </div>
@@ -15018,6 +15017,10 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 
       function editTeamSafe(button) {
         const teamId = button.getAttribute('data-team-id');
+        // Clear stale modal content before fetching fresh data to prevent
+        // race conditions with the delayed closeTeamEditModal timer.
+        var mc = document.getElementById('team-edit-modal-content');
+        if (mc) mc.innerHTML = '';
         // Load edit modal content via HTMX
         htmx.ajax('GET', window.ROOT_PATH + '/admin/teams/' + teamId + '/edit', {
           target: '#team-edit-modal-content',
@@ -15033,7 +15036,8 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       }
 
       function loadTeamMembersView(teamId) {
-        // Load team members management modal
+        var mc = document.getElementById('team-edit-modal-content');
+        if (mc) mc.innerHTML = '';
         htmx.ajax('GET', window.ROOT_PATH + '/admin/teams/' + teamId + '/members', {
           target: '#team-edit-modal-content',
           swap: 'innerHTML'
@@ -15043,7 +15047,8 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       }
 
       function loadAddMembersView(teamId) {
-        // Load add members interface
+        var mc = document.getElementById('team-edit-modal-content');
+        if (mc) mc.innerHTML = '';
         htmx.ajax('GET', window.ROOT_PATH + '/admin/teams/' + teamId + '/members/add', {
           target: '#team-edit-modal-content',
           swap: 'innerHTML'

--- a/tests/playwright/test_organization.py
+++ b/tests/playwright/test_organization.py
@@ -155,6 +155,8 @@ class TestTeams:
         # Verify other form fields are present
         expect(modal_content.locator('input[name="slug"]')).to_be_visible()
         expect(modal_content.locator('select[name="visibility"]')).to_be_visible()
+        expect(modal_content.locator('input[name="max_members"]')).to_be_visible()
+        expect(modal_content.locator('input[name="use_default_max_members"]')).to_be_visible()
 
         # Close modal without saving
         cancel_btn = team_edit_modal.locator('button:has-text("Cancel")')
@@ -165,6 +167,64 @@ class TestTeams:
             team_page.page.evaluate("document.getElementById('team-edit-modal').classList.add('hidden')")
 
         # Cleanup
+        team_page.delete_team(team_name)
+
+    @pytest.mark.flaky(reruns=2, reruns_delay=1, reason="HTMX search DOM swap timing in headless mode")
+    def test_edit_settings_max_members_defaults_to_global(self, team_page):
+        """New teams use global default: checkbox is checked and number input is disabled."""
+        team_page.navigate_to_teams_tab()
+        team_name = f"Test Team {uuid.uuid4().hex[:8]}"
+
+        # Create test team (max_members is NULL = use global default)
+        with team_page.page.expect_response(lambda response: "/admin/teams" in response.url and response.request.method == "POST"):
+            team_page.create_team(team_name)
+
+        team_page.page.wait_for_load_state("domcontentloaded")
+        team_page.page.reload(wait_until="domcontentloaded")
+        team_page.navigate_to_teams_tab()
+
+        team_search = team_page.page.locator("#team-search")
+        team_search.wait_for(state="visible", timeout=30000)
+        team_search.fill(team_name)
+        team_page.wait_for_team_visible(team_name)
+
+        team_page.page.wait_for_function(
+            "() => !document.querySelector('#teams-loading.htmx-request')",
+            timeout=15000,
+        )
+
+        edit_btn = team_page.get_team_edit_settings_btn(team_name)
+        try:
+            expect(edit_btn).to_be_visible(timeout=15000)
+        except AssertionError:
+            pytest.skip("Edit Settings button not visible")
+        edit_btn.click(force=True, timeout=15000)
+
+        modal_content = team_page.page.locator("#team-edit-modal-content")
+        expect(modal_content).to_contain_text("Edit Team", timeout=5000)
+
+        # Verify the "Use global default" checkbox exists and is checked
+        checkbox = modal_content.locator('input[name="use_default_max_members"]')
+        expect(checkbox).to_be_visible()
+        expect(checkbox).to_be_checked()
+
+        # Verify the max_members number input is disabled (checkbox is checked)
+        max_members_input = modal_content.locator('input[name="max_members"]')
+        expect(max_members_input).to_be_visible()
+        expect(max_members_input).to_be_disabled()
+
+        # Uncheck the checkbox — number input should become enabled
+        checkbox.uncheck()
+        expect(max_members_input).to_be_enabled()
+
+        # Re-check — number input should become disabled again
+        checkbox.check()
+        expect(max_members_input).to_be_disabled()
+
+        # Close and cleanup
+        cancel_btn = team_page.page.locator('#team-edit-modal button:has-text("Cancel")')
+        if cancel_btn.count() > 0:
+            cancel_btn.first.click()
         team_page.delete_team(team_name)
 
     @pytest.mark.flaky(reruns=2, reruns_delay=1, reason="HTMX refresh timing in headless mode")

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -1135,9 +1135,11 @@ class TestTeamsRouter:
         """Non-admin users cannot set max_members above the configured limit."""
         request = TeamCreateRequest(name="Test Team", description="desc", visibility="private", max_members=9999)
 
-        with patch("mcpgateway.routers.teams.settings") as mock_settings:
+        with patch("mcpgateway.routers.teams.settings") as mock_settings, patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
             mock_settings.allow_team_creation = True
-            mock_settings.max_members_per_team = 100
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.create_team = AsyncMock(side_effect=ValueError("max_members cannot exceed the configured limit of 100"))
+            MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
 
@@ -1145,7 +1147,7 @@ class TestTeamsRouter:
                 await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-            assert "max_members cannot exceed 100" in str(exc_info.value.detail)
+            assert "max_members cannot exceed" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_create_team_non_admin_max_members_at_limit(self, mock_user_context, mock_team, mock_db):
@@ -1192,6 +1194,7 @@ class TestTeamsRouter:
             mock_settings.max_members_per_team = 100
             mock_service = AsyncMock(spec=TeamManagementService)
             mock_service.get_user_role_in_team = AsyncMock(return_value="owner")
+            mock_service.update_team = AsyncMock(side_effect=ValueError("max_members cannot exceed the configured limit of 100"))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import update_team
@@ -1200,7 +1203,7 @@ class TestTeamsRouter:
                 await update_team(team_id, request, current_user=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-            assert "max_members cannot exceed 100" in str(exc_info.value.detail)
+            assert "max_members cannot exceed" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_update_team_non_admin_max_members_at_limit(self, mock_user_context, mock_team, mock_db):

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1392,6 +1392,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         # Only update description
@@ -1434,9 +1435,11 @@ class TestGatewayService:
         test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
         test_db.commit = Mock(side_effect=Exception("Database error"))
         test_db.rollback = Mock()
+        test_db.refresh = Mock()
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(description="New description")
@@ -1485,9 +1488,11 @@ class TestGatewayService:
         # Use return_value for all execute calls
         test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
         test_db.commit = Mock(side_effect=SQLIntegrityError("statement", "params", BaseException("orig")))
+        test_db.refresh = Mock()
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(description="New description")

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailUser
 from mcpgateway.services.team_invitation_service import TeamInvitationService
+from mcpgateway.services.team_management_service import TeamMemberLimitExceededError
 
 
 class TestTeamInvitationService:
@@ -376,8 +377,48 @@ class TestTeamInvitationService:
 
         mock_db.query.side_effect = query_side_effect
 
-        with pytest.raises(ValueError, match="maximum member limit"):
+        with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
             await service.create_invitation(team_id="team123", email="user@example.com", role="member", invited_by="admin@example.com")
+
+    @pytest.mark.asyncio
+    async def test_create_invitation_null_max_members_uses_global_default(self, service, mock_team, mock_inviter, mock_membership, mock_db):
+        """Test that create_invitation falls back to settings.max_members_per_team when team.max_members is None."""
+        mock_team.max_members = None  # no per-team override
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailUser:
+                mock_query.filter.return_value.first.return_value = mock_inviter
+            elif model == EmailTeamMember:
+                if not hasattr(query_side_effect, "member_call_count"):
+                    query_side_effect.member_call_count = 0
+                query_side_effect.member_call_count += 1
+
+                if query_side_effect.member_call_count == 1:
+                    mock_query.filter.return_value.first.return_value = mock_membership
+                elif query_side_effect.member_call_count == 2:
+                    mock_query.filter.return_value.first.return_value = None
+                else:
+                    mock_query.filter.return_value.count.return_value = 8
+            elif model == EmailTeamInvitation:
+                if not hasattr(query_side_effect, "invitation_call_count"):
+                    query_side_effect.invitation_call_count = 0
+                query_side_effect.invitation_call_count += 1
+
+                if query_side_effect.invitation_call_count == 1:
+                    mock_query.filter.return_value.first.return_value = None
+                else:
+                    mock_query.filter.return_value.count.return_value = 2  # 8 + 2 = 10
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+
+        with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+            mock_settings.max_members_per_team = 10  # global limit matches total (8+2)
+            with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
+                await service.create_invitation(team_id="team123", email="user@example.com", role="member", invited_by="admin@example.com")
 
     # =========================================================================
     # Invitation Retrieval Tests
@@ -568,8 +609,36 @@ class TestTeamInvitationService:
         mock_db.query.side_effect = query_side_effect
 
         with patch.object(service, "get_invitation_by_token", return_value=mock_invitation):
-            with pytest.raises(ValueError, match="maximum member limit"):
+            with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
                 await service.accept_invitation("token")
+
+    @pytest.mark.asyncio
+    async def test_accept_invitation_null_max_members_uses_global_default(self, service, mock_invitation, mock_team, mock_db):
+        """Test that accept_invitation falls back to settings.max_members_per_team when team.max_members is None."""
+        mock_team.max_members = None  # no per-team override
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailTeamMember:
+                if not hasattr(query_side_effect, "call_count"):
+                    query_side_effect.call_count = 0
+                query_side_effect.call_count += 1
+
+                if query_side_effect.call_count == 1:
+                    mock_query.filter.return_value.first.return_value = None
+                else:
+                    mock_query.filter.return_value.count.return_value = 10
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+
+        with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+            mock_settings.max_members_per_team = 10  # global limit matches count
+            with patch.object(service, "get_invitation_by_token", return_value=mock_invitation):
+                with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
+                    await service.accept_invitation("token")
 
     # =========================================================================
     # Invitation Decline Tests

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import EmailTeam, EmailTeamJoinRequest, EmailTeamMember, EmailUser
-from mcpgateway.services.team_management_service import TeamManagementService, get_effective_max_members
+from mcpgateway.services.team_management_service import TeamManagementService, TeamMemberLimitExceededError, get_effective_max_members
 
 
 class TestGetEffectiveMaxMembers:
@@ -407,6 +407,30 @@ class TestTeamManagementService:
 
             assert result is False
             mock_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_team_clear_max_members(self, service, mock_db, mock_team):
+        """Test that passing max_members=None clears the per-team override."""
+        mock_team.max_members = 25  # explicit override
+
+        with patch.object(service, "get_team_by_id", return_value=mock_team):
+            result = await service.update_team(team_id="team123", max_members=None)
+
+            assert result is True
+            assert mock_team.max_members is None
+            mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_team_omit_max_members_leaves_unchanged(self, service, mock_db, mock_team):
+        """Test that omitting max_members leaves the existing value unchanged."""
+        mock_team.max_members = 25
+
+        with patch.object(service, "get_team_by_id", return_value=mock_team):
+            result = await service.update_team(team_id="team123", name="Renamed")
+
+            assert result is True
+            assert mock_team.max_members == 25
+            mock_db.commit.assert_called_once()
 
     # =========================================================================
     # Team Deletion Tests
@@ -1452,6 +1476,47 @@ class TestTeamManagementService:
         assert result is member
         mock_role_service.get_role_by_name.assert_called_once_with("viewer", scope="team")
         mock_role_service.assign_role_to_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_approve_join_request_member_limit_exceeded(self, service, mock_db):
+        """Test approve_join_request rejects when team is at capacity."""
+        join_request = MagicMock(spec=EmailTeamJoinRequest)
+        join_request.team_id = "team-1"
+        join_request.user_email = "user@example.com"
+        join_request.is_expired.return_value = False
+        mock_db.query.return_value.filter.return_value.first.return_value = join_request
+        mock_db.query.return_value.filter.return_value.count.return_value = 10
+
+        mock_team = MagicMock()
+        mock_team.max_members = 10
+
+        with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+            mock_settings.max_teams_per_user = 50
+            mock_settings.max_members_per_team = 100
+
+            with patch.object(service, "get_team_by_id", new=AsyncMock(return_value=mock_team)):
+                with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
+                    await service.approve_join_request("req-1", "admin@example.com")
+
+        mock_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_approve_join_request_team_not_found(self, service, mock_db):
+        """Test approve_join_request rejects when team does not exist."""
+        join_request = MagicMock(spec=EmailTeamJoinRequest)
+        join_request.team_id = "team-gone"
+        join_request.user_email = "user@example.com"
+        join_request.is_expired.return_value = False
+        mock_db.query.return_value.filter.return_value.first.return_value = join_request
+
+        with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+            mock_settings.max_teams_per_user = 50
+
+            with patch.object(service, "get_team_by_id", new=AsyncMock(return_value=None)):
+                with pytest.raises(ValueError, match="not found or inactive"):
+                    await service.approve_join_request("req-1", "admin@example.com")
+
+        mock_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_reject_join_request_success(self, service, mock_db):

--- a/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import EmailTeam, EmailTeamJoinRequest, EmailTeamMember, EmailTeamMemberHistory, EmailUser
-from mcpgateway.services.team_management_service import TeamManagementService
+from mcpgateway.services.team_management_service import TeamManagementService, TeamMemberLimitExceededError
 
 
 @pytest.fixture(autouse=True)
@@ -773,9 +773,6 @@ class TestApproveJoinRequestEdge:
         join_req.is_expired = MagicMock(return_value=False)
         join_req.status = "pending"
 
-        mock_team = MagicMock()
-        mock_team.max_members = None
-
         mock_query = MagicMock()
         mock_filter = MagicMock()
         mock_filter.first = MagicMock(return_value=join_req)
@@ -783,13 +780,19 @@ class TestApproveJoinRequestEdge:
         mock_query.filter = MagicMock(return_value=mock_filter)
         db.query = MagicMock(return_value=mock_query)
 
-        team = _mock_team(max_members=100)
+        # Use max_members=None so the NULL-fallback through settings is exercised
+        team = _mock_team(max_members=None)
         with (
             patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)),
             patch.object(svc, "_log_team_member_action"),
             patch.object(svc, "invalidate_team_member_count_cache", AsyncMock()),
             patch("mcpgateway.services.team_management_service.asyncio") as mock_asyncio,
+            patch("mcpgateway.services.team_management_service.settings") as mock_settings,
         ):
+            mock_settings.max_members_per_team = 100
+            mock_settings.max_teams_per_user = 50
+            mock_settings.default_team_member_role = "developer"
+            mock_settings.default_team_owner_role = "team_admin"
             mock_asyncio.create_task = MagicMock(side_effect=RuntimeError("no loop"))
 
             result = await svc.approve_join_request("jr1", "owner@t.com")
@@ -1447,7 +1450,7 @@ class TestApproveJoinRequestMaxTeamsLimit:
         with patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)):
             with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
                 mock_settings.max_teams_per_user = 50
-                with pytest.raises(ValueError, match="maximum member limit"):
+                with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
                     await svc.approve_join_request("jr1", approved_by="owner@t.com")
 
 
@@ -1485,7 +1488,11 @@ class TestMaxMembersCapEnforcement:
         mock_query.filter = MagicMock(return_value=mock_filter)
         db.query = MagicMock(return_value=mock_query)
 
-        with patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache, patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin, patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+        with (
+            patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache,
+            patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin,
+            patch("mcpgateway.services.team_management_service.settings") as mock_settings,
+        ):
             mock_cache.invalidate_user_teams = AsyncMock()
             mock_cache.invalidate_team_membership = AsyncMock()
             mock_cache.invalidate_user_role = AsyncMock()
@@ -1506,7 +1513,11 @@ class TestMaxMembersCapEnforcement:
         mock_query.filter = MagicMock(return_value=mock_filter)
         db.query = MagicMock(return_value=mock_query)
 
-        with patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache, patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin, patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+        with (
+            patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache,
+            patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin,
+            patch("mcpgateway.services.team_management_service.settings") as mock_settings,
+        ):
             mock_cache.invalidate_user_teams = AsyncMock()
             mock_cache.invalidate_team_membership = AsyncMock()
             mock_cache.invalidate_user_role = AsyncMock()
@@ -1527,7 +1538,11 @@ class TestMaxMembersCapEnforcement:
         mock_query.filter = MagicMock(return_value=mock_filter)
         db.query = MagicMock(return_value=mock_query)
 
-        with patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache, patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin, patch("mcpgateway.services.team_management_service.settings") as mock_settings:
+        with (
+            patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache,
+            patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin,
+            patch("mcpgateway.services.team_management_service.settings") as mock_settings,
+        ):
             mock_cache.invalidate_user_teams = AsyncMock()
             mock_cache.invalidate_team_membership = AsyncMock()
             mock_cache.invalidate_user_role = AsyncMock()
@@ -1576,12 +1591,23 @@ class TestMaxMembersCapEnforcement:
         assert team.max_members == 500
 
     @pytest.mark.asyncio
-    async def test_update_with_none_max_members_preserves_existing(self, svc, db):
-        """Update with max_members=None leaves the existing value unchanged."""
+    async def test_update_with_none_max_members_clears_override(self, svc, db):
+        """Update with max_members=None clears the per-team override (reverts to global default)."""
         team = _mock_team(max_members=75)
 
         with patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)):
             result = await svc.update_team("t1", max_members=None, skip_limits=False)
+
+        assert result is True
+        assert team.max_members is None  # cleared — global default applies at check time
+
+    @pytest.mark.asyncio
+    async def test_update_omitting_max_members_preserves_existing(self, svc, db):
+        """Omitting max_members entirely leaves the existing value unchanged."""
+        team = _mock_team(max_members=75)
+
+        with patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)):
+            result = await svc.update_team("t1", name="Renamed", skip_limits=False)
 
         assert result is True
         assert team.max_members == 75  # unchanged

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -278,6 +278,7 @@ from mcpgateway.services.prompt_service import PromptNotFoundError, PromptServic
 from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService
 from mcpgateway.services.root_service import RootService, RootServiceNotFoundError
 from mcpgateway.services.server_service import ServerService
+from mcpgateway.services.team_management_service import UNSET
 from mcpgateway.services.tool_service import (
     ToolError,
     ToolNotFoundError,
@@ -7134,6 +7135,19 @@ async def test_admin_create_team_with_nonnumeric_max_members(monkeypatch, mock_d
 
 
 @pytest.mark.asyncio
+async def test_admin_create_team_with_zero_max_members(monkeypatch, mock_db, allow_permission):
+    """Zero max_members in create form returns a 400 error."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    request = MagicMock(spec=Request)
+    request.scope = {"root_path": ""}
+    request.form = AsyncMock(return_value=FakeForm({"name": "Safe Team", "visibility": "private", "max_members": "0"}))
+
+    response = await admin_create_team(request=request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    assert response.status_code == 400
+    assert "at least 1" in response.body.decode()
+
+
+@pytest.mark.asyncio
 async def test_admin_create_team_integrity_error(monkeypatch, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     request = MagicMock(spec=Request)
@@ -7426,7 +7440,7 @@ async def test_admin_update_team_with_max_members(monkeypatch, mock_db, allow_pe
 
 @pytest.mark.asyncio
 async def test_admin_update_team_with_nonnumeric_max_members(monkeypatch, mock_db, allow_permission):
-    """Non-numeric max_members in update form falls back to None (preserves existing value)."""
+    """Non-numeric max_members in update form maps to UNSET (leaves existing value unchanged)."""
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     request = MagicMock(spec=Request)
     request.scope = {"root_path": ""}
@@ -7441,7 +7455,21 @@ async def test_admin_update_team_with_nonnumeric_max_members(monkeypatch, mock_d
     assert isinstance(response, HTMLResponse)
     assert response.headers.get("HX-Trigger") is not None
     _, kwargs = team_service.update_team.call_args
-    assert kwargs.get("max_members") is None
+    assert kwargs.get("max_members") is UNSET
+
+
+@pytest.mark.asyncio
+async def test_admin_update_team_with_zero_max_members(monkeypatch, mock_db, allow_permission):
+    """Zero max_members in update form returns a 400 error."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    request = MagicMock(spec=Request)
+    request.scope = {"root_path": ""}
+    request.headers = {"HX-Request": "true"}
+    request.form = AsyncMock(return_value=FakeForm({"name": "Team One", "description": "Desc", "visibility": "private", "max_members": "0"}))
+
+    response = await admin_update_team("team-1", request=request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    assert response.status_code == 400
+    assert "at least 1" in response.body.decode()
 
 
 @pytest.mark.asyncio
@@ -7487,6 +7515,61 @@ async def test_admin_get_team_edit_over_limit_admin(monkeypatch, mock_request, m
     assert 'value="500"' in body
     assert 'max="100"' not in body
     assert "Admins can set any limit" in body
+    # Checkbox should be unchecked (explicit override present)
+    assert 'id="use-default-max-members"' in body
+
+
+@pytest.mark.asyncio
+async def test_admin_get_team_edit_null_max_members(monkeypatch, mock_request, mock_db, allow_permission):
+    """Team with max_members=None shows checkbox checked and input disabled."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    monkeypatch.setattr(settings, "max_members_per_team", 100)
+    team_service = MagicMock()
+    team_service.get_team_by_id = AsyncMock(return_value=SimpleNamespace(id="team-1", name="Team One", slug="team-one", description="Desc", visibility="private", is_personal=False, max_members=None))
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    body = response.body.decode()
+    assert "checked" in body
+    assert "disabled" in body
+    assert "Currently using global default (100)" in body
+
+
+@pytest.mark.asyncio
+async def test_admin_update_team_use_default_checkbox_clears_override(monkeypatch, mock_db, allow_permission):
+    """Checking 'Use global default' checkbox passes max_members=None to clear the per-team override."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    request = MagicMock(spec=Request)
+    request.scope = {"root_path": ""}
+    request.headers = {"HX-Request": "true"}
+    request.form = AsyncMock(return_value=FakeForm({"name": "Team One", "description": "Desc", "visibility": "private", "use_default_max_members": "on"}))
+
+    team_service = MagicMock()
+    team_service.update_team = AsyncMock(return_value=True)
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_update_team("team-1", request=request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    assert isinstance(response, HTMLResponse)
+    _, kwargs = team_service.update_team.call_args
+    assert kwargs.get("max_members") is None
+
+
+@pytest.mark.asyncio
+async def test_admin_update_team_empty_max_members_no_checkbox_sends_unset(monkeypatch, mock_db, allow_permission):
+    """Empty max_members without the checkbox sends UNSET (leave unchanged)."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    request = MagicMock(spec=Request)
+    request.scope = {"root_path": ""}
+    request.headers = {"HX-Request": "true"}
+    request.form = AsyncMock(return_value=FakeForm({"name": "Team One", "description": "Desc", "visibility": "private"}))
+
+    team_service = MagicMock()
+    team_service.update_team = AsyncMock(return_value=True)
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_update_team("team-1", request=request, db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    assert isinstance(response, HTMLResponse)
+    _, kwargs = team_service.update_team.call_args
+    assert kwargs.get("max_members") is UNSET
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Stop baking `MAX_MEMBERS_PER_TEAM` config default into team DB rows at creation time; store `NULL` instead so changing the env var takes effect for all teams without explicit per-team overrides
- Add `get_effective_max_members()` helper that resolves `NULL` → current `settings.max_members_per_team` at check time
- Add missing member limit check in `approve_join_request()` (was not checked at all)
- Update all 4 member-limit check sites (add_member, create_invitation, accept_invitation, approve_join_request) to use the new helper

Closes #3588