### PR TITLE
chore: prevent fake AWS key in unit test from falsely flagged as exposed secrets

### DIFF
--- a/tests/unit/mcpgateway/services/test_encryption_service.py
+++ b/tests/unit/mcpgateway/services/test_encryption_service.py
@@ -415,7 +415,7 @@ class TestEncryptionService:
         api_keys = [
             "sk-1234567890abcdefghijklmnopqrst",  # OpenAI format
             "ghp_1234567890abcdefghijklmnopqrst",  # GitHub format
-            "AKIA1234567890ABCDEF",  # AWS format
+            "AKIAIOSFODNN7EXAMPLE",  # AWS format
             base64.urlsafe_b64encode(b"some_api_key_data" * 5).decode(),  # Base64 encoded key
         ]
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #

---

## 📝 Summary
Container scanning tools e.g. Aqua will flag this line as exposed secret
This can be bypassed by setting secret value to default example secret value in [AWS docs](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html)

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
