### PR TITLE
feat(auth): verify OAuth access tokens via JWKS for virtual server MCP

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-12T07:25:34Z",
+  "generated_at": "2026-04-12T07:51:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -6540,7 +6540,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 568,
+        "line_number": 571,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -10020,7 +10020,7 @@
         "hashed_secret": "b5920aa41ccde1341077fdb2636afc16d6da0e1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 180,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10028,7 +10028,7 @@
         "hashed_secret": "467be688b21f5d43370f5dc983fe5ed58dea4b00",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 206,
+        "line_number": 216,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10036,7 +10036,7 @@
         "hashed_secret": "d955debea8e960a293ecbb257048680898cc9d94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 221,
+        "line_number": 231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10044,7 +10044,7 @@
         "hashed_secret": "4ee9e7b8482f6e0282b0117eb81651c98b537589",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 255,
+        "line_number": 265,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10052,7 +10052,7 @@
         "hashed_secret": "500886a66d19ebfe2d5c0ee86cf4612f9458ee4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 328,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10060,7 +10060,7 @@
         "hashed_secret": "f2169f1a808382eb7b521206debaef01c91f1b60",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 367,
+        "line_number": 377,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10068,7 +10068,7 @@
         "hashed_secret": "cd61d9f689e9992aec40aeec7210b45a681309f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 411,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10076,7 +10076,7 @@
         "hashed_secret": "ae97d9e9201a9bc1806069d80e5809ab745a91e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 436,
+        "line_number": 446,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10084,7 +10084,7 @@
         "hashed_secret": "eb2344b0e2d6529ced74f8b09be362a460defa15",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 473,
+        "line_number": 483,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10092,7 +10092,7 @@
         "hashed_secret": "89be7e8e88bc7b0cdb5ddaa01dab1cd1728541e2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 537,
+        "line_number": 547,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10100,7 +10100,7 @@
         "hashed_secret": "5a539b200edec3aaa5167e1cde5d8fd0e8cf4aee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10108,7 +10108,7 @@
         "hashed_secret": "8be6db326ca95f74590bd09c9c328fc9a3db3b6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 688,
+        "line_number": 698,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10116,7 +10116,7 @@
         "hashed_secret": "2368055dc74fca43f2f9c849dbbaaa04616670cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 737,
+        "line_number": 747,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10124,7 +10124,7 @@
         "hashed_secret": "8ce647089e0614d3b924f4a0b8fb78268562ec7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1426,
+        "line_number": 1436,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10132,7 +10132,7 @@
         "hashed_secret": "dc6f6cc49f767ae38db110a9e6c1adf5c651ecbf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1480,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10140,7 +10140,7 @@
         "hashed_secret": "7939ea1cdfc6d73115b0d736fa04012be2b25b18",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1561,
+        "line_number": 1571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10148,7 +10148,7 @@
         "hashed_secret": "91014bcbf183cf77807b4bd24f2e8652f67b56a0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2069,
+        "line_number": 2079,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10156,7 +10156,7 @@
         "hashed_secret": "61ac75f7e6677b79c219ce819d954e05f61b5d2c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2087,
+        "line_number": 2097,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10164,7 +10164,7 @@
         "hashed_secret": "8223fafd35f399e55c3cf611c3d6ebbf43d68d71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2743,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10172,7 +10172,7 @@
         "hashed_secret": "dfd99b5f25f839608a3c275c0f8ceb363f8f0bc0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3510,
+        "line_number": 3538,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10180,7 +10180,7 @@
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3619,
+        "line_number": 3647,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10188,7 +10188,7 @@
         "hashed_secret": "f5cd573c18bf811f82a886ceb6866b05d5ef02cd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3697,
+        "line_number": 3725,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10196,7 +10196,7 @@
         "hashed_secret": "79bead8e6d65862a00cffaa12ccde1189ec34d29",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4080,
+        "line_number": 4108,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -118,6 +118,19 @@ mcp_auth_cache_events_counter = Counter(
     ["outcome"],
 )
 
+# OAuth / JWKS access-token verification on oauth_enabled virtual servers.
+# Outcome labels:
+#   success          — IdP-issued token verified and user context populated
+#   failed           — verification attempted and rejected (401/503 emitted)
+#   not_applicable   — target server is not oauth_enabled, issuer outside the
+#                      allowlist, token undecodable, or URL path missing a
+#                      server id; caller falls through to internal verify
+oauth_verify_events_counter = Counter(
+    "oauth_verify_events_total",
+    "OAuth access token verification outcomes on virtual server MCP endpoints",
+    ["outcome"],
+)
+
 
 def setup_metrics(app):
     """

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -3406,12 +3406,38 @@ class _StreamableHttpAuthHandler:
     async def _auth_jwt(self, *, token: str) -> bool:
         """Verify a JWT Bearer token and populate the user context.
 
+        Routes to ContextForge-issued or IdP-issued (OAuth) verification based
+        on the token's ``iss`` claim. IdP-issued tokens are only accepted for
+        virtual servers with ``oauth_enabled=True``.
+
         Args:
             token: Bearer token value extracted from the Authorization header.
 
         Returns:
             True if verification succeeds, False if rejected (401/403/503 sent).
         """
+        # Peek at the token issuer to decide verification path.
+        # ContextForge-issued tokens (SSO session, API tokens) have iss == settings.jwt_issuer.
+        # IdP-issued tokens (OAuth access tokens from e.g. Keycloak, Authentik) have the IdP's issuer.
+        # Third-Party
+        import jwt  # pylint: disable=import-outside-toplevel
+
+        try:
+            unverified = jwt.decode(token, options={"verify_signature": False})
+        except jwt.DecodeError:
+            return await self._send_error(detail="Invalid token format", headers={"WWW-Authenticate": "Bearer"})
+
+        token_issuer = unverified.get("iss", "")
+        if token_issuer != settings.jwt_issuer:
+            # IdP-issued token — delegate to OAuth access token verification
+            oauth_result = await self._try_oauth_access_token(token)
+            if oauth_result is True:
+                return True
+            if oauth_result is False:
+                return False  # Error response already sent
+            # Not an oauth_enabled server — reject
+            return await self._send_error(detail="Invalid authentication credentials", headers={"WWW-Authenticate": "Bearer"})
+
         try:
             user_payload = await verify_credentials(token)
             # Store enriched user context with normalized teams
@@ -3671,7 +3697,7 @@ class _StreamableHttpAuthHandler:
                 team_name=trace_team_name,
             )
         except HTTPException:
-            # JWT verification failed (expired, malformed, bad signature, etc.)
+            # Internal JWT verification failed (expired, malformed, bad signature, etc.)
             return await self._send_error(detail="Invalid authentication credentials", headers={"WWW-Authenticate": "Bearer"})
         except SQLAlchemyError:
             # DB failure during team resolution or membership validation
@@ -3682,6 +3708,104 @@ class _StreamableHttpAuthHandler:
             logger.exception("Unexpected error during MCP JWT authentication")
             return await self._send_error(detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
 
+        return True
+
+    async def _try_oauth_access_token(self, token: str) -> Optional[bool]:
+        """Attempt OAuth access token verification for oauth_enabled virtual servers.
+
+        Called when internal JWT verification fails. Checks if the target server
+        has ``oauth_enabled=True``, verifies the token against the server's
+        configured authorization servers via JWKS, and resolves the user from DB.
+
+        Args:
+            token: Raw Bearer token that failed internal JWT verification.
+
+        Returns:
+            True if OAuth verification and user resolution succeeded.
+            False if verification succeeded but user resolution failed (error sent).
+            None if this server does not use OAuth (caller should send standard 401).
+        """
+        path = self.scope.get("path", "")
+        match = _SERVER_ID_RE.search(path)
+        if not match:
+            return None
+
+        server_id = match.group("server_id")
+
+        # Look up server OAuth configuration
+        # Third-Party
+        from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+
+        # First-Party
+        from mcpgateway.db import Server as DbServer  # pylint: disable=import-outside-toplevel
+
+        try:
+            async with get_db() as db:
+                server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
+        except SQLAlchemyError:
+            logger.exception("DB error looking up server %s for OAuth verification", server_id)
+            await self._send_error(detail="Service unavailable", status_code=503)
+            return False
+
+        if not server or not server.oauth_enabled or not server.oauth_config:
+            return None
+
+        authorization_servers = server.oauth_config.get("authorization_servers", [])
+        if not authorization_servers:
+            auth_server = server.oauth_config.get("authorization_server")
+            if isinstance(auth_server, str) and auth_server.strip():
+                authorization_servers = [auth_server.strip()]
+        if not authorization_servers:
+            return None
+
+        client_id = server.oauth_config.get("client_id")
+
+        # Verify token against the IdP's JWKS
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=client_id)
+        if claims is None:
+            resource_metadata = _build_resource_metadata_url(self.scope, server_id)
+            www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
+            await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
+            return False
+
+        # Resolve user identity from verified claims
+        user_email = claims.get("email") or claims.get("preferred_username") or claims.get("sub")
+        if not user_email or not isinstance(user_email, str) or "@" not in user_email:
+            await self._send_error(detail="OAuth token missing valid email claim")
+            return False
+
+        user_email = user_email.strip().lower()
+
+        # Look up user in ContextForge DB — user must already exist (no auto-creation)
+        # First-Party
+        from mcpgateway.auth import _get_user_by_email_sync, _resolve_teams_from_db  # pylint: disable=import-outside-toplevel
+
+        user_record = await asyncio.to_thread(_get_user_by_email_sync, user_email)
+        if user_record is None:
+            await self._send_error(detail="User not registered in ContextForge. Please log in via SSO first.")
+            return False
+        if not user_record.is_active:
+            await self._send_error(detail="Account disabled")
+            return False
+
+        # Resolve teams from DB (same path as session tokens)
+        is_admin = bool(user_record.is_admin)
+        final_teams = None if is_admin else await _resolve_teams_from_db(user_email, user_record)
+
+        user_context_var.set(
+            {
+                "email": user_email,
+                "teams": final_teams,
+                "is_authenticated": True,
+                "is_admin": is_admin,
+                "permission_is_admin": is_admin,
+                "token_use": "oauth_access_token",
+            }
+        )
+        _oauth_checked_var.set(True)
         return True
 
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -261,10 +261,18 @@ def _resolve_authorization_servers(oauth_config: Dict[str, Any]) -> List[str]:
     if isinstance(servers, list):
         cleaned = [s.strip() for s in servers if isinstance(s, str) and s.strip()]
         if cleaned:
+            non_https = [s for s in cleaned if not s.lower().startswith("https://")]
+            if non_https:
+                logger.warning("Ignoring non-HTTPS authorization_servers (SSRF risk): %s", non_https)
+                cleaned = [s for s in cleaned if s.lower().startswith("https://")]
             return cleaned
     singular = oauth_config.get("authorization_server")
     if isinstance(singular, str) and singular.strip():
-        return [singular.strip()]
+        url = singular.strip()
+        if not url.lower().startswith("https://"):
+            logger.warning("Ignoring non-HTTPS authorization_server (SSRF risk): %s", url)
+            return []
+        return [url]
     return []
 
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -36,6 +36,7 @@ import asyncio
 from contextlib import asynccontextmanager, AsyncExitStack, ExitStack
 import contextvars
 from dataclasses import dataclass
+from enum import Enum
 import re
 from typing import Any, AsyncGenerator, ContextManager, Dict, List, Optional, Pattern, Tuple, Union
 from urllib.parse import urlsplit, urlunsplit
@@ -46,6 +47,7 @@ import anyio
 from fastapi import HTTPException
 from fastapi.security.utils import get_authorization_scheme_param
 import httpx
+import jwt
 from mcp import ClientSession, types
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.server.lowlevel import Server
@@ -69,7 +71,7 @@ from mcpgateway.observability import create_span
 from mcpgateway.services.completion_service import CompletionService
 from mcpgateway.services.http_client_service import get_http_client, get_http_limits
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.metrics import mcp_auth_cache_events_counter
+from mcpgateway.services.metrics import mcp_auth_cache_events_counter, oauth_verify_events_counter
 from mcpgateway.services.oauth_manager import OAuthEnforcementUnavailableError, OAuthRequiredError
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.prompt_service import PromptService
@@ -78,10 +80,11 @@ from mcpgateway.services.tool_service import ToolService
 from mcpgateway.transports.redis_event_store import RedisEventStore
 from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_gateway_access, extract_gateway_id_from_headers, GATEWAY_ID_HEADER
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
 from mcpgateway.utils.trace_context import set_trace_context_from_teams, set_trace_session_id
-from mcpgateway.utils.verify_credentials import is_proxy_auth_trust_active, require_auth_header_first, verify_credentials
+from mcpgateway.utils.verify_credentials import is_proxy_auth_trust_active, require_auth_header_first, verify_credentials, verify_oauth_access_token
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -226,6 +229,45 @@ server_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("server_id",
 request_headers_var: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar("request_headers", default={})
 user_context_var: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar("user_context", default={})
 _oauth_checked_var: contextvars.ContextVar[bool] = contextvars.ContextVar("_oauth_checked", default=False)
+
+
+class OAuthAuthResult(Enum):
+    """Outcome of an OAuth access-token verification attempt.
+
+    Used by :meth:`_StreamableHttpAuthHandler._try_oauth_access_token` to
+    communicate whether the token was handled, rejected, or not applicable
+    without relying on a tri-state ``Optional[bool]``.
+    """
+
+    SUCCESS = "success"  # Verified; user context populated.
+    FAILED = "failed"  # Verification attempted and rejected; error already sent.
+    NOT_APPLICABLE = "not_applicable"  # Target server does not use OAuth; caller should continue.
+
+
+def _resolve_authorization_servers(oauth_config: Dict[str, Any]) -> List[str]:
+    """Normalise a virtual-server ``oauth_config`` into an issuer allowlist.
+
+    Accepts either the plural ``authorization_servers`` (list of URLs) or the
+    legacy singular ``authorization_server`` (single URL string). Returns an
+    empty list when neither key is present or both are empty.
+
+    Args:
+        oauth_config: The ``server.oauth_config`` dict from a virtual server.
+
+    Returns:
+        A list of allowed issuer URLs, with surrounding whitespace stripped.
+    """
+    servers = oauth_config.get("authorization_servers") or []
+    if isinstance(servers, list):
+        cleaned = [s.strip() for s in servers if isinstance(s, str) and s.strip()]
+        if cleaned:
+            return cleaned
+    singular = oauth_config.get("authorization_server")
+    if isinstance(singular, str) and singular.strip():
+        return [singular.strip()]
+    return []
+
+
 _shared_session_registry: Optional[Any] = None
 _rust_event_store_client: Optional[httpx.AsyncClient] = None
 _rust_event_store_client_lock = asyncio.Lock()
@@ -739,8 +781,8 @@ def _should_enforce_streamable_rbac(user_context: Optional[dict[str, Any]]) -> b
     return isinstance(user_context, dict) and user_context.get("is_authenticated", False) is True
 
 
-def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
-    """Construct the RFC 9728 OAuth Protected Resource Metadata URL from ASGI scope.
+def _build_public_base_url(scope: Scope) -> str:
+    """Derive the public-facing base URL (``scheme://host[/root_path]``) from an ASGI scope.
 
     Inspects ``x-forwarded-proto`` and ``host`` headers first (reverse-proxy
     scenario), then falls back to ``scope["scheme"]`` and ``scope["server"]``.
@@ -749,10 +791,10 @@ def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
 
     Args:
         scope: ASGI connection scope.
-        server_id: Virtual-server identifier.
 
     Returns:
-        Fully-qualified URL string, or ``""`` if construction fails.
+        Base URL with trailing root_path (no trailing slash), or ``""`` if
+        construction fails.
     """
     try:
         headers = Headers(scope=scope)
@@ -778,9 +820,78 @@ def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
                 return ""
 
         root_path = scope.get("root_path", "").rstrip("/")
-        return f"{proto}://{host}{root_path}/.well-known/oauth-protected-resource/servers/{server_id}/mcp"
-    except Exception:
+        return f"{proto}://{host}{root_path}"
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        # Malformed ASGI scope (missing keys, wrong types, unparseable
+        # header bytes). Log at WARNING so upstream 401s have a forensic
+        # trail — callers treat "" as a fail-closed sentinel and reject
+        # the request, but without this log operators have no visibility
+        # into *why* URL derivation failed. Include the request path and
+        # client tuple so a flood of failures can be traced to a specific
+        # route or peer.
+        scope_path = scope.get("path") if isinstance(scope, dict) else None
+        scope_client = scope.get("client") if isinstance(scope, dict) else None
+        logger.warning(
+            "Failed to derive public base URL from ASGI scope (path=%s, client=%s): %s: %s",
+            scope_path,
+            scope_client,
+            type(exc).__name__,
+            exc,
+        )
         return ""
