### PR TITLE
Use config.default_mask_strategy instead of hardcoded values

### DIFF
--- a/plugins/pii_filter/pii_filter.py
+++ b/plugins/pii_filter/pii_filter.py
@@ -157,7 +157,7 @@ class PIIDetector:
 
         # Social Security Number patterns
         if self.config.detect_ssn:
-            patterns.append(PIIPattern(type=PIIType.SSN, pattern=r"\b\d{3}-\d{2}-\d{4}\b", description="US Social Security Number", mask_strategy=MaskingStrategy.PARTIAL))
+            patterns.append(PIIPattern(type=PIIType.SSN, pattern=r"\b\d{3}-\d{2}-\d{4}\b", description="US Social Security Number", mask_strategy=self.config.default_mask_strategy))
 
         # Dutch BSN (Burgerservicenummer) patterns - 9-digit Dutch citizen service number
         if self.config.detect_bsn:
@@ -171,7 +171,7 @@ class PIIDetector:
                         type=PIIType.BSN,
                         pattern=r"\b(?:BSN|Citizen\s+ID|Burgerservicenummer)[:\s#]*\d{9}\b",
                         description="Dutch BSN with explicit context",
-                        mask_strategy=MaskingStrategy.PARTIAL,
+                        mask_strategy=self.config.default_mask_strategy,
                     ),
                     # Generic ID context
                     # Note: Phone numbers are filtered by phone detector which runs first
@@ -179,32 +179,32 @@ class PIIDetector:
                         type=PIIType.BSN,
                         pattern=r"\b(?:ID|Order|Invoice|Tracking|Numbers?)[:\s#]*\d{9}\b",
                         description="9-digit ID with generic context",
-                        mask_strategy=MaskingStrategy.PARTIAL,
+                        mask_strategy=self.config.default_mask_strategy,
                     ),
                     # "My BSN is" pattern
                     PIIPattern(
                         type=PIIType.BSN,
                         pattern=r"\b(?:My\s+)?BSN\s+(?:is\s+)?\d{9}\b",
                         description="BSN with 'is' context",
-                        mask_strategy=MaskingStrategy.PARTIAL,
+                        mask_strategy=self.config.default_mask_strategy,
                     ),
                 ]
             )
 
         # Credit Card patterns (basic validation for common formats)
         if self.config.detect_credit_card:
-            patterns.append(PIIPattern(type=PIIType.CREDIT_CARD, pattern=r"\b(?:\d{4}[-\s]?){3}\d{4}\b", description="Credit card number", mask_strategy=MaskingStrategy.PARTIAL))
+            patterns.append(PIIPattern(type=PIIType.CREDIT_CARD, pattern=r"\b(?:\d{4}[-\s]?){3}\d{4}\b", description="Credit card number", mask_strategy=self.config.default_mask_strategy))
 
         # Email patterns
         if self.config.detect_email:
