### PR TITLE
chore(api): standardize user context parameter naming from _user to current_user_ctx (#2505)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1791,13 +1791,13 @@ async def get_overview_partial(
 @rate_limit(requests_per_minute=30)  # Lower limit for config endpoints
 async def get_global_passthrough_headers(
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> GlobalConfigRead:
     """Get the global passthrough headers configuration.
 
     Args:
         db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         GlobalConfigRead: The current global passthrough headers configuration
@@ -1825,7 +1825,7 @@ async def update_global_passthrough_headers(
     request: Request,  # pylint: disable=unused-argument
     config_update: GlobalConfigUpdate,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> GlobalConfigRead:
     """Update the global passthrough headers configuration.
 
@@ -1833,7 +1833,7 @@ async def update_global_passthrough_headers(
         request: HTTP request object
         config_update: The new configuration
         db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Raises:
         HTTPException: If there is a conflict or validation error
@@ -1877,7 +1877,7 @@ async def update_global_passthrough_headers(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 @rate_limit(requests_per_minute=10)  # Strict limit for cache operations
 async def invalidate_passthrough_headers_cache(
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Invalidate the GlobalConfig cache.
@@ -1887,7 +1887,7 @@ async def invalidate_passthrough_headers_cache(
     changes to propagate immediately across all workers.
 
     Args:
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
         _db: Database session for permission checks.
 
     Returns:
@@ -1916,7 +1916,7 @@ async def invalidate_passthrough_headers_cache(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 @rate_limit(requests_per_minute=30)
 async def get_passthrough_headers_cache_stats(
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Get GlobalConfig cache statistics.
@@ -1925,7 +1925,7 @@ async def get_passthrough_headers_cache_stats(
     Useful for monitoring cache effectiveness and debugging.
 
     Args:
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
         _db: Database session for permission checks.
 
     Returns:
@@ -1953,7 +1953,7 @@ async def get_passthrough_headers_cache_stats(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 @rate_limit(requests_per_minute=10)
 async def invalidate_a2a_stats_cache(
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Invalidate the A2A stats cache.
@@ -1963,7 +1963,7 @@ async def invalidate_a2a_stats_cache(
     changes to propagate immediately.
 
     Args:
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
         _db: Database session for permission checks.
 
     Returns:
@@ -1990,7 +1990,7 @@ async def invalidate_a2a_stats_cache(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 @rate_limit(requests_per_minute=30)
 async def get_a2a_stats_cache_stats(
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Get A2A stats cache statistics.
@@ -1999,7 +1999,7 @@ async def get_a2a_stats_cache_stats(
     Useful for monitoring cache effectiveness and debugging.
 
     Args:
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
         _db: Database session for permission checks.
 
     Returns:
@@ -2021,7 +2021,7 @@ async def get_a2a_stats_cache_stats(
 @rate_limit(requests_per_minute=60)
 async def get_mcp_session_pool_metrics(
     request: Request,  # pylint: disable=unused-argument
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Get MCP session pool metrics.
@@ -2032,7 +2032,7 @@ async def get_mcp_session_pool_metrics(
 
     Args:
         request: HTTP request object (required by rate_limit decorator)
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
         _db: Database session for permission checks.
 
     Returns:
@@ -2075,7 +2075,7 @@ async def get_mcp_session_pool_metrics(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_configuration_settings(
     _db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> Dict[str, Any]:
     """Get application configuration settings grouped by category.
 
@@ -2083,7 +2083,7 @@ async def get_configuration_settings(
 
     Args:
         _db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         Dict with configuration groups and their settings
@@ -5599,13 +5599,14 @@ async def admin_get_team_edit(
     team_id: str,
     _request: Request,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> HTMLResponse:
     """Get team edit form via admin UI.
 
     Args:
         team_id: ID of the team to edit
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         HTMLResponse: Rendered team edit form
@@ -7292,13 +7293,14 @@ async def admin_get_user_edit(
     user_email: str,
     _request: Request,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Get user edit form via admin UI.
 
     Args:
         user_email: Email of user to edit
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         HTMLResponse: User edit form HTML
@@ -7323,7 +7325,7 @@ async def admin_get_user_edit(
             return HTMLResponse(content='<div class="text-red-500">User not found</div>', status_code=404)
 
         # Get current user's email to check if editing self
-        current_user_email = get_user_email(_user)
+        current_user_email = get_user_email(current_user_ctx)
         is_editing_self = current_user_email.lower() == decoded_email.lower()
 
         # Build Password Requirements HTML separately to avoid backslash issues inside f-strings
@@ -7460,7 +7462,7 @@ async def admin_update_user(
     user_email: str,
     request: Request,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ) -> HTMLResponse:
     """Update user via admin UI.
 
@@ -7468,6 +7470,7 @@ async def admin_update_user(
         user_email: Email of user to update
         request: FastAPI request object
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         HTMLResponse: Success message or error response
@@ -7496,7 +7499,7 @@ async def admin_update_user(
             return HTMLResponse(content='<div class="text-red-500">Passwords do not match</div>', status_code=400, headers={"HX-Retarget": "#edit-user-error"})
 
         # Get current user's email to prevent self-demotion
-        current_user_email = get_user_email(_user)
+        current_user_email = get_user_email(current_user_ctx)
 
         # Check if trying to remove admin privileges from last admin
         user_obj = await auth_service.get_user_by_email(decoded_email)
@@ -12851,7 +12854,7 @@ MetricsDict = Dict[str, Union[ToolMetrics, ResourceMetrics, ServerMetrics, Promp
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_aggregated_metrics(
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> Dict[str, Any]:
     """Retrieve aggregated metrics and top performers for all entity types.
 
@@ -12861,6 +12864,7 @@ async def get_aggregated_metrics(
 
     Args:
         db (Session): Database session dependency for querying metrics.
+        current_user_ctx: The current authenticated user
 
     Returns:
         Dict[str, Any]: A dictionary containing aggregated metrics and top performers
@@ -13171,7 +13175,7 @@ async def admin_test_gateway(
 # Event Streaming via SSE to the Admin UI
 @admin_router.get("/events")
 @require_permission("admin.events", allow_admin_bypass=False)
-async def admin_events(request: Request, _user=Depends(get_current_user_with_permissions), _db: Session = Depends(get_db)):
+async def admin_events(request: Request, current_user_ctx=Depends(get_current_user_with_permissions), _db: Session = Depends(get_db)):  # pylint: disable=unused-argument
     """
     Stream admin events from all services via SSE (Server-Sent Events).
 
@@ -13181,7 +13185,7 @@ async def admin_events(request: Request, _user=Depends(get_current_user_with_per
 
     Args:
         request (Request): The FastAPI request object, used to detect client disconnection.
-        _user (Any): Authenticated user dependency (ensures admin permissions).
+        current_user_ctx (Any): Authenticated user dependency (ensures admin permissions).
         _db: Database session for permission checks.
 
     Returns:
@@ -16011,7 +16015,7 @@ async def list_catalog_servers(
     limit: int = 100,
     offset: int = 0,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> CatalogListResponse:
     """Get list of catalog servers with filtering.
 
@@ -16027,7 +16031,7 @@ async def list_catalog_servers(
         limit: Maximum results
         offset: Pagination offset
         db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         List of catalog servers matching filters
@@ -16060,7 +16064,7 @@ async def register_catalog_server(
     http_request: Request,
     request: Optional[CatalogServerRegisterRequest] = None,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> Union[CatalogServerRegisterResponse, HTMLResponse]:
     """Register a catalog server.
 
@@ -16069,7 +16073,7 @@ async def register_catalog_server(
         http_request: FastAPI request object (for HTMX detection)
         request: Optional registration parameters
         db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         Registration response with success status (JSON or HTML)
@@ -16159,14 +16163,14 @@ async def register_catalog_server(
 async def check_catalog_server_status(
     server_id: str,
     _db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> CatalogServerStatusResponse:
     """Check catalog server availability.
 
     Args:
         server_id: Catalog server ID to check
         _db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         Server status including availability and response time
@@ -16185,14 +16189,14 @@ async def check_catalog_server_status(
 async def bulk_register_catalog_servers(
     request: CatalogBulkRegisterRequest,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> CatalogBulkRegisterResponse:
     """Register multiple catalog servers at once.
 
     Args:
         request: Bulk registration request with server IDs
         db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         Bulk registration response with success/failure details
@@ -16215,7 +16219,7 @@ async def catalog_partial(
     search: Optional[str] = None,
     page: int = 1,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ) -> HTMLResponse:
     """Get HTML partial for catalog servers (used by HTMX).
 
@@ -16226,7 +16230,7 @@ async def catalog_partial(
         search: Search term
         page: Page number (1-indexed)
         db: Database session
-        _user: Authenticated user
+        current_user_ctx: Authenticated user
 
     Returns:
         HTML partial with filtered catalog servers
@@ -16460,7 +16464,7 @@ async def admin_generate_support_bundle(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_maintenance_partial(
     request: Request,
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ):
     """Render the maintenance dashboard partial (platform admin only).
@@ -16474,7 +16478,7 @@ async def get_maintenance_partial(
 
     Args:
         request: FastAPI request object
-        _user: Authenticated user with admin permissions
+        current_user_ctx: Authenticated user with admin permissions
         _db: Database session for permission checks.
 
     Returns:
@@ -16508,12 +16512,12 @@ async def get_maintenance_partial(
 
 @admin_router.get("/observability/partial", response_class=HTMLResponse)
 @require_permission("admin.system_config", allow_admin_bypass=False)
-async def get_observability_partial(request: Request, _user=Depends(get_current_user_with_permissions), _db: Session = Depends(get_db)):
+async def get_observability_partial(request: Request, current_user_ctx=Depends(get_current_user_with_permissions), _db: Session = Depends(get_db)):  # pylint: disable=unused-argument
     """Render the observability dashboard partial.
 
     Args:
         request: FastAPI request object
-        _user: Authenticated user with admin permissions (required by dependency)
+        current_user_ctx: Authenticated user with admin permissions (required by dependency)
         _db: Database session for permission checks.
 
     Returns:
@@ -16525,12 +16529,12 @@ async def get_observability_partial(request: Request, _user=Depends(get_current_
 
 @admin_router.get("/observability/metrics/partial", response_class=HTMLResponse)
 @require_permission("admin.system_config", allow_admin_bypass=False)
-async def get_observability_metrics_partial(request: Request, _user=Depends(get_current_user_with_permissions), _db: Session = Depends(get_db)):
+async def get_observability_metrics_partial(request: Request, current_user_ctx=Depends(get_current_user_with_permissions), _db: Session = Depends(get_db)):  # pylint: disable=unused-argument
     """Render the advanced metrics dashboard partial.
 
     Args:
         request: FastAPI request object
-        _user: Authenticated user with admin permissions (required by dependency)
+        current_user_ctx: Authenticated user with admin permissions (required by dependency)
         _db: Database session for permission checks.
 
     Returns:
@@ -16542,13 +16546,15 @@ async def get_observability_metrics_partial(request: Request, _user=Depends(get_
 
 @admin_router.get("/observability/stats", response_class=HTMLResponse)
 @require_permission("admin.system_config", allow_admin_bypass=False)
-async def get_observability_stats(request: Request, hours: int = Query(24, ge=1, le=168), _user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+async def get_observability_stats(
+    request: Request, hours: int = Query(24, ge=1, le=168), current_user_ctx=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)
+):  # pylint: disable=unused-argument
     """Get observability statistics for the dashboard.
 
     Args:
         request: FastAPI request object
         hours: Number of hours to look back for statistics (1-168)
-        _user: Authenticated user with admin permissions (required by dependency)
+        current_user_ctx: Authenticated user with admin permissions (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -16599,7 +16605,7 @@ async def get_observability_traces(
     name_search: Optional[str] = Query(None),
     attribute_search: Optional[str] = Query(None),
     tool_name: Optional[str] = Query(None),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get list of traces for the dashboard.
@@ -16616,7 +16622,7 @@ async def get_observability_traces(
         name_search: Trace name search
         attribute_search: Full-text attribute search
         tool_name: Filter by tool name (shows traces that invoked this tool)
-        _user: Authenticated user with admin permissions (required by dependency)
+        current_user_ctx: Authenticated user with admin permissions (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -16688,13 +16694,15 @@ async def get_observability_traces(
 
 @admin_router.get("/observability/trace/{trace_id}", response_class=HTMLResponse)
 @require_permission("admin.system_config", allow_admin_bypass=False)
-async def get_observability_trace_detail(request: Request, trace_id: str, _user=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)):
+async def get_observability_trace_detail(
+    request: Request, trace_id: str, current_user_ctx=Depends(get_current_user_with_permissions), db: Session = Depends(get_db)
+):  # pylint: disable=unused-argument
     """Get detailed trace information with spans.
 
     Args:
         request: FastAPI request object
         trace_id: UUID of the trace to retrieve
-        _user: Authenticated user with admin permissions (required by dependency)
+        current_user_ctx: Authenticated user with admin permissions (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17036,7 +17044,7 @@ async def get_latency_percentiles(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     interval_minutes: int = Query(60, ge=5, le=1440, description="Aggregation interval in minutes"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get latency percentiles (p50, p90, p95, p99) over time.
@@ -17045,7 +17053,7 @@ async def get_latency_percentiles(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         interval_minutes: Aggregation interval in minutes (5-1440)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17200,7 +17208,7 @@ async def get_timeseries_metrics(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     interval_minutes: int = Query(60, ge=5, le=1440, description="Aggregation interval in minutes"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get time-series metrics (request rate, error rate, throughput).
@@ -17209,7 +17217,7 @@ async def get_timeseries_metrics(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         interval_minutes: Aggregation interval in minutes (5-1440)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17527,7 +17535,7 @@ async def get_top_slow_endpoints(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(10, ge=1, le=100, description="Number of results"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get top N slowest endpoints by average duration.
@@ -17536,7 +17544,7 @@ async def get_top_slow_endpoints(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Number of results to return (1-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17596,7 +17604,7 @@ async def get_top_volume_endpoints(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(10, ge=1, le=100, description="Number of results"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get top N highest volume endpoints by request count.
@@ -17605,7 +17613,7 @@ async def get_top_volume_endpoints(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Number of results to return (1-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17663,7 +17671,7 @@ async def get_top_error_endpoints(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(10, ge=1, le=100, description="Number of results"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get top N error-prone endpoints by error count and rate.
@@ -17672,7 +17680,7 @@ async def get_top_error_endpoints(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Number of results to return (1-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17734,7 +17742,7 @@ async def get_latency_heatmap(
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     time_buckets: int = Query(24, ge=10, le=100, description="Number of time buckets"),
     latency_buckets: int = Query(20, ge=5, le=50, description="Number of latency buckets"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get latency distribution heatmap data.
@@ -17747,7 +17755,7 @@ async def get_latency_heatmap(
         hours: Number of hours to look back (1-168)
         time_buckets: Number of time buckets (10-100)
         latency_buckets: Number of latency buckets (5-50)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17782,7 +17790,7 @@ async def get_tool_usage(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of tools to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get tool usage frequency statistics.
@@ -17791,7 +17799,7 @@ async def get_tool_usage(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of tools to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17855,7 +17863,7 @@ async def get_tool_performance(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of tools to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get tool performance metrics (avg, min, max duration).
@@ -17864,7 +17872,7 @@ async def get_tool_performance(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of tools to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17907,7 +17915,7 @@ async def get_tool_errors(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of tools to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get tool error rates and statistics.
@@ -17916,7 +17924,7 @@ async def get_tool_errors(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of tools to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -17979,7 +17987,7 @@ async def get_tool_chains(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of chains to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get tool chain analysis (which tools are invoked together in the same trace).
@@ -17988,7 +17996,7 @@ async def get_tool_chains(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of chains to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18057,14 +18065,14 @@ async def get_tool_chains(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_tools_partial(
     request: Request,
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ):
     """Render the tool invocation metrics dashboard HTML partial.
 
     Args:
         request: FastAPI request object
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         _db: Database session for permission checks.
 
     Returns:
@@ -18092,7 +18100,7 @@ async def get_prompt_usage(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of prompts to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get prompt rendering frequency statistics.
@@ -18101,7 +18109,7 @@ async def get_prompt_usage(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of prompts to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18165,7 +18173,7 @@ async def get_prompt_performance(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of prompts to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get prompt performance metrics (avg, min, max duration).
@@ -18174,7 +18182,7 @@ async def get_prompt_performance(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of prompts to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18216,7 +18224,7 @@ async def get_prompt_performance(
 async def get_prompts_errors(
     hours: int = Query(24, description="Time range in hours"),
     limit: int = Query(20, description="Maximum number of results"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get prompt error rates.
@@ -18224,7 +18232,7 @@ async def get_prompts_errors(
     Args:
         hours: Time range in hours to analyze
         limit: Maximum number of prompts to return
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18279,14 +18287,14 @@ async def get_prompts_errors(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_prompts_partial(
     request: Request,
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ):
     """Render the prompt rendering metrics dashboard HTML partial.
 
     Args:
         request: FastAPI request object
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         _db: Database session for permission checks.
 
     Returns:
@@ -18314,7 +18322,7 @@ async def get_resource_usage(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of resources to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get resource fetch frequency statistics.
@@ -18323,7 +18331,7 @@ async def get_resource_usage(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of resources to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18387,7 +18395,7 @@ async def get_resource_performance(
     request: Request,  # pylint: disable=unused-argument
     hours: int = Query(24, ge=1, le=168, description="Time range in hours"),
     limit: int = Query(20, ge=5, le=100, description="Number of resources to return"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get resource performance metrics (avg, min, max duration).
@@ -18396,7 +18404,7 @@ async def get_resource_performance(
         request: FastAPI request object
         hours: Number of hours to look back (1-168)
         limit: Maximum number of resources to return (5-100)
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18438,7 +18446,7 @@ async def get_resource_performance(
 async def get_resources_errors(
     hours: int = Query(24, description="Time range in hours"),
     limit: int = Query(20, description="Maximum number of results"),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     db: Session = Depends(get_db),
 ):
     """Get resource error rates.
@@ -18446,7 +18454,7 @@ async def get_resources_errors(
     Args:
         hours: Time range in hours to analyze
         limit: Maximum number of resources to return
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         db: Database session for permission checks.
 
     Returns:
@@ -18501,14 +18509,14 @@ async def get_resources_errors(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_resources_partial(
     request: Request,
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
 ):
     """Render the resource fetch metrics dashboard HTML partial.
 
     Args:
         request: FastAPI request object
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
         _db: Database session for permission checks.
 
     Returns:
@@ -18535,7 +18543,7 @@ async def get_resources_partial(
 async def get_performance_stats(
     request: Request,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
     """Get comprehensive performance metrics for the dashboard.
 
@@ -18545,7 +18553,7 @@ async def get_performance_stats(
     Args:
         request: FastAPI request object
         db: Database session dependency
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
 
     Returns:
         HTMLResponse or JSONResponse: Performance dashboard data
@@ -18597,13 +18605,13 @@ async def get_performance_stats(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_performance_system(
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
     """Get current system resource metrics.
 
     Args:
         db: Database session dependency
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
 
     Returns:
         JSONResponse: System metrics (CPU, memory, disk, network)
@@ -18623,13 +18631,13 @@ async def get_performance_system(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_performance_workers(
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
     """Get metrics for all worker processes.
 
     Args:
         db: Database session dependency
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
 
     Returns:
         JSONResponse: List of worker metrics
@@ -18649,13 +18657,13 @@ async def get_performance_workers(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_performance_requests(
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
     """Get HTTP request performance metrics.
 
     Args:
         db: Database session dependency
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
 
     Returns:
         JSONResponse: Request metrics from Prometheus
@@ -18675,13 +18683,13 @@ async def get_performance_requests(
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def get_performance_cache(
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
     """Get Redis cache metrics.
 
     Args:
         db: Database session dependency
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
 
     Returns:
         JSONResponse: Redis cache metrics
@@ -18703,7 +18711,7 @@ async def get_performance_history(
     period_type: str = Query("hourly", description="Aggregation period: hourly or daily"),
     hours: int = Query(24, ge=1, le=168, description="Number of hours to look back"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
 ):
     """Get historical performance aggregates.
 
@@ -18711,7 +18719,7 @@ async def get_performance_history(
         period_type: Aggregation type (hourly, daily)
         hours: Hours of history to retrieve
         db: Database session dependency
-        _user: Authenticated user (required by dependency)
+        current_user_ctx: Authenticated user (required by dependency)
 
     Returns:
         JSONResponse: Historical performance aggregates

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -7271,13 +7271,13 @@ async def readiness_check():
 
 
 @app.get("/health/security", tags=["health"])
-async def security_health(request: Request, _user=Depends(require_admin_auth)):  # pylint: disable=unused-argument
+async def security_health(request: Request, current_user_ctx=Depends(require_admin_auth)):  # pylint: disable=unused-argument
     """
     Get the security configuration health status (admin only).
 
     Args:
         request (Request): The incoming HTTP request.
-        _user: Authenticated admin user (injected by require_admin_auth).
+        current_user_ctx: Authenticated admin user context (injected by require_admin_auth).
 
     Returns:
         dict: A dictionary containing the overall security health status, score,

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -548,7 +548,7 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
                 HTTPException: If user authentication or permission check fails
             """
             # Extract user context from named kwargs only (security: avoid picking up request body dicts)
-            user_context = kwargs.get("user") or kwargs.get("_user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
+            user_context = kwargs.get("user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
 
@@ -768,7 +768,7 @@ def require_admin_permission():
                 HTTPException: If user authentication or admin permission check fails
             """
             # Extract user context from named kwargs only (security: avoid picking up request body dicts)
-            user_context = kwargs.get("user") or kwargs.get("_user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
+            user_context = kwargs.get("user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
 
@@ -854,7 +854,7 @@ def require_any_permission(permissions: List[str], resource_type: Optional[str] 
                 HTTPException: If user authentication or any-permission check fails
             """
             # Extract user context from named kwargs only (security: avoid picking up request body dicts)
-            user_context = kwargs.get("user") or kwargs.get("_user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
+            user_context = kwargs.get("user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
 

--- a/mcpgateway/routers/cancellation_router.py
+++ b/mcpgateway/routers/cancellation_router.py
@@ -67,13 +67,13 @@ class CancelResponse(BaseModel):
 
 @router.post("/cancel", response_model=CancelResponse)
 @require_permission("admin.system_config")
-async def cancel_run(payload: CancelRequest, _user=Depends(get_current_user_with_permissions)) -> CancelResponse:
+async def cancel_run(payload: CancelRequest, current_user_ctx=Depends(get_current_user_with_permissions)) -> CancelResponse:
     """
     Cancel a run by its request ID.
 
     Args:
         payload: The cancellation request payload.
-        _user: The current user (dependency injection).
+        current_user_ctx: The current user (dependency injection).
 
     Returns:
         CancelResponse: The cancellation response indicating whether the run was cancelled or queued.
@@ -105,13 +105,13 @@ async def cancel_run(payload: CancelRequest, _user=Depends(get_current_user_with
 
 @router.get("/status/{request_id}")
 @require_permission("admin.system_config")
-async def get_status(request_id: str, _user=Depends(get_current_user_with_permissions)):
+async def get_status(request_id: str, current_user_ctx=Depends(get_current_user_with_permissions)):
     """
     Get the status of a run by its request ID.
 
     Args:
         request_id: The ID of the request to get the status for.
-        _user: The current user (dependency injection).
+        current_user_ctx: The current user (dependency injection).
 
     Returns:
         dict: The status dictionary for the run (e.g. keys: 'name', 'registered_at', 'cancelled').

--- a/mcpgateway/routers/llmchat_router.py
+++ b/mcpgateway/routers/llmchat_router.py
@@ -1282,7 +1282,7 @@ async def get_config(user_id: str, user=Depends(get_current_user_with_permission
 
 @llmchat_router.get("/gateway/models")
 @require_permission("llm.read")
-async def get_gateway_models(_user=Depends(get_current_user_with_permissions)):
+async def get_gateway_models(current_user_ctx=Depends(get_current_user_with_permissions)):
     """Get available models from configured LLM providers.
 
     Returns a list of enabled models from enabled providers configured
@@ -1319,7 +1319,7 @@ async def get_gateway_models(_user=Depends(get_current_user_with_permissions)):
         HTTPException: If there is an error retrieving gateway models.
 
     Args:
-        _user: Authenticated user context.
+        current_user_ctx: Authenticated user context.
     """
     # Import here to avoid circular dependency
     # First-Party

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -71,7 +71,7 @@ async def list_traces(
     limit: int = Query(100, ge=1, le=1000, description="Maximum results"),
     offset: int = Query(0, ge=0, description="Result offset"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """List traces with optional filtering.
 
@@ -94,6 +94,7 @@ async def list_traces(
         limit: Maximum results
         offset: Result offset
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         List[ObservabilityTraceRead]: List of traces matching filters
@@ -119,7 +120,7 @@ async def list_traces(
         ...         return [FakeTrace('t1')]
         >>> obs.ObservabilityService = FakeService
         >>> async def run_list_traces():
-        ...     traces = await obs.list_traces(db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     traces = await obs.list_traces(db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return traces[0].trace_id
         >>> asyncio.run(run_list_traces())
         't1'
@@ -148,7 +149,7 @@ async def query_traces_advanced(
     # Third-Party
     request_body: dict,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """Advanced trace querying with attribute filtering.
 
@@ -177,6 +178,7 @@ async def query_traces_advanced(
     Args:
         request_body: JSON request body with filter criteria
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         List[ObservabilityTraceRead]: List of traces matching filters
@@ -190,7 +192,7 @@ async def query_traces_advanced(
         >>> from mcpgateway.config import settings
         >>> async def run_invalid_query():
         ...     try:
-        ...         await query_traces_advanced({"start_time": "not-a-date"}, db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...         await query_traces_advanced({"start_time": "not-a-date"}, db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     except HTTPException as e:
         ...         return (e.status_code, "Invalid request body" in str(e.detail))
         >>> asyncio.run(run_invalid_query())
@@ -207,7 +209,7 @@ async def query_traces_advanced(
         ...         return [FakeTrace()]
         >>> obs.ObservabilityService = FakeService2
         >>> async def run_query_traces():
-        ...     traces = await obs.query_traces_advanced({}, db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     traces = await obs.query_traces_advanced({}, db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return traces[0].trace_id
         >>> asyncio.run(run_query_traces())
         'tx'
@@ -258,7 +260,7 @@ async def query_traces_advanced(
 
 @router.get("/traces/{trace_id}", response_model=ObservabilityTraceWithSpans)
 @require_permission("admin.system_config")
-async def get_trace(trace_id: str, db: Session = Depends(get_db), _user=Depends(get_current_user_with_permissions)):
+async def get_trace(trace_id: str, db: Session = Depends(get_db), current_user_ctx=Depends(get_current_user_with_permissions)):
     """Get a trace by ID with all its spans and events.
 
     Returns a complete trace with all nested spans and their events,
@@ -267,6 +269,7 @@ async def get_trace(trace_id: str, db: Session = Depends(get_db), _user=Depends(
     Args:
         trace_id: UUID of the trace to retrieve
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         ObservabilityTraceWithSpans: Complete trace with all spans and events
@@ -284,7 +287,7 @@ async def get_trace(trace_id: str, db: Session = Depends(get_db), _user=Depends(
         >>> obs.ObservabilityService = FakeService
         >>> async def run_missing_trace():
         ...     try:
-        ...         await obs.get_trace("missing", db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...         await obs.get_trace("missing", db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     except obs.HTTPException as e:
         ...         return e.status_code
         >>> asyncio.run(run_missing_trace())
@@ -294,7 +297,7 @@ async def get_trace(trace_id: str, db: Session = Depends(get_db), _user=Depends(
         ...         return {'trace_id': trace_id}
         >>> obs.ObservabilityService = FakeService2
         >>> async def run_found_trace():
-        ...     trace = await obs.get_trace("found", db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     trace = await obs.get_trace("found", db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return trace["trace_id"]
         >>> asyncio.run(run_found_trace())
         'found'
@@ -317,7 +320,7 @@ async def list_spans(
     limit: int = Query(100, ge=1, le=1000, description="Maximum results"),
     offset: int = Query(0, ge=0, description="Result offset"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """List spans with optional filtering.
 
@@ -333,6 +336,7 @@ async def list_spans(
         limit: Maximum results
         offset: Result offset
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         List[ObservabilitySpanRead]: List of spans matching filters
@@ -351,7 +355,7 @@ async def list_spans(
         ...         return [FakeSpan()]
         >>> obs.ObservabilityService = FakeService
         >>> async def run_list_spans():
-        ...     spans = await obs.list_spans(db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     spans = await obs.list_spans(db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return spans[0].span_id
         >>> asyncio.run(run_list_spans())
         's1'
@@ -375,7 +379,7 @@ async def list_spans(
 async def cleanup_old_traces(
     days: int = Query(7, ge=1, description="Delete traces older than this many days"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """Delete traces older than a specified number of days.
 
@@ -385,6 +389,7 @@ async def cleanup_old_traces(
     Args:
         days: Delete traces older than this many days
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         dict: Number of deleted traces and cutoff time
@@ -398,7 +403,7 @@ async def cleanup_old_traces(
         ...         return 5
         >>> obs.ObservabilityService = FakeService
         >>> async def run_cleanup():
-        ...     res = await obs.cleanup_old_traces(days=7, db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     res = await obs.cleanup_old_traces(days=7, db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return res["deleted"]
         >>> asyncio.run(run_cleanup())
         5
@@ -414,7 +419,7 @@ async def cleanup_old_traces(
 async def get_stats(
     hours: int = Query(24, ge=1, le=168, description="Time window in hours"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """Get observability statistics.
 
@@ -427,6 +432,7 @@ async def get_stats(
     Args:
         hours: Time window in hours
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         dict: Statistics including counts, error rate, and slowest endpoints
@@ -476,7 +482,7 @@ async def export_traces(
     request_body: dict,
     format: str = Query("json", description="Export format (json, csv, ndjson)"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """Export traces in various formats.
 
@@ -492,6 +498,7 @@ async def export_traces(
         request_body: JSON request body with filter criteria (same as /traces/query)
         format: Export format (json, csv, ndjson)
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         StreamingResponse or JSONResponse with exported data
@@ -507,7 +514,7 @@ async def export_traces(
         >>> from mcpgateway.config import settings
         >>> async def run_invalid_export():
         ...     try:
-        ...         await export_traces({}, format="xml", db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...         await export_traces({}, format="xml", db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     except HTTPException as e:
         ...         return (e.status_code, "format must be one of" in str(e.detail))
         >>> asyncio.run(run_invalid_export())
@@ -529,17 +536,17 @@ async def export_traces(
         ...         return [FakeTrace()]
         >>> obs.ObservabilityService = FakeService
         >>> async def run_json_export():
-        ...     out = await obs.export_traces({}, format="json", db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     out = await obs.export_traces({}, format="json", db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return out[0]["trace_id"]
         >>> asyncio.run(run_json_export())
         'tx'
         >>> async def run_csv_export():
-        ...     resp = await obs.export_traces({}, format="csv", db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     resp = await obs.export_traces({}, format="csv", db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return hasattr(resp, "media_type") and "csv" in resp.media_type
         >>> asyncio.run(run_csv_export())
         True
         >>> async def run_ndjson_export():
-        ...     resp2 = await obs.export_traces({}, format="ndjson", db=None, _user={"email": settings.platform_admin_email, "db": None})
+        ...     resp2 = await obs.export_traces({}, format="ndjson", db=None, current_user_ctx={"email": settings.platform_admin_email, "db": None})
         ...     return type(resp2).__name__
         >>> asyncio.run(run_ndjson_export())
         'StreamingResponse'
@@ -654,7 +661,7 @@ async def export_traces(
 async def get_query_performance(
     hours: int = Query(24, ge=1, le=168, description="Time window in hours"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ):
     """Get query performance analytics.
 
@@ -666,6 +673,7 @@ async def get_query_performance(
     Args:
         hours: Time window in hours
         db: Database session
+        current_user_ctx: The current authenticated user
 
     Returns:
         dict: Performance analytics
@@ -688,7 +696,7 @@ async def get_query_performance(
         ...     def all(self):
         ...         return []
         >>> async def run_empty_stats():
-        ...     return (await obs.get_query_performance(hours=1, db=EmptyDB(), _user={"email": settings.platform_admin_email, "db": None}))["total_traces"]
+        ...     return (await obs.get_query_performance(hours=1, db=EmptyDB(), current_user_ctx={"email": settings.platform_admin_email, "db": None}))["total_traces"]
         >>> asyncio.run(run_empty_stats())
         0
 
@@ -702,7 +710,7 @@ async def get_query_performance(
         ...     def all(self):
         ...         return [(10,), (20,), (30,), (40,)]
         >>> async def run_small_stats():
-        ...     return await obs.get_query_performance(hours=1, db=SmallDB(), _user={"email": settings.platform_admin_email, "db": None})
+        ...     return await obs.get_query_performance(hours=1, db=SmallDB(), current_user_ctx={"email": settings.platform_admin_email, "db": None})
         >>> res = asyncio.run(run_small_stats())
         >>> res["total_traces"]
         4

--- a/mcpgateway/routers/toolops_router.py
+++ b/mcpgateway/routers/toolops_router.py
@@ -72,7 +72,7 @@ async def generate_testcases_for_tool(
     number_of_nl_variations: int = Query(1, description="Number of NL utterance variations per test case"),
     mode: str = Query("generate", description="Three modes: 'generate' for test case generation, 'query' for obtaining test cases from DB , 'status' to check test generation status"),
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    current_user_ctx=Depends(get_current_user_with_permissions),
 ) -> List[Dict]:
     """
     Generate test cases for a tool
@@ -87,6 +87,7 @@ async def generate_testcases_for_tool(
         number_of_nl_variations: Number of Natural language variations(parapharses) per test case (optional)
         mode: Three supported modes - 'generate' for test case generation, 'query' for obtaining test cases from DB , 'status' to check test generation status
         db: DB session to connect with database
+        current_user_ctx: The current authenticated user
 
     Returns:
         List: A list of test cases generated for the tool , each test case is dictionary object
@@ -108,7 +109,7 @@ async def generate_testcases_for_tool(
 
 @toolops_router.post("/validation/execute_tool_nl_testcases")
 @require_permission("admin.system_config")
-async def execute_tool_nl_testcases(tool_nl_test_input: ToolNLTestInput, db: Session = Depends(get_db), _user=Depends(get_current_user_with_permissions)) -> List:
+async def execute_tool_nl_testcases(tool_nl_test_input: ToolNLTestInput, db: Session = Depends(get_db), current_user_ctx=Depends(get_current_user_with_permissions)) -> List:
     """
     Execute test cases for a tool
 
@@ -121,6 +122,7 @@ async def execute_tool_nl_testcases(tool_nl_test_input: ToolNLTestInput, db: Ses
             - tool_id: Tool ID in ContextForge\
             - tool_nl_test_cases: List of natural language test cases (utteances) for testing MCP tool with the agent
         db: DB session to connect with database
+        current_user_ctx: The current authenticated user
 
     Returns:
         List: A list of tool outputs after agent execution for the provided tool nl test cases
@@ -144,13 +146,14 @@ async def execute_tool_nl_testcases(tool_nl_test_input: ToolNLTestInput, db: Ses
 
 @toolops_router.post("/enrichment/enrich_tool")
 @require_permission("admin.system_config")
-async def enrich_a_tool(tool_id: str = Query(None, description="Tool ID"), db: Session = Depends(get_db), _user=Depends(get_current_user_with_permissions)) -> dict[str, Any]:
+async def enrich_a_tool(tool_id: str = Query(None, description="Tool ID"), db: Session = Depends(get_db), current_user_ctx=Depends(get_current_user_with_permissions)) -> dict[str, Any]:
     """
     Enriches an input tool
 
     Args:
         tool_id: Unique Tool ID MCP-CF.
         db: The database session used to interact with the data store.
+        current_user_ctx: The current authenticated user
 
     Returns:
         result: A dict having the keys "tool_id", "tool_name", "original_desc" and "enriched_desc" with their corresponding values

--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -265,12 +265,12 @@ def setup_metrics(app):
         from mcpgateway.utils.verify_credentials import require_auth
 
         @app.get("/metrics/prometheus", include_in_schema=True, tags=["Metrics"])
-        def prometheus_metrics(request: Request, _user=Depends(require_auth)):
+        def prometheus_metrics(request: Request, current_user_ctx=Depends(require_auth)):  # pylint: disable=unused-argument
             """Prometheus metrics endpoint (requires authentication).
 
             Args:
                 request: The incoming HTTP request (used to check Accept-Encoding).
-                _user: Authenticated user from require_auth dependency.
+                current_user_ctx: Authenticated user from require_auth dependency.
 
             Returns:
                 Response: Prometheus metrics in text exposition format.
@@ -299,11 +299,11 @@ def setup_metrics(app):
         from mcpgateway.utils.verify_credentials import require_auth
 
         @app.get("/metrics/prometheus", tags=["Metrics"])
-        async def metrics_disabled(_user=Depends(require_auth)):  # pylint: disable=unused-argument
+        async def metrics_disabled(current_user_ctx=Depends(require_auth)):  # pylint: disable=unused-argument
             """Returns 503 when metrics collection is disabled (requires authentication).
 
             Args:
-                _user: Authenticated user from require_auth dependency.
+                current_user_ctx: Authenticated user from require_auth dependency.
 
             Returns:
                 Response: HTTP 503 response indicating metrics are disabled.

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -733,7 +733,7 @@ async def version_endpoint(
     request: Request,
     fmt: Optional[str] = None,
     partial: Optional[bool] = False,
-    _user=Depends(require_admin_auth),
+    current_user_ctx=Depends(require_admin_auth),  # pylint: disable=unused-argument
 ) -> Response:
     """Serve diagnostics as JSON, full HTML, or partial HTML.
 
@@ -749,7 +749,7 @@ async def version_endpoint(
         request (Request): The incoming FastAPI request object.
         fmt (Optional[str]): Query parameter to force format ('html' for HTML output).
         partial (Optional[bool]): Query parameter to request partial HTML fragment.
-        _user: Injected authenticated admin user from require_admin_auth dependency.
+        current_user_ctx: Injected authenticated admin user from require_admin_auth dependency.
 
     Returns:
         Response: JSONResponse with diagnostic data, or HTMLResponse with formatted page.
@@ -769,7 +769,7 @@ async def version_endpoint(
         ...     with patch('mcpgateway.version.REDIS_AVAILABLE', False):
         ...         with patch('mcpgateway.version._build_payload') as mock_build:
         ...             mock_build.return_value = {"test": "data"}
-        ...             response = await version_endpoint(mock_request, fmt=None, partial=False, _user="testuser")
+        ...             response = await version_endpoint(mock_request, fmt=None, partial=False, current_user_ctx="testuser")
         ...             return response
         >>>
         >>> response = asyncio.run(test_json())
@@ -783,7 +783,7 @@ async def version_endpoint(
         ...             with patch('mcpgateway.version._render_html') as mock_render:
         ...                 mock_build.return_value = {"test": "data"}
         ...                 mock_render.return_value = "<html>test</html>"
-        ...                 response = await version_endpoint(mock_request, fmt="html", partial=False, _user="testuser")
+        ...                 response = await version_endpoint(mock_request, fmt="html", partial=False, current_user_ctx="testuser")
         ...                 return response
         >>>
         >>> response = asyncio.run(test_html_fmt())
@@ -811,7 +811,7 @@ async def version_endpoint(
         ...                 with patch('mcpgateway.version.get_redis_client', mock_get_redis_client):
         ...                     with patch('mcpgateway.version._build_payload') as mock_build:
         ...                         mock_build.return_value = {"redis": {"version": "7.0.5"}}
-        ...                         response = await version_endpoint(mock_request, _user="testuser")
+        ...                         response = await version_endpoint(mock_request, current_user_ctx="testuser")
         ...                         # Verify Redis info was retrieved
         ...                         mock_redis.info.assert_called_once()
         ...                         # Verify payload was built with Redis info

--- a/tests/unit/mcpgateway/routers/test_cancellation_router.py
+++ b/tests/unit/mcpgateway/routers/test_cancellation_router.py
@@ -169,7 +169,7 @@ async def test_cancel_run_broadcasts_notifications(allow_permission, monkeypatch
     monkeypatch.setattr("mcpgateway.routers.cancellation_router.cancellation_service", MagicMock(cancel_run=AsyncMock(return_value=True)))
 
     payload = CancelRequest(requestId="req-1", reason="test")
-    result = await cancel_run(payload, _user={"email": "user@example.com"})
+    result = await cancel_run(payload, current_user_ctx={"email": "user@example.com"})
 
     assert result.status == "cancelled"
     assert mock_registry.broadcast.await_count == 2
@@ -188,7 +188,7 @@ async def test_cancel_run_handles_session_errors(allow_permission, monkeypatch):
     monkeypatch.setattr("mcpgateway.routers.cancellation_router.cancellation_service", MagicMock(cancel_run=AsyncMock(return_value=False)))
 
     payload = CancelRequest(requestId="req-2", reason=None)
-    result = await cancel_run(payload, _user={"email": "user@example.com"})
+    result = await cancel_run(payload, current_user_ctx={"email": "user@example.com"})
 
     assert result.status == "queued"
 
@@ -207,7 +207,7 @@ async def test_cancel_run_handles_per_session_broadcast_errors(allow_permission,
     monkeypatch.setattr("mcpgateway.routers.cancellation_router.cancellation_service", MagicMock(cancel_run=AsyncMock(return_value=True)))
 
     payload = CancelRequest(requestId="req-err", reason="test")
-    result = await cancel_run(payload, _user={"email": "user@example.com"})
+    result = await cancel_run(payload, current_user_ctx={"email": "user@example.com"})
 
     assert result.status == "cancelled"
     assert mock_registry.broadcast.await_count == 2
@@ -225,7 +225,7 @@ async def test_get_status_not_found(allow_permission, monkeypatch):
     monkeypatch.setattr("mcpgateway.routers.cancellation_router.cancellation_service", mock_service)
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_status("missing", _user={"email": "user@example.com"})
+        await get_status("missing", current_user_ctx={"email": "user@example.com"})
 
     assert "Run not found" in str(exc_info.value)
 
@@ -247,7 +247,7 @@ async def test_get_status_filters_cancel_callback(allow_permission, monkeypatch)
     )
     monkeypatch.setattr("mcpgateway.routers.cancellation_router.cancellation_service", mock_service)
 
-    result = await get_status("req-3", _user={"email": "user@example.com"})
+    result = await get_status("req-3", current_user_ctx={"email": "user@example.com"})
 
     assert "cancel_callback" not in result
 
@@ -264,6 +264,6 @@ async def test_get_status_not_found_when_status_is_none(allow_permission, monkey
     monkeypatch.setattr("mcpgateway.routers.cancellation_router.cancellation_service", mock_service)
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_status("req-none", _user={"email": "user@example.com"})
+        await get_status("req-none", current_user_ctx={"email": "user@example.com"})
 
     assert exc_info.value.status_code == 404

--- a/tests/unit/mcpgateway/routers/test_llmchat_router.py
+++ b/tests/unit/mcpgateway/routers/test_llmchat_router.py
@@ -692,7 +692,7 @@ async def test_get_gateway_models_success(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DummyPermissionService)
 
-    result = await llmchat_router.get_gateway_models(_user={"id": "user1", "email": "user1@test.com", "db": MagicMock()})
+    result = await llmchat_router.get_gateway_models(current_user_ctx={"id": "user1", "email": "user1@test.com", "db": MagicMock()})
 
     assert result["count"] == 1
     assert result["models"][0]["id"] == "m1"
@@ -728,7 +728,7 @@ async def test_get_gateway_models_failure(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DummyPermissionService)
 
     with pytest.raises(HTTPException) as excinfo:
-        await llmchat_router.get_gateway_models(_user={"id": "user1", "email": "user1@test.com", "db": MagicMock()})
+        await llmchat_router.get_gateway_models(current_user_ctx={"id": "user1", "email": "user1@test.com", "db": MagicMock()})
 
     assert excinfo.value.status_code == 500
 

--- a/tests/unit/mcpgateway/routers/test_observability_sql.py
+++ b/tests/unit/mcpgateway/routers/test_observability_sql.py
@@ -169,7 +169,7 @@ class TestQueryPerformanceRouting:
                 result = await get_query_performance(
                     hours=1,
                     db=mock_db,
-                    _user={"email": settings.platform_admin_email, "db": mock_db},
+                    current_user_ctx={"email": settings.platform_admin_email, "db": mock_db},
                 )
 
                 # Verify PostgreSQL path was called
@@ -199,7 +199,7 @@ class TestQueryPerformanceRouting:
                 result = await get_query_performance(
                     hours=1,
                     db=mock_db,
-                    _user={"email": settings.platform_admin_email, "db": mock_db},
+                    current_user_ctx={"email": settings.platform_admin_email, "db": mock_db},
                 )
 
                 # Verify Python path was called
@@ -276,7 +276,7 @@ class TestObservabilityRouterEndpoints:
         with patch("mcpgateway.routers.observability.ObservabilityService") as mock_service:
             mock_service.return_value.query_traces.return_value = [fake_trace]
 
-            result = await list_traces(db=mock_db, _user={"email": "admin", "db": mock_db})
+            result = await list_traces(db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
 
         assert result == [fake_trace]
 
@@ -294,7 +294,7 @@ class TestObservabilityRouterEndpoints:
             result = await query_traces_advanced(
                 {"start_time": "2025-01-01T00:00:00Z", "end_time": "2025-01-02T00:00:00Z"},
                 db=mock_db,
-                _user={"email": "admin", "db": mock_db},
+                current_user_ctx={"email": "admin", "db": mock_db},
             )
 
         assert result == [fake_trace]
@@ -308,7 +308,7 @@ class TestObservabilityRouterEndpoints:
         from mcpgateway.routers.observability import query_traces_advanced
 
         with pytest.raises(HTTPException) as exc_info:
-            await query_traces_advanced({"start_time": "not-a-date"}, db=MagicMock(), _user={"email": "admin", "db": MagicMock()})
+            await query_traces_advanced({"start_time": "not-a-date"}, db=MagicMock(), current_user_ctx={"email": "admin", "db": MagicMock()})
 
         assert exc_info.value.status_code == 400
 
@@ -322,7 +322,7 @@ class TestObservabilityRouterEndpoints:
             mock_service.return_value.get_trace_with_spans.return_value = None
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_trace("missing", db=mock_db, _user={"email": "admin", "db": mock_db})
+                await get_trace("missing", db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
 
         assert exc_info.value.status_code == 404
 
@@ -336,7 +336,7 @@ class TestObservabilityRouterEndpoints:
         with patch("mcpgateway.routers.observability.ObservabilityService") as mock_service:
             mock_service.return_value.get_trace_with_spans.return_value = trace
 
-            result = await get_trace("t1", db=mock_db, _user={"email": "admin", "db": mock_db})
+            result = await get_trace("t1", db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
 
         assert result == trace
 
@@ -351,7 +351,7 @@ class TestObservabilityRouterEndpoints:
         with patch("mcpgateway.routers.observability.ObservabilityService") as mock_service:
             mock_service.return_value.query_spans.return_value = [fake_span]
 
-            result = await list_spans(db=mock_db, _user={"email": "admin", "db": mock_db})
+            result = await list_spans(db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
 
         assert result == [fake_span]
 
@@ -364,7 +364,7 @@ class TestObservabilityRouterEndpoints:
         with patch("mcpgateway.routers.observability.ObservabilityService") as mock_service:
             mock_service.return_value.delete_old_traces.return_value = 5
 
-            result = await cleanup_old_traces(days=3, db=mock_db, _user={"email": "admin", "db": mock_db})
+            result = await cleanup_old_traces(days=3, db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
 
         assert result["deleted"] == 5
 
@@ -388,7 +388,7 @@ class TestObservabilityRouterEndpoints:
 
         mock_db.query.side_effect = [query_total, query_success, query_error, query_avg, query_slowest]
 
-        result = await get_stats(hours=24, db=mock_db, _user={"email": "admin", "db": mock_db})
+        result = await get_stats(hours=24, db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
 
         assert result["total_traces"] == 10
         assert result["success_count"] == 7
@@ -402,7 +402,7 @@ class TestObservabilityRouterEndpoints:
         from mcpgateway.routers.observability import export_traces
 
         with pytest.raises(HTTPException) as exc_info:
-            await export_traces({}, format="xml", db=MagicMock(), _user={"email": "admin", "db": MagicMock()})
+            await export_traces({}, format="xml", db=MagicMock(), current_user_ctx={"email": "admin", "db": MagicMock()})
 
         assert exc_info.value.status_code == 400
 
@@ -428,14 +428,14 @@ class TestObservabilityRouterEndpoints:
         with patch("mcpgateway.routers.observability.ObservabilityService") as mock_service:
             mock_service.return_value.query_traces.return_value = [fake_trace]
 
-            json_resp = await export_traces({}, format="json", db=mock_db, _user={"email": "admin", "db": mock_db})
+            json_resp = await export_traces({}, format="json", db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
             assert json_resp[0]["trace_id"] == "t1"
 
-            csv_resp = await export_traces({}, format="csv", db=mock_db, _user={"email": "admin", "db": mock_db})
+            csv_resp = await export_traces({}, format="csv", db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
             assert csv_resp.media_type == "text/csv"
             assert b"trace_id" in csv_resp.body
 
-            ndjson_resp = await export_traces({}, format="ndjson", db=mock_db, _user={"email": "admin", "db": mock_db})
+            ndjson_resp = await export_traces({}, format="ndjson", db=mock_db, current_user_ctx={"email": "admin", "db": mock_db})
             chunks = [chunk async for chunk in ndjson_resp.body_iterator]
             first_chunk = chunks[0]
             assert "trace_id" in (first_chunk.decode() if isinstance(first_chunk, bytes) else first_chunk)
@@ -453,7 +453,7 @@ class TestObservabilityRouterEndpoints:
                 {"start_time": "2025-01-01T00:00:00Z", "end_time": "2025-01-02T00:00:00Z"},
                 format="json",
                 db=mock_db,
-                _user={"email": "admin", "db": mock_db},
+                current_user_ctx={"email": "admin", "db": mock_db},
             )
 
         kwargs = mock_service.return_value.query_traces.call_args.kwargs
@@ -469,7 +469,7 @@ class TestObservabilityRouterEndpoints:
             mock_service.return_value.query_traces.side_effect = RuntimeError("boom")
 
             with pytest.raises(HTTPException) as exc_info:
-                await export_traces({}, format="json", db=MagicMock(), _user={"email": "admin", "db": MagicMock()})
+                await export_traces({}, format="json", db=MagicMock(), current_user_ctx={"email": "admin", "db": MagicMock()})
 
         assert exc_info.value.status_code == 400
         assert "Export failed:" in exc_info.value.detail

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3225,7 +3225,7 @@ class TestAdminMetricsRoutes:
         mock_server_top.return_value = []
         mock_prompt_top.return_value = []
 
-        result = await get_aggregated_metrics(mock_db, _user={"email": "test-user@example.com", "db": mock_db})
+        result = await get_aggregated_metrics(mock_db, current_user_ctx={"email": "test-user@example.com", "db": mock_db})
 
         assert result["tools"].total_executions == 0
         assert result["resources"].total_executions == 100
@@ -4529,7 +4529,7 @@ class TestGlobalConfigurationEndpoints:
         mock_db.query.return_value.first.return_value = mock_config
 
         # First-Party
-        result = await get_global_passthrough_headers(db=mock_db, _user={"email": "test-user", "db": mock_db})
+        result = await get_global_passthrough_headers(db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, GlobalConfigRead)
         assert result.passthrough_headers == ["X-Custom-Header", "X-Auth-Token"]
@@ -4541,7 +4541,7 @@ class TestGlobalConfigurationEndpoints:
         mock_db.query.return_value.first.return_value = None
 
         # First-Party
-        result = await get_global_passthrough_headers(db=mock_db, _user={"email": "test-user", "db": mock_db})
+        result = await get_global_passthrough_headers(db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, GlobalConfigRead)
         assert result.passthrough_headers == []
@@ -4555,7 +4555,7 @@ class TestGlobalConfigurationEndpoints:
         config_update = GlobalConfigUpdate(passthrough_headers=["X-New-Header"])
 
         # First-Party
-        result = await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, _user={"email": "test-user", "db": mock_db})
+        result = await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         # Should create new config
         mock_db.add.assert_called_once()
@@ -4574,7 +4574,7 @@ class TestGlobalConfigurationEndpoints:
         config_update = GlobalConfigUpdate(passthrough_headers=["X-Updated-Header"])
 
         # First-Party
-        result = await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, _user={"email": "test-user", "db": mock_db})
+        result = await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         # Should update existing config
         assert mock_config.passthrough_headers == ["X-Updated-Header"]
@@ -4592,7 +4592,7 @@ class TestGlobalConfigurationEndpoints:
 
         # First-Party
         with pytest.raises(HTTPException) as excinfo:
-            await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, _user={"email": "test-user", "db": mock_db})
+            await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         assert excinfo.value.status_code == 409
         assert "Passthrough headers conflict" in str(excinfo.value.detail)
@@ -4608,7 +4608,7 @@ class TestGlobalConfigurationEndpoints:
 
         # First-Party
         with pytest.raises(HTTPException) as excinfo:
-            await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, _user={"email": "test-user", "db": mock_db})
+            await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         assert excinfo.value.status_code == 422
         assert "Invalid passthrough headers format" in str(excinfo.value.detail)
@@ -4624,7 +4624,7 @@ class TestGlobalConfigurationEndpoints:
 
         # First-Party
         with pytest.raises(HTTPException) as excinfo:
-            await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, _user={"email": "test-user", "db": mock_db})
+            await update_global_passthrough_headers(request=mock_request, config_update=config_update, db=mock_db, current_user_ctx={"email": "test-user", "db": mock_db})
 
         assert excinfo.value.status_code == 500
         assert "Custom error" in str(excinfo.value.detail)
@@ -6960,7 +6960,7 @@ async def test_admin_get_team_edit_success(monkeypatch, mock_request, mock_db, a
     team_service = MagicMock()
     team_service.get_team_by_id = AsyncMock(return_value=SimpleNamespace(id="team-1", name="Team One", slug="team-one", description="Desc", visibility="private", is_personal=False, max_members=50))
     monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
-    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert "Edit Team" in response.body.decode()
 
@@ -6968,7 +6968,7 @@ async def test_admin_get_team_edit_success(monkeypatch, mock_request, mock_db, a
 @pytest.mark.asyncio
 async def test_admin_get_team_edit_email_auth_disabled(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", False)
-    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     assert response.status_code == 403
 
 
@@ -6979,7 +6979,7 @@ async def test_admin_get_team_edit_team_not_found(monkeypatch, mock_request, moc
     team_service.get_team_by_id = AsyncMock(return_value=None)
     monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
 
-    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     assert response.status_code == 404
 
 
@@ -6990,7 +6990,7 @@ async def test_admin_get_team_edit_exception(monkeypatch, mock_request, mock_db,
     team_service.get_team_by_id = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
 
-    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     assert response.status_code == 500
     assert "error loading team" in response.body.decode().lower()
 
@@ -7099,7 +7099,7 @@ async def test_admin_get_team_edit_renders_max_members(monkeypatch, mock_request
     team_service = MagicMock()
     team_service.get_team_by_id = AsyncMock(return_value=SimpleNamespace(id="team-1", name="Team One", slug="team-one", description="Desc", visibility="private", is_personal=False, max_members=25))
     monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
-    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-1", mock_request, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     body = response.body.decode()
     assert 'name="max_members"' in body
     assert 'value="25"' in body
@@ -7161,7 +7161,7 @@ async def test_admin_get_team_edit_blocks_other_personal_team(monkeypatch, mock_
     )
     monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
 
-    response = await admin_get_team_edit("team-personal", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-personal", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 403
     assert "cannot be edited" in response.body.decode().lower()
 
@@ -7184,7 +7184,7 @@ async def test_admin_get_team_edit_blocks_own_personal_team(monkeypatch, mock_re
     )
     monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
 
-    response = await admin_get_team_edit("team-personal", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_team_edit("team-personal", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 403
     assert "cannot be edited" in response.body.decode().lower()
 
@@ -8403,7 +8403,7 @@ async def test_admin_get_user_edit_success(monkeypatch, mock_request, mock_db, a
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="a@example.com", full_name="A", is_admin=False, is_email_verified=lambda: False))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert "Edit User" in response.body.decode()
 
@@ -8415,7 +8415,7 @@ async def test_admin_get_user_edit_exception(monkeypatch, mock_request, mock_db,
     auth_service.get_user_by_email = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 500
     assert "error loading user" in response.body.decode().lower()
 
@@ -8430,7 +8430,7 @@ async def test_admin_update_user_password_mismatch(monkeypatch, mock_db, allow_p
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="a@example.com", is_admin=True))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
     assert "Passwords do not match" in response.body.decode()
 
@@ -8446,7 +8446,7 @@ async def test_admin_update_user_last_admin_block(monkeypatch, mock_db, allow_pe
     auth_service.is_last_active_admin = AsyncMock(return_value=True)
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
     assert "last remaining admin" in response.body.decode()
 
@@ -8464,7 +8464,7 @@ async def test_admin_update_user_success(monkeypatch, mock_db, allow_permission)
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
     monkeypatch.setattr("mcpgateway.admin.validate_password_strength", lambda pw: (True, ""))
 
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 200
     assert response.headers.get("HX-Trigger") is not None
 
@@ -8473,7 +8473,7 @@ async def test_admin_update_user_success(monkeypatch, mock_db, allow_permission)
 async def test_admin_update_user_email_auth_disabled(monkeypatch, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", False)
     request = MagicMock(spec=Request)
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 403
 
 
@@ -8489,7 +8489,7 @@ async def test_admin_update_user_password_invalid(monkeypatch, mock_db, allow_pe
     auth_service.update_user = AsyncMock(return_value=None)
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
     assert "password validation failed" in response.body.decode().lower()
 
@@ -8505,7 +8505,7 @@ async def test_admin_update_user_exception(monkeypatch, mock_db, allow_permissio
     auth_service.update_user = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
     assert "error updating user" in response.body.decode().lower()
 
@@ -8519,7 +8519,7 @@ async def test_admin_get_user_edit_hides_admin_checkbox_when_editing_self(monkey
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # User editing themselves (same email)
-    response = await admin_get_user_edit("admin%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_user_edit("admin%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     body = response.body.decode()
     assert "Edit User" in body
@@ -8536,7 +8536,7 @@ async def test_admin_get_user_edit_shows_admin_checkbox_when_editing_other(monke
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # Admin editing another user (different email)
-    response = await admin_get_user_edit("other%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_user_edit("other%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     body = response.body.decode()
     assert "Edit User" in body
@@ -8554,7 +8554,7 @@ async def test_admin_get_user_edit_case_insensitive_self_check(monkeypatch, mock
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # User with different case should still be recognized as self
-    response = await admin_get_user_edit("admin%40example.com", mock_request, db=mock_db, _user={"email": "ADMIN@EXAMPLE.COM", "db": mock_db})
+    response = await admin_get_user_edit("admin%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "ADMIN@EXAMPLE.COM", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     body = response.body.decode()
     # Administrator checkbox should NOT be present (case-insensitive match)
@@ -8575,7 +8575,7 @@ async def test_admin_update_user_self_demotion_blocked(monkeypatch, mock_db, all
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # Self-edit should succeed with admin status preserved
-    response = await admin_update_user("admin%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("admin%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 200
     # Verify update_user was called with is_admin=True (preserved from DB)
     auth_service.update_user.assert_called_once()
@@ -8596,7 +8596,7 @@ async def test_admin_update_user_self_demotion_case_insensitive(monkeypatch, moc
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # Self-edit with different case should still preserve admin status
-    response = await admin_update_user("admin%40example.com", request=request, db=mock_db, _user={"email": "ADMIN@EXAMPLE.COM", "db": mock_db})
+    response = await admin_update_user("admin%40example.com", request=request, db=mock_db, current_user_ctx={"email": "ADMIN@EXAMPLE.COM", "db": mock_db})
     assert response.status_code == 200
     auth_service.update_user.assert_called_once()
     call_kwargs = auth_service.update_user.call_args[1]
@@ -8618,7 +8618,7 @@ async def test_admin_update_user_can_demote_others(monkeypatch, mock_db, allow_p
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # Admin demoting another user (should succeed)
-    response = await admin_update_user("other%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("other%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 200
     assert response.headers.get("HX-Trigger") is not None
 
@@ -8637,7 +8637,7 @@ async def test_admin_update_user_self_can_update_other_fields(monkeypatch, mock_
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # User updating their own name; admin status preserved from DB
-    response = await admin_update_user("admin%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("admin%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 200
     assert response.headers.get("HX-Trigger") is not None
     # Verify admin status was preserved
@@ -9142,7 +9142,7 @@ async def test_get_overview_partial_error_returns_html(monkeypatch, mock_request
 
 @pytest.mark.asyncio
 async def test_get_configuration_settings_masks_sensitive(mock_db, allow_permission):
-    result = await get_configuration_settings(_db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    result = await get_configuration_settings(_db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert "Basic Settings" in result["groups"]
     assert result["groups"]["Authentication & Security"]["basic_auth_password"] == settings.masked_auth_value
 
@@ -9151,14 +9151,14 @@ async def test_get_configuration_settings_masks_sensitive(mock_db, allow_permiss
 async def test_get_configuration_settings_masks_sensitive_plain_string(monkeypatch, mock_db, allow_permission):
     """Cover masking branch for non-SecretStr sensitive values."""
     monkeypatch.setattr(settings, "basic_auth_password", "plain-text")
-    result = await get_configuration_settings(_db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    result = await get_configuration_settings(_db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert result["groups"]["Authentication & Security"]["basic_auth_password"] == settings.masked_auth_value
 
 
 @pytest.mark.asyncio
 async def test_get_configuration_settings_does_not_mask_empty_sensitive_values(monkeypatch, mock_db, allow_permission):
     monkeypatch.setattr(settings, "basic_auth_password", "")
-    result = await get_configuration_settings(_db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    result = await get_configuration_settings(_db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert result["groups"]["Authentication & Security"]["basic_auth_password"] == ""
 
 
@@ -11487,7 +11487,7 @@ class TestAdminAdditionalCoverage:
     async def test_admin_get_user_edit_disabled_and_not_found(self, monkeypatch, mock_request, mock_db, allow_permission):
         """Cover disabled email auth and user-not-found branches."""
         monkeypatch.setattr(settings, "email_auth_enabled", False)
-        response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+        response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
         assert response.status_code == 403
 
         monkeypatch.setattr(settings, "email_auth_enabled", True)
@@ -11495,7 +11495,7 @@ class TestAdminAdditionalCoverage:
         auth_service.get_user_by_email = AsyncMock(return_value=None)
         monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-        response = await admin_get_user_edit("missing%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+        response = await admin_get_user_edit("missing%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
         assert response.status_code == 404
 
     async def test_admin_list_a2a_agents_enabled(self, monkeypatch, mock_db):
@@ -11794,24 +11794,24 @@ async def test_cache_invalidation_endpoints(monkeypatch, mock_db, allow_permissi
     cache.stats.return_value = {"hits": 1}
     monkeypatch.setattr("mcpgateway.admin.global_config_cache", cache)
 
-    result = await _unwrap(invalidate_passthrough_headers_cache)(_user={"email": "user@example.com", "db": mock_db})
+    result = await _unwrap(invalidate_passthrough_headers_cache)(current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert result["status"] == "invalidated"
     assert result["cache_stats"]["hits"] == 1
     assert cache.invalidate.called
 
-    stats = await _unwrap(get_passthrough_headers_cache_stats)(_user={"email": "user@example.com", "db": mock_db})
+    stats = await _unwrap(get_passthrough_headers_cache_stats)(current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert stats["hits"] == 1
 
     a2a_cache = MagicMock()
     a2a_cache.stats.return_value = {"hits": 2}
     monkeypatch.setattr("mcpgateway.admin.a2a_stats_cache", a2a_cache)
 
-    result = await _unwrap(invalidate_a2a_stats_cache)(_user={"email": "user@example.com", "db": mock_db})
+    result = await _unwrap(invalidate_a2a_stats_cache)(current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert result["status"] == "invalidated"
     assert result["cache_stats"]["hits"] == 2
     assert a2a_cache.invalidate.called
 
-    stats = await _unwrap(get_a2a_stats_cache_stats)(_user={"email": "user@example.com", "db": mock_db})
+    stats = await _unwrap(get_a2a_stats_cache_stats)(current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert stats["hits"] == 2
 
 
@@ -11821,19 +11821,19 @@ async def test_get_mcp_session_pool_metrics_paths(monkeypatch, mock_db, allow_pe
     request.client = SimpleNamespace(host="10.0.0.1")
 
     monkeypatch.setattr(settings, "mcp_session_pool_enabled", False)
-    result = await get_mcp_session_pool_metrics(request=request, _user={"email": "user@example.com", "db": mock_db})
+    result = await get_mcp_session_pool_metrics(request=request, current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert result["enabled"] is False
 
     monkeypatch.setattr(settings, "mcp_session_pool_enabled", True)
     pool = MagicMock()
     pool.get_metrics.return_value = {"hits": 1, "misses": 0}
     monkeypatch.setattr("mcpgateway.admin.get_mcp_session_pool", lambda: pool)
-    result = await get_mcp_session_pool_metrics(request=request, _user={"email": "user@example.com", "db": mock_db})
+    result = await get_mcp_session_pool_metrics(request=request, current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert result["enabled"] is True
     assert result["hits"] == 1
 
     monkeypatch.setattr("mcpgateway.admin.get_mcp_session_pool", lambda: (_ for _ in ()).throw(RuntimeError("not ready")))
-    result = await get_mcp_session_pool_metrics(request=request, _user={"email": "user@example.com", "db": mock_db})
+    result = await get_mcp_session_pool_metrics(request=request, current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert result["enabled"] is True
     assert result["message"] == "Pool not yet initialized"
 
@@ -12480,7 +12480,7 @@ async def test_admin_get_user_edit_with_password_requirements(monkeypatch, mock_
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="a@example.com", full_name="A", is_admin=False, is_email_verified=lambda: False))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert "Password Requirements" in response.body.decode()
 
@@ -12493,7 +12493,7 @@ async def test_admin_get_user_edit_has_error_display(monkeypatch, mock_request, 
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="a@example.com", full_name="A", is_admin=False, is_email_verified=lambda: False))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_get_user_edit("a%40example.com", mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     body = response.body.decode()
 
@@ -12517,7 +12517,7 @@ async def test_admin_update_user_errors_include_retarget_header(monkeypatch, moc
     auth_service.get_user_by_email = AsyncMock(side_effect=RuntimeError("Test error"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await admin_update_user("a%40example.com", request=request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
     assert response.headers.get("HX-Retarget") == "#edit-user-error", "Generic error should include HX-Retarget header"
 
@@ -12529,7 +12529,7 @@ async def test_admin_update_user_errors_include_retarget_header(monkeypatch, moc
     auth_service2.is_last_active_admin = AsyncMock(return_value=True)
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service2)
 
-    response2 = await admin_update_user("a%40example.com", request=request2, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response2 = await admin_update_user("a%40example.com", request=request2, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response2.status_code == 400
     assert "last remaining admin" in response2.body.decode()
     assert response2.headers.get("HX-Retarget") == "#edit-user-error", "Admin protection error should include HX-Retarget header"
@@ -12740,7 +12740,7 @@ async def test_catalog_partial(monkeypatch, mock_request, mock_db):
     mock_get_catalog = AsyncMock(side_effect=[response_page, response_all])
     monkeypatch.setattr("mcpgateway.admin.catalog_service.get_catalog_servers", mock_get_catalog)
 
-    response = await catalog_partial(mock_request, category="Dev", auth_type="api_key", search=None, page=1, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+    response = await catalog_partial(mock_request, category="Dev", auth_type="api_key", search=None, page=1, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     template_call = mock_request.app.state.templates.TemplateResponse.call_args
     stats = template_call[0][2]["stats"]
@@ -12752,7 +12752,7 @@ async def test_catalog_partial(monkeypatch, mock_request, mock_db):
 async def test_catalog_partial_disabled_raises_404(monkeypatch, mock_request, mock_db):
     monkeypatch.setattr(settings, "mcpgateway_catalog_enabled", False)
     with pytest.raises(HTTPException) as excinfo:
-        await catalog_partial(mock_request, category=None, auth_type=None, search=None, page=1, db=mock_db, _user={"email": "u@example.com", "db": mock_db})
+        await catalog_partial(mock_request, category=None, auth_type=None, search=None, page=1, db=mock_db, current_user_ctx={"email": "u@example.com", "db": mock_db})
     assert excinfo.value.status_code == 404
 
 
@@ -12787,7 +12787,7 @@ async def test_get_observability_traces_with_filters(monkeypatch, mock_request, 
         name_search="trace",
         attribute_search="attr",
         tool_name="tool",
-        _user={"email": "admin@example.com", "db": mock_db},
+        current_user_ctx={"email": "admin@example.com", "db": mock_db},
     )
 
     assert isinstance(response, HTMLResponse)
@@ -12810,7 +12810,7 @@ async def test_get_top_slow_endpoints(monkeypatch, mock_db):
     mock_db.query.return_value = _mock_top_query_result(row)
     monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_db]))
 
-    result = await get_top_slow_endpoints(request=MagicMock(), hours=1, limit=5, _user={"email": "admin@example.com", "db": mock_db})
+    result = await get_top_slow_endpoints(request=MagicMock(), hours=1, limit=5, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert result["endpoints"][0]["avg_duration_ms"] == 12.34
 
 
@@ -12820,7 +12820,7 @@ async def test_get_top_volume_endpoints(monkeypatch, mock_db):
     mock_db.query.return_value = _mock_top_query_result(row)
     monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_db]))
 
-    result = await get_top_volume_endpoints(request=MagicMock(), hours=1, limit=5, _user={"email": "admin@example.com", "db": mock_db})
+    result = await get_top_volume_endpoints(request=MagicMock(), hours=1, limit=5, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert result["endpoints"][0]["avg_duration_ms"] == 0
 
 
@@ -12830,7 +12830,7 @@ async def test_get_top_error_endpoints(monkeypatch, mock_db):
     mock_db.query.return_value = _mock_top_query_result(row)
     monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_db]))
 
-    result = await get_top_error_endpoints(request=MagicMock(), hours=1, limit=5, _user={"email": "admin@example.com", "db": mock_db})
+    result = await get_top_error_endpoints(request=MagicMock(), hours=1, limit=5, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert result["endpoints"][0]["error_rate"] == 50.0
 
 
@@ -13157,7 +13157,7 @@ async def test_admin_test_gateway_oauth_authorization_code_missing_user_email(mo
     """Cover the 401 branch when OAuth auth-code flow requires a user email."""
     gateway = SimpleNamespace(id="gw-1", name="GW", auth_type="oauth", oauth_config={"grant_type": "authorization_code"})
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
-    monkeypatch.setattr("mcpgateway.admin.get_user_email", lambda _user: "", raising=True)
+    monkeypatch.setattr("mcpgateway.admin.get_user_email", lambda current_user_ctx: "", raising=True)
     monkeypatch.setattr("mcpgateway.services.token_storage_service.TokenStorageService", lambda _db: MagicMock(), raising=True)
 
     request = GatewayTestRequest(base_url="https://api.example.com", path="/test", method="GET", headers={}, body=None)
@@ -13659,7 +13659,7 @@ async def test_get_gateways_section_exception_returns_500(monkeypatch, mock_db, 
 async def test_get_performance_stats_paths(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "mcpgateway_performance_tracking", False)
     mock_request.headers = {"hx-request": "true"}
-    response = await get_performance_stats(mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await get_performance_stats(mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
 
     monkeypatch.setattr(settings, "mcpgateway_performance_tracking", True)
@@ -13677,11 +13677,11 @@ async def test_get_performance_stats_paths(monkeypatch, mock_request, mock_db, a
     monkeypatch.setattr("mcpgateway.admin.get_performance_service", lambda db: service)
 
     mock_request.headers = {"hx-request": "true"}
-    response = await get_performance_stats(mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await get_performance_stats(mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
 
     mock_request.headers = {}
-    response = await get_performance_stats(mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+    response = await get_performance_stats(mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert response.media_type == "application/json"
 
 
@@ -13691,7 +13691,7 @@ async def test_get_performance_stats_disabled_non_htmx_raises_404(monkeypatch, m
     monkeypatch.setattr(settings, "mcpgateway_performance_tracking", False)
     mock_request.headers = {}
     with pytest.raises(HTTPException) as excinfo:
-        await get_performance_stats(mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+        await get_performance_stats(mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert excinfo.value.status_code == 404
 
 
@@ -13706,7 +13706,7 @@ async def test_get_performance_stats_exception_raises_500(monkeypatch, mock_requ
 
     mock_request.headers = {}
     with pytest.raises(HTTPException) as excinfo:
-        await get_performance_stats(mock_request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
+        await get_performance_stats(mock_request, db=mock_db, current_user_ctx={"email": "admin@example.com", "db": mock_db})
     assert excinfo.value.status_code == 500
 
 
@@ -14500,13 +14500,13 @@ async def test_get_performance_endpoints(monkeypatch, allow_permission):
     user = {"email": "u@example.com", "db": db}
     request = MagicMock(spec=Request)
 
-    result = await get_tool_performance(request=request, hours=24, limit=5, _user=user)
+    result = await get_tool_performance(request=request, hours=24, limit=5, current_user_ctx=user)
     assert result["tools"]
 
-    result = await get_prompt_performance(request=request, hours=24, limit=5, _user=user)
+    result = await get_prompt_performance(request=request, hours=24, limit=5, current_user_ctx=user)
     assert result["prompts"]
 
-    result = await get_resource_performance(request=request, hours=24, limit=5, _user=user)
+    result = await get_resource_performance(request=request, hours=24, limit=5, current_user_ctx=user)
     assert result["resources"]
 
 
@@ -16295,7 +16295,7 @@ class TestCatalogEndpoints:
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_catalog_enabled", False, raising=False)
         request = MagicMock(spec=Request)
         with pytest.raises(HTTPException) as exc_info:
-            await list_catalog_servers(request, db=mock_db, _user={"email": "admin@test.com"})
+            await list_catalog_servers(request, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16305,7 +16305,7 @@ class TestCatalogEndpoints:
         monkeypatch.setattr("mcpgateway.admin.catalog_service.get_catalog_servers", AsyncMock(return_value=mock_result))
 
         request = MagicMock(spec=Request)
-        result = await list_catalog_servers(request, tags=[], db=mock_db, _user={"email": "admin@test.com"})
+        result = await list_catalog_servers(request, tags=[], db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result == mock_result
 
     @pytest.mark.asyncio
@@ -16313,7 +16313,7 @@ class TestCatalogEndpoints:
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_catalog_enabled", False, raising=False)
         request = MagicMock(spec=Request)
         with pytest.raises(HTTPException) as exc_info:
-            await register_catalog_server("srv-1", request, db=mock_db, _user={"email": "admin@test.com"})
+            await register_catalog_server("srv-1", request, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16324,7 +16324,7 @@ class TestCatalogEndpoints:
 
         request = MagicMock(spec=Request)
         request.headers = {}
-        result = await register_catalog_server("srv-1", request, db=mock_db, _user={"email": "admin@test.com"})
+        result = await register_catalog_server("srv-1", request, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result == reg_result
 
     @pytest.mark.asyncio
@@ -16335,7 +16335,7 @@ class TestCatalogEndpoints:
 
         request = MagicMock(spec=Request)
         request.headers = {"HX-Request": "true"}
-        result = await register_catalog_server("srv-1", request, db=mock_db, _user={"email": "admin@test.com"})
+        result = await register_catalog_server("srv-1", request, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert isinstance(result, HTMLResponse)
         assert "Registered Successfully" in result.body.decode()
 
@@ -16343,7 +16343,7 @@ class TestCatalogEndpoints:
     async def test_check_catalog_server_status_disabled(self, monkeypatch, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_catalog_enabled", False, raising=False)
         with pytest.raises(HTTPException) as exc_info:
-            await check_catalog_server_status("srv-1", _db=mock_db, _user={"email": "admin@test.com"})
+            await check_catalog_server_status("srv-1", _db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16352,7 +16352,7 @@ class TestCatalogEndpoints:
         status = SimpleNamespace(available=True, response_time=0.1)
         monkeypatch.setattr("mcpgateway.admin.catalog_service.check_server_availability", AsyncMock(return_value=status))
 
-        result = await check_catalog_server_status("srv-1", _db=mock_db, _user={"email": "admin@test.com"})
+        result = await check_catalog_server_status("srv-1", _db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result.available is True
 
     @pytest.mark.asyncio
@@ -16363,7 +16363,7 @@ class TestCatalogEndpoints:
 
         req = CatalogBulkRegisterRequest(server_ids=["a", "b"])
         with pytest.raises(HTTPException) as exc_info:
-            await bulk_register_catalog_servers(req, db=mock_db, _user={"email": "admin@test.com"})
+            await bulk_register_catalog_servers(req, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16376,7 +16376,7 @@ class TestCatalogEndpoints:
         from mcpgateway.schemas import CatalogBulkRegisterRequest
 
         req = CatalogBulkRegisterRequest(server_ids=["a", "b"])
-        result = await bulk_register_catalog_servers(req, db=mock_db, _user={"email": "admin@test.com"})
+        result = await bulk_register_catalog_servers(req, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result == bulk_result
 
 
@@ -16396,7 +16396,7 @@ class TestObservability:
         request.app.state.templates = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = HTMLResponse("<html>Obs</html>")
 
-        result = await get_observability_partial(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        result = await get_observability_partial(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         assert isinstance(result, HTMLResponse)
         request.app.state.templates.TemplateResponse.assert_called_once()
 
@@ -16408,7 +16408,7 @@ class TestObservability:
         request.app.state.templates = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = HTMLResponse("<html>Metrics</html>")
 
-        result = await get_observability_metrics_partial(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        result = await get_observability_metrics_partial(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         assert isinstance(result, HTMLResponse)
 
     @pytest.mark.asyncio
@@ -16431,7 +16431,7 @@ class TestObservability:
         request.app.state.templates = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = HTMLResponse("<html>Stats</html>")
 
-        result = await get_observability_stats(request, hours=24, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_observability_stats(request, hours=24, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert isinstance(result, HTMLResponse)
 
     @pytest.mark.asyncio
@@ -16449,7 +16449,7 @@ class TestObservability:
         request.app.state.templates = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = HTMLResponse("<html>Detail</html>")
 
-        result = await get_observability_trace_detail(request, trace_id="abc-123", _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_observability_trace_detail(request, trace_id="abc-123", current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert isinstance(result, HTMLResponse)
 
     @pytest.mark.asyncio
@@ -16462,7 +16462,7 @@ class TestObservability:
 
         request = MagicMock(spec=Request)
         with pytest.raises(HTTPException) as exc_info:
-            await get_observability_trace_detail(request, trace_id="missing", _user={"email": "admin@test.com"}, db=mock_session)
+            await get_observability_trace_detail(request, trace_id="missing", current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16558,7 +16558,7 @@ class TestPerformanceEndpoints:
     async def test_get_performance_system_disabled(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_performance_tracking", False, raising=False)
         with pytest.raises(HTTPException) as exc_info:
-            await get_performance_system(db=mock_db, _user={"email": "admin@test.com"})
+            await get_performance_system(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16570,14 +16570,14 @@ class TestPerformanceEndpoints:
         mock_service.get_system_metrics.return_value = mock_metrics
         monkeypatch.setattr("mcpgateway.admin.get_performance_service", lambda db: mock_service)
 
-        result = await get_performance_system(db=mock_db, _user={"email": "admin@test.com"})
+        result = await get_performance_system(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result["cpu"] == 30.0
 
     @pytest.mark.asyncio
     async def test_get_performance_workers_disabled(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_performance_tracking", False, raising=False)
         with pytest.raises(HTTPException) as exc_info:
-            await get_performance_workers(db=mock_db, _user={"email": "admin@test.com"})
+            await get_performance_workers(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16589,7 +16589,7 @@ class TestPerformanceEndpoints:
         mock_service.get_worker_metrics.return_value = [mock_worker]
         monkeypatch.setattr("mcpgateway.admin.get_performance_service", lambda db: mock_service)
 
-        result = await get_performance_workers(db=mock_db, _user={"email": "admin@test.com"})
+        result = await get_performance_workers(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert len(result) == 1
         assert result[0]["pid"] == 1234
 
@@ -16597,7 +16597,7 @@ class TestPerformanceEndpoints:
     async def test_get_performance_requests_disabled(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_performance_tracking", False, raising=False)
         with pytest.raises(HTTPException) as exc_info:
-            await get_performance_requests(db=mock_db, _user={"email": "admin@test.com"})
+            await get_performance_requests(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16609,14 +16609,14 @@ class TestPerformanceEndpoints:
         mock_service.get_request_metrics.return_value = mock_metrics
         monkeypatch.setattr("mcpgateway.admin.get_performance_service", lambda db: mock_service)
 
-        result = await get_performance_requests(db=mock_db, _user={"email": "admin@test.com"})
+        result = await get_performance_requests(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result["total"] == 1000
 
     @pytest.mark.asyncio
     async def test_get_performance_cache_disabled(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_performance_tracking", False, raising=False)
         with pytest.raises(HTTPException) as exc_info:
-            await get_performance_cache(db=mock_db, _user={"email": "admin@test.com"})
+            await get_performance_cache(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16628,14 +16628,14 @@ class TestPerformanceEndpoints:
         mock_service.get_cache_metrics = AsyncMock(return_value=mock_metrics)
         monkeypatch.setattr("mcpgateway.admin.get_performance_service", lambda db: mock_service)
 
-        result = await get_performance_cache(db=mock_db, _user={"email": "admin@test.com"})
+        result = await get_performance_cache(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert result["hits"] == 500
 
     @pytest.mark.asyncio
     async def test_get_performance_history_disabled(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_performance_tracking", False, raising=False)
         with pytest.raises(HTTPException) as exc_info:
-            await get_performance_history(db=mock_db, _user={"email": "admin@test.com"})
+            await get_performance_history(db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -16647,7 +16647,7 @@ class TestPerformanceEndpoints:
         mock_service.get_history = AsyncMock(return_value=mock_history)
         monkeypatch.setattr("mcpgateway.admin.get_performance_service", lambda db: mock_service)
 
-        result = await get_performance_history(period_type="hourly", hours=24, db=mock_db, _user={"email": "admin@test.com"})
+        result = await get_performance_history(period_type="hourly", hours=24, db=mock_db, current_user_ctx={"email": "admin@test.com"})
         assert "periods" in result
 
 
@@ -16671,7 +16671,7 @@ class TestMaintenanceMisc:
         request.app.state.templates = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = HTMLResponse("<html>Maintenance</html>")
 
-        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        result = await get_maintenance_partial(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         assert isinstance(result, HTMLResponse)
         request.app.state.templates.TemplateResponse.assert_called_once()
 
@@ -16822,7 +16822,7 @@ class TestMaintenanceMisc:
         mock_tool_service.subscribe_events = MagicMock(return_value=AsyncMock().__aiter__())
         monkeypatch.setattr("mcpgateway.admin.ToolService", lambda: mock_tool_service)
 
-        result = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        result = await admin_events(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         assert isinstance(result, StreamingResponse)
 
     @pytest.mark.asyncio
@@ -16846,7 +16846,7 @@ class TestMaintenanceMisc:
         monkeypatch.setattr("mcpgateway.admin.gateway_service.subscribe_events", lambda: gw_events())
         monkeypatch.setattr("mcpgateway.admin.tool_service.subscribe_events", lambda: tool_events())
 
-        response = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        response = await admin_events(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         assert isinstance(response, StreamingResponse)
 
         chunks = []
@@ -16874,7 +16874,7 @@ class TestMaintenanceMisc:
         monkeypatch.setattr("mcpgateway.admin.gateway_service.subscribe_events", lambda: bad_events())
         monkeypatch.setattr("mcpgateway.admin.tool_service.subscribe_events", lambda: tool_events())
 
-        response = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        response = await admin_events(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         chunks = [chunk async for chunk in response.body_iterator]
         assert chunks
 
@@ -16902,7 +16902,7 @@ class TestMaintenanceMisc:
 
         monkeypatch.setattr("mcpgateway.admin.asyncio.wait_for", fake_wait_for, raising=True)
 
-        response = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        response = await admin_events(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         chunks = [chunk async for chunk in response.body_iterator]
         assert chunks
         first = chunks[0].decode() if isinstance(chunks[0], (bytes, bytearray)) else chunks[0]
@@ -16931,7 +16931,7 @@ class TestMaintenanceMisc:
 
         monkeypatch.setattr("mcpgateway.admin.asyncio.wait_for", fake_wait_for, raising=True)
 
-        response = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        response = await admin_events(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         with pytest.raises(asyncio.CancelledError):
             async for _ in response.body_iterator:
                 pass
@@ -16956,7 +16956,7 @@ class TestMaintenanceMisc:
         monkeypatch.setattr("mcpgateway.admin.gateway_service.subscribe_events", lambda: gw_events())
         monkeypatch.setattr("mcpgateway.admin.tool_service.subscribe_events", lambda: tool_events())
 
-        response = await admin_events(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        response = await admin_events(request, current_user_ctx={"email": "admin@test.com"}, _db=mock_db)
         chunks = [chunk async for chunk in response.body_iterator]
         assert chunks == []
         assert logger.error.called
@@ -17101,7 +17101,7 @@ class TestToolUsageErrorsChains:
         row = SimpleNamespace(tool_name="my_tool", count=10)
         session = _make_obs_session(monkeypatch, [row])
         request = MagicMock(spec=Request)
-        result = await get_tool_usage(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=session)
+        result = await get_tool_usage(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=session)
         assert result["total_invocations"] == 10
         assert result["tools"][0]["tool_name"] == "my_tool"
 
@@ -17109,7 +17109,7 @@ class TestToolUsageErrorsChains:
     async def test_get_tool_usage_empty(self, monkeypatch, allow_permission):
         session = _make_obs_session(monkeypatch, [])
         request = MagicMock(spec=Request)
-        result = await get_tool_usage(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=session)
+        result = await get_tool_usage(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=session)
         assert result["total_invocations"] == 0
         assert result["tools"] == []
 
@@ -17118,7 +17118,7 @@ class TestToolUsageErrorsChains:
         row = SimpleNamespace(tool_name="bad_tool", total_count=100, error_count=5)
         session = _make_obs_session(monkeypatch, [row])
         request = MagicMock(spec=Request)
-        result = await get_tool_errors(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=session)
+        result = await get_tool_errors(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=session)
         assert result["tools"][0]["tool_name"] == "bad_tool"
         assert result["tools"][0]["error_rate"] == 5.0
 
@@ -17126,7 +17126,7 @@ class TestToolUsageErrorsChains:
     async def test_get_tool_errors_empty(self, monkeypatch, allow_permission):
         session = _make_obs_session(monkeypatch, [])
         request = MagicMock(spec=Request)
-        result = await get_tool_errors(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=session)
+        result = await get_tool_errors(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=session)
         assert result["tools"] == []
 
     @pytest.mark.asyncio
@@ -17145,7 +17145,7 @@ class TestToolUsageErrorsChains:
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
 
         request = MagicMock(spec=Request)
-        result = await get_tool_chains(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_tool_chains(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["total_traces_with_tools"] == 1
         assert len(result["chains"]) == 1
         assert result["chains"][0]["chain"] == "toolA -> toolB"
@@ -17162,7 +17162,7 @@ class TestToolUsageErrorsChains:
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
 
         request = MagicMock(spec=Request)
-        result = await get_tool_chains(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_tool_chains(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["chains"] == []
 
 
@@ -17174,7 +17174,7 @@ class TestPromptResourceUsageErrors:
         row = SimpleNamespace(prompt_id="p1", count=5)
         session = _make_obs_session(monkeypatch, [row])
         request = MagicMock(spec=Request)
-        result = await get_prompt_usage(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=session)
+        result = await get_prompt_usage(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=session)
         assert result["total_renders"] == 5
         assert result["prompts"][0]["prompt_id"] == "p1"
 
@@ -17191,7 +17191,7 @@ class TestPromptResourceUsageErrors:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
 
-        result = await get_prompts_errors(hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_prompts_errors(hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["prompts"][0]["prompt_id"] == "p1"
         assert result["prompts"][0]["error_rate"] == 4.0
 
@@ -17200,7 +17200,7 @@ class TestPromptResourceUsageErrors:
         row = SimpleNamespace(resource_uri="r1", count=8)
         session = _make_obs_session(monkeypatch, [row])
         request = MagicMock(spec=Request)
-        result = await get_resource_usage(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=session)
+        result = await get_resource_usage(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=session)
         assert result["total_fetches"] == 8
         assert result["resources"][0]["resource_uri"] == "r1"
 
@@ -17217,7 +17217,7 @@ class TestPromptResourceUsageErrors:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
 
-        result = await get_resources_errors(hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_resources_errors(hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["resources"][0]["resource_uri"] == "r1"
         assert result["resources"][0]["error_rate"] == 10.0
 
@@ -17257,7 +17257,7 @@ class TestObservabilityExceptionHandlers:
 
         request = MagicMock(spec=Request)
         with pytest.raises(HTTPException) as excinfo:
-            await endpoint(request, _user={"email": "admin@test.com", "db": session}, db=session, **kwargs)
+            await endpoint(request, current_user_ctx={"email": "admin@test.com", "db": session}, db=session, **kwargs)
         assert excinfo.value.status_code == 500
 
 
@@ -17306,7 +17306,7 @@ class TestLatencyPercentiles:
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
 
         request = MagicMock(spec=Request)
-        result = await get_latency_percentiles(request, hours=24, interval_minutes=60, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_latency_percentiles(request, hours=24, interval_minutes=60, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"timestamps": [], "p50": [], "p90": [], "p95": [], "p99": []}
 
     @pytest.mark.asyncio
@@ -17321,7 +17321,7 @@ class TestLatencyPercentiles:
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
 
         request = MagicMock(spec=Request)
-        result = await get_latency_percentiles(request, hours=24, interval_minutes=60, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_latency_percentiles(request, hours=24, interval_minutes=60, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"timestamps": [], "p50": [], "p90": [], "p95": [], "p99": []}
 
 
@@ -17374,7 +17374,7 @@ class TestTimeseriesMetrics:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_timeseries_metrics(request, hours=24, interval_minutes=60, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_timeseries_metrics(request, hours=24, interval_minutes=60, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"timestamps": [], "request_count": [], "success_count": [], "error_count": [], "error_rate": []}
 
     @pytest.mark.asyncio
@@ -17388,7 +17388,7 @@ class TestTimeseriesMetrics:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_timeseries_metrics(request, hours=24, interval_minutes=60, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_timeseries_metrics(request, hours=24, interval_minutes=60, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"timestamps": [], "request_count": [], "success_count": [], "error_count": [], "error_rate": []}
 
 
@@ -17454,7 +17454,7 @@ class TestLatencyHeatmap:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_latency_heatmap(request, hours=24, time_buckets=10, latency_buckets=5, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_latency_heatmap(request, hours=24, time_buckets=10, latency_buckets=5, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"time_labels": [], "latency_labels": [], "data": []}
 
     @pytest.mark.asyncio
@@ -17469,7 +17469,7 @@ class TestLatencyHeatmap:
         monkeypatch.setattr("mcpgateway.admin._get_latency_heatmap_postgresql", lambda *_args, **_kwargs: {"ok": True})
 
         request = MagicMock(spec=Request)
-        result = await get_latency_heatmap(request, hours=24, time_buckets=10, latency_buckets=5, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_latency_heatmap(request, hours=24, time_buckets=10, latency_buckets=5, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"ok": True}
 
 
@@ -17484,7 +17484,7 @@ class TestTopEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_top_slow_endpoints(request, hours=24, limit=10, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_top_slow_endpoints(request, hours=24, limit=10, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"endpoints": []}
 
     @pytest.mark.asyncio
@@ -17501,7 +17501,7 @@ class TestTopEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_top_slow_endpoints(request, hours=24, limit=10, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_top_slow_endpoints(request, hours=24, limit=10, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert len(result["endpoints"]) == 1
         ep = result["endpoints"][0]
         assert ep["endpoint"] == "GET /api/tools"
@@ -17516,7 +17516,7 @@ class TestTopEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_top_volume_endpoints(request, hours=24, limit=10, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_top_volume_endpoints(request, hours=24, limit=10, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"endpoints": []}
 
     @pytest.mark.asyncio
@@ -17532,7 +17532,7 @@ class TestTopEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_top_volume_endpoints(request, hours=24, limit=10, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_top_volume_endpoints(request, hours=24, limit=10, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert len(result["endpoints"]) == 1
         assert result["endpoints"][0]["count"] == 1000
 
@@ -17544,7 +17544,7 @@ class TestTopEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_top_error_endpoints(request, hours=24, limit=10, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_top_error_endpoints(request, hours=24, limit=10, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result == {"endpoints": []}
 
     @pytest.mark.asyncio
@@ -17560,7 +17560,7 @@ class TestTopEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_top_error_endpoints(request, hours=24, limit=10, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_top_error_endpoints(request, hours=24, limit=10, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert len(result["endpoints"]) == 1
         ep = result["endpoints"][0]
         assert ep["error_count"] == 25
@@ -17594,7 +17594,7 @@ class TestObservabilityTraces:
             name_search=None,
             attribute_search=None,
             tool_name=None,
-            _user={"email": "admin@test.com"},
+            current_user_ctx={"email": "admin@test.com"},
             db=mock_session,
         )
         assert result == template_resp
@@ -17627,7 +17627,7 @@ class TestObservabilityTraces:
             name_search=None,
             attribute_search=None,
             tool_name=None,
-            _user={"email": "admin@test.com"},
+            current_user_ctx={"email": "admin@test.com"},
             db=mock_session,
         )
         assert result == template_resp
@@ -17642,7 +17642,7 @@ class TestObservabilityPartials:
         request.scope = {"root_path": ""}
         template_resp = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = template_resp
-        result = await get_tools_partial(request, _user={"email": "admin@test.com"}, _db=MagicMock())
+        result = await get_tools_partial(request, current_user_ctx={"email": "admin@test.com"}, _db=MagicMock())
         assert result == template_resp
 
     @pytest.mark.asyncio
@@ -17651,7 +17651,7 @@ class TestObservabilityPartials:
         request.scope = {"root_path": ""}
         template_resp = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = template_resp
-        result = await get_prompts_partial(request, _user={"email": "admin@test.com"}, _db=MagicMock())
+        result = await get_prompts_partial(request, current_user_ctx={"email": "admin@test.com"}, _db=MagicMock())
         assert result == template_resp
 
     @pytest.mark.asyncio
@@ -17660,7 +17660,7 @@ class TestObservabilityPartials:
         request.scope = {"root_path": ""}
         template_resp = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = template_resp
-        result = await get_resources_partial(request, _user={"email": "admin@test.com"}, _db=MagicMock())
+        result = await get_resources_partial(request, current_user_ctx={"email": "admin@test.com"}, _db=MagicMock())
         assert result == template_resp
 
 
@@ -17676,7 +17676,7 @@ class TestToolPromptResourcePerformanceEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_tool_performance(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_tool_performance(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["tools"] == []
         assert result["time_range_hours"] == 24
 
@@ -17689,7 +17689,7 @@ class TestToolPromptResourcePerformanceEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_prompt_performance(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_prompt_performance(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["prompts"] == []
         assert result["time_range_hours"] == 24
 
@@ -17702,7 +17702,7 @@ class TestToolPromptResourcePerformanceEndpoints:
         mock_session.close = MagicMock()
         monkeypatch.setattr("mcpgateway.admin.get_db", lambda: iter([mock_session]))
         request = MagicMock(spec=Request)
-        result = await get_resource_performance(request, hours=24, limit=20, _user={"email": "admin@test.com"}, db=mock_session)
+        result = await get_resource_performance(request, hours=24, limit=20, current_user_ctx={"email": "admin@test.com"}, db=mock_session)
         assert result["resources"] == []
         assert result["time_range_hours"] == 24
 

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -335,7 +335,7 @@ async def test_global_passthrough_headers_endpoints(monkeypatch):
     monkeypatch.setattr(admin.global_config_cache, "get_passthrough_headers", lambda *_args: ["X-Test"])
 
     get_func = _unwrap(admin.get_global_passthrough_headers)
-    result = await get_func(db, _user={"email": "user@example.com"})
+    result = await get_func(db, current_user_ctx={"email": "user@example.com"})
     assert result.passthrough_headers == ["X-Test"]
 
     invalidate_called = []
@@ -344,14 +344,14 @@ async def test_global_passthrough_headers_endpoints(monkeypatch):
     config_update = admin.GlobalConfigUpdate(passthrough_headers=["X-New"])
     update_func = _unwrap(admin.update_global_passthrough_headers)
     db.query.return_value.first.return_value = None
-    update_result = await update_func(MagicMock(), config_update, db, _user={"email": "user@example.com"})
+    update_result = await update_func(MagicMock(), config_update, db, current_user_ctx={"email": "user@example.com"})
     assert update_result.passthrough_headers == ["X-New"]
     assert invalidate_called
 
     stats = {"hits": 1}
     monkeypatch.setattr(admin.global_config_cache, "stats", lambda: stats)
     invalidate_func = _unwrap(admin.invalidate_passthrough_headers_cache)
-    cache_result = await invalidate_func(_user={"email": "user@example.com"})
+    cache_result = await invalidate_func(current_user_ctx={"email": "user@example.com"})
     assert cache_result["status"] == "invalidated"
     assert cache_result["cache_stats"] == stats
 
@@ -369,7 +369,7 @@ async def test_update_global_passthrough_headers_errors(monkeypatch):
 
     db.commit.side_effect = IntegrityError("stmt", {}, None)
     with pytest.raises(admin.HTTPException) as excinfo:
-        await update_func(MagicMock(), config_update, db, _user={"email": "user@example.com"})
+        await update_func(MagicMock(), config_update, db, current_user_ctx={"email": "user@example.com"})
     assert excinfo.value.status_code == 409
     db.rollback.assert_called()
 
@@ -379,13 +379,13 @@ async def test_update_global_passthrough_headers_errors(monkeypatch):
 
     db.commit.side_effect = ValidationError.from_exception_data("test", [InitErrorDetails(type="missing", loc=("passthrough_headers",), input={})])
     with pytest.raises(admin.HTTPException) as excinfo:
-        await update_func(MagicMock(), config_update, db, _user={"email": "user@example.com"})
+        await update_func(MagicMock(), config_update, db, current_user_ctx={"email": "user@example.com"})
     assert excinfo.value.status_code == 422
     db.rollback.assert_called()
 
     db.commit.side_effect = PassthroughHeadersError("boom")
     with pytest.raises(admin.HTTPException) as excinfo:
-        await update_func(MagicMock(), config_update, db, _user={"email": "user@example.com"})
+        await update_func(MagicMock(), config_update, db, current_user_ctx={"email": "user@example.com"})
     assert excinfo.value.status_code == 500
 
 
@@ -1421,10 +1421,10 @@ async def test_admin_get_all_team_ids_admin_and_user(monkeypatch):
 
     class _StubAuthService:
         def __init__(self, _db):
-            self._user = None
+            self.current_user_ctx = None
 
         async def get_user_by_email(self, _email):
-            return self._user
+            return self.current_user_ctx
 
     auth_service = _StubAuthService(mock_db)
     team_service = _StubTeamService()
@@ -1433,12 +1433,12 @@ async def test_admin_get_all_team_ids_admin_and_user(monkeypatch):
     monkeypatch.setattr(admin, "EmailAuthService", lambda db: auth_service)
     _allow_permissions(monkeypatch)
 
-    auth_service._user = SimpleNamespace(is_admin=True)
+    auth_service.current_user_ctx = SimpleNamespace(is_admin=True)
     result = await admin.admin_get_all_team_ids(include_inactive=True, visibility=None, q=None, db=mock_db, user={"email": "admin@example.com"})
     assert result["team_ids"] == ["team-1", "team-2"]
     assert result["count"] == 2
 
-    auth_service._user = SimpleNamespace(is_admin=False)
+    auth_service.current_user_ctx = SimpleNamespace(is_admin=False)
     result = await admin.admin_get_all_team_ids(include_inactive=False, visibility="public", q="alp", db=mock_db, user={"email": "user@example.com"})
     assert result["team_ids"] == ["team-3"]
     assert result["count"] == 1
@@ -1481,10 +1481,10 @@ async def test_admin_search_teams_admin_and_user(monkeypatch):
 
     class _StubAuthService:
         def __init__(self, _db):
-            self._user = None
+            self.current_user_ctx = None
 
         async def get_user_by_email(self, _email):
-            return self._user
+            return self.current_user_ctx
 
     auth_service = _StubAuthService(mock_db)
     team_service = _StubTeamService()
@@ -1493,13 +1493,13 @@ async def test_admin_search_teams_admin_and_user(monkeypatch):
     monkeypatch.setattr(admin, "EmailAuthService", lambda db: auth_service)
     _allow_permissions(monkeypatch)
 
-    auth_service._user = SimpleNamespace(is_admin=True)
+    auth_service.current_user_ctx = SimpleNamespace(is_admin=True)
     result = await admin.admin_search_teams(q="alp", include_inactive=False, limit=10, visibility=None, db=mock_db, user={"email": "admin@example.com"})
     assert result == [
         {"id": "t-1", "name": "Alpha", "slug": "alpha", "description": "desc", "visibility": "public", "is_active": True}
     ]
 
-    auth_service._user = SimpleNamespace(is_admin=False)
+    auth_service.current_user_ctx = SimpleNamespace(is_admin=False)
     result = await admin.admin_search_teams(q="be", include_inactive=False, limit=10, visibility="public", db=mock_db, user={"email": "user@example.com"})
     assert result == [
         {"id": "t-2", "name": "Beta", "slug": "beta", "description": "desc", "visibility": "public", "is_active": True}

--- a/tests/unit/mcpgateway/test_admin_observability_sql.py
+++ b/tests/unit/mcpgateway/test_admin_observability_sql.py
@@ -337,7 +337,7 @@ class TestToolUsageStatistics:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_tool_usage(mock_request, hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_tool_usage(mock_request, hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "tools" in result
         assert result["tools"][0]["tool_name"] == "test_tool"
@@ -379,7 +379,7 @@ class TestToolErrorStatistics:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_tool_errors(mock_request, hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_tool_errors(mock_request, hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "tools" in result
         assert result["tools"][0]["tool_name"] == "test_tool"
@@ -425,7 +425,7 @@ class TestToolChains:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_tool_chains(mock_request, hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_tool_chains(mock_request, hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "chains" in result
         assert len(result["chains"]) > 0
@@ -466,7 +466,7 @@ class TestPromptStatistics:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_prompt_usage(mock_request, hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_prompt_usage(mock_request, hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "prompts" in result
         assert result["prompts"][0]["prompt_id"] == "test_prompt"
@@ -502,7 +502,7 @@ class TestPromptStatistics:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_prompts_errors(hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_prompts_errors(hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "prompts" in result
 
@@ -542,7 +542,7 @@ class TestResourceStatistics:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_resource_usage(mock_request, hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_resource_usage(mock_request, hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "resources" in result
         assert result["resources"][0]["resource_uri"] == "file:///test.txt"
@@ -578,6 +578,6 @@ class TestResourceStatistics:
         with patch("mcpgateway.admin.get_db", return_value=iter([mock_db])):
             with patch("mcpgateway.admin.get_current_user_with_permissions", return_value=mock_user):
                 import asyncio
-                result = asyncio.run(get_resources_errors(hours=24, limit=20, _user=mock_user))
+                result = asyncio.run(get_resources_errors(hours=24, limit=20, current_user_ctx=mock_user))
 
         assert "resources" in result

--- a/tests/unit/mcpgateway/test_final_coverage_push.py
+++ b/tests/unit/mcpgateway/test_final_coverage_push.py
@@ -480,7 +480,7 @@ async def test_toolops_generate_testcases_success(monkeypatch):
         number_of_nl_variations=1,
         mode="generate",
         db=MagicMock(),
-        _user={"email": "user@example.com"},
+        current_user_ctx={"email": "user@example.com"},
     )
 
     assert result == [{"case": 1}]
@@ -507,7 +507,7 @@ async def test_toolops_generate_testcases_invalid_json(monkeypatch):
             number_of_nl_variations=1,
             mode="generate",
             db=MagicMock(),
-            _user={"email": "user@example.com"},
+            current_user_ctx={"email": "user@example.com"},
         )
 
     assert exc.value.status_code == 400
@@ -531,7 +531,7 @@ async def test_toolops_execute_nl_testcases_success(monkeypatch):
         monkeypatch,
         tool_nl_test_input=payload,
         db=MagicMock(),
-        _user={"email": "user@example.com"},
+        current_user_ctx={"email": "user@example.com"},
     )
 
     assert result == ["ok"]
@@ -558,7 +558,7 @@ async def test_toolops_enrich_tool_success(monkeypatch):
         monkeypatch,
         tool_id="tool1",
         db=MagicMock(),
-        _user={"email": "user@example.com"},
+        current_user_ctx={"email": "user@example.com"},
     )
 
     assert result["tool_id"] == "tool1"
@@ -583,7 +583,7 @@ async def test_toolops_enrich_tool_error(monkeypatch):
             monkeypatch,
             tool_id="tool1",
             db=MagicMock(),
-            _user={"email": "user@example.com"},
+            current_user_ctx={"email": "user@example.com"},
         )
 
     assert exc.value.status_code == 400

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -1539,7 +1539,7 @@ class TestServerEndpointCoverage:
         db = MagicMock()
         tool = SimpleNamespace(to_dict=lambda **_kwargs: {"id": "tool-1"})
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", [], False))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=tool))
 
@@ -1601,7 +1601,7 @@ class TestServerEndpointCoverage:
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "tool-1"}
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, True))
         list_tools = AsyncMock(return_value=[tool])
         monkeypatch.setattr("mcpgateway.main.tool_service.list_server_tools", list_tools)
 
@@ -1617,7 +1617,7 @@ class TestServerEndpointCoverage:
         resource = MagicMock()
         resource.model_dump.return_value = {"id": "res-1"}
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, False))
         list_resources = AsyncMock(return_value=[resource])
         monkeypatch.setattr("mcpgateway.main.resource_service.list_server_resources", list_resources)
 
@@ -1633,7 +1633,7 @@ class TestServerEndpointCoverage:
         prompt = MagicMock()
         prompt.model_dump.return_value = {"id": "prompt-1"}
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, False))
         list_prompts = AsyncMock(return_value=[prompt])
         monkeypatch.setattr("mcpgateway.main.prompt_service.list_server_prompts", list_prompts)
 
@@ -1646,7 +1646,7 @@ class TestServerEndpointCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id="team-1")
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", ["team-1"], False))
 
         response = await list_resources(
             request,
@@ -1664,7 +1664,7 @@ class TestServerEndpointCoverage:
         resource = MagicMock()
         resource.model_dump.return_value = {"id": "res-1"}
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, True))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
             AsyncMock(return_value=([resource], "next-cursor")),
@@ -1688,7 +1688,7 @@ class TestServerEndpointCoverage:
         resource = MagicMock()
         resource.model_dump.return_value = {"id": "res-1"}
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, True))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
             AsyncMock(return_value=([resource], None)),
@@ -1709,7 +1709,7 @@ class TestServerEndpointCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
 
-        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr("mcpgateway.main._get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, False))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
             AsyncMock(return_value=([], None)),
@@ -2336,7 +2336,7 @@ class TestSecurityHealthEndpoint:
     """Cover /health/security endpoint branches in main.py.
 
     The endpoint now requires admin auth via ``require_admin_auth`` dependency.
-    Tests call the handler directly with ``_user`` kwarg to simulate DI.
+    Tests call the handler directly with ``current_user_ctx`` kwarg to simulate DI.
     """
 
     @pytest.mark.asyncio
@@ -2359,7 +2359,7 @@ class TestSecurityHealthEndpoint:
             },
         )
 
-        result = await main_mod.security_health(request, _user="admin@example.com")
+        result = await main_mod.security_health(request, current_user_ctx="admin@example.com")
         assert result["status"] == "healthy"
         assert result["score"] == 80
         assert "warnings" not in result
@@ -2384,7 +2384,7 @@ class TestSecurityHealthEndpoint:
             },
         )
 
-        result = await main_mod.security_health(request, _user="admin@example.com")
+        result = await main_mod.security_health(request, current_user_ctx="admin@example.com")
         assert result["status"] == "healthy"
         assert result["warnings"] == ["w1"]
 
@@ -2408,7 +2408,7 @@ class TestSecurityHealthEndpoint:
             },
         )
 
-        result = await main_mod.security_health(request, _user="admin@example.com")
+        result = await main_mod.security_health(request, current_user_ctx="admin@example.com")
         assert result["status"] == "unhealthy"
         assert result["warnings"] == ["w1", "w2"]
 
@@ -2506,7 +2506,7 @@ class TestToolListEndpointCoverage:
         tool.model_dump.return_value = {"id": "tool-1"}
         list_tools_mock = AsyncMock(return_value=([tool], "next"))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", list_tools_mock)
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", ["team-1"], False))
 
         result = await main_mod.list_tools(
             request,
@@ -2537,7 +2537,7 @@ class TestToolListEndpointCoverage:
         list_tools_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", list_tools_mock)
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, True))
         await main_mod.list_tools(
             request,
             cursor=None,
@@ -2555,7 +2555,7 @@ class TestToolListEndpointCoverage:
         assert list_tools_mock.await_args.kwargs["user_email"] is None
         assert list_tools_mock.await_args.kwargs["token_teams"] is None
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, False))
         await main_mod.list_tools(
             request,
             cursor=None,
@@ -2580,7 +2580,7 @@ class TestToolListEndpointCoverage:
         request.state = SimpleNamespace(team_id="team-1")
         db = MagicMock()
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", ["team-1"], False))
         response = await main_mod.list_tools(
             request,
             cursor=None,
@@ -2613,7 +2613,7 @@ class TestPromptListEndpointCoverage:
         prompt.model_dump.return_value = {"id": "prompt-1"}
         list_prompts_mock = AsyncMock(return_value=([prompt], "next"))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts_mock)
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", ["team-1"], False))
 
         result = await main_mod.list_prompts(
             request,
@@ -2639,7 +2639,7 @@ class TestPromptListEndpointCoverage:
         request.state = SimpleNamespace(team_id="team-1")
         db = MagicMock()
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", ["team-1"], False))
         response = await main_mod.list_prompts(
             request,
             cursor=None,
@@ -3979,7 +3979,7 @@ class TestA2ABranchCoverage:
         svc = MagicMock()
         svc.invoke_agent = AsyncMock(return_value={"ok": True})
         monkeypatch.setattr(main_mod, "a2a_service", svc)
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, False))
         result = await main_mod.invoke_a2a_agent("agent", request, parameters={}, interaction_type="query", db=MagicMock(), user={"email": "user@example.com"})
         assert result["ok"] is True
         assert svc.invoke_agent.await_args.kwargs["token_teams"] == []
@@ -3995,7 +3995,7 @@ class TestA2ABranchCoverage:
         assert excinfo.value.status_code == 400
 
         # Cover user_id=str(user) branch by bypassing RBAC wrapper.
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, True))
         svc.invoke_agent = AsyncMock(return_value={"ok": True})
         result = await main_mod.invoke_a2a_agent.__wrapped__("agent", request, parameters={}, interaction_type="query", db=MagicMock(), user="basic-user")
         assert result["ok"] is True
@@ -4032,7 +4032,7 @@ class TestA2ABranchCoverage:
         svc.list_agents = AsyncMock(return_value=([agent], "next"))
         svc.get_agent = AsyncMock(side_effect=A2AAgentNotFoundError("missing"))
         monkeypatch.setattr(main_mod, "a2a_service", svc)
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", None, True))
 
         result = await main_mod.list_a2a_agents(
             request,
@@ -5834,7 +5834,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("user@example.com", [], False))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
         monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(return_value={"filtered": True}))
 
@@ -5930,11 +5930,11 @@ class TestRemainingCoverageGaps:
 
         monkeypatch.setattr(main_mod.resource_service, "list_resource_templates", AsyncMock(return_value=[]))
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", None, True))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("u", None, True))
         result = await main_mod.list_resource_templates.__wrapped__(request, db=MagicMock(), include_inactive=False, tags="a, b", visibility=None, user={"email": "u"})
         assert result.resource_templates == []
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", None, False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("u", None, False))
         result = await main_mod.list_resource_templates.__wrapped__(request, db=MagicMock(), include_inactive=False, tags=None, visibility=None, user={"email": "u"})
         assert result.resource_templates == []
 
@@ -5947,7 +5947,7 @@ class TestRemainingCoverageGaps:
         list_prompts = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts)
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", None, True))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("u", None, True))
         await main_mod.list_prompts.__wrapped__(
             request,
             cursor=None,
@@ -5963,7 +5963,7 @@ class TestRemainingCoverageGaps:
         assert list_prompts.call_args.kwargs["user_email"] is None
         assert list_prompts.call_args.kwargs["token_teams"] is None
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", None, False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("u", None, False))
         await main_mod.list_prompts.__wrapped__(
             request,
             cursor=None,
@@ -5992,7 +5992,7 @@ class TestRemainingCoverageGaps:
         prompt.model_dump.return_value = {"id": "p1"}
         monkeypatch.setattr(main_mod.prompt_service, "list_server_prompts", AsyncMock(return_value=[prompt]))
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", None, True))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("u", None, True))
         result = await main_mod.server_get_resources.__wrapped__(request, "srv", include_inactive=False, db=MagicMock(), user={"email": "u"})
         assert result == [{"id": "r1"}]
 
@@ -6136,7 +6136,7 @@ class TestRemainingCoverageGaps:
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("u", None, False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("u", None, False))
         monkeypatch.setattr(main_mod.tool_service, "list_server_tools", AsyncMock(return_value=[tool]))
 
         result = await main_mod.server_get_tools.__wrapped__(request, "srv", include_inactive=False, include_metrics=False, db=MagicMock(), user={"email": "u"})
@@ -6146,7 +6146,7 @@ class TestRemainingCoverageGaps:
         import mcpgateway.main as main_mod
 
         request = _make_request("/tags")
-        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _request, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _request, current_user_ctx: ("u", [], False))
 
         monkeypatch.setattr(main_mod.tag_service, "get_all_tags", AsyncMock(return_value=[]))
         _ = await main_mod.list_tags.__wrapped__(request, "Tools, Servers", include_entities=False, db=MagicMock(), user={"email": "u"})
@@ -6731,7 +6731,7 @@ async def test_protocol_completion_endpoint_direct_admin_null_teams_preserves_by
     db = object()
 
     monkeypatch.setattr(main_mod, "_read_request_json", AsyncMock(return_value=payload))
-    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("admin@example.com", None, True))
+    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("admin@example.com", None, True))
     completion_mock = AsyncMock(return_value={"result": "ok"})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -6753,7 +6753,7 @@ async def test_protocol_completion_endpoint_direct_non_admin_none_teams_becomes_
     db = object()
 
     monkeypatch.setattr(main_mod, "_read_request_json", AsyncMock(return_value=payload))
-    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("viewer@example.com", None, False))
+    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("viewer@example.com", None, False))
     completion_mock = AsyncMock(return_value={"result": "ok"})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -6779,7 +6779,7 @@ async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(mo
     db = MagicMock()
 
     monkeypatch.setattr(main_mod.settings, "mcpgateway_session_affinity_enabled", False)
-    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("admin@example.com", None, True))
+    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("admin@example.com", None, True))
     completion_mock = AsyncMock(return_value={"done": True})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -6805,7 +6805,7 @@ async def test_handle_rpc_completion_direct_non_admin_none_teams_becomes_public_
     db = MagicMock()
 
     monkeypatch.setattr(main_mod.settings, "mcpgateway_session_affinity_enabled", False)
-    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, _user: ("viewer@example.com", None, False))
+    monkeypatch.setattr(main_mod, "_get_rpc_filter_context", lambda _req, current_user_ctx: ("viewer@example.com", None, False))
     completion_mock = AsyncMock(return_value={"done": True})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 

--- a/tests/unit/mcpgateway/test_toolops_altk_service.py
+++ b/tests/unit/mcpgateway/test_toolops_altk_service.py
@@ -220,7 +220,7 @@ async def test_execute_tool_nl_testcases_json_decode_error_maps_to_http_400(monk
         await router.execute_tool_nl_testcases(
             router.ToolNLTestInput(tool_id="tool-1", tool_nl_test_cases=["ping"]),
             db=MagicMock(),
-            _user={"email": "test@example.com"},
+            current_user_ctx={"email": "test@example.com"},
         )
 
     assert exc_info.value.status_code == 400


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #2505 

---

## 📝 Summary
_What does this PR do and why?_
Standardizes user context parameter naming across the codebase by replacing `_user` with `current_user_ctx`.

This change updates function signatures, internal usage, and RBAC decorator checks to ensure consistent naming and avoid ambiguity when passing user context.

Additionally, minor pylint adjustments were added where required to prevent unused argument warnings.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |  pass     |
| Unit tests                | `make test`     |  pass     |
| Coverage ≥ 80%            | `make coverage` |    pass   |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