+
+
+def _build_server_resource_url(scope: Scope, server_id: str) -> str:
+    """Construct the canonical MCP resource URL for a virtual server.
+
+    This is the URL that RFC 8707 / RFC 9728 identify as the *resource* —
+    i.e. the value clients should request tokens for and that the server
+    MUST enforce as the access-token ``aud`` claim.
+
+    .. important::
+        The base URL is derived from :data:`settings.app_domain`, **not** the
+        inbound ``Host`` / ``X-Forwarded-Host`` headers. Both are
+        caller-controlled (any client can send an arbitrary ``Host``; a
+        permissive proxy can forward one too), so trusting them here would
+        let a client bypass audience binding simply by sending the hostname
+        their token happens to name. ``settings.app_domain`` is operator-set
+        at deployment time and therefore a safe trust anchor. Operators MUST
+        set it to the gateway's public URL for OAuth audience validation to
+        be effective.
+
+    Args:
+        scope: ASGI connection scope (retained for signature compatibility
+            with related helpers; unused in the resource-URL derivation).
+        server_id: Virtual-server identifier.
+
+    Returns:
+        Fully-qualified resource URL string, or ``""`` if construction fails.
+    """
+    del scope  # intentionally ignored — see docstring
+    try:
+        raw = str(settings.app_domain).rstrip("/")
+    except (AttributeError, ValueError) as exc:
+        logger.warning("settings.app_domain is not a usable URL: %s: %s", type(exc).__name__, exc)
+        return ""
+    if not raw:
+        return ""
+    return f"{raw}/servers/{server_id}/mcp"
+
+
+def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
+    """Construct the RFC 9728 OAuth Protected Resource Metadata URL from ASGI scope.
+
+    Args:
+        scope: ASGI connection scope.
+        server_id: Virtual-server identifier.
+
+    Returns:
+        Fully-qualified URL string, or ``""`` if construction fails.
+    """
+    base = _build_public_base_url(scope)
+    if not base:
+        return ""
+    return f"{base}/.well-known/oauth-protected-resource/servers/{server_id}/mcp"
 
 
 async def _check_server_oauth_enforcement(server_id: str, user_context: Optional[dict[str, Any]]) -> None:
@@ -3403,7 +3514,7 @@ class _StreamableHttpAuthHandler:
         set_trace_context_from_teams([], auth_method="anonymous")
         return True  # Allow request to proceed with public-only access
 
-    async def _auth_jwt(self, *, token: str) -> bool:
+    async def _auth_jwt(self, *, token: str) -> bool:  # noqa: PLR0911
         """Verify a JWT Bearer token and populate the user context.
 
         Routes to ContextForge-issued or IdP-issued (OAuth) verification based
@@ -3416,27 +3527,9 @@ class _StreamableHttpAuthHandler:
         Returns:
             True if verification succeeds, False if rejected (401/403/503 sent).
         """
-        # Peek at the token issuer to decide verification path.
-        # ContextForge-issued tokens (SSO session, API tokens) have iss == settings.jwt_issuer.
-        # IdP-issued tokens (OAuth access tokens from e.g. Keycloak, Authentik) have the IdP's issuer.
-        # Third-Party
-        import jwt  # pylint: disable=import-outside-toplevel
-
-        try:
-            unverified = jwt.decode(token, options={"verify_signature": False})
-        except jwt.DecodeError:
-            return await self._send_error(detail="Invalid token format", headers={"WWW-Authenticate": "Bearer"})
-
-        token_issuer = unverified.get("iss", "")
-        if token_issuer != settings.jwt_issuer:
-            # IdP-issued token — delegate to OAuth access token verification
-            oauth_result = await self._try_oauth_access_token(token)
-            if oauth_result is True:
-                return True
-            if oauth_result is False:
-                return False  # Error response already sent
-            # Not an oauth_enabled server — reject
-            return await self._send_error(detail="Invalid authentication credentials", headers={"WWW-Authenticate": "Bearer"})
+        routed = await self._route_idp_issued_token(token)
+        if routed is not None:
+            return routed
 
         try:
             user_payload = await verify_credentials(token)
@@ -3710,29 +3803,111 @@ class _StreamableHttpAuthHandler:
 
         return True
 
-    async def _try_oauth_access_token(self, token: str) -> Optional[bool]:
-        """Attempt OAuth access token verification for oauth_enabled virtual servers.
+    async def _route_idp_issued_token(self, token: str) -> Optional[bool]:
+        """Route IdP-issued tokens to the OAuth verification path when applicable.
 
-        Called when internal JWT verification fails. Checks if the target server
-        has ``oauth_enabled=True``, verifies the token against the server's
-        configured authorization servers via JWKS, and resolves the user from DB.
+        Peeks at the token's unverified ``iss`` claim. When the claim does not
+        match ``settings.jwt_issuer`` the token is treated as potentially
+        IdP-issued and delegated to :meth:`_try_oauth_access_token`. This
+        routing is intentionally independent of
+        ``settings.jwt_issuer_verification`` — that toggle governs how
+        ContextForge's *own* JWTs are checked and must not be allowed to
+        bypass OAuth enforcement for virtual servers with
+        ``oauth_enabled=True``.
 
         Args:
-            token: Raw Bearer token that failed internal JWT verification.
+            token: Raw Bearer token to inspect.
 
         Returns:
-            True if OAuth verification and user resolution succeeded.
-            False if verification succeeded but user resolution failed (error sent).
-            None if this server does not use OAuth (caller should send standard 401).
+            True on successful OAuth verification (user context populated).
+            False when an error response has already been sent. ``None`` when
+            the caller should continue with ContextForge-issued JWT
+            verification (undecodable token, internal ``iss``, or an
+            IdP-issued token on a server that does not handle it).
         """
+        try:
+            unverified = jwt.decode(token, options={"verify_signature": False})
+        except jwt.DecodeError:
+            # Undecodable bearer token. Flow through to verify_credentials()
+            # which will emit the canonical 401. Log at DEBUG only — auth
+            # floods would otherwise pollute WARN-level observability.
+            logger.debug("Bearer token is not a decodable JWT; deferring to internal verify_credentials")
+            return None
+
+        if unverified.get("iss", "") == settings.jwt_issuer:
+            return None
+
+        try:
+            oauth_result = await self._try_oauth_access_token(token, unverified)
+        except Exception:
+            # An unexpected error escaped _try_oauth_access_token (e.g. a
+            # bug in claims parsing or an unhandled DB error). Emit an
+            # ``error`` metric so this path is visible in dashboards —
+            # otherwise the exception propagates silently through the
+            # counter increments below — and re-raise so higher layers
+            # can convert to a 500.
+            oauth_verify_events_counter.labels(outcome="error").inc()
+            logger.exception("Unexpected error in _try_oauth_access_token")
+            raise
+
+        if oauth_result is OAuthAuthResult.SUCCESS:
+            oauth_verify_events_counter.labels(outcome="success").inc()
+            return True
+        if oauth_result is OAuthAuthResult.FAILED:
+            oauth_verify_events_counter.labels(outcome="failed").inc()
+            return False  # Error response already sent
+        # OAuthAuthResult.NOT_APPLICABLE — this handler is not responsible for
+        # the token (target server is not oauth_enabled, token's issuer is
+        # outside the allowlist, or the URL carries no server id). When
+        # internal issuer verification is enabled, an iss mismatch will be
+        # rejected by verify_credentials() anyway, so short-circuit with the
+        # canonical 401. When it is disabled, fall through so legacy internal
+        # JWTs whose iss differs from settings.jwt_issuer remain accepted.
+        oauth_verify_events_counter.labels(outcome="not_applicable").inc()
+        if settings.jwt_issuer_verification:
+            return await self._send_error(detail="Invalid authentication credentials", headers={"WWW-Authenticate": "Bearer"})
+        return None
+
+    async def _try_oauth_access_token(self, token: str, unverified: Optional[Dict[str, Any]] = None) -> OAuthAuthResult:  # noqa: PLR0911
+        """Attempt OAuth access token verification for oauth_enabled virtual servers.
+
+        Invoked by :meth:`_route_idp_issued_token` when the token's ``iss``
+        claim does not match ``settings.jwt_issuer``. Checks if the target
+        server has ``oauth_enabled=True``, verifies the token against the
+        server's configured authorization servers via JWKS, and resolves the
+        user from the DB.
+
+        Args:
+            token: Raw Bearer token whose ``iss`` does not match the internal
+                issuer.
+            unverified: Already-decoded (but signature-unverified) claims for
+                ``token``. Optional — :meth:`_route_idp_issued_token` always
+                threads its own decode through to avoid a second parse, but
+                direct callers (tests) may omit it and have this method
+                decode lazily.
+
+        Returns:
+            :class:`OAuthAuthResult` — ``SUCCESS`` when verification and user
+            resolution succeeded, ``FAILED`` when an error response has
+            already been sent, ``NOT_APPLICABLE`` when the target virtual
+            server does not use OAuth *or* when this server is not the right
+            handler for the token (issuer outside the allowlist); in the
+            latter case the caller should defer to internal JWT verification.
+        """
+        if unverified is None:
+            try:
+                unverified = jwt.decode(token, options={"verify_signature": False})
+            except jwt.DecodeError:
+                return OAuthAuthResult.NOT_APPLICABLE
+
         path = self.scope.get("path", "")
         match = _SERVER_ID_RE.search(path)
         if not match:
-            return None
+            return OAuthAuthResult.NOT_APPLICABLE
 
         server_id = match.group("server_id")
+        server_id_log = sanitize_for_log(server_id)
 
-        # Look up server OAuth configuration
         # Third-Party
         from sqlalchemy import select  # pylint: disable=import-outside-toplevel
 
@@ -3743,39 +3918,95 @@ class _StreamableHttpAuthHandler:
             async with get_db() as db:
                 server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
         except SQLAlchemyError:
-            logger.exception("DB error looking up server %s for OAuth verification", server_id)
+            logger.exception("DB error looking up server %s for OAuth verification", server_id_log)
             await self._send_error(detail="Service unavailable", status_code=503)
-            return False
+            return OAuthAuthResult.FAILED
 
-        if not server or not server.oauth_enabled or not server.oauth_config:
-            return None
+        if not server or not server.oauth_enabled:
+            return OAuthAuthResult.NOT_APPLICABLE
 
-        authorization_servers = server.oauth_config.get("authorization_servers", [])
+        # ``oauth_enabled=True`` + empty/missing ``oauth_config`` is a
+        # server-side misconfiguration. Returning NOT_APPLICABLE here would
+        # let the caller fall through to internal JWT verification, so an
+        # internal ContextForge JWT could reach a resource that is supposed
+        # to require OAuth. Fail closed — same semantics as the empty
+        # ``authorization_servers`` branch below.
+        if not server.oauth_config:
+            logger.error(
+                "Server %s has oauth_enabled=True but no oauth_config configured; rejecting token",
+                server_id_log,
+            )
+            await self._send_error(detail="OAuth authorization server not configured for this resource", status_code=503)
+            return OAuthAuthResult.FAILED
+
+        authorization_servers = _resolve_authorization_servers(server.oauth_config)
         if not authorization_servers:
-            auth_server = server.oauth_config.get("authorization_server")
-            if isinstance(auth_server, str) and auth_server.strip():
-                authorization_servers = [auth_server.strip()]
-        if not authorization_servers:
-            return None
+            # Same class of misconfiguration: oauth_config is present but
+            # carries no issuer allowlist. Fail closed rather than fall
+            # through to internal JWT verification.
+            logger.error(
+                "Server %s has oauth_enabled=True but no authorization_servers configured; rejecting token",
+                server_id_log,
+            )
+            await self._send_error(detail="OAuth authorization server not configured for this resource", status_code=503)
+            return OAuthAuthResult.FAILED
 
-        client_id = server.oauth_config.get("client_id")
+        # Check whether this server is the right handler for the token. If
+        # the issuer is not in the allowlist (including tokens with a
+        # missing/empty iss), return NOT_APPLICABLE so the caller can fall
+        # through to internal JWT verification. This preserves legacy
+        # behaviour on ``oauth_enabled`` servers for gateway-issued JWTs
+        # whose iss is missing or predates the current ``settings.jwt_issuer``
+        # value — those tokens would previously have been accepted by
+        # ``verify_credentials()`` when ``JWT_ISSUER_VERIFICATION=false``,
+        # and rejecting them here would be a regression. Tokens with a
+        # non-matching iss that are *not* legitimate internal JWTs will
+        # still fail signature verification in the internal path and be
+        # rejected there.
+        token_issuer = unverified.get("iss")
+        normalized_allowed = {s.rstrip("/") for s in authorization_servers if isinstance(s, str)}
+        if not isinstance(token_issuer, str) or token_issuer.rstrip("/") not in normalized_allowed:
+            logger.info(
+                "Token issuer %s not in allowlist for server %s; deferring to internal verify",
+                sanitize_for_log(token_issuer) if token_issuer else "<missing>",
+                server_id_log,
+            )
+            return OAuthAuthResult.NOT_APPLICABLE
 
-        # Verify token against the IdP's JWKS
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+        # Per RFC 8707/9728, the resource URL is the canonical audience for an
+        # access token bound to this MCP server. We MUST enforce it so that a
+        # token minted for a different API cannot authenticate here just
+        # because it was signed by an allowed issuer. Additional audiences may
+        # be declared explicitly in oauth_config (``resource``, or — for
+        # backward compat — ``client_id``) to accommodate IdPs that issue
+        # tokens with the client_id in ``aud``.
+        resource_url = _build_server_resource_url(self.scope, server_id)
+        if not resource_url:
+            # Can't build a canonical audience — fail closed rather than
+            # accept a token we cannot bind to this resource.
+            logger.warning("Unable to derive resource URL for server %s; rejecting OAuth token", server_id)
+            await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": "Bearer"})
+            return OAuthAuthResult.FAILED
 
-        claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=client_id)
+        expected_audiences: list[str] = [resource_url]
+        extra_audience = server.oauth_config.get("resource") or server.oauth_config.get("client_id")
+        if isinstance(extra_audience, str) and extra_audience.strip():
+            expected_audiences.append(extra_audience.strip())
+        elif isinstance(extra_audience, list):
+            expected_audiences.extend(s.strip() for s in extra_audience if isinstance(s, str) and s.strip())
+
+        claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=expected_audiences)
         if claims is None:
             resource_metadata = _build_resource_metadata_url(self.scope, server_id)
             www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
             await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
-            return False
+            return OAuthAuthResult.FAILED
 
         # Resolve user identity from verified claims
         user_email = claims.get("email") or claims.get("preferred_username") or claims.get("sub")
         if not user_email or not isinstance(user_email, str) or "@" not in user_email:
             await self._send_error(detail="OAuth token missing valid email claim")
-            return False
+            return OAuthAuthResult.FAILED
 
         user_email = user_email.strip().lower()
 
@@ -3783,18 +4014,40 @@ class _StreamableHttpAuthHandler:
         # First-Party
         from mcpgateway.auth import _get_user_by_email_sync, _resolve_teams_from_db  # pylint: disable=import-outside-toplevel
 
-        user_record = await asyncio.to_thread(_get_user_by_email_sync, user_email)
+        try:
+            user_record = await asyncio.to_thread(_get_user_by_email_sync, user_email)
+        except SQLAlchemyError:
+            logger.exception("DB error looking up user %s during OAuth access-token verification", user_email)
+            await self._send_error(detail="Service unavailable", status_code=503)
+            return OAuthAuthResult.FAILED
+        except Exception:
+            logger.exception("Unexpected error looking up user %s during OAuth access-token verification", user_email)
+            await self._send_error(detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
+            return OAuthAuthResult.FAILED
+
         if user_record is None:
             await self._send_error(detail="User not registered in ContextForge. Please log in via SSO first.")
-            return False
+            return OAuthAuthResult.FAILED
         if not user_record.is_active:
             await self._send_error(detail="Account disabled")
-            return False
+            return OAuthAuthResult.FAILED
 
         # Resolve teams from DB (same path as session tokens)
         is_admin = bool(user_record.is_admin)
-        final_teams = None if is_admin else await _resolve_teams_from_db(user_email, user_record)
+        try:
+            final_teams = None if is_admin else await _resolve_teams_from_db(user_email, user_record)
+        except SQLAlchemyError:
+            logger.exception("DB error resolving teams for user %s during OAuth access-token verification", user_email)
+            await self._send_error(detail="Service unavailable", status_code=503)
+            return OAuthAuthResult.FAILED
+        except Exception:
+            logger.exception("Unexpected error resolving teams for user %s during OAuth access-token verification", user_email)
+            await self._send_error(detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
+            return OAuthAuthResult.FAILED
 
+        # token_use="session" aligns with downstream RBAC gates (main.py, rbac.py,
+        # token_scoping.py) that treat DB-resolved teams as the session semantic.
+        # auth_method distinguishes the origin for audit/logging.
         user_context_var.set(
             {
                 "email": user_email,
@@ -3802,11 +4055,12 @@ class _StreamableHttpAuthHandler:
                 "is_authenticated": True,
                 "is_admin": is_admin,
                 "permission_is_admin": is_admin,
-                "token_use": "oauth_access_token",
+                "token_use": "session",  # nosec B105 - JWT claim type marker, not a password
+                "auth_method": "oauth_access_token",
             }
         )
         _oauth_checked_var.set(True)
-        return True
+        return OAuthAuthResult.SUCCESS
 
 
 async def streamable_http_auth(scope: Any, receive: Any, send: Any) -> bool:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -55,7 +55,8 @@ Examples:
 import asyncio
 from base64 import b64decode
 import binascii
-from typing import Any, Optional
+from time import monotonic
+from typing import Any, Dict, List, Optional, Tuple
 
 # Third-Party
 from fastapi import Cookie, Depends, HTTPException, Request, status
@@ -1219,3 +1220,116 @@ async def require_admin_auth(
         else:
             # Re-raise the basic auth error
             raise
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OAuth access token verification via JWKS (RFC 9728 — Virtual Server MCP auth)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Module-level caches for OIDC discovery and JWKS clients.
+# Same caching pattern used in sso_service.py for id_token verification.
+_oauth_oidc_metadata_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+_OAUTH_OIDC_METADATA_TTL = 300  # seconds
+_oauth_jwks_client_cache: Dict[str, jwt.PyJWKClient] = {}
+
+
+async def _discover_oidc_metadata(issuer: str) -> Optional[Dict[str, Any]]:
+    """Fetch and cache OIDC provider metadata via well-known endpoint.
+
+    Args:
+        issuer: OIDC issuer URL.
+
+    Returns:
+        Provider metadata dict, or None on failure.
+    """
+    normalized = issuer.rstrip("/")
+    cached = _oauth_oidc_metadata_cache.get(normalized)
+    if cached is not None:
+        cached_at, metadata = cached
+        if monotonic() - cached_at < _OAUTH_OIDC_METADATA_TTL:
+            return metadata
+        _oauth_oidc_metadata_cache.pop(normalized, None)
+
+    # First-Party
+    from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+
+    try:
+        client = await get_http_client()
+        resp = await client.get(f"{normalized}/.well-known/openid-configuration", timeout=10)
+        if resp.status_code != 200:
+            logger.warning("OAuth OIDC discovery failed for %s: HTTP %s", normalized, resp.status_code)
+            return None
+        metadata = resp.json()
+        if not isinstance(metadata, dict):
+            return None
+        _oauth_oidc_metadata_cache[normalized] = (monotonic(), metadata)
+        return metadata
+    except Exception as exc:
+        logger.warning("OAuth OIDC discovery request failed for %s: %s", normalized, exc)
+        return None
+
+
+async def verify_oauth_access_token(token: str, authorization_servers: List[str], *, expected_audience: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Verify an OAuth access token issued by a configured authorization server.
+
+    Used for Virtual Server MCP endpoints with ``oauth_enabled=True``.
+    Validates the token issuer against the server's allowlist, discovers
+    the JWKS endpoint via OIDC metadata, and verifies the signature.
+    When ``expected_audience`` is provided (from ``oauth_config.client_id``),
+    the token's ``aud`` claim is also validated.
+
+    Args:
+        token: Raw JWT Bearer token string.
+        authorization_servers: Allowed issuer URLs from ``server.oauth_config``.
+        expected_audience: Optional audience to validate against (typically the OAuth client_id).
+
+    Returns:
+        Verified claims dict on success, None on failure.
+    """
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+    except jwt.DecodeError:
+        return None
+
+    token_issuer = unverified.get("iss")
+    if not token_issuer:
+        return None
+
+    # Validate issuer against allowlist (normalize trailing slashes)
+    normalized_issuer = token_issuer.rstrip("/")
+    normalized_allowed = {s.rstrip("/") for s in authorization_servers if isinstance(s, str)}
+    if normalized_issuer not in normalized_allowed:
+        logger.warning("OAuth token issuer %s not in allowlist %s", normalized_issuer, normalized_allowed)
+        return None
+
+    # Discover OIDC metadata and resolve JWKS URI
+    metadata = await _discover_oidc_metadata(normalized_issuer)
+    if not metadata:
+        return None
+
+    jwks_uri = metadata.get("jwks_uri")
+    if not isinstance(jwks_uri, str) or not jwks_uri.strip():
+        logger.warning("No jwks_uri in OIDC metadata for issuer %s", normalized_issuer)
+        return None
+
+    try:
+        jwks_uri = jwks_uri.strip()
+        if jwks_uri not in _oauth_jwks_client_cache:
+            _oauth_jwks_client_cache[jwks_uri] = jwt.PyJWKClient(jwks_uri)
+        jwks_client = _oauth_jwks_client_cache[jwks_uri]
+
+        signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
+        decode_options = {"verify_signature": True, "verify_exp": True, "verify_iat": True, "verify_iss": False, "verify_aud": bool(expected_audience)}
+        decode_kwargs: Dict[str, Any] = {
+            "key": signing_key.key,
+            "algorithms": ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "EdDSA"],
+            "options": decode_options,
+        }
+        if expected_audience:
+            decode_kwargs["audience"] = expected_audience
+        verified = await asyncio.to_thread(jwt.decode, token, **decode_kwargs)
+        logger.info("OAuth access token verified (issuer=%s, sub=%s)", normalized_issuer, verified.get("sub", "unknown"))
+        return verified
+    except jwt.PyJWTError as exc:
+        logger.warning("OAuth access token verification failed (issuer=%s): %s", normalized_issuer, exc)
+        return None

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -69,6 +69,7 @@ import jwt
 from mcpgateway.config import settings
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.jwt_config_helper import validate_jwt_algo_and_keys
+from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.time_restrictions import validate_time_restrictions
 
 basic_security = HTTPBasic(auto_error=False)
