### PR TITLE
feat(sso): extract groups claim for generic OIDC providers

### DIFF
--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1444,6 +1444,15 @@ class SSOService:
         # _is_email_verified_claim's absent-means-pass-through logic applies correctly.
         # Injecting None (via .get()) when the key is missing would cause the key to
         # be present in the dict with a falsy value, silently blocking login.
+        metadata = provider.provider_metadata or {}
+        groups_claim = metadata.get("groups_claim", "groups")
+        groups = []
+        if groups_claim in user_data:
+            gc = user_data.get(groups_claim, [])
+            if isinstance(gc, list):
+                groups = gc
+            elif isinstance(gc, str):
+                groups = [gc]
         generic_normalized: Dict[str, Any] = {
             "email": user_data.get("email"),
             "full_name": user_data.get("name"),
@@ -1451,6 +1460,7 @@ class SSOService:
             "provider_id": user_data.get("sub"),
             "username": user_data.get("preferred_username") or user_data.get("email", "").split("@")[0],
             "provider": provider.id,
+            "groups": groups,
         }
         if "email_verified" in user_data:
             generic_normalized["email_verified"] = user_data["email_verified"]

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1252,6 +1252,15 @@ class SSOService:
                     if claim in keycloak_id_token_claims and claim not in user_data:
                         user_data[claim] = keycloak_id_token_claims[claim]
 
+            # For generic OIDC providers, merge the configured groups claim from the
+            # verified id_token when the userinfo response did not include it.  Some
+            # providers (e.g. JumpCloud) only emit groups in the id_token.
+            if provider.id not in ("github", "google", "ibm_verify", "okta", "keycloak", "entra") and verified_id_token_claims:
+                metadata = provider.provider_metadata or {}
+                groups_claim = metadata.get("groups_claim", "groups")
+                if groups_claim in verified_id_token_claims and groups_claim not in user_data:
+                    user_data[groups_claim] = verified_id_token_claims[groups_claim]
+
             # Normalize user info across providers
             return self._normalize_user_info(provider, user_data)
 
@@ -1450,7 +1459,7 @@ class SSOService:
         if groups_claim in user_data:
             gc = user_data.get(groups_claim, [])
             if isinstance(gc, list):
-                groups = gc
+                groups = [g for g in gc if isinstance(g, str)]
             elif isinstance(gc, str):
                 groups = [gc]
         generic_normalized: Dict[str, Any] = {

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -1275,6 +1275,75 @@ class TestGetUserInfo:
         assert "admin" in result["groups"]
         assert "/team" in result["groups"]
 
+    @pytest.mark.asyncio
+    async def test_get_user_info_generic_oidc_merges_groups_from_id_token(self, sso_service):
+        """Generic OIDC provider merges configured groups claim from id_token when userinfo omits it."""
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.json.return_value = {"email": "user@jumpcloud.com", "name": "JC User", "sub": "jc-123"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=user_response)
+
+        provider = _make_provider(id="jumpcloud", name="jumpcloud", provider_type="oidc", provider_metadata={"groups_claim": "groups"})
+
+        id_token_claims = {"sub": "jc-123", "groups": ["Engineering", "Platform"]}
+        token_data = {"access_token": "at", "_verified_id_token_claims": id_token_claims}
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client, patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_get_client.return_value = mock_client
+            mock_settings.sso_github_admin_orgs = []
+            result = await sso_service._get_user_info(provider, "at", token_data)
+
+        assert result is not None
+        assert result["groups"] == ["Engineering", "Platform"]
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_generic_oidc_prefers_userinfo_groups_over_id_token(self, sso_service):
+        """When userinfo already contains the groups claim, id_token groups are not merged."""
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.json.return_value = {"email": "user@provider.com", "name": "Test", "sub": "u-1", "groups": ["FromUserinfo"]}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=user_response)
+
+        provider = _make_provider(id="custom_oidc", name="custom_oidc", provider_type="oidc", provider_metadata={})
+
+        id_token_claims = {"sub": "u-1", "groups": ["FromIdToken"]}
+        token_data = {"access_token": "at", "_verified_id_token_claims": id_token_claims}
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client, patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_get_client.return_value = mock_client
+            mock_settings.sso_github_admin_orgs = []
+            result = await sso_service._get_user_info(provider, "at", token_data)
+
+        assert result is not None
+        assert result["groups"] == ["FromUserinfo"]
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_generic_oidc_custom_groups_claim_from_id_token(self, sso_service):
+        """Generic OIDC provider merges custom-named groups claim from id_token."""
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.json.return_value = {"email": "user@auth0.com", "name": "A0 User", "sub": "a0-1"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=user_response)
+
+        provider = _make_provider(id="auth0", name="auth0", provider_type="oidc", provider_metadata={"groups_claim": "https://myapp/roles"})
+
+        id_token_claims = {"sub": "a0-1", "https://myapp/roles": ["admin", "editor"]}
+        token_data = {"access_token": "at", "_verified_id_token_claims": id_token_claims}
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client, patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_get_client.return_value = mock_client
+            mock_settings.sso_github_admin_orgs = []
+            result = await sso_service._get_user_info(provider, "at", token_data)
+
+        assert result is not None
+        assert result["groups"] == ["admin", "editor"]
+
 
 # ---------------------------------------------------------------------------
 # Normalization tests

