### PR TITLE
feat(api): expand /health API to include database and Redis status

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-16T16:00:33Z",
+  "generated_at": "2026-04-16T17:23:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11112,7 +11112,7 @@ async def readiness_check(response: Response):
 
     This endpoint checks:
     - Database connectivity (via asyncio.to_thread to avoid blocking)
-    - Redis availability (if enabled)
+    - Cache availability (if enabled)
 
     Returns HTTP 200 when ready, HTTP 503 when not ready.
 
@@ -11142,7 +11142,7 @@ async def readiness_check(response: Response):
         try:
             # is_redis_available() checks if Redis is available and responding to ping.
             if await is_redis_available():
-                status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_200_OK, message="ready"))
+                status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_200_OK, message="Cache Connection Successful"))
             else:
                 status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
         except Exception as e:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11038,27 +11038,28 @@ async def reset_metrics(entity: Optional[str] = None, entity_id: Optional[int] =
 # Healthcheck      #
 ####################
 @app.get("/health")
-async def healthcheck(response: Response):
+def healthcheck(response: Response = None):
     """
     Perform a basic health check to verify database connectivity.
 
-    Async function so FastAPI runs it in a threadpool, avoiding event loop blocking.
+    Sync function so FastAPI runs it in a threadpool, avoiding event loop blocking.
     Uses a dedicated session to avoid cross-thread issues and double-commit
     from get_db dependency. All DB operations happen in the same thread.
 
     Args:
-        response: Response object used to attach runtime-mode headers.
+        response: Optional response object used to attach runtime-mode headers.
 
     Returns:
-        A HealthCheckResponse with the health status and optional error message.
+        A dictionary with the health status and optional error message.
     """
-    status_items = []
     db = SessionLocal()
     try:
         db.execute(text("SELECT 1"))
         # Explicitly commit to release PgBouncer backend connection in transaction mode.
         db.commit()
-        status_items.append(HealthStatusItem(name="Database", status_code=status.HTTP_200_OK, message="Database Connection Successful"))
+        if response is not None:
+            _apply_runtime_mode_headers(response)
+        return {"status": "healthy", "mcp_runtime": _mcp_runtime_status_payload()}
     except Exception as e:
         # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
         try:
@@ -11068,11 +11069,72 @@ async def healthcheck(response: Response):
                 db.invalidate()
             except Exception:
                 pass  # nosec B110 - Best effort cleanup on connection failure
-        error_message = f"Database health check failed: {str(e)}"
+        error_message = f"Database connection error: {str(e)}"
         logger.error(error_message)
-        status_items.append(HealthStatusItem(name="Database", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Database"))
+        if response is not None:
+            _apply_runtime_mode_headers(response)
+        return {"status": "unhealthy", "error": error_message, "mcp_runtime": _mcp_runtime_status_payload()}
     finally:
         db.close()
+
+
+def _check_db_ready() -> tuple[bool, str | None]:
+    """
+    Check database connectivity in a thread-safe manner.
+
+    Returns:
+        tuple: (success: bool, error_message: str | None)
+    """
+    db = SessionLocal()
+    try:
+        db.execute(text("SELECT 1"))
+        # Explicitly commit to release PgBouncer backend connection in transaction mode.
+        db.commit()
+        return (True, None)
+    except Exception as e:
+        # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
+        try:
+            db.rollback()
+        except Exception:
+            try:
+                db.invalidate()
+            except Exception:
+                pass  # nosec B110 - Best effort cleanup on connection failure
+        return (False, str(e))
+    finally:
+        db.close()
+
+
+@app.get("/ready", response_model=HealthCheckResponse)
+async def readiness_check(response: Response):
+    """
+    Perform a comprehensive readiness check to verify all dependencies.
+
+    This endpoint checks:
+    - Database connectivity (via asyncio.to_thread to avoid blocking)
+    - Redis availability (if enabled)
+
+    Returns HTTP 200 when ready, HTTP 503 when not ready.
+
+    Args:
+        response: Response object used to attach runtime-mode headers and status code.
+
+    Returns:
+        A HealthCheckResponse with detailed component health status.
+        HTTP 200 if all components are healthy (ready).
+        HTTP 503 if any component is unhealthy (not ready).
+    """
+    status_items = []
+
+    # Database health check (run in thread to avoid blocking event loop)
+    db_success, db_error = await asyncio.to_thread(_check_db_ready)
+
+    if db_success:
+        status_items.append(HealthStatusItem(name="Database", status_code=status.HTTP_200_OK, message="Database Connection Successful"))
+    else:
+        error_message = f"Database health check failed: {db_error}"
+        logger.error(error_message)
+        status_items.append(HealthStatusItem(name="Database", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Database"))
 
     # Check Redis health only if it's enabled (cache_type is redis and redis_url is configured)
     redis_enabled = settings.cache_type == "redis" and settings.redis_url
@@ -11088,17 +11150,22 @@ async def healthcheck(response: Response):
             status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
 
     # Determine overall status:
-    # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
-    # - "unhealthy" if Database is unhealthy (503) OR Redis is unhealthy when enabled
+    # - "ready" if Database is healthy (200) AND Redis is healthy when enabled
+    # - "unready" if Database is unhealthy (503) OR Redis is unhealthy when enabled
     database_status = next((item for item in status_items if item.name == "Database"), None)
     redis_status = next((item for item in status_items if item.name == "Cache"), None)
 
     # Check database health
     database_healthy = database_status and database_status.status_code == 200
 
+    # Redis is healthy if: not enabled OR (enabled AND status is 200)
     redis_healthy = not redis_enabled or (redis_status and redis_status.status_code == 200)
 
-    overall_status = "healthy" if database_healthy and redis_healthy else "unhealthy"
+    is_ready = database_healthy and redis_healthy
+    overall_status = "ready" if is_ready else "unready"
+
+    # Set HTTP status code: 200 for ready, 503 for unready
+    response.status_code = status.HTTP_200_OK if is_ready else status.HTTP_503_SERVICE_UNAVAILABLE
 
     _apply_runtime_mode_headers(response)
     return HealthCheckResponse(status=overall_status, status_items=status_items, mcp_runtime=_mcp_runtime_status_payload())

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -81,7 +81,10 @@ from mcpgateway.common.models import JSONRPCError as PydanticJSONRPCError
 from mcpgateway.common.models import ListResourceTemplatesResult, LogLevel, Root
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
-from mcpgateway.db import A2AAgent as DbA2AAgent, A2APushNotificationConfig, A2ATask as DbA2ATask, refresh_slugs_on_startup, SessionLocal
+from mcpgateway.db import A2AAgent as DbA2AAgent
+from mcpgateway.db import A2APushNotificationConfig
+from mcpgateway.db import A2ATask as DbA2ATask
+from mcpgateway.db import refresh_slugs_on_startup, SessionLocal
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.handlers.sampling import SamplingHandler
 from mcpgateway.middleware.compression import SSEAwareCompressMiddleware
@@ -111,8 +114,8 @@ from mcpgateway.routers.well_known import router as well_known_router
 from mcpgateway.schemas import (
     A2AAgentCreate,
     A2AAgentRead,
-    A2APushNotificationConfigCreate,
     A2AAgentUpdate,
+    A2APushNotificationConfigCreate,
     CursorPaginatedA2AAgentsResponse,
     CursorPaginatedGatewaysResponse,
     CursorPaginatedPromptsResponse,
@@ -145,8 +148,8 @@ from mcpgateway.schemas import (
     ToolRead,
     ToolUpdate,
 )
-from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
 from mcpgateway.services.a2a_server_service import A2AServerService
+from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
 from mcpgateway.services.cancellation_service import cancellation_service
 from mcpgateway.services.completion_service import CompletionService
 from mcpgateway.services.content_security import ContentSizeError, ContentTypeError
@@ -11169,57 +11172,6 @@ async def readiness_check(response: Response):
 
     _apply_runtime_mode_headers(response)
     return HealthCheckResponse(status=overall_status, status_items=status_items, mcp_runtime=_mcp_runtime_status_payload())
-
-@app.get("/ready")
-async def readiness_check():
-    """
-    Perform a readiness check to verify if the application is ready to receive traffic.
-
-    Creates and manages its own session inside the worker thread to ensure all DB
-    operations (create, execute, commit, rollback, close) happen in the same thread.
-    This avoids cross-thread session issues and double-commit from get_db.
-
-    Returns:
-        JSONResponse with status 200 if ready, 503 if not.
-    """
-
-    def _check_db() -> str | None:
-        """Check database connectivity by executing a simple query.
-
-        Returns:
-            None if successful, error message string if failed.
-        """
-        # Create session in this thread - all DB operations stay in the same thread.
-        db = SessionLocal()
-        try:
-            db.execute(text("SELECT 1"))
-            # Explicitly commit to release PgBouncer backend connection.
-            db.commit()
-            return None  # Success
-        except Exception as e:
-            # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
-            try:
-                db.rollback()
-            except Exception:
-                try:
-                    db.invalidate()
-                except Exception:
-                    pass  # nosec B110 - Best effort cleanup on connection failure
-            return str(e)
-        finally:
-            db.close()
-
-    # Run the blocking DB check in a thread to avoid blocking the event loop.
-    error = await asyncio.to_thread(_check_db)
-    if error:
-        error_message = f"Readiness check failed: {error}"
-        logger.error(error_message)
-        response = ORJSONResponse(content={"status": "not ready", "error": error_message, "mcp_runtime": _mcp_runtime_status_payload()}, status_code=503)
-        _apply_runtime_mode_headers(response)
-        return response
-    response = ORJSONResponse(content={"status": "ready", "mcp_runtime": _mcp_runtime_status_payload()}, status_code=200)
-    _apply_runtime_mode_headers(response)
-    return response
 
 
 @app.get("/health/security", tags=["health"])

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11058,7 +11058,7 @@ async def healthcheck(response: Response):
         db.execute(text("SELECT 1"))
         # Explicitly commit to release PgBouncer backend connection in transaction mode.
         db.commit()
-        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_200_OK, message="Database Connection Successful"))
+        status_items.append(HealthStatusItem(name="Database", status_code=status.HTTP_200_OK, message="Database Connection Successful"))
     except Exception as e:
         # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
         try:
@@ -11070,7 +11070,7 @@ async def healthcheck(response: Response):
                 pass  # nosec B110 - Best effort cleanup on connection failure
         error_message = f"Database health check failed: {str(e)}"
         logger.error(error_message)
-        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Database"))
+        status_items.append(HealthStatusItem(name="Database", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Database"))
     finally:
         db.close()
 
@@ -11080,28 +11080,28 @@ async def healthcheck(response: Response):
         try:
             # is_redis_available() checks if Redis is available and responding to ping.
             if await is_redis_available():
-                status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_200_OK, message="ready"))
+                status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_200_OK, message="ready"))
             else:
-                status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
+                status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
         except Exception as e:
             logger.error(f"Redis health check failed: {str(e)}")
-            status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
+            status_items.append(HealthStatusItem(name="Cache", status_code=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
 
     # Determine overall status:
     # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
     # - "unhealthy" if Database is unhealthy (503) OR Redis is unhealthy when enabled
     database_status = next((item for item in status_items if item.name == "Database"), None)
-    redis_status = next((item for item in status_items if item.name == "Redis"), None)
+    redis_status = next((item for item in status_items if item.name == "Cache"), None)
 
     # Check database health
-    database_healthy = database_status and database_status.statusCode == 200
+    database_healthy = database_status and database_status.status_code == 200
 
-    redis_healthy = not redis_enabled or (redis_status and redis_status.statusCode == 200)
+    redis_healthy = not redis_enabled or (redis_status and redis_status.status_code == 200)
 
     overall_status = "healthy" if database_healthy and redis_healthy else "unhealthy"
 
     _apply_runtime_mode_headers(response)
-    return HealthCheckResponse(status=overall_status, statusItems=status_items, mcp_runtime=_mcp_runtime_status_payload())
+    return HealthCheckResponse(status=overall_status, status_items=status_items, mcp_runtime=_mcp_runtime_status_payload())
 
 @app.get("/ready")
 async def readiness_check():

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -123,6 +123,8 @@ from mcpgateway.schemas import (
     GatewayRead,
     GatewayRefreshResponse,
     GatewayUpdate,
+    HealthCheckResponse,
+    HealthStatusItem,
     JsonPathModifier,
     MetricsResponse,
     PromptCreate,
@@ -178,7 +180,7 @@ from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import set_global_passthrough_headers
 from mcpgateway.utils.paths import resolve_root_path
-from mcpgateway.utils.redis_client import close_redis_client, get_redis_client
+from mcpgateway.utils.redis_client import close_redis_client, get_redis_client, is_redis_available
 from mcpgateway.utils.redis_isready import wait_for_redis_ready
 from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.token_scoping import validate_server_access
@@ -11036,7 +11038,7 @@ async def reset_metrics(entity: Optional[str] = None, entity_id: Optional[int] =
 # Healthcheck      #
 ####################
 @app.get("/health")
-def healthcheck(response: Response = None):
+async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_OK):
     """
     Perform a basic health check to verify database connectivity.
 
@@ -11050,14 +11052,22 @@ def healthcheck(response: Response = None):
     Returns:
         A dictionary with the health status and optional error message.
     """
+    status_items = []
     db = SessionLocal()
     try:
         db.execute(text("SELECT 1"))
         # Explicitly commit to release PgBouncer backend connection in transaction mode.
         db.commit()
-        if response is not None:
-            _apply_runtime_mode_headers(response)
-        return {"status": "healthy", "mcp_runtime": _mcp_runtime_status_payload()}
+        # if response is not None:
+        #     _apply_runtime_mode_headers(response)
+        # return {"status": "healthy", "mcp_runtime": _mcp_runtime_status_payload()}
+        status_items.append(
+            HealthStatusItem(
+                name="Database",
+                statusCode=status.HTTP_200_OK,
+                message="[POSTGRES]: Postgres Connection Successful"
+            )
+        )
     except Exception as e:
         # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
         try:
@@ -11067,13 +11077,76 @@ def healthcheck(response: Response = None):
                 db.invalidate()
             except Exception:
                 pass  # nosec B110 - Best effort cleanup on connection failure
-        error_message = f"Database connection error: {str(e)}"
+        error_message = f"Database health check failed: {str(e)}"
         logger.error(error_message)
-        if response is not None:
-            _apply_runtime_mode_headers(response)
-        return {"status": "unhealthy", "error": error_message, "mcp_runtime": _mcp_runtime_status_payload()}
+        # if response is not None:
+        #     _apply_runtime_mode_headers(response)
+        # return {"status": "unhealthy", "error": error_message, "mcp_runtime": _mcp_runtime_status_payload()}
+        status_items.append(
+            HealthStatusItem(
+                name="Database",
+                statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
+                message="Cannot connect to Postgres"
+            )
+        )
     finally:
         db.close()
+
+    # Check Redis
+    if settings.cache_type == "redis" and settings.redis_url:
+        try:
+            # is_redis_available() checks if Redis is available and responding to ping.
+            if await is_redis_available():
+                status_items.append(
+                    HealthStatusItem(
+                        name="Redis",
+                        statusCode=status.HTTP_200_OK,
+                        message="ready"
+                    )
+                )
+            else:
+                status_items.append(
+                    HealthStatusItem(
+                        name="Redis",
+                        statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        message="Cannot connect to Redis"
+                    )
+                )
+        except Exception as e:
+            logger.error(f"Redis health check failed: {str(e)}")
+            status_items.append(
+                HealthStatusItem(
+                    name="Redis",
+                    statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    message="Cannot connect to Redis"
+                )
+            )
+    else:
+        # Redis not configured
+        status_items.append(
+            HealthStatusItem(
+                name="Redis",
+                statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
+                message="Redis is not enabled"
+            )
+        )
+
+    # Determine overall status:
+    # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
+    # - "unhealthy" if Database is unhealthy (503) OR Redis is unhealthy when enabled
+    database_status = next((item for item in status_items if item.name == "Database"), None)
+    redis_status = next((item for item in status_items if item.name == "Redis"), None)
+
+    # Check database health
+    database_healthy = database_status and database_status.statusCode == 200
+
+    # Check Redis health only if it's enabled (cache_type is redis and redis_url is configured)
+    redis_enabled = settings.cache_type == "redis" and settings.redis_url
+    redis_healthy = not redis_enabled or (redis_status and redis_status.statusCode == 200)
+
+    overall_status = "healthy" if database_healthy and redis_healthy else "unhealthy"
+
+    return HealthCheckResponse(status=overall_status, statusItems=status_items)
 
 
 @app.get("/ready")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11038,7 +11038,7 @@ async def reset_metrics(entity: Optional[str] = None, entity_id: Optional[int] =
 # Healthcheck      #
 ####################
 @app.get("/health")
-async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_OK):
+async def healthcheck(response: Response):
     """
     Perform a basic health check to verify database connectivity.
 
@@ -11047,10 +11047,10 @@ async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_
     from get_db dependency. All DB operations happen in the same thread.
 
     Args:
-        response: Optional response object used to attach runtime-mode headers.
+        response: Response object used to attach runtime-mode headers.
 
     Returns:
-        A dictionary with the health status and optional error message.
+        A HealthCheckResponse with the health status and optional error message.
     """
     status_items = []
     db = SessionLocal()
@@ -11061,13 +11061,7 @@ async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_
         # if response is not None:
         #     _apply_runtime_mode_headers(response)
         # return {"status": "healthy", "mcp_runtime": _mcp_runtime_status_payload()}
-        status_items.append(
-            HealthStatusItem(
-                name="Database",
-                statusCode=status.HTTP_200_OK,
-                message="[POSTGRES]: Postgres Connection Successful"
-            )
-        )
+        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_200_OK, message="Databse Connection Successful"))
     except Exception as e:
         # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
         try:
@@ -11082,13 +11076,7 @@ async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_
         # if response is not None:
         #     _apply_runtime_mode_headers(response)
         # return {"status": "unhealthy", "error": error_message, "mcp_runtime": _mcp_runtime_status_payload()}
-        status_items.append(
-            HealthStatusItem(
-                name="Database",
-                statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
-                message="Cannot connect to Postgres"
-            )
-        )
+        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Databse"))
     finally:
         db.close()
 
@@ -11097,39 +11085,15 @@ async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_
         try:
             # is_redis_available() checks if Redis is available and responding to ping.
             if await is_redis_available():
-                status_items.append(
-                    HealthStatusItem(
-                        name="Redis",
-                        statusCode=status.HTTP_200_OK,
-                        message="ready"
-                    )
-                )
+                status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_200_OK, message="ready"))
             else:
-                status_items.append(
-                    HealthStatusItem(
-                        name="Redis",
-                        statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
-                        message="Cannot connect to Redis"
-                    )
-                )
+                status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Redis"))
         except Exception as e:
             logger.error(f"Redis health check failed: {str(e)}")
-            status_items.append(
-                HealthStatusItem(
-                    name="Redis",
-                    statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    message="Cannot connect to Redis"
-                )
-            )
+            status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Redis"))
     else:
         # Redis not configured
-        status_items.append(
-            HealthStatusItem(
-                name="Redis",
-                statusCode=status.HTTP_503_SERVICE_UNAVAILABLE,
-                message="Redis is not enabled"
-            )
-        )
+        status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Redis is not enabled"))
 
     # Determine overall status:
     # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
@@ -11146,8 +11110,8 @@ async def healthcheck(response=HealthCheckResponse, status_code=status.HTTP_200_
 
     overall_status = "healthy" if database_healthy and redis_healthy else "unhealthy"
 
-    return HealthCheckResponse(status=overall_status, statusItems=status_items)
-
+    _apply_runtime_mode_headers(response)
+    return HealthCheckResponse(status=overall_status, statusItems=status_items, mcp_runtime=_mcp_runtime_status_payload())
 
 @app.get("/ready")
 async def readiness_check():

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11085,7 +11085,7 @@ async def healthcheck(response: Response):
         except Exception as e:
             logger.error(f"Redis health check failed: {str(e)}")
             status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Redis"))
-    
+
     # Determine overall status:
     # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
     # - "unhealthy" if Database is unhealthy (503) OR Redis is unhealthy when enabled

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11042,7 +11042,7 @@ async def healthcheck(response: Response):
     """
     Perform a basic health check to verify database connectivity.
 
-    Sync function so FastAPI runs it in a threadpool, avoiding event loop blocking.
+    Async function so FastAPI runs it in a threadpool, avoiding event loop blocking.
     Uses a dedicated session to avoid cross-thread issues and double-commit
     from get_db dependency. All DB operations happen in the same thread.
 
@@ -11058,7 +11058,7 @@ async def healthcheck(response: Response):
         db.execute(text("SELECT 1"))
         # Explicitly commit to release PgBouncer backend connection in transaction mode.
         db.commit()
-        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_200_OK, message="Databse Connection Successful"))
+        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_200_OK, message="Database Connection Successful"))
     except Exception as e:
         # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
         try:
@@ -11070,21 +11070,22 @@ async def healthcheck(response: Response):
                 pass  # nosec B110 - Best effort cleanup on connection failure
         error_message = f"Database health check failed: {str(e)}"
         logger.error(error_message)
-        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Databse"))
+        status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Database"))
     finally:
         db.close()
 
-    # Check Redis
-    if settings.cache_type == "redis" and settings.redis_url:
+    # Check Redis health only if it's enabled (cache_type is redis and redis_url is configured)
+    redis_enabled = settings.cache_type == "redis" and settings.redis_url
+    if redis_enabled:
         try:
             # is_redis_available() checks if Redis is available and responding to ping.
             if await is_redis_available():
                 status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_200_OK, message="ready"))
             else:
-                status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Redis"))
+                status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
         except Exception as e:
             logger.error(f"Redis health check failed: {str(e)}")
-            status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Redis"))
+            status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Cache"))
 
     # Determine overall status:
     # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
@@ -11095,8 +11096,6 @@ async def healthcheck(response: Response):
     # Check database health
     database_healthy = database_status and database_status.statusCode == 200
 
-    # Check Redis health only if it's enabled (cache_type is redis and redis_url is configured)
-    redis_enabled = settings.cache_type == "redis" and settings.redis_url
     redis_healthy = not redis_enabled or (redis_status and redis_status.statusCode == 200)
 
     overall_status = "healthy" if database_healthy and redis_healthy else "unhealthy"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11058,9 +11058,6 @@ async def healthcheck(response: Response):
         db.execute(text("SELECT 1"))
         # Explicitly commit to release PgBouncer backend connection in transaction mode.
         db.commit()
-        # if response is not None:
-        #     _apply_runtime_mode_headers(response)
-        # return {"status": "healthy", "mcp_runtime": _mcp_runtime_status_payload()}
         status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_200_OK, message="Databse Connection Successful"))
     except Exception as e:
         # Rollback, then invalidate if rollback fails (mirrors get_db cleanup).
@@ -11073,9 +11070,6 @@ async def healthcheck(response: Response):
                 pass  # nosec B110 - Best effort cleanup on connection failure
         error_message = f"Database health check failed: {str(e)}"
         logger.error(error_message)
-        # if response is not None:
-        #     _apply_runtime_mode_headers(response)
-        # return {"status": "unhealthy", "error": error_message, "mcp_runtime": _mcp_runtime_status_payload()}
         status_items.append(HealthStatusItem(name="Database", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Databse"))
     finally:
         db.close()
@@ -11091,10 +11085,7 @@ async def healthcheck(response: Response):
         except Exception as e:
             logger.error(f"Redis health check failed: {str(e)}")
             status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Cannot connect to Redis"))
-    else:
-        # Redis not configured
-        status_items.append(HealthStatusItem(name="Redis", statusCode=status.HTTP_503_SERVICE_UNAVAILABLE, message="Redis is not enabled"))
-
+    
     # Determine overall status:
     # - "healthy" if Database is healthy (200) AND Redis is healthy when enabled
     # - "unhealthy" if Database is unhealthy (503) OR Redis is unhealthy when enabled

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8049,6 +8049,7 @@ class CacheMetricsSchema(BaseModel):
     keyspace_hits: int = Field(0, description="Successful key lookups")
     keyspace_misses: int = Field(0, description="Failed key lookups")
 
+
 class HealthStatusItem(BaseModel):
     """Individual health status item for a service component."""
 
@@ -8062,6 +8063,7 @@ class HealthCheckResponse(BaseModel):
 
     status: str = Field(..., description="Overall health status: 'healthy' if all components are healthy, 'unhealthy' otherwise")
     statusItems: List[HealthStatusItem] = Field(..., description="List of component health statuses")
+    mcp_runtime: Dict[str, Any] = Field(default_factory=dict, description="MCP runtime diagnostics and configuration")
 
 
 class GunicornMetricsSchema(BaseModel):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8049,6 +8049,20 @@ class CacheMetricsSchema(BaseModel):
     keyspace_hits: int = Field(0, description="Successful key lookups")
     keyspace_misses: int = Field(0, description="Failed key lookups")
 
+class HealthStatusItem(BaseModel):
+    """Individual health status item for a service component."""
+
+    name: str = Field(..., description="Component name (e.g., 'Database', 'Redis')")
+    statusCode: int = Field(..., description="HTTP status code (200 for healthy, 503 for unhealthy)")
+    message: str = Field(..., description="Status message describing the component state")
+
+
+class HealthCheckResponse(BaseModel):
+    """Health check response containing status of all monitored components."""
+
+    status: str = Field(..., description="Overall health status: 'healthy' if all components are healthy, 'unhealthy' otherwise")
+    statusItems: List[HealthStatusItem] = Field(..., description="List of component health statuses")
+
 
 class GunicornMetricsSchema(BaseModel):
     """Gunicorn server metrics."""

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8053,8 +8053,8 @@ class CacheMetricsSchema(BaseModel):
 class HealthStatusItem(BaseModel):
     """Individual health status item for a service component."""
 
-    name: str = Field(..., description="Component name (e.g., 'Database', 'Redis')")
-    statusCode: int = Field(..., description="HTTP status code (200 for healthy, 503 for unhealthy)")
+    name: str = Field(..., description="Component name (e.g., 'Database', 'Cache')")
+    status_code: int = Field(..., description="HTTP status code (200 for healthy, 503 for unhealthy)")
     message: str = Field(..., description="Status message describing the component state")
 
 
@@ -8062,7 +8062,7 @@ class HealthCheckResponse(BaseModel):
     """Health check response containing status of all monitored components."""
 
     status: str = Field(..., description="Overall health status: 'healthy' if all components are healthy, 'unhealthy' otherwise")
-    statusItems: List[HealthStatusItem] = Field(..., description="List of component health statuses")
+    status_Items: List[HealthStatusItem] = Field(..., description="List of component health statuses")
     mcp_runtime: Dict[str, Any] = Field(default_factory=dict, description="MCP runtime diagnostics and configuration")
 
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8062,7 +8062,7 @@ class HealthCheckResponse(BaseModel):
     """Health check response containing status of all monitored components."""
 
     status: str = Field(..., description="Overall health status: 'healthy' if all components are healthy, 'unhealthy' otherwise")
-    status_Items: List[HealthStatusItem] = Field(..., description="List of component health statuses")
+    status_items: List[HealthStatusItem] = Field(..., description="List of component health statuses")
     mcp_runtime: Dict[str, Any] = Field(default_factory=dict, description="MCP runtime diagnostics and configuration")
 
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -482,10 +482,12 @@ class TestHealthAndInfrastructure:
         assert response.status_code == 200
         assert response.json()["status"] == "ready"
 
-    def test_health_check_db_error(self):
+    @pytest.mark.asyncio
+    async def test_health_check_db_error(self):
         """Test health check error path with rollback failure."""
         # First-Party
         from mcpgateway import main as mcpgateway_main
+        from starlette.responses import Response as FastAPIResponse
 
         class DummySession:
             def __init__(self):
@@ -508,8 +510,9 @@ class TestHealthAndInfrastructure:
 
         session = DummySession()
         with patch("mcpgateway.main.SessionLocal", return_value=session):
-            response = mcpgateway_main.healthcheck()
-        assert response["status"] == "unhealthy"
+            response_obj = FastAPIResponse()
+            result = await mcpgateway_main.healthcheck(response_obj)
+        assert result.status == "unhealthy"
         assert session.invalidate_called is True
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -511,8 +511,9 @@ class TestHealthAndInfrastructure:
         session = DummySession()
         with patch("mcpgateway.main.SessionLocal", return_value=session):
             response_obj = FastAPIResponse()
-            result = await mcpgateway_main.healthcheck(response_obj)
-        assert result.status == "unhealthy"
+            result = mcpgateway_main.healthcheck(response_obj)
+        assert result["status"] == "unhealthy"
+        assert "error" in result
         assert session.invalidate_called is True
 
     @pytest.mark.asyncio
@@ -520,6 +521,7 @@ class TestHealthAndInfrastructure:
         """Test readiness check error path with rollback failure."""
         # First-Party
         from mcpgateway import main as mcpgateway_main
+        from starlette.responses import Response as FastAPIResponse
 
         class DummySession:
             def __init__(self):
@@ -541,12 +543,11 @@ class TestHealthAndInfrastructure:
                 pass
 
         session = DummySession()
-        with (
-            patch("mcpgateway.main.SessionLocal", return_value=session),
-            patch("mcpgateway.main.asyncio.to_thread", side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs)),
-        ):
-            response = await mcpgateway_main.readiness_check()
-        assert response.status_code == 503
+        with patch("mcpgateway.main.SessionLocal", return_value=session):
+            response_obj = FastAPIResponse()
+            result = await mcpgateway_main.readiness_check(response_obj)
+        assert result.status == "unready"
+        assert response_obj.status_code == 503
         assert session.invalidate_called is True
 
     def test_root_redirect(self, test_client):

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10054,7 +10054,6 @@ class TestRemainingCoverageGaps:
         assert result["mcp_runtime"]["resume_core_mode"] == "python"
         assert result["mcp_runtime"]["live_stream_core_mode"] == "python"
         assert result["mcp_runtime"]["session_auth_reuse_mode"] == "python"
-        
         # Check response headers
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "python-rust-built-disabled"
         assert response.headers["x-contextforge-mcp-transport-mounted"] == "python"
@@ -10308,33 +10307,26 @@ class TestRemainingCoverageGaps:
                 return None
 
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
-        
         # Mock Redis availability check to return True (healthy)
         async def mock_is_redis_available():
             return True
         monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
-        
         # Configure Redis to be enabled for this test
         monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
         monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
 
         response_obj = FastAPIResponse()
         result = await main_mod.readiness_check(response_obj)
-
         # Check overall status
         assert result.status == "ready"
         assert response_obj.status_code == 200
-        
         # Check status_items for Database and Redis
-        print("iiiitemmmms", result)
         assert len(result.status_items) == 2
-        
         # Check Database status
         db_status = next((item for item in result.status_items if item.name == "Database"), None)
         assert db_status is not None
         assert db_status.status_code == 200
         assert db_status.message == "Database Connection Successful"
-        
         # Check Redis status
         redis_status = next((item for item in result.status_items if item.name == "Cache"), None)
         assert redis_status is not None

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10060,7 +10060,7 @@ class TestRemainingCoverageGaps:
         db_status = next((item for item in result.statusItems if item.name == "Database"), None)
         assert db_status is not None
         assert db_status.statusCode == 200
-        assert db_status.message == "Databse Connection Successful"
+        assert db_status.message == "Database Connection Successful"
         
         # Check Redis status
         redis_status = next((item for item in result.statusItems if item.name == "Redis"), None)
@@ -10126,7 +10126,7 @@ class TestRemainingCoverageGaps:
         db_status = next((item for item in result.statusItems if item.name == "Database"), None)
         assert db_status is not None
         assert db_status.statusCode == 200
-        assert db_status.message == "Databse Connection Successful"
+        assert db_status.message == "Database Connection Successful"
         
         # Check Redis status - should be unhealthy due to exception
         redis_status = next((item for item in result.statusItems if item.name == "Redis"), None)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -9988,7 +9988,7 @@ class TestRemainingCoverageGaps:
         assert sess.invalidated is True
         assert sess.closed is True
 
-    def test_healthcheck_invalidate_failure_is_best_effort(self, monkeypatch):
+    async def test_healthcheck_invalidate_failure_is_best_effort(self, monkeypatch):
         # First-Party
         import mcpgateway.main as main_mod
 
@@ -10014,12 +10014,12 @@ class TestRemainingCoverageGaps:
         sess = FakeSession()
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: sess)
 
-        result = main_mod.healthcheck()
-        assert result["status"] == "unhealthy"
-        assert "db down" in result["error"]
+        response = FastAPIResponse()
+        result = await main_mod.healthcheck(response)
+        assert result.status == "unhealthy"
         assert sess.closed is True
 
-    def test_healthcheck_reports_runtime_mode_and_headers(self, monkeypatch):
+    async def test_healthcheck_reports_runtime_mode_and_headers(self, monkeypatch):
         # First-Party
         import mcpgateway.main as main_mod
 
@@ -10039,17 +10039,17 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_runtime_enabled", False)
 
         response = FastAPIResponse()
-        result = main_mod.healthcheck(response)
+        result = await main_mod.healthcheck(response)
 
-        assert result["status"] == "healthy"
-        assert result["mcp_runtime"]["mode"] == "python-rust-built-disabled"
-        assert result["mcp_runtime"]["mounted"] == "python"
-        assert result["mcp_runtime"]["rust_build_included"] is True
-        assert result["mcp_runtime"]["session_core_mode"] == "python"
-        assert result["mcp_runtime"]["event_store_mode"] == "python"
-        assert result["mcp_runtime"]["resume_core_mode"] == "python"
-        assert result["mcp_runtime"]["live_stream_core_mode"] == "python"
-        assert result["mcp_runtime"]["session_auth_reuse_mode"] == "python"
+        assert result.status == "healthy"
+        assert result.mcp_runtime["mode"] == "python-rust-built-disabled"
+        assert result.mcp_runtime["mounted"] == "python"
+        assert result.mcp_runtime["rust_build_included"] is True
+        assert result.mcp_runtime["session_core_mode"] == "python"
+        assert result.mcp_runtime["event_store_mode"] == "python"
+        assert result.mcp_runtime["resume_core_mode"] == "python"
+        assert result.mcp_runtime["live_stream_core_mode"] == "python"
+        assert result.mcp_runtime["session_auth_reuse_mode"] == "python"
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "python-rust-built-disabled"
         assert response.headers["x-contextforge-mcp-transport-mounted"] == "python"
         assert response.headers["x-contextforge-rust-build-included"] == "true"

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10053,19 +10053,19 @@ class TestRemainingCoverageGaps:
         # Check overall status
         assert result.status == "healthy"
         
-        # Check statusItems for Database and Redis
-        assert len(result.statusItems) == 2
+        # Check status_items for Database and Redis
+        assert len(result.status_items) == 2
         
         # Check Database status
-        db_status = next((item for item in result.statusItems if item.name == "Database"), None)
+        db_status = next((item for item in result.status_items if item.name == "Database"), None)
         assert db_status is not None
-        assert db_status.statusCode == 200
+        assert db_status.status_code == 200
         assert db_status.message == "Database Connection Successful"
         
         # Check Redis status
-        redis_status = next((item for item in result.statusItems if item.name == "Redis"), None)
+        redis_status = next((item for item in result.status_items if item.name == "Cache"), None)
         assert redis_status is not None
-        assert redis_status.statusCode == 200
+        assert redis_status.status_code == 200
         assert redis_status.message == "ready"
         
         # Check MCP runtime fields
@@ -10119,20 +10119,20 @@ class TestRemainingCoverageGaps:
         # Check overall status - should be unhealthy due to Redis failure
         assert result.status == "unhealthy"
         
-        # Check statusItems
-        assert len(result.statusItems) == 2
+        # Check status_items
+        assert len(result.status_items) == 2
         
         # Check Database status - should be healthy
-        db_status = next((item for item in result.statusItems if item.name == "Database"), None)
+        db_status = next((item for item in result.status_items if item.name == "Database"), None)
         assert db_status is not None
-        assert db_status.statusCode == 200
+        assert db_status.status_code == 200
         assert db_status.message == "Database Connection Successful"
         
-        # Check Redis status - should be unhealthy due to exception
-        redis_status = next((item for item in result.statusItems if item.name == "Redis"), None)
-        assert redis_status is not None
-        assert redis_status.statusCode == 503
-        assert redis_status.message == "Cannot connect to Redis"
+        # Check cache status - should be unhealthy due to exception
+        cache_status = next((item for item in result.status_items if item.name == "Cache"), None)
+        assert cache_status is not None
+        assert cache_status.status_code == 503
+        assert cache_status.message == "Cannot connect to Cache"
 
 
     async def test_readiness_check_invalidate_failure_is_best_effort(self, monkeypatch):

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10044,7 +10044,7 @@ class TestRemainingCoverageGaps:
 
         # Check overall status
         assert result["status"] == "healthy"
-        
+
         # Check MCP runtime fields
         assert result["mcp_runtime"]["mode"] == "python-rust-built-disabled"
         assert result["mcp_runtime"]["mounted"] == "python"
@@ -10080,7 +10080,7 @@ class TestRemainingCoverageGaps:
                 return None
 
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
-        
+
         # Configure Redis to be enabled - but /health should not check it
         monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
         monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
@@ -10090,7 +10090,7 @@ class TestRemainingCoverageGaps:
 
         # Check overall status - should be healthy (Redis not checked)
         assert result["status"] == "healthy"
-        
+
         # Verify no status_items in response (simple dict format)
         assert "status_items" not in result
         assert "mcp_runtime" in result
@@ -10260,12 +10260,12 @@ class TestRemainingCoverageGaps:
                 return None
 
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
-        
+
         # Mock Redis availability check to raise an exception
         async def mock_is_redis_available_exception():
             raise RuntimeError("Redis connection timeout")
         monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available_exception)
-        
+
         # Configure Redis to be enabled for this test
         monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
         monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
@@ -10276,16 +10276,16 @@ class TestRemainingCoverageGaps:
         # Check overall status - should be unready due to Redis failure
         assert result.status == "unready"
         assert response_obj.status_code == 503
-        
+
         # Check status_items
         assert len(result.status_items) == 2
-        
+
         # Check Database status - should be healthy
         db_status = next((item for item in result.status_items if item.name == "Database"), None)
         assert db_status is not None
         assert db_status.status_code == 200
         assert db_status.message == "Database Connection Successful"
-        
+
         # Check cache status - should be unhealthy due to exception
         cache_status = next((item for item in result.status_items if item.name == "Cache"), None)
         assert cache_status is not None
@@ -10315,7 +10315,7 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
         
         # Configure Redis to be enabled for this test
-        monkeypatch.setattr(main_mod.settings, "cache_type", "Cache Connection Successful")
+        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
         monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
 
         response_obj = FastAPIResponse()
@@ -10326,6 +10326,7 @@ class TestRemainingCoverageGaps:
         assert response_obj.status_code == 200
         
         # Check status_items for Database and Redis
+        print("iiiitemmmms", result)
         assert len(result.status_items) == 2
         
         # Check Database status
@@ -10338,7 +10339,7 @@ class TestRemainingCoverageGaps:
         redis_status = next((item for item in result.status_items if item.name == "Cache"), None)
         assert redis_status is not None
         assert redis_status.status_code == 200
-        assert redis_status.message == "ready"
+        assert redis_status.message == "Cache Connection Successful"
 
 
     async def test_sse_endpoint_cookie_auth_and_disconnect_cleanup(self, monkeypatch):

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10015,8 +10015,9 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: sess)
 
         response = FastAPIResponse()
-        result = await main_mod.healthcheck(response)
-        assert result.status == "unhealthy"
+        result = main_mod.healthcheck(response)
+        assert result["status"] == "unhealthy"
+        assert "error" in result
         assert sess.closed is True
 
     async def test_healthcheck_reports_runtime_mode_and_headers(self, monkeypatch):
@@ -10037,46 +10038,22 @@ class TestRemainingCoverageGaps:
         monkeypatch.setenv("CONTEXTFORGE_ENABLE_RUST_BUILD", "true")
         monkeypatch.setenv("EXPERIMENTAL_RUST_MCP_RUNTIME_MANAGED", "false")
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_runtime_enabled", False)
-        
-        # Mock Redis availability check to return True (healthy)
-        async def mock_is_redis_available():
-            return True
-        monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
-        
-        # Configure Redis to be enabled for this test
-        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
-        monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
 
         response = FastAPIResponse()
-        result = await main_mod.healthcheck(response)
+        result = main_mod.healthcheck(response)
 
         # Check overall status
-        assert result.status == "healthy"
-        
-        # Check status_items for Database and Redis
-        assert len(result.status_items) == 2
-        
-        # Check Database status
-        db_status = next((item for item in result.status_items if item.name == "Database"), None)
-        assert db_status is not None
-        assert db_status.status_code == 200
-        assert db_status.message == "Database Connection Successful"
-        
-        # Check Redis status
-        redis_status = next((item for item in result.status_items if item.name == "Cache"), None)
-        assert redis_status is not None
-        assert redis_status.status_code == 200
-        assert redis_status.message == "ready"
+        assert result["status"] == "healthy"
         
         # Check MCP runtime fields
-        assert result.mcp_runtime["mode"] == "python-rust-built-disabled"
-        assert result.mcp_runtime["mounted"] == "python"
-        assert result.mcp_runtime["rust_build_included"] is True
-        assert result.mcp_runtime["session_core_mode"] == "python"
-        assert result.mcp_runtime["event_store_mode"] == "python"
-        assert result.mcp_runtime["resume_core_mode"] == "python"
-        assert result.mcp_runtime["live_stream_core_mode"] == "python"
-        assert result.mcp_runtime["session_auth_reuse_mode"] == "python"
+        assert result["mcp_runtime"]["mode"] == "python-rust-built-disabled"
+        assert result["mcp_runtime"]["mounted"] == "python"
+        assert result["mcp_runtime"]["rust_build_included"] is True
+        assert result["mcp_runtime"]["session_core_mode"] == "python"
+        assert result["mcp_runtime"]["event_store_mode"] == "python"
+        assert result["mcp_runtime"]["resume_core_mode"] == "python"
+        assert result["mcp_runtime"]["live_stream_core_mode"] == "python"
+        assert result["mcp_runtime"]["session_auth_reuse_mode"] == "python"
         
         # Check response headers
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "python-rust-built-disabled"
@@ -10087,8 +10064,8 @@ class TestRemainingCoverageGaps:
         assert response.headers["x-contextforge-mcp-resume-core-mode"] == "python"
         assert response.headers["x-contextforge-mcp-live-stream-core-mode"] == "python"
         assert response.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "python"
-    async def test_healthcheck_redis_exception_handling(self, monkeypatch):
-        """Test that Redis health check exceptions are caught and logged."""
+    async def test_healthcheck_redis_removed(self, monkeypatch):
+        """Test that /health endpoint no longer checks Redis."""
         # First-Party
         import mcpgateway.main as main_mod
 
@@ -10104,35 +10081,19 @@ class TestRemainingCoverageGaps:
 
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
         
-        # Mock Redis availability check to raise an exception
-        async def mock_is_redis_available_exception():
-            raise RuntimeError("Redis connection timeout")
-        monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available_exception)
-        
-        # Configure Redis to be enabled for this test
+        # Configure Redis to be enabled - but /health should not check it
         monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
         monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
 
         response = FastAPIResponse()
-        result = await main_mod.healthcheck(response)
+        result = main_mod.healthcheck(response)
 
-        # Check overall status - should be unhealthy due to Redis failure
-        assert result.status == "unhealthy"
+        # Check overall status - should be healthy (Redis not checked)
+        assert result["status"] == "healthy"
         
-        # Check status_items
-        assert len(result.status_items) == 2
-        
-        # Check Database status - should be healthy
-        db_status = next((item for item in result.status_items if item.name == "Database"), None)
-        assert db_status is not None
-        assert db_status.status_code == 200
-        assert db_status.message == "Database Connection Successful"
-        
-        # Check cache status - should be unhealthy due to exception
-        cache_status = next((item for item in result.status_items if item.name == "Cache"), None)
-        assert cache_status is not None
-        assert cache_status.status_code == 503
-        assert cache_status.message == "Cannot connect to Cache"
+        # Verify no status_items in response (simple dict format)
+        assert "status_items" not in result
+        assert "mcp_runtime" in result
 
 
     async def test_readiness_check_invalidate_failure_is_best_effort(self, monkeypatch):
@@ -10157,15 +10118,10 @@ class TestRemainingCoverageGaps:
 
         monkeypatch.setattr(main_mod, "SessionLocal", FakeSession)
 
-        async def _to_thread(func, *args, **kwargs):  # noqa: ANN001
-            return func(*args, **kwargs)
-
-        monkeypatch.setattr(main_mod.asyncio, "to_thread", _to_thread)
-
-        response = await main_mod.readiness_check()
-        assert response.status_code == 503
-        payload = json.loads(response.body.decode())
-        assert payload["status"] == "not ready"
+        response_obj = FastAPIResponse()
+        result = await main_mod.readiness_check(response_obj)
+        assert result.status == "unready"
+        assert response_obj.status_code == 503
 
     async def test_readiness_check_reports_runtime_mode_headers(self, monkeypatch):
         # First-Party
@@ -10182,11 +10138,6 @@ class TestRemainingCoverageGaps:
                 return None
 
         monkeypatch.setattr(main_mod, "SessionLocal", FakeSession)
-
-        async def _to_thread(func, *args, **kwargs):  # noqa: ANN001
-            return func(*args, **kwargs)
-
-        monkeypatch.setattr(main_mod.asyncio, "to_thread", _to_thread)
         monkeypatch.setenv("CONTEXTFORGE_ENABLE_RUST_BUILD", "true")
         monkeypatch.setenv("EXPERIMENTAL_RUST_MCP_RUNTIME_MANAGED", "true")
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_runtime_enabled", True)
@@ -10197,27 +10148,27 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_live_stream_core_enabled", True)
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_session_auth_reuse_enabled", True)
 
-        response = await main_mod.readiness_check()
-        payload = json.loads(response.body.decode())
+        response_obj = FastAPIResponse()
+        result = await main_mod.readiness_check(response_obj)
 
-        assert response.status_code == 200
-        assert payload["status"] == "ready"
-        assert payload["mcp_runtime"]["mode"] == "rust-managed"
-        assert payload["mcp_runtime"]["mounted"] == "rust"
-        assert payload["mcp_runtime"]["sidecar_transport"] == "uds"
-        assert payload["mcp_runtime"]["session_core_mode"] == "rust"
-        assert payload["mcp_runtime"]["event_store_mode"] == "rust"
-        assert payload["mcp_runtime"]["resume_core_mode"] == "rust"
-        assert payload["mcp_runtime"]["live_stream_core_mode"] == "rust"
-        assert payload["mcp_runtime"]["session_auth_reuse_mode"] == "rust"
-        assert response.headers["x-contextforge-mcp-runtime-mode"] == "rust-managed"
-        assert response.headers["x-contextforge-mcp-transport-mounted"] == "rust"
-        assert response.headers["x-contextforge-rust-build-included"] == "true"
-        assert response.headers["x-contextforge-mcp-session-core-mode"] == "rust"
-        assert response.headers["x-contextforge-mcp-event-store-mode"] == "rust"
-        assert response.headers["x-contextforge-mcp-resume-core-mode"] == "rust"
-        assert response.headers["x-contextforge-mcp-live-stream-core-mode"] == "rust"
-        assert response.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "rust"
+        assert result.status == "ready"
+        assert response_obj.status_code == 200
+        assert result.mcp_runtime["mode"] == "rust-managed"
+        assert result.mcp_runtime["mounted"] == "rust"
+        assert result.mcp_runtime["sidecar_transport"] == "uds"
+        assert result.mcp_runtime["session_core_mode"] == "rust"
+        assert result.mcp_runtime["event_store_mode"] == "rust"
+        assert result.mcp_runtime["resume_core_mode"] == "rust"
+        assert result.mcp_runtime["live_stream_core_mode"] == "rust"
+        assert result.mcp_runtime["session_auth_reuse_mode"] == "rust"
+        assert response_obj.headers["x-contextforge-mcp-runtime-mode"] == "rust-managed"
+        assert response_obj.headers["x-contextforge-mcp-transport-mounted"] == "rust"
+        assert response_obj.headers["x-contextforge-rust-build-included"] == "true"
+        assert response_obj.headers["x-contextforge-mcp-session-core-mode"] == "rust"
+        assert response_obj.headers["x-contextforge-mcp-event-store-mode"] == "rust"
+        assert response_obj.headers["x-contextforge-mcp-resume-core-mode"] == "rust"
+        assert response_obj.headers["x-contextforge-mcp-live-stream-core-mode"] == "rust"
+        assert response_obj.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "rust"
 
     def test_runtime_status_payload_reports_http_transport_and_rust_affinity_core(self, monkeypatch):
         # First-Party
@@ -10288,10 +10239,107 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_runtime_enabled", True)
 
         response = FastAPIResponse()
-        result = await main_mod.healthcheck(response)
+        result = main_mod.healthcheck(response)
 
-        assert result.status == "unhealthy"
+        assert result["status"] == "unhealthy"
+        assert "error" in result
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "rust-managed"
+    async def test_readiness_check_redis_exception_handling(self, monkeypatch):
+        """Test that /ready endpoint checks Redis and handles exceptions."""
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        class FakeSession:  # noqa: D401 - test helper
+            def execute(self, _stmt):  # noqa: ANN001
+                return None
+
+            def commit(self):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
+        
+        # Mock Redis availability check to raise an exception
+        async def mock_is_redis_available_exception():
+            raise RuntimeError("Redis connection timeout")
+        monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available_exception)
+        
+        # Configure Redis to be enabled for this test
+        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
+        monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
+
+        response_obj = FastAPIResponse()
+        result = await main_mod.readiness_check(response_obj)
+
+        # Check overall status - should be unready due to Redis failure
+        assert result.status == "unready"
+        assert response_obj.status_code == 503
+        
+        # Check status_items
+        assert len(result.status_items) == 2
+        
+        # Check Database status - should be healthy
+        db_status = next((item for item in result.status_items if item.name == "Database"), None)
+        assert db_status is not None
+        assert db_status.status_code == 200
+        assert db_status.message == "Database Connection Successful"
+        
+        # Check cache status - should be unhealthy due to exception
+        cache_status = next((item for item in result.status_items if item.name == "Cache"), None)
+        assert cache_status is not None
+        assert cache_status.status_code == 503
+        assert cache_status.message == "Cannot connect to Cache"
+
+    async def test_readiness_check_redis_healthy(self, monkeypatch):
+        """Test that /ready endpoint reports healthy when Redis is available."""
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        class FakeSession:  # noqa: D401 - test helper
+            def execute(self, _stmt):  # noqa: ANN001
+                return None
+
+            def commit(self):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
+        
+        # Mock Redis availability check to return True (healthy)
+        async def mock_is_redis_available():
+            return True
+        monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
+        
+        # Configure Redis to be enabled for this test
+        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
+        monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
+
+        response_obj = FastAPIResponse()
+        result = await main_mod.readiness_check(response_obj)
+
+        # Check overall status
+        assert result.status == "ready"
+        assert response_obj.status_code == 200
+        
+        # Check status_items for Database and Redis
+        assert len(result.status_items) == 2
+        
+        # Check Database status
+        db_status = next((item for item in result.status_items if item.name == "Database"), None)
+        assert db_status is not None
+        assert db_status.status_code == 200
+        assert db_status.message == "Database Connection Successful"
+        
+        # Check Redis status
+        redis_status = next((item for item in result.status_items if item.name == "Cache"), None)
+        assert redis_status is not None
+        assert redis_status.status_code == 200
+        assert redis_status.message == "ready"
+
 
     async def test_sse_endpoint_cookie_auth_and_disconnect_cleanup(self, monkeypatch):
         # First-Party

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10194,7 +10194,7 @@ class TestRemainingCoverageGaps:
         assert payload["rust_affinity_core_enabled"] is False
         assert payload["session_auth_reuse_mode"] == "python"
 
-    def test_healthcheck_unhealthy_applies_runtime_headers(self, monkeypatch):
+    async def test_healthcheck_unhealthy_applies_runtime_headers(self, monkeypatch):
         # First-Party
         import mcpgateway.main as main_mod
 
@@ -10212,9 +10212,9 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_runtime_enabled", True)
 
         response = FastAPIResponse()
-        result = main_mod.healthcheck(response)
+        result = await main_mod.healthcheck(response)
 
-        assert result["status"] == "unhealthy"
+        assert result.status == "unhealthy"
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "rust-managed"
 
     async def test_sse_endpoint_cookie_auth_and_disconnect_cleanup(self, monkeypatch):

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10315,7 +10315,7 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
         
         # Configure Redis to be enabled for this test
-        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
+        monkeypatch.setattr(main_mod.settings, "cache_type", "Cache Connection Successful")
         monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
 
         response_obj = FastAPIResponse()

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -10037,11 +10037,38 @@ class TestRemainingCoverageGaps:
         monkeypatch.setenv("CONTEXTFORGE_ENABLE_RUST_BUILD", "true")
         monkeypatch.setenv("EXPERIMENTAL_RUST_MCP_RUNTIME_MANAGED", "false")
         monkeypatch.setattr(main_mod.settings, "experimental_rust_mcp_runtime_enabled", False)
+        
+        # Mock Redis availability check to return True (healthy)
+        async def mock_is_redis_available():
+            return True
+        monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
+        
+        # Configure Redis to be enabled for this test
+        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
+        monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
 
         response = FastAPIResponse()
         result = await main_mod.healthcheck(response)
 
+        # Check overall status
         assert result.status == "healthy"
+        
+        # Check statusItems for Database and Redis
+        assert len(result.statusItems) == 2
+        
+        # Check Database status
+        db_status = next((item for item in result.statusItems if item.name == "Database"), None)
+        assert db_status is not None
+        assert db_status.statusCode == 200
+        assert db_status.message == "Databse Connection Successful"
+        
+        # Check Redis status
+        redis_status = next((item for item in result.statusItems if item.name == "Redis"), None)
+        assert redis_status is not None
+        assert redis_status.statusCode == 200
+        assert redis_status.message == "ready"
+        
+        # Check MCP runtime fields
         assert result.mcp_runtime["mode"] == "python-rust-built-disabled"
         assert result.mcp_runtime["mounted"] == "python"
         assert result.mcp_runtime["rust_build_included"] is True
@@ -10050,6 +10077,8 @@ class TestRemainingCoverageGaps:
         assert result.mcp_runtime["resume_core_mode"] == "python"
         assert result.mcp_runtime["live_stream_core_mode"] == "python"
         assert result.mcp_runtime["session_auth_reuse_mode"] == "python"
+        
+        # Check response headers
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "python-rust-built-disabled"
         assert response.headers["x-contextforge-mcp-transport-mounted"] == "python"
         assert response.headers["x-contextforge-rust-build-included"] == "true"
@@ -10058,6 +10087,53 @@ class TestRemainingCoverageGaps:
         assert response.headers["x-contextforge-mcp-resume-core-mode"] == "python"
         assert response.headers["x-contextforge-mcp-live-stream-core-mode"] == "python"
         assert response.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "python"
+    async def test_healthcheck_redis_exception_handling(self, monkeypatch):
+        """Test that Redis health check exceptions are caught and logged."""
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        class FakeSession:  # noqa: D401 - test helper
+            def execute(self, _stmt):  # noqa: ANN001
+                return None
+
+            def commit(self):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
+        
+        # Mock Redis availability check to raise an exception
+        async def mock_is_redis_available_exception():
+            raise RuntimeError("Redis connection timeout")
+        monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available_exception)
+        
+        # Configure Redis to be enabled for this test
+        monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
+        monkeypatch.setattr(main_mod.settings, "redis_url", "redis://localhost:6379/0")
+
+        response = FastAPIResponse()
+        result = await main_mod.healthcheck(response)
+
+        # Check overall status - should be unhealthy due to Redis failure
+        assert result.status == "unhealthy"
+        
+        # Check statusItems
+        assert len(result.statusItems) == 2
+        
+        # Check Database status - should be healthy
+        db_status = next((item for item in result.statusItems if item.name == "Database"), None)
+        assert db_status is not None
+        assert db_status.statusCode == 200
+        assert db_status.message == "Databse Connection Successful"
+        
+        # Check Redis status - should be unhealthy due to exception
+        redis_status = next((item for item in result.statusItems if item.name == "Redis"), None)
+        assert redis_status is not None
+        assert redis_status.statusCode == 503
+        assert redis_status.message == "Cannot connect to Redis"
+
 
     async def test_readiness_check_invalidate_failure_is_best_effort(self, monkeypatch):
         # First-Party


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes # https://github.com/IBM/mcp-context-forge/issues/3817

---

## 📝 Summary

Goal: The /health API currently provides a basic health signal by validating Postgres connectivity and returning a generic healthy response. To improve observability and support more granular health monitoring, the endpoint should be expanded to include explicit status checks for additional infrastructure dependencies.
This change will enhance the /health response to report the health of both Postgres and Redis, while continuing to expose a clear overall service health indicator


### Service healthy
<img width="544" height="652" alt="Screenshot 2026-03-24 at 14 28 03" src="https://github.com/user-attachments/assets/c83c7e8c-1779-415b-acb8-527eeef28788" />

Response headers with _apply_runtime_mode_headers(response: Response) 


<img width="1270" height="956" alt="Screenshot 2026-03-24 at 14 39 39" src="https://github.com/user-attachments/assets/2e0c14e0-2320-498f-89ae-73f1a4ae9991" />



### Redis is not configured

<img width="640" height="951" alt="Screenshot 2026-03-24 at 14 50 15" src="https://github.com/user-attachments/assets/fe70beec-777c-4165-adee-8215dd7a17c0" />


### Redis configured but unhealthy
<img width="676" height="701" alt="Screenshot 2026-03-24 at 14 26 08" src="https://github.com/user-attachments/assets/7a8f1c7a-1c9d-4e80-be95-899bec0a7680" />


## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
