### PR TITLE
chore: remove unused PaginationParams, ObservabilityQueryParams, and PerformanceHistoryParams schemas

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7463,31 +7463,6 @@ class PaginatedResponse(BaseModel):
     links: Optional[PaginationLinks] = Field(None, description="Navigation links")
 
 
-class PaginationParams(BaseModel):
-    """Common pagination query parameters.
-
-    Attributes:
-        page: Page number (1-indexed)
-        per_page: Items per page
-        cursor: Cursor for cursor-based pagination
-        sort_by: Field to sort by
-        sort_order: Sort order (asc/desc)
-
-    Examples:
-        >>> params = PaginationParams(page=1, per_page=50)
-        >>> params.page
-        1
-        >>> params.sort_order
-        'desc'
-    """
-
-    page: int = Field(default=1, ge=1, description="Page number (1-indexed)")
-    per_page: int = Field(default=50, ge=1, le=500, description="Items per page (max 500)")
-    cursor: Optional[str] = Field(None, description="Cursor for cursor-based pagination")
-    sort_by: Optional[str] = Field("created_at", description="Sort field")
-    sort_order: Optional[str] = Field("desc", pattern="^(asc|desc)$", description="Sort order")
-
-
 # ============================================================================
 # Cursor Pagination Response Schemas (for main API endpoints)
 # ============================================================================
@@ -7708,21 +7683,6 @@ class ObservabilitySpanWithEvents(ObservabilitySpanRead):
     events: List[ObservabilityEventRead] = Field(default_factory=list, description="List of events in this span")
 
 
-class ObservabilityQueryParams(BaseModel):
-    """Query parameters for filtering observability data."""
-
-    start_time: Optional[datetime] = Field(None, description="Filter traces/spans/metrics after this time")
-    end_time: Optional[datetime] = Field(None, description="Filter traces/spans/metrics before this time")
-    status: Optional[str] = Field(None, description="Filter by status (ok, error, unset)")
-    http_status_code: Optional[int] = Field(None, description="Filter by HTTP status code")
-    user_email: Optional[str] = Field(None, description="Filter by user email")
-    resource_type: Optional[str] = Field(None, description="Filter by resource type")
-    resource_name: Optional[str] = Field(None, description="Filter by resource name")
-    trace_id: Optional[str] = Field(None, description="Filter by trace ID")
-    limit: int = Field(default=100, ge=1, le=1000, description="Maximum number of results")
-    offset: int = Field(default=0, ge=0, description="Result offset for pagination")
-
-
 # --- Performance Monitoring Schemas ---
 
 
@@ -7908,16 +7868,6 @@ class PerformanceDashboard(BaseModel):
     # Cluster info (for distributed mode)
     cluster_hosts: List[str] = Field(default_factory=list, description="Known cluster hosts")
     is_distributed: bool = Field(False, description="Running in distributed mode")
-
-
-class PerformanceHistoryParams(BaseModel):
-    """Query parameters for historical performance data."""
-
-    start_time: Optional[datetime] = Field(None, description="Start of time range")
-    end_time: Optional[datetime] = Field(None, description="End of time range")
-    period_type: str = Field("hourly", description="Aggregation period (hourly, daily)")
-    host: Optional[str] = Field(None, description="Filter by host")
-    limit: int = Field(default=168, ge=1, le=1000, description="Maximum results")
 
 
 class PerformanceHistoryResponse(BaseModel):

--- a/tests/unit/mcpgateway/test_performance_schemas.py
+++ b/tests/unit/mcpgateway/test_performance_schemas.py
@@ -8,25 +8,21 @@ SPDX-License-Identifier: Apache-2.0
 # Standard
 from datetime import datetime, timezone
 
-# Third-Party
-import pytest
-
 # First-Party
 from mcpgateway.schemas import (
-    WorkerMetrics,
-    SystemMetricsSchema,
-    RequestMetricsSchema,
-    DatabaseMetricsSchema,
     CacheMetricsSchema,
+    DatabaseMetricsSchema,
     GunicornMetricsSchema,
-    PerformanceSnapshotCreate,
-    PerformanceSnapshotRead,
     PerformanceAggregateBase,
     PerformanceAggregateCreate,
     PerformanceAggregateRead,
     PerformanceDashboard,
-    PerformanceHistoryParams,
     PerformanceHistoryResponse,
+    PerformanceSnapshotCreate,
+    PerformanceSnapshotRead,
+    RequestMetricsSchema,
+    SystemMetricsSchema,
+    WorkerMetrics,
 )
 
 
@@ -388,27 +384,6 @@ class TestPerformanceDashboard:
 
 class TestPerformanceHistorySchemas:
     """Tests for PerformanceHistory schemas."""
-
-    def test_history_params_defaults(self):
-        """Test PerformanceHistoryParams with defaults."""
-        params = PerformanceHistoryParams()
-        assert params.period_type == "hourly"
-        assert params.limit == 168
-        assert params.start_time is None
-
-    def test_history_params_custom(self):
-        """Test PerformanceHistoryParams with custom values."""
-        now = datetime.now(timezone.utc)
-        params = PerformanceHistoryParams(
-            start_time=now,
-            end_time=now,
-            period_type="daily",
-            host="test-host",
-            limit=100,
-        )
-        assert params.period_type == "daily"
-        assert params.limit == 100
-        assert params.host == "test-host"
 
     def test_history_response_empty(self):
         """Test PerformanceHistoryResponse with no data."""


### PR DESCRIPTION
  ## 🔗 Related Issue                                                                                                  
  Closes #3706                                                                                                                                                                                                                                
  ---                                                                                                                  

  ## 📝 Summary                                                                                                          
Remove three unused Pydantic schema classes (`PaginationParams`, `ObservabilityQueryParams`, `PerformanceHistoryParams`) from `mcpgateway/schemas.py`. These are dead code that no endpoint imports or uses. Notably, `PaginationParams` hardcodes `le=500` which would silently conflict with the configurable `PAGINATION_MAX_PAGE_SIZE` setting if anyone used it, potentially reintroducing the 422 bug fixed in #3469.          
  
  ---

  ## 🏷️ Type of Change                                                                                                   
  - [ ] Bug fix
  - [ ] Feature / Enhancement                                                                                            
  - [ ] Documentation
  - [ ] Refactor                                                                                                       
  - [x] Chore (deps, CI, tooling)                                                                                        
  - [ ] Other (describe below)                                                                                         
                                                                                                                  
                                                                                                                       
  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | ✅      |
  | Unit tests                | `make test`     | ✅      |                                                              
| Coverage ≥ 80%            | `make coverage` | ✅      |
                                                                                                                       
  ---

  ## ✅ Checklist                                                                                                        
  - [x] Code formatted (`make black isort pre-commit`)
  - [x] Tests added/updated for changes                                                                                  
  - [x] Documentation updated (if applicable)
  - [x] No secrets or credentials committed                                                                            
  
  ---

  ## 📓 Notes (optional)
  - Removed the corresponding `PerformanceHistoryParams` unit tests from `test_performance_schemas.py` and cleaned up
  the now-unused `pytest` import                                                                                         
- The `getPaginationParams` JavaScript function in `admin.html`/`admin.js` is unrelated (client-side pagination
  state) and was not touched                                                                                             
- The auto-generated `classes.svg` diagram in `docs/` still references these classes; it will update on next
  regeneration                                                                                                         