--- a/tests/unit/mcpgateway/services/test_sso_user_normalization.py
+++ b/tests/unit/mcpgateway/services/test_sso_user_normalization.py
@@ -862,6 +862,105 @@ class TestGenericOIDCNormalization:
 
         assert normalized["email_verified"] is False
 
+    def test_generic_oidc_groups_default_claim(self, sso_service):
+        """Groups are extracted from the default 'groups' claim."""
+        provider = SSOProvider(id="jumpcloud", name="jumpcloud", display_name="JumpCloud", provider_type="oidc")
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "groups": ["Engineering", "Platform"],
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == ["Engineering", "Platform"]
+
+    def test_generic_oidc_groups_custom_claim(self, sso_service):
+        """Groups are extracted from a custom claim specified in provider_metadata."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc", provider_metadata={"groups_claim": "roles"})
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "roles": ["admin", "editor"],
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == ["admin", "editor"]
+
+    def test_generic_oidc_groups_string_value(self, sso_service):
+        """A single string group value is wrapped in a list."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc")
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "groups": "Engineering",
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == ["Engineering"]
+
+    def test_generic_oidc_groups_absent_claim(self, sso_service):
+        """When no groups claim is present, groups defaults to empty list."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc")
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == []
+
+    def test_generic_oidc_groups_empty_metadata(self, sso_service):
+        """When provider_metadata is None, groups_claim defaults to 'groups'."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc", provider_metadata=None)
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "groups": ["DevOps"],
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == ["DevOps"]
+
+    def test_generic_oidc_groups_non_list_non_string_ignored(self, sso_service):
+        """Non-list, non-string group values (e.g. int, dict) result in empty groups."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc")
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "groups": 42,
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == []
+
+    def test_generic_oidc_groups_with_email_verified(self, sso_service):
+        """Groups extraction works alongside email_verified handling."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc", provider_metadata={"groups_claim": "team_memberships"})
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "email_verified": True,
+            "team_memberships": ["backend", "sre"],
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == ["backend", "sre"]
+        assert normalized["email_verified"] is True
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/mcpgateway/services/test_sso_user_normalization.py
+++ b/tests/unit/mcpgateway/services/test_sso_user_normalization.py
@@ -945,6 +945,20 @@ class TestGenericOIDCNormalization:
 
         assert normalized["groups"] == []
 
+    def test_generic_oidc_groups_nested_structures_filtered(self, sso_service):
+        """Nested structures (dicts, lists) in the groups list are filtered to strings only."""
+        provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc")
+        user_data = {
+            "email": "user@company.com",
+            "name": "Test User",
+            "sub": "user-123",
+            "groups": ["Engineering", {"nested": "value"}, 42, "Platform", None],
+        }
+
+        normalized = sso_service._normalize_user_info(provider, user_data)
+
+        assert normalized["groups"] == ["Engineering", "Platform"]
+
     def test_generic_oidc_groups_with_email_verified(self, sso_service):
         """Groups extraction works alongside email_verified handling."""
         provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc", provider_metadata={"groups_claim": "team_memberships"})


### PR DESCRIPTION
## Summary

The generic OIDC normalization path in `_normalize_user_info` does not extract group claims from the identity token or userinfo response. This means `_apply_team_mapping` has no groups to work with for any provider that isn't Keycloak or Entra ID — so `team_mapping` on generic OIDC providers (JumpCloud, Okta, Auth0, etc.) silently does nothing.

## Change

Adds groups extraction to the generic OIDC fallback in `_normalize_user_info`, following the exact same pattern already used by the Keycloak and Entra paths:

- Reads `groups_claim` from `provider_metadata` (defaults to `"groups"`)
- Extracts the claim value from `user_data` (handles both list and string)
- Includes `"groups"` key in the normalized return dict

**10 lines added, 0 removed. Single file change.**

## Use case

We're using ContextForge with JumpCloud as a generic OIDC provider. JumpCloud includes a `groups` claim in the ID token when configured. Without this patch, those groups are silently dropped by `_normalize_user_info`, making `team_mapping` on the SSO provider record non-functional.

With the patch, setting `provider_metadata: {"groups_claim": "groups"}` and `team_mapping: {"Engineering": "<team-id>"}` on the SSO provider works as expected — users are auto-added to teams on login based on their IdP groups.

## Testing

- Verified with JumpCloud OIDC provider on ContextForge 1.0.0-RC-2
- Confirmed Keycloak and Entra paths remain unchanged (they have their own extraction logic that runs before the generic fallback)
- The generic path only executes for providers that don't match `keycloak`, `entra`, `github`, or `okta` by ID