### PR TITLE
fix: resolve psycopg import error on s390x architecture (#3804)

### DIFF
--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -120,7 +120,7 @@ RUN set -euo pipefail \
     && dnf install -y \
         python${PYTHON_VERSION} \
         python${PYTHON_VERSION}-devel \
-        binutils openssl-devel gcc postgresql-devel gcc-c++ curl \
+        binutils openssl-devel gcc postgresql-devel gcc-c++ curl libpq-devel \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && dnf clean all
 
@@ -170,10 +170,8 @@ RUN set -euo pipefail \
     && /app/.venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel pdm uv \
     && if [ "$(uname -m)" = "s390x" ]; then \
         echo "📦 Installing dependencies for s390x architecture..."; \
-        dnf install -y libpq-devel 2>/dev/null || true; \
         /app/.venv/bin/pip install --no-cache-dir ".[redis,observability,granian]" \
-        && (/app/.venv/bin/pip install --no-cache-dir "psycopg[c]>=3.3.3" \
-            || /app/.venv/bin/pip install --no-cache-dir "psycopg>=3.3.3"); \
+        && /app/.venv/bin/pip install --no-cache-dir "psycopg[c]>=3.3.3"; \
     else \
         /app/.venv/bin/uv pip install ".[redis,postgres,observability,granian]"; \
     fi \
@@ -279,6 +277,7 @@ RUN microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 \
     ca-certificates \
     procps-ng \
     shadow-utils \
+    libpq \
     && microdnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
This change adds s390x-specific runtime fixes for the psycopg library. On s390x, psycopg is built from source and requires system libpq.so.5. Adding postgresql-libs and running ldconfig on s390x ensures that the library is available and correctively cached.

Closes #3804

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #

---

## 📝 Summary
_What does this PR do and why?_

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
