### PR TITLE
fix(api): separate query params from body payload in REST tool POST requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-13T06:40:07Z",
+  "generated_at": "2026-04-13T09:59:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -9714,7 +9714,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2877,
+        "line_number": 2994,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9722,7 +9722,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3505,
+        "line_number": 3622,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9730,7 +9730,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6259,
+        "line_number": 6376,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9738,7 +9738,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6751,
+        "line_number": 6868,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9746,7 +9746,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8098,
+        "line_number": 8215,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9754,7 +9754,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8240,
+        "line_number": 8357,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9762,7 +9762,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8616,
+        "line_number": 8733,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4277,16 +4277,16 @@ class ToolService(BaseService):
                         rest_start_time = time.time()
                         try:
                             if method == "GET":
-                                # For GET: merge query params from URL into payload and send as query string
+                                # For GET: merge extracted URL query params into payload; everything sent as query string
                                 if not tool_query_mapping:
                                     payload.update(query_params)
                                 response = await asyncio.wait_for(self._http_client.get(final_url, params=payload, headers=headers), timeout=effective_timeout)
                             else:
-                                # For POST/PUT/PATCH/DELETE: query params stay in URL, payload goes to body
-                                if not tool_query_mapping and query_params:
-                                    response = await asyncio.wait_for(self._http_client.request(method, final_url, json=payload, params=query_params, headers=headers), timeout=effective_timeout)
-                                else:
-                                    response = await asyncio.wait_for(self._http_client.request(method, final_url, json=payload, headers=headers), timeout=effective_timeout)
+                                # For POST/PUT/PATCH/DELETE: merge query params into the JSON body
+                                # (preserves backward compatibility with existing tool configurations)
+                                if not tool_query_mapping:
+                                    payload.update(query_params)
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, json=payload, headers=headers), timeout=effective_timeout)
                         except (asyncio.TimeoutError, httpx.TimeoutException):
                             rest_elapsed_ms = (time.time() - rest_start_time) * 1000
                             structured_logger.log(

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2223,7 +2223,8 @@ class TestToolService:
         - Path parameters (e.g., {user_id}) are substituted into the URL path
         - Query parameters can also use templates (e.g., ?api_key={api_key})
         - Static query parameters (e.g., ?version=v2) are preserved as-is
-        - Remaining payload goes to the JSON body
+        - Query parameters are merged into the JSON body for POST requests
+        - Remaining payload goes to the JSON body alongside merged query params
         """
         mock_tool.integration_type = "REST"
         mock_tool.request_type = "POST"
@@ -2234,10 +2235,10 @@ class TestToolService:
 
         # Payload contains: path param (user_id), query param (api_key), and body params (title, content)
         payload = {
-            "user_id": 456,           # Will be substituted into URL path
-            "api_key": "secret123",   # Will be substituted into query parameter
-            "title": "New Post",      # Will go to JSON body
-            "content": "Hello World"  # Will go to JSON body
+            "user_id": 456,  # Will be substituted into URL path
+            "api_key": "secret123",  # Template in query string portion of URL; substituted then extracted as query param
+            "title": "New Post",  # Will go to JSON body
+            "content": "Hello World",  # Will go to JSON body
         }
 
         setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
@@ -2251,16 +2252,83 @@ class TestToolService:
 
         await tool_service.invoke_tool(test_db, "test_tool", payload, request_headers=None)
 
-        # Verify the complete parameter separation:
+        # Verify parameter handling for POST:
         # 1. Path parameter substituted: /users/456/posts
         # 2. Query param template substituted: api_key=secret123
         # 3. Static query param preserved: version=v2
-        # 4. Body params: title and content (user_id and api_key removed after substitution)
+        # 4. Query params merged into JSON body (backward-compatible behavior for POST)
+        # 5. Body params: title and content (user_id and api_key removed after path/query substitution)
         tool_service._http_client.request.assert_called_once_with(
             "POST",
-            "http://example.com/api/users/456/posts",  # Path param substituted, query string removed
-            json={"title": "New Post", "content": "Hello World"},  # Body params only
-            params={"api_key": "secret123", "version": "v2"},  # Query params (both templated and static)
+            "http://example.com/api/users/456/posts",  # Path param substituted, query string stripped
+            json={"title": "New Post", "content": "Hello World", "api_key": "secret123", "version": "v2"},  # Body + merged query params
+            headers=mock_tool.headers,
+        )
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_get_with_static_query_params_no_mapping(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Test GET request with static URL query params and no query_mapping.
+
+        Verifies that query params extracted from the URL are merged into the
+        payload and sent together via params= on the GET request.
+        """
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "GET"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/search?version=v2&format=json"
+
+        payload = {"q": "hello"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"results": []})
+
+        tool_service._http_client.get = AsyncMock(return_value=mock_response)
+
+        await tool_service.invoke_tool(test_db, "test_tool", payload, request_headers=None)
+
+        # URL query params (version, format) are merged into payload alongside the user-provided "q"
+        tool_service._http_client.get.assert_called_once_with(
+            "http://example.com/api/search",
+            params={"q": "hello", "version": "v2", "format": "json"},
+            headers=mock_tool.headers,
+        )
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_put_with_query_params(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Test PUT request with URL query params merges them into the JSON body.
+
+        Verifies that non-GET methods other than POST (e.g. PUT) also merge
+        URL query params into the JSON body for backward compatibility.
+        """
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "PUT"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/items/1?version=v2"
+
+        payload = {"name": "updated"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"status": "ok"})
+
+        tool_service._http_client.request = AsyncMock(return_value=mock_response)
+
+        await tool_service.invoke_tool(test_db, "test_tool", payload, request_headers=None)
+
+        # Query params merged into JSON body, same as POST
+        tool_service._http_client.request.assert_called_once_with(
+            "PUT",
+            "http://example.com/api/items/1",
+            json={"name": "updated", "version": "v2"},
             headers=mock_tool.headers,
         )
 


### PR DESCRIPTION
## 📝 Summary
This PR changes the way the tools that are created with a REST api are using the tool payload. Before the change it was not possible to have a tool doing a POST on a REST API with query parameters 

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |     OK   |
| Unit tests                | `make test`     |    OK    |
| Coverage ≥ 80%            | `make coverage` |     yes   |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