@@ -1357,6 +1358,16 @@ async def _discover_oidc_metadata(issuer: str) -> Optional[dict[str, Any]]:
             probe_errors.append(f"{url}: metadata is not a JSON object")
             continue
 
+        # RFC 8414 §3.3: verify the metadata ``issuer`` matches what we
+        # expected. A compromised CDN/proxy could serve metadata for a
+        # different issuer; caching it would let an attacker control the
+        # jwks_uri for a legitimate issuer.
+        metadata_issuer = metadata.get("issuer", "")
+        if isinstance(metadata_issuer, str) and metadata_issuer.rstrip("/") != normalized:
+            probe_errors.append(f"{url}: metadata issuer {metadata_issuer!r} does not match expected {normalized!r}")
+            logger.debug("Metadata issuer mismatch at %s: got %s, expected %s", url, metadata_issuer, normalized)
+            continue
+
         _oauth_oidc_metadata_cache[normalized] = (monotonic(), metadata, _OAUTH_OIDC_METADATA_TTL)
         return metadata
 
@@ -1413,7 +1424,7 @@ async def verify_oauth_access_token(
     normalized_issuer = token_issuer.rstrip("/")
     normalized_allowed = {s.rstrip("/") for s in authorization_servers if isinstance(s, str)}
     if normalized_issuer not in normalized_allowed:
-        logger.warning("OAuth token issuer %s not in allowlist %s", normalized_issuer, normalized_allowed)
+        logger.warning("OAuth token issuer %s not in allowlist %s", sanitize_for_log(normalized_issuer), normalized_allowed)
         return None
 
     # Discover OIDC metadata and resolve JWKS URI
@@ -1423,7 +1434,20 @@ async def verify_oauth_access_token(
 
     jwks_uri = metadata.get("jwks_uri")
     if not isinstance(jwks_uri, str) or not jwks_uri.strip():
-        logger.warning("No jwks_uri in OIDC metadata for issuer %s", normalized_issuer)
+        logger.warning("No jwks_uri in OIDC metadata for issuer %s", sanitize_for_log(normalized_issuer))
+        return None
+
+    # Defense-in-depth: the jwks_uri from metadata must share the issuer's
+    # origin and use HTTPS. A compromised metadata endpoint could otherwise
+    # redirect key fetches to an attacker-controlled or internal host.
+    jwks_parts = urlsplit(jwks_uri.strip())
+    issuer_parts = urlsplit(normalized_issuer)
+    if jwks_parts.scheme != "https" or jwks_parts.netloc != issuer_parts.netloc:
+        logger.warning(
+            "jwks_uri %s does not match issuer origin %s; rejecting (SSRF defense)",
+            sanitize_for_log(jwks_uri),
+            sanitize_for_log(normalized_issuer),
+        )
         return None
 
     # Reject OIDC ID tokens before signature verification. ID tokens are
@@ -1445,7 +1469,7 @@ async def verify_oauth_access_token(
     if id_token_markers:
         logger.warning(
             "Rejecting OIDC ID token masquerading as OAuth access token (issuer=%s, claims=%s)",
-            normalized_issuer,
+            sanitize_for_log(normalized_issuer),
             id_token_markers,
         )
         return None
@@ -1466,8 +1490,22 @@ async def verify_oauth_access_token(
         if expected_audience:
             decode_kwargs["audience"] = expected_audience
         verified = await asyncio.to_thread(jwt.decode, token, **decode_kwargs)
-        logger.debug("OAuth access token verified (issuer=%s, sub=%s)", normalized_issuer, verified.get("sub", "unknown"))
+
+        # Re-verify the issuer in the *signed* payload against the issuer
+        # we resolved JWKS keys for (defense-in-depth). PyJWT's built-in
+        # ``verify_iss`` does not normalize trailing slashes, so we do it
+        # ourselves with the same normalization applied to the allowlist.
+        verified_iss = verified.get("iss", "")
+        if not isinstance(verified_iss, str) or verified_iss.rstrip("/") != normalized_issuer:
+            logger.warning(
+                "Verified token iss %s does not match expected issuer %s",
+                sanitize_for_log(str(verified_iss)),
+                sanitize_for_log(normalized_issuer),
+            )
+            return None
+
+        logger.debug("OAuth access token verified (issuer=%s, sub=%s)", sanitize_for_log(normalized_issuer), verified.get("sub", "unknown"))
         return verified
     except jwt.PyJWTError as exc:
-        logger.warning("OAuth access token verification failed (issuer=%s): %s", normalized_issuer, exc)
+        logger.warning("OAuth access token verification failed (issuer=%s): %s", sanitize_for_log(normalized_issuer), exc)
         return None

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -56,7 +56,8 @@ import asyncio
 from base64 import b64decode
 import binascii
 from time import monotonic
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional, Union
+from urllib.parse import urlsplit, urlunsplit
 
 # Third-Party
 from fastapi import Cookie, Depends, HTTPException, Request, status
@@ -1228,16 +1229,84 @@ async def require_admin_auth(
 
 # Module-level caches for OIDC discovery and JWKS clients.
 # Same caching pattern used in sso_service.py for id_token verification.
-_oauth_oidc_metadata_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
-_OAUTH_OIDC_METADATA_TTL = 300  # seconds
-_oauth_jwks_client_cache: Dict[str, jwt.PyJWKClient] = {}
+# A cached value of ``None`` is a negative result (discovery failure) cached
+# with a shorter TTL to avoid thrashing a misbehaving IdP.
+#
+# Negative caching distinguishes *transient* failures (network errors, 5xx,
+# request timeouts — the IdP may recover shortly) from *permanent* failures
+# (404, malformed JSON — the URL is simply wrong for this issuer). A short
+# transient TTL keeps IdP restarts from blackholing every virtual server
+# sharing that issuer for the longer permanent TTL.
+# Cache entry: (cached_at, metadata_or_None, ttl_seconds). The TTL is part
+# of the entry so we can distinguish transient from permanent negatives.
+_oauth_oidc_metadata_cache: dict[str, tuple[float, Optional[dict[str, Any]], float]] = {}
+_OAUTH_OIDC_METADATA_TTL = 300  # seconds — successful discovery
+_OAUTH_OIDC_METADATA_NEGATIVE_TTL_PERMANENT = 30  # seconds — 404/malformed
+_OAUTH_OIDC_METADATA_NEGATIVE_TTL_TRANSIENT = 5  # seconds — timeouts / 5xx / network
+_oauth_jwks_client_cache: dict[str, jwt.PyJWKClient] = {}
 
 
-async def _discover_oidc_metadata(issuer: str) -> Optional[Dict[str, Any]]:
-    """Fetch and cache OIDC provider metadata via well-known endpoint.
+def _build_metadata_urls(issuer: str) -> list[str]:
+    """Return the well-known metadata URLs to probe for ``issuer``.
+
+    Supports both RFC 8414 (OAuth Authorization Server Metadata) and OpenID
+    Connect Discovery 1.0. The two specs differ in where the well-known
+    segment is inserted relative to the issuer's path component:
+
+    * **RFC 8414**: the well-known segment is inserted between the host and
+      any path component — ``https://example.com/issuer1`` →
+      ``https://example.com/.well-known/oauth-authorization-server/issuer1``.
+    * **OIDC Discovery 1.0**: the well-known segment is *appended* to the
+      issuer path — ``https://example.com/issuer1`` →
+      ``https://example.com/issuer1/.well-known/openid-configuration``.
+
+    Both are tried in order; RFC 8414 comes first because ``authorization_servers``
+    in RFC 9728 is a generic OAuth issuer list and may point at servers that
+    do not publish an OIDC document at all.
+
+    For issuers with no path component, the two OIDC and OAuth URLs collapse
+    to ``{host}/.well-known/<segment>``.
 
     Args:
-        issuer: OIDC issuer URL.
+        issuer: The authorization server issuer URL.
+
+    Returns:
+        A list of candidate metadata URLs, in the order they should be tried.
+    """
+    parts = urlsplit(issuer.rstrip("/"))
+    issuer_path = parts.path  # "" or "/..."
+
+    oauth_path = "/.well-known/oauth-authorization-server"
+    if issuer_path:
+        oauth_path = f"{oauth_path}{issuer_path}"
+    oauth_url = urlunsplit((parts.scheme, parts.netloc, oauth_path, "", ""))
+
+    oidc_path = f"{issuer_path}/.well-known/openid-configuration"
+    oidc_url = urlunsplit((parts.scheme, parts.netloc, oidc_path, "", ""))
+
+    # When issuer has no path, both URLs differ only by the well-known
+    # segment; still probe both so a server that only publishes one form is
+    # discovered. ``dict.fromkeys`` preserves order while de-duplicating.
+    return list(dict.fromkeys([oauth_url, oidc_url]))
+
+
+async def _discover_oidc_metadata(issuer: str) -> Optional[dict[str, Any]]:
+    """Fetch and cache authorization-server metadata via RFC 8414 / OIDC discovery.
+
+    Tries both the RFC 8414 OAuth authorization server metadata endpoint
+    (``/.well-known/oauth-authorization-server``) and the OIDC discovery
+    endpoint (``/.well-known/openid-configuration``). Either one producing a
+    valid JSON metadata document is considered a success. Only when *both*
+    probes fail is the issuer negatively cached, so a non-OIDC OAuth server
+    is not permanently blocked by a single failing probe.
+
+    Successful responses are cached for ``_OAUTH_OIDC_METADATA_TTL`` seconds.
+    Failures (no probe returned metadata) are cached as ``None`` for
+    ``_OAUTH_OIDC_METADATA_NEGATIVE_TTL`` seconds so a misbehaving IdP cannot
+    amplify request volume on every inbound token.
+
+    Args:
+        issuer: Authorization server issuer URL.
 
     Returns:
         Provider metadata dict, or None on failure.
@@ -1245,43 +1314,88 @@ async def _discover_oidc_metadata(issuer: str) -> Optional[Dict[str, Any]]:
     normalized = issuer.rstrip("/")
     cached = _oauth_oidc_metadata_cache.get(normalized)
     if cached is not None:
-        cached_at, metadata = cached
-        if monotonic() - cached_at < _OAUTH_OIDC_METADATA_TTL:
+        cached_at, metadata, ttl = cached
+        if monotonic() - cached_at < ttl:
             return metadata
         _oauth_oidc_metadata_cache.pop(normalized, None)
 
     # First-Party
     from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
 
-    try:
-        client = await get_http_client()
-        resp = await client.get(f"{normalized}/.well-known/openid-configuration", timeout=10)
+    client = await get_http_client()
+    probe_errors: list[str] = []
+    saw_transient = False
+    for url in _build_metadata_urls(normalized):
+        try:
+            resp = await client.get(url, timeout=10)
+        except Exception as exc:
+            # Network errors (DNS, connection refused, TLS, timeout) are
+            # transient — the IdP may recover within seconds.
+            probe_errors.append(f"{url}: {type(exc).__name__}: {exc}")
+            logger.debug("OAuth metadata probe errored for %s: %s", url, exc)
+            saw_transient = True
+            continue
+
         if resp.status_code != 200:
-            logger.warning("OAuth OIDC discovery failed for %s: HTTP %s", normalized, resp.status_code)
-            return None
-        metadata = resp.json()
+            # 5xx is transient (server-side outage); 404 / other 4xx is
+            # permanent (URL is simply wrong for this issuer).
+            probe_errors.append(f"{url}: HTTP {resp.status_code}")
+            logger.debug("OAuth metadata probe returned %s for %s", resp.status_code, url)
+            if resp.status_code >= 500 or resp.status_code in {408, 429}:
+                saw_transient = True
+            continue
+
+        try:
+            metadata = resp.json()
+        except Exception as exc:
+            # Malformed JSON is permanent — fix the IdP config.
+            probe_errors.append(f"{url}: invalid JSON: {exc}")
+            logger.debug("OAuth metadata probe returned invalid JSON for %s: %s", url, exc)
+            continue
+
         if not isinstance(metadata, dict):
-            return None
-        _oauth_oidc_metadata_cache[normalized] = (monotonic(), metadata)
+            probe_errors.append(f"{url}: metadata is not a JSON object")
+            continue
+
+        _oauth_oidc_metadata_cache[normalized] = (monotonic(), metadata, _OAUTH_OIDC_METADATA_TTL)
         return metadata
-    except Exception as exc:
-        logger.warning("OAuth OIDC discovery request failed for %s: %s", normalized, exc)
-        return None
+
+    # All probes failed. Choose TTL based on whether any probe looked
+    # transient: if yes, cache for the short transient window so a brief
+    # IdP blip does not blackhole all virtual servers sharing this issuer
+    # for the permanent window.
+    ttl_on_failure = _OAUTH_OIDC_METADATA_NEGATIVE_TTL_TRANSIENT if saw_transient else _OAUTH_OIDC_METADATA_NEGATIVE_TTL_PERMANENT
+    logger.warning(
+        "Authorization server metadata discovery failed for %s (ttl=%ss, probes=%s)",
+        normalized,
+        ttl_on_failure,
+        probe_errors,
+    )
+    _oauth_oidc_metadata_cache[normalized] = (monotonic(), None, ttl_on_failure)
+    return None
 
 
-async def verify_oauth_access_token(token: str, authorization_servers: List[str], *, expected_audience: Optional[str] = None) -> Optional[Dict[str, Any]]:
+async def verify_oauth_access_token(
+    token: str,
+    authorization_servers: list[str],
+    *,
+    expected_audience: Optional[Union[str, list[str]]] = None,
+) -> Optional[dict[str, Any]]:
     """Verify an OAuth access token issued by a configured authorization server.
 
     Used for Virtual Server MCP endpoints with ``oauth_enabled=True``.
     Validates the token issuer against the server's allowlist, discovers
-    the JWKS endpoint via OIDC metadata, and verifies the signature.
-    When ``expected_audience`` is provided (from ``oauth_config.client_id``),
-    the token's ``aud`` claim is also validated.
+    the JWKS endpoint via RFC 8414 / OIDC metadata, and verifies the signature.
+    When ``expected_audience`` is provided, the token's ``aud`` claim is also
+    validated; a list value means any one of the supplied audiences is
+    accepted (PyJWT's native semantics).
 
     Args:
         token: Raw JWT Bearer token string.
         authorization_servers: Allowed issuer URLs from ``server.oauth_config``.
-        expected_audience: Optional audience to validate against (typically the OAuth client_id).
+        expected_audience: Audience value(s) to validate against. Typically
+            the canonical MCP resource URL (RFC 8707/9728), optionally plus
+            the OAuth client_id for IdPs that populate ``aud`` that way.
 
     Returns:
         Verified claims dict on success, None on failure.
@@ -1312,6 +1426,30 @@ async def verify_oauth_access_token(token: str, authorization_servers: List[str]
         logger.warning("No jwks_uri in OIDC metadata for issuer %s", normalized_issuer)
         return None
 
+    # Reject OIDC ID tokens before signature verification. ID tokens are
+    # front-channel credentials (authorization code / implicit flow) and
+    # must never be accepted as MCP bearer tokens. A matching ``aud`` alone
+    # is insufficient to distinguish them — an IdP configured with
+    # ``client_id`` in ``oauth_config`` would otherwise let a client replay
+    # an ID token it obtained via SSO.
+    #
+    # ``nonce`` and ``at_hash`` are defined only for ID tokens (OIDC Core
+    # §2); their presence on a bearer token is a reliable indicator from
+    # the IdPs that matter in practice (Keycloak, Auth0, Entra ID, Okta,
+    # Authentik all populate at least ``nonce`` on ID tokens for standard
+    # flows). The ``typ: at+jwt`` header (RFC 9068) is a positive access
+    # token marker but not required, so we do not key the decision on it —
+    # rejecting on its absence would break providers and PyJWT's default
+    # ``typ: JWT`` header which is used by many test/fake signers.
+    id_token_markers = [claim for claim in ("nonce", "at_hash") if claim in unverified]
+    if id_token_markers:
+        logger.warning(
+            "Rejecting OIDC ID token masquerading as OAuth access token (issuer=%s, claims=%s)",
+            normalized_issuer,
+            id_token_markers,
+        )
+        return None
+
     try:
         jwks_uri = jwks_uri.strip()
         if jwks_uri not in _oauth_jwks_client_cache:
@@ -1320,7 +1458,7 @@ async def verify_oauth_access_token(token: str, authorization_servers: List[str]
 
         signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
         decode_options = {"verify_signature": True, "verify_exp": True, "verify_iat": True, "verify_iss": False, "verify_aud": bool(expected_audience)}
-        decode_kwargs: Dict[str, Any] = {
+        decode_kwargs: dict[str, Any] = {
             "key": signing_key.key,
             "algorithms": ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "EdDSA"],
             "options": decode_options,
@@ -1328,7 +1466,7 @@ async def verify_oauth_access_token(token: str, authorization_servers: List[str]
         if expected_audience:
             decode_kwargs["audience"] = expected_audience
         verified = await asyncio.to_thread(jwt.decode, token, **decode_kwargs)
-        logger.info("OAuth access token verified (issuer=%s, sub=%s)", normalized_issuer, verified.get("sub", "unknown"))
+        logger.debug("OAuth access token verified (issuer=%s, sub=%s)", normalized_issuer, verified.get("sub", "unknown"))
         return verified
     except jwt.PyJWTError as exc:
         logger.warning("OAuth access token verification failed (issuer=%s): %s", normalized_issuer, exc)

--- a/tests/e2e/test_oauth_jwks_e2e.py
+++ b/tests/e2e/test_oauth_jwks_e2e.py
@@ -1,0 +1,330 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/e2e/test_oauth_jwks_e2e.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: ContextForge Contributors
+
+E2E tests for OAuth access token verification via JWKS on virtual server MCP endpoints.
+
+Exercises the issuer-based token routing in _auth_jwt() and the JWKS verification flow
+in _try_oauth_access_token() / verify_oauth_access_token() against a real ContextForge +
+Keycloak docker-compose stack.
+
+Requirements:
+    - ContextForge running with docker-compose --profile sso (default: http://localhost:8080)
+    - Keycloak running (default: http://localhost:8180) with mcp-gateway realm imported
+    - playwright installed: pip install playwright
+
+Usage:
+    docker compose --profile sso up -d
+    pytest tests/e2e/test_oauth_jwks_e2e.py -v -s --tb=short
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from contextlib import suppress
+import logging
+import os
+from typing import Any, Generator
+import uuid
+
+# Third-Party
+import pytest
+
+pw = pytest.importorskip("playwright", reason="playwright is not installed – pip install playwright")
+from playwright.sync_api import APIRequestContext, Playwright
+
+# First-Party
+from mcpgateway.utils.create_jwt_token import _create_jwt_token
+
+# Local
+from .mcp_test_helpers import (
+    BASE_URL,
+    skip_no_gateway,
+    TEST_PASSWORD,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://localhost:8180")
+KEYCLOAK_INTERNAL_URL = os.getenv("KEYCLOAK_INTERNAL_URL", "http://keycloak:8080")
+KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "mcp-gateway")
+KEYCLOAK_CLIENT_ID = os.getenv("KEYCLOAK_CLIENT_ID", "mcp-gateway")
+KEYCLOAK_CLIENT_SECRET = os.getenv("KEYCLOAK_CLIENT_SECRET", "keycloak-dev-secret")
+# Issuer in JWTs depends on how Keycloak is accessed. When accessed via docker-internal
+# URL (keycloak:8080), the issuer matches what the gateway can reach for OIDC discovery.
+KEYCLOAK_ISSUER = f"{KEYCLOAK_INTERNAL_URL}/realms/{KEYCLOAK_REALM}"
+KEYCLOAK_TOKEN_URL = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
+KEYCLOAK_TEST_USER = "admin@example.com"
+KEYCLOAK_TEST_PASSWORD = "changeme"
+OAUTH_PREFIX = "oauth-jwks"
+_JWT_SECRET = os.getenv("JWT_SECRET_KEY", "my-test-key")
+
+
+# ---------------------------------------------------------------------------
+# Skip condition: Keycloak must be reachable
+# ---------------------------------------------------------------------------
+def _keycloak_reachable() -> bool:
+    try:
+        import httpx
+
+        resp = httpx.get(f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/.well-known/openid-configuration", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+skip_no_keycloak = pytest.mark.skipif(not _keycloak_reachable(), reason=f"Keycloak not reachable at {KEYCLOAK_URL}")
+pytestmark.append(skip_no_keycloak)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_jwt(email: str, is_admin: bool = False, teams=None) -> str:
+    return _create_jwt_token(
+        {"sub": email},
+        user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        teams=teams,
+        secret=_JWT_SECRET,
+    )
+
+
+def _api_context(playwright: Playwright, token: str) -> APIRequestContext:
+    return playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+
+
+def _get_keycloak_token(email: str, password: str = KEYCLOAK_TEST_PASSWORD) -> str:
+    """Obtain an access token from Keycloak via Resource Owner Password Credentials grant.
+
+    Uses docker exec to request the token from inside the docker network so that the
+    JWT issuer claim matches the internal URL (keycloak:8080) that the gateway can reach
+    for OIDC discovery. Falls back to the external URL if docker exec fails.
+    """
+    import subprocess
+
+    # Request token from inside the gateway container so issuer = keycloak:8080
+    cmd = [
+        "docker", "compose", "exec", "-T", "gateway",
+        "curl", "-sf", "-X", "POST",
+        f"{KEYCLOAK_INTERNAL_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token",
+        "-d", f"grant_type=password&client_id={KEYCLOAK_CLIENT_ID}&client_secret={KEYCLOAK_CLIENT_SECRET}"
+               f"&username={email}&password={password}&scope=openid+profile+email",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    if result.returncode == 0 and result.stdout.strip():
+        import json
+
+        data = json.loads(result.stdout)
+        token = data.get("access_token")
+        if token:
+            return token
+
+    # Fallback: request from host (issuer may differ)
+    import httpx
+
+    resp = httpx.post(
+        KEYCLOAK_TOKEN_URL,
+        data={
+            "grant_type": "password",
+            "client_id": KEYCLOAK_CLIENT_ID,
+            "client_secret": KEYCLOAK_CLIENT_SECRET,
+            "username": email,
+            "password": password,
+            "scope": "openid profile email",
+        },
+        timeout=10,
+    )
+    assert resp.status_code == 200, f"Keycloak token request failed: {resp.status_code} {resp.text}"
+    return resp.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Admin API context using CF-issued JWT."""
+    token = _make_jwt(KEYCLOAK_TEST_USER, is_admin=True)
+    ctx = _api_context(playwright, token)
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def cf_test_user(admin_api: APIRequestContext) -> str:
+    """Ensure the Keycloak test user exists in ContextForge DB."""
+    email = KEYCLOAK_TEST_USER
+    resp = admin_api.post(
+        "/auth/email/admin/users",
+        data={
+            "email": email,
+            "password": TEST_PASSWORD,
+            "full_name": "OAuth JWKS Test User",
+            "is_admin": False,
+            "is_active": True,
+            "password_change_required": False,
+        },
+    )
+    if resp.status not in (200, 201, 409):
+        pytest.fail(f"Failed to create CF user {email}: {resp.status} {resp.text()}")
+    logger.info("CF user %s ready", email)
+    return email
+
+
+@pytest.fixture(scope="module")
+def oauth_server(admin_api: APIRequestContext) -> Generator[dict[str, Any], None, None]:
+    """Create a virtual server with oauth_enabled=True pointing to Keycloak."""
+    uid = uuid.uuid4().hex[:8]
+    name = f"{OAUTH_PREFIX}-server-{uid}"
+    payload = {
+        "server": {
+            "name": name,
+            "description": "OAuth JWKS E2E test server",
+            "oauth_enabled": True,
+            "oauth_config": {
+                "authorization_servers": [KEYCLOAK_ISSUER],
+            },
+        },
+        "visibility": "public",
+    }
+    resp = admin_api.post("/servers", data=payload)
+    assert resp.status in (200, 201), f"Failed to create OAuth server: {resp.status} {resp.text()}"
+    server = resp.json()
+    logger.info("Created OAuth server: %s (id=%s)", name, server["id"])
+
+    yield {"id": server["id"], "name": name}
+
+    with suppress(Exception):
+        admin_api.delete(f"/servers/{server['id']}")
+
+
+@pytest.fixture(scope="module")
+def non_oauth_server(admin_api: APIRequestContext) -> Generator[dict[str, Any], None, None]:
+    """Create a virtual server WITHOUT oauth_enabled."""
+    uid = uuid.uuid4().hex[:8]
+    name = f"{OAUTH_PREFIX}-no-oauth-{uid}"
+    payload = {
+        "server": {
+            "name": name,
+            "description": "Non-OAuth E2E test server",
+        },
+        "visibility": "public",
+    }
+    resp = admin_api.post("/servers", data=payload)
+    assert resp.status in (200, 201), f"Failed to create non-OAuth server: {resp.status} {resp.text()}"
+    server = resp.json()
+    logger.info("Created non-OAuth server: %s (id=%s)", name, server["id"])
+
+    yield {"id": server["id"], "name": name}
+
+    with suppress(Exception):
+        admin_api.delete(f"/servers/{server['id']}")
+
+
+@pytest.fixture(scope="module")
+def wrong_issuer_server(admin_api: APIRequestContext) -> Generator[dict[str, Any], None, None]:
+    """Create a virtual server with oauth_enabled but a different issuer allowlist."""
+    uid = uuid.uuid4().hex[:8]
+    name = f"{OAUTH_PREFIX}-wrong-issuer-{uid}"
+    payload = {
+        "server": {
+            "name": name,
+            "description": "OAuth server with wrong issuer",
+            "oauth_enabled": True,
+            "oauth_config": {
+                "authorization_servers": ["https://other-idp.example.com"],
+            },
+        },
+        "visibility": "public",
+    }
+    resp = admin_api.post("/servers", data=payload)
+    assert resp.status in (200, 201), f"Failed to create wrong-issuer server: {resp.status} {resp.text()}"
+    server = resp.json()
+    logger.info("Created wrong-issuer server: %s (id=%s)", name, server["id"])
+
+    yield {"id": server["id"], "name": name}
+
+    with suppress(Exception):
+        admin_api.delete(f"/servers/{server['id']}")
+
+
+# ---------------------------------------------------------------------------
+# MCP JSON-RPC helper
+# ---------------------------------------------------------------------------
+_INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "id": 1,
+    "params": {
+        "capabilities": {},
+        "protocolVersion": "2025-03-26",
+        "clientInfo": {"name": "oauth-jwks-test", "version": "1.0"},
+    },
+}
+
+
+def _mcp_request(playwright: Playwright, server_id: str, token: str) -> int:
+    """Send an MCP initialize request to a virtual server and return the HTTP status code."""
+    ctx = playwright.request.new_context(
+        base_url=BASE_URL,
+        extra_http_headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+    )
+    try:
+        resp = ctx.post(f"/servers/{server_id}/mcp", data=_INITIALIZE_REQUEST)
+        return resp.status
+    finally:
+        ctx.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestOAuthJWKSVerification:
+    """E2E tests for OAuth access token verification via JWKS."""
+
+    def test_valid_keycloak_jwt_accepted(self, playwright: Playwright, oauth_server: dict, cf_test_user: str):
+        """Valid Keycloak JWT on oauth_enabled server is accepted."""
+        kc_token = _get_keycloak_token(cf_test_user)
+        status = _mcp_request(playwright, oauth_server["id"], kc_token)
+        assert status != 401, "Valid Keycloak JWT should not be rejected"
+        assert status != 403, "Valid Keycloak JWT should not be forbidden"
+        logger.info("Valid Keycloak JWT accepted (status=%d)", status)
+
+    def test_non_oauth_server_rejects_keycloak_jwt(self, playwright: Playwright, non_oauth_server: dict, cf_test_user: str):
+        """Keycloak JWT on a server without oauth_enabled is rejected."""
+        kc_token = _get_keycloak_token(cf_test_user)
+        status = _mcp_request(playwright, non_oauth_server["id"], kc_token)
+        assert status == 401, f"Non-OAuth server should reject IdP token, got {status}"
+
+    def test_wrong_issuer_rejected(self, playwright: Playwright, wrong_issuer_server: dict, cf_test_user: str):
+        """Keycloak JWT is rejected when issuer is not in the server's allowlist."""
+        kc_token = _get_keycloak_token(cf_test_user)
+        status = _mcp_request(playwright, wrong_issuer_server["id"], kc_token)
+        assert status == 401, f"Wrong issuer should be rejected, got {status}"
+
+    def test_invalid_token_rejected(self, playwright: Playwright, oauth_server: dict):
+        """Garbage token is rejected."""
+        status = _mcp_request(playwright, oauth_server["id"], "not-a-valid-jwt-token")
+        assert status == 401, f"Invalid token should be rejected, got {status}"
+
+    def test_user_not_in_cf_rejected(self, playwright: Playwright, oauth_server: dict):
+        """Keycloak JWT for a user not registered in ContextForge is rejected."""
+        # newuser@example.com exists in Keycloak but NOT registered in CF
+        kc_token = _get_keycloak_token("newuser@example.com")
+        status = _mcp_request(playwright, oauth_server["id"], kc_token)
+        assert status in (401, 403), f"Unregistered user should be rejected, got {status}"

--- a/tests/e2e/test_oauth_jwks_e2e.py
+++ b/tests/e2e/test_oauth_jwks_e2e.py
@@ -34,17 +34,14 @@ import uuid
 import pytest
 
 pw = pytest.importorskip("playwright", reason="playwright is not installed – pip install playwright")
-from playwright.sync_api import APIRequestContext, Playwright
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright  # noqa: E402
 
 # First-Party
-from mcpgateway.utils.create_jwt_token import _create_jwt_token
+from mcpgateway.utils.create_jwt_token import _create_jwt_token  # noqa: E402
 
 # Local
-from .mcp_test_helpers import (
-    BASE_URL,
-    skip_no_gateway,
-    TEST_PASSWORD,
-)
+from .mcp_test_helpers import BASE_URL, skip_no_gateway, TEST_PASSWORD  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +60,7 @@ KEYCLOAK_CLIENT_SECRET = os.getenv("KEYCLOAK_CLIENT_SECRET", "keycloak-dev-secre
 KEYCLOAK_ISSUER = f"{KEYCLOAK_INTERNAL_URL}/realms/{KEYCLOAK_REALM}"
 KEYCLOAK_TOKEN_URL = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
 KEYCLOAK_TEST_USER = "admin@example.com"
-KEYCLOAK_TEST_PASSWORD = "changeme"
+KEYCLOAK_TEST_PASSWORD = "changeme"  # pragma: allowlist secret — e2e Keycloak fixture, not a real credential
 OAUTH_PREFIX = "oauth-jwks"
 _JWT_SECRET = os.getenv("JWT_SECRET_KEY", "my-test-key")
 
@@ -73,11 +70,19 @@ _JWT_SECRET = os.getenv("JWT_SECRET_KEY", "my-test-key")
 # ---------------------------------------------------------------------------
 def _keycloak_reachable() -> bool:
     try:
+        # Third-Party
         import httpx
 
         resp = httpx.get(f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/.well-known/openid-configuration", timeout=5)
         return resp.status_code == 200
-    except Exception:
+    except Exception as exc:
+        # Surface the real reason so a missing dependency (e.g. httpx not
+        # installed in CI) or a config error is not silently hidden as
+        # "Keycloak not reachable".
+        # Standard
+        import warnings
+
+        warnings.warn(f"_keycloak_reachable probe failed: {type(exc).__name__}: {exc}", stacklevel=2)
         return False
 
 
@@ -111,18 +116,27 @@ def _get_keycloak_token(email: str, password: str = KEYCLOAK_TEST_PASSWORD) -> s
     JWT issuer claim matches the internal URL (keycloak:8080) that the gateway can reach
     for OIDC discovery. Falls back to the external URL if docker exec fails.
     """
+    # Standard
     import subprocess
 
     # Request token from inside the gateway container so issuer = keycloak:8080
     cmd = [
-        "docker", "compose", "exec", "-T", "gateway",
-        "curl", "-sf", "-X", "POST",
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "gateway",
+        "curl",
+        "-sf",
+        "-X",
+        "POST",
         f"{KEYCLOAK_INTERNAL_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token",
-        "-d", f"grant_type=password&client_id={KEYCLOAK_CLIENT_ID}&client_secret={KEYCLOAK_CLIENT_SECRET}"
-               f"&username={email}&password={password}&scope=openid+profile+email",
+        "-d",
+        f"grant_type=password&client_id={KEYCLOAK_CLIENT_ID}&client_secret={KEYCLOAK_CLIENT_SECRET}" f"&username={email}&password={password}&scope=openid+profile+email",
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=15, check=False)
     if result.returncode == 0 and result.stdout.strip():
+        # Standard
         import json
 
         data = json.loads(result.stdout)
@@ -131,6 +145,7 @@ def _get_keycloak_token(email: str, password: str = KEYCLOAK_TEST_PASSWORD) -> s
             return token
 
     # Fallback: request from host (issuer may differ)
+    # Third-Party
     import httpx
 
     resp = httpx.post(
@@ -194,6 +209,12 @@ def oauth_server(admin_api: APIRequestContext) -> Generator[dict[str, Any], None
             "oauth_enabled": True,
             "oauth_config": {
                 "authorization_servers": [KEYCLOAK_ISSUER],
+                # Keycloak's default access tokens put the client_id (and
+                # "account") in the aud claim, not the MCP resource URL.
+                # Declaring it here as an extra accepted audience lets the
+                # enforced aud check pass without requiring a custom
+                # Keycloak audience mapper for the E2E stack.
+                "client_id": KEYCLOAK_CLIENT_ID,
             },
         },
         "visibility": "public",

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -4106,3 +4106,240 @@ class TestTenantIdPropagation:
                 await get_current_user(credentials=credentials, request=request)
 
             assert mock_prop.called, "_propagate_tenant_id must be called on the batched-query return path"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OAuth access token verification via JWKS (RFC 9728)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVerifyOauthAccessToken:
+    """Tests for verify_oauth_access_token() in verify_credentials.py.
+
+    Covers token verification via OIDC discovery + JWKS for Virtual Server
+    MCP endpoints with oauth_enabled=True (RFC 9728).
+    """
+
+    ISSUER = "https://auth.example.com/application/o/test/"
+    JWKS_URI = "https://auth.example.com/application/o/test/jwks/"
+
+    @staticmethod
+    def _generate_rsa_keypair():
+        # Third-Party
+        from cryptography.hazmat.primitives.asymmetric import rsa  # pylint: disable=import-outside-toplevel
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        return private_key, private_key.public_key()
+
+    @classmethod
+    def _sign_token(cls, claims: dict, private_key, kid: str = "test-key-1") -> str:
+        # Third-Party
+        import jwt  # pylint: disable=import-outside-toplevel
+
+        return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": kid})
+
+    @pytest.fixture(autouse=True)
+    def _clear_oauth_caches(self):
+        # First-Party
+        from mcpgateway.utils.verify_credentials import _oauth_jwks_client_cache, _oauth_oidc_metadata_cache  # pylint: disable=import-outside-toplevel
+
+        _oauth_oidc_metadata_cache.clear()
+        _oauth_jwks_client_cache.clear()
+        yield
+        _oauth_oidc_metadata_cache.clear()
+        _oauth_jwks_client_cache.clear()
+
+    def _mock_discovery_and_jwks(self, public_key):
+        """Return a context manager that mocks OIDC discovery and JWKS client."""
+        mock_jwks_client = MagicMock()
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = public_key
+        mock_jwks_client.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        # Standard
+        from contextlib import ExitStack  # pylint: disable=import-outside-toplevel
+
+        stack = ExitStack()
+        stack.enter_context(patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)))
+        stack.enter_context(patch("mcpgateway.utils.verify_credentials._oauth_jwks_client_cache", {self.JWKS_URI: mock_jwks_client}))
+        return stack
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_claims(self):
+        """A properly signed token from an allowed issuer returns verified claims."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER])
+
+        assert result is not None
+        assert result["sub"] == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_issuer_not_in_allowlist_returns_none(self):
+        """A token whose issuer is not in the allowlist is rejected."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, _ = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": "https://evil.example.com/", "sub": "attacker", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        result = await verify_oauth_access_token(token, [self.ISSUER])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_issuer_claim_returns_none(self):
+        """A token without an iss claim is rejected."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, _ = self._generate_rsa_keypair()
+        token = self._sign_token({"sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        result = await verify_oauth_access_token(token, [self.ISSUER])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_token_returns_none(self):
+        """A non-JWT string is rejected gracefully."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        result = await verify_oauth_access_token("not-a-jwt", [self.ISSUER])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_expired_token_returns_none(self):
+        """An expired token is rejected."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 1000000000, "iat": 999999000}, private_key)
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER])
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wrong_signature_returns_none(self):
+        """A token signed with a different key than JWKS provides is rejected."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, _ = self._generate_rsa_keypair()
+        _, wrong_public_key = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        with self._mock_discovery_and_jwks(wrong_public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER])
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_oidc_discovery_failure_returns_none(self):
+        """When OIDC discovery fails, verification returns None."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, _ = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            result = await verify_oauth_access_token(token, [self.ISSUER])
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_normalization(self):
+        """Trailing slash differences between token issuer and allowlist are tolerated."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        issuer_no_slash = "https://auth.example.com/application/o/test"
+        token = self._sign_token({"iss": issuer_no_slash, "sub": "user@example.com", "email": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER])  # allowlist has trailing slash
+
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_discovery_cache_reused(self):
+        """Second call within TTL reuses cached OIDC metadata."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import _discover_oidc_metadata  # pylint: disable=import-outside-toplevel
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            r1 = await _discover_oidc_metadata(self.ISSUER)
+            r2 = await _discover_oidc_metadata(self.ISSUER)
+
+        assert r1 == r2
+        assert mock_http.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_valid_audience_passes(self):
+        """Token with matching aud claim passes when expected_audience is set."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        client_id = "my-client-id"
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "aud": client_id, "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER], expected_audience=client_id)
+
+        assert result is not None
+        assert result["aud"] == client_id
+
+    @pytest.mark.asyncio
+    async def test_wrong_audience_rejected(self):
+        """Token with mismatched aud claim is rejected when expected_audience is set."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "aud": "wrong-client", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER], expected_audience="correct-client")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_audience_check_when_not_configured(self):
+        """Token passes without aud check when expected_audience is not provided."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "aud": "any-audience", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(token, [self.ISSUER])  # no expected_audience
+
+        assert result is not None

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -27,6 +27,16 @@ from sqlalchemy.orm import Session
 from mcpgateway.auth import get_current_user, get_db, get_user_team_roles
 from mcpgateway.config import settings
 from mcpgateway.db import EmailUser
+from mcpgateway.transports.streamablehttp_transport import (
+    _StreamableHttpAuthHandler,
+    OAuthAuthResult,
+)
+from mcpgateway.utils.verify_credentials import (
+    _discover_oidc_metadata,
+    _oauth_jwks_client_cache,
+    _oauth_oidc_metadata_cache,
+    verify_oauth_access_token,
+)
 
 
 class TestGetDb:
@@ -3153,6 +3163,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_no_jwt_teams_returns_full_db_teams(self):
         """Without a JWT teams claim, returns full DB membership."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com"}
@@ -3165,6 +3176,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_jwt_teams_narrows_to_intersection(self):
         """JWT teams claim narrows result to intersection with DB teams."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com", "teams": ["t1"]}
@@ -3176,6 +3188,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_jwt_teams_all_revoked_returns_empty(self):
         """If all JWT teams were revoked, returns empty list (public-only / denied)."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com", "teams": ["revoked-team"]}
@@ -3187,6 +3200,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_admin_bypass_ignores_jwt_teams(self):
         """Admin bypass (None from DB) is returned regardless of JWT teams."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "admin@example.com", "teams": ["t1"]}
@@ -3198,6 +3212,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_empty_db_teams_returns_empty(self):
         """User with no DB teams returns empty list (public-only)."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com", "teams": ["t1"]}
@@ -3209,6 +3224,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_preresolved_db_teams_skips_db_call(self):
         """When preresolved_db_teams is provided, skips the DB call."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com", "teams": ["t1"]}
@@ -3226,6 +3242,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_preresolved_none_returns_admin_bypass(self):
         """Preresolved None (admin) returns None without DB call."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "admin@example.com"}
@@ -3243,6 +3260,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_jwt_teams_null_returns_full_db_teams(self):
         """Explicit teams: null in JWT is not a list, so no narrowing."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com", "teams": None}
@@ -3254,6 +3272,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_jwt_teams_empty_list_returns_full_db_teams(self):
         """Explicit teams: [] in JWT is empty, so no narrowing."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         payload = {"sub": "u@example.com", "teams": []}
@@ -3265,6 +3284,7 @@ class TestResolveSessionTeams:
     @pytest.mark.asyncio
     async def test_no_email_returns_public_only(self):
         """Identity-less session token gets public-only scope, never admin bypass."""
+        # First-Party
         from mcpgateway.auth import resolve_session_teams
 
         # Even with is_admin=True, no email means no DB lookup and no admin bypass
@@ -3278,6 +3298,7 @@ class TestNarrowByJwtTeams:
 
     def test_admin_bypass_passthrough(self):
         """Admin bypass (db_teams=None) is returned unchanged regardless of JWT teams."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         assert _narrow_by_jwt_teams({"teams": ["t1"]}, None) is None
@@ -3285,6 +3306,7 @@ class TestNarrowByJwtTeams:
 
     def test_normal_intersection(self):
         """Intersection of DB teams and JWT teams returns only the overlap."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         result = _narrow_by_jwt_teams({"teams": ["t1", "t3"]}, ["t1", "t2"])
@@ -3292,6 +3314,7 @@ class TestNarrowByJwtTeams:
 
     def test_empty_intersection(self):
         """No overlap between JWT and DB teams returns empty list."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         result = _narrow_by_jwt_teams({"teams": ["gone"]}, ["t1", "t2"])
@@ -3299,6 +3322,7 @@ class TestNarrowByJwtTeams:
 
     def test_empty_jwt_teams_no_narrowing(self):
         """Explicit teams: [] means 'no restriction' — returns full DB teams."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         result = _narrow_by_jwt_teams({"teams": []}, ["t1", "t2"])
@@ -3306,6 +3330,7 @@ class TestNarrowByJwtTeams:
 
     def test_missing_jwt_teams_no_narrowing(self):
         """Missing teams key means 'no restriction' — returns full DB teams."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         result = _narrow_by_jwt_teams({}, ["t1", "t2"])
@@ -3313,6 +3338,7 @@ class TestNarrowByJwtTeams:
 
     def test_null_jwt_teams_no_narrowing(self):
         """Explicit teams: null is not a list — returns full DB teams."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         result = _narrow_by_jwt_teams({"teams": None}, ["t1"])
@@ -3320,6 +3346,7 @@ class TestNarrowByJwtTeams:
 
     def test_malformed_entries_filtered_by_normalize(self):
         """Non-string entries in JWT teams are handled by normalize_token_teams."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         # normalize_token_teams stringifies numeric entries
@@ -3328,6 +3355,7 @@ class TestNarrowByJwtTeams:
 
     def test_empty_db_teams_returns_empty(self):
         """If user has no DB teams, intersection with any JWT teams is empty."""
+        # First-Party
         from mcpgateway.auth import _narrow_by_jwt_teams
 
         result = _narrow_by_jwt_teams({"teams": ["t1"]}, [])
@@ -4140,9 +4168,6 @@ class TestVerifyOauthAccessToken:
 
     @pytest.fixture(autouse=True)
     def _clear_oauth_caches(self):
-        # First-Party
-        from mcpgateway.utils.verify_credentials import _oauth_jwks_client_cache, _oauth_oidc_metadata_cache  # pylint: disable=import-outside-toplevel
-
         _oauth_oidc_metadata_cache.clear()
         _oauth_jwks_client_cache.clear()
         yield
@@ -4173,9 +4198,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_valid_token_returns_claims(self):
         """A properly signed token from an allowed issuer returns verified claims."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, public_key = self._generate_rsa_keypair()
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
 
@@ -4188,9 +4210,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_issuer_not_in_allowlist_returns_none(self):
         """A token whose issuer is not in the allowlist is rejected."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, _ = self._generate_rsa_keypair()
         token = self._sign_token({"iss": "https://evil.example.com/", "sub": "attacker", "exp": 9999999999, "iat": 1700000000}, private_key)
 
@@ -4200,9 +4219,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_missing_issuer_claim_returns_none(self):
         """A token without an iss claim is rejected."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, _ = self._generate_rsa_keypair()
         token = self._sign_token({"sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
 
@@ -4212,18 +4228,12 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_malformed_token_returns_none(self):
         """A non-JWT string is rejected gracefully."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         result = await verify_oauth_access_token("not-a-jwt", [self.ISSUER])
         assert result is None
 
     @pytest.mark.asyncio
     async def test_expired_token_returns_none(self):
         """An expired token is rejected."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, public_key = self._generate_rsa_keypair()
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 1000000000, "iat": 999999000}, private_key)
 
@@ -4235,9 +4245,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_wrong_signature_returns_none(self):
         """A token signed with a different key than JWKS provides is rejected."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, _ = self._generate_rsa_keypair()
         _, wrong_public_key = self._generate_rsa_keypair()
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
@@ -4250,9 +4257,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_oidc_discovery_failure_returns_none(self):
         """When OIDC discovery fails, verification returns None."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, _ = self._generate_rsa_keypair()
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
 
@@ -4269,9 +4273,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_trailing_slash_normalization(self):
         """Trailing slash differences between token issuer and allowlist are tolerated."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, public_key = self._generate_rsa_keypair()
         issuer_no_slash = "https://auth.example.com/application/o/test"
         token = self._sign_token({"iss": issuer_no_slash, "sub": "user@example.com", "email": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
@@ -4284,9 +4285,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_discovery_cache_reused(self):
         """Second call within TTL reuses cached OIDC metadata."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import _discover_oidc_metadata  # pylint: disable=import-outside-toplevel
-
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
@@ -4303,9 +4301,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_valid_audience_passes(self):
         """Token with matching aud claim passes when expected_audience is set."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, public_key = self._generate_rsa_keypair()
         client_id = "my-client-id"
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "aud": client_id, "exp": 9999999999, "iat": 1700000000}, private_key)
@@ -4319,9 +4314,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_wrong_audience_rejected(self):
         """Token with mismatched aud claim is rejected when expected_audience is set."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, public_key = self._generate_rsa_keypair()
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "aud": "wrong-client", "exp": 9999999999, "iat": 1700000000}, private_key)
 
@@ -4333,9 +4325,6 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_no_audience_check_when_not_configured(self):
         """Token passes without aud check when expected_audience is not provided."""
-        # First-Party
-        from mcpgateway.utils.verify_credentials import verify_oauth_access_token  # pylint: disable=import-outside-toplevel
-
         private_key, public_key = self._generate_rsa_keypair()
         token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "aud": "any-audience", "exp": 9999999999, "iat": 1700000000}, private_key)
 
