### PR TITLE
fix(ui): clean z-index structure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -103,10 +103,11 @@ recursive-include plugins_rust *.toml
 recursive-include plugins_rust *.md
 recursive-include plugins_rust *.py
 recursive-include plugins_rust *.pyi
-recursive-include plugins_rust *.lock
+recursive-include plugins_rust *.json
 recursive-include plugins_rust Makefile
-exclude plugins_rust/Cargo.lock
+include plugins_rust/*/Cargo.lock
 prune plugins_rust/target
+recursive-exclude plugins_rust/*/target *
 
 # 5️⃣  (Optional) include MKDocs-based docs in the sdist
 # graft docs

--- a/mcpgateway/static/admin.css
+++ b/mcpgateway/static/admin.css
@@ -3,12 +3,6 @@
     /* Panels handle their own internal padding */
 }
 
-/* Sidebar navigation */
-.sidebar-nav {
-    position: relative;
-    z-index: 50;
-    flex-shrink: 0;
-}
 
 /* Sidebar scrollbar */
 .sidebar-scroll {
@@ -56,17 +50,6 @@
     padding-bottom: 0.25rem;
 }
 
-/* Mobile sidebar overlay */
-@media (width <=1023px) {
-    .sidebar-nav {
-        position: fixed;
-        top: 0;
-        left: 0;
-        height: 100vh;
-        z-index: 60;
-        box-shadow: 4px 0 6px -1px rgb(0 0 0 / 10%);
-    }
-}
 
 /* CodeMirror code example styling (for LLM API Info) */
 .code-example {
@@ -116,41 +99,6 @@
     /* Ensures it behaves like a block-level element */
 }
 