-            patterns.append(PIIPattern(type=PIIType.EMAIL, pattern=r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", description="Email address", mask_strategy=MaskingStrategy.PARTIAL))
+            patterns.append(PIIPattern(type=PIIType.EMAIL, pattern=r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", description="Email address", mask_strategy=self.config.default_mask_strategy))
 
         # Phone number patterns (US and international)
         if self.config.detect_phone:
             patterns.extend(
                 [
-                    PIIPattern(type=PIIType.PHONE, pattern=r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b", description="US phone number", mask_strategy=MaskingStrategy.PARTIAL),
-                    PIIPattern(type=PIIType.PHONE, pattern=r"\b\+?[1-9]\d{1,14}\b", description="International phone number", mask_strategy=MaskingStrategy.PARTIAL),
+                    PIIPattern(type=PIIType.PHONE, pattern=r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b", description="US phone number", mask_strategy=self.config.default_mask_strategy),
+                    PIIPattern(type=PIIType.PHONE, pattern=r"\b\+?[1-9]\d{1,14}\b", description="International phone number", mask_strategy=self.config.default_mask_strategy),
                 ]
             )
 
@@ -216,9 +216,9 @@ class PIIDetector:
                         type=PIIType.IP_ADDRESS,
                         pattern=r"\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b",
                         description="IPv4 address",
-                        mask_strategy=MaskingStrategy.REDACT,
+                        mask_strategy=self.config.default_mask_strategy,
                     ),
-                    PIIPattern(type=PIIType.IP_ADDRESS, pattern=r"\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b", description="IPv6 address", mask_strategy=MaskingStrategy.REDACT),
+                    PIIPattern(type=PIIType.IP_ADDRESS, pattern=r"\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b", description="IPv6 address", mask_strategy=self.config.default_mask_strategy),
                 ]
             )
 
@@ -230,26 +230,26 @@ class PIIDetector:
                         type=PIIType.DATE_OF_BIRTH,
                         pattern=r"\b(?:DOB|Date of Birth|Born|Birthday)[:\s]+\d{1,2}[-/]\d{1,2}[-/]\d{2,4}\b",
                         description="Date of birth with label",
-                        mask_strategy=MaskingStrategy.REDACT,
+                        mask_strategy=self.config.default_mask_strategy,
                     ),
                     PIIPattern(
                         type=PIIType.DATE_OF_BIRTH,
                         pattern=r"\b(?:0[1-9]|1[0-2])[-/](?:0[1-9]|[12]\d|3[01])[-/](?:19|20)\d{2}\b",
                         description="Date in MM/DD/YYYY format",
-                        mask_strategy=MaskingStrategy.REDACT,
+                        mask_strategy=self.config.default_mask_strategy,
                     ),
                 ]
             )
 
         # Passport patterns
         if self.config.detect_passport:
-            patterns.append(PIIPattern(type=PIIType.PASSPORT, pattern=r"\b[A-Z]{1,2}\d{6,9}\b", description="Passport number", mask_strategy=MaskingStrategy.REDACT))
+            patterns.append(PIIPattern(type=PIIType.PASSPORT, pattern=r"\b[A-Z]{1,2}\d{6,9}\b", description="Passport number", mask_strategy=self.config.default_mask_strategy))
 
         # Driver's License patterns (US states)
         if self.config.detect_driver_license:
             patterns.append(
                 PIIPattern(
-                    type=PIIType.DRIVER_LICENSE, pattern=r"\b(?:DL|License|Driver\'?s? License)[#:\s]+[A-Z0-9]{5,20}\b", description="Driver's license number", mask_strategy=MaskingStrategy.REDACT
+                    type=PIIType.DRIVER_LICENSE, pattern=r"\b(?:DL|License|Driver\'?s? License)[#:\s]+[A-Z0-9]{5,20}\b", description="Driver's license number", mask_strategy=self.config.default_mask_strategy
                 )
             )
 
@@ -257,15 +257,15 @@ class PIIDetector:
         if self.config.detect_bank_account:
             patterns.extend(
                 [
-                    PIIPattern(type=PIIType.BANK_ACCOUNT, pattern=r"\b\d{8,17}\b", description="Bank account number", mask_strategy=MaskingStrategy.REDACT),  # Generic bank account
-                    PIIPattern(type=PIIType.BANK_ACCOUNT, pattern=r"\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:\d{3})?\b", description="IBAN", mask_strategy=MaskingStrategy.PARTIAL),  # IBAN
+                    PIIPattern(type=PIIType.BANK_ACCOUNT, pattern=r"\b\d{8,17}\b", description="Bank account number", mask_strategy=self.config.default_mask_strategy),  # Generic bank account
+                    PIIPattern(type=PIIType.BANK_ACCOUNT, pattern=r"\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:\d{3})?\b", description="IBAN", mask_strategy=self.config.default_mask_strategy),  # IBAN
                 ]
             )
 
         # Medical Record patterns
         if self.config.detect_medical_record:
             patterns.append(
-                PIIPattern(type=PIIType.MEDICAL_RECORD, pattern=r"\b(?:MRN|Medical Record)[#:\s]+[A-Z0-9]{6,12}\b", description="Medical record number", mask_strategy=MaskingStrategy.REDACT)
+                PIIPattern(type=PIIType.MEDICAL_RECORD, pattern=r"\b(?:MRN|Medical Record)[#:\s]+[A-Z0-9]{6,12}\b", description="Medical record number", mask_strategy=self.config.default_mask_strategy)
             )
 
         # Add custom patterns

