### PR TITLE
fix(llmchat): mark tool/parsing errors as recoverable in streaming

### DIFF
--- a/mcpgateway/routers/llmchat_router.py
+++ b/mcpgateway/routers/llmchat_router.py
@@ -43,6 +43,7 @@ from mcpgateway.config import settings
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.mcp_client_chat_service import (
+    ChatProcessingError,
     GatewayConfig,
     LLMConfig,
     MCPChatService,
@@ -964,10 +965,14 @@ async def token_streamer(chat_service: MCPChatService, message: str, user_id: st
         error_event = {"type": "error", "error": "Request timed out waiting for LLM response", "recoverable": True}
         async for part in sse("error", error_event):
             yield part
+    except ChatProcessingError as cpe:
+        # ChatProcessingError wraps tool/parsing/model errors —
+        # the session is still valid, so the frontend can retry.
+        error_event = {"type": "error", "error": f"Service error: {str(cpe)}", "recoverable": True}
+        async for part in sse("error", error_event):
+            yield part
     except RuntimeError as re:
-        # RuntimeError from chat_events wraps tool/parsing/model errors —
-        # the session is still valid, only ConnectionError is non-recoverable.
-        error_event = {"type": "error", "error": f"Service error: {str(re)}", "recoverable": True}
+        error_event = {"type": "error", "error": f"Service error: {str(re)}", "recoverable": False}
         async for part in sse("error", error_event):
             yield part
     except Exception as e:

--- a/mcpgateway/services/mcp_client_chat_service.py
+++ b/mcpgateway/services/mcp_client_chat_service.py
@@ -100,6 +100,10 @@ logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
 
+class ChatProcessingError(RuntimeError):
+    """Recoverable error wrapping tool, parsing, or model failures during chat streaming."""
+
+
 class MCPServerConfig(BaseModel):
     """
     Configuration for MCP server connection.
@@ -2639,6 +2643,7 @@ class MCPChatService:
             ValueError: If message is empty or whitespace only.
             ConnectionError: If the underlying MCP connection is lost.
             TimeoutError: If the LLM request times out.
+            ChatProcessingError: If a tool, parsing, or model error occurs during streaming.
 
         Examples:
             >>> import asyncio
@@ -2905,7 +2910,7 @@ class MCPChatService:
             raise
         except Exception as e:
             logger.error(f"Error in chat_events: {e}")
-            raise RuntimeError(f"Chat processing error: {e}") from e
+            raise ChatProcessingError(f"Chat processing error: {e}") from e
 
     async def get_conversation_history(self) -> List[Dict[str, str]]:
         """

--- a/tests/unit/mcpgateway/routers/test_llmchat_router.py
+++ b/tests/unit/mcpgateway/routers/test_llmchat_router.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 # First-Party
 from mcpgateway.routers import llmchat_router
 from mcpgateway.routers.llmchat_router import ChatInput, ConnectInput, DisconnectInput, LLMInput, ServerInput
+from mcpgateway.services.mcp_client_chat_service import ChatProcessingError
 
 
 class DummyChatService:
@@ -649,6 +650,7 @@ async def test_token_streamer_emits_events():
 
 @pytest.mark.asyncio
 async def test_token_streamer_handles_runtime_error():
+    """Plain RuntimeError (e.g. 'not initialized') must be non-recoverable."""
     chat_service = FailingStreamChatService(config=None, user_id="user1")
 
     parts = []
@@ -657,6 +659,27 @@ async def test_token_streamer_handles_runtime_error():
 
     joined = "".join(parts)
     assert "event: error" in joined
+    assert '"recoverable":false' in joined
+
+
+@pytest.mark.asyncio
+async def test_token_streamer_handles_chat_processing_error():
+    """ChatProcessingError (tool/parsing/model failures) must be recoverable."""
+
+    class ChatProcessingErrService(DummyChatService):
+        async def chat_events(self, message):
+            raise ChatProcessingError("tool parse failed")
+            if message:  # pragma: no cover - keep generator signature
+                yield {"type": "token", "content": message}
+
+    svc = ChatProcessingErrService(config=None, user_id="user1")
+    parts = []
+    async for part in llmchat_router.token_streamer(svc, "hi", "user1"):
+        parts.append(part.decode("utf-8"))
+
+    joined = "".join(parts)
+    assert "event: error" in joined
+    assert "tool parse failed" in joined
     assert '"recoverable":true' in joined
 
 

--- a/tests/unit/mcpgateway/services/test_mcp_client_chat_service.py
+++ b/tests/unit/mcpgateway/services/test_mcp_client_chat_service.py
@@ -1258,7 +1258,7 @@ async def test_chat_events_wraps_astream_event_errors(monkeypatch, patch_logger)
     service._agent = SimpleNamespace(astream_events=_astream_events)
     monkeypatch.setattr(svc, "HumanMessage", MagicMock(return_value=MagicMock()))
 
-    with pytest.raises(RuntimeError, match="Chat processing error: stream blew up"):
+    with pytest.raises(svc.ChatProcessingError, match="Chat processing error: stream blew up"):
         async for _ev in service.chat_events("hello"):
             pass
 


### PR DESCRIPTION
## 🔗 Related Issue
Close: #3763 

---

## 📝 Summary
When a tool invocation fails or a response parsing error occurs during LLM Chat streaming, the frontend disconnects the session and asks the user to reconnect. This happens because `chat_events()` wraps all exceptions — including `ConnectionError` and `TimeoutError` — into a single `RuntimeError`, which the router always marks as `recoverable: False`.

This PR lets `ConnectionError`/`TimeoutError` propagate with their original type so the router's existing handlers catch them correctly. The remaining `RuntimeError`s (tool failures, parsing errors, model issues) are now marked `recoverable: True` since the session is still valid.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |   pass     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
<img width="1161" height="1020" alt="스크린샷 2026-03-19 오전 10 49 34" src="https://github.com/user-attachments/assets/1d0a9aa3-aa27-45fa-9909-4970427f345b" />

**Before:** any error during streaming → `RuntimeError("Chat processing error: ...")` → `recoverable: False` → session killed


<img width="1145" height="1125" alt="스크린샷 2026-03-19 오후 1 36 21" src="https://github.com/user-attachments/assets/9b32eb23-90c7-47aa-9d21-f10905325684" />

**After:** `ConnectionError`/`TimeoutError` → re-raised as-is → caught by existing router handlers. 
Everything else → `RuntimeError` → `recoverable: True` → error shown but session stays alive.
