### PR TITLE
Fix: resolve s390x container build and protobuf segfault (fixes #3699)

### DIFF
--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -168,7 +168,15 @@ RUN set -euo pipefail \
     && . /etc/profile.d/use-openssl.sh \
     && python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel pdm uv \
-    && /app/.venv/bin/uv pip install ".[redis,postgres,mysql,observability,granian]" \
+    && if [ "$(uname -m)" = "s390x" ]; then \
+        echo "📦 Installing dependencies for s390x architecture..."; \
+        dnf install -y libpq-devel 2>/dev/null || true; \
+        /app/.venv/bin/pip install --no-cache-dir ".[redis,mysql,observability,granian]" \
+        && (/app/.venv/bin/pip install --no-cache-dir "psycopg[c]>=3.3.3" \
+            || /app/.venv/bin/pip install --no-cache-dir "psycopg>=3.3.3"); \
+    else \
+        /app/.venv/bin/uv pip install ".[redis,postgres,mysql,observability,granian]"; \
+    fi \
     && if [ "$ENABLE_RUST" = "true" ] && ls /tmp/rust-wheels/*.whl 1> /dev/null 2>&1; then \
         echo "🦀 Installing Rust plugins..."; \
         /app/.venv/bin/python3 -m pip install /tmp/rust-wheels/*.whl && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# s390x: Force protobuf to use pure-Python implementation.
+# The UPB C extension (google._upb._message) segfaults on s390x when
+# importing OpenTelemetry protobuf definitions.
+if [ "$(uname -m)" = "s390x" ]; then
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+fi
+
 HTTP_SERVER="${HTTP_SERVER:-gunicorn}"
 RUST_MCP_MODE="${RUST_MCP_MODE:-off}"
 RUST_MCP_LOG="${RUST_MCP_LOG:-warn}"


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3699 

---

## 📝 Summary
This PR fixes the s390x container build and runtime segfault issues detailed in #3699. It adds the required PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION variable and fixes the missing psycopg-binary installation for the s390x architecture only.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
