### PR TITLE
Fixed model selection dropdown appearance and interaction 

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -32734,17 +32734,22 @@ function _renderLLMModelDropdown(models) {
     if (!ul) {
         return;
     }
+    ul.innerHTML = "";
     if (!models.length) {
-        ul.innerHTML =
-            '<li class="px-3 py-2 text-xs text-gray-400 dark:text-gray-500">No models found. Enter ID manually.</li>';
+        const li = document.createElement("li");
+        li.className = "px-3 py-2 text-xs text-gray-400 dark:text-gray-500";
+        li.textContent = "No models found. Enter ID manually.";
+        ul.appendChild(li);
         return;
     }
-    ul.innerHTML = models
-        .map(
-            (m) =>
-                `<li class="px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100" data-model-id="${m.id.replace(/"/g, "&quot;")}">${m.id}</li>`,
-        )
-        .join("");
+    models.forEach((m) => {
+        const li = document.createElement("li");
+        li.className =
+            "px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100";
+        li.dataset.modelId = m.id;
+        li.textContent = m.id;
+        ul.appendChild(li);
+    });
 }
 
 // Wire up delegated events on the dropdown once at load time
@@ -32891,6 +32896,8 @@ window.fetchModelsForModelModal = fetchModelsForModelModal;
  * Edit LLM Model
  */
 async function editLLMModel(modelId) {
+    _llmAllModels = [];
+    llmModelComboboxClose();
     try {
         const response = await fetch(
             `${window.ROOT_PATH}/llm/models/${modelId}`,

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -32704,7 +32704,6 @@ function refreshLLMProviders() {
 let _llmAllModels = [];
 var _llmModelsFetched = false; // eslint-disable-line no-var -- reassigned across function scopes
 let _llmComboboxActiveIndex = -1;
-
 function _llmComboboxSetExpanded(expanded) {
     const input = document.getElementById("llm-model-model-id");
     if (input) input.setAttribute("aria-expanded", String(expanded));
@@ -32918,6 +32917,10 @@ async function onModelProviderChange() {
     await fetchModelsForModelModal();
 }
 
+// Monotonic counter — each fetchModelsForModelModal call bumps it; stale
+// responses (from a prior call to the same or different provider) are discarded.
+var _llmFetchSeq = 0; // eslint-disable-line no-var -- reassigned across function scopes
+
 /**
  * Fetch available models for the model modal
  */
@@ -32930,6 +32933,8 @@ async function fetchModelsForModelModal() {
         showToast("Please select a provider first", "warning");
         return;
     }
+
+    const seq = ++_llmFetchSeq;
 
     statusEl.textContent = "Fetching models...";
     statusEl.classList.remove("hidden");
@@ -32947,8 +32952,8 @@ async function fetchModelsForModelModal() {
 
         const result = await response.json();
 
-        // Guard against stale response if provider changed during fetch
-        if (providerSelect.value !== providerId) return;
+        // Discard stale: provider changed, or a newer request superseded this one
+        if (providerSelect.value !== providerId || seq !== _llmFetchSeq) return;
 
         if (result.success && result.models && result.models.length > 0) {
             _llmAllModels = result.models;
@@ -32966,8 +32971,7 @@ async function fetchModelsForModelModal() {
         }
     } catch (error) {
         console.error("Error fetching models:", error);
-        // Guard against stale response if provider changed during fetch
-        if (providerSelect.value !== providerId) return;
+        if (providerSelect.value !== providerId || seq !== _llmFetchSeq) return;
         _llmAllModels = [];
         _llmModelsFetched = true;
         statusEl.textContent =

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -32702,10 +32702,20 @@ function refreshLLMProviders() {
 
 // Full model list for the model-id combobox (reset on each modal open)
 let _llmAllModels = [];
+var _llmModelsFetched = false; // eslint-disable-line no-var -- reassigned across function scopes
+let _llmComboboxActiveIndex = -1;
+
+function _llmComboboxSetExpanded(expanded) {
+    const input = document.getElementById("llm-model-model-id");
+    if (input) input.setAttribute("aria-expanded", String(expanded));
+}
 
 function llmModelComboboxOpen() {
+    if (!_llmModelsFetched) return;
+    _llmComboboxActiveIndex = -1;
     _renderLLMModelDropdown(_llmAllModels);
     document.getElementById("llm-model-dropdown").classList.remove("hidden");
+    _llmComboboxSetExpanded(true);
 }
 
 function llmModelComboboxClose() {
@@ -32713,20 +32723,85 @@ function llmModelComboboxClose() {
     if (ul) {
         ul.classList.add("hidden");
     }
+    _llmComboboxActiveIndex = -1;
+    _llmComboboxSetExpanded(false);
+    _llmComboboxClearHighlight();
 }
 
 function llmModelComboboxFilter(text) {
+    if (!_llmModelsFetched) return;
     const lower = text.toLowerCase();
     const filtered = _llmAllModels.filter((m) =>
         m.id.toLowerCase().includes(lower),
     );
+    _llmComboboxActiveIndex = -1;
     _renderLLMModelDropdown(filtered);
     document.getElementById("llm-model-dropdown").classList.remove("hidden");
+    _llmComboboxSetExpanded(true);
 }
 
 function llmModelComboboxSelect(value) {
     document.getElementById("llm-model-model-id").value = value;
     llmModelComboboxClose();
+}
+
+function llmModelComboboxKeydown(event) {
+    const ul = document.getElementById("llm-model-dropdown");
+    if (!ul || ul.classList.contains("hidden")) return;
+    const items = ul.querySelectorAll("li[data-model-id]");
+    if (!items.length) return;
+
+    if (event.key === "ArrowDown") {
+        event.preventDefault();
+        _llmComboboxActiveIndex = Math.min(
+            _llmComboboxActiveIndex + 1,
+            items.length - 1,
+        );
+        _llmComboboxHighlight(items);
+    } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        _llmComboboxActiveIndex = Math.max(_llmComboboxActiveIndex - 1, 0);
+        _llmComboboxHighlight(items);
+    } else if (event.key === "Enter") {
+        if (_llmComboboxActiveIndex >= 0 && items[_llmComboboxActiveIndex]) {
+            event.preventDefault();
+            llmModelComboboxSelect(
+                items[_llmComboboxActiveIndex].dataset.modelId,
+            );
+        }
+    } else if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        llmModelComboboxClose();
+    }
+}
+
+function _llmComboboxHighlight(items) {
+    const ul = document.getElementById("llm-model-dropdown");
+    _llmComboboxClearHighlight();
+    if (_llmComboboxActiveIndex >= 0 && items[_llmComboboxActiveIndex]) {
+        const active = items[_llmComboboxActiveIndex];
+        active.classList.add("bg-indigo-100", "dark:bg-indigo-700");
+        active.id = "llm-model-active-option";
+        const input = document.getElementById("llm-model-model-id");
+        if (input) {
+            input.setAttribute("aria-activedescendant", active.id);
+        }
+        if (ul && active.scrollIntoView) {
+            active.scrollIntoView({ block: "nearest" });
+        }
+    }
+}
+
+function _llmComboboxClearHighlight() {
+    const ul = document.getElementById("llm-model-dropdown");
+    if (!ul) return;
+    ul.querySelectorAll("li").forEach((li) => {
+        li.classList.remove("bg-indigo-100", "dark:bg-indigo-700");
+        li.removeAttribute("id");
+    });
+    const input = document.getElementById("llm-model-model-id");
+    if (input) input.removeAttribute("aria-activedescendant");
 }
 
 function _renderLLMModelDropdown(models) {
@@ -32746,6 +32821,7 @@ function _renderLLMModelDropdown(models) {
         const li = document.createElement("li");
         li.className =
             "px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100";
+        li.setAttribute("role", "option");
         li.dataset.modelId = m.id;
         li.textContent = m.id;
         ul.appendChild(li);
@@ -32772,6 +32848,7 @@ async function showAddModelModal() {
     document.getElementById("llm-model-modal-title").textContent =
         "Add LLM Model";
     _llmAllModels = [];
+    _llmModelsFetched = false;
     llmModelComboboxClose();
 
     // Populate providers dropdown
@@ -32826,6 +32903,7 @@ async function onModelProviderChange() {
 
     // Clear existing suggestions
     _llmAllModels = [];
+    _llmModelsFetched = false;
     llmModelComboboxClose();
 
     if (!providerId) {
@@ -32844,7 +32922,8 @@ async function onModelProviderChange() {
  * Fetch available models for the model modal
  */
 async function fetchModelsForModelModal() {
-    const providerId = document.getElementById("llm-model-provider").value;
+    const providerSelect = document.getElementById("llm-model-provider");
+    const providerId = providerSelect.value;
     const statusEl = document.getElementById("llm-model-fetch-status");
 
     if (!providerId) {
@@ -32868,21 +32947,29 @@ async function fetchModelsForModelModal() {
 
         const result = await response.json();
 
+        // Guard against stale response if provider changed during fetch
+        if (providerSelect.value !== providerId) return;
+
         if (result.success && result.models && result.models.length > 0) {
             _llmAllModels = result.models;
+            _llmModelsFetched = true;
             _renderLLMModelDropdown(_llmAllModels);
 
             statusEl.textContent = `Found ${result.models.length} models. Type to filter or enter custom.`;
             statusEl.classList.remove("hidden");
         } else {
             _llmAllModels = [];
+            _llmModelsFetched = true;
             statusEl.textContent =
                 result.error || "No models found. Enter model ID manually.";
             statusEl.classList.remove("hidden");
         }
     } catch (error) {
         console.error("Error fetching models:", error);
+        // Guard against stale response if provider changed during fetch
+        if (providerSelect.value !== providerId) return;
         _llmAllModels = [];
+        _llmModelsFetched = true;
         statusEl.textContent =
             "Failed to fetch models. Enter model ID manually.";
         statusEl.classList.remove("hidden");
@@ -32897,6 +32984,7 @@ window.fetchModelsForModelModal = fetchModelsForModelModal;
  */
 async function editLLMModel(modelId) {
     _llmAllModels = [];
+    _llmModelsFetched = false;
     llmModelComboboxClose();
     try {
         const response = await fetch(
@@ -33294,6 +33382,7 @@ window.llmModelComboboxOpen = llmModelComboboxOpen;
 window.llmModelComboboxClose = llmModelComboboxClose;
 window.llmModelComboboxFilter = llmModelComboboxFilter;
 window.llmModelComboboxSelect = llmModelComboboxSelect;
+window.llmModelComboboxKeydown = llmModelComboboxKeydown;
 window.editLLMModel = editLLMModel;
 window.saveLLMModel = saveLLMModel;
 window.deleteLLMModel = deleteLLMModel;

--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -32700,6 +32700,64 @@ function refreshLLMProviders() {
     }
 }
 
+// Full model list for the model-id combobox (reset on each modal open)
+let _llmAllModels = [];
+
+function llmModelComboboxOpen() {
+    _renderLLMModelDropdown(_llmAllModels);
+    document.getElementById("llm-model-dropdown").classList.remove("hidden");
+}
+
+function llmModelComboboxClose() {
+    const ul = document.getElementById("llm-model-dropdown");
+    if (ul) {
+        ul.classList.add("hidden");
+    }
+}
+
+function llmModelComboboxFilter(text) {
+    const lower = text.toLowerCase();
+    const filtered = _llmAllModels.filter((m) =>
+        m.id.toLowerCase().includes(lower),
+    );
+    _renderLLMModelDropdown(filtered);
+    document.getElementById("llm-model-dropdown").classList.remove("hidden");
+}
+
+function llmModelComboboxSelect(value) {
+    document.getElementById("llm-model-model-id").value = value;
+    llmModelComboboxClose();
+}
+
+function _renderLLMModelDropdown(models) {
+    const ul = document.getElementById("llm-model-dropdown");
+    if (!ul) {
+        return;
+    }
+    if (!models.length) {
+        ul.innerHTML =
+            '<li class="px-3 py-2 text-xs text-gray-400 dark:text-gray-500">No models found. Enter ID manually.</li>';
+        return;
+    }
+    ul.innerHTML = models
+        .map(
+            (m) =>
+                `<li class="px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100" data-model-id="${m.id.replace(/"/g, "&quot;")}">${m.id}</li>`,
+        )
+        .join("");
+}
+
+// Wire up delegated events on the dropdown once at load time
+document.addEventListener("DOMContentLoaded", () => {
+    const ul = document.getElementById("llm-model-dropdown");
+    if (!ul) return;
+    ul.addEventListener("mousedown", (e) => e.preventDefault());
+    ul.addEventListener("click", (e) => {
+        const li = e.target.closest("li[data-model-id]");
+        if (li) llmModelComboboxSelect(li.dataset.modelId);
+    });
+});
+
 /**
  * Show Add Model Modal
  */
@@ -32708,6 +32766,8 @@ async function showAddModelModal() {
     document.getElementById("llm-model-form").reset();
     document.getElementById("llm-model-modal-title").textContent =
         "Add LLM Model";
+    _llmAllModels = [];
+    llmModelComboboxClose();
 
     // Populate providers dropdown
     await populateProviderDropdown();
@@ -32757,11 +32817,11 @@ function closeLLMModelModal() {
 async function onModelProviderChange() {
     const providerId = document.getElementById("llm-model-provider").value;
     const modelInput = document.getElementById("llm-model-model-id");
-    const datalist = document.getElementById("llm-model-suggestions");
     const statusEl = document.getElementById("llm-model-fetch-status");
 
     // Clear existing suggestions
-    datalist.innerHTML = "";
+    _llmAllModels = [];
+    llmModelComboboxClose();
 
     if (!providerId) {
         modelInput.placeholder = "Select provider first...";
@@ -32780,7 +32840,6 @@ async function onModelProviderChange() {
  */
 async function fetchModelsForModelModal() {
     const providerId = document.getElementById("llm-model-provider").value;
-    const datalist = document.getElementById("llm-model-suggestions");
     const statusEl = document.getElementById("llm-model-fetch-status");
 
     if (!providerId) {
@@ -32805,24 +32864,20 @@ async function fetchModelsForModelModal() {
         const result = await response.json();
 
         if (result.success && result.models && result.models.length > 0) {
-            // Populate datalist with model suggestions
-            datalist.innerHTML = "";
-            result.models.forEach((model) => {
-                const option = document.createElement("option");
-                option.value = model.id;
-                option.textContent = model.name || model.id;
-                datalist.appendChild(option);
-            });
+            _llmAllModels = result.models;
+            _renderLLMModelDropdown(_llmAllModels);
 
             statusEl.textContent = `Found ${result.models.length} models. Type to filter or enter custom.`;
             statusEl.classList.remove("hidden");
         } else {
+            _llmAllModels = [];
             statusEl.textContent =
                 result.error || "No models found. Enter model ID manually.";
             statusEl.classList.remove("hidden");
         }
     } catch (error) {
         console.error("Error fetching models:", error);
+        _llmAllModels = [];
         statusEl.textContent =
             "Failed to fetch models. Enter model ID manually.";
         statusEl.classList.remove("hidden");
@@ -33228,6 +33283,10 @@ window.fetchLLMProviderModels = fetchLLMProviderModels;
 window.syncLLMProviderModels = syncLLMProviderModels;
 window.showAddModelModal = showAddModelModal;
 window.closeLLMModelModal = closeLLMModelModal;
+window.llmModelComboboxOpen = llmModelComboboxOpen;
+window.llmModelComboboxClose = llmModelComboboxClose;
+window.llmModelComboboxFilter = llmModelComboboxFilter;
+window.llmModelComboboxSelect = llmModelComboboxSelect;
 window.editLLMModel = editLLMModel;
 window.saveLLMModel = saveLLMModel;
 window.deleteLLMModel = deleteLLMModel;

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2221,14 +2221,14 @@
                         <label for="llm-model-model-id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Model ID *</label>
                         <div class="relative" id="llm-model-combobox-container">
                           <div class="flex mt-1">
-                            <input type="text" id="llm-model-model-id" name="model_id" required autocomplete="off" class="px-3 py-2 block w-full rounded-l-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white sm:text-sm" placeholder="Select provider first..." oninput="llmModelComboboxFilter(this.value)" onfocus="llmModelComboboxOpen()" onclick="llmModelComboboxOpen()" onblur="setTimeout(llmModelComboboxClose, 150)">
+                            <input type="text" id="llm-model-model-id" name="model_id" required autocomplete="off" role="combobox" aria-expanded="false" aria-controls="llm-model-dropdown" aria-autocomplete="list" class="px-3 py-2 block w-full rounded-l-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white sm:text-sm" placeholder="Select provider first..." oninput="llmModelComboboxFilter(this.value)" onfocus="llmModelComboboxOpen()" onclick="llmModelComboboxOpen()" onblur="setTimeout(llmModelComboboxClose, 150)" onkeydown="llmModelComboboxKeydown(event)">
                             <button type="button" onclick="fetchModelsForModelModal()" class="inline-flex items-center px-3 py-2 border border-l-0 border-gray-300 rounded-r-md bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-600 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-500" title="Fetch available models">
                               <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                               </svg>
                             </button>
                           </div>
-                          <ul id="llm-model-dropdown" class="hidden absolute z-50 mt-1 w-full max-h-48 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg text-sm"></ul>
+                          <ul id="llm-model-dropdown" role="listbox" class="hidden absolute z-50 mt-1 w-full max-h-48 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg text-sm"></ul>
                         </div>
                         <p id="llm-model-fetch-status" class="mt-1 text-xs text-gray-400 hidden"></p>
                       </div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2202,7 +2202,7 @@
           <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="closeLLMModelModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-            <div class="relative z-20 inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+            <div class="relative z-20 inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-visible shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
               <form id="llm-model-form" onsubmit="saveLLMModel(event)">
                 <input type="hidden" id="llm-model-id" name="model_id" value="">
                 <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
@@ -2219,14 +2219,16 @@
                       </div>
                       <div>
                         <label for="llm-model-model-id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Model ID *</label>
-                        <div class="flex mt-1">
-                          <input type="text" id="llm-model-model-id" name="model_id" required list="llm-model-suggestions" class="px-3 py-2 block w-full rounded-l-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white sm:text-sm" placeholder="Select provider first...">
-                          <datalist id="llm-model-suggestions"></datalist>
-                          <button type="button" onclick="fetchModelsForModelModal()" class="inline-flex items-center px-3 py-2 border border-l-0 border-gray-300 rounded-r-md bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-600 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-500" title="Fetch available models">
-                            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
-                          </button>
+                        <div class="relative" id="llm-model-combobox-container">
+                          <div class="flex mt-1">
+                            <input type="text" id="llm-model-model-id" name="model_id" required autocomplete="off" class="px-3 py-2 block w-full rounded-l-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white sm:text-sm" placeholder="Select provider first..." oninput="llmModelComboboxFilter(this.value)" onfocus="llmModelComboboxOpen()" onclick="llmModelComboboxOpen()" onblur="setTimeout(llmModelComboboxClose, 150)">
+                            <button type="button" onclick="fetchModelsForModelModal()" class="inline-flex items-center px-3 py-2 border border-l-0 border-gray-300 rounded-r-md bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-600 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-500" title="Fetch available models">
+                              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                              </svg>
+                            </button>
+                          </div>
+                          <ul id="llm-model-dropdown" class="hidden absolute z-50 mt-1 w-full max-h-48 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg text-sm"></ul>
                         </div>
                         <p id="llm-model-fetch-status" class="mt-1 text-xs text-gray-400 hidden"></p>
                       </div>

--- a/tests/js/admin-llm-model-combobox.test.js
+++ b/tests/js/admin-llm-model-combobox.test.js
@@ -453,6 +453,50 @@ describe("fetchModelsForModelModal", () => {
         expect(items.length).toBe(1);
         expect(items[0].dataset.modelId).toBe("old");
     });
+
+    test("discards earlier response when same provider is fetched twice", async () => {
+        await populateModelsViaFetch([{ id: "initial" }]);
+        // Set up two pending fetches to the same provider
+        const resolvers = [];
+        win.fetch = vi.fn().mockImplementation(
+            () =>
+                new win.Promise((r) => {
+                    resolvers.push(r);
+                }),
+        );
+        // Fire first request (e.g., auto-fetch on provider change)
+        const fetch1 = win.fetchModelsForModelModal();
+        // Yield so the first fetch() call registers before we start the second
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        // Fire second request (e.g., user clicks refresh) before first resolves
+        const fetch2 = win.fetchModelsForModelModal();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(resolvers.length).toBe(2);
+        // Resolve the SECOND (newer) request first
+        resolvers[1]({
+            ok: true,
+            json: async () => ({
+                success: true,
+                models: [{ id: "newer" }],
+            }),
+        });
+        await fetch2;
+        // Now resolve the FIRST (older, stale) request
+        resolvers[0]({
+            ok: true,
+            json: async () => ({
+                success: true,
+                models: [{ id: "older-stale" }],
+            }),
+        });
+        await fetch1;
+        // Only the newer response should be applied
+        win.llmModelComboboxOpen();
+        const ul = doc.getElementById("llm-model-dropdown");
+        const items = ul.querySelectorAll("li[data-model-id]");
+        expect(items.length).toBe(1);
+        expect(items[0].dataset.modelId).toBe("newer");
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/js/admin-llm-model-combobox.test.js
+++ b/tests/js/admin-llm-model-combobox.test.js
@@ -1,0 +1,314 @@
+/**
+ * Unit tests for the LLM model-id combobox (PR #3806).
+ *
+ * Covers:
+ *   - llmModelComboboxOpen: renders models and shows dropdown
+ *   - llmModelComboboxClose: hides dropdown, null-safe
+ *   - llmModelComboboxFilter: type-ahead filtering
+ *   - llmModelComboboxSelect: sets input value and closes dropdown
+ *   - _renderLLMModelDropdown: DOM rendering, empty-state, XSS safety
+ *   - DOMContentLoaded delegation: mousedown preventDefault, click-to-select
+ *   - fetchModelsForModelModal: populates combobox from API response
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    vi,
+} from "vitest";
+import { loadAdminJs, cleanupAdminJs } from "./helpers/admin-env.js";
+
+let win;
+let doc;
+
+beforeAll(() => {
+    win = loadAdminJs({
+        beforeEval: (window) => {
+            window.getPaginationParams = function () {
+                return { page: 1, perPage: 10, includeInactive: null };
+            };
+            window.buildTableUrl = function (_tableName, baseUrl) {
+                return baseUrl;
+            };
+            window.safeReplaceState = function () {};
+        },
+    });
+    doc = win.document;
+});
+
+afterAll(() => {
+    cleanupAdminJs();
+});
+
+beforeEach(() => {
+    doc.body.textContent = "";
+    vi.restoreAllMocks();
+});
+
+/** Create the minimal DOM elements the combobox functions expect. */
+function setupComboboxDOM() {
+    const input = doc.createElement("input");
+    input.id = "llm-model-model-id";
+    input.type = "text";
+    doc.body.appendChild(input);
+
+    const ul = doc.createElement("ul");
+    ul.id = "llm-model-dropdown";
+    ul.classList.add("hidden");
+    doc.body.appendChild(ul);
+
+    return { input, ul };
+}
+
+/** Create the full modal DOM needed by fetchModelsForModelModal. */
+function setupFullModalDOM() {
+    const { input, ul } = setupComboboxDOM();
+
+    const provider = doc.createElement("select");
+    provider.id = "llm-model-provider";
+    const opt = doc.createElement("option");
+    opt.value = "prov-1";
+    opt.textContent = "Test Provider";
+    provider.appendChild(opt);
+    provider.value = "prov-1";
+    doc.body.appendChild(provider);
+
+    const status = doc.createElement("p");
+    status.id = "llm-model-fetch-status";
+    status.classList.add("hidden");
+    doc.body.appendChild(status);
+
+    return { input, ul, provider, status };
+}
+
+/**
+ * Populate the closure-scoped _llmAllModels via fetchModelsForModelModal.
+ * Returns the models that were loaded.
+ */
+async function populateModelsViaFetch(models) {
+    setupFullModalDOM();
+    win.ROOT_PATH = "";
+    win.getAuthToken = async () => "fake-token";
+    win.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, models }),
+    });
+    await win.fetchModelsForModelModal();
+    return models;
+}
+
+// ---------------------------------------------------------------------------
+// _renderLLMModelDropdown
+// ---------------------------------------------------------------------------
+
+describe("_renderLLMModelDropdown", () => {
+    test("renders empty-state message when models list is empty", () => {
+        const { ul } = setupComboboxDOM();
+        win._renderLLMModelDropdown([]);
+        expect(ul.children.length).toBe(1);
+        expect(ul.children[0].textContent).toContain("No models found");
+    });
+
+    test("renders one <li> per model with correct data-model-id", () => {
+        const { ul } = setupComboboxDOM();
+        const models = [{ id: "gpt-4o" }, { id: "claude-3" }];
+        win._renderLLMModelDropdown(models);
+        expect(ul.children.length).toBe(2);
+        expect(ul.children[0].dataset.modelId).toBe("gpt-4o");
+        expect(ul.children[0].textContent).toBe("gpt-4o");
+        expect(ul.children[1].dataset.modelId).toBe("claude-3");
+    });
+
+    test("escapes HTML-significant characters in model IDs (XSS safety)", () => {
+        const { ul } = setupComboboxDOM();
+        const malicious = "<img onerror=alert(1) src=x>";
+        win._renderLLMModelDropdown([{ id: malicious }]);
+        // textContent is used, so the string should appear literally, not as HTML
+        expect(ul.children[0].textContent).toBe(malicious);
+        // No <img> element should exist
+        expect(ul.querySelector("img")).toBeNull();
+    });
+
+    test("is a no-op when the dropdown element does not exist", () => {
+        // No DOM setup — should not throw
+        expect(() => win._renderLLMModelDropdown([{ id: "x" }])).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// llmModelComboboxOpen
+// ---------------------------------------------------------------------------
+
+describe("llmModelComboboxOpen", () => {
+    test("removes 'hidden' class from dropdown", () => {
+        setupComboboxDOM();
+        // Even with empty models, open should show the dropdown
+        win.llmModelComboboxOpen();
+        const ul = doc.getElementById("llm-model-dropdown");
+        expect(ul.classList.contains("hidden")).toBe(false);
+    });
+
+    test("renders fetched models into dropdown on open", async () => {
+        await populateModelsViaFetch([{ id: "a" }, { id: "b" }]);
+        const ul = doc.getElementById("llm-model-dropdown");
+        // fetchModelsForModelModal already renders, but open should re-render
+        win.llmModelComboboxOpen();
+        expect(ul.querySelectorAll("li[data-model-id]").length).toBe(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// llmModelComboboxClose
+// ---------------------------------------------------------------------------
+
+describe("llmModelComboboxClose", () => {
+    test("adds 'hidden' class to dropdown", () => {
+        const { ul } = setupComboboxDOM();
+        ul.classList.remove("hidden");
+        win.llmModelComboboxClose();
+        expect(ul.classList.contains("hidden")).toBe(true);
+    });
+
+    test("is a no-op when the dropdown element does not exist", () => {
+        // No DOM setup — should not throw
+        expect(() => win.llmModelComboboxClose()).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// llmModelComboboxFilter
+// ---------------------------------------------------------------------------
+
+describe("llmModelComboboxFilter", () => {
+    test("filters models by case-insensitive substring match", async () => {
+        await populateModelsViaFetch([
+            { id: "gpt-4o" },
+            { id: "gpt-3.5-turbo" },
+            { id: "claude-3-opus" },
+        ]);
+        const ul = doc.getElementById("llm-model-dropdown");
+        win.llmModelComboboxFilter("gpt");
+        const items = ul.querySelectorAll("li[data-model-id]");
+        expect(items.length).toBe(2);
+        expect(items[0].dataset.modelId).toBe("gpt-4o");
+        expect(items[1].dataset.modelId).toBe("gpt-3.5-turbo");
+    });
+
+    test("shows all models when filter text is empty", async () => {
+        await populateModelsViaFetch([{ id: "a" }, { id: "b" }]);
+        const ul = doc.getElementById("llm-model-dropdown");
+        win.llmModelComboboxFilter("");
+        expect(ul.querySelectorAll("li[data-model-id]").length).toBe(2);
+    });
+
+    test("shows empty-state when no models match", async () => {
+        await populateModelsViaFetch([{ id: "gpt-4o" }]);
+        const ul = doc.getElementById("llm-model-dropdown");
+        win.llmModelComboboxFilter("zzz-no-match");
+        expect(ul.querySelectorAll("li[data-model-id]").length).toBe(0);
+        expect(ul.textContent).toContain("No models found");
+    });
+
+    test("ensures dropdown is visible after filtering", async () => {
+        await populateModelsViaFetch([{ id: "m1" }]);
+        const ul = doc.getElementById("llm-model-dropdown");
+        ul.classList.add("hidden");
+        win.llmModelComboboxFilter("m1");
+        expect(ul.classList.contains("hidden")).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// llmModelComboboxSelect
+// ---------------------------------------------------------------------------
+
+describe("llmModelComboboxSelect", () => {
+    test("sets input value and closes dropdown", () => {
+        const { input, ul } = setupComboboxDOM();
+        ul.classList.remove("hidden");
+        win.llmModelComboboxSelect("gpt-4o-mini");
+        expect(input.value).toBe("gpt-4o-mini");
+        expect(ul.classList.contains("hidden")).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchModelsForModelModal — combobox integration
+// ---------------------------------------------------------------------------
+
+describe("fetchModelsForModelModal", () => {
+    test("populates dropdown with models from API response", async () => {
+        const models = [{ id: "gpt-4o" }, { id: "claude-3-opus" }];
+        await populateModelsViaFetch(models);
+        const ul = doc.getElementById("llm-model-dropdown");
+        expect(ul.querySelectorAll("li[data-model-id]").length).toBe(2);
+    });
+
+    test("clears models on empty API response", async () => {
+        // First populate
+        await populateModelsViaFetch([{ id: "m1" }]);
+        // Then fetch returns empty
+        win.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true, models: [] }),
+        });
+        await win.fetchModelsForModelModal();
+        // open should show empty state
+        win.llmModelComboboxOpen();
+        const ul = doc.getElementById("llm-model-dropdown");
+        expect(ul.querySelectorAll("li[data-model-id]").length).toBe(0);
+    });
+
+    test("clears models on fetch error", async () => {
+        await populateModelsViaFetch([{ id: "m1" }]);
+        win.fetch = vi.fn().mockRejectedValue(new win.Error("network error"));
+        await win.fetchModelsForModelModal();
+        win.llmModelComboboxOpen();
+        const ul = doc.getElementById("llm-model-dropdown");
+        expect(ul.querySelectorAll("li[data-model-id]").length).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// DOMContentLoaded delegation
+// ---------------------------------------------------------------------------
+
+describe("DOMContentLoaded dropdown delegation", () => {
+    test("mousedown on dropdown prevents default (keeps focus on input)", () => {
+        const { ul } = setupComboboxDOM();
+
+        // Fire the DOMContentLoaded handler so delegation is wired
+        const event = doc.createEvent("Event");
+        event.initEvent("DOMContentLoaded", true, true);
+        doc.dispatchEvent(event);
+
+        const mousedown = doc.createEvent("MouseEvent");
+        mousedown.initEvent("mousedown", true, true);
+        const spy = vi.spyOn(mousedown, "preventDefault");
+        ul.dispatchEvent(mousedown);
+        expect(spy).toHaveBeenCalled();
+    });
+
+    test("click on <li> with data-model-id selects the model", () => {
+        const { input, ul } = setupComboboxDOM();
+        win._renderLLMModelDropdown([{ id: "test-model" }]);
+
+        // Fire DOMContentLoaded to wire delegation
+        const domReady = doc.createEvent("Event");
+        domReady.initEvent("DOMContentLoaded", true, true);
+        doc.dispatchEvent(domReady);
+
+        // Click the first <li>
+        const li = ul.querySelector("li[data-model-id]");
+        const click = doc.createEvent("MouseEvent");
+        click.initEvent("click", true, true);
+        li.dispatchEvent(click);
+
+        expect(input.value).toBe("test-model");
+        expect(ul.classList.contains("hidden")).toBe(true);
+    });
+});

--- a/tests/js/admin-llm-model-combobox.test.js
+++ b/tests/js/admin-llm-model-combobox.test.js
@@ -3,12 +3,13 @@
  *
  * Covers:
  *   - llmModelComboboxOpen: renders models and shows dropdown
- *   - llmModelComboboxClose: hides dropdown, null-safe
+ *   - llmModelComboboxClose: hides dropdown, null-safe, ARIA expanded
  *   - llmModelComboboxFilter: type-ahead filtering
  *   - llmModelComboboxSelect: sets input value and closes dropdown
- *   - _renderLLMModelDropdown: DOM rendering, empty-state, XSS safety
+ *   - llmModelComboboxKeydown: ArrowDown/ArrowUp/Enter/Escape keyboard nav
+ *   - _renderLLMModelDropdown: DOM rendering, empty-state, XSS safety, ARIA roles
  *   - DOMContentLoaded delegation: mousedown preventDefault, click-to-select
- *   - fetchModelsForModelModal: populates combobox from API response
+ *   - fetchModelsForModelModal: populates combobox, stale-response guard
  */
 
 import {
@@ -87,10 +88,10 @@ function setupFullModalDOM() {
 
 /**
  * Populate the closure-scoped _llmAllModels via fetchModelsForModelModal.
- * Returns the models that were loaded.
+ * Returns the DOM elements for further assertions.
  */
 async function populateModelsViaFetch(models) {
-    setupFullModalDOM();
+    const dom = setupFullModalDOM();
     win.ROOT_PATH = "";
     win.getAuthToken = async () => "fake-token";
     win.fetch = vi.fn().mockResolvedValue({
@@ -98,7 +99,7 @@ async function populateModelsViaFetch(models) {
         json: async () => ({ success: true, models }),
     });
     await win.fetchModelsForModelModal();
-    return models;
+    return dom;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,18 +124,23 @@ describe("_renderLLMModelDropdown", () => {
         expect(ul.children[1].dataset.modelId).toBe("claude-3");
     });
 
+    test("sets role=option on each model <li>", () => {
+        const { ul } = setupComboboxDOM();
+        win._renderLLMModelDropdown([{ id: "m1" }, { id: "m2" }]);
+        ul.querySelectorAll("li[data-model-id]").forEach((li) => {
+            expect(li.getAttribute("role")).toBe("option");
+        });
+    });
+
     test("escapes HTML-significant characters in model IDs (XSS safety)", () => {
         const { ul } = setupComboboxDOM();
         const malicious = "<img onerror=alert(1) src=x>";
         win._renderLLMModelDropdown([{ id: malicious }]);
-        // textContent is used, so the string should appear literally, not as HTML
         expect(ul.children[0].textContent).toBe(malicious);
-        // No <img> element should exist
         expect(ul.querySelector("img")).toBeNull();
     });
 
     test("is a no-op when the dropdown element does not exist", () => {
-        // No DOM setup — should not throw
         expect(() => win._renderLLMModelDropdown([{ id: "x" }])).not.toThrow();
     });
 });
@@ -144,20 +150,26 @@ describe("_renderLLMModelDropdown", () => {
 // ---------------------------------------------------------------------------
 
 describe("llmModelComboboxOpen", () => {
-    test("removes 'hidden' class from dropdown", () => {
-        setupComboboxDOM();
-        // Even with empty models, open should show the dropdown
+    test("does not open dropdown before any fetch has occurred", () => {
+        const { ul } = setupComboboxDOM();
         win.llmModelComboboxOpen();
-        const ul = doc.getElementById("llm-model-dropdown");
-        expect(ul.classList.contains("hidden")).toBe(false);
+        expect(ul.classList.contains("hidden")).toBe(true);
     });
 
-    test("renders fetched models into dropdown on open", async () => {
+    test("opens dropdown after models have been fetched", async () => {
         await populateModelsViaFetch([{ id: "a" }, { id: "b" }]);
         const ul = doc.getElementById("llm-model-dropdown");
-        // fetchModelsForModelModal already renders, but open should re-render
+        ul.classList.add("hidden");
         win.llmModelComboboxOpen();
+        expect(ul.classList.contains("hidden")).toBe(false);
         expect(ul.querySelectorAll("li[data-model-id]").length).toBe(2);
+    });
+
+    test("sets aria-expanded=true on the input", async () => {
+        await populateModelsViaFetch([{ id: "m1" }]);
+        const input = doc.getElementById("llm-model-model-id");
+        win.llmModelComboboxOpen();
+        expect(input.getAttribute("aria-expanded")).toBe("true");
     });
 });
 
@@ -173,8 +185,14 @@ describe("llmModelComboboxClose", () => {
         expect(ul.classList.contains("hidden")).toBe(true);
     });
 
+    test("sets aria-expanded=false on the input", () => {
+        const { input } = setupComboboxDOM();
+        input.setAttribute("aria-expanded", "true");
+        win.llmModelComboboxClose();
+        expect(input.getAttribute("aria-expanded")).toBe("false");
+    });
+
     test("is a no-op when the dropdown element does not exist", () => {
-        // No DOM setup — should not throw
         expect(() => win.llmModelComboboxClose()).not.toThrow();
     });
 });
@@ -184,6 +202,15 @@ describe("llmModelComboboxClose", () => {
 // ---------------------------------------------------------------------------
 
 describe("llmModelComboboxFilter", () => {
+    test("does not open dropdown before any fetch has occurred", () => {
+        // Reset _llmModelsFetched via onModelProviderChange with empty provider
+        const dom = setupFullModalDOM();
+        dom.provider.value = "";
+        win.onModelProviderChange();
+        win.llmModelComboboxFilter("gpt");
+        expect(dom.ul.classList.contains("hidden")).toBe(true);
+    });
+
     test("filters models by case-insensitive substring match", async () => {
         await populateModelsViaFetch([
             { id: "gpt-4o" },
@@ -237,27 +264,149 @@ describe("llmModelComboboxSelect", () => {
 });
 
 // ---------------------------------------------------------------------------
+// llmModelComboboxKeydown — keyboard navigation
+// ---------------------------------------------------------------------------
+
+describe("llmModelComboboxKeydown", () => {
+    async function setupKeyboardTest() {
+        const dom = await populateModelsViaFetch([
+            { id: "alpha" },
+            { id: "bravo" },
+            { id: "charlie" },
+        ]);
+        win.llmModelComboboxOpen();
+        return dom;
+    }
+
+    function fireKey(key) {
+        const event = doc.createEvent("Event");
+        event.initEvent("keydown", true, true);
+        event.key = key;
+        event.preventDefault = vi.fn();
+        event.stopPropagation = vi.fn();
+        win.llmModelComboboxKeydown(event);
+        return event;
+    }
+
+    test("ArrowDown moves highlight to the first item", async () => {
+        await setupKeyboardTest();
+        fireKey("ArrowDown");
+        const ul = doc.getElementById("llm-model-dropdown");
+        const active = ul.querySelector("#llm-model-active-option");
+        expect(active).not.toBeNull();
+        expect(active.dataset.modelId).toBe("alpha");
+    });
+
+    test("ArrowDown then ArrowDown moves to second item", async () => {
+        await setupKeyboardTest();
+        fireKey("ArrowDown");
+        fireKey("ArrowDown");
+        const ul = doc.getElementById("llm-model-dropdown");
+        const active = ul.querySelector("#llm-model-active-option");
+        expect(active.dataset.modelId).toBe("bravo");
+    });
+
+    test("ArrowDown clamps at the last item", async () => {
+        await setupKeyboardTest();
+        fireKey("ArrowDown");
+        fireKey("ArrowDown");
+        fireKey("ArrowDown");
+        fireKey("ArrowDown"); // beyond last
+        const ul = doc.getElementById("llm-model-dropdown");
+        const active = ul.querySelector("#llm-model-active-option");
+        expect(active.dataset.modelId).toBe("charlie");
+    });
+
+    test("ArrowUp moves highlight upward", async () => {
+        await setupKeyboardTest();
+        fireKey("ArrowDown");
+        fireKey("ArrowDown");
+        fireKey("ArrowUp");
+        const ul = doc.getElementById("llm-model-dropdown");
+        const active = ul.querySelector("#llm-model-active-option");
+        expect(active.dataset.modelId).toBe("alpha");
+    });
+
+    test("ArrowUp clamps at the first item", async () => {
+        await setupKeyboardTest();
+        fireKey("ArrowDown");
+        fireKey("ArrowUp");
+        fireKey("ArrowUp"); // beyond first
+        const ul = doc.getElementById("llm-model-dropdown");
+        const active = ul.querySelector("#llm-model-active-option");
+        expect(active.dataset.modelId).toBe("alpha");
+    });
+
+    test("Enter selects the highlighted item", async () => {
+        const { input } = await setupKeyboardTest();
+        fireKey("ArrowDown");
+        fireKey("ArrowDown");
+        const event = fireKey("Enter");
+        expect(input.value).toBe("bravo");
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test("Enter does nothing with no highlight", async () => {
+        const { input } = await setupKeyboardTest();
+        input.value = "";
+        fireKey("Enter"); // no ArrowDown first
+        expect(input.value).toBe("");
+    });
+
+    test("Escape closes the dropdown and stops propagation", async () => {
+        await setupKeyboardTest();
+        const ul = doc.getElementById("llm-model-dropdown");
+        expect(ul.classList.contains("hidden")).toBe(false);
+        const event = fireKey("Escape");
+        expect(ul.classList.contains("hidden")).toBe(true);
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    test("sets aria-activedescendant on highlight", async () => {
+        await setupKeyboardTest();
+        const input = doc.getElementById("llm-model-model-id");
+        fireKey("ArrowDown");
+        expect(input.getAttribute("aria-activedescendant")).toBe(
+            "llm-model-active-option",
+        );
+    });
+
+    test("clears aria-activedescendant on close", async () => {
+        await setupKeyboardTest();
+        const input = doc.getElementById("llm-model-model-id");
+        fireKey("ArrowDown");
+        win.llmModelComboboxClose();
+        expect(input.hasAttribute("aria-activedescendant")).toBe(false);
+    });
+
+    test("is a no-op when dropdown is hidden", () => {
+        setupComboboxDOM();
+        // dropdown starts hidden — should not throw
+        expect(() => fireKey("ArrowDown")).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
 // fetchModelsForModelModal — combobox integration
 // ---------------------------------------------------------------------------
 
 describe("fetchModelsForModelModal", () => {
     test("populates dropdown with models from API response", async () => {
-        const models = [{ id: "gpt-4o" }, { id: "claude-3-opus" }];
-        await populateModelsViaFetch(models);
+        await populateModelsViaFetch([
+            { id: "gpt-4o" },
+            { id: "claude-3-opus" },
+        ]);
         const ul = doc.getElementById("llm-model-dropdown");
         expect(ul.querySelectorAll("li[data-model-id]").length).toBe(2);
     });
 
     test("clears models on empty API response", async () => {
-        // First populate
         await populateModelsViaFetch([{ id: "m1" }]);
-        // Then fetch returns empty
         win.fetch = vi.fn().mockResolvedValue({
             ok: true,
             json: async () => ({ success: true, models: [] }),
         });
         await win.fetchModelsForModelModal();
-        // open should show empty state
         win.llmModelComboboxOpen();
         const ul = doc.getElementById("llm-model-dropdown");
         expect(ul.querySelectorAll("li[data-model-id]").length).toBe(0);
@@ -271,6 +420,39 @@ describe("fetchModelsForModelModal", () => {
         const ul = doc.getElementById("llm-model-dropdown");
         expect(ul.querySelectorAll("li[data-model-id]").length).toBe(0);
     });
+
+    test("discards response if provider changed during fetch", async () => {
+        const { provider } = await populateModelsViaFetch([{ id: "old" }]);
+        // Set up a fetch that resolves, but we change the provider before it does
+        let resolveResponse;
+        win.fetch = vi.fn().mockReturnValue(
+            new win.Promise((resolve) => {
+                resolveResponse = resolve;
+            }),
+        );
+        const fetchPromise = win.fetchModelsForModelModal();
+        // Simulate user switching provider while fetch is in-flight
+        const opt2 = doc.createElement("option");
+        opt2.value = "prov-2";
+        provider.appendChild(opt2);
+        provider.value = "prov-2";
+        // Now resolve the original prov-1 response
+        resolveResponse({
+            ok: true,
+            json: async () => ({
+                success: true,
+                models: [{ id: "stale-model" }],
+            }),
+        });
+        await fetchPromise;
+        // The stale response should be discarded; old models should remain
+        win.llmModelComboboxOpen();
+        const ul = doc.getElementById("llm-model-dropdown");
+        const items = ul.querySelectorAll("li[data-model-id]");
+        // Should still show "old" from the first fetch, not "stale-model"
+        expect(items.length).toBe(1);
+        expect(items[0].dataset.modelId).toBe("old");
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -281,7 +463,6 @@ describe("DOMContentLoaded dropdown delegation", () => {
     test("mousedown on dropdown prevents default (keeps focus on input)", () => {
         const { ul } = setupComboboxDOM();
 
-        // Fire the DOMContentLoaded handler so delegation is wired
         const event = doc.createEvent("Event");
         event.initEvent("DOMContentLoaded", true, true);
         doc.dispatchEvent(event);
@@ -297,12 +478,10 @@ describe("DOMContentLoaded dropdown delegation", () => {
         const { input, ul } = setupComboboxDOM();
         win._renderLLMModelDropdown([{ id: "test-model" }]);
 
-        // Fire DOMContentLoaded to wire delegation
         const domReady = doc.createEvent("Event");
         domReady.initEvent("DOMContentLoaded", true, true);
         doc.dispatchEvent(domReady);
 
-        // Click the first <li>
         const li = ul.querySelector("li[data-model-id]");
         const click = doc.createEvent("MouseEvent");
         click.initEvent("click", true, true);


### PR DESCRIPTION
## 🔗 Related Issue
Closes #3800

---

## 📝 Summary
 Replaces the native HTML `datalist` on the Model ID field in the Add/Edit LLM Model modal with a custom styled combobox. The datalist had two problems: it rendered as a browser-native tooltip bubble inconsistent with the rest of the admin UI, and after selecting a model it filtered suggestions down to a single matching entry, preventing the user from switching to a different model without manually clearing the field. The replacement uses a Tailwind-styled `ul` dropdown with vanilla JS event delegation, matching the existing patterns in the admin panel. Selecting a model populates the input; clicking the field again reopens the full list. Free-text entry for unlisted model IDs is preserved. Also fixes `overflow-hidden` on the model modal card which was clipping the dropdown and making items unclickable.

---

## 🏷️ Type of Change
Bug fix

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |  ✅  |
| Unit tests                | `make test`     |  ✅  |
| Coverage ≥ 80%            | `make coverage` |  ✅   |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

https://github.com/user-attachments/assets/5a7595cf-bae2-459e-bf37-df87cdb1cb9f

---

🤖 AI assisted
🧑🏻‍💻 human reviewed / edited 

