### PR TITLE
fix(ui): preserve tag filters across page navigation on Virtual Servers

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -8918,17 +8918,26 @@ function showTab(tabName) {
                     const serversList = safeGetElement("servers-table");
                     if (serversList) {
                         const hasLoadingMessage =
-                            serversList.innerHTML.includes("Loading servers...");
+                            serversList.innerHTML.includes(
+                                "Loading servers...",
+                            );
                         if (hasLoadingMessage) {
                             if (window.htmx && window.htmx.trigger) {
                                 window.htmx.trigger(serversList, "load");
                             }
                         } else {
-                            const catalogConfig = getPanelSearchConfig("catalog");
+                            const catalogConfig =
+                                getPanelSearchConfig("catalog");
                             if (catalogConfig) {
-                                const searchState = getPanelSearchStateFromUrl(catalogConfig.tableName);
-                                const tagInput = document.getElementById(catalogConfig.tagInputId);
-                                const searchInput = document.getElementById(catalogConfig.searchInputId);
+                                const searchState = getPanelSearchStateFromUrl(
+                                    catalogConfig.tableName,
+                                );
+                                const tagInput = document.getElementById(
+                                    catalogConfig.tagInputId,
+                                );
+                                const searchInput = document.getElementById(
+                                    catalogConfig.searchInputId,
+                                );
                                 if (tagInput && searchState.tags) {
                                     tagInput.value = searchState.tags;
                                 }
@@ -20056,10 +20065,12 @@ function extractAvailableTags(entityType) {
     const tags = new Set();
 
     if (entityType === "catalog") {
-        document.querySelectorAll("#servers-table-body [data-tag]").forEach((el) => {
-            const t = el.getAttribute("data-tag").trim();
-            if (t && t.length >= 1 && t.length <= 50) tags.add(t);
-        });
+        document
+            .querySelectorAll("#servers-table-body [data-tag]")
+            .forEach((el) => {
+                const t = el.getAttribute("data-tag").trim();
+                if (t && t.length >= 1 && t.length <= 50) tags.add(t);
+            });
         return Array.from(tags).sort();
     }
 
@@ -20152,8 +20163,14 @@ function addTagToFilter(entityType, tag) {
         filterInput.value = currentTags.join(", ");
         const panelConfig = getPanelSearchConfig(entityType);
         if (panelConfig) {
-            const searchInput = document.getElementById(panelConfig.searchInputId);
-            updatePanelSearchStateInUrl(panelConfig.tableName, searchInput?.value || "", filterInput.value);
+            const searchInput = document.getElementById(
+                panelConfig.searchInputId,
+            );
+            updatePanelSearchStateInUrl(
+                panelConfig.tableName,
+                searchInput?.value || "",
+                filterInput.value,
+            );
             queueSearchablePanelReload(entityType, 0);
         } else {
             filterEntitiesByTags(entityType, filterInput.value);

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -20077,10 +20077,6 @@ function extractAvailableTags(entityType) {
     const tableSelector = `#${entityType}-panel tbody tr:not(.inactive-row)`;
     const rows = document.querySelectorAll(tableSelector);
 
-    console.log(
-        `[DEBUG] extractAvailableTags for ${entityType}: Found ${rows.length} rows`,
-    );
-
     const tableHeaderSelector = `#${entityType}-panel thead tr th`;
     const headerCells = document.querySelectorAll(tableHeaderSelector);
     let tagsColumnIndex = -1;
@@ -20205,34 +20201,11 @@ function filterEntitiesByTags(entityType, tagsInput) {
             return;
         }
 
-        // Extract tags from this row using specific tag selectors (not status badges)
+        // Extract tags from this row using data-tag attributes
         const rowTags = new Set();
-
-        const tagElements = row.querySelectorAll(`
-            /* Gateways */
-            span.inline-block.bg-blue-100.text-blue-800.text-xs.px-2.py-1.rounded-full,
-            /* A2A Agents */
-            span.inline-flex.items-center.px-2.py-1.rounded.text-xs.bg-gray-100.text-gray-700,
-            /* Prompts & Resources */
-            span.inline-flex.items-center.px-2.py-0\\.5.rounded.text-xs.font-medium.bg-blue-100.text-blue-800,
-            /* Gray tags for A2A agent metadata */
-            span.inline-flex.items-center.px-2\\.5.py-0\\.5.rounded-full.text-xs.font-medium.bg-gray-100.text-gray-700
-        `);
-
-        tagElements.forEach((tagEl) => {
-            const tagText = tagEl.textContent.trim().toLowerCase();
-            // Filter out any remaining non-tag content
-            if (
-                tagText &&
-                tagText !== "no tags" &&
-                tagText !== "none" &&
-                tagText !== "active" &&
-                tagText !== "inactive" &&
-                tagText !== "online" &&
-                tagText !== "offline"
-            ) {
-                rowTags.add(tagText);
-            }
+        row.querySelectorAll("[data-tag]").forEach((el) => {
+            const t = el.getAttribute("data-tag").trim().toLowerCase();
+            if (t) rowTags.add(t);
         });
 
         // Check if any of the filter tags match any of the row tags (OR logic)

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -493,31 +493,33 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
+    const tableToEntityType = {
+        "servers-table": "catalog",
+        "tools-table": "tools",
+        "resources-table": "resources",
+        "prompts-table": "prompts",
+        "gateways-table": "gateways",
+        "agents-table": "a2a-agents",
+    };
+
     // Re-initialize search inputs when HTMX content loads
     // Only re-initialize if the swap affects search-related content
     document.body.addEventListener("htmx:afterSwap", function (event) {
-        const target = event.detail.target;
-        const relevantPanels = [
-            "catalog-panel",
-            "gateways-panel",
-            "tools-panel",
-            "resources-panel",
-            "prompts-panel",
-            "a2a-agents-panel",
-        ];
-
-        if (
-            target &&
-            relevantPanels.some(
-                (panelId) =>
-                    target.id === panelId || target.closest(`#${panelId}`),
-            )
-        ) {
+        const targetId = event.detail.target && event.detail.target.id;
+        if (targetId && tableToEntityType[targetId]) {
             console.log(
-                `📝 HTMX swap detected in ${target.id}, resetting search state`,
+                `📝 HTMX swap detected in ${targetId}, resetting search state`,
             );
             resetSearchInputsState();
             initializeSearchInputsDebounced();
+        }
+    });
+
+    document.body.addEventListener("htmx:afterSettle", function (event) {
+        const targetId = event.detail.target && event.detail.target.id;
+        const entityType = targetId && tableToEntityType[targetId];
+        if (entityType) {
+            updateAvailableTags(entityType);
         }
     });
 
@@ -8913,17 +8915,29 @@ function showTab(tabName) {
                 }
 
                 if (tabName === "catalog") {
-                    // Load servers list if not already loaded
                     const serversList = safeGetElement("servers-table");
                     if (serversList) {
                         const hasLoadingMessage =
-                            serversList.innerHTML.includes(
-                                "Loading servers...",
-                            );
+                            serversList.innerHTML.includes("Loading servers...");
                         if (hasLoadingMessage) {
-                            // Trigger HTMX load manually if HTMX is available
                             if (window.htmx && window.htmx.trigger) {
                                 window.htmx.trigger(serversList, "load");
+                            }
+                        } else {
+                            const catalogConfig = getPanelSearchConfig("catalog");
+                            if (catalogConfig) {
+                                const searchState = getPanelSearchStateFromUrl(catalogConfig.tableName);
+                                const tagInput = document.getElementById(catalogConfig.tagInputId);
+                                const searchInput = document.getElementById(catalogConfig.searchInputId);
+                                if (tagInput && searchState.tags) {
+                                    tagInput.value = searchState.tags;
+                                }
+                                if (searchInput && searchState.query) {
+                                    searchInput.value = searchState.query;
+                                }
+                                if (searchState.tags || searchState.query) {
+                                    queueSearchablePanelReload("catalog", 0);
+                                }
                             }
                         }
                     }
@@ -18634,8 +18648,8 @@ const PANEL_SEARCH_CONFIG = {
         partialPath: "servers/partial",
         targetSelector: "#servers-table",
         indicatorSelector: "#servers-loading",
-        searchInputId: "catalog-search-input",
-        tagInputId: "catalog-tag-filter",
+        searchInputId: "servers-search-input",
+        tagInputId: "servers-tag-filter",
         inactiveCheckboxId: "show-inactive-servers",
         defaultPerPage: 50,
     },
@@ -20040,6 +20054,15 @@ window.goBackToSelection = goBackToSelection;
  */
 function extractAvailableTags(entityType) {
     const tags = new Set();
+
+    if (entityType === "catalog") {
+        document.querySelectorAll("#servers-table-body [data-tag]").forEach((el) => {
+            const t = el.getAttribute("data-tag").trim();
+            if (t && t.length >= 1 && t.length <= 50) tags.add(t);
+        });
+        return Array.from(tags).sort();
+    }
+
     const tableSelector = `#${entityType}-panel tbody tr:not(.inactive-row)`;
     const rows = document.querySelectorAll(tableSelector);
 
@@ -20047,7 +20070,6 @@ function extractAvailableTags(entityType) {
         `[DEBUG] extractAvailableTags for ${entityType}: Found ${rows.length} rows`,
     );
 
-    // Find the Tags column index by examining the table header
     const tableHeaderSelector = `#${entityType}-panel thead tr th`;
     const headerCells = document.querySelectorAll(tableHeaderSelector);
     let tagsColumnIndex = -1;
@@ -20056,67 +20078,25 @@ function extractAvailableTags(entityType) {
         const headerText = header.textContent.trim().toLowerCase();
         if (headerText === "tags") {
             tagsColumnIndex = index;
-            console.log(
-                `[DEBUG] Found Tags column at index ${index} for ${entityType}`,
-            );
         }
     });
 
     if (tagsColumnIndex === -1) {
-        console.log(`[DEBUG] Could not find Tags column for ${entityType}`);
         return [];
     }
 
-    rows.forEach((row, index) => {
+    rows.forEach((row) => {
         const cells = row.querySelectorAll("td");
-
         if (tagsColumnIndex < cells.length) {
             const tagsCell = cells[tagsColumnIndex];
-
-            // Look for tag badges ONLY within the Tags column
-            const tagElements = tagsCell.querySelectorAll(`
-                span.inline-flex.items-center.px-2.py-0\\.5.rounded.text-xs.font-medium.bg-blue-100.text-blue-800,
-                span.inline-block.bg-blue-100.text-blue-800.text-xs.px-2.py-1.rounded-full
-            `);
-
-            console.log(
-                `[DEBUG] Row ${index}: Found ${tagElements.length} tag elements in Tags column`,
-            );
-
-            tagElements.forEach((tagEl) => {
-                const tagText = tagEl.textContent.trim();
-                console.log(
-                    `[DEBUG] Row ${index}: Tag element text: "${tagText}"`,
-                );
-
-                // Basic validation for tag content
-                if (
-                    tagText &&
-                    tagText !== "No tags" &&
-                    tagText !== "None" &&
-                    tagText !== "N/A" &&
-                    tagText.length >= 2 &&
-                    tagText.length <= 50
-                ) {
-                    tags.add(tagText);
-                    console.log(
-                        `[DEBUG] Row ${index}: Added tag: "${tagText}"`,
-                    );
-                } else {
-                    console.log(
-                        `[DEBUG] Row ${index}: Filtered out: "${tagText}"`,
-                    );
-                }
+            tagsCell.querySelectorAll("[data-tag]").forEach((el) => {
+                const t = el.getAttribute("data-tag").trim();
+                if (t && t.length >= 1 && t.length <= 50) tags.add(t);
             });
         }
     });
 
-    const result = Array.from(tags).sort();
-    console.log(
-        `[DEBUG] extractAvailableTags for ${entityType}: Final result:`,
-        result,
-    );
-    return result;
+    return Array.from(tags).sort();
 }
 
 /**
@@ -20170,7 +20150,10 @@ function addTagToFilter(entityType, tag) {
     if (!currentTags.includes(tag)) {
         currentTags.push(tag);
         filterInput.value = currentTags.join(", ");
-        if (getPanelSearchConfig(entityType)) {
+        const panelConfig = getPanelSearchConfig(entityType);
+        if (panelConfig) {
+            const searchInput = document.getElementById(panelConfig.searchInputId);
+            updatePanelSearchStateInUrl(panelConfig.tableName, searchInput?.value || "", filterInput.value);
             queueSearchablePanelReload(entityType, 0);
         } else {
             filterEntitiesByTags(entityType, filterInput.value);

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -20149,7 +20149,11 @@ function updateAvailableTags(entityType) {
  * @param {string} tag - The tag to add
  */
 function addTagToFilter(entityType, tag) {
-    const filterInput = document.getElementById(`${entityType}-tag-filter`);
+    const panelConfig = getPanelSearchConfig(entityType);
+    const tagInputId = panelConfig
+        ? panelConfig.tagInputId
+        : `${entityType}-tag-filter`;
+    const filterInput = document.getElementById(tagInputId);
     if (!filterInput) {
         return;
     }
@@ -20161,7 +20165,6 @@ function addTagToFilter(entityType, tag) {
     if (!currentTags.includes(tag)) {
         currentTags.push(tag);
         filterInput.value = currentTags.join(", ");
-        const panelConfig = getPanelSearchConfig(entityType);
         if (panelConfig) {
             const searchInput = document.getElementById(
                 panelConfig.searchInputId,
@@ -20305,12 +20308,16 @@ function updateFilterEmptyState(entityType, visibleCount, isFiltering) {
  * @param {string} entityType - The entity type
  */
 function clearTagFilter(entityType) {
-    const filterInput = document.getElementById(`${entityType}-tag-filter`);
+    const panelConfig = getPanelSearchConfig(entityType);
+    const tagInputId = panelConfig
+        ? panelConfig.tagInputId
+        : `${entityType}-tag-filter`;
+    const filterInput = document.getElementById(tagInputId);
     if (filterInput) {
         filterInput.value = "";
         // Apply immediate local reset for responsive UX and test compatibility.
         filterEntitiesByTags(entityType, "");
-        if (getPanelSearchConfig(entityType)) {
+        if (panelConfig) {
             loadSearchablePanel(entityType);
         }
     }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2415,7 +2415,7 @@
               x-init="syncCheckboxFromUrl('servers', 'show-inactive-servers')"
               @change="updateInactiveUrlState('servers', $el.checked)"
               hx-get="{{ root_path }}/admin/servers/partial?page=1{% if selected_team_id %}&team_id={{ selected_team_id }}{% endif %}"
-              hx-vals="js:{include_inactive: document.getElementById('show-inactive-servers').checked, per_page: document.querySelector('#servers-pagination-controls select')?.value || 50, q: document.getElementById('catalog-search-input')?.value || '', tags: document.getElementById('catalog-tag-filter')?.value || ''}"
+              hx-vals="js:{include_inactive: document.getElementById('show-inactive-servers').checked, per_page: document.querySelector('#servers-pagination-controls select')?.value || 50, q: document.getElementById('servers-search-input')?.value || '', tags: document.getElementById('servers-tag-filter')?.value || ''}"
               hx-target="#servers-table"
               hx-swap="outerHTML"
               hx-indicator="#servers-loading"
@@ -2439,7 +2439,7 @@
               <div class="relative">
                 <input
                   type="text"
-                  id="catalog-search-input"
+                  id="servers-search-input"
                   data-testid="search-input"
                   placeholder="Search servers..."
                   class="w-64 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
@@ -2458,7 +2458,7 @@
             </div>
 
             <!-- Hidden tag filter (for internal JavaScript usage) -->
-            <input type="hidden" id="catalog-tag-filter" />
+            <input type="hidden" id="servers-tag-filter" />
 
             <!-- Filter Status Badge (optional, if you want to show active filter count) -->
             <div class="mt-2">

--- a/mcpgateway/templates/agents_partial.html
+++ b/mcpgateway/templates/agents_partial.html
@@ -63,7 +63,7 @@
         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
           {% if agent.tags %}
             {% for tag in agent.tags %}
-            <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 mr-1">
+            <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 mr-1" data-tag="{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}">
               {% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}
             </span>
             {% endfor %}

--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -74,7 +74,7 @@
         <td class="px-6 py-4 whitespace-nowrap">
           {% if gateway.tags %}
             {% for tag in gateway.tags %}
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1">
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1" data-tag="{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}">
               {% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}
             </span>
             {% endfor %}

--- a/mcpgateway/templates/prompts_partial.html
+++ b/mcpgateway/templates/prompts_partial.html
@@ -62,7 +62,7 @@
           <div class="font-mono text-xs">{{ prompt.id }}</div>
         </td>
         <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300">{% set clean_desc = (prompt.description or "") | decode_html | replace('\n', ' ') | replace('\r', ' ') %} {% set refactor_desc = clean_desc | striptags | trim %} {% if refactor_desc | length is greaterthan 220 %} {{ refactor_desc[:400] + "..." }} {% else %} {{ refactor_desc }} {% endif %}</td>
-        <td class="px-6 py-4 whitespace-nowrap">{% if prompt.tags %} {% for tag in prompt.tags %}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1">{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}</span>{% endfor %} {% else %}<span class="text-gray-500 dark:text-gray-300 text-xs">None</span>{% endif %}</td>
+        <td class="px-6 py-4 whitespace-nowrap">{% if prompt.tags %} {% for tag in prompt.tags %}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1" data-tag="{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}">{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}</span>{% endfor %} {% else %}<span class="text-gray-500 dark:text-gray-300 text-xs">None</span>{% endif %}</td>
         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 w-20">{{ prompt.ownerEmail or prompt.owner_email }}</td>
         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 w-20">{% if prompt.team %}{{ prompt.team }}{% else %}<span class="text-gray-400 dark:text-gray-600 text-xs">None</span>{% endif %}</td>
         <td class="px-6 py-4 whitespace-nowrap text-sm w-20">

--- a/mcpgateway/templates/resources_partial.html
+++ b/mcpgateway/templates/resources_partial.html
@@ -47,7 +47,7 @@
         </td>
         <td class="px-6 py-4 whitespace-normal break-words text-sm font-medium text-gray-900 dark:text-gray-100 w-24">{{ resource.name }}</td>
         <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300">{{ (resource.description or 'N/A') | decode_html }}</td>
-        <td class="px-6 py-4 whitespace-nowrap">{% if resource.tags %}{% for tag in resource.tags %}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1">{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}</span>{% endfor %}{% else %}<span class="text-gray-500 dark:text-gray-300 text-xs">None</span>{% endif %}</td>
+        <td class="px-6 py-4 whitespace-nowrap">{% if resource.tags %}{% for tag in resource.tags %}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1" data-tag="{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}">{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}</span>{% endfor %}{% else %}<span class="text-gray-500 dark:text-gray-300 text-xs">None</span>{% endif %}</td>
         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 w-20">{% if resource.ownerEmail %}{{ resource.ownerEmail }}{% else %}<span class="text-gray-400 dark:text-gray-600 text-xs">None</span>{% endif %}</td>
         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 w-20">{% if resource.team %}{{ resource.team }}{% else %}<span class="text-gray-400 dark:text-gray-600 text-xs">None</span>{% endif %}</td>
         <td class="px-6 py-4 whitespace-nowrap text-sm w-20">

--- a/mcpgateway/templates/servers_partial.html
+++ b/mcpgateway/templates/servers_partial.html
@@ -108,7 +108,7 @@
     <td class="px-6 py-4 whitespace-nowrap">
       {% if server.tags %}
         {% for tag in server.tags %}
-        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1">
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1" data-tag="{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}">
           {% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}
         </span>
         {% endfor %}

--- a/mcpgateway/templates/tools_partial.html
+++ b/mcpgateway/templates/tools_partial.html
@@ -164,6 +164,7 @@
           {% if tool.tags %} {% for tag in tool.tags %}
           <span
             class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1"
+            data-tag="{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}"
             >{% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}</span
           >
           {% endfor %} {% else %}

--- a/tests/js/admin-tag-extraction.test.js
+++ b/tests/js/admin-tag-extraction.test.js
@@ -1,0 +1,343 @@
+/**
+ * Tests for tag extraction via data-tag attributes and tag filter URL persistence.
+ *
+ * Covers the data-tag based extraction introduced to replace fragile CSS-class
+ * selectors, the catalog special-case path, and URL state sync in addTagToFilter.
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    beforeAll,
+    beforeEach,
+    afterAll,
+} from "vitest";
+import { loadAdminJs, cleanupAdminJs } from "./helpers/admin-env.js";
+
+let win;
+let doc;
+
+beforeAll(() => {
+    win = loadAdminJs();
+    doc = win.document;
+});
+
+afterAll(() => {
+    cleanupAdminJs();
+});
+
+beforeEach(() => {
+    doc.body.textContent = "";
+    // Reset URL search params between tests
+    win.history.replaceState(null, "", "http://localhost/");
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a panel table with data-tag attributes
+// ---------------------------------------------------------------------------
+function buildPanelTable(entityType, headers, rows) {
+    const panel = doc.createElement("div");
+    panel.id = `${entityType}-panel`;
+
+    const table = doc.createElement("table");
+    const thead = doc.createElement("thead");
+    const headerRow = doc.createElement("tr");
+    headers.forEach((h) => {
+        const th = doc.createElement("th");
+        th.textContent = h;
+        headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = doc.createElement("tbody");
+    rows.forEach((cells) => {
+        const tr = doc.createElement("tr");
+        cells.forEach((cell) => {
+            const td = doc.createElement("td");
+            if (Array.isArray(cell)) {
+                // Array of tags — render as span elements with data-tag
+                cell.forEach((tag) => {
+                    const span = doc.createElement("span");
+                    span.setAttribute("data-tag", tag);
+                    span.textContent = tag;
+                    td.appendChild(span);
+                });
+            } else {
+                td.textContent = cell;
+            }
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    panel.appendChild(table);
+    doc.body.appendChild(panel);
+    return panel;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build servers-table-body with data-tag attributes (catalog path)
+// ---------------------------------------------------------------------------
+function buildServersTableBody(tags) {
+    const table = doc.createElement("table");
+    const tbody = doc.createElement("tbody");
+    tbody.id = "servers-table-body";
+    tags.forEach((tagList) => {
+        const tr = doc.createElement("tr");
+        const td = doc.createElement("td");
+        tagList.forEach((tag) => {
+            const span = doc.createElement("span");
+            span.setAttribute("data-tag", tag);
+            span.textContent = tag;
+            td.appendChild(span);
+        });
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    doc.body.appendChild(table);
+    return tbody;
+}
+
+// ---------------------------------------------------------------------------
+// extractAvailableTags — catalog special case
+// ---------------------------------------------------------------------------
+describe("extractAvailableTags — catalog (data-tag)", () => {
+    const f = () => win.extractAvailableTags;
+
+    test("extracts tags from #servers-table-body [data-tag]", () => {
+        buildServersTableBody([["prod", "staging"], ["dev"]]);
+        const result = f()("catalog");
+        expect(result).toEqual(["dev", "prod", "staging"]);
+    });
+
+    test("returns sorted unique tags", () => {
+        buildServersTableBody([
+            ["z-tag", "a-tag"],
+            ["a-tag", "m-tag"],
+        ]);
+        const result = f()("catalog");
+        expect(result).toEqual(["a-tag", "m-tag", "z-tag"]);
+    });
+
+    test("returns empty array when no servers-table-body", () => {
+        const result = f()("catalog");
+        expect(result).toEqual([]);
+    });
+
+    test("skips empty data-tag attributes", () => {
+        const tbody = buildServersTableBody([["valid"]]);
+        const emptySpan = doc.createElement("span");
+        emptySpan.setAttribute("data-tag", "");
+        tbody.querySelector("td").appendChild(emptySpan);
+
+        const result = f()("catalog");
+        expect(result).toEqual(["valid"]);
+    });
+
+    test("skips whitespace-only data-tag", () => {
+        const tbody = buildServersTableBody([["valid"]]);
+        const wsSpan = doc.createElement("span");
+        wsSpan.setAttribute("data-tag", "   ");
+        tbody.querySelector("td").appendChild(wsSpan);
+
+        const result = f()("catalog");
+        expect(result).toEqual(["valid"]);
+    });
+
+    test("skips tags exceeding 50 characters", () => {
+        const longTag = "a".repeat(51);
+        buildServersTableBody([["ok", longTag]]);
+        const result = f()("catalog");
+        expect(result).toEqual(["ok"]);
+    });
+
+    test("accepts single-character tags", () => {
+        buildServersTableBody([["x"]]);
+        const result = f()("catalog");
+        expect(result).toEqual(["x"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractAvailableTags — generic entity path (data-tag in panel table)
+// ---------------------------------------------------------------------------
+describe("extractAvailableTags — generic entity (data-tag)", () => {
+    const f = () => win.extractAvailableTags;
+
+    test("extracts tags from panel table using data-tag attributes", () => {
+        buildPanelTable(
+            "tools",
+            ["Name", "Tags", "Status"],
+            [
+                ["tool-a", ["prod", "staging"], "active"],
+                ["tool-b", ["dev"], "active"],
+            ],
+        );
+        const result = f()("tools");
+        expect(result).toEqual(["dev", "prod", "staging"]);
+    });
+
+    test("returns empty array when no Tags header exists", () => {
+        buildPanelTable(
+            "tools",
+            ["Name", "Description", "Status"],
+            [["tool-a", "desc", "active"]],
+        );
+        const result = f()("tools");
+        expect(result).toEqual([]);
+    });
+
+    test("returns empty array when panel does not exist", () => {
+        const result = f()("nonexistent");
+        expect(result).toEqual([]);
+    });
+
+    test("skips inactive rows", () => {
+        const panel = buildPanelTable(
+            "gateways",
+            ["Name", "Tags"],
+            [
+                ["gw-a", ["prod"]],
+                ["gw-b", ["staging"]],
+            ],
+        );
+        // Mark second row as inactive
+        const rows = panel.querySelectorAll("tbody tr");
+        rows[1].classList.add("inactive-row");
+
+        const result = f()("gateways");
+        expect(result).toEqual(["prod"]);
+    });
+
+    test("handles rows with fewer cells than tagsColumnIndex", () => {
+        buildPanelTable("resources", ["Name", "Tags"], [["only-one-cell"]]);
+        // The row only has 1 cell but tags column is at index 1
+        // This is handled by the tagsColumnIndex < cells.length check
+        const result = f()("resources");
+        expect(result).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// updateAvailableTags — renders tag buttons from extracted data
+// ---------------------------------------------------------------------------
+describe("updateAvailableTags", () => {
+    const f = () => win.updateAvailableTags;
+
+    test("populates container with tag buttons", () => {
+        buildServersTableBody([["alpha", "beta"]]);
+
+        const container = doc.createElement("div");
+        container.id = "catalog-available-tags";
+        doc.body.appendChild(container);
+
+        f()("catalog");
+
+        const buttons = container.querySelectorAll("button");
+        expect(buttons).toHaveLength(2);
+        expect(buttons[0].textContent).toBe("alpha");
+        expect(buttons[1].textContent).toBe("beta");
+    });
+
+    test("shows 'No tags found' when no tags exist", () => {
+        const container = doc.createElement("div");
+        container.id = "catalog-available-tags";
+        doc.body.appendChild(container);
+
+        f()("catalog");
+
+        expect(container.textContent).toContain("No tags found");
+    });
+
+    test("does nothing when container does not exist", () => {
+        expect(() => f()("catalog")).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// addTagToFilter — URL state persistence
+// ---------------------------------------------------------------------------
+describe("addTagToFilter — URL state sync", () => {
+    const f = () => win.addTagToFilter;
+
+    test("updates URL with tag filter state for searchable panels", () => {
+        // Intercept safeReplaceState to capture URL updates
+        let capturedUrl = null;
+        win.safeReplaceState = (_state, _title, url) => {
+            capturedUrl = url;
+        };
+
+        // Use servers-tag-filter (resolved via PANEL_SEARCH_CONFIG for catalog)
+        const tagInput = doc.createElement("input");
+        tagInput.id = "servers-tag-filter";
+        tagInput.value = "";
+        doc.body.appendChild(tagInput);
+
+        const searchInput = doc.createElement("input");
+        searchInput.id = "servers-search-input";
+        searchInput.value = "";
+        doc.body.appendChild(searchInput);
+
+        f()("catalog", "production");
+
+        expect(capturedUrl).not.toBeNull();
+        expect(capturedUrl).toContain("servers_tags=production");
+    });
+
+    test("preserves search query in URL when adding tag", () => {
+        let capturedUrl = null;
+        win.safeReplaceState = (_state, _title, url) => {
+            capturedUrl = url;
+        };
+
+        const tagInput = doc.createElement("input");
+        tagInput.id = "servers-tag-filter";
+        tagInput.value = "";
+        doc.body.appendChild(tagInput);
+
+        const searchInput = doc.createElement("input");
+        searchInput.id = "servers-search-input";
+        searchInput.value = "my-search";
+        doc.body.appendChild(searchInput);
+
+        f()("catalog", "staging");
+
+        expect(capturedUrl).not.toBeNull();
+        expect(capturedUrl).toContain("servers_q=my-search");
+        expect(capturedUrl).toContain("servers_tags=staging");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// tableToEntityType mapping
+// ---------------------------------------------------------------------------
+describe("tableToEntityType mapping", () => {
+    test("servers-table maps to catalog", () => {
+        // Verify the htmx:afterSettle handler correctly resolves entity types
+        // by dispatching a simulated htmx:afterSettle event.
+        buildServersTableBody([["test-tag"]]);
+        const container = doc.createElement("div");
+        container.id = "catalog-available-tags";
+        doc.body.appendChild(container);
+
+        // Create a mock target element with the expected table ID
+        const target = doc.createElement("div");
+        target.id = "servers-table";
+        doc.body.appendChild(target);
+
+        // Dispatch htmx:afterSettle targeting the servers-table
+        const event = new win.Event("htmx:afterSettle", { bubbles: true });
+        Object.defineProperty(event, "detail", {
+            value: { target: target },
+        });
+        doc.body.dispatchEvent(event);
+
+        // The handler should have called updateAvailableTags("catalog")
+        const buttons = container.querySelectorAll("button");
+        expect(buttons.length).toBeGreaterThanOrEqual(1);
+        expect(buttons[0].textContent).toBe("test-tag");
+    });
+});

--- a/tests/js/admin-tag-extraction.test.js
+++ b/tests/js/admin-tag-extraction.test.js
@@ -12,6 +12,8 @@ import {
     beforeAll,
     beforeEach,
     afterAll,
+    afterEach,
+    vi,
 } from "vitest";
 import { loadAdminJs, cleanupAdminJs } from "./helpers/admin-env.js";
 
@@ -339,5 +341,180 @@ describe("tableToEntityType mapping", () => {
         const buttons = container.querySelectorAll("button");
         expect(buttons.length).toBeGreaterThanOrEqual(1);
         expect(buttons[0].textContent).toBe("test-tag");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a servers-table with real table content (no loading message)
+// ---------------------------------------------------------------------------
+function buildLoadedServersTable() {
+    const wrapper = doc.createElement("div");
+    wrapper.id = "servers-table";
+    const table = doc.createElement("table");
+    const tbody = doc.createElement("tbody");
+    const tr = doc.createElement("tr");
+    const td = doc.createElement("td");
+    td.textContent = "Server A";
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+    table.appendChild(tbody);
+    wrapper.appendChild(table);
+    doc.body.appendChild(wrapper);
+    return wrapper;
+}
+
+// ---------------------------------------------------------------------------
+// showTab("catalog") — regression path: restore filters from URL
+// ---------------------------------------------------------------------------
+describe("showTab catalog — restore filters from URL on return", () => {
+    const showTab = () => win.showTab;
+
+    // showTab wraps content-loading logic in setTimeout; use fake timers
+    // so vi.runAllTimers() flushes the callback synchronously.
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test("restores tag and search inputs from URL when table is already loaded", () => {
+        // Seed URL with persisted filter state
+        win.history.replaceState(
+            {},
+            "",
+            "http://localhost/?servers_tags=prod&servers_q=my-search#catalog",
+        );
+
+        buildLoadedServersTable();
+
+        // Create the renamed inputs (resolved via PANEL_SEARCH_CONFIG)
+        const tagInput = doc.createElement("input");
+        tagInput.id = "servers-tag-filter";
+        tagInput.value = "";
+        doc.body.appendChild(tagInput);
+
+        const searchInput = doc.createElement("input");
+        searchInput.id = "servers-search-input";
+        searchInput.value = "";
+        doc.body.appendChild(searchInput);
+
+        // Panel must have "hidden" class so the idempotency guard
+        // (classList.contains("hidden")) doesn't short-circuit showTab.
+        const panel = doc.createElement("div");
+        panel.id = "catalog-panel";
+        panel.classList.add("tab-panel", "hidden");
+        doc.body.appendChild(panel);
+
+        showTab()("catalog");
+        vi.runAllTimers();
+
+        expect(tagInput.value).toBe("prod");
+        expect(searchInput.value).toBe("my-search");
+    });
+
+    test("does not overwrite inputs when URL has no filter state", () => {
+        win.history.replaceState({}, "", "http://localhost/#catalog");
+
+        buildLoadedServersTable();
+
+        const tagInput = doc.createElement("input");
+        tagInput.id = "servers-tag-filter";
+        tagInput.value = "existing";
+        doc.body.appendChild(tagInput);
+
+        const searchInput = doc.createElement("input");
+        searchInput.id = "servers-search-input";
+        searchInput.value = "existing-q";
+        doc.body.appendChild(searchInput);
+
+        const panel = doc.createElement("div");
+        panel.id = "catalog-panel";
+        panel.classList.add("tab-panel", "hidden");
+        doc.body.appendChild(panel);
+
+        showTab()("catalog");
+        vi.runAllTimers();
+
+        // Inputs should remain unchanged — no URL state to restore
+        expect(tagInput.value).toBe("existing");
+        expect(searchInput.value).toBe("existing-q");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// filterEntitiesByTags — uses data-tag attributes
+// ---------------------------------------------------------------------------
+describe("filterEntitiesByTags — data-tag contract", () => {
+    const f = () => win.filterEntitiesByTags;
+
+    function buildTaggedPanel(entityType, rows) {
+        const panel = doc.createElement("div");
+        panel.id = `${entityType}-panel`;
+        const table = doc.createElement("table");
+        const tbody = doc.createElement("tbody");
+        rows.forEach(({ text, tags }) => {
+            const tr = doc.createElement("tr");
+            const td1 = doc.createElement("td");
+            td1.textContent = text;
+            tr.appendChild(td1);
+            const td2 = doc.createElement("td");
+            tags.forEach((tag) => {
+                const span = doc.createElement("span");
+                span.setAttribute("data-tag", tag);
+                span.textContent = tag;
+                td2.appendChild(span);
+            });
+            tr.appendChild(td2);
+            tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        panel.appendChild(table);
+        doc.body.appendChild(panel);
+        return tbody;
+    }
+
+    test("shows rows matching filter tag", () => {
+        const tbody = buildTaggedPanel("tools", [
+            { text: "Tool A", tags: ["production"] },
+            { text: "Tool B", tags: ["staging"] },
+        ]);
+        f()("tools", "production");
+        const rows = tbody.querySelectorAll("tr");
+        expect(rows[0].style.display).toBe("");
+        expect(rows[1].style.display).toBe("none");
+    });
+
+    test("hides all rows when no tags match", () => {
+        const tbody = buildTaggedPanel("tools", [
+            { text: "Tool A", tags: ["alpha"] },
+            { text: "Tool B", tags: ["beta"] },
+        ]);
+        f()("tools", "nonexistent");
+        const rows = tbody.querySelectorAll("tr");
+        expect(rows[0].style.display).toBe("none");
+        expect(rows[1].style.display).toBe("none");
+    });
+
+    test("empty filter shows all rows", () => {
+        const tbody = buildTaggedPanel("tools", [
+            { text: "Tool A", tags: ["production"] },
+            { text: "Tool B", tags: ["staging"] },
+        ]);
+        f()("tools", "");
+        const rows = tbody.querySelectorAll("tr");
+        expect(rows[0].style.display).toBe("");
+        expect(rows[1].style.display).toBe("");
+    });
+
+    test("partial tag match works (OR substring logic)", () => {
+        const tbody = buildTaggedPanel("tools", [
+            { text: "Tool A", tags: ["production-us"] },
+            { text: "Tool B", tags: ["staging"] },
+        ]);
+        f()("tools", "production");
+        const rows = tbody.querySelectorAll("tr");
+        expect(rows[0].style.display).toBe("");
+        expect(rows[1].style.display).toBe("none");
     });
 });


### PR DESCRIPTION

Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
closes #3662 
## 💡 Fix Description

Fixed tag loss issue on Virtual Servers page by correcting input IDs from catalog-* to servers-*.

Ensured tag filter values persist by updating hx-vals to use the correct hidden inputs.

Added data-tag attribute to tag elements for reliable tag extraction after UI updates.

Improved HTMX lifecycle handling using htmx:afterSwap and htmx:afterSettle events.

Re-initialized search inputs and restored filter state after dynamic content reloads.

Introduced tableToEntityType mapping to handle tag updates across different panels.

Enhanced tag extraction logic to dynamically read tags from the updated DOM.

Synced search query and tag filters with URL state for consistency across navigation.

Triggered panel reload when filters are present to maintain UI state.

Overall, ensured tags remain visible and consistent when navigating between pages.
## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |Pass    |
| Unit tests                            | `make test`          |Pass    |

## 📐 MCP Compliance (if relevant)
- [X] Matches current MCP spec
- [X] No breaking change to MCP clients

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