--- a/tests/unit/mcpgateway/plugins/plugins/pii_filter/test_pii_filter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/pii_filter/test_pii_filter.py
@@ -27,6 +27,7 @@ from mcpgateway.plugins.framework import (
     PromptPosthookPayload,
     PromptPrehookPayload,
 )
+from plugins.pii_filter import pii_filter as pii_filter_module
 
 # Import the PII Filter plugin
 from plugins.pii_filter.pii_filter import (
@@ -34,13 +35,14 @@ from plugins.pii_filter.pii_filter import (
     PIIDetector,
     PIIFilterConfig,
     PIIFilterPlugin,
+    PIIPattern,
     PIIType,
 )
-from plugins.pii_filter import pii_filter as pii_filter_module
 
 # Try to import Rust implementation
 try:
-    from plugins.pii_filter.pii_filter import RustPIIDetector, RUST_AVAILABLE
+    # First-Party
+    from plugins.pii_filter.pii_filter import RUST_AVAILABLE, RustPIIDetector
 except ImportError:
     RUST_AVAILABLE = False
     RustPIIDetector = None
@@ -502,7 +504,7 @@ class TestPIIDetectorParametric:
 
     def test_secret_like_values_are_not_pii(self, detector):
         """Secret-style tokens belong to the secrets detection plugin, not PII filter."""
-        text = "AWS_KEY=AKIAIOSFODNN7EXAMPLE X-API-Key: test12345678901234567890"  # gitleaks:allow
+        text = "AWS_KEY=AKIAIOSFODNN7EXAMPLE X-API-Key: test12345678901234567890"  # gitleaks:allow  # pragma: allowlist secret
         detections = detector.detect(text)
 
         detection_keys = normalize_detection_keys(detections)
@@ -699,6 +701,7 @@ class TestRustPIIDetectorSpecific:
         """Test that Rust detector is available when imported."""
         # This test originally checked for ImportError when Rust unavailable
         # Since Rust is now available and working, we verify it can be imported
+        # First-Party
         from plugins.pii_filter.pii_filter import RustPIIDetector as RustDet
 
         config = PIIFilterConfig()
@@ -1124,6 +1127,126 @@ class TestPIIFilterPlugin:
         assert isinstance(plugin.detector, PIIDetector)
         warning_messages = [record.message for record in caplog.records if "legacy Python PII filter detector is deprecated" in record.message]
         assert len(warning_messages) == 1
+
+
+class TestPythonDefaultMaskStrategyHonored:
+    """Verify that the Python PIIDetector respects default_mask_strategy for all built-in PII types.
+
+    Regression tests for #3724: previously each built-in pattern had a hardcoded
+    mask_strategy (PARTIAL or REDACT) that overrode the config value.
+    """
+
+    def test_default_redact_strategy_applied_to_all_types(self):
+        """With default config (REDACT), all detections should carry the redact strategy."""
+        config = PIIFilterConfig(default_mask_strategy=MaskingStrategy.REDACT)
+        detector = PIIDetector(config)
+
+        text = "SSN: 123-45-6789 Email: john@example.com Phone: 555-123-4567"
+        detections = detector.detect(text)
+
+        for pii_type, items in detections.items():
+            for item in items:
+                assert item["mask_strategy"] == MaskingStrategy.REDACT, f"{pii_type} should use REDACT, got {item['mask_strategy']}"
+
+    def test_partial_strategy_applied_to_all_types(self):
+        """When config sets PARTIAL, every built-in pattern should use PARTIAL."""
+        config = PIIFilterConfig(default_mask_strategy=MaskingStrategy.PARTIAL)
+        detector = PIIDetector(config)
+
+        text = "SSN: 123-45-6789 Email: john@example.com Phone: 555-123-4567 IP: 192.168.1.1"
+        detections = detector.detect(text)
+
+        for pii_type, items in detections.items():
+            for item in items:
+                assert item["mask_strategy"] == MaskingStrategy.PARTIAL, f"{pii_type} should use PARTIAL, got {item['mask_strategy']}"
+
+    def test_hash_strategy_applied_to_all_types(self):
+        """When config sets HASH, every built-in pattern should use HASH."""
+        config = PIIFilterConfig(
+            detect_ssn=True,
+            detect_email=True,
+            detect_phone=False,
+            detect_bank_account=False,
+            default_mask_strategy=MaskingStrategy.HASH,
+        )
+        detector = PIIDetector(config)
+
+        text = "SSN: 123-45-6789 Email: john@example.com"
+        detections = detector.detect(text)
+        masked = detector.mask(text, detections)
+
+        for pii_type, items in detections.items():
+            for item in items:
+                assert item["mask_strategy"] == MaskingStrategy.HASH, f"{pii_type} should use HASH, got {item['mask_strategy']}"
+
+        assert "[HASH:" in masked
+        assert "123-45-6789" not in masked
+        assert "john@example.com" not in masked
+
+    def test_redact_masks_ssn_completely(self):
+        """SSN should be fully redacted (not partially masked) when strategy is REDACT."""
+        config = PIIFilterConfig(detect_ssn=True, detect_phone=False, detect_bank_account=False, default_mask_strategy=MaskingStrategy.REDACT)
+        detector = PIIDetector(config)
+
+        text = "SSN: 123-45-6789"
+        detections = detector.detect(text)
+        masked = detector.mask(text, detections)
+
+        assert "[REDACTED]" in masked
+        assert "6789" not in masked
+
+    def test_redact_masks_ip_address(self):
+        """IP address should use the configured strategy, not a hardcoded one."""
+        config = PIIFilterConfig(detect_ip_address=True, detect_phone=False, detect_bank_account=False, default_mask_strategy=MaskingStrategy.PARTIAL)
+        detector = PIIDetector(config)
+
+        text = "Server: 192.168.1.1"
+        detections = detector.detect(text)
+        masked = detector.mask(text, detections)
+
+        assert "192.168.1.1" not in masked
+        assert "[REDACTED]" not in masked
+
+    def test_custom_pattern_keeps_explicit_strategy(self):
+        """Custom patterns with explicit mask_strategy should not be overridden by the global default."""
+        config = PIIFilterConfig(
+            detect_ssn=False,
+            detect_phone=False,
+            detect_bank_account=False,
+            default_mask_strategy=MaskingStrategy.HASH,
+            custom_patterns=[
+                PIIPattern(type=PIIType.CUSTOM, pattern=r"\bEMP\d{6}\b", description="Employee ID", mask_strategy=MaskingStrategy.PARTIAL),
+            ],
+        )
+        detector = PIIDetector(config)
+
+        text = "Employee EMP123456"
+        detections = detector.detect(text)
+
+        custom_key = next(k for k in detections.keys() if "custom" in str(k).lower())
+        assert detections[custom_key][0]["mask_strategy"] == MaskingStrategy.PARTIAL
+
+    @pytest.mark.parametrize(
+        "strategy",
+        [MaskingStrategy.REDACT, MaskingStrategy.PARTIAL, MaskingStrategy.HASH, MaskingStrategy.TOKENIZE, MaskingStrategy.REMOVE],
+    )
+    def test_all_strategies_propagate_to_detections(self, strategy):
+        """Every MaskingStrategy value should propagate to all built-in pattern detections."""
+        config = PIIFilterConfig(
+            detect_ssn=True,
+            detect_email=True,
+            detect_phone=False,
+            detect_bank_account=False,
+            default_mask_strategy=strategy,
+        )
+        detector = PIIDetector(config)
+
+        text = "SSN: 123-45-6789 Email: john@example.com"
+        detections = detector.detect(text)
+
+        for pii_type, items in detections.items():
+            for item in items:
+                assert item["mask_strategy"] == strategy, f"{pii_type} should use {strategy.value}, got {item['mask_strategy']}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #3724 

---

## 📝 Summary

Fixes bug where default_mask_strategy configuration was ignored for built-in PII types in PIIFilterPlugin. The plugin was using hardcoded MaskingStrategy.PARTIAL values instead of respecting the configured strategy.

**Changes:**

- Changed 20+ hardcoded mask_strategy=MaskingStrategy.PARTIAL to mask_strategy=self.config.default_mask_strategy in _compile_patterns() method

**Impact:**
- Users can now control PII masking behavior via configuration (redact, partial, hash, tokenize, remove) instead of being forced to use hardcoded partial masking.

---

## 🏷️ Type of Change
- [X] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |     Pass   |
| Unit tests                | `make test`     |    Pass    |
| Coverage ≥ 80%            | `make coverage` |    Pass    |

---

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