-/* CSS for the tooltip */
-.tooltip {
-    position: fixed;
-    z-index: 9999;
-    background-color: #1f2937;
-
-    /* Tailwind's gray-800 */
-    color: white;
-    font-size: 0.875rem;
-
-    /* text-sm */
-    border-radius: 0.5rem;
-
-    /* Increased rounded corners */
-    padding: 0.75rem 1rem;
-
-    /* More padding */
-    pointer-events: none;
-    opacity: 0;
-    transform: scale(0.8);
-
-    /* Tooltip starts slightly smaller */
-    transition:
-        transform 0.2s ease,
-        opacity 0.3s ease;
-
-    /* Added smooth transition */
-}
-
-.tooltip.show {
-    opacity: 1;
-    transform: scale(1);
-
-    /* Scales up smoothly */
-}
 
 @keyframes spin {
     0% {
@@ -170,10 +118,6 @@
   display: none;
 }
 
-/* Modal z-index to prevent sticky header overlap */
-.fixed.z-10 {
-    z-index: 9999 !important;
-}
 
 /* ===== LLM Chat — Toolbar-based layout with maximized chat area ===== */
 

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -4847,7 +4847,7 @@ async function runResourceTest() {
             e.stopPropagation();
         };
         overlay.className =
-            "fixed inset-0 bg-black bg-opacity-70 z-[9999] flex items-center justify-center p-4";
+            "fixed inset-0 bg-black bg-opacity-70 z-40 flex items-center justify-center p-4";
 
         const box = document.createElement("div");
         box.onclick = (e) => {
@@ -17403,7 +17403,7 @@ function setupTooltipsWithAlpine() {
                 tooltipEl.textContent = text;
                 tooltipEl.setAttribute("role", "tooltip");
                 tooltipEl.className =
-                    "fixed z-50 max-w-xs px-3 py-2 text-sm text-white bg-black/80 rounded-lg shadow-lg pointer-events-none opacity-0 transition-opacity duration-200";
+                    "fixed z-30 max-w-xs px-3 py-2 text-sm text-white bg-black/80 rounded-lg shadow-lg pointer-events-none opacity-0 transition-opacity duration-200";
 
                 document.body.appendChild(tooltipEl);
 
@@ -21735,7 +21735,7 @@ function showCopyableModal(title, message, type = "info") {
     const overlay = document.createElement("div");
     overlay.id = "copyable-modal-overlay";
     overlay.className =
-        "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50";
+        "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-40";
     overlay.onclick = (e) => {
         if (e.target === overlay) {
             overlay.remove();
@@ -22705,7 +22705,7 @@ async function createToken(form) {
 function showTokenCreatedModal(tokenData) {
     const modal = document.createElement("div");
     modal.className =
-        "fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50";
+        "fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-40";
     modal.innerHTML = `
         <div class="relative top-20 mx-auto p-5 border w-11/12 max-w-lg shadow-lg rounded-md bg-white dark:bg-gray-800">
             <div class="mt-3">
@@ -22947,7 +22947,7 @@ async function viewTokenUsage(tokenId) {
 function showUsageStatsModal(stats) {
     const modal = document.createElement("div");
     modal.className =
-        "fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50";
+        "fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-40";
     modal.innerHTML = `
         <div class="relative top-20 mx-auto p-5 border w-11/12 max-w-2xl shadow-lg rounded-md bg-white dark:bg-gray-800">
             <div class="flex items-center justify-between mb-4">
@@ -23100,7 +23100,7 @@ function showTokenDetailsModal(token) {
 
     const modal = document.createElement("div");
     modal.className =
-        "fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50";
+        "fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-40";
     modal.innerHTML = `
         <div class="relative top-10 mx-auto p-5 border w-11/12 max-w-2xl shadow-lg rounded-md bg-white dark:bg-gray-800 mb-10">
             <div class="flex items-center justify-between mb-4">
@@ -26353,16 +26353,11 @@ async function loadVirtualServersForChat() {
                     ${
                         requiresToken
                             ? `
-                        <div class="tooltip"
-                        style="position: absolute; left: 50%; transform: translateX(-50%); bottom: 120%; margin-bottom: 8px;
-                                background-color: #6B7280; color: white; font-size: 10px; border-radius: 4px;
-                                padding: 4px 20px; /* More horizontal width */
-                                opacity: 0; visibility: hidden; transition: opacity 0.2s ease-in;
-                                z-index: 1000;"> <!-- Added higher z-index to ensure it's above other elements -->
+                        <div data-role="tooltip"
+                             class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 bg-gray-500 text-white text-[10px] rounded py-1 px-5 z-30 transition-opacity duration-200 ease-in pointer-events-none"
+                             style="opacity: 0; visibility: hidden;">
                         ${tooltipMessage}
-                        <div style="position: absolute; left: 50%; bottom: -5px; transform: translateX(-50%);
-                                    width: 0; height: 0; border-left: 5px solid transparent;
-                                    border-right: 5px solid transparent; border-top: 5px solid #6B7280;"></div>
+                        <div class="absolute left-1/2 -translate-x-1/2 -bottom-[5px] w-0 h-0 border-l-[5px] border-r-[5px] border-t-[5px] border-l-transparent border-r-transparent border-t-gray-500"></div>
                         </div>`
                             : ""
                     }
@@ -26386,7 +26381,7 @@ async function loadVirtualServersForChat() {
         // Add hover event to show tooltip immediately on hover
         const serverItems = document.querySelectorAll(".server-item");
         serverItems.forEach((item) => {
-            const tooltip = item.querySelector(".tooltip");
+            const tooltip = item.querySelector('[data-role="tooltip"]');
             item.addEventListener("mouseenter", () => {
                 if (tooltip) {
                     tooltip.style.opacity = "1"; // Make tooltip visible

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -31042,7 +31042,7 @@ function generateStatusBadgeHtml(enabled, reachable, typeLabel) {
                 Inactive
                 <svg class="ml-1 h-4 w-4 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M6.293 6.293a1 1 0 011.414 0L10 8.586l2.293-2.293a1 1 0 111.414 1.414L11.414 10l2.293 2.293a1 1 0 11-1.414 1.414L10 11.414l-2.293 2.293a1 1 0 11-1.414-1.414L8.586 10 6.293 7.707a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
             </span>
-            <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">💡${label} is Manually Deactivated</div>
+            <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow">💡${label} is Manually Deactivated</div>
         </div>`;
     } else if (!reachable) {
         // CASE 2: Offline (Enabled but Unreachable/Health Check Failed) -> YELLOW
@@ -31052,7 +31052,7 @@ function generateStatusBadgeHtml(enabled, reachable, typeLabel) {
                 Offline
                 <svg class="ml-1 h-4 w-4 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-10h2v4h-2V8zm0 6h2v2h-2v-2z" clip-rule="evenodd"/></svg>
             </span>
-            <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">💡${label} is Not Reachable (Health Check Failed)</div>
+            <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow">💡${label} is Not Reachable (Health Check Failed)</div>
         </div>`;
     } else {
         // CASE 3: Active (Enabled and Reachable) -> GREEN
@@ -31062,7 +31062,7 @@ function generateStatusBadgeHtml(enabled, reachable, typeLabel) {
                 Active
                 <svg class="ml-1 h-4 w-4 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-4.586l5.293-5.293-1.414-1.414L9 11.586 7.121 9.707 5.707 11.121 9 14.414z" clip-rule="evenodd"/></svg>
             </span>
-            <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">💡${label} is Active</div>
+            <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow">💡${label} is Active</div>
         </div>`;
     }
 }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -427,7 +427,7 @@
       <div
         x-show="sidebarOpen"
         @click="sidebarOpen = false"
-        class="fixed inset-0 bg-gray-900/50 z-40 lg:hidden"
+        class="fixed inset-0 bg-gray-900/50 z-10 lg:hidden"
         x-transition:enter="transition-opacity ease-linear duration-300"
         x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100"
@@ -440,7 +440,7 @@
       <!-- Sidebar -->
       <aside
         id="sidebar"
-        class="sidebar-nav flex flex-col bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transition-all duration-300"
+        class="relative z-20 shrink-0 max-lg:fixed max-lg:top-0 max-lg:left-0 max-lg:h-screen max-lg:shadow-[4px_0_6px_-1px_rgb(0_0_0/10%)] flex flex-col bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transition-all duration-300"
         :class="{
           'w-64': !sidebarCollapsed,
           'w-16': sidebarCollapsed,
@@ -888,7 +888,7 @@
                   x-transition:leave="transition ease-in duration-75"
                   x-transition:leave-start="transform opacity-100 scale-100"
                   x-transition:leave-end="transform opacity-0 scale-95"
-                  class="origin-top-right absolute right-0 mt-2 w-72 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 z-50"
+                  class="origin-top-right absolute right-0 mt-2 w-72 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 z-30"
                   role="menu"
                   aria-orientation="vertical"
                   aria-labelledby="team-selector-button"
@@ -980,7 +980,7 @@
         </div>
 
         <!-- Global Search Modal -->
-        <div id="global-search-modal" class="fixed inset-0 z-50 hidden" aria-hidden="true">
+        <div id="global-search-modal" class="fixed inset-0 z-40 hidden" aria-hidden="true">
           <div class="absolute inset-0 bg-black/40" onclick="closeGlobalSearchModal()"></div>
           <div class="relative max-w-3xl mx-auto mt-24 px-4">
             <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl overflow-hidden">
@@ -1740,7 +1740,7 @@
                       x-transition:leave="transition ease-in duration-75"
                       x-transition:leave-start="transform opacity-100 scale-100"
                       x-transition:leave-end="transform opacity-0 scale-95"
-                      class="absolute left-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-50 max-h-96 overflow-hidden flex flex-col"
+                      class="absolute left-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-30 max-h-96 overflow-hidden flex flex-col"
                       style="display: none">
                       <!-- Dropdown Header -->
                       <div
@@ -1803,7 +1803,7 @@
                       x-transition:leave="transition ease-in duration-75"
                       x-transition:leave-start="transform opacity-100 scale-100"
                       x-transition:leave-end="transform opacity-0 scale-95" id="llm-config-form"
-                      class="absolute left-0 mt-2 w-[600px] bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-50 p-4"
+                      class="absolute left-0 mt-2 w-[600px] bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-30 p-4"
                       style="display: none">
                       <form id="llm-chat-config-form" class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <!-- Model Selection -->
@@ -1868,7 +1868,7 @@
 
                       <!-- Enhanced tooltip card -->
                       <div
-                        class="absolute left-1/2 -translate-x-1/2 top-full mt-3 hidden group-hover:block w-80 z-50 animate-fade-in">
+                        class="absolute left-1/2 -translate-x-1/2 top-full mt-3 hidden group-hover:block w-80 z-30 animate-fade-in">
                         <div
                           class="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border-2 border-blue-200 dark:border-blue-700 p-4">
                           <!-- Header -->
@@ -2100,7 +2100,7 @@
         </div>
 
         <!-- Add/Edit Provider Modal -->
-        <div id="llm-provider-modal" class="fixed inset-0 z-50 hidden overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div id="llm-provider-modal" class="fixed inset-0 z-40 hidden overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
           <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="closeLLMProviderModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
@@ -2198,7 +2198,7 @@
         </div>
 
         <!-- Add/Edit Model Modal -->
-        <div id="llm-model-modal" class="fixed inset-0 z-50 hidden overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div id="llm-model-modal" class="fixed inset-0 z-40 hidden overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
           <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="closeLLMModelModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
@@ -2327,7 +2327,7 @@
         <!-- API Key Modal -->
         <div
           id="api-key-modal"
-          class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50"
+          class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-40"
         >
           <div
             class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white"
@@ -3586,7 +3586,7 @@
               <!-- Dropdown Menu -->
               <div
                 id="bulk-import-dropdown"
-                class="hidden absolute right-0 mt-2 w-96 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg z-50"
+                class="hidden absolute right-0 mt-2 w-96 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg z-30"
               >
                 <div class="p-4">
                   <!-- Information Section -->
@@ -4299,7 +4299,7 @@
       </div>
 
       <!-- Bulk Import Modal -->
-      <div id="bulk-import-modal" class="fixed inset-0 z-[60] hidden">
+      <div id="bulk-import-modal" class="fixed inset-0 z-40 hidden">
         <div
           id="bulk-import-backdrop"
           class="absolute inset-0 bg-black/50"
@@ -8143,7 +8143,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
 
       <!-- Modals -->
       <!-- Tool Detail Modal -->
-      <div id="tool-modal" class="fixed z-10 inset-0 overflow-y-auto hidden">
+      <div id="tool-modal" class="fixed z-40 inset-0 overflow-y-auto hidden">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
         >
@@ -8181,7 +8181,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
       <!-- New Modal: Test Case Generation -->
 <div
 id="testcase-gen-modal"
-class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
+class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
 >
 <div
   class="bg-white dark:bg-gray-900 w-full max-w-md rounded-lg shadow-lg p-6"
@@ -8259,7 +8259,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 
 <div
 id="bulk-testcase-gen-modal"
-class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
+class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
 >
 <div
   class="bg-white dark:bg-gray-900 w-full max-w-md rounded-lg shadow-lg p-6"
@@ -8339,7 +8339,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 <!-- View Description Modal -->
 <div
   id="description-view-modal"
-  class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
+  class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
 >
   <div
     class="bg-white dark:bg-gray-900 w-full max-w-3xl rounded-lg shadow-lg p-6"
@@ -8400,7 +8400,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
   </div>
 </div>
 
-      <div id="tool-validation-modal" class="fixed inset-0 hidden z-50 overflow-y-auto bg-black bg-opacity-50">
+      <div id="tool-validation-modal" class="fixed inset-0 hidden z-40 overflow-y-auto bg-black bg-opacity-50">
     <div
       class="relative bg-white dark:bg-gray-900 w-full max-w-3xl mx-auto my-10 rounded-lg shadow-lg p-6"
     >
@@ -8442,7 +8442,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Tool Test Modal -->
       <div
         id="tool-test-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -8534,7 +8534,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Tool Edit Modal -->
       <div
         id="tool-edit-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -8894,7 +8894,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Resource Detail Modal -->
       <div
         id="resource-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -8936,7 +8936,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Resource Test Modal -->
       <div
         id="resource-test-modal"
-        class="fixed z-50 inset-0 hidden overflow-y-auto"
+        class="fixed z-40 inset-0 hidden overflow-y-auto"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -9025,7 +9025,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Resource Edit Modal -->
       <div
         id="resource-edit-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -9209,7 +9209,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       </div>
 
       <!-- Prompt Detail Modal -->
-      <div id="prompt-modal" class="fixed z-10 inset-0 overflow-y-auto hidden">
+      <div id="prompt-modal" class="fixed z-40 inset-0 overflow-y-auto hidden">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
         >
@@ -9248,7 +9248,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Prompt Edit Modal -->
       <div
         id="prompt-edit-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -9436,7 +9436,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Prompt Test Modal -->
       <div
         id="prompt-test-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -9540,7 +9540,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       </div>
 
       <!-- Gateway Detail Modal -->
-      <div id="gateway-modal" class="fixed z-10 inset-0 overflow-y-auto hidden">
+      <div id="gateway-modal" class="fixed z-40 inset-0 overflow-y-auto hidden">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
         >
@@ -9579,7 +9579,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Test Gateway Modal -->
       <div
         id="gateway-test-modal"
-        class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
+        class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
       >
         <div
           class="bg-white dark:bg-gray-900 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg shadow-lg p-6"
@@ -9732,7 +9732,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Gateway Edit Modal -->
       <div
         id="gateway-edit-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden">
+        class="fixed z-40 inset-0 overflow-y-auto hidden">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
         >
@@ -10289,7 +10289,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       </div>
 
       <!-- A2A Agent Edit Modal -->
-       <div id="a2a-edit-modal" class="fixed z-10 inset-0 overflow-y-auto hidden">
+       <div id="a2a-edit-modal" class="fixed z-40 inset-0 overflow-y-auto hidden">
           <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
             <div class="fixed inset-0 transition-opacity pointer-events-none" aria-hidden="true">
               <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
@@ -10820,7 +10820,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 
 
       <!-- Server Detail Modal -->
-      <div id="server-modal" class="fixed z-10 inset-0 overflow-y-auto hidden">
+      <div id="server-modal" class="fixed z-40 inset-0 overflow-y-auto hidden">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
         >
@@ -10859,7 +10859,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Server Edit Modal -->
       <div
         id="server-edit-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -11413,7 +11413,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       </div>
 
       <!-- Agent Detail Modal -->
-      <div id="agent-modal" class="fixed z-10 inset-0 overflow-y-auto hidden">
+      <div id="agent-modal" class="fixed z-40 inset-0 overflow-y-auto hidden">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
         >
@@ -11452,7 +11452,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- A2A Agent Test Modal -->
       <div
         id="a2a-test-modal"
-        class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
+        class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center hidden"
       >
         <div
           class="bg-white dark:bg-gray-900 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg shadow-lg p-6"
@@ -11527,7 +11527,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Config Selection Modal -->
       <div
         id="config-selection-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -11618,7 +11618,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Config Display Modal -->
       <div
         id="config-display-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -11703,7 +11703,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Root Details Modal -->
       <div
         id="root-details-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -11743,7 +11743,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       <!-- Root Edit Modal -->
       <div
         id="root-edit-modal"
-        class="fixed z-10 inset-0 overflow-y-auto hidden"
+        class="fixed z-40 inset-0 overflow-y-auto hidden"
       >
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -13001,7 +13001,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
             // Create a modal to show available files
             const modal = document.createElement("div");
             modal.className =
-              "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50";
+              "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-40";
             modal.innerHTML = `
               <div class="bg-white rounded-lg p-6 max-w-md w-full max-h-96 overflow-y-auto">
                 <h3 class="text-lg font-bold mb-4">Available Log Files</h3>
@@ -14050,7 +14050,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
     <!-- Bulk Import Modal -->
     <div
       id="bulk-import-modal-2"
-      class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full hidden z-50"
+      class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full hidden z-40"
     >
       <div
         class="relative top-20 mx-auto p-5 border w-11/12 md:w-3/4 lg:w-1/2 shadow-lg rounded-md bg-white dark:bg-gray-800"
@@ -14442,7 +14442,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
     </div>
 
     <!-- User Edit Modal -->
-    <div id="user-edit-modal" class="fixed inset-0 z-50 hidden">
+    <div id="user-edit-modal" class="fixed inset-0 z-40 hidden">
       <div
         class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
       >
@@ -14466,7 +14466,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
     </div>
 
     <!-- Create Team Modal -->
-    <div id="create-team-modal" class="fixed inset-0 z-50 hidden">
+    <div id="create-team-modal" class="fixed inset-0 z-40 hidden">
       <div
         class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
       >
@@ -14646,7 +14646,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
     </div>
 
     <!-- Team Edit Modal -->
-    <div id="team-edit-modal" class="fixed inset-0 z-50 hidden">
+    <div id="team-edit-modal" class="fixed inset-0 z-40 hidden">
       <div
         class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
       >
@@ -14672,7 +14672,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
     </div>
 
     <!-- Team Join Requests Modal -->
-    <div id="team-join-requests-modal" class="fixed inset-0 z-50 hidden">
+    <div id="team-join-requests-modal" class="fixed inset-0 z-40 hidden">
       <div
         class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
       >
@@ -14721,7 +14721,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
 
     {% if is_admin %}
     <!-- User Invitation Modal -->
-    <div id="invite-user-modal" class="fixed inset-0 z-50 hidden">
+    <div id="invite-user-modal" class="fixed inset-0 z-40 hidden">
       <div
         class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
       >
@@ -14838,7 +14838,7 @@ class="fixed z-50 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
     </div>
 
     <!-- Role Assignment Modal -->
-    <div id="role-assignment-modal" class="fixed inset-0 z-50 hidden">
+    <div id="role-assignment-modal" class="fixed inset-0 z-40 hidden">
       <div
         class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
       >

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5234,7 +5234,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         {% endif %}
                       </span>
                       <div
-                        class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow"
+                        class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow"
                       >
                         {% if not enabled %} 💡Gateway is Manually Deactivated
                         {% elif not reachable %} 💡Gateway is Not Reachable {%

--- a/mcpgateway/templates/tools_partial.html
+++ b/mcpgateway/templates/tools_partial.html
@@ -202,7 +202,7 @@
               <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium w-fit {% if enabled and reachable %}bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200{% elif enabled %}bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200{% else %}bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200{% endif %}">
                 {% if enabled and reachable %}● Online{% elif enabled %}● Offline{% else %}● Inactive{% endif %}
               </span>
-              <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">
+              <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow">
                 {% if not enabled %}Tool is Manually Deactivated{% elif not reachable %}Gateway unreachable{% else %}Everything stable{% endif %}
               </div>
             </div>

--- a/mcpgateway/templates/tools_with_pagination.html
+++ b/mcpgateway/templates/tools_with_pagination.html
@@ -103,7 +103,7 @@
               </svg>
             {% endif %}
           </span>
-          <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">
+          <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow">
             {% if not enabled %} 💡Tool is Manually Deactivated. {%
             elif not reachable %} 💡The host gateway for this tool
             is unreachable. {% else %} 💡Everything stable. {% endif
@@ -266,7 +266,7 @@
               </svg>
             {% endif %}
           </span>
-          <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-10 whitespace-nowrap shadow">
+          <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded py-1 px-2 z-30 whitespace-nowrap shadow">
             {% if not enabled %} 💡Tool is Manually Deactivated. {%
             elif not reachable %} 💡The host gateway for this tool
             is unreachable. {% else %} 💡Everything stable. {% endif

--- a/tests/js/admin-zindex.test.js
+++ b/tests/js/admin-zindex.test.js
@@ -80,24 +80,39 @@ describe("modal z-index hierarchy", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tooltip setup uses z-30 (below modals, above sidebar)
+// Status badge tooltips must use z-30 (below modals, above sidebar)
 // ---------------------------------------------------------------------------
-describe("tooltip z-index hierarchy", () => {
-    test("setupTooltipsWithAlpine creates tooltip elements with z-30", () => {
-        const trigger = doc.createElement("span");
-        trigger.setAttribute("data-tooltip", "Helpful tip");
-        doc.body.appendChild(trigger);
+describe("status badge tooltip z-index hierarchy", () => {
+    function parseBadgeHtml(html) {
+        // Use DOMParser to safely parse the generated markup (test-only).
+        const parsed = new win.DOMParser().parseFromString(html, "text/html");
+        return parsed.body;
+    }
 
-        win.setupTooltipsWithAlpine();
+    test("inactive badge tooltip uses z-30", () => {
+        const body = parseBadgeHtml(
+            win.generateStatusBadgeHtml(false, true, "gateway"),
+        );
+        const tooltip = body.querySelector(".group-hover\\:block");
+        expect(tooltip).not.toBeNull();
+        expect(tooltip.classList.contains("z-30")).toBe(true);
+    });
 
-        // Simulate mouseenter to create the tooltip
-        const mouseenterEvent = new win.Event("mouseenter");
-        trigger.dispatchEvent(mouseenterEvent);
+    test("offline badge tooltip uses z-30", () => {
+        const body = parseBadgeHtml(
+            win.generateStatusBadgeHtml(true, false, "gateway"),
+        );
+        const tooltip = body.querySelector(".group-hover\\:block");
+        expect(tooltip).not.toBeNull();
+        expect(tooltip.classList.contains("z-30")).toBe(true);
+    });
 
-        const tooltip = doc.querySelector('[role="tooltip"]');
-        if (tooltip) {
-            expect(tooltip.classList.contains("z-30")).toBe(true);
-            expect(tooltip.classList.contains("z-50")).toBe(false);
-        }
+    test("active badge tooltip uses z-30", () => {
+        const body = parseBadgeHtml(
+            win.generateStatusBadgeHtml(true, true, "gateway"),
+        );
+        const tooltip = body.querySelector(".group-hover\\:block");
+        expect(tooltip).not.toBeNull();
+        expect(tooltip.classList.contains("z-30")).toBe(true);
     });
 });

--- a/tests/js/admin-zindex.test.js
+++ b/tests/js/admin-zindex.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for z-index hierarchy in admin UI elements.
+ *
+ * Verifies the stacking order:
+ *   z-10  Sticky header / LLM toolbar
+ *   z-20  Sidebar
+ *   z-30  Dropdowns / tooltips
+ *   z-40  Modals
+ *   z-50  Toast notifications
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    beforeAll,
+    beforeEach,
+    afterAll,
+} from "vitest";
+import { loadAdminJs, cleanupAdminJs } from "./helpers/admin-env.js";
+
+let win;
+let doc;
+
+beforeAll(() => {
+    win = loadAdminJs();
+    doc = win.document;
+});
+
+afterAll(() => {
+    cleanupAdminJs();
+});
+
+beforeEach(() => {
+    doc.body.textContent = "";
+});
+
+// ---------------------------------------------------------------------------
+// Toast notifications must use z-50 (above modals at z-40)
+// ---------------------------------------------------------------------------
+describe("toast z-index hierarchy", () => {
+    test("showErrorMessage creates toast with z-50", () => {
+        win.showErrorMessage("error");
+        const el = doc.querySelector(".fixed.bg-red-600");
+        expect(el).not.toBeNull();
+        expect(el.classList.contains("z-50")).toBe(true);
+    });
+
+    test("showSuccessMessage creates toast with z-50", () => {
+        win.showSuccessMessage("success");
+        const el = doc.querySelector(".fixed.bg-green-600");
+        expect(el).not.toBeNull();
+        expect(el.classList.contains("z-50")).toBe(true);
+    });
+
+    test("showNotification creates toast with z-50", () => {
+        win.showNotification("info", "info");
+        const el = doc.querySelector(".fixed.z-50");
+        expect(el).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// JS-created modals must use z-40 (below toasts, above dropdowns)
+// ---------------------------------------------------------------------------
+describe("modal z-index hierarchy", () => {
+    test("showCopyableModal creates overlay with z-40", () => {
+        win.showCopyableModal("Title", "message", "info");
+        const overlay = doc.getElementById("copyable-modal-overlay");
+        expect(overlay).not.toBeNull();
+        expect(overlay.classList.contains("z-40")).toBe(true);
+        expect(overlay.classList.contains("z-50")).toBe(false);
+    });
+
+    test("showTokenCreatedModal creates modal with z-40", () => {
+        win.showTokenCreatedModal({ token: "tok_123", name: "test" });
+        const modals = doc.querySelectorAll(".fixed.inset-0.z-40");
+        expect(modals.length).toBeGreaterThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tooltip setup uses z-30 (below modals, above sidebar)
+// ---------------------------------------------------------------------------
+describe("tooltip z-index hierarchy", () => {
+    test("setupTooltipsWithAlpine creates tooltip elements with z-30", () => {
+        const trigger = doc.createElement("span");
+        trigger.setAttribute("data-tooltip", "Helpful tip");
+        doc.body.appendChild(trigger);
+
+        win.setupTooltipsWithAlpine();
+
+        // Simulate mouseenter to create the tooltip
+        const mouseenterEvent = new win.Event("mouseenter");
+        trigger.dispatchEvent(mouseenterEvent);
+
+        const tooltip = doc.querySelector('[role="tooltip"]');
+        if (tooltip) {
+            expect(tooltip.classList.contains("z-30")).toBe(true);
+            expect(tooltip.classList.contains("z-50")).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Toast notifications and error messages are not visible when a modal dialog is open. Users miss critical feedback because toasts render below or at the same stacking level as modals.

Closes #3646

## 🔁 Reproduction Steps
1. Start the admin UI (`make dev`)
2. Open any page and trigger a modal (e.g. click "Add Server", "Create Token", or "Invite User")
3. While the modal is open, trigger a toast notification:
   - For an error toast: submit the modal form with an invalid/missing field
   - For a success toast: force one via the browser console: `showToast("Test", "success")`

## 🐞 Root Cause
1 - Z-index collision between toasts and modals
- Toasts are assigned `z-50` (Tailwind → `z-index: 50`)
- Most modals also use `z-50` → same stacking level, browser renders whichever is later in the DOM on top (toasts lose)
- The bulk-import modal uses `z-[60]` → toasts at `z-50` are explicitly below it

2 - CSS hack on some modals overriding z-10 to `z-index: 9999`

In `admin.css` (lines 173–176):
```css
/* Modal z-index to prevent sticky header overlap */
.fixed.z-10 {
    z-index: 9999 !important;
}
```
Any element with **both** the Tailwind utility classes `fixed` and `z-10` gets forced to `z-index: 9999` regardless of what the Tailwind class implies. Roughly 18 modals in `admin.html` use `fixed z-10`, all silently elevated to 9999 — well above toasts at 50.

3 - Custom `.tooltip` CSS class with z-index side effects
`admin.css` defines a `.tooltip` class with `z-index: 9999`. Although this is effectively overridden by inline styles on the only element using it, it adds to the z-index chaos and the class needs a full Tailwind migration.


## 💡 Fix Description
Replaced custom classes and hacks with proper tailwind utility classes, and re-organise the z-index hierarchy.

| Layer                                       | Value       |
|-----------------------------|----------|
| Sticky header / LLM toolbar |  z-10 (10) |
| Sidebar                                   | z-20 (20) |
| Dropdowns / tooltips             | z-30 (30) |
| Modals                                    | z-40 (40) |
| Toast notifications                 | z-50 (50) |
