### PR TITLE
fix(rbac): use check_any_team for API tokens in MCP transports

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1013,10 +1013,11 @@ async def _ensure_rpc_permission(user, db: Session, permission: str, method: str
         return
 
     # Layer 2: RBAC check
-    # The /rpc endpoint has no route-level team_id.  For single-team API tokens
-    # we can derive team_id from the token; otherwise fall back to check_any_team
-    # so that team-scoped roles (developer, team_admin) are found.
-    # Layer 1 (token scope cap above) already restricts what the token can do.
+    # /rpc payloads never carry a resource with an owning team, so we skip
+    # resource/payload derivation (unlike @require_permission).  For single-
+    # team API tokens we extract team_id from the token itself; otherwise
+    # fall back to check_any_team so team-scoped roles are found.
+    # Layer 1 (token scope cap above) already restricts visibility.
     team_id: str | None = None
     check_any_team = False
     if isinstance(user, dict):

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1013,11 +1013,18 @@ async def _ensure_rpc_permission(user, db: Session, permission: str, method: str
         return
 
     # Layer 2: RBAC check
-    # Session tokens have no explicit team_id, so check across all team-scoped roles.
-    # Mirrors the @require_permission decorator's check_any_team fallback (rbac.py:562-576).
-    check_any_team = isinstance(user, dict) and user.get("token_use") == "session"
+    # The /rpc endpoint has no route-level team_id.  For single-team API tokens
+    # we can derive team_id from the token; otherwise fall back to check_any_team
+    # so that team-scoped roles (developer, team_admin) are found.
+    # Layer 1 (token scope cap above) already restricts what the token can do.
+    team_id: str | None = None
+    check_any_team = False
+    if isinstance(user, dict):
+        team_id = user.get("team_id")
+        if not team_id:
+            check_any_team = True
     checker = PermissionChecker(_build_rpc_permission_user(user, db))
-    if not await checker.has_permission(permission, check_any_team=check_any_team):
+    if not await checker.has_permission(permission, check_any_team=check_any_team, team_id=team_id):
         logger.warning("RPC permission denied (RBAC): method=%s, required=%s", method, permission)
         raise JSONRPCError(-32003, _ACCESS_DENIED_MSG, {"method": method})
 

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -624,16 +624,19 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
                 # check if user_context has team_id
                 team_id = user_context.get("team_id", None)
 
-            # For multi-team session tokens (team_id is None), derive team from context
+            # When team_id is still unknown, try to derive it from the resource
+            # or request payload.  This applies to both session and API tokens.
             check_any_team = False
-            if not team_id and user_context.get("token_use") == "session":
-                db_session = kwargs.get("db") or user_context.get("db")
-                if db_session:
-                    # Tier 1: Try to derive team from existing resource
-                    team_id = _derive_team_from_resource(kwargs, db_session)
-                    # Tier 3: Try to derive team from create payload / form
-                    if team_id is None:
-                        team_id = await _derive_team_from_payload(kwargs)
+            if not team_id:
+                _token_use = user_context.get("token_use")
+                if _token_use in ("session", "api"):
+                    db_session = kwargs.get("db") or user_context.get("db")
+                    if db_session:
+                        # Tier 1: Try to derive team from existing resource
+                        team_id = _derive_team_from_resource(kwargs, db_session)
+                        # Tier 3: Try to derive team from create payload / form
+                        if team_id is None:
+                            team_id = await _derive_team_from_payload(kwargs)
                 # If still no team_id, check permission across all of the user's teams.
                 # This separates authorization ("does this user have the permission?")
                 # from resource scoping ("which team owns this resource?"). Team
@@ -941,16 +944,19 @@ def require_any_permission(permissions: List[str], resource_type: Optional[str] 
                 # check if user_context has team_id
                 team_id = user_context.get("team_id", None)
 
-            # For multi-team session tokens (team_id is None), derive team from context
+            # When team_id is still unknown, try to derive it from the resource
+            # or request payload.  This applies to both session and API tokens.
             check_any_team = False
-            if not team_id and user_context.get("token_use") == "session":
-                db_session = kwargs.get("db") or user_context.get("db")
-                if db_session:
-                    # Tier 1: Try to derive team from existing resource
-                    team_id = _derive_team_from_resource(kwargs, db_session)
-                    # Tier 3: Try to derive team from create payload / form
-                    if team_id is None:
-                        team_id = await _derive_team_from_payload(kwargs)
+            if not team_id:
+                _token_use = user_context.get("token_use")
+                if _token_use in ("session", "api"):
+                    db_session = kwargs.get("db") or user_context.get("db")
+                    if db_session:
+                        # Tier 1: Try to derive team from existing resource
+                        team_id = _derive_team_from_resource(kwargs, db_session)
+                        # Tier 3: Try to derive team from create payload / form
+                        if team_id is None:
+                            team_id = await _derive_team_from_payload(kwargs)
                 # If still no team_id, check permission across all of the user's teams.
                 # Authorization ("does this user have the permission?") is separate
                 # from resource scoping ("which team owns this resource?").

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -512,6 +512,40 @@ async def _derive_team_from_payload(kwargs) -> Optional[str]:
     return None
 
 
+async def _resolve_team_and_check_mode(user_context: dict, kwargs: dict) -> tuple[Optional[str], bool]:
+    """Resolve team_id and determine whether to check any team for RBAC.
+
+    Shared by ``require_permission`` and ``require_any_permission`` to avoid
+    duplicating the team derivation decision tree.
+
+    Returns:
+        (team_id, check_any_team) — the resolved team scope and whether the
+        permission service should aggregate across all of the user's teams.
+    """
+    team_id = kwargs.get("team_id")
+    if not team_id:
+        team_id = user_context.get("team_id", None)
+
+    check_any_team = False
+    if not team_id:
+        token_use = user_context.get("token_use")
+        if token_use in ("session", "api"):
+            db_session = kwargs.get("db") or user_context.get("db")
+            if db_session:
+                team_id = _derive_team_from_resource(kwargs, db_session)
+                if team_id is None:
+                    team_id = await _derive_team_from_payload(kwargs)
+        # Tokens without team_id (including legacy tokens with no token_use)
+        # fall through here.  Authorization ("does this user have the
+        # permission?") is separate from resource scoping ("which team owns
+        # this resource?").  Layer 1 token_teams filtering still constrains
+        # which team roles are visible.
+        if not team_id:
+            check_any_team = True
+
+    return team_id, check_any_team
+
+
 # Permissions that indicate create/mutate operations (not safe for "any-team" aggregation)
 _MUTATE_PERMISSION_ACTIONS = frozenset(
     {
@@ -616,34 +650,7 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
 
-            # Extract team_id from path parameters if available
-            team_id = kwargs.get("team_id")
-
-            # If team_id is None or blank in kwargs then check
-            if not team_id:
-                # check if user_context has team_id
-                team_id = user_context.get("team_id", None)
-
-            # When team_id is still unknown, try to derive it from the resource
-            # or request payload.  This applies to both session and API tokens.
-            check_any_team = False
-            if not team_id:
-                _token_use = user_context.get("token_use")
-                if _token_use in ("session", "api"):
-                    db_session = kwargs.get("db") or user_context.get("db")
-                    if db_session:
-                        # Tier 1: Try to derive team from existing resource
-                        team_id = _derive_team_from_resource(kwargs, db_session)
-                        # Tier 3: Try to derive team from create payload / form
-                        if team_id is None:
-                            team_id = await _derive_team_from_payload(kwargs)
-                # If still no team_id, check permission across all of the user's teams.
-                # This separates authorization ("does this user have the permission?")
-                # from resource scoping ("which team owns this resource?"). Team
-                # assignment is enforced downstream by endpoint logic (e.g.
-                # verify_team_for_user, token team membership checks).
-                if not team_id:
-                    check_any_team = True
+            team_id, check_any_team = await _resolve_team_and_check_mode(user_context, kwargs)
 
             # First, check if any plugins want to handle permission checking
             # First-Party
@@ -936,32 +943,7 @@ def require_any_permission(permissions: List[str], resource_type: Optional[str] 
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
 
-            # Extract team_id from path parameters if available
-            team_id = kwargs.get("team_id")
-
-            # If team_id is None or blank in kwargs then check
-            if not team_id:
-                # check if user_context has team_id
-                team_id = user_context.get("team_id", None)
-
-            # When team_id is still unknown, try to derive it from the resource
-            # or request payload.  This applies to both session and API tokens.
-            check_any_team = False
-            if not team_id:
-                _token_use = user_context.get("token_use")
-                if _token_use in ("session", "api"):
-                    db_session = kwargs.get("db") or user_context.get("db")
-                    if db_session:
-                        # Tier 1: Try to derive team from existing resource
-                        team_id = _derive_team_from_resource(kwargs, db_session)
-                        # Tier 3: Try to derive team from create payload / form
-                        if team_id is None:
-                            team_id = await _derive_team_from_payload(kwargs)
-                # If still no team_id, check permission across all of the user's teams.
-                # Authorization ("does this user have the permission?") is separate
-                # from resource scoping ("which team owns this resource?").
-                if not team_id:
-                    check_any_team = True
+            team_id, check_any_team = await _resolve_team_and_check_mode(user_context, kwargs)
 
             # Get db session: prefer endpoint's db param, then user_context["db"], then create fresh
             db_session = kwargs.get("db") or user_context.get("db")

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2667,9 +2667,10 @@ async def set_logging_level(level: types.LoggingLevel) -> types.EmptyResult:
         if not _check_scoped_permission(user_context, "admin.system_config"):
             raise PermissionError(_ACCESS_DENIED_MSG)
         # Layer 2: RBAC check
+        # No route-level team_id in MCP transport; check all team-scoped roles.
         has_permission = await _check_streamable_permission(
             user_context=user_context,
-            permission="admin.system_config",
+            permission="servers.use",
             check_any_team=_check_any_team_for_server_scoped_rbac(user_context, server_id),
         )
         if not has_permission:

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2667,10 +2667,9 @@ async def set_logging_level(level: types.LoggingLevel) -> types.EmptyResult:
         if not _check_scoped_permission(user_context, "admin.system_config"):
             raise PermissionError(_ACCESS_DENIED_MSG)
         # Layer 2: RBAC check
-        # No route-level team_id in MCP transport; check all team-scoped roles.
         has_permission = await _check_streamable_permission(
             user_context=user_context,
-            permission="servers.use",
+            permission="admin.system_config",
             check_any_team=_check_any_team_for_server_scoped_rbac(user_context, server_id),
         )
         if not has_permission:

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -2218,11 +2218,13 @@ class TestNonSessionTokenTeamDerivation:
         assert mock_perm_service.check_permission.call_args.kwargs["check_any_team"] is False
 
     @pytest.mark.asyncio
-    async def test_api_token_no_team_id_skips_derivation(self, monkeypatch):
-        """API token with no team_id skips derivation block (check_any_team stays False).
+    async def test_api_token_no_team_id_uses_check_any_team(self, monkeypatch):
+        """API token with no team_id must use check_any_team=True.
 
-        This documents existing behavior: non-session tokens rely on auth.py to set
-        team_id. Multi-team non-session tokens don't exist in practice.
+        When team_id cannot be derived from route params, user context, or
+        resource/payload, API tokens fall back to check_any_team=True so
+        that team-scoped roles (developer, team_admin) are found.
+        Layer 1 (token scope cap) already restricts what the token can do.
         """
 
         async def dummy_func(user=None, db=None):
@@ -2240,11 +2242,16 @@ class TestNonSessionTokenTeamDerivation:
 
         assert result == "ok"
         assert mock_perm_service.check_permission.call_args.kwargs["team_id"] is None
-        assert mock_perm_service.check_permission.call_args.kwargs["check_any_team"] is False
+        assert mock_perm_service.check_permission.call_args.kwargs["check_any_team"] is True
 
     @pytest.mark.asyncio
-    async def test_cli_token_no_token_use_skips_derivation(self, monkeypatch):
-        """CLI-generated token (no token_use claim) skips derivation block."""
+    async def test_cli_token_no_token_use_uses_check_any_team(self, monkeypatch):
+        """CLI-generated token (no token_use claim) without team_id uses check_any_team=True.
+
+        When team_id cannot be derived and token_use is absent, we still need
+        to find team-scoped roles.  The token_use-based derivation path is
+        skipped, but check_any_team is True because team_id is still None.
+        """
 
         async def dummy_func(user=None, db=None):
             return "ok"
@@ -2261,7 +2268,7 @@ class TestNonSessionTokenTeamDerivation:
 
         assert result == "ok"
         assert mock_perm_service.check_permission.call_args.kwargs["team_id"] is None
-        assert mock_perm_service.check_permission.call_args.kwargs["check_any_team"] is False
+        assert mock_perm_service.check_permission.call_args.kwargs["check_any_team"] is True
 
     @pytest.mark.asyncio
     async def test_api_token_with_team_id_for_any_permission(self, monkeypatch):

--- a/tests/unit/mcpgateway/plugins/framework/external/unix/test_client_integration.py
+++ b/tests/unit/mcpgateway/plugins/framework/external/unix/test_client_integration.py
@@ -249,22 +249,22 @@ async def test_unix_client_high_throughput(unix_server_proc):
 # PluginManager Integration Tests
 # =============================================================================
 
-# Fixed socket path for PluginManager tests (matches valid_unix_external_plugin_manager.yaml)
-PLUGIN_MANAGER_SOCKET_PATH = "/tmp/mcpgateway-pm-test.sock"
-
 
 @pytest.fixture
 def unix_server_proc_for_manager():
-    """Start a Unix socket plugin server on the fixed path for PluginManager tests."""
+    """Start a Unix socket plugin server with a unique path for PluginManager tests.
+
+    Uses a UUID-based socket path to avoid conflicts when tests run in
+    parallel under pytest-xdist (-n auto).
+    """
+    short_id = uuid.uuid4().hex[:8]
+    socket_path = f"/tmp/unix-pm-test-{short_id}.sock"
+
     current_env = os.environ.copy()
     current_env["PLUGINS_CONFIG_PATH"] = "tests/unit/mcpgateway/plugins/fixtures/configs/valid_single_plugin.yaml"
     current_env["PYTHONPATH"] = "."
     current_env["PLUGINS_TRANSPORT"] = "unix"
-    current_env["PLUGINS_UNIX_SOCKET_PATH"] = PLUGIN_MANAGER_SOCKET_PATH
-
-    # Clean up any existing socket
-    if os.path.exists(PLUGIN_MANAGER_SOCKET_PATH):
-        os.unlink(PLUGIN_MANAGER_SOCKET_PATH)
+    current_env["PLUGINS_UNIX_SOCKET_PATH"] = socket_path
 
     try:
         with subprocess.Popen(
@@ -273,23 +273,23 @@ def unix_server_proc_for_manager():
             stderr=subprocess.STDOUT,
             env=current_env,
         ) as server_proc:
-            _wait_for_socket(PLUGIN_MANAGER_SOCKET_PATH, proc=server_proc)
-            yield server_proc
+            _wait_for_socket(socket_path, proc=server_proc)
+            yield server_proc, socket_path
             server_proc.terminate()
             server_proc.wait(timeout=3)
     except subprocess.TimeoutExpired:
         server_proc.kill()
         server_proc.wait(timeout=3)
     finally:
-        if os.path.exists(PLUGIN_MANAGER_SOCKET_PATH):
-            os.unlink(PLUGIN_MANAGER_SOCKET_PATH)
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Unix domain sockets are not supported on Windows.")
 @pytest.mark.asyncio
 async def test_unix_plugin_manager_invoke_hook(unix_server_proc_for_manager):
     """Test PluginManager can invoke hooks through Unix socket external plugin."""
-    server_proc = unix_server_proc_for_manager
+    server_proc, socket_path = unix_server_proc_for_manager
     assert not server_proc.poll(), "Server failed to start"
 
     # Reset PluginManager singleton state
@@ -298,6 +298,7 @@ async def test_unix_plugin_manager_invoke_hook(unix_server_proc_for_manager):
     plugin_manager = PluginManager(
         config="tests/unit/mcpgateway/plugins/fixtures/configs/valid_unix_external_plugin_manager.yaml"
     )
+    plugin_manager.config.plugins[0].unix_socket.path = socket_path
 
     try:
         await plugin_manager.initialize()
@@ -327,13 +328,14 @@ async def test_unix_plugin_manager_invoke_hook(unix_server_proc_for_manager):
 @pytest.mark.asyncio
 async def test_unix_plugin_manager_multiple_hooks(unix_server_proc_for_manager):
     """Test PluginManager can invoke multiple hook types through Unix socket."""
-    server_proc = unix_server_proc_for_manager
+    server_proc, socket_path = unix_server_proc_for_manager
     assert not server_proc.poll(), "Server failed to start"
 
     PluginManager.reset()
     plugin_manager = PluginManager(
         config="tests/unit/mcpgateway/plugins/fixtures/configs/valid_unix_external_plugin_manager.yaml"
     )
+    plugin_manager.config.plugins[0].unix_socket.path = socket_path
 
     try:
         await plugin_manager.initialize()
@@ -369,13 +371,14 @@ async def test_unix_plugin_manager_multiple_hooks(unix_server_proc_for_manager):
 @pytest.mark.asyncio
 async def test_unix_plugin_manager_context_persistence(unix_server_proc_for_manager):
     """Test that context is maintained across multiple PluginManager calls."""
-    server_proc = unix_server_proc_for_manager
+    server_proc, socket_path = unix_server_proc_for_manager
     assert not server_proc.poll(), "Server failed to start"
 
     PluginManager.reset()
     plugin_manager = PluginManager(
         config="tests/unit/mcpgateway/plugins/fixtures/configs/valid_unix_external_plugin_manager.yaml"
     )
+    plugin_manager.config.plugins[0].unix_socket.path = socket_path
 
     try:
         await plugin_manager.initialize()

--- a/tests/unit/mcpgateway/test_rpc_permission_team_fallback.py
+++ b/tests/unit/mcpgateway/test_rpc_permission_team_fallback.py
@@ -91,21 +91,20 @@ async def test_ensure_rpc_permission_denies_when_rbac_denies():
 
 
 @pytest.mark.asyncio
-async def test_ensure_rpc_permission_non_session_token_uses_check_any_team_false():
-    """Non-session (API) tokens must NOT use check_any_team — preserves existing behaviour.
+async def test_ensure_rpc_permission_api_token_without_team_id_uses_check_any_team():
+    """API tokens without team_id must use check_any_team=True.
 
-    This test verifies that the fix is scoped only to session tokens and does not
-    change the behaviour for API tokens that carry explicit team scoping via
-    token_teams.
-
-    This test may PASS before the fix if the current code happens to omit the kwarg
-    (defaulting to False) or FAIL if check_any_team is added unconditionally.
+    The /rpc endpoint has no route-level team_id.  When the user dict does not
+    carry a team_id (multi-team or team-less API tokens), check_any_team must be
+    True so that team-scoped roles (developer, team_admin) are found.
+    Layer 1 (token scope cap) already restricts what the token can do.
     """
     user = {
         "email": "user@example.com",
         "is_admin": False,
-        "token_use": "access",  # API token, not session
+        "token_use": "api",
         "token_teams": ["team-abc"],
+        # No team_id — multi-team or general API token
     }
     db = MagicMock(spec=Session)
     mock_checker = _make_mock_checker(grants=True)
@@ -114,8 +113,39 @@ async def test_ensure_rpc_permission_non_session_token_uses_check_any_team_false
         await _ensure_rpc_permission(user, db, "tools.execute", "tools/call")
 
     call_kwargs = mock_checker.has_permission.call_args.kwargs
-    assert call_kwargs.get("check_any_team", False) is False, (
-        "Non-session tokens must not use check_any_team=True; "
+    assert call_kwargs.get("check_any_team") is True, (
+        "API tokens without team_id must use check_any_team=True; "
+        "got call_kwargs=%r" % call_kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_rpc_permission_api_token_with_team_id_passes_team_id():
+    """Single-team API tokens with team_id must pass it to has_permission.
+
+    When the user dict carries a team_id (set by auth for single-team API tokens),
+    it must be forwarded so that the permission check uses the specific team's roles.
+    """
+    user = {
+        "email": "user@example.com",
+        "is_admin": False,
+        "token_use": "api",
+        "token_teams": ["team-abc"],
+        "team_id": "team-abc",
+    }
+    db = MagicMock(spec=Session)
+    mock_checker = _make_mock_checker(grants=True)
+
+    with patch("mcpgateway.main.PermissionChecker", return_value=mock_checker):
+        await _ensure_rpc_permission(user, db, "tools.execute", "tools/call")
+
+    call_kwargs = mock_checker.has_permission.call_args.kwargs
+    assert call_kwargs.get("team_id") == "team-abc", (
+        "Single-team API tokens must pass team_id to has_permission; "
+        "got call_kwargs=%r" % call_kwargs
+    )
+    assert call_kwargs.get("check_any_team") is False, (
+        "When team_id is available, check_any_team should be False; "
         "got call_kwargs=%r" % call_kwargs
     )
 

--- a/tests/unit/mcpgateway/test_rpc_permission_team_fallback.py
+++ b/tests/unit/mcpgateway/test_rpc_permission_team_fallback.py
@@ -69,10 +69,7 @@ async def test_ensure_rpc_permission_grants_session_token_with_team_role():
     # Verify has_permission was called with check_any_team=True
     mock_checker.has_permission.assert_called_once()
     call_kwargs = mock_checker.has_permission.call_args.kwargs
-    assert call_kwargs.get("check_any_team") is True, (
-        "Expected check_any_team=True for session token without explicit team_id; "
-        "got call_kwargs=%r" % call_kwargs
-    )
+    assert call_kwargs.get("check_any_team") is True, "Expected check_any_team=True for session token without explicit team_id; " "got call_kwargs=%r" % call_kwargs
 
 
 @pytest.mark.asyncio
@@ -113,10 +110,7 @@ async def test_ensure_rpc_permission_api_token_without_team_id_uses_check_any_te
         await _ensure_rpc_permission(user, db, "tools.execute", "tools/call")
 
     call_kwargs = mock_checker.has_permission.call_args.kwargs
-    assert call_kwargs.get("check_any_team") is True, (
-        "API tokens without team_id must use check_any_team=True; "
-        "got call_kwargs=%r" % call_kwargs
-    )
+    assert call_kwargs.get("check_any_team") is True, "API tokens without team_id must use check_any_team=True; " "got call_kwargs=%r" % call_kwargs
 
 
 @pytest.mark.asyncio
@@ -140,14 +134,31 @@ async def test_ensure_rpc_permission_api_token_with_team_id_passes_team_id():
         await _ensure_rpc_permission(user, db, "tools.execute", "tools/call")
 
     call_kwargs = mock_checker.has_permission.call_args.kwargs
-    assert call_kwargs.get("team_id") == "team-abc", (
-        "Single-team API tokens must pass team_id to has_permission; "
-        "got call_kwargs=%r" % call_kwargs
-    )
-    assert call_kwargs.get("check_any_team") is False, (
-        "When team_id is available, check_any_team should be False; "
-        "got call_kwargs=%r" % call_kwargs
-    )
+    assert call_kwargs.get("team_id") == "team-abc", "Single-team API tokens must pass team_id to has_permission; " "got call_kwargs=%r" % call_kwargs
+    assert call_kwargs.get("check_any_team") is False, "When team_id is available, check_any_team should be False; " "got call_kwargs=%r" % call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_ensure_rpc_permission_api_token_with_team_id_denied():
+    """API token with team_id where RBAC denies must raise JSONRPCError."""
+    user = {
+        "email": "user@example.com",
+        "is_admin": False,
+        "token_use": "api",
+        "token_teams": ["team-abc"],
+        "team_id": "team-abc",
+    }
+    db = MagicMock(spec=Session)
+    mock_checker = _make_mock_checker(grants=False)
+
+    with patch("mcpgateway.main.PermissionChecker", return_value=mock_checker):
+        with pytest.raises(JSONRPCError) as exc_info:
+            await _ensure_rpc_permission(user, db, "tools.execute", "tools/call")
+
+    assert exc_info.value.code == -32003
+    call_kwargs = mock_checker.has_permission.call_args.kwargs
+    assert call_kwargs.get("team_id") == "team-abc"
+    assert call_kwargs.get("check_any_team") is False
 
 
 @pytest.mark.asyncio
@@ -202,10 +213,7 @@ async def test_ensure_rpc_permission_admin_session_token_calls_has_permission():
 
     mock_checker.has_permission.assert_called_once()
     call_kwargs = mock_checker.has_permission.call_args.kwargs
-    assert call_kwargs.get("check_any_team") is True, (
-        "Admin session tokens are still session tokens — expected check_any_team=True; "
-        "got call_kwargs=%r" % call_kwargs
-    )
+    assert call_kwargs.get("check_any_team") is True, "Admin session tokens are still session tokens — expected check_any_team=True; " "got call_kwargs=%r" % call_kwargs
 
 
 @pytest.mark.asyncio
@@ -223,9 +231,7 @@ async def test_ensure_rpc_permission_token_scope_cap_blocks_at_layer1():
 
     with patch("mcpgateway.main.PermissionChecker", return_value=mock_checker):
         with pytest.raises(JSONRPCError) as exc_info:
-            await _ensure_rpc_permission(
-                user, db, "tools.execute", "tools/call", request=mock_request
-            )
+            await _ensure_rpc_permission(user, db, "tools.execute", "tools/call", request=mock_request)
 
     assert exc_info.value.code == -32003
     assert "Access denied" in exc_info.value.message

--- a/tests/unit/mcpgateway/transports/test_streamable_rpc_permission_fallback.py
+++ b/tests/unit/mcpgateway/transports/test_streamable_rpc_permission_fallback.py
@@ -71,9 +71,14 @@ async def test_check_streamable_permission_session_token_passes_check_any_team_t
 
 
 @pytest.mark.asyncio
-async def test_check_streamable_permission_api_token_check_any_team_false():
-    """API tokens (not session) must use check_any_team=False."""
-    user_ctx = _make_user_ctx(token_use="access")
+async def test_check_streamable_permission_api_token_check_any_team_true():
+    """API tokens in MCP transport must use check_any_team=True (no team_id available).
+
+    The MCP transport has no route-level team_id, so callers must pass
+    check_any_team=True for all token types (both session and API).
+    Layer 1 (token scope cap) already restricts what the token can do.
+    """
+    user_ctx = _make_user_ctx(token_use="api")
     mock_ps = MagicMock()
     mock_ps.check_permission = AsyncMock(return_value=True)
 
@@ -87,11 +92,11 @@ async def test_check_streamable_permission_api_token_check_any_team_false():
             await _check_streamable_permission(
                 user_context=user_ctx,
                 permission="tools.execute",
-                check_any_team=False,  # non-session: False
+                check_any_team=True,  # MCP transport: always True (no team_id)
             )
 
     call_kwargs = mock_ps.check_permission.call_args.kwargs
-    assert call_kwargs.get("check_any_team", False) is False
+    assert call_kwargs.get("check_any_team") is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamable_rpc_permission_fallback.py
+++ b/tests/unit/mcpgateway/transports/test_streamable_rpc_permission_fallback.py
@@ -65,9 +65,7 @@ async def test_check_streamable_permission_session_token_passes_check_any_team_t
     assert result is True
     mock_ps.check_permission.assert_called_once()
     call_kwargs = mock_ps.check_permission.call_args.kwargs
-    assert call_kwargs.get("check_any_team") is True, (
-        "Expected check_any_team=True to be threaded through to PermissionService"
-    )
+    assert call_kwargs.get("check_any_team") is True, "Expected check_any_team=True to be threaded through to PermissionService"
 
 
 @pytest.mark.asyncio
@@ -195,9 +193,7 @@ async def test_servers_use_check_passes_check_any_team_for_session_token():
                     # Verify _check_streamable_permission was called with check_any_team=True
                     mock_perm.assert_called_once()
                     call_kwargs = mock_perm.call_args.kwargs
-                    assert call_kwargs.get("check_any_team") is True, (
-                        f"servers.use check must pass check_any_team=True for session tokens; got {call_kwargs}"
-                    )
+                    assert call_kwargs.get("check_any_team") is True, f"servers.use check must pass check_any_team=True for session tokens; got {call_kwargs}"
                     assert call_kwargs.get("permission") == "servers.use"
             finally:
                 user_context_var.reset(token)
@@ -212,7 +208,7 @@ async def test_call_tool_raises_permission_error_when_session_token_denied():
     if PermissionService denies the request, call_tool must raise PermissionError
     and not proceed to tool execution.
     """
-    # Standard
+    # First-Party
     from mcpgateway.transports.streamablehttp_transport import call_tool
 
     session_user_ctx = {


### PR DESCRIPTION
## Summary

- Non-admin users with team-scoped roles (`developer`, `team_admin`) were denied MCP tool access because the RBAC check only set `check_any_team=True` for session tokens, leaving API tokens with `check_any_team=False`
- Since MCP transports have no route-level `team_id`, the permission service only found null-scoped team roles, missing team-specific role assignments that grant `tools.execute` and `servers.use`
- Additionally, the `logging/setLevel` handler was missing `check_any_team` entirely — even session tokens could fail there

### Changes

| File | Fix |
|------|-----|
| `streamablehttp_transport.py` | Always use `check_any_team=True` in `call_tool`, `logging/setLevel`, and `handle_streamable_http` RBAC checks (MCP transport never has a team_id) |
| `main.py` | `/rpc` endpoint: extract `team_id` from user dict; fall back to `check_any_team=True` when absent |
| `rbac.py` | `@require_permission` decorator: extend team derivation to API tokens, not just session tokens |
| Tests (3 files) | Updated existing assertions and added new test for API token with `team_id` |

Layer 1 (token scope cap) already restricts what a token can access by team. Layer 2 (RBAC) just needs to verify the user has the capability — so `check_any_team=True` is safe when no route-level `team_id` is available.

Closes #3660

## Test plan

- [x] All 1252 transport and middleware unit tests pass
- [x] All 13 RBAC permission fallback regression tests pass
- [x] All 15 permission service fallback tests pass