@@ -4343,3 +4332,1233 @@ class TestVerifyOauthAccessToken:
             result = await verify_oauth_access_token(token, [self.ISSUER])  # no expected_audience
 
         assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_discovery_negative_result_cached(self):
+        """Failed discovery is cached so a misbehaving IdP is not retried every call."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            r1 = await _discover_oidc_metadata(self.ISSUER)
+            r2 = await _discover_oidc_metadata(self.ISSUER)
+
+        assert r1 is None
+        assert r2 is None
+        # First call probes both the RFC 8414 OAuth metadata URL and the
+        # OIDC discovery URL; only after BOTH fail is the issuer negatively
+        # cached. The second call is served entirely from that cache.
+        assert mock_http.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_rfc8414_metadata_used_when_oidc_missing(self):
+        """A non-OIDC OAuth server's RFC 8414 metadata document is accepted."""
+
+        async def fake_get(url, *_args, **_kwargs):
+            resp = MagicMock()
+            if url.endswith("/.well-known/oauth-authorization-server"):
+                resp.status_code = 200
+                resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_http = AsyncMock()
+        mock_http.get.side_effect = fake_get
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            metadata = await _discover_oidc_metadata("https://auth.example.com")
+
+        assert metadata is not None
+        assert metadata["jwks_uri"] == self.JWKS_URI
+
+    @pytest.mark.asyncio
+    async def test_oidc_metadata_used_when_rfc8414_missing(self):
+        """A pure OIDC server with no RFC 8414 document still discovers successfully."""
+
+        async def fake_get(url, *_args, **_kwargs):
+            resp = MagicMock()
+            if url.endswith("/.well-known/openid-configuration"):
+                resp.status_code = 200
+                resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_http = AsyncMock()
+        mock_http.get.side_effect = fake_get
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            metadata = await _discover_oidc_metadata("https://auth.example.com")
+
+        assert metadata is not None
+        assert metadata["jwks_uri"] == self.JWKS_URI
+
+    def test_build_metadata_urls_rfc8414_path_insertion(self):
+        """RFC 8414 inserts the well-known segment between host and path."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import _build_metadata_urls  # pylint: disable=import-outside-toplevel
+
+        urls = _build_metadata_urls("https://example.com/issuer1")
+        assert "https://example.com/.well-known/oauth-authorization-server/issuer1" in urls
+        assert "https://example.com/issuer1/.well-known/openid-configuration" in urls
+
+    def test_build_metadata_urls_no_path(self):
+        """With no issuer path, both well-known URLs share the root host."""
+        # First-Party
+        from mcpgateway.utils.verify_credentials import _build_metadata_urls  # pylint: disable=import-outside-toplevel
+
+        urls = _build_metadata_urls("https://example.com")
+        assert urls == [
+            "https://example.com/.well-known/oauth-authorization-server",
+            "https://example.com/.well-known/openid-configuration",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_id_token_with_nonce_rejected(self):
+        """OIDC ID tokens carrying a ``nonce`` claim must not be accepted as access tokens.
+
+        An attacker who obtains an ID token via SSO could otherwise replay it
+        as an MCP bearer token when the virtual server is configured with the
+        same ``client_id`` that ID token has in ``aud``. The claim-based
+        detection catches this for every major IdP (Keycloak, Auth0, Entra,
+        Okta, Authentik) without requiring RFC 9068 ``typ`` support.
+        """
+        private_key, public_key = self._generate_rsa_keypair()
+        id_token = self._sign_token(
+            {
+                "iss": self.ISSUER,
+                "sub": "user@example.com",
+                "email": "user@example.com",
+                "aud": "my-client",
+                "nonce": "abc-123",  # ← ID-token-only claim
+                "exp": 9999999999,
+                "iat": 1700000000,
+            },
+            private_key,
+        )
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(id_token, [self.ISSUER], expected_audience="my-client")
+
+        assert result is None  # Signature would have verified; claim check fails closed.
+
+    @pytest.mark.asyncio
+    async def test_id_token_with_at_hash_rejected(self):
+        """An ID token with ``at_hash`` (OIDC Core §2) is rejected."""
+        private_key, public_key = self._generate_rsa_keypair()
+        id_token = self._sign_token(
+            {
+                "iss": self.ISSUER,
+                "sub": "user@example.com",
+                "aud": "my-client",
+                "at_hash": "xxxx",  # ← ID-token-only claim
+                "exp": 9999999999,
+                "iat": 1700000000,
+            },
+            private_key,
+        )
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(id_token, [self.ISSUER], expected_audience="my-client")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_access_token_without_id_claims_accepted(self):
+        """A token lacking nonce/at_hash is still accepted (regression guard)."""
+        private_key, public_key = self._generate_rsa_keypair()
+        access_token = self._sign_token(
+            {
+                "iss": self.ISSUER,
+                "sub": "user@example.com",
+                "email": "user@example.com",
+                "aud": "my-client",
+                "exp": 9999999999,
+                "iat": 1700000000,
+            },
+            private_key,
+        )
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(access_token, [self.ISSUER], expected_audience="my-client")
+
+        assert result is not None
+        assert result["sub"] == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_id_token_rejected_before_jwks_client_called(self):
+        """ID-token rejection must happen *before* the JWKS signing-key lookup.
+
+        This locks the ordering invariant: a refactor that moves the
+        nonce/at_hash check after ``get_signing_key_from_jwt`` would still
+        reject the token but would have already made an outbound call to
+        the IdP's JWKS endpoint — an unnecessary attack surface and a
+        potential DoS vector. Asserting the JWKS client is never touched
+        proves the check is genuinely defensive.
+        """
+        private_key, public_key = self._generate_rsa_keypair()
+        id_token = self._sign_token(
+            {
+                "iss": self.ISSUER,
+                "sub": "user@example.com",
+                "aud": "my-client",
+                "nonce": "abc-123",
+                "exp": 9999999999,
+                "iat": 1700000000,
+            },
+            private_key,
+        )
+
+        mock_jwks_client = MagicMock()
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = public_key
+        mock_jwks_client.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with (
+            patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)),
+            patch("mcpgateway.utils.verify_credentials._oauth_jwks_client_cache", {self.JWKS_URI: mock_jwks_client}),
+        ):
+            result = await verify_oauth_access_token(id_token, [self.ISSUER], expected_audience="my-client")
+
+        assert result is None
+        # The critical invariant: the JWKS client was never consulted.
+        assert mock_jwks_client.get_signing_key_from_jwt.called is False
+
+    @pytest.mark.asyncio
+    async def test_list_audience_any_match_accepted(self):
+        """PyJWT's list-audience semantics: a token whose ``aud`` matches any list entry passes."""
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token(
+            {
+                "iss": self.ISSUER,
+                "sub": "user@example.com",
+                "email": "user@example.com",
+                "aud": "second-audience",
+                "exp": 9999999999,
+                "iat": 1700000000,
+            },
+            private_key,
+        )
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(
+                token,
+                [self.ISSUER],
+                expected_audience=["first-audience", "second-audience", "third-audience"],
+            )
+
+        assert result is not None
+        assert result["sub"] == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_list_audience_none_match_rejected(self):
+        """A token whose ``aud`` matches none of the list entries is rejected."""
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token(
+            {
+                "iss": self.ISSUER,
+                "sub": "user@example.com",
+                "aud": "wrong-audience",
+                "exp": 9999999999,
+                "iat": 1700000000,
+            },
+            private_key,
+        )
+
+        with self._mock_discovery_and_jwks(public_key):
+            result = await verify_oauth_access_token(
+                token,
+                [self.ISSUER],
+                expected_audience=["first-audience", "second-audience"],
+            )
+
+        assert result is None
+
+
+class TestResolveAuthorizationServers:
+    """Tests for the ``_resolve_authorization_servers`` helper."""
+
+    def test_plural_list_returned_cleaned(self):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_authorization_servers  # pylint: disable=import-outside-toplevel
+
+        result = _resolve_authorization_servers({"authorization_servers": ["  https://a.example  ", "https://b.example"]})
+        assert result == ["https://a.example", "https://b.example"]
+
+    def test_plural_list_with_empty_strings_skipped(self):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_authorization_servers  # pylint: disable=import-outside-toplevel
+
+        result = _resolve_authorization_servers({"authorization_servers": ["", "   ", "https://a.example"]})
+        assert result == ["https://a.example"]
+
+    def test_singular_fallback_used_when_plural_missing(self):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_authorization_servers  # pylint: disable=import-outside-toplevel
+
+        result = _resolve_authorization_servers({"authorization_server": "  https://single.example  "})
+        assert result == ["https://single.example"]
+
+    def test_singular_fallback_used_when_plural_empty(self):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_authorization_servers  # pylint: disable=import-outside-toplevel
+
+        result = _resolve_authorization_servers({"authorization_servers": [], "authorization_server": "https://single.example"})
+        assert result == ["https://single.example"]
+
+    def test_empty_config_returns_empty(self):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_authorization_servers  # pylint: disable=import-outside-toplevel
+
+        assert _resolve_authorization_servers({}) == []
+        assert _resolve_authorization_servers({"authorization_servers": None, "authorization_server": None}) == []
+        assert _resolve_authorization_servers({"authorization_server": "   "}) == []
+
+
+class TestTryOAuthAccessTokenDbErrors:
+    """Tests that DB failures inside ``_try_oauth_access_token`` fail closed.
+
+    Covers the new ``SQLAlchemyError``/``Exception`` handlers around
+    ``_get_user_by_email_sync`` and ``_resolve_teams_from_db``, and the
+    singular ``authorization_server`` fallback path.
+    """
+
+    @pytest.fixture
+    def handler_and_responses(self):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler  # pylint: disable=import-outside-toplevel
+
+        responses: list = []
+
+        async def fake_send(msg):
+            responses.append(msg)
+
+        async def fake_receive():
+            return {}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/servers/srv-1/mcp",
+            "root_path": "",
+            "scheme": "https",
+            "server": ("gateway.example.com", 443),
+            "headers": [(b"host", b"gateway.example.com")],
+        }
+        return _StreamableHttpAuthHandler(scope=scope, receive=fake_receive, send=fake_send), responses
+
+    _OAUTH_TEST_ISSUER = "https://auth.example.com/application/o/test/"
+
+    @staticmethod
+    def _make_token(issuer: str) -> str:
+        """Encode a minimal JWT whose unverified ``iss`` matches the allowlist peek."""
+        # Third-Party
+        import jwt as _jwt  # pylint: disable=import-outside-toplevel
+
+        return _jwt.encode({"iss": issuer, "sub": "user@example.com"}, "unused", algorithm="HS256")
+
+    @pytest.fixture
+    def oauth_server_row(self):
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [self._OAUTH_TEST_ISSUER], "client_id": "test-client"}
+        return server
+
+    @staticmethod
+    def _patched_get_db(server_row):
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server_row
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm)
+
+    @pytest.mark.asyncio
+    async def test_user_lookup_sqlalchemy_error_returns_failed_503(self, handler_and_responses, oauth_server_row):
+        # Third-Party
+        from sqlalchemy.exc import SQLAlchemyError  # pylint: disable=import-outside-toplevel
+
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import OAuthAuthResult  # pylint: disable=import-outside-toplevel
+
+        handler, responses = handler_and_responses
+        token = self._make_token(self._OAUTH_TEST_ISSUER)
+
+        async def fake_verify(*args, **kwargs):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        with (
+            self._patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", side_effect=SQLAlchemyError("db down")),
+        ):
+            result = await handler._try_oauth_access_token(token)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 503
+
+    @pytest.mark.asyncio
+    async def test_user_lookup_unexpected_error_returns_failed_401(self, handler_and_responses, oauth_server_row):
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import OAuthAuthResult  # pylint: disable=import-outside-toplevel
+
+        handler, responses = handler_and_responses
+        token = self._make_token(self._OAUTH_TEST_ISSUER)
+
+        async def fake_verify(*args, **kwargs):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        with (
+            self._patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", side_effect=RuntimeError("boom")),
+        ):
+            result = await handler._try_oauth_access_token(token)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_teams_resolution_sqlalchemy_error_returns_failed_503(self, handler_and_responses, oauth_server_row):
+        # Third-Party
+        from sqlalchemy.exc import SQLAlchemyError  # pylint: disable=import-outside-toplevel
+
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import OAuthAuthResult  # pylint: disable=import-outside-toplevel
+
+        handler, responses = handler_and_responses
+        mock_user = MagicMock(is_active=True, is_admin=False)
+        token = self._make_token(self._OAUTH_TEST_ISSUER)
+
+        async def fake_verify(*args, **kwargs):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        with (
+            self._patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=SQLAlchemyError("teams unavailable")),
+        ):
+            result = await handler._try_oauth_access_token(token)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 503
+
+    @pytest.mark.asyncio
+    async def test_singular_authorization_server_fallback_invoked(self, handler_and_responses, monkeypatch):
+        """``oauth_config={"authorization_server": "..."}`` routes through the singular fallback."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import OAuthAuthResult  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "app_domain", "https://gateway.example.com")
+        handler, _responses = handler_and_responses
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_server": "https://single.example/"}
+        token = self._make_token("https://single.example/")
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            # Returning None causes the helper to send a 401 and return FAILED.
+            captured["authorization_servers"] = authorization_servers
+            captured["expected_audience"] = expected_audience
+
+        with (
+            self._patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(token)
+
+        assert result is OAuthAuthResult.FAILED
+        assert captured["authorization_servers"] == ["https://single.example/"]
+        # Audience enforcement: the canonical MCP resource URL (derived from
+        # ``settings.app_domain``, not the Host header) is always included.
+        # Without an explicit ``client_id``/``resource`` override, the list
+        # contains only that one entry.
+        assert captured["expected_audience"] == ["https://gateway.example.com/servers/srv-1/mcp"]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the OAuth audience & routing security fix
+# ---------------------------------------------------------------------------
+
+SERVER_ID = "srv-1"
+GATEWAY_HOST = "gateway.example.com"
+EXPECTED_RESOURCE_URL = f"https://{GATEWAY_HOST}/servers/{SERVER_ID}/mcp"
+IDP_ISSUER = "https://idp.example.com/"
+INTERNAL_JWT_ISSUER = "mcpgateway"
+
+
+def _make_handler():
+    """Build a ``_StreamableHttpAuthHandler`` against a fully-populated scope.
+
+    The scope is rich enough for ``_build_server_resource_url`` to derive
+    ``EXPECTED_RESOURCE_URL``. Tests that want to exercise the fail-closed
+    "cannot derive URL" branch should use ``_make_handler_unknown_host``.
+    """
+    responses: list = []
+
+    async def fake_send(msg):
+        responses.append(msg)
+
+    async def fake_receive():
+        return {}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": f"/servers/{SERVER_ID}/mcp",
+        "root_path": "",
+        "scheme": "https",
+        "server": (GATEWAY_HOST, 443),
+        "headers": [(b"host", GATEWAY_HOST.encode())],
+    }
+    return _StreamableHttpAuthHandler(scope=scope, receive=fake_receive, send=fake_send), responses
+
+
+def _make_handler_unknown_host():
+    """Build a handler whose scope cannot yield a public base URL.
+
+    No ``host`` header and ``server`` is ``None``, so ``_build_public_base_url``
+    returns ``""`` and ``_try_oauth_access_token`` must take the fail-closed
+    branch.
+    """
+    responses: list = []
+
+    async def fake_send(msg):
+        responses.append(msg)
+
+    async def fake_receive():
+        return {}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": f"/servers/{SERVER_ID}/mcp",
+        "root_path": "",
+        "scheme": "https",
+        "server": None,
+        "headers": [],
+    }
+    return _StreamableHttpAuthHandler(scope=scope, receive=fake_receive, send=fake_send), responses
+
+
+def _patched_get_db(server_row):
+    db_mock = MagicMock()
+    db_mock.execute.return_value.scalar_one_or_none.return_value = server_row
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=db_mock)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm)
+
+
+def _make_idp_token(issuer: str = IDP_ISSUER) -> str:
+    """Encode a minimal JWT with the given ``iss`` claim.
+
+    Only the unverified ``iss`` peek in ``_route_idp_issued_token`` inspects
+    this token — the signing key and algorithm are irrelevant to the routing
+    decision, so we use HS256 with a throwaway key.
+    """
+    # Third-Party
+    import jwt as _jwt  # pylint: disable=import-outside-toplevel
+
+    return _jwt.encode({"iss": issuer, "sub": "user@example.com"}, "unused-key", algorithm="HS256")
+
+
+def _response_body(responses: list) -> bytes:
+    """Concatenate the body bytes from captured ASGI http.response.* messages."""
+    return b"".join(m.get("body", b"") for m in responses if m["type"] == "http.response.body")
+
+
+@pytest.fixture
+def _pinned_app_domain(monkeypatch):
+    """Pin ``settings.app_domain`` to the expected test gateway origin.
+
+    The resource URL is derived from ``settings.app_domain`` (not from
+    ASGI scope headers) to prevent Host-header replay. Tests exercising
+    audience-binding must pin this value so the assertions against
+    ``EXPECTED_RESOURCE_URL`` are deterministic and independent of whatever
+    value the runtime config happens to load.
+    """
+    monkeypatch.setattr(settings, "app_domain", f"https://{GATEWAY_HOST}")
+
+
+class TestOAuthAudienceEnforcement:
+    """Every OAuth-enabled server must bind tokens to its canonical resource URL.
+
+    Invariant: ``_try_oauth_access_token`` MUST pass a non-empty
+    ``expected_audience`` list containing the canonical MCP resource URL
+    (per RFC 8707 / RFC 9728) to ``verify_oauth_access_token``. Explicit
+    ``resource`` / legacy ``client_id`` values extend the list; they never
+    replace the resource URL or silently disable audience validation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resource_url_is_sole_audience_when_no_override(self, _pinned_app_domain):
+        """Server with only ``authorization_servers`` must enforce the resource URL."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            # Returning implicitly (None) causes _try_oauth_access_token
+            # to send a 401 and return FAILED.
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        # Length-1 list: exactly the resource URL, nothing else. This is the
+        # core audience-binding invariant — any mutation that drops the
+        # resource URL or re-introduces a ``None`` default fails here.
+        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL]
+
+    @pytest.mark.asyncio
+    async def test_resource_field_extends_expected_audiences(self, _pinned_app_domain):
+        """``oauth_config.resource`` (scalar) is appended after the resource URL."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {
+            "authorization_servers": [IDP_ISSUER],
+            "resource": "https://api.example.com",
+        }
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL, "https://api.example.com"]
+
+    @pytest.mark.asyncio
+    async def test_resource_field_trims_whitespace(self, _pinned_app_domain):
+        """Scalar ``resource`` entries are stripped of leading/trailing whitespace."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {
+            "authorization_servers": [IDP_ISSUER],
+            "resource": "   https://api.example.com   ",
+        }
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            await handler._try_oauth_access_token(_make_idp_token())
+
+        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL, "https://api.example.com"]
+
+    @pytest.mark.asyncio
+    async def test_resource_field_accepts_list_of_audiences(self, _pinned_app_domain):
+        """``oauth_config.resource`` may be a list; each entry is appended."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {
+            "authorization_servers": [IDP_ISSUER],
+            "resource": ["https://api-a.example.com", "https://api-b.example.com"],
+        }
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        assert captured["expected_audience"] == [
+            EXPECTED_RESOURCE_URL,
+            "https://api-a.example.com",
+            "https://api-b.example.com",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resource_list_filters_invalid_entries(self, _pinned_app_domain):
+        """Empty strings, whitespace, and non-string entries are dropped from ``resource`` lists."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {
+            "authorization_servers": [IDP_ISSUER],
+            "resource": ["https://api-a.example.com", "", "   ", 42, None, "https://api-b.example.com"],
+        }
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            await handler._try_oauth_access_token(_make_idp_token())
+
+        assert captured["expected_audience"] == [
+            EXPECTED_RESOURCE_URL,
+            "https://api-a.example.com",
+            "https://api-b.example.com",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_when_resource_url_cannot_be_derived(self, monkeypatch):
+        """If ``settings.app_domain`` is unusable, reject without verifying.
+
+        Operators MUST set ``app_domain`` to the gateway's public URL for
+        OAuth audience validation to work. If it is empty / missing the
+        handler must fail closed, not fall back to the caller-controlled
+        Host header (which would let a client forge the audience).
+        """
+        monkeypatch.setattr(settings, "app_domain", "")
+        handler, responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        verify_called = False
+
+        async def fake_verify(*_args, **_kwargs):
+            nonlocal verify_called
+            verify_called = True
+            return {"sub": "x"}
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), {"iss": IDP_ISSUER})
+
+        assert result is OAuthAuthResult.FAILED
+        assert verify_called is False  # Verification was short-circuited.
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+        assert b"Invalid OAuth access token" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_audience_ignores_host_header(self, monkeypatch):
+        """The resource URL is anchored on ``settings.app_domain``, not the caller's Host header.
+
+        If the audience were derived from the inbound ``Host`` header, a
+        client could replay a token minted for ``https://other.example.com``
+        simply by sending ``Host: other.example.com``. Pin ``app_domain`` to
+        one value and the handler's scope Host to a *different* value — the
+        computed audience must match ``app_domain``.
+        """
+        monkeypatch.setattr(settings, "app_domain", "https://canonical.example.com")
+
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler  # pylint: disable=import-outside-toplevel
+
+        responses: list = []
+
+        async def fake_send(msg):
+            responses.append(msg)
+
+        async def fake_receive():
+            return {}
+
+        # Scope advertises a DIFFERENT host — if the helper trusted it, the
+        # captured audience would be ``https://attacker.example.com/...``.
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": f"/servers/{SERVER_ID}/mcp",
+            "root_path": "",
+            "scheme": "https",
+            "server": ("attacker.example.com", 443),
+            "headers": [(b"host", b"attacker.example.com")],
+        }
+        handler = _StreamableHttpAuthHandler(scope=scope, receive=fake_receive, send=fake_send)
+
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            await handler._try_oauth_access_token(_make_idp_token())
+
+        assert captured["expected_audience"] == [f"https://canonical.example.com/servers/{SERVER_ID}/mcp"]
+        assert not any("attacker.example.com" in aud for aud in captured["expected_audience"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "spoofed_header",
+        [
+            (b"x-forwarded-host", b"attacker.example.com"),
+            (b"forwarded", b"host=attacker.example.com"),
+            (b"x-original-host", b"attacker.example.com"),
+        ],
+    )
+    async def test_audience_ignores_forwarded_host_headers(self, monkeypatch, spoofed_header):
+        """Forwarded-host header variants must not influence the audience either.
+
+        Today the resource URL is anchored on ``settings.app_domain`` and
+        the scope is explicitly ignored — but if a future change re-reads
+        any host-indicator header from the scope, this parametrized test
+        fails loudly for each forwarded-host variant.
+        """
+        monkeypatch.setattr(settings, "app_domain", "https://canonical.example.com")
+
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler  # pylint: disable=import-outside-toplevel
+
+        responses: list = []
+
+        async def fake_send(msg):
+            responses.append(msg)
+
+        async def fake_receive():
+            return {}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": f"/servers/{SERVER_ID}/mcp",
+            "root_path": "",
+            "scheme": "https",
+            "server": ("attacker.example.com", 443),
+            "headers": [
+                (b"host", b"attacker.example.com"),
+                spoofed_header,
+            ],
+        }
+        handler = _StreamableHttpAuthHandler(scope=scope, receive=fake_receive, send=fake_send)
+
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            await handler._try_oauth_access_token(_make_idp_token())
+
+        assert captured["expected_audience"] == [f"https://canonical.example.com/servers/{SERVER_ID}/mcp"]
+        assert not any("attacker.example.com" in aud for aud in captured["expected_audience"])
+
+
+class TestOAuthServerMisconfigurationRejected:
+    """Invariant: an ``oauth_enabled`` server with an empty issuer allowlist fails closed.
+
+    No IdP-issued token can be verified against an empty allowlist, so the
+    handler must reject the request with 503 (server misconfiguration) rather
+    than fall through to internal JWT verification, which would let an
+    internal ContextForge JWT reach a resource that is supposed to require
+    OAuth.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_authorization_servers_returns_failed_503(self):
+        handler, responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        # Truthy dict so we pass the `not server.oauth_config` guard, but the
+        # allowlist is empty — the misconfiguration we want to reject.
+        server.oauth_config = {"authorization_servers": []}
+
+        with _patched_get_db(server):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 503
+        assert b"OAuth authorization server not configured" in _response_body(responses)
+
+
+class TestLegacyJwtOnOauthEnabledServer:
+    """Invariant: tokens whose issuer is outside an oauth_enabled server's allowlist
+    defer to internal JWT verification instead of being rejected as IdP tokens.
+
+    A gateway-issued JWT may carry a missing ``iss`` claim or an older value
+    that no longer matches ``settings.jwt_issuer``. Such tokens are still
+    valid when ``JWT_ISSUER_VERIFICATION=false`` and must remain usable on
+    ``oauth_enabled`` virtual servers: the caller (``_route_idp_issued_token``)
+    is responsible for routing them to internal verification. The OAuth
+    path must therefore return ``NOT_APPLICABLE`` — not reject — when the
+    token's issuer is not in the server's OAuth allowlist.
+    """
+
+    def _oauth_server(self):
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+        return server
+
+    @pytest.mark.asyncio
+    async def test_token_with_unknown_issuer_yields_not_applicable(self):
+        """Token from an issuer outside the allowlist is not rejected by the OAuth path."""
+        handler, responses = _make_handler()
+        token = _make_idp_token(issuer="https://other-idp.example.com/")
+
+        verify_called = False
+
+        async def fake_verify(*_args, **_kwargs):
+            nonlocal verify_called
+            verify_called = True
+            return {"sub": "x"}
+
+        with (
+            _patched_get_db(self._oauth_server()),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(token)
+
+        assert result is OAuthAuthResult.NOT_APPLICABLE
+        assert verify_called is False  # OAuth verification was never attempted.
+        assert responses == []  # No error response sent — caller decides.
+
+    @pytest.mark.asyncio
+    async def test_token_with_missing_iss_yields_not_applicable(self):
+        """Token with no ``iss`` claim is treated as a potential legacy internal JWT."""
+        # Third-Party
+        import jwt as _jwt  # pylint: disable=import-outside-toplevel
+
+        handler, responses = _make_handler()
+        token = _jwt.encode({"sub": "user@example.com"}, "unused", algorithm="HS256")
+
+        with (
+            _patched_get_db(self._oauth_server()),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=AssertionError("must not be called")),
+        ):
+            result = await handler._try_oauth_access_token(token)
+
+        assert result is OAuthAuthResult.NOT_APPLICABLE
+        assert responses == []
+
+    @pytest.mark.asyncio
+    async def test_undecodable_token_yields_not_applicable(self):
+        """A non-JWT bearer token on an oauth_enabled server defers to the internal path."""
+        handler, responses = _make_handler()
+
+        with (
+            _patched_get_db(self._oauth_server()),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=AssertionError("must not be called")),
+        ):
+            result = await handler._try_oauth_access_token("not-a-jwt")
+
+        assert result is OAuthAuthResult.NOT_APPLICABLE
+        assert responses == []
+
+    @pytest.mark.asyncio
+    async def test_route_idp_falls_through_to_internal_verify_on_oauth_server(self, monkeypatch):
+        """End-to-end: legacy JWT + oauth_enabled server + issuer check off → internal verify runs.
+
+        This is the exact regression scenario: ``_route_idp_issued_token``
+        peeks a mismatched ``iss``, routes to ``_try_oauth_access_token``,
+        which now returns ``NOT_APPLICABLE`` (not ``FAILED``) so the caller
+        falls through to internal verification instead of emitting a 401.
+        """
+        monkeypatch.setattr(settings, "jwt_issuer_verification", False)
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+
+        handler, responses = _make_handler()
+        # Legacy token with an outdated iss, not in the server's allowlist.
+        token = _make_idp_token(issuer="mcpgateway-legacy")
+
+        with _patched_get_db(self._oauth_server()):
+            result = await handler._route_idp_issued_token(token)
+
+        # ``None`` means "continue with internal verify_credentials" — the
+        # caller will validate signature + claims against the internal
+        # signing key, which is exactly the legacy path we must preserve.
+        assert result is None
+        assert responses == []  # No 401 sent yet.
+
+
+class TestRouteIdpIssuedToken:
+    """Invariant: OAuth routing is independent of ``settings.jwt_issuer_verification``.
+
+    ``_route_idp_issued_token`` dispatches based solely on whether the
+    token's unverified ``iss`` claim matches the internal issuer. When it
+    does not match, routing to the OAuth path must run regardless of the
+    ``jwt_issuer_verification`` toggle — that toggle governs how
+    ContextForge's *own* JWTs are checked, not whether externally-issued
+    tokens are eligible for OAuth validation. Legacy fall-through to
+    internal JWT verification is preserved only for non-OAuth servers when
+    issuer verification is disabled.
+    """
+
+    @pytest.mark.asyncio
+    async def test_matching_iss_skips_oauth_routing(self, monkeypatch):
+        """A token whose ``iss`` equals ``settings.jwt_issuer`` is never routed to OAuth."""
+        handler, _responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        monkeypatch.setattr(settings, "jwt_issuer_verification", True)
+        token = _make_idp_token(issuer=INTERNAL_JWT_ISSUER)
+
+        called = False
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            nonlocal called
+            called = True
+            return OAuthAuthResult.SUCCESS
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            result = await handler._route_idp_issued_token(token)
+
+        # ``None`` means "caller should continue with internal JWT
+        # verification"; crucially, OAuth dispatch must not fire when the
+        # issuer already matches the internal one.
+        assert result is None
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_undecodable_token_falls_through_without_routing(self, monkeypatch):
+        """A non-JWT bearer token yields ``None`` so the canonical 401 is emitted downstream."""
+        handler, responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        monkeypatch.setattr(settings, "jwt_issuer_verification", True)
+
+        called = False
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            nonlocal called
+            called = True
+            return OAuthAuthResult.SUCCESS
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            result = await handler._route_idp_issued_token("not-a-jwt")
+
+        assert result is None
+        assert called is False
+        assert responses == []  # Downstream verify_credentials produces the 401.
+
+    @pytest.mark.asyncio
+    async def test_idp_token_routes_to_oauth_even_when_issuer_verification_disabled(self, monkeypatch):
+        """An IdP-issued token still reaches ``_try_oauth_access_token`` regardless of the toggle."""
+        handler, _responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer_verification", False)
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        token = _make_idp_token()
+
+        called_with: dict = {}
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            called_with["token"] = tok
+            return OAuthAuthResult.SUCCESS
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            result = await handler._route_idp_issued_token(token)
+
+        assert result is True
+        assert called_with["token"] == token
+
+    @pytest.mark.asyncio
+    async def test_non_oauth_server_falls_through_when_issuer_verification_disabled(self, monkeypatch):
+        """NOT_APPLICABLE + issuer verification disabled → ``None`` (continue to internal verify)."""
+        handler, responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer_verification", False)
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        token = _make_idp_token()
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            return OAuthAuthResult.NOT_APPLICABLE
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            result = await handler._route_idp_issued_token(token)
+
+        # ``None`` means "continue with internal JWT verification" — a
+        # legacy internal token whose ``iss`` differs from
+        # ``settings.jwt_issuer`` remains acceptable when issuer
+        # verification is disabled.
+        assert result is None
+        assert responses == []  # No 401 sent yet.
+
+    @pytest.mark.asyncio
+    async def test_non_oauth_server_rejects_when_issuer_verification_enabled(self, monkeypatch):
+        """When issuer verification is on, a mismatched ``iss`` on a non-OAuth server is a 401."""
+        handler, responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer_verification", True)
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        token = _make_idp_token()
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            return OAuthAuthResult.NOT_APPLICABLE
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            result = await handler._route_idp_issued_token(token)
+
+        assert result is False
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_idp_token_failed_returns_false_and_does_not_double_send(self, monkeypatch):
+        """``_try_oauth_access_token`` → ``FAILED`` must surface as ``False`` without sending a second error.
+
+        The FAILED contract is: the inner method already sent a 4xx/5xx
+        response. The router must NOT wrap it in a second 401. Locks the
+        third enum cell of the routing matrix (SUCCESS/FAILED/NOT_APPLICABLE)
+        that was previously covered only by the SUCCESS and NOT_APPLICABLE
+        tests.
+        """
+        handler, responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        token = _make_idp_token()
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            # Simulate that _try_oauth_access_token already emitted a 401.
+            await self._send_error(detail="simulated oauth failure", headers={"WWW-Authenticate": "Bearer"})
+            return OAuthAuthResult.FAILED
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            result = await handler._route_idp_issued_token(token)
+
+        assert result is False
+        # Exactly one http.response.start — the router did not send a second.
+        starts = [m for m in responses if m["type"] == "http.response.start"]
+        assert len(starts) == 1
+        assert starts[0]["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_exception_from_try_oauth_increments_error_metric(self, monkeypatch):
+        """Unhandled exceptions must surface in ``oauth_verify_events_counter`` before propagating."""
+        # First-Party
+        from mcpgateway.services.metrics import oauth_verify_events_counter  # pylint: disable=import-outside-toplevel
+
+        handler, _responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        token = _make_idp_token()
+
+        async def fake_try_oauth(self, tok, unverified=None):  # pylint: disable=unused-argument
+            raise RuntimeError("unexpected")
+
+        before = oauth_verify_events_counter.labels(outcome="error")._value.get()  # pylint: disable=protected-access
+
+        with patch(
+            "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+            new=fake_try_oauth,
+        ):
+            with pytest.raises(RuntimeError, match="unexpected"):
+                await handler._route_idp_issued_token(token)
+
+        after = oauth_verify_events_counter.labels(outcome="error")._value.get()  # pylint: disable=protected-access
+        assert after == before + 1
+
+    @pytest.mark.asyncio
+    async def test_success_failed_not_applicable_metric_labels(self, monkeypatch):
+        """Each OAuthAuthResult outcome maps to its own ``oauth_verify_events_counter`` label.
+
+        A label-swap mutation (e.g. ``outcome="failed"`` on the success
+        branch) would previously ship green — no test referenced the
+        counter. This test snapshots each label value before/after
+        routing through a stubbed ``_try_oauth_access_token``.
+        """
+        # First-Party
+        from mcpgateway.services.metrics import oauth_verify_events_counter  # pylint: disable=import-outside-toplevel
+
+        handler, _responses = _make_handler()
+        monkeypatch.setattr(settings, "jwt_issuer", INTERNAL_JWT_ISSUER)
+        token = _make_idp_token()
+
+        def snapshot(label):
+            return oauth_verify_events_counter.labels(outcome=label)._value.get()  # pylint: disable=protected-access
+
+        for outcome_enum, label in (
+            (OAuthAuthResult.SUCCESS, "success"),
+            (OAuthAuthResult.FAILED, "failed"),
+            (OAuthAuthResult.NOT_APPLICABLE, "not_applicable"),
+        ):
+            before = snapshot(label)
+
+            async def fake_try_oauth(self, tok, unverified=None, _outcome=outcome_enum):  # pylint: disable=unused-argument
+                return _outcome
+
+            with patch(
+                "mcpgateway.transports.streamablehttp_transport._StreamableHttpAuthHandler._try_oauth_access_token",
+                new=fake_try_oauth,
+            ):
+                await handler._route_idp_issued_token(token)
+
+            after = snapshot(label)
+            assert after == before + 1, f"outcome={label}: counter did not increment"
+
+    @pytest.mark.asyncio
+    async def test_non_string_iss_yields_not_applicable(self):
+        """Tokens with a non-string ``iss`` defer to internal verification.
+
+        Locks the ``isinstance(token_issuer, str)`` guard against a future
+        refactor that coerces ``str(token_issuer)`` and accidentally
+        matches ``['https://idp.example.com/']`` against its repr.
+        """
+        handler, responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        for bad_iss in (123, ["https://idp.example.com/"], {"nested": "dict"}, None):
+            with _patched_get_db(server):
+                result = await handler._try_oauth_access_token("irrelevant-token", {"iss": bad_iss})
+            assert result is OAuthAuthResult.NOT_APPLICABLE, f"iss={bad_iss!r} should yield NOT_APPLICABLE"
+        assert responses == []

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -4355,12 +4355,13 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_rfc8414_metadata_used_when_oidc_missing(self):
         """A non-OIDC OAuth server's RFC 8414 metadata document is accepted."""
+        test_issuer = "https://auth.example.com"
 
         async def fake_get(url, *_args, **_kwargs):
             resp = MagicMock()
-            if url.endswith("/.well-known/oauth-authorization-server"):
+            if "oauth-authorization-server" in url:
                 resp.status_code = 200
-                resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+                resp.json.return_value = {"issuer": test_issuer, "jwks_uri": self.JWKS_URI}
             else:
                 resp.status_code = 404
             return resp
@@ -4369,7 +4370,7 @@ class TestVerifyOauthAccessToken:
         mock_http.get.side_effect = fake_get
 
         with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
-            metadata = await _discover_oidc_metadata("https://auth.example.com")
+            metadata = await _discover_oidc_metadata(test_issuer)
 
         assert metadata is not None
         assert metadata["jwks_uri"] == self.JWKS_URI
@@ -4377,12 +4378,13 @@ class TestVerifyOauthAccessToken:
     @pytest.mark.asyncio
     async def test_oidc_metadata_used_when_rfc8414_missing(self):
         """A pure OIDC server with no RFC 8414 document still discovers successfully."""
+        test_issuer = "https://auth.example.com"
 
         async def fake_get(url, *_args, **_kwargs):
             resp = MagicMock()
-            if url.endswith("/.well-known/openid-configuration"):
+            if "openid-configuration" in url:
                 resp.status_code = 200
-                resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+                resp.json.return_value = {"issuer": test_issuer, "jwks_uri": self.JWKS_URI}
             else:
                 resp.status_code = 404
             return resp
@@ -4391,7 +4393,7 @@ class TestVerifyOauthAccessToken:
         mock_http.get.side_effect = fake_get
 
         with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
-            metadata = await _discover_oidc_metadata("https://auth.example.com")
+            metadata = await _discover_oidc_metadata(test_issuer)
 
         assert metadata is not None
         assert metadata["jwks_uri"] == self.JWKS_URI
@@ -4582,6 +4584,143 @@ class TestVerifyOauthAccessToken:
             )
 
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_expired_cache_entry_is_popped_and_reprobed(self, monkeypatch):
+        """A cached entry past its TTL is evicted and rediscovery runs."""
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc  # pylint: disable=import-outside-toplevel
+
+        # Seed a fake cached entry with a 0s TTL so the expiry branch fires.
+        vc._oauth_oidc_metadata_cache[self.ISSUER.rstrip("/")] = (0.0, {"stale": True}, 0.0)  # pylint: disable=protected-access
+
+        # Make the rediscovery produce fresh metadata.
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            metadata = await _discover_oidc_metadata(self.ISSUER)
+
+        assert metadata == {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+        assert metadata != {"stale": True}
+
+    @pytest.mark.asyncio
+    async def test_probe_network_exception_marks_transient_and_logs(self):
+        """Network errors (DNS, TLS, timeout) drive the transient-failure branch."""
+        mock_http = AsyncMock()
+        mock_http.get.side_effect = RuntimeError("dns down")
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            metadata = await _discover_oidc_metadata("https://unreachable.example.com")
+
+        assert metadata is None
+        # Both probes fail with the same exception, so the cache entry uses
+        # the transient TTL (5s) rather than the permanent TTL (30s).
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc  # pylint: disable=import-outside-toplevel
+
+        cached_at, cached_metadata, ttl = vc._oauth_oidc_metadata_cache["https://unreachable.example.com"]  # pylint: disable=protected-access
+        assert cached_metadata is None
+        assert ttl == vc._OAUTH_OIDC_METADATA_NEGATIVE_TTL_TRANSIENT  # pylint: disable=protected-access
+        del cached_at  # silence ruff
+
+    @pytest.mark.asyncio
+    async def test_probe_invalid_json_treated_as_permanent_failure(self):
+        """A 200 response with malformed JSON is a permanent (not transient) failure."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.side_effect = ValueError("not json")
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            metadata = await _discover_oidc_metadata("https://badjson.example.com")
+
+        assert metadata is None
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc  # pylint: disable=import-outside-toplevel
+
+        _, cached_metadata, ttl = vc._oauth_oidc_metadata_cache["https://badjson.example.com"]  # pylint: disable=protected-access
+        assert cached_metadata is None
+        assert ttl == vc._OAUTH_OIDC_METADATA_NEGATIVE_TTL_PERMANENT  # pylint: disable=protected-access
+
+    @pytest.mark.asyncio
+    async def test_probe_non_dict_metadata_rejected(self):
+        """A JSON array (or other non-dict) is not valid metadata."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = ["not", "a", "dict"]
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            metadata = await _discover_oidc_metadata("https://weird.example.com")
+
+        assert metadata is None
+
+    @pytest.mark.asyncio
+    async def test_metadata_without_jwks_uri_rejected(self):
+        """Discovery returns 200 but no ``jwks_uri`` → verification bails out."""
+        private_key, _ = self._generate_rsa_keypair()
+        token = self._sign_token({"iss": self.ISSUER, "sub": "user@example.com", "exp": 9999999999, "iat": 1700000000}, private_key)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"issuer": self.ISSUER}  # no jwks_uri
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)):
+            result = await verify_oauth_access_token(token, [self.ISSUER])
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_jwks_client_lazily_created_on_cache_miss(self):
+        """A JWKS URI not yet in the client cache triggers PyJWKClient construction.
+
+        Previous tests pre-populate ``_oauth_jwks_client_cache`` with a mock
+        to bypass construction. This one lets the real ``jwt.PyJWKClient``
+        instantiation path run (with ``PyJWKClient`` patched on the module
+        so no network call is actually made).
+        """
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc  # pylint: disable=import-outside-toplevel
+
+        private_key, public_key = self._generate_rsa_keypair()
+        token = self._sign_token(
+            {"iss": self.ISSUER, "sub": "user@example.com", "email": "user@example.com", "exp": 9999999999, "iat": 1700000000},
+            private_key,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"issuer": self.ISSUER, "jwks_uri": self.JWKS_URI}
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_resp
+
+        # Ensure the JWKS cache does not already contain our test JWKS URI.
+        vc._oauth_jwks_client_cache.pop(self.JWKS_URI, None)  # pylint: disable=protected-access
+
+        fake_signing_key = MagicMock()
+        fake_signing_key.key = public_key
+        fake_jwks_client = MagicMock()
+        fake_jwks_client.get_signing_key_from_jwt.return_value = fake_signing_key
+
+        with (
+            patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)),
+            patch("mcpgateway.utils.verify_credentials.jwt.PyJWKClient", return_value=fake_jwks_client) as mock_ctor,
+        ):
+            result = await verify_oauth_access_token(token, [self.ISSUER])
+
+        assert result is not None
+        assert result["sub"] == "user@example.com"
+        # The constructor was called exactly once with the discovered JWKS URI.
+        mock_ctor.assert_called_once_with(self.JWKS_URI)
+        assert self.JWKS_URI in vc._oauth_jwks_client_cache  # pylint: disable=protected-access
 
 
 class TestResolveAuthorizationServers:
