### PR TITLE
fix(llm): align Bedrock GatewayProvider config keys with DB schema

### DIFF
--- a/mcpgateway/services/mcp_client_chat_service.py
+++ b/mcpgateway/services/mcp_client_chat_service.py
@@ -1583,7 +1583,7 @@ class GatewayProvider:
                     raise ImportError("AWS Bedrock provider requires langchain-aws. Install with: pip install langchain-aws boto3")
 
                 # Map DB schema keys to boto3 kwargs.
-                # DB stores: region, access_key_id, secret_access_key, session_token
+                # DB stores: region, access_key_id, secret_access_key, session_token, profile_name
                 # (see llm_provider_configs.AWSBedrockConfig)
                 region_name = config.get("region", "us-east-1")
                 credentials_kwargs = {}
@@ -1593,6 +1593,8 @@ class GatewayProvider:
                     credentials_kwargs["aws_secret_access_key"] = config["secret_access_key"]
                 if config.get("session_token"):
                     credentials_kwargs["aws_session_token"] = config["session_token"]
+                if config.get("profile_name"):
+                    credentials_kwargs["credentials_profile_name"] = config["profile_name"]
 
                 model_kwargs = {
                     "temperature": temperature,

--- a/tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py
@@ -1479,6 +1479,22 @@ def test_gateway_provider_bedrock_default_region(monkeypatch):
     assert llm.kwargs["region_name"] == "us-east-1"
 
 
+def test_gateway_provider_bedrock_profile_name(monkeypatch):
+    """GatewayProvider bedrock maps profile_name to credentials_profile_name."""
+    _patch_gateway_llms(monkeypatch)
+    model, provider = _make_model_and_provider(
+        "bedrock",
+        config={"region": "us-east-1", "profile_name": "my-profile"},
+    )
+    _patch_gateway_session(monkeypatch, model, provider)
+    monkeypatch.setattr("mcpgateway.utils.services_auth.decode_auth", lambda _v: {"api_key": "decoded"})
+
+    gateway = svc.GatewayProvider(svc.GatewayConfig(model="gpt-4"))
+    llm = gateway.get_llm(model_type="chat")
+    assert llm.kwargs["credentials_profile_name"] == "my-profile"
+    assert "aws_access_key_id" not in llm.kwargs
+
+
 def test_gateway_provider_anthropic_not_available(monkeypatch):
     """GatewayProvider raises ImportError when anthropic not available."""
     _patch_gateway_llms(monkeypatch)


### PR DESCRIPTION
## 🔗 Related Issue
Close: #3761

---

## 📝 Summary
`GatewayProvider.get_llm()` reads Bedrock credentials using boto3-style key names (`aws_access_key_id`, `aws_secret_access_key`, `region_name`), but the Admin UI stores them via `llm_provider_configs.AWSBedrockConfig` which uses shorter key names (`access_key_id`, `secret_access_key`, `region`).

This mismatch causes `config.get("aws_access_key_id")` to always return `None`, silently falling back to the node IAM role instead of using the user-configured credentials.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |   pass     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