@@ -5562,3 +5701,265 @@ class TestRouteIdpIssuedToken:
                 result = await handler._try_oauth_access_token("irrelevant-token", {"iss": bad_iss})
             assert result is OAuthAuthResult.NOT_APPLICABLE, f"iss={bad_iss!r} should yield NOT_APPLICABLE"
         assert responses == []
+
+
+class TestTryOauthAccessTokenErrorBranches:
+    """Coverage for the reject/error paths in ``_try_oauth_access_token``.
+
+    These are the branches that the happy-path and invariant tests don't
+    reach: DB failure on server lookup, misconfigured / disabled servers,
+    missing email claim, unknown / disabled users, and team-resolution
+    failures. Each test drives a single branch to keep failures specific.
+    """
+
+    _GOOD_UNVERIFIED = {"iss": IDP_ISSUER}
+
+    @pytest.fixture
+    def oauth_server_row(self):
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+        return server
+
+    @pytest.mark.asyncio
+    async def test_missing_server_id_in_path_yields_not_applicable(self):
+        """Requests whose URL does not match ``/servers/<id>/mcp`` are not handled here."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler  # pylint: disable=import-outside-toplevel
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/health",  # no server id
+            "root_path": "",
+            "scheme": "https",
+            "server": (GATEWAY_HOST, 443),
+            "headers": [(b"host", GATEWAY_HOST.encode())],
+        }
+
+        async def fake_send(_msg):
+            pass
+
+        async def fake_receive():
+            return {}
+
+        handler = _StreamableHttpAuthHandler(scope=scope, receive=fake_receive, send=fake_send)
+        result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+        assert result is OAuthAuthResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_db_sqlalchemy_error_sends_503(self):
+        """A DB failure during the server lookup produces a 503 FAILED."""
+        # Third-Party
+        from sqlalchemy.exc import SQLAlchemyError  # pylint: disable=import-outside-toplevel
+
+        handler, responses = _make_handler()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(side_effect=SQLAlchemyError("db down"))
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 503
+
+    @pytest.mark.asyncio
+    async def test_server_oauth_disabled_yields_not_applicable(self):
+        """A virtual server with ``oauth_enabled=False`` defers to internal verify."""
+        handler, responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = False
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        with _patched_get_db(server):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.NOT_APPLICABLE
+        assert responses == []
+
+    @pytest.mark.asyncio
+    async def test_empty_oauth_config_fails_closed_503(self):
+        """oauth_enabled=True with empty oauth_config → 503 (not fall-through)."""
+        handler, responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {}
+
+        with _patched_get_db(server):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 503
+        assert b"OAuth authorization server not configured" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_token_missing_valid_email_claim_rejected(self, _pinned_app_domain, oauth_server_row):
+        """A verified token without an email-like claim is rejected with 401."""
+        del _pinned_app_domain
+        handler, responses = _make_handler()
+
+        async def fake_verify(*_args, **_kwargs):
+            # sub without @, no email, no preferred_username.
+            return {"sub": "no-at-sign"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+        assert b"missing valid email claim" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_user_not_registered_rejected(self, _pinned_app_domain, oauth_server_row):
+        """A verified token for a user absent from the ContextForge DB is rejected."""
+        del _pinned_app_domain
+        handler, responses = _make_handler()
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=None),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        assert b"not registered in ContextForge" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_inactive_user_rejected(self, _pinned_app_domain, oauth_server_row):
+        """A verified token for a disabled user is rejected with 401."""
+        del _pinned_app_domain
+        handler, responses = _make_handler()
+        mock_user = MagicMock(is_active=False, is_admin=False)
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        assert b"Account disabled" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_teams_resolution_unexpected_exception_rejected(self, _pinned_app_domain, oauth_server_row):
+        """A non-``SQLAlchemyError`` from team resolution falls into the generic 401 handler."""
+        del _pinned_app_domain
+        handler, responses = _make_handler()
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=RuntimeError("team lookup exploded")),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+        assert b"Authentication failed" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_full_success_path_populates_user_context(self, _pinned_app_domain, oauth_server_row):
+        """End-to-end SUCCESS: verified claims → DB lookup → teams resolved → user_context set."""
+        del _pinned_app_domain
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import user_context_var  # pylint: disable=import-outside-toplevel
+
+        handler, _responses = _make_handler()
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"sub": "user@example.com", "email": "User@Example.com"}
+
+        async def fake_resolve_teams(*_args, **_kwargs):
+            return ["team-a", "team-b"]
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=fake_resolve_teams),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.SUCCESS
+        ctx = user_context_var.get()
+        assert ctx["is_authenticated"] is True
+        assert ctx["email"] == "user@example.com"  # lowercased
+        assert ctx["teams"] == ["team-a", "team-b"]
+        assert ctx["auth_method"] == "oauth_access_token"
+        assert ctx["token_use"] == "session"
+
+
+class TestBuildServerResourceUrlAppDomainError:
+    """``_build_server_resource_url`` fails closed when ``settings.app_domain`` is unusable."""
+
+    def test_app_domain_stringification_raises(self, monkeypatch, caplog):
+        """``str(settings.app_domain)`` raising AttributeError is caught and logged."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _build_server_resource_url  # pylint: disable=import-outside-toplevel
+
+        class Exploding:
+            def __str__(self):
+                raise AttributeError("no __str__ for you")
+
+        monkeypatch.setattr(settings, "app_domain", Exploding())
+
+        with caplog.at_level(logging.WARNING):
+            result = _build_server_resource_url(None, "srv-1")
+
+        assert result == ""
+        assert any("settings.app_domain is not a usable URL" in rec.message for rec in caplog.records)
+
+
+class TestAuthJwtRoutingReturn:
+    """``_auth_jwt`` returns the outcome of ``_route_idp_issued_token`` without reaching verify_credentials."""
+
+    @pytest.mark.asyncio
+    async def test_auth_jwt_returns_true_when_route_succeeds(self, monkeypatch):
+        handler, _responses = _make_handler()
+
+        async def fake_route(_self, _tok):
+            return True
+
+        monkeypatch.setattr(_StreamableHttpAuthHandler, "_route_idp_issued_token", fake_route)
+
+        # verify_credentials should never be called on this path.
+        with patch("mcpgateway.transports.streamablehttp_transport.verify_credentials", side_effect=AssertionError("must not be called")):
+            result = await handler._auth_jwt(token="unused")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_auth_jwt_returns_false_when_route_fails(self, monkeypatch):
+        handler, _responses = _make_handler()
+
+        async def fake_route(_self, _tok):
+            return False
+
+        monkeypatch.setattr(_StreamableHttpAuthHandler, "_route_idp_issued_token", fake_route)
+
+        with patch("mcpgateway.transports.streamablehttp_transport.verify_credentials", side_effect=AssertionError("must not be called")):
+            result = await handler._auth_jwt(token="unused")
+
+        assert result is False


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Partially addresses #2659 

---

## 📝 Summary
Virtual servers with `oauth_enabled=True` advertise RFC 9728 Protected Resource Metadata, directing MCP clients to authenticate via an IdP (e.g., Keycloak, Authentik). However, when the client presents the IdP-issued access token, ContextForge rejects it with "Invalid token" because `verify_credentials()` only validates ContextForge-issued JWTs (`iss: "mcpgateway"`).

This PR adds IdP-issued OAuth access token verification via OIDC discovery + JWKS:

- **Issuer-based routing**: Peeks at the token's `iss` claim before verification. ContextForge-issued tokens (`iss == settings.jwt_issuer`) go through the existing path; IdP-issued tokens are routed to JWKS-based verification.
- **OIDC discovery + JWKS**: Fetches `/.well-known/openid-configuration` from the token's issuer, resolves `jwks_uri`, and verifies the signature using the IdP's public keys. Metadata is cached (300s TTL).
- **Per-server issuer allowlist**: Each virtual server's `oauth_config.authorization_servers` determines which issuers are trusted. Server A (Authentik) and Server B (Keycloak) are fully independent.
- **Audience validation**: When `oauth_config.client_id` is configured, the token's `aud` claim is validated. When not configured, audience check is skipped (opt-in).
- **User resolution**: Verified tokens are resolved against the ContextForge user database. Users must already exist (no auto-creation) — the expected flow is SSO login first, then MCP client access.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

- **OIDC discovery cache duplication**: `sso_service.py` has a similar OIDC discovery + JWKS cache for SSO id_token verification. The two caches serve different request paths (SSO callback vs MCP transport) with different lifecycles. A shared utility extraction is possible as a follow-up.

### Auth flow

```
MCP Client → POST /servers/{id}/mcp (Bearer <IdP token>)
  → peek token iss claim
  → iss != "mcpgateway" → _try_oauth_access_token()
    → DB lookup: server.oauth_enabled? oauth_config?
    → issuer in authorization_servers allowlist?
    → OIDC discovery → JWKS → signature verification
    → (optional) audience validation against client_id
    → DB user lookup (must exist, must be active)
    → teams resolved from DB → user_context populated
```
