### PR TITLE
feat(discovery): add automatic tool discovery with hot/cold classification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2145,13 +2145,28 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # Maximum concurrent health checks per worker (default: 10)
 # MAX_CONCURRENT_HEALTH_CHECKS=10
 
-# Enable automatic tools/prompts/resources refresh from the mcp servers during health checks (default: false)
-# If the tools/prompts/resources in the mcp servers are not updated frequently, it is recommended to keep this disabled to reduce load on the servers
+# -----------------------------------------------------------------------------
+# Auto-Refresh / Polling  (requires health checks above)
+# -----------------------------------------------------------------------------
+# Automatically re-fetch tools, prompts, and resources from upstream MCP
+# servers during health-check cycles.  When disabled (default), tool lists
+# are only updated on manual refresh or gateway registration.
+#
 # AUTO_REFRESH_SERVERS=false
+# GATEWAY_AUTO_REFRESH_INTERVAL=300      # interval in seconds (minimum: 60)
 
-# Default refresh interval in seconds for gateway tools/resources/prompts sync
-# Minimum: 60 seconds
-# GATEWAY_AUTO_REFRESH_INTERVAL=300
+# -----------------------------------------------------------------------------
+# Hot/Cold Server Classification  (requires auto-refresh + Redis)
+# -----------------------------------------------------------------------------
+# Classifies upstream servers by MCP session pool usage:
+#   hot  (top 20% by recent usage) → polled at 1x GATEWAY_AUTO_REFRESH_INTERVAL
+#   cold (remaining 80%)           → polled at 3x GATEWAY_AUTO_REFRESH_INTERVAL
+#
+# Requires Redis for multi-worker leader election and state sharing.
+# Falls back to local-only (always-poll) in single-worker mode (make dev).
+# Poll intervals are auto-derived — no additional config needed.
+#
+# HOT_COLD_CLASSIFICATION_ENABLED=false
 
 # File lock name for gateway service leader election
 # Used to coordinate multiple gateway instances when running in cluster mode

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|Cargo.lock|^.secrets.baseline$|scripts/sign_image.sh|scripts/zap|sonar-project.properties|^/Users/brian/dev/github.ibm.com/contextforge-org/sps-pipeline-config/.secrets.baseline$|^./.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-02T17:00:21Z",
+  "generated_at": "2026-04-03T00:05:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1130,7 +1130,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 296,
+        "line_number": 306,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1138,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 302,
+        "line_number": 312,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1146,7 +1146,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 354,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1154,7 +1154,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 352,
+        "line_number": 362,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1162,7 +1162,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 868,
+        "line_number": 878,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1170,7 +1170,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 965,
+        "line_number": 975,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1178,7 +1178,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1026,
+        "line_number": 1036,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1186,7 +1186,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1061,
+        "line_number": 1071,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1194,7 +1194,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1600,
+        "line_number": 1610,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1202,7 +1202,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1687,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1210,7 +1210,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1989,
+        "line_number": 1999,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1218,7 +1218,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2445,
+        "line_number": 2455,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1226,7 +1226,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2445,
+        "line_number": 2455,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1234,7 +1234,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2458,
+        "line_number": 2468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1242,7 +1242,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2600,
+        "line_number": 2610,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1250,7 +1250,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2621,
+        "line_number": 2631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1258,7 +1258,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2629,
+        "line_number": 2639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1266,7 +1266,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2634,
+        "line_number": 2644,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5760,7 +5760,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2108,
+        "line_number": 2140,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9394,7 +9394,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4908,
+        "line_number": 5033,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9402,7 +9402,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4913,
+        "line_number": 5038,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9410,7 +9410,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6450,
+        "line_number": 6575,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9418,7 +9418,7 @@
         "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7047,
+        "line_number": 7172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9426,7 +9426,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7066,
+        "line_number": 7191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9434,7 +9434,7 @@
         "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7272,
+        "line_number": 7397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9442,7 +9442,7 @@
         "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7291,
+        "line_number": 7416,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -41,6 +41,7 @@ include .env.make
 include .env.example
 include .interrogaterc
 include .jshintrc
+include .npmrc
 include whitesource.config
 include .darglint
 include .dockerignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -283,6 +283,16 @@ services:
       - GATEWAY_VALIDATION_TIMEOUT=5
       # Max concurrent health checks per worker (default: 10)
       - MAX_CONCURRENT_HEALTH_CHECKS=10
+      # Auto-refresh tools/resources/prompts from MCP servers during health checks
+      # SSE gateways use polling only; StreamableHTTP gateways with session pooling
+      # also receive push notifications via notifications/tools/list_changed
+      - AUTO_REFRESH_SERVERS=true
+      - GATEWAY_AUTO_REFRESH_INTERVAL=300
+      # Hot/cold server classification - Stagger polling based on upstream MCP session usage
+      # Classifies servers into hot (top 20% by recent usage) and cold (remaining 80%)
+      # Hot servers polled at GATEWAY_AUTO_REFRESH_INTERVAL (1x), cold at 3x (auto-derived)
+      - HOT_COLD_CLASSIFICATION_ENABLED=true
+      # Poll intervals auto-derived: hot = 1x GATEWAY_AUTO_REFRESH_INTERVAL, cold = 3x
       # JWT Configuration - Choose ONE approach:
       # Option 1: HMAC (Default - Simple deployments)
       - JWT_ALGORITHM=HS256

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1700,6 +1700,12 @@ class Settings(BaseSettings):
     # Gateways can override this with their own refresh_interval_seconds
     gateway_auto_refresh_interval: int = Field(default=300, ge=60, description="Default refresh interval in seconds for gateway tools/resources/prompts sync (minimum 60 seconds)")
 
+    # Hot/Cold Server Classification
+    # Classify servers by usage (hot = active sessions, cold = inactive) for optimized polling
+    # Poll intervals auto-derived: hot = gateway_auto_refresh_interval (1x), cold = 3x
+    # Classification refresh uses gateway_auto_refresh_interval (no separate config needed)
+    hot_cold_classification_enabled: bool = Field(default=False, description="Enable hot/cold server classification for staggered polling (requires Redis for multi-worker)")
+
     # Validation Gateway URL
     gateway_validation_timeout: int = 5  # seconds
     gateway_max_redirects: int = 5
@@ -1932,6 +1938,32 @@ Disallow: /
         except orjson.JSONDecodeError:
             logger.error(f"Invalid JSON in WELL_KNOWN_CUSTOM_FILES: {self.well_known_custom_files}")
             return {}
+
+    @property
+    def hot_server_check_interval(self) -> float:
+        """Hot server polling interval (auto-derived from gateway_auto_refresh_interval).
+
+        Hot servers (top 20% by usage) are polled at the same rate as gateway tool refresh.
+
+        Returns:
+            float: Hot server check interval in seconds (equals gateway_auto_refresh_interval)
+        """
+        return float(self.gateway_auto_refresh_interval)
+
+    @property
+    def cold_server_check_interval(self) -> float:
+        """Cold server polling interval (auto-derived from gateway_auto_refresh_interval).
+
+        Cold servers (remaining 80%) are polled at 3x the gateway refresh rate to save resources.
+
+        Examples:
+            - gateway_auto_refresh_interval=300s → cold=900s (15 minutes)
+            - gateway_auto_refresh_interval=60s → cold=180s (3 minutes)
+
+        Returns:
+            float: Cold server check interval in seconds (3x gateway_auto_refresh_interval)
+        """
+        return float(self.gateway_auto_refresh_interval * 3)
 
     @field_validator("well_known_security_txt_enabled", mode="after")
     @classmethod

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -485,6 +485,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         self._active_gateways: Set[str] = set()  # Track active gateway URLs
         self._stream_response = None
         self._pending_responses = {}
+        # Hot/cold server classification service (initialized in initialize())
+        self._classification_service: Optional[Any] = None
         # Prefer using the globally-initialized singletons from the service modules
         # so events propagate via their initialized EventService/Redis clients.
         # Import lazily and fall back to creating local instances when the module-level
@@ -663,6 +665,15 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             # No Redis available - always create the health check task in filelock mode
             self._health_check_task = asyncio.create_task(self._run_health_checks(user_email))
 
+        # Initialize hot/cold classification service (if enabled)
+        if settings.hot_cold_classification_enabled:
+            # First-Party
+            from mcpgateway.services.server_classification_service import ServerClassificationService
+
+            self._classification_service = ServerClassificationService(redis_client=self._redis_client)
+            await self._classification_service.start()
+            logger.info("Hot/cold classification service initialized")
+
     async def shutdown(self) -> None:
         """Shutdown the service.
 
@@ -698,6 +709,12 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             except asyncio.CancelledError:
                 pass
 
+        # Stop classification service
+        if self._classification_service:
+            await self._classification_service.stop()
+            logger.info("Classification service stopped")
+
+        # Cancel leader heartbeat task if running
         if getattr(self, "_leader_heartbeat_task", None):
             self._leader_heartbeat_task.cancel()
             try:
@@ -1271,9 +1288,12 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 gateway_mode=gateway_mode,
             )
 
-            # Add to DB
+            # Add to DB and commit immediately so tools/resources/prompts are visible
+            # to other workers before the HTTP response reaches the client.
+            # Without this, clients issuing follow-up requests (e.g., manual refresh)
+            # can hit a different worker that hasn't seen the uncommitted data yet.
             db.add(db_gateway)
-            db.flush()  # Flush to get the ID without committing
+            db.commit()
             db.refresh(db_gateway)
 
             # Update tracking
@@ -1281,6 +1301,19 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
             # Notify subscribers
             await self._notify_gateway_added(db_gateway)
+
+            # Invalidate caches so other workers see the new gateway and its tools/resources/prompts
+            cache = _get_registry_cache()
+            await cache.invalidate_gateways()
+            await cache.invalidate_tools()
+            await cache.invalidate_resources()
+            await cache.invalidate_prompts()
+            tool_lookup_cache = _get_tool_lookup_cache()
+            await tool_lookup_cache.invalidate_gateway(str(db_gateway.id))
+            # First-Party
+            from mcpgateway.cache.admin_stats_cache import admin_stats_cache  # pylint: disable=import-outside-toplevel
+
+            await admin_stats_cache.invalidate_tags()
 
             # Invalidate loopback passthrough cache when a new gateway has passthrough headers (#3640)
             if gateway.passthrough_headers:
@@ -2245,6 +2278,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 tools_to_add = []
                 resources_to_add = []
                 prompts_to_add = []
+                reinit_succeeded = False
 
                 try:
                     ca_certificate = getattr(gateway, "ca_certificate", None)
@@ -2384,8 +2418,10 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     # Update tracking with new URL
                     self._active_gateways.discard(gateway.url)
                     self._active_gateways.add(gateway.url)
+                    reinit_succeeded = True
                 except Exception as e:
                     logger.warning(f"Failed to initialize updated gateway: {e}")
+                    reinit_succeeded = False
 
                 # Update tags if provided
                 if gateway_update.tags is not None:
@@ -2425,6 +2461,13 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 from mcpgateway.cache.admin_stats_cache import admin_stats_cache  # pylint: disable=import-outside-toplevel
 
                 await admin_stats_cache.invalidate_tags()
+
+                # Advance hot/cold poll schedule only after successful tool re-init
+                if reinit_succeeded and self._classification_service and gateway.url:
+                    try:
+                        await self._classification_service.mark_poll_completed(gateway.url, "tool_discovery", gateway_id=str(gateway.id))
+                    except Exception as poll_ts_err:
+                        logger.debug(f"Best-effort tool_discovery poll timestamp update failed: {poll_ts_err}")
 
                 # Invalidate loopback passthrough cache when gateway headers change (#3640)
                 if gateway_update.passthrough_headers is not None:
@@ -3405,6 +3448,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         # Handle query_param auth - decrypt and apply to URL for health check
         auth_query_params_decrypted: Optional[Dict[str, str]] = None
+        # Preserve the base URL (without auth query params) for classification lookups.
+        # Classification uses Gateway.url from the DB, so poll-state keys must match.
+        gateway_base_url = gateway_url
         if gateway_auth_type == "query_param" and gateway_auth_query_params:
             auth_query_params_decrypted = {}
             for param_key, encrypted_value in gateway_auth_query_params.items():
@@ -3419,6 +3465,10 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         # Sanitize URL for logging/telemetry (redacts sensitive query params)
         gateway_url_sanitized = sanitize_url_for_logging(gateway_url, auth_query_params_decrypted)
+
+        # NOTE: Health checks always run regardless of hot/cold classification.
+        # Classification only gates auto-refresh (tool discovery), not health monitoring.
+        # Skipping health checks would blind the gateway to outages on cold servers.
 
         # Create span for individual gateway health check
         with create_span(
@@ -3616,7 +3666,22 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         logger.warning(f"Failed to update last_seen for gateway {gateway_name}: {update_error}")
 
                     # Auto-refresh tools/resources/prompts if enabled
+                    should_auto_refresh = False
                     if settings.auto_refresh_servers:
+                        # Hot/cold classification: Check if this server should have tools refreshed now
+                        if self._classification_service:
+                            try:
+                                should_auto_refresh = await self._classification_service.should_poll_server(gateway_base_url, "tool_discovery", gateway_id=str(gateway_id))
+                                if not should_auto_refresh:
+                                    logger.debug(f"Skipping auto-refresh for {SecurityValidator.sanitize_log_message(gateway_name)}: " f"not yet due based on hot/cold classification")
+                            except Exception as e:
+                                # Fail open: proceed with auto-refresh if classification check fails
+                                logger.warning(f"Classification check failed for {SecurityValidator.sanitize_log_message(gateway_name)}, proceeding with auto-refresh (fail-open): {e}")
+                                should_auto_refresh = True
+                        else:
+                            should_auto_refresh = True
+
+                    if should_auto_refresh:
                         try:
                             # Throttling: Check if refresh is needed based on last_refresh_at
                             refresh_needed = True
@@ -3651,6 +3716,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                             pre_auth_headers=headers if headers else None,
                                             gateway=gateway,
                                         )
+                                        # mark_poll_completed is called inside _refresh_gateway_tools_resources_prompts
                                 else:
                                     logger.debug(f"Skipping auto-refresh for {gateway_name}: lock held (likely manual refresh in progress)")
                         except Exception as refresh_error:
@@ -4833,6 +4899,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 refresh_client_cert = getattr(gateway_obj, "client_cert", None)
                 refresh_client_key = getattr(gateway_obj, "client_key", None)
 
+        # Preserve base URL before auth mutation for classification poll-state keys
+        gateway_base_url = gateway_url
+
         # Handle query_param auth - decrypt and apply to URL for refresh
         auth_query_params_decrypted: Optional[Dict[str, str]] = None
         if gateway_auth_type == "query_param" and gateway_auth_query_params:
@@ -5029,6 +5098,15 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             else:
                 db.commit()
                 logger.debug(f"No changes detected during refresh of gateway {gateway_name}")
+
+        # Advance poll schedule so hot/cold classification tracks the actual last refresh
+        # regardless of whether the refresh was triggered by health check, manual API, or registration.
+        # Use gateway_base_url (pre-auth) to match classification keys.
+        if self._classification_service and gateway_base_url:
+            try:
+                await self._classification_service.mark_poll_completed(gateway_base_url, "tool_discovery", gateway_id=str(gateway_id))
+            except Exception as poll_ts_err:
+                logger.debug(f"Best-effort tool_discovery poll timestamp update failed: {poll_ts_err}")
 
         return result
 

--- a/mcpgateway/services/server_classification_service.py
+++ b/mcpgateway/services/server_classification_service.py
@@ -1,0 +1,578 @@
+# -*- coding: utf-8 -*-
+"""
+Server Classification Service.
+
+Manages hot/cold server classification based on MCP session pool usage patterns.
+Provides staggered polling to optimize resource allocation and reduce polling overhead.
+
+Classification is based ONLY on upstream MCP pooled session state (gateway -> MCP servers).
+
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# flake8: noqa: DAR101, DAR201, DAR401
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+from dataclasses import asdict, dataclass
+import hashlib
+import logging
+from math import floor
+import time
+from typing import Dict, List, Literal, Optional, TYPE_CHECKING
+
+# Third-Party
+import orjson
+
+# First-Party
+from mcpgateway.config import settings
+
+if TYPE_CHECKING:
+    # Third-Party
+    from redis.asyncio import Redis
+
+    # First-Party
+    from mcpgateway.services.mcp_session_pool import MCPSessionPool
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServerUsageMetrics:
+    """Aggregated usage metrics for a single server from pooled sessions."""
+
+    url: str
+    server_last_used: float = 0.0  # max(last_used) across all pooled sessions
+    active_session_count: int = 0  # Count from _active dict
+    total_use_count: int = 0  # Sum of use_count from all sessions
+    pooled_session_count: int = 0  # Total pooled sessions for this server
+
+
+@dataclass
+class ClassificationMetadata:
+    """Metadata about classification run."""
+
+    total_servers: int  # Total servers
+    hot_cap: int  # Maximum hot servers (20% of total_servers)
+    hot_actual: int  # Actual hot servers selected
+    eligible_count: int  # Servers with pooled sessions
+    timestamp: float  # Classification timestamp
+    underutilized_reason: Optional[str] = None  # Why hot < 20% (if applicable)
+
+
+@dataclass
+class ClassificationResult:
+    """Result of server classification."""
+
+    hot_servers: List[str]  # URLs of hot servers
+    cold_servers: List[str]  # URLs of cold servers
+    metadata: ClassificationMetadata
+
+
+class ServerClassificationService:
+    """
+    Manages hot/cold server classification based on MCP session pool state.
+
+    Classification Logic:
+        1. Scope: Uses only upstream MCP pooled session state
+        2. Hot cap: floor(20% * total_servers)
+        3. Eligibility: Server must have pooled session with valid last_used
+        4. Ranking: server_last_used descending (newest first)
+        5. Tie-breakers: active_count, use_count, URL (deterministic)
+        6. Hot selection: Top min(hot_cap, eligible_count)
+        7. Cold: All remaining servers
+        8. Guarantees: No overlap, full coverage, deterministic
+
+    Thread-safe for multi-worker deployments via Redis state management.
+    Falls back to local-only operation when Redis unavailable.
+    """
+
+    # Redis key templates
+    CLASSIFICATION_HOT_KEY = "mcpgateway:server_classification:hot"
+    CLASSIFICATION_COLD_KEY = "mcpgateway:server_classification:cold"
+    CLASSIFICATION_METADATA_KEY = "mcpgateway:server_classification:metadata"
+    CLASSIFICATION_TIMESTAMP_KEY = "mcpgateway:server_classification:timestamp"
+    POLL_STATE_KEY_TEMPLATE = "mcpgateway:server_poll_state:{scope_hash}:last_{poll_type}"
+    LEADER_KEY = "mcpgateway:server_classification:leader"
+
+    # Lua script for atomic leader lock acquire-or-renew.
+    # Executes as a single atomic operation in Redis, preventing the race where
+    # the key expires between a GET and EXPIRE in separate round-trips.
+    _LEADER_LOCK_SCRIPT = """
+    if redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]), 'NX') then
+        return 1
+    end
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+        redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+        return 1
+    end
+    return 0
+    """
+
+    def __init__(self, redis_client: Optional[Redis] = None):
+        """Initialize classification service.
+
+        Args:
+            redis_client: Redis client for state management (optional for single-worker)
+        """
+        self._redis = redis_client
+        self._classification_task: Optional[asyncio.Task] = None
+        self._instance_id = f"classifier_{id(self)}"
+        # TTL = 3x interval gives ample margin for classification + sleep.
+        # Classification is idempotent (deterministic algorithm), so even if the lock
+        # expires and a second worker classifies concurrently, the result is identical.
+        self._leader_ttl = int(settings.gateway_auto_refresh_interval * 3)
+        self._running = False
+        self._error_backoff_seconds: float = 30.0  # Back off duration on loop errors (override in tests)
+        self._leader_lock_sha: Optional[str] = None  # Cached SHA for leader lock Lua script
+
+    async def start(self) -> None:
+        """Start background classification loop (if enabled)."""
+        if not settings.hot_cold_classification_enabled:
+            logger.info("Hot/cold classification disabled")
+            return
+
+        if self._running:
+            logger.warning("Classification service already running")
+            return
+
+        self._running = True
+        self._classification_task = asyncio.create_task(self._run_classification_loop())
+        self._classification_task.add_done_callback(self._on_classification_task_done)
+        logger.info(f"Server classification service started " f"(instance={self._instance_id}, redis={'enabled' if self._redis else 'disabled'})")
+
+    def _on_classification_task_done(self, task: asyncio.Task) -> None:
+        """Callback when the classification background task exits unexpectedly."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            logger.error(f"Classification background task died: {exc}", exc_info=exc)
+        self._running = False
+
+    async def stop(self) -> None:
+        """Stop background classification."""
+        self._running = False
+        if self._classification_task:
+            self._classification_task.cancel()
+            try:
+                await self._classification_task
+            except asyncio.CancelledError:
+                logger.info("Classification task cancelled")
+            except Exception as e:
+                # Task already died with an error — don't let it crash shutdown
+                logger.warning(f"Classification task had failed: {e}")
+
+    async def _run_classification_loop(self) -> None:
+        """Background loop: classify servers periodically with leader election."""
+        while self._running:
+            try:
+                # Leader election (Redis-based for multi-worker, local-only otherwise)
+                is_leader = await self._try_acquire_leader_lock()
+
+                if is_leader:
+                    logger.debug(f"Classification leader acquired (instance={self._instance_id})")
+                    # Classification is idempotent (deterministic algorithm on shared pool state),
+                    # so concurrent execution by multiple workers produces identical results.
+                    # Leader election reduces redundant work; it is not a correctness requirement.
+                    # Timeout prevents unbounded runs from holding the loop.
+                    try:
+                        await asyncio.wait_for(self._perform_classification(), timeout=self._leader_ttl * 0.8)
+                    except asyncio.TimeoutError:
+                        logger.warning(f"Classification timed out after {self._leader_ttl * 0.8:.0f}s, skipping this cycle")
+                    # Renew lock after classification to keep it alive during sleep
+                    await self._try_acquire_leader_lock()
+                else:
+                    logger.debug(f"Not classification leader, skipping (instance={self._instance_id})")
+
+                await asyncio.sleep(settings.gateway_auto_refresh_interval)
+
+            except asyncio.CancelledError:
+                logger.info("Classification loop cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Classification loop error: {e}", exc_info=True)
+                await asyncio.sleep(self._error_backoff_seconds)  # Back off on error
+
+    async def _try_acquire_leader_lock(self) -> bool:
+        """Try to acquire or renew leader lock for classification.
+
+        Uses an atomic Lua script that either acquires a new lock (SET NX)
+        or renews the TTL if this instance already holds it. The script
+        runs as a single Redis transaction, preventing the race where the
+        key expires between a GET and EXPIRE in separate round-trips.
+
+        Returns:
+            True if this instance is leader, False otherwise
+        """
+        if not self._redis:
+            # Single-worker mode (no Redis), always leader
+            return True
+
+        try:
+            # Load Lua script on first call (cached by Redis server via SHA)
+            if self._leader_lock_sha is None:
+                self._leader_lock_sha = await self._redis.script_load(self._LEADER_LOCK_SCRIPT)
+
+            try:
+                result = await self._redis.evalsha(self._leader_lock_sha, 1, self.LEADER_KEY, self._instance_id, str(self._leader_ttl))
+            except Exception as evalsha_err:
+                # Handle NOSCRIPT (Redis restarted / SCRIPT FLUSH) by re-registering
+                if "NOSCRIPT" in str(evalsha_err):
+                    logger.debug("Lua script evicted, re-registering")
+                    self._leader_lock_sha = await self._redis.script_load(self._LEADER_LOCK_SCRIPT)
+                    result = await self._redis.evalsha(self._leader_lock_sha, 1, self.LEADER_KEY, self._instance_id, str(self._leader_ttl))
+                else:
+                    raise
+            return result == 1
+        except Exception as e:
+            logger.warning(f"Failed to acquire leader lock: {e}")
+            return False  # Fail safe: don't classify on error
+
+    async def _perform_classification(self) -> None:
+        """Perform classification and publish to Redis (if available)."""
+        try:
+            # Get MCP session pool
+            # First-Party
+            from mcpgateway.services.mcp_session_pool import get_mcp_session_pool
+
+            try:
+                pool = get_mcp_session_pool()
+            except RuntimeError:
+                logger.debug("MCP session pool not initialized, skipping classification")
+                return
+
+            # Get gateway_id → canonical URL mapping from database
+            gateway_url_map = await self._get_gateway_url_map()
+            if not gateway_url_map:
+                logger.debug("No gateways found, skipping classification")
+                return
+
+            # Deduplicate: multiple gateways may share the same upstream URL
+            # (different credentials/scopes). Classification operates on unique servers.
+            all_gateway_urls = list(dict.fromkeys(gateway_url_map.values()))
+
+            # Perform classification
+            result = self._classify_servers_from_pool(pool, all_gateway_urls, gateway_url_map)
+
+            # Publish to Redis (if available)
+            if self._redis:
+                await self._publish_classification_to_redis(result)
+
+            logger.info(
+                f"Classification completed: {len(result.hot_servers)} hot, " f"{len(result.cold_servers)} cold (N={result.metadata.total_servers}, " f"eligible={result.metadata.eligible_count})"
+            )
+
+            if result.metadata.underutilized_reason:
+                logger.debug(f"Underutilization: {result.metadata.underutilized_reason}")
+
+        except Exception as e:
+            logger.error(f"Classification failed: {e}", exc_info=True)
+
+    def _resolve_canonical_url(self, pool_key: tuple, gateway_url_map: Dict[str, str]) -> Optional[str]:
+        """Resolve the canonical gateway URL for a pool key.
+
+        Pool keys may contain auth-mutated URLs (e.g. with query-param secrets).
+        Use gateway_id from the pool key to look up the canonical Gateway.url,
+        preventing secret leakage into classification Redis sets.
+
+        Args:
+            pool_key: PoolKey tuple (user_identity, url, identity_hash, transport_type, gateway_id)
+            gateway_url_map: Mapping of gateway_id → canonical URL from database
+
+        Returns:
+            Canonical URL if gateway_id resolves, else None
+        """
+        gateway_id = pool_key[4] if len(pool_key) > 4 else ""
+        if gateway_id and gateway_id in gateway_url_map:
+            return gateway_url_map[gateway_id]
+        return None
+
+    def _classify_servers_from_pool(self, pool: MCPSessionPool, all_gateway_urls: List[str], gateway_url_map: Optional[Dict[str, str]] = None) -> ClassificationResult:
+        """Classify servers based on pooled session state.
+
+        Algorithm (deterministic):
+            1. Get total servers N
+            2. Calculate hot_cap = floor(0.20 * N)
+            3. Extract server metrics from pooled sessions (idle + active)
+            4. Filter eligible (has valid last_used or active sessions)
+            5. Sort by (server_last_used desc, active_count desc, use_count desc, url asc)
+            6. Select top min(hot_cap, eligible_count) as hot
+            7. Remaining servers are cold
+
+        Args:
+            pool: MCP session pool
+            all_gateway_urls: All registered gateway URLs
+            gateway_url_map: Optional mapping of gateway_id → canonical URL for URL normalization
+
+        Returns:
+            ClassificationResult with hot/cold servers and metadata
+        """
+        total_servers = len(all_gateway_urls)
+        hot_cap = floor(0.20 * total_servers)
+        canonical_url_set = set(all_gateway_urls)
+
+        # Step 3: Extract server usage from pooled sessions
+        server_metrics: Dict[str, ServerUsageMetrics] = {}
+
+        # Helper to accumulate metrics from a single PooledSession
+        def _accumulate_session(url: str, session: object) -> None:
+            if url not in server_metrics:
+                server_metrics[url] = ServerUsageMetrics(url=url)
+            if hasattr(session, "last_used") and session.last_used > 0:
+                server_metrics[url].server_last_used = max(server_metrics[url].server_last_used, session.last_used)
+                server_metrics[url].total_use_count += getattr(session, "use_count", 0)
+                server_metrics[url].pooled_session_count += 1
+
+        # Iterate over pool._pools (Dict[PoolKey, Queue[PooledSession]])
+        # PoolKey = (user_identity, url, identity_hash, transport_type, gateway_id)
+        for pool_key, session_queue in pool._pools.items():  # pylint: disable=protected-access
+            # Resolve canonical URL: prefer gateway_id lookup, fall back to raw pool URL
+            url = (self._resolve_canonical_url(pool_key, gateway_url_map) if gateway_url_map else None) or pool_key[1]
+
+            # Only track URLs that correspond to known gateways
+            if url not in canonical_url_set:
+                continue
+
+            if url not in server_metrics:
+                server_metrics[url] = ServerUsageMetrics(url=url)
+
+            # Process each idle session in the queue
+            try:
+                if hasattr(session_queue, "_queue"):
+                    sessions_list = list(session_queue._queue)  # pylint: disable=protected-access
+                else:
+                    sessions_list = []
+
+                for session in sessions_list:
+                    _accumulate_session(url, session)
+            except Exception as e:
+                logger.warning(f"Error extracting idle metrics for {url}: {e}")
+                continue
+
+        # Process active sessions (checked-out from the pool)
+        # This ensures busy servers with all sessions in use are still eligible.
+        for pool_key, active_set in pool._active.items():  # pylint: disable=protected-access
+            url = (self._resolve_canonical_url(pool_key, gateway_url_map) if gateway_url_map else None) or pool_key[1]
+
+            if url not in canonical_url_set:
+                continue
+
+            if url not in server_metrics:
+                server_metrics[url] = ServerUsageMetrics(url=url)
+
+            server_metrics[url].active_session_count += len(active_set)
+
+            # Extract last_used / use_count from active sessions too
+            for session in active_set:
+                try:
+                    _accumulate_session(url, session)
+                except Exception as active_err:
+                    logger.debug(f"Skipping active session metric for {url}: {active_err}")
+                    continue
+
+        # Step 4: Filter eligible servers (has valid last_used)
+        eligible_servers = [metrics for metrics in server_metrics.values() if metrics.server_last_used > 0.0]
+        eligible_count = len(eligible_servers)
+
+        # Step 5: Sort by recency (newer first), then tie-breakers
+        eligible_servers.sort(
+            key=lambda m: (
+                -m.server_last_used,  # Primary: most recent first (descending)
+                -m.active_session_count,  # Tie-breaker 1: more active sessions
+                -m.total_use_count,  # Tie-breaker 2: higher use count
+                m.url,  # Tie-breaker 3: deterministic (ascending)
+            )
+        )
+
+        # Step 6: Select hot servers (up to hot_cap, no backfill)
+        hot_actual = min(hot_cap, eligible_count)
+        hot_servers = [m.url for m in eligible_servers[:hot_actual]]
+
+        # Step 7: Cold servers = all remaining
+        hot_set = set(hot_servers)
+        cold_servers = [url for url in all_gateway_urls if url not in hot_set]
+
+        # Step 8: Build metadata
+        underutilized_reason = None
+        if eligible_count < hot_cap:
+            underutilized_reason = f"Only {eligible_count} servers have pooled sessions, " f"below hot_cap={hot_cap}"
+
+        return ClassificationResult(
+            hot_servers=hot_servers,
+            cold_servers=cold_servers,
+            metadata=ClassificationMetadata(
+                total_servers=total_servers, hot_cap=hot_cap, hot_actual=hot_actual, eligible_count=eligible_count, timestamp=time.time(), underutilized_reason=underutilized_reason
+            ),
+        )
+
+    async def _get_gateway_url_map(self) -> Dict[str, str]:
+        """Get mapping of gateway_id → canonical URL for all enabled gateways.
+
+        Returns:
+            Dict mapping gateway ID to its canonical URL
+        """
+        # Third-Party
+        from sqlalchemy import select
+
+        # First-Party
+        from mcpgateway.db import Gateway, SessionLocal
+
+        try:
+            with SessionLocal() as db:
+                result = db.execute(select(Gateway.id, Gateway.url).where(Gateway.enabled.is_(True)))
+                return {str(row[0]): row[1] for row in result}
+        except Exception as e:
+            logger.error(f"Failed to get gateway URL map: {e}")
+            return {}
+
+    async def _publish_classification_to_redis(self, result: ClassificationResult) -> None:
+        """Publish classification result to Redis atomically.
+
+        Args:
+            result: Classification result to publish
+        """
+        if not self._redis:
+            return
+
+        try:
+            # Atomic pipeline for transactional updates
+            async with self._redis.pipeline(transaction=True) as pipe:
+                # Clear old classification
+                await pipe.delete(self.CLASSIFICATION_HOT_KEY, self.CLASSIFICATION_COLD_KEY)
+
+                # Set new classification
+                # Set TTL on classification sets to prevent stale data after worker crash
+                ttl = int(settings.gateway_auto_refresh_interval * 2)
+
+                if result.hot_servers:
+                    await pipe.sadd(self.CLASSIFICATION_HOT_KEY, *result.hot_servers)
+
+                if result.cold_servers:
+                    await pipe.sadd(self.CLASSIFICATION_COLD_KEY, *result.cold_servers)
+
+                # Expire classification sets regardless of whether they had members
+                await pipe.expire(self.CLASSIFICATION_HOT_KEY, ttl)
+                await pipe.expire(self.CLASSIFICATION_COLD_KEY, ttl)
+
+                # Store metadata (expire after 2x classification interval)
+                metadata_json = orjson.dumps(asdict(result.metadata))
+                await pipe.set(self.CLASSIFICATION_METADATA_KEY, metadata_json, ex=ttl)
+
+                await pipe.set(self.CLASSIFICATION_TIMESTAMP_KEY, result.metadata.timestamp, ex=ttl)
+
+                await pipe.execute()
+
+            logger.debug("Classification published to Redis successfully")
+
+        except Exception as e:
+            logger.error(f"Failed to publish classification to Redis: {e}")
+
+    async def get_server_classification(self, url: str) -> Optional[str]:
+        """Get classification for a server (hot/cold).
+
+        Args:
+            url: Server URL
+
+        Returns:
+            "hot", "cold", or None if not classified
+        """
+        if not self._redis:
+            return None  # No Redis, classification not available
+
+        try:
+            is_hot = await self._redis.sismember(self.CLASSIFICATION_HOT_KEY, url)
+            if is_hot:
+                return "hot"
+
+            is_cold = await self._redis.sismember(self.CLASSIFICATION_COLD_KEY, url)
+            if is_cold:
+                return "cold"
+
+            return None  # Not yet classified
+        except Exception as e:
+            logger.warning(f"Failed to get classification for {url}: {e}")
+            return None  # Fail open
+
+    def _poll_state_key(self, url: str, poll_type: str, gateway_id: str = "") -> str:
+        """Build the Redis key for poll-state tracking.
+
+        Includes gateway_id when provided so that distinct gateways sharing the
+        same upstream URL track their refresh schedules independently.
+        """
+        scope = f"{url}\0{gateway_id}" if gateway_id else url
+        scope_hash = hashlib.sha256(scope.encode()).hexdigest()[:32]
+        return self.POLL_STATE_KEY_TEMPLATE.format(scope_hash=scope_hash, poll_type=poll_type)
+
+    async def should_poll_server(self, url: str, poll_type: Literal["health", "tool_discovery"], gateway_id: str = "") -> bool:
+        """Determine if server should be polled now based on classification.
+
+        Args:
+            url: Server URL
+            poll_type: Type of poll (health or tool_discovery)
+            gateway_id: Optional gateway ID for per-gateway poll tracking
+
+        Returns:
+            True if should poll now, False otherwise
+        """
+        if not settings.hot_cold_classification_enabled:
+            return True  # Feature disabled, always poll
+
+        if not self._redis:
+            return True  # No Redis, always poll (single-worker mode)
+
+        try:
+            classification = await self.get_server_classification(url)
+            if classification is None:
+                return True  # Not yet classified, poll anyway
+
+            last_poll_key = self._poll_state_key(url, poll_type, gateway_id)
+            last_poll_str = await self._redis.get(last_poll_key)
+
+            if last_poll_str is None:
+                # Never polled, should poll now (caller must call mark_poll_completed after)
+                return True
+
+            last_poll = float(last_poll_str)
+            now = time.time()
+            if not 0 < last_poll <= now + 60:
+                last_poll = 0.0  # treat as never polled; prevents manipulation via future timestamps
+            elapsed = now - last_poll
+
+            # Determine interval based on classification
+            interval = settings.hot_server_check_interval if classification == "hot" else settings.cold_server_check_interval
+
+            should_poll = elapsed >= interval
+
+            return should_poll
+
+        except Exception as e:
+            logger.warning(f"Error checking poll status for {url}: {e}")
+            return True  # Fail open: poll on error
+
+    async def mark_poll_completed(self, url: str, poll_type: Literal["health", "tool_discovery"], gateway_id: str = "") -> None:
+        """Record that a poll was actually performed.
+
+        Call this AFTER the poll/refresh succeeds, not at decision time.
+        This prevents wasting poll slots when downstream throttling skips the refresh.
+
+        Args:
+            url: Server URL
+            poll_type: Type of poll
+            gateway_id: Optional gateway ID for per-gateway poll tracking
+        """
+        if not self._redis:
+            return
+
+        try:
+            classification = await self.get_server_classification(url)
+            interval = settings.hot_server_check_interval if classification == "hot" else settings.cold_server_check_interval
+
+            last_poll_key = self._poll_state_key(url, poll_type, gateway_id)
+            await self._redis.set(last_poll_key, time.time(), ex=int(interval * 2))  # Expire after 2x interval
+        except Exception as e:
+            logger.warning(f"Failed to update poll timestamp for {url}: {e}")

--- a/tests/unit/mcpgateway/services/test_gateway_hot_cold_integration.py
+++ b/tests/unit/mcpgateway/services/test_gateway_hot_cold_integration.py
@@ -1,0 +1,818 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for hot/cold server classification with GatewayService.
+
+Tests the integration between ServerClassificationService and GatewayService
+for health checks and auto-refresh polling.
+
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Standard
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import Gateway as DbGateway
+from mcpgateway.services.gateway_service import GatewayService
+from mcpgateway.services.server_classification_service import ServerClassificationService
+
+
+@pytest.fixture(autouse=True)
+def mock_logging_services():
+    """Mock audit_trail and structured_logger to prevent database writes during tests."""
+    with (
+        patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit,
+        patch("mcpgateway.services.gateway_service.structured_logger") as mock_logger,
+    ):
+        mock_audit.log_action = MagicMock(return_value=None)
+        mock_logger.log = MagicMock(return_value=None)
+        yield {"audit_trail": mock_audit, "structured_logger": mock_logger}
+
+
+@pytest.fixture
+def gateway_service_with_classification():
+    """Create a GatewayService instance with classification service."""
+    with patch("mcpgateway.services.gateway_service.SessionLocal"):
+        service = GatewayService()
+        service.oauth_manager = AsyncMock()
+
+        # Mock classification service
+        mock_classification = AsyncMock(spec=ServerClassificationService)
+        service._classification_service = mock_classification
+
+        return service, mock_classification
+
+
+def _make_mock_gateway(
+    gateway_id: str = "gw-123",
+    name: str = "test-gateway",
+    url: str = "http://test-server:8000",
+    enabled: bool = True,
+    reachable: bool = True,
+) -> MagicMock:
+    """Create a mock gateway object."""
+    mock = MagicMock(spec=DbGateway)
+    mock.id = gateway_id
+    mock.name = name
+    mock.url = url
+    mock.enabled = enabled
+    mock.reachable = reachable
+    mock.transport = "SSE"
+    mock.auth_type = None
+    mock.auth_value = None
+    mock.oauth_config = None
+    mock.ca_certificate = None
+    mock.ca_certificate_sig = None
+    mock.client_cert = None
+    mock.client_key = None
+    mock.auth_query_params = None
+    mock.visibility = "private"
+    mock.last_refresh_at = None
+    mock.refresh_interval_seconds = None
+    return mock
+
+
+class TestHealthCheckHotColdIntegration:
+    """Tests for health check integration with hot/cold polling.
+
+    Health checks always run regardless of classification — only auto-refresh
+    (tool discovery) is gated by hot/cold intervals.
+    """
+
+    @pytest.mark.asyncio
+    async def test_health_check_always_runs_regardless_of_classification(self, gateway_service_with_classification):
+        """Health checks must never be skipped — classification only gates auto-refresh."""
+        gateway_service, mock_classification = gateway_service_with_classification
+
+        # Classification says "don't poll" — but health check must still run
+        mock_classification.should_poll_server = AsyncMock(return_value=False)
+
+        mock_gateway = _make_mock_gateway(url="http://cold-server:8000")
+
+        with (
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_http.stream = AsyncMock(return_value=mock_response)
+            mock_response.__aenter__.return_value = mock_response
+            mock_response.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+            # Health check HTTP call must have been made even though classification said "skip"
+            mock_client.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_health_check_proceeds_when_classification_disabled(self, gateway_service_with_classification):
+        """Health check always proceeds when classification feature is disabled."""
+        gateway_service, mock_classification = gateway_service_with_classification
+        gateway_service._classification_service = None
+
+        mock_gateway = _make_mock_gateway(url="http://any-server:8000")
+
+        with (
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_http.stream = AsyncMock(return_value=mock_response)
+            mock_response.__aenter__.return_value = mock_response
+            mock_response.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+            mock_client.assert_called()
+
+
+class TestPollTypeIndependence:
+    """Tests for independent tracking of health and tool_discovery poll types."""
+
+    @pytest.mark.asyncio
+    async def test_health_and_tool_discovery_polled_independently(self, gateway_service_with_classification):
+        """Test health and tool_discovery polls tracked independently."""
+        gateway_service, mock_classification = gateway_service_with_classification
+
+        url = "http://test-server:8000"
+
+        async def should_poll_side_effect(url_arg, poll_type):
+            if poll_type == "health":
+                return False
+            elif poll_type == "tool_discovery":
+                return True
+            return True
+
+        mock_classification.should_poll_server = AsyncMock(side_effect=should_poll_side_effect)
+
+        # Health check not due
+        health_result = await mock_classification.should_poll_server(url, "health")
+        assert health_result is False
+
+        # Tool discovery is due
+        tools_result = await mock_classification.should_poll_server(url, "tool_discovery")
+        assert tools_result is True
+
+        assert mock_classification.should_poll_server.await_count == 2
+
+
+class TestClassificationServiceInitialization:
+    """Tests for classification service initialization in GatewayService."""
+
+    @pytest.mark.asyncio
+    async def test_classification_service_initialized_when_enabled(self):
+        """Test classification service initialized when feature enabled."""
+        mock_redis = AsyncMock()
+
+        with (
+            patch("mcpgateway.services.gateway_service.settings") as mock_settings,
+            patch("mcpgateway.services.gateway_service.SessionLocal"),
+            patch("mcpgateway.services.gateway_service.get_redis_client") as mock_get_redis,
+        ):
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.platform_admin_email = "admin@example.com"
+            mock_get_redis.return_value = mock_redis
+
+            service = GatewayService()
+
+            # Initialize the service (which would normally create classification service)
+            with patch.object(service, "_run_health_checks") as mock_run_health:
+                mock_run_health.return_value = None
+
+                await service.initialize()
+
+                # Verify classification service was created
+                assert service._classification_service is not None
+
+    @pytest.mark.asyncio
+    async def test_classification_service_not_initialized_when_disabled(self):
+        """Test classification service not initialized when feature disabled."""
+        with (
+            patch("mcpgateway.services.gateway_service.settings") as mock_settings,
+            patch("mcpgateway.services.gateway_service.SessionLocal"),
+        ):
+            mock_settings.hot_cold_classification_enabled = False
+            mock_settings.platform_admin_email = "admin@example.com"
+
+            service = GatewayService()
+
+            with patch.object(service, "_run_health_checks") as mock_run_health:
+                mock_run_health.return_value = None
+
+                await service.initialize()
+
+                # Classification service should not be created
+                assert service._classification_service is None or not hasattr(service, "_classification_service")
+
+
+class TestConfigurationValues:
+    """Tests for hot/cold polling interval configuration."""
+
+    @pytest.mark.asyncio
+    async def test_hot_server_interval_equals_gateway_auto_refresh(self):
+        """Test hot server check interval equals gateway_auto_refresh_interval."""
+        # First-Party
+        from mcpgateway.config import Settings
+
+        # Create a real config instance with specific value
+        config = Settings(gateway_auto_refresh_interval=300)
+
+        # Access the property
+        assert config.hot_server_check_interval == 300
+
+    @pytest.mark.asyncio
+    async def test_cold_server_interval_is_3x_gateway_auto_refresh(self):
+        """Test cold server check interval is 3x gateway_auto_refresh_interval."""
+        # First-Party
+        from mcpgateway.config import Settings
+
+        # Create a real config instance with specific value
+        config = Settings(gateway_auto_refresh_interval=300)
+
+        # Access the property
+        assert config.cold_server_check_interval == 900  # 3x
+
+    @pytest.mark.asyncio
+    async def test_intervals_derive_correctly_from_config(self):
+        """Test intervals correctly derived from configuration."""
+        # First-Party
+        from mcpgateway.config import Settings
+
+        # Test different base intervals
+        base_intervals = [60, 120, 300, 600]
+
+        for base in base_intervals:
+            # Create a config instance for each test value
+            config = Settings(gateway_auto_refresh_interval=base)
+
+            # Verify derived intervals
+            hot_interval = config.hot_server_check_interval
+            cold_interval = config.cold_server_check_interval
+
+            assert hot_interval == base
+            assert cold_interval == base * 3
+
+
+class TestFailOpenBehavior:
+    """Tests for fail-open behavior on errors."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_proceeds_on_classification_error(self, gateway_service_with_classification):
+        """Test health check proceeds when classification check fails."""
+        gateway_service, mock_classification = gateway_service_with_classification
+
+        # Classification service raises error
+        mock_classification.should_poll_server = AsyncMock(side_effect=Exception("Redis connection error"))
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000")
+
+        # Health check should still proceed (fail-open)
+        with (
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+            # Mock HTTP response
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_http.stream = AsyncMock(return_value=mock_response)
+            mock_response.__aenter__.return_value = mock_response
+            mock_response.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            # Should not raise exception, health check should proceed
+            try:
+                await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+            except Exception as e:
+                pytest.fail(f"Health check should not raise exception on classification error: {e}")
+
+    @pytest.mark.asyncio
+    async def test_auto_refresh_proceeds_on_classification_error_via_health_check(self, gateway_service_with_classification, monkeypatch):
+        """Test auto-refresh proceeds when classification check fails during health check (fail-open)."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+
+        # Classification service raises error
+        mock_classification.should_poll_server = AsyncMock(side_effect=Exception("Redis connection error"))
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000", name="test-gateway")
+        mock_gateway.last_refresh_at = None
+
+        # Mock the internal refresh method call
+        with patch.object(gateway_service, "_refresh_gateway_tools_resources_prompts", AsyncMock(return_value={"added": 0, "updated": 0, "removed": 0})):
+            with patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db:
+                mock_session = MagicMock()
+                mock_fresh_db.return_value.__enter__.return_value = mock_session
+                mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+                mock_session.commit = MagicMock()
+
+                with patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_client:
+                    # Mock HTTP response
+                    mock_response = AsyncMock()
+                    mock_response.status_code = 200
+                    mock_response.raise_for_status = MagicMock()
+                    mock_http = AsyncMock()
+                    mock_http.__aenter__.return_value = mock_http
+                    mock_http.__aexit__.return_value = None
+                    mock_http.stream = AsyncMock(return_value=mock_response)
+                    mock_response.__aenter__.return_value = mock_response
+                    mock_response.__aexit__.return_value = None
+                    mock_client.return_value = mock_http
+
+                    # Should not raise exception, auto-refresh should proceed with fail-open
+                    try:
+                        await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+                    except Exception as e:
+                        pytest.fail(f"Health check with auto-refresh should not raise exception on classification error: {e}")
+
+    @pytest.mark.asyncio
+    async def test_auto_refresh_skipped_when_tools_classification_not_due(self, gateway_service_with_classification, monkeypatch):
+        """Test auto-refresh is skipped when classification says tools are not due, even after health check passes."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+
+        # Tool discovery poll is not due
+        mock_classification.should_poll_server = AsyncMock(return_value=False)
+        mock_classification.mark_poll_completed = AsyncMock()
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000")
+        mock_refresh = AsyncMock()
+
+        with (
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_get_client,
+            patch.object(gateway_service, "_refresh_gateway_tools_resources_prompts", mock_refresh),
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+            mock_session.commit = MagicMock()
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_stream_cm = MagicMock()
+            mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_http_client = MagicMock()
+            mock_http_client.stream = MagicMock(return_value=mock_stream_cm)
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_get_client.return_value = mock_client_cm
+
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+        # Tools refresh must NOT have been called (classification said not due)
+        mock_refresh.assert_not_awaited()
+        # Only tool_discovery poll type checked (health checks always run)
+        mock_classification.should_poll_server.assert_awaited_once_with("http://test-server:8000", "tool_discovery", gateway_id="gw-123")
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_tool_discovery_exception_ignored(self, gateway_service_with_classification, monkeypatch):
+        """Test that exceptions from mark_poll_completed(tool_discovery) are silently ignored."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+
+        # Both health and tools polls are due
+        mock_classification.should_poll_server = AsyncMock(return_value=True)
+
+        # mark_poll_completed raises only for tool_discovery
+        async def _mark_side_effect(url, poll_type):
+            if poll_type == "tool_discovery":
+                raise Exception("Redis write error")
+
+        mock_classification.mark_poll_completed = AsyncMock(side_effect=_mark_side_effect)
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000", name="test-gateway")
+        mock_gateway.last_refresh_at = None
+
+        with (
+            patch.object(gateway_service, "_refresh_gateway_tools_resources_prompts", AsyncMock(return_value={"added": 0, "updated": 0, "removed": 0})),
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_get_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+            mock_session.commit = MagicMock()
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_stream_cm = MagicMock()
+            mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_http_client = MagicMock()
+            mock_http_client.stream = MagicMock(return_value=mock_stream_cm)
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_get_client.return_value = mock_client_cm
+
+            # Exception from mark_poll_completed(tool_discovery) must not propagate
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+
+def _make_http_client_context_manager():
+    """Build the async context manager chain used by tests that go through get_isolated_http_client."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_stream_cm = MagicMock()
+    mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_http_client = MagicMock()
+    mock_http_client.stream = MagicMock(return_value=mock_stream_cm)
+    mock_client_cm = MagicMock()
+    mock_client_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+    mock_client_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_client_cm
+
+
+class TestBranchSpecificMissingLines:
+    """Tests that cover lines identified as missing in this branch's changes."""
+
+    # ------------------------------------------------------------------
+    # Line 3590: last_refresh.replace(tzinfo=timezone.utc) — naive datetime
+    # inside the new `should_auto_refresh` gate added by this branch.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_auto_refresh_naive_last_refresh_at_triggers_tzinfo_fix(self, gateway_service_with_classification, monkeypatch):
+        """Naive datetime in last_refresh_at gets UTC tzinfo applied before comparison (line 3590)."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.gateway_auto_refresh_interval", 300)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+        # Disable classification so should_auto_refresh=True via the unconditional else branch
+        gateway_service._classification_service = None
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000", name="test-gateway")
+        # Naive datetime (no tzinfo), old enough that time_since_refresh > 300s
+        mock_gateway.last_refresh_at = datetime.utcnow() - timedelta(hours=2)
+        mock_gateway.refresh_interval_seconds = None
+
+        mock_refresh = AsyncMock(return_value={"added": 0, "updated": 0, "removed": 0})
+
+        with (
+            patch.object(gateway_service, "_refresh_gateway_tools_resources_prompts", mock_refresh),
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_get_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+            mock_session.commit = MagicMock()
+            mock_get_client.return_value = _make_http_client_context_manager()
+
+            # Should not raise; tzinfo fix is applied and refresh proceeds
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+        # Refresh must have been called (naive datetime was handled correctly)
+        mock_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_refresh_naive_last_refresh_at_within_interval_skips_refresh(self, gateway_service_with_classification, monkeypatch):
+        """Naive datetime recent enough to skip refresh is still handled without error (line 3590 + throttle)."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.gateway_auto_refresh_interval", 3600)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+        gateway_service._classification_service = None
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000", name="test-gateway")
+        # Naive datetime, refreshed 30 seconds ago (within 3600s interval)
+        mock_gateway.last_refresh_at = datetime.utcnow() - timedelta(seconds=30)
+        mock_gateway.refresh_interval_seconds = None
+
+        mock_refresh = AsyncMock(return_value={"added": 0, "updated": 0, "removed": 0})
+
+        with (
+            patch.object(gateway_service, "_refresh_gateway_tools_resources_prompts", mock_refresh),
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_get_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+            mock_session.commit = MagicMock()
+            mock_get_client.return_value = _make_http_client_context_manager()
+
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+        # Not due for refresh yet
+        mock_refresh.assert_not_awaited()
+
+    # ------------------------------------------------------------------
+    # Lines 3344-3345: decode_auth exception on query_param auth type
+    # Inside _check_single_gateway_health, modified by this branch.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_health_check_query_param_decryption_failure_proceeds_fail_open(self, gateway_service_with_classification):
+        """Health check proceeds when query-param auth decryption raises an exception (lines 3344-3345)."""
+        gateway_service, mock_classification = gateway_service_with_classification
+        mock_classification.should_poll_server = AsyncMock(return_value=True)
+        mock_classification.mark_poll_completed = AsyncMock()
+
+        mock_gateway = _make_mock_gateway(url="http://test-server:8000", name="test-gateway")
+        mock_gateway.auth_type = "query_param"
+        mock_gateway.auth_query_params = {"api_key": "badly_encrypted_value"}  # pragma: allowlist secret
+
+        with (
+            patch("mcpgateway.services.gateway_service.decode_auth", side_effect=Exception("Decryption failed")),
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client") as mock_get_client,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+            mock_session.commit = MagicMock()
+            mock_get_client.return_value = _make_http_client_context_manager()
+
+            # Must not raise; decryption failure is silently logged (line 3344-3345)
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+        # Health check still executed (get_isolated_http_client was called)
+        mock_get_client.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Line 3398: ssl_context = None (else branch) for https URL with no CA cert
+    # Inside _check_single_gateway_health, modified by this branch.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_health_check_https_url_no_ca_cert_ssl_context_none(self, gateway_service_with_classification):
+        """ssl_context is None for https URL with no CA certificate (line 3398 else branch)."""
+        gateway_service, mock_classification = gateway_service_with_classification
+        mock_classification.should_poll_server = AsyncMock(return_value=True)
+        mock_classification.mark_poll_completed = AsyncMock()
+
+        # https URL + no CA certificate → falls into the else: ssl_context = None branch (line 3398)
+        mock_gateway = _make_mock_gateway(url="https://secure-server:8443", name="test-gateway")
+        # ca_certificate is None by default in _make_mock_gateway — no valid cert, no ssl override
+
+        ssl_context_captured = {}
+
+        original_get_isolated = __import__("mcpgateway.services.gateway_service", fromlist=["get_isolated_http_client"])
+
+        def capture_ssl_context(*args, **kwargs):
+            ssl_context_captured["verify"] = kwargs.get("verify")
+            return _make_http_client_context_manager()
+
+        with (
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service.get_isolated_http_client", side_effect=capture_ssl_context),
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+            mock_session.commit = MagicMock()
+
+            await gateway_service._check_single_gateway_health(mock_gateway, user_email="test@example.com")
+
+        # ssl_context should be None (the else branch at line 3398)
+        assert ssl_context_captured.get("verify") is None
+
+
+class TestMarkPollCompletedInRefreshPath:
+    """Tests that mark_poll_completed runs inside _refresh_gateway_tools_resources_prompts."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_calls_mark_poll_completed_on_success(self, gateway_service_with_classification, monkeypatch):
+        """Successful tool refresh must advance the hot/cold poll schedule."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+        mock_classification.should_poll_server = AsyncMock(return_value=True)
+        mock_classification.mark_poll_completed = AsyncMock()
+
+        mock_gateway = _make_mock_gateway(url="http://refresh-gw:8000")
+        mock_gateway.last_refresh_at = None
+        mock_gateway.refresh_interval_seconds = None
+
+        # Mock _initialize_gateway to return empty (no changes, but success)
+        with (
+            patch.object(gateway_service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], []))),
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service._get_registry_cache") as mock_cache_fn,
+            patch("mcpgateway.services.gateway_service._get_tool_lookup_cache") as mock_tl_fn,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+
+            # Return gateway from DB query inside refresh
+            mock_gw_db = MagicMock()
+            mock_gw_db.id = "gw-123"
+            mock_gw_db.tools = []
+            mock_gw_db.resources = []
+            mock_gw_db.prompts = []
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gw_db
+            mock_session.commit = MagicMock()
+            mock_session.dirty = set()
+
+            mock_cache = AsyncMock()
+            mock_cache_fn.return_value = mock_cache
+            mock_tl = AsyncMock()
+            mock_tl_fn.return_value = mock_tl
+
+            result = await gateway_service._refresh_gateway_tools_resources_prompts(
+                gateway_id="gw-123",
+                gateway=mock_gateway,
+            )
+
+        # mark_poll_completed must have been called with the base URL
+        mock_classification.mark_poll_completed.assert_awaited_once_with(
+            "http://refresh-gw:8000", "tool_discovery", gateway_id="gw-123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_mark_poll_exception_ignored(self, gateway_service_with_classification, monkeypatch):
+        """Exception from mark_poll_completed inside refresh must not crash the refresh."""
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.auto_refresh_servers", True)
+
+        gateway_service, mock_classification = gateway_service_with_classification
+        mock_classification.should_poll_server = AsyncMock(return_value=True)
+        mock_classification.mark_poll_completed = AsyncMock(side_effect=Exception("Redis down"))
+
+        mock_gateway = _make_mock_gateway(url="http://err-gw:8000")
+        mock_gateway.last_refresh_at = None
+        mock_gateway.refresh_interval_seconds = None
+
+        with (
+            patch.object(gateway_service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], []))),
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
+            patch("mcpgateway.services.gateway_service._get_registry_cache") as mock_cache_fn,
+            patch("mcpgateway.services.gateway_service._get_tool_lookup_cache") as mock_tl_fn,
+        ):
+            mock_session = MagicMock()
+            mock_fresh_db.return_value.__enter__.return_value = mock_session
+            mock_gw_db = MagicMock()
+            mock_gw_db.id = "gw-123"
+            mock_gw_db.tools = []
+            mock_gw_db.resources = []
+            mock_gw_db.prompts = []
+            mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gw_db
+            mock_session.commit = MagicMock()
+            mock_session.dirty = set()
+            mock_cache_fn.return_value = AsyncMock()
+            mock_tl_fn.return_value = AsyncMock()
+
+            # Must not raise despite mark_poll_completed failure
+            result = await gateway_service._refresh_gateway_tools_resources_prompts(
+                gateway_id="gw-123", gateway=mock_gateway,
+            )
+            assert result["success"]
+
+
+class TestUpdateGatewayPollSchedule:
+    """Tests for mark_poll_completed in the update_gateway path."""
+
+    @pytest.mark.asyncio
+    async def test_update_gateway_advances_poll_on_successful_reinit(self):
+        """update_gateway must call mark_poll_completed after successful re-initialization."""
+        from mcpgateway.services.server_classification_service import ServerClassificationService
+
+        with patch("mcpgateway.services.gateway_service.SessionLocal"):
+            service = GatewayService()
+            service.oauth_manager = AsyncMock()
+
+            mock_classification = AsyncMock(spec=ServerClassificationService)
+            mock_classification.mark_poll_completed = AsyncMock()
+            service._classification_service = mock_classification
+
+        mock_db = MagicMock()
+
+        # Build a mock gateway in DB
+        mock_gw = MagicMock()
+        mock_gw.id = "gw-update-1"
+        mock_gw.url = "http://update-gw:8000"
+        mock_gw.name = "update-gw"
+        mock_gw.enabled = True
+        mock_gw.reachable = True
+        mock_gw.transport = "SSE"
+        mock_gw.auth_type = None
+        mock_gw.auth_value = None
+        mock_gw.auth_query_params = None
+        mock_gw.oauth_config = None
+        mock_gw.ca_certificate = None
+        mock_gw.client_cert = None
+        mock_gw.client_key = None
+        mock_gw.tools = []
+        mock_gw.resources = []
+        mock_gw.prompts = []
+        mock_gw.tags = []
+        mock_gw.version = 1
+        mock_gw.visibility = "public"
+        mock_gw.passthrough_headers = None
+        mock_gw.team_id = None
+        mock_gw.owner_email = "admin@example.com"
+        mock_gw.capabilities = {}
+        mock_gw.gateway_mode = "cache"
+        mock_gw.team = None
+        mock_gw.created_by = "admin@example.com"
+        mock_gw.created_from_ip = "127.0.0.1"
+        mock_gw.created_via = "api"
+        mock_gw.created_user_agent = "test"
+        mock_gw.modified_by = None
+        mock_gw.modified_from_ip = None
+        mock_gw.modified_via = None
+        mock_gw.modified_user_agent = None
+        mock_gw.updated_at = datetime.now()
+        mock_gw.last_seen = datetime.now()
+        mock_gw.created_at = datetime.now()
+        mock_gw.slug = "update-gw"
+        mock_gw.last_refresh_at = None
+        mock_gw.refresh_interval_seconds = None
+        mock_gw.description = None
+        mock_gw.import_batch_id = None
+        mock_gw.federation_source = None
+        mock_gw.ca_certificate_sig = None
+        mock_gw.signing_algorithm = "ed25519"
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gw
+        mock_db.commit = MagicMock()
+        mock_db.refresh = MagicMock()
+        mock_db.flush = MagicMock()
+
+        # GatewayUpdate with a URL change to trigger re-init
+        from mcpgateway.schemas import GatewayUpdate
+
+        gateway_update = MagicMock(spec=GatewayUpdate)
+        gateway_update.url = "http://update-gw:8000"
+        gateway_update.name = None
+        gateway_update.description = None
+        gateway_update.transport = None
+        gateway_update.tags = None
+        gateway_update.passthrough_headers = None
+        gateway_update.auth_type = None
+        gateway_update.auth_username = None
+        gateway_update.auth_password = None
+        gateway_update.auth_token = None
+        gateway_update.auth_header_key = None
+        gateway_update.auth_header_value = None
+        gateway_update.auth_headers = None
+        gateway_update.auth_value = None
+        gateway_update.oauth_config = None
+        gateway_update.auth_query_param_key = None
+        gateway_update.auth_query_param_value = None
+        gateway_update.ca_certificate = None
+        gateway_update.ca_certificate_sig = None
+        gateway_update.signing_algorithm = None
+        gateway_update.client_cert = None
+        gateway_update.client_key = None
+        gateway_update.one_time_auth = None
+        gateway_update.visibility = None
+        gateway_update.team_id = None
+        gateway_update.refresh_interval_seconds = None
+        gateway_update.gateway_mode = None
+
+        with (
+            patch.object(service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], []))),
+            patch.object(service, "_notify_gateway_updated", AsyncMock()),
+            patch("mcpgateway.services.gateway_service._get_registry_cache", return_value=AsyncMock()),
+            patch("mcpgateway.services.gateway_service._get_tool_lookup_cache", return_value=AsyncMock()),
+            patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit,
+            patch("mcpgateway.services.gateway_service.structured_logger") as mock_slog,
+            patch("mcpgateway.cache.admin_stats_cache.admin_stats_cache", AsyncMock()),
+        ):
+            mock_audit.log_action = MagicMock()
+            mock_slog.log = MagicMock()
+
+            await service.update_gateway(mock_db, "gw-update-1", gateway_update)
+
+        mock_classification.mark_poll_completed.assert_awaited_once_with(
+            "http://update-gw:8000", "tool_discovery", gateway_id="gw-update-1"
+        )

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -245,7 +245,7 @@ class TestGatewayService:
             ]
         )
         test_db.add = Mock()
-        test_db.flush = Mock()  # Implementation uses flush() not commit()
+        test_db.commit = Mock()
         test_db.refresh = Mock()
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
@@ -286,7 +286,7 @@ class TestGatewayService:
         result = await gateway_service.register_gateway(test_db, gateway_create)
 
         test_db.add.assert_called_once()
-        test_db.flush.assert_called_once()  # Implementation uses flush() not commit()
+        test_db.commit.assert_called_once()
         test_db.refresh.assert_called_once()
         gateway_service._initialize_gateway.assert_called_once()
         gateway_service._notify_gateway_added.assert_called_once()
@@ -351,7 +351,7 @@ class TestGatewayService:
             ]
         )
         test_db.add = Mock()
-        test_db.flush = Mock()  # Implementation uses flush() not commit()
+        test_db.commit = Mock()
         test_db.refresh = Mock()
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
@@ -387,7 +387,7 @@ class TestGatewayService:
         await gateway_service.register_gateway(test_db, gateway_create)
 
         test_db.add.assert_called_once()
-        test_db.flush.assert_called_once()  # Implementation uses flush() not commit()
+        test_db.commit.assert_called_once()
         gateway_service._initialize_gateway.assert_called_once()
 
     @pytest.mark.asyncio
@@ -474,7 +474,7 @@ class TestGatewayService:
         """Test database error during gateway registration."""
         test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
         test_db.add = Mock()
-        test_db.flush = Mock(side_effect=Exception("Database error"))  # Implementation uses flush() not commit()
+        test_db.commit = Mock(side_effect=Exception("Database error"))
         test_db.rollback = Mock()
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
@@ -541,7 +541,7 @@ class TestGatewayService:
         test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
         test_db.add = Mock()
         test_db.rollback = Mock()
-        test_db.flush = Mock(side_effect=SQLIntegrityError("statement", "params", BaseException("orig")))  # Implementation uses flush()
+        test_db.commit = Mock(side_effect=SQLIntegrityError("statement", "params", BaseException("orig")))
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
 
@@ -568,7 +568,7 @@ class TestGatewayService:
             ]
         )
         test_db.add = Mock()
-        test_db.flush = Mock()  # Implementation uses flush() not commit()
+        test_db.commit = Mock()
         test_db.refresh = Mock()
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
@@ -598,7 +598,7 @@ class TestGatewayService:
             await gateway_service.register_gateway(test_db, gateway_create)
 
         test_db.add.assert_called_once()
-        test_db.flush.assert_called_once()  # Implementation uses flush() not commit()
+        test_db.commit.assert_called_once()
         gateway_service._initialize_gateway.assert_called_once()
 
     @pytest.mark.asyncio
@@ -780,7 +780,7 @@ class TestGatewayService:
         """Test rollback on exception during gateway registration."""
         test_db.execute = Mock(return_value=_make_execute_result(scalar=None))
         test_db.add = Mock()
-        test_db.flush = Mock(side_effect=Exception("Flush failed"))  # Implementation uses flush() not commit()
+        test_db.commit = Mock(side_effect=Exception("Commit failed"))
         test_db.rollback = Mock()
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
@@ -796,7 +796,7 @@ class TestGatewayService:
         with pytest.raises(Exception) as exc_info:
             await gateway_service.register_gateway(test_db, gateway_create)
 
-        assert "Flush failed" in str(exc_info.value)  # Error message matches the mocked exception
+        assert "Commit failed" in str(exc_info.value)  # Error message matches the mocked exception
         test_db.rollback.assert_called_once()  # Exception handlers now rollback to prevent orphaned records
 
     @pytest.mark.asyncio
@@ -3159,6 +3159,88 @@ class TestGatewayHealth:
                     gateway_service._refresh_gateway_tools_resources_prompts.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_health_skips_refresh_classification_says_no(self, gateway_service, mock_gateway_health, mock_db_session):
+        """Test that health check skips refresh when classification service says not to poll."""
+        gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock()
+        gateway_service.set_gateway_state = AsyncMock()
+        gateway_service._get_refresh_lock = MagicMock()
+
+        # Mock classification service that says NOT to poll
+        mock_classification = AsyncMock()
+        mock_classification.should_poll_server = AsyncMock(return_value=False)
+        gateway_service._classification_service = mock_classification
+
+        lock = MagicMock()
+        lock.locked.return_value = False
+        lock.__aenter__ = AsyncMock(return_value=None)
+        lock.__aexit__ = AsyncMock(return_value=None)
+        gateway_service._get_refresh_lock.return_value = lock
+
+        # Mock http client
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.get.return_value = MagicMock(status_code=200)
+
+        with patch("mcpgateway.services.gateway_service.settings") as mock_settings:
+            mock_settings.auto_refresh_servers = True
+            mock_settings.gateway_auto_refresh_interval = 300
+            mock_settings.enable_ed25519_signing = False
+            mock_settings.httpx_admin_read_timeout = 5.0
+
+            with patch("mcpgateway.services.http_client_service.get_isolated_http_client", return_value=mock_client):
+                with patch("mcpgateway.services.gateway_service.fresh_db_session", return_value=mock_db_session):
+                    session = mock_db_session.__enter__()
+                    session.execute.return_value = _make_execute_result(scalar=mock_gateway_health)
+
+                    await gateway_service._check_single_gateway_health(mock_gateway_health)
+
+                    # Should NOT call refresh because classification service said no
+                    gateway_service._refresh_gateway_tools_resources_prompts.assert_not_called()
+                    # Should have checked with classification service
+                    mock_classification.should_poll_server.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_health_proceeds_refresh_classification_fails(self, gateway_service, mock_gateway_health, mock_db_session):
+        """Test that health check proceeds with refresh when classification check fails (fail-open)."""
+        gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock()
+        gateway_service.set_gateway_state = AsyncMock()
+        gateway_service._get_refresh_lock = MagicMock()
+
+        # Mock classification service that raises an exception
+        mock_classification = AsyncMock()
+        mock_classification.should_poll_server = AsyncMock(side_effect=Exception("Classification error"))
+        gateway_service._classification_service = mock_classification
+
+        lock = MagicMock()
+        lock.locked.return_value = False
+        lock.__aenter__ = AsyncMock(return_value=None)
+        lock.__aexit__ = AsyncMock(return_value=None)
+        gateway_service._get_refresh_lock.return_value = lock
+
+        # Mock http client
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.get.return_value = MagicMock(status_code=200)
+
+        with patch("mcpgateway.services.gateway_service.settings") as mock_settings:
+            mock_settings.auto_refresh_servers = True
+            mock_settings.gateway_auto_refresh_interval = 300
+            mock_settings.enable_ed25519_signing = False
+            mock_settings.httpx_admin_read_timeout = 5.0
+
+            with patch("mcpgateway.services.http_client_service.get_isolated_http_client", return_value=mock_client):
+                with patch("mcpgateway.services.gateway_service.fresh_db_session", return_value=mock_db_session):
+                    session = mock_db_session.__enter__()
+                    session.execute.return_value = _make_execute_result(scalar=mock_gateway_health)
+
+                    await gateway_service._check_single_gateway_health(mock_gateway_health)
+
+                    # Should call refresh despite classification error (fail-open)
+                    gateway_service._refresh_gateway_tools_resources_prompts.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_initialize_redis_ping_failure(self, monkeypatch):
         # First-Party
         import mcpgateway.services.gateway_service as gs
@@ -3910,6 +3992,49 @@ async def test_shutdown_releases_redis_leader_success():
     await service.shutdown()
 
     service._redis_client.eval.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stops_classification_service():
+    """Test that shutdown stops classification service if present."""
+    service = GatewayService()
+    service._redis_client = None
+    service._http_client = SimpleNamespace(aclose=AsyncMock())
+    service._event_service = SimpleNamespace(shutdown=AsyncMock())
+
+    # Create mock classification service
+    mock_classification = AsyncMock()
+    mock_classification.stop = AsyncMock()
+    service._classification_service = mock_classification
+
+    await service.shutdown()
+
+    # Verify classification service stop was called
+    mock_classification.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_leader_heartbeat_task():
+    """Test that shutdown cancels leader heartbeat task if present."""
+    service = GatewayService()
+    service._redis_client = None
+    service._http_client = SimpleNamespace(aclose=AsyncMock())
+    service._event_service = SimpleNamespace(shutdown=AsyncMock())
+    service._classification_service = None
+
+    # Create a real asyncio task that can be cancelled and awaited
+    async def dummy_heartbeat():
+        try:
+            await asyncio.sleep(1000)  # Long sleep to ensure it gets cancelled
+        except asyncio.CancelledError:
+            pass
+
+    service._leader_heartbeat_task = asyncio.create_task(dummy_heartbeat())
+
+    await service.shutdown()
+
+    # Verify task was cancelled
+    assert service._leader_heartbeat_task.cancelled()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_server_classification_service.py
+++ b/tests/unit/mcpgateway/services/test_server_classification_service.py
@@ -1,0 +1,2145 @@
+# -*- coding: utf-8 -*-
+"""Tests for the server classification service.
+
+Tests hot/cold server classification and staggered polling feature.
+
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Standard
+import asyncio
+import time
+from collections import deque
+from typing import Dict, List, Set
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services.mcp_session_pool import MCPSessionPool, PooledSession, TransportType
+from mcpgateway.services.server_classification_service import (
+    ClassificationMetadata,
+    ClassificationResult,
+    ServerClassificationService,
+    ServerUsageMetrics,
+)
+
+
+class TestServerClassificationServiceInit:
+    """Tests for ServerClassificationService initialization."""
+
+    def test_init_without_redis(self):
+        """Test service initialization without Redis."""
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 60
+            service = ServerClassificationService(redis_client=None)
+
+            assert service._redis is None
+            assert service._classification_task is None
+            assert service._instance_id.startswith("classifier_")
+            assert service._leader_ttl == 180
+            assert service._running is False
+
+    def test_init_with_redis(self):
+        """Test service initialization with Redis."""
+        mock_redis = MagicMock()
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        assert service._redis is mock_redis
+        assert service._classification_task is None
+        assert service._running is False
+
+    def test_redis_key_templates(self):
+        """Test Redis key templates are correctly defined."""
+        assert ServerClassificationService.CLASSIFICATION_HOT_KEY == "mcpgateway:server_classification:hot"
+        assert ServerClassificationService.CLASSIFICATION_COLD_KEY == "mcpgateway:server_classification:cold"
+        assert ServerClassificationService.CLASSIFICATION_METADATA_KEY == "mcpgateway:server_classification:metadata"
+        assert ServerClassificationService.CLASSIFICATION_TIMESTAMP_KEY == "mcpgateway:server_classification:timestamp"
+        assert ServerClassificationService.POLL_STATE_KEY_TEMPLATE == "mcpgateway:server_poll_state:{scope_hash}:last_{poll_type}"
+        assert ServerClassificationService.LEADER_KEY == "mcpgateway:server_classification:leader"
+
+
+class TestServerUsageMetrics:
+    """Tests for ServerUsageMetrics dataclass."""
+
+    def test_server_usage_metrics_defaults(self):
+        """Test ServerUsageMetrics default values."""
+        metrics = ServerUsageMetrics(url="http://test:8080")
+
+        assert metrics.url == "http://test:8080"
+        assert metrics.server_last_used == 0.0
+        assert metrics.active_session_count == 0
+        assert metrics.total_use_count == 0
+        assert metrics.pooled_session_count == 0
+
+    def test_server_usage_metrics_custom_values(self):
+        """Test ServerUsageMetrics with custom values."""
+        now = time.time()
+        metrics = ServerUsageMetrics(
+            url="http://test:8080",
+            server_last_used=now,
+            active_session_count=3,
+            total_use_count=15,
+            pooled_session_count=5,
+        )
+
+        assert metrics.url == "http://test:8080"
+        assert metrics.server_last_used == now
+        assert metrics.active_session_count == 3
+        assert metrics.total_use_count == 15
+        assert metrics.pooled_session_count == 5
+
+
+class TestClassificationMetadata:
+    """Tests for ClassificationMetadata dataclass."""
+
+    def test_metadata_required_fields(self):
+        """Test ClassificationMetadata required fields."""
+        now = time.time()
+        metadata = ClassificationMetadata(
+            total_servers=10,
+            hot_cap=2,
+            hot_actual=2,
+            eligible_count=5,
+            timestamp=now,
+        )
+
+        assert metadata.total_servers == 10
+        assert metadata.hot_cap == 2
+        assert metadata.hot_actual == 2
+        assert metadata.eligible_count == 5
+        assert metadata.timestamp == now
+        assert metadata.underutilized_reason is None
+
+    def test_metadata_with_underutilization(self):
+        """Test ClassificationMetadata with underutilization reason."""
+        metadata = ClassificationMetadata(
+            total_servers=10, hot_cap=2, hot_actual=1, eligible_count=1, timestamp=time.time(), underutilized_reason="Only 1 servers have pooled sessions, below hot_cap=2"
+        )
+
+        assert metadata.hot_actual == 1
+        assert metadata.underutilized_reason is not None
+        assert "Only 1 servers" in metadata.underutilized_reason
+
+
+class TestClassificationResult:
+    """Tests for ClassificationResult dataclass."""
+
+    def test_classification_result_structure(self):
+        """Test ClassificationResult structure."""
+        metadata = ClassificationMetadata(total_servers=5, hot_cap=1, hot_actual=1, eligible_count=3, timestamp=time.time())
+
+        result = ClassificationResult(hot_servers=["http://hot1:8080"], cold_servers=["http://cold1:8080", "http://cold2:8080", "http://cold3:8080", "http://cold4:8080"], metadata=metadata)
+
+        assert len(result.hot_servers) == 1
+        assert len(result.cold_servers) == 4
+        assert result.metadata.total_servers == 5
+        assert set(result.hot_servers + result.cold_servers) == {
+            "http://hot1:8080",
+            "http://cold1:8080",
+            "http://cold2:8080",
+            "http://cold3:8080",
+            "http://cold4:8080",
+        }
+
+
+class TestClassificationLogic:
+    """Tests for server classification algorithm."""
+
+    def _create_pooled_session(self, url: str, last_used: float, use_count: int = 0) -> PooledSession:
+        """Helper to create a mock PooledSession."""
+        mock_session = MagicMock()
+        mock_transport = MagicMock()
+
+        return PooledSession(
+            session=mock_session,
+            transport_context=mock_transport,
+            url=url,
+            identity_key="anonymous",
+            transport_type=TransportType.STREAMABLE_HTTP,
+            headers={},
+            created_at=time.time() - 300,
+            last_used=last_used,
+            use_count=use_count,
+        )
+
+    def _setup_pool_with_sessions(self, sessions_by_url: Dict[str, List[PooledSession]]) -> MCPSessionPool:
+        """Helper to setup MCPSessionPool with mock sessions."""
+        pool = MCPSessionPool()
+
+        # Mock the _pools dict (Dict[PoolKey, Queue[PooledSession]])
+        pool._pools = {}
+        pool._active = {}
+
+        for url, sessions in sessions_by_url.items():
+            # Create pool key: (user_identity, url, identity_hash, transport_type, gateway_id)
+            pool_key = ("anonymous", url, "hash123", TransportType.STREAMABLE_HTTP, None)
+
+            # Create queue with sessions
+            queue = asyncio.Queue()
+            queue._queue = deque(sessions)  # Direct access to internal deque
+
+            pool._pools[pool_key] = queue
+            pool._active[pool_key] = set()  # Empty active set for simplicity
+
+        return pool
+
+    def test_classification_basic_20_percent(self):
+        """Test basic 20% hot server classification."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Create 5 servers (20% = 1 hot server)
+        sessions_by_url = {
+            f"http://server{i}:8080": [self._create_pooled_session(f"http://server{i}:8080", now - (i * 10), use_count=10 - i)]
+            for i in range(5)
+        }
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+        all_urls = list(sessions_by_url.keys())
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # Should have 1 hot server (floor(5 * 0.20) = 1)
+        assert result.metadata.total_servers == 5
+        assert result.metadata.hot_cap == 1
+        assert result.metadata.hot_actual == 1
+        assert result.metadata.eligible_count == 5
+        assert len(result.hot_servers) == 1
+        assert len(result.cold_servers) == 4
+
+        # Most recently used server should be hot
+        assert result.hot_servers[0] == "http://server0:8080"
+
+    def test_classification_sorting_by_recency(self):
+        """Test servers sorted by most recent usage (primary sort key)."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Create 10 servers with different last_used times
+        sessions_by_url = {f"http://server{i}:8080": [self._create_pooled_session(f"http://server{i}:8080", now - (i * 100))] for i in range(10)}
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+        all_urls = list(sessions_by_url.keys())
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # Should have 2 hot servers (floor(10 * 0.20) = 2)
+        assert result.metadata.hot_cap == 2
+        assert len(result.hot_servers) == 2
+
+        # Most recent servers should be hot
+        assert "http://server0:8080" in result.hot_servers
+        assert "http://server1:8080" in result.hot_servers
+
+    def test_classification_tie_breaker_active_sessions(self):
+        """Test tie-breaking by active session count when last_used is equal."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Create 6 servers with same last_used but different active counts (need 6 for hot_cap=1)
+        sessions_by_url = {
+            "http://server1:8080": [self._create_pooled_session("http://server1:8080", now)],
+            "http://server2:8080": [self._create_pooled_session("http://server2:8080", now)],
+            "http://server3:8080": [self._create_pooled_session("http://server3:8080", now)],
+            "http://server4:8080": [self._create_pooled_session("http://server4:8080", now)],
+            "http://server5:8080": [self._create_pooled_session("http://server5:8080", now)],
+            "http://server6:8080": [self._create_pooled_session("http://server6:8080", now)],
+        }
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+
+        # Mock active sessions (server2 has most active)
+        pool._active[("anonymous", "http://server1:8080", "hash123", TransportType.STREAMABLE_HTTP, None)] = {1}  # 1 active
+        pool._active[("anonymous", "http://server2:8080", "hash123", TransportType.STREAMABLE_HTTP, None)] = {1, 2, 3}  # 3 active
+        pool._active[("anonymous", "http://server3:8080", "hash123", TransportType.STREAMABLE_HTTP, None)] = {1, 2}  # 2 active
+        pool._active[("anonymous", "http://server4:8080", "hash123", TransportType.STREAMABLE_HTTP, None)] = set()  # 0 active
+        pool._active[("anonymous", "http://server5:8080", "hash123", TransportType.STREAMABLE_HTTP, None)] = set()  # 0 active
+        pool._active[("anonymous", "http://server6:8080", "hash123", TransportType.STREAMABLE_HTTP, None)] = set()  # 0 active
+
+        all_urls = list(sessions_by_url.keys())
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # hot_cap = floor(6 * 0.20) = 1
+        assert result.metadata.hot_cap == 1
+        assert len(result.hot_servers) == 1
+        # Server with most active sessions should be first hot
+        assert result.hot_servers[0] == "http://server2:8080"
+
+    def test_classification_tie_breaker_use_count(self):
+        """Test tie-breaking by total use count."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Create 6 servers with same last_used and active count, different use_count
+        sessions_by_url = {
+            "http://server1:8080": [self._create_pooled_session("http://server1:8080", now, use_count=50)],
+            "http://server2:8080": [self._create_pooled_session("http://server2:8080", now, use_count=100)],
+            "http://server3:8080": [self._create_pooled_session("http://server3:8080", now, use_count=75)],
+            "http://server4:8080": [self._create_pooled_session("http://server4:8080", now, use_count=30)],
+            "http://server5:8080": [self._create_pooled_session("http://server5:8080", now, use_count=20)],
+            "http://server6:8080": [self._create_pooled_session("http://server6:8080", now, use_count=10)],
+        }
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+        all_urls = list(sessions_by_url.keys())
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # hot_cap = floor(6 * 0.20) = 1
+        assert result.metadata.hot_cap == 1
+        assert len(result.hot_servers) == 1
+        # Server with highest use_count should be first hot
+        assert result.hot_servers[0] == "http://server2:8080"
+
+    def test_classification_deterministic_url_tie_breaker(self):
+        """Test deterministic tie-breaking by URL (alphabetical)."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Create 6 servers with identical metrics (need 6 for hot_cap=1)
+        sessions_by_url = {
+            "http://zebra:8080": [self._create_pooled_session("http://zebra:8080", now, use_count=10)],
+            "http://alpha:8080": [self._create_pooled_session("http://alpha:8080", now, use_count=10)],
+            "http://beta:8080": [self._create_pooled_session("http://beta:8080", now, use_count=10)],
+            "http://charlie:8080": [self._create_pooled_session("http://charlie:8080", now, use_count=10)],
+            "http://delta:8080": [self._create_pooled_session("http://delta:8080", now, use_count=10)],
+            "http://echo:8080": [self._create_pooled_session("http://echo:8080", now, use_count=10)],
+        }
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+        all_urls = list(sessions_by_url.keys())
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # hot_cap = floor(6 * 0.20) = 1
+        assert result.metadata.hot_cap == 1
+        assert len(result.hot_servers) == 1
+        # Should sort by URL alphabetically (ascending) as final tie-breaker
+        assert result.hot_servers[0] == "http://alpha:8080"
+
+    def test_classification_no_sessions_all_cold(self):
+        """Test classification when no servers have pooled sessions."""
+        service = ServerClassificationService(redis_client=None)
+
+        # Empty pool
+        pool = MCPSessionPool()
+        pool._pools = {}
+        pool._active = {}
+
+        all_urls = ["http://server1:8080", "http://server2:8080", "http://server3:8080"]
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # No hot servers, all cold
+        assert result.metadata.total_servers == 3
+        assert result.metadata.hot_cap == 0  # floor(3 * 0.20) = 0
+        assert result.metadata.eligible_count == 0
+        assert len(result.hot_servers) == 0
+        assert len(result.cold_servers) == 3
+        # No underutilization reason when both hot_cap and eligible are 0
+        assert result.metadata.underutilized_reason is None
+
+    def test_classification_partial_eligibility(self):
+        """Test classification when only some servers have sessions."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Only 2 out of 10 servers have sessions
+        sessions_by_url = {
+            "http://server1:8080": [self._create_pooled_session("http://server1:8080", now)],
+            "http://server2:8080": [self._create_pooled_session("http://server2:8080", now - 100)],
+        }
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+
+        # Total 10 servers in database
+        all_urls = [f"http://server{i}:8080" for i in range(1, 11)]
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # hot_cap = floor(10 * 0.20) = 2, but only 2 eligible
+        assert result.metadata.total_servers == 10
+        assert result.metadata.hot_cap == 2
+        assert result.metadata.eligible_count == 2
+        assert result.metadata.hot_actual == 2
+        assert len(result.hot_servers) == 2
+        assert len(result.cold_servers) == 8
+
+    def test_classification_underutilization_reason(self):
+        """Test underutilization reason when eligible < hot_cap."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Only 1 server has session, but hot_cap = 4
+        sessions_by_url = {"http://server1:8080": [self._create_pooled_session("http://server1:8080", now)]}
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+        all_urls = [f"http://server{i}:8080" for i in range(1, 21)]  # 20 servers
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        assert result.metadata.hot_cap == 4  # floor(20 * 0.20)
+        assert result.metadata.eligible_count == 1
+        assert result.metadata.underutilized_reason is not None
+        assert "Only 1 servers have pooled sessions" in result.metadata.underutilized_reason
+        assert "below hot_cap=4" in result.metadata.underutilized_reason
+
+    def test_classification_no_overlap_full_coverage(self):
+        """Test that hot and cold sets have no overlap and cover all servers."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        sessions_by_url = {f"http://server{i}:8080": [self._create_pooled_session(f"http://server{i}:8080", now - (i * 10))] for i in range(15)}
+
+        pool = self._setup_pool_with_sessions(sessions_by_url)
+        all_urls = list(sessions_by_url.keys())
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # Verify no overlap
+        hot_set = set(result.hot_servers)
+        cold_set = set(result.cold_servers)
+        assert len(hot_set & cold_set) == 0
+
+        # Verify full coverage
+        all_set = set(all_urls)
+        classified_set = hot_set | cold_set
+        assert classified_set == all_set
+
+    def test_classification_multiple_sessions_per_server(self):
+        """Test server metrics aggregation across multiple pooled sessions."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Server has 3 pooled sessions with different last_used times
+        server_url = "http://server1:8080"
+        sessions = [
+            self._create_pooled_session(server_url, now - 50, use_count=10),  # Oldest
+            self._create_pooled_session(server_url, now - 20, use_count=5),  # Middle
+            self._create_pooled_session(server_url, now - 5, use_count=15),  # Most recent
+        ]
+
+        pool = self._setup_pool_with_sessions({server_url: sessions})
+        # Need at least 5 servers for hot_cap = 1
+        all_urls = [server_url, "http://server2:8080", "http://server3:8080", "http://server4:8080", "http://server5:8080"]
+
+        # Add other servers with older last_used
+        for i in range(2, 6):
+            other_url = f"http://server{i}:8080"
+            other_sessions = [self._create_pooled_session(other_url, now - (100 * i), use_count=100)]
+            pool._pools[("anonymous", other_url, "hash123", TransportType.STREAMABLE_HTTP, None)] = asyncio.Queue()
+            pool._pools[("anonymous", other_url, "hash123", TransportType.STREAMABLE_HTTP, None)]._queue = deque(other_sessions)
+            pool._active[("anonymous", other_url, "hash123", TransportType.STREAMABLE_HTTP, None)] = set()
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # hot_cap = floor(5 * 0.20) = 1
+        assert result.metadata.hot_cap == 1
+        assert len(result.hot_servers) == 1
+        # Server1 should be hot (most recent aggregate last_used = now - 5)
+        assert result.hot_servers[0] == server_url
+        # Total use_count should be summed: 10 + 5 + 15 = 30
+        # (Verification via classification order, not direct assertion)
+
+    def test_classification_handles_session_extraction_error(self):
+        """Test classification handles errors when extracting session metrics."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        server_url = "http://server1:8080"
+
+        # Create a mock pool with a problematic session that raises error on attribute access
+        pool = MagicMock()
+        pool_key = ("anonymous", server_url, "hash123", TransportType.STREAMABLE_HTTP, None)
+
+        # Create a mock session that raises error when accessing attributes
+        bad_session = MagicMock()
+        bad_session.last_used = property(lambda self: 1 / 0)  # Will raise ZeroDivisionError
+
+        mock_queue = MagicMock()
+        mock_queue._queue = [bad_session]
+
+        pool._pools = {pool_key: mock_queue}
+        pool._active = {pool_key: set()}  # Empty active set
+
+        all_urls = [server_url]
+
+        # Should handle error gracefully and continue
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # Server should be classified as cold (no valid metrics extracted)
+        assert server_url in result.cold_servers
+        assert server_url not in result.hot_servers
+
+    def test_classification_counts_active_sessions(self):
+        """Test classification counts active sessions from pool._active."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        server_url = "http://server1:8080"
+        pool_key = ("anonymous", server_url, "hash123", TransportType.STREAMABLE_HTTP, None)
+
+        # Create pool with one pooled session
+        pooled_session = self._create_pooled_session(server_url, now - 10, use_count=5)
+
+        pool = MagicMock()
+        mock_queue = MagicMock()
+        mock_queue._queue = [pooled_session]
+
+        # Add 3 active sessions (mocked as a set with 3 items)
+        active_sessions = {MagicMock(), MagicMock(), MagicMock()}
+
+        pool._pools = {pool_key: mock_queue}
+        pool._active = {pool_key: active_sessions}
+
+        all_urls = [server_url, "http://server2:8080", "http://server3:8080", "http://server4:8080", "http://server5:8080"]
+
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        # Server should be hot (has both pooled and active sessions)
+        assert server_url in result.hot_servers
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_without_redis(self):
+        """Test _publish_classification_to_redis returns early when Redis is None."""
+        service = ServerClassificationService(redis_client=None)
+
+        metadata = ClassificationMetadata(total_servers=5, hot_cap=1, hot_actual=1, eligible_count=3, timestamp=time.time())
+        result = ClassificationResult(hot_servers=["http://hot1:8080"], cold_servers=["http://cold1:8080", "http://cold2:8080"], metadata=metadata)
+
+        # Should return early without error
+        await service._publish_classification_to_redis(result)
+
+        # No assertions needed - just verify it doesn't crash
+
+
+class TestLeaderElection:
+    """Tests for leader election in multi-worker deployments (atomic Lua script)."""
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_without_redis(self):
+        """Test leader lock always acquired in single-worker mode (no Redis)."""
+        service = ServerClassificationService(redis_client=None)
+
+        is_leader = await service._try_acquire_leader_lock()
+
+        assert is_leader is True
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_with_redis_success(self):
+        """Test successful leader lock acquisition with Redis via Lua script."""
+        mock_redis = AsyncMock()
+        mock_redis.script_load = AsyncMock(return_value="sha123")
+        mock_redis.evalsha = AsyncMock(return_value=1)  # Script returns 1 = acquired
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 60
+            service = ServerClassificationService(redis_client=mock_redis)
+            is_leader = await service._try_acquire_leader_lock()
+
+            assert is_leader is True
+            mock_redis.script_load.assert_awaited_once()
+            mock_redis.evalsha.assert_awaited_once_with(
+                "sha123", 1, ServerClassificationService.LEADER_KEY,
+                service._instance_id, str(180),
+            )
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_with_redis_contention(self):
+        """Test leader lock acquisition failure when another instance holds lock."""
+        mock_redis = AsyncMock()
+        mock_redis.script_load = AsyncMock(return_value="sha123")
+        mock_redis.evalsha = AsyncMock(return_value=0)  # Script returns 0 = not leader
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        is_leader = await service._try_acquire_leader_lock()
+
+        assert is_leader is False
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_renewal(self):
+        """Test leader retains lock on subsequent calls (Lua script renews TTL atomically)."""
+        mock_redis = AsyncMock()
+        mock_redis.script_load = AsyncMock(return_value="sha123")
+        # First call: acquired. Second call: renewed (both return 1).
+        mock_redis.evalsha = AsyncMock(return_value=1)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 60
+            service = ServerClassificationService(redis_client=mock_redis)
+
+            is_leader_1 = await service._try_acquire_leader_lock()
+            is_leader_2 = await service._try_acquire_leader_lock()
+
+            assert is_leader_1 is True
+            assert is_leader_2 is True
+            # script_load only called once (cached SHA)
+            assert mock_redis.script_load.await_count == 1
+            assert mock_redis.evalsha.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_redis_error_fail_safe(self):
+        """Test fail-safe behavior on Redis error during leader election."""
+        mock_redis = AsyncMock()
+        mock_redis.script_load = AsyncMock(side_effect=Exception("Redis connection error"))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        is_leader = await service._try_acquire_leader_lock()
+
+        # Should fail safe and NOT become leader on error
+        assert is_leader is False
+
+
+class TestPollingDecisions:
+    """Tests for should_poll_server logic."""
+
+    @pytest.mark.asyncio
+    async def test_should_poll_when_feature_disabled(self):
+        """Test polling always allowed when hot/cold classification is disabled."""
+        mock_redis = AsyncMock()
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = False
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is True
+            mock_redis.sismember.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_poll_without_redis(self):
+        """Test polling always allowed in single-worker mode (no Redis)."""
+        service = ServerClassificationService(redis_client=None)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is True
+
+    @pytest.mark.asyncio
+    async def test_should_poll_when_not_yet_classified(self):
+        """Test polling allowed when server not yet classified."""
+        mock_redis = AsyncMock()
+        # Server not in hot or cold sets
+        mock_redis.sismember = AsyncMock(return_value=False)
+        mock_redis.get = AsyncMock(return_value=None)
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is True
+
+    @pytest.mark.asyncio
+    async def test_should_poll_hot_server_interval_elapsed(self):
+        """Test hot server polling when interval has elapsed."""
+        mock_redis = AsyncMock()
+        # Server is hot
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # hot=True, cold=False
+        # Last polled 400 seconds ago
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 400))
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300  # 5 minutes
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is True
+            # Timestamp update is deferred to mark_poll_completed, not done here
+            mock_redis.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_poll_hot_server_interval_not_elapsed(self):
+        """Test hot server polling skipped when interval not elapsed."""
+        mock_redis = AsyncMock()
+        # Server is hot
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])
+        # Last polled 100 seconds ago
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 100))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is False
+
+    @pytest.mark.asyncio
+    async def test_should_poll_cold_server_interval_elapsed(self):
+        """Test cold server polling when interval has elapsed."""
+        mock_redis = AsyncMock()
+        # Server is cold
+        mock_redis.sismember = AsyncMock(side_effect=[False, True])  # hot=False, cold=True
+        # Last polled 950 seconds ago
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 950))
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.cold_server_check_interval = 900  # 15 minutes
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is True
+            # Timestamp update is deferred to mark_poll_completed, not done here
+            mock_redis.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_poll_cold_server_interval_not_elapsed(self):
+        """Test cold server polling skipped when interval not elapsed."""
+        mock_redis = AsyncMock()
+        # Server is cold
+        mock_redis.sismember = AsyncMock(side_effect=[False, True])
+        # Last polled 400 seconds ago
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 400))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.cold_server_check_interval = 900
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is False
+
+    @pytest.mark.asyncio
+    async def test_should_poll_never_polled_before(self):
+        """Test first poll of a classified server."""
+        mock_redis = AsyncMock()
+        # Server is hot but never polled
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])
+        mock_redis.get = AsyncMock(return_value=None)  # No previous poll
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_poll is True
+            # Timestamp update is deferred to mark_poll_completed, not done here
+            mock_redis.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_poll_different_poll_types_independent(self):
+        """Test health and tool_discovery polls tracked independently."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False, True, False])  # Both calls: hot server
+        now = time.time()
+
+        # Health polled recently, tools never polled
+        async def get_side_effect(key):
+            if "health" in key:
+                return str(now - 100)  # Recent health poll
+            elif "tool_discovery" in key:
+                return None  # Never polled tools
+            return None
+
+        mock_redis.get = AsyncMock(side_effect=get_side_effect)
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            # Health check should be skipped (too recent)
+            should_poll_health = await service.should_poll_server("http://test:8080", "health")
+            assert should_poll_health is False
+
+            # Tool discovery should proceed (never polled)
+            should_poll_tools = await service.should_poll_server("http://test:8080", "tool_discovery")
+            assert should_poll_tools is True
+
+    @pytest.mark.asyncio
+    async def test_should_poll_redis_error_fail_open(self):
+        """Test fail-open behavior on Redis error (allow polling)."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=Exception("Redis error"))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            should_poll = await service.should_poll_server("http://test:8080", "health")
+
+            # Should fail open and allow polling
+            assert should_poll is True
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_updates_redis(self):
+        """Test mark_poll_completed writes timestamp to Redis after actual poll."""
+        mock_redis = AsyncMock()
+        # Server is hot
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            await service.mark_poll_completed("http://test:8080", "health")
+
+            # Should write timestamp to Redis
+            mock_redis.set.assert_awaited_once()
+            call_args = mock_redis.set.await_args
+            assert call_args[1]["ex"] == 600  # 2x hot interval
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_no_redis(self):
+        """Test mark_poll_completed is a no-op without Redis."""
+        service = ServerClassificationService(redis_client=None)
+        # Should not raise
+        await service.mark_poll_completed("http://test:8080", "health")
+
+
+class TestRedisStateManagement:
+    """Tests for Redis state management."""
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_to_redis(self):
+        """Test classification result published to Redis atomically."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock()
+        mock_pipeline.delete = AsyncMock()
+        mock_pipeline.sadd = AsyncMock()
+        mock_pipeline.set = AsyncMock()
+        mock_pipeline.execute = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        metadata = ClassificationMetadata(total_servers=5, hot_cap=1, hot_actual=1, eligible_count=3, timestamp=time.time())
+        result = ClassificationResult(hot_servers=["http://hot1:8080"], cold_servers=["http://cold1:8080", "http://cold2:8080", "http://cold3:8080", "http://cold4:8080"], metadata=metadata)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 300
+
+            await service._publish_classification_to_redis(result)
+
+            # Verify pipeline was used (atomic transaction)
+            mock_redis.pipeline.assert_called_once_with(transaction=True)
+            mock_pipeline.execute.assert_awaited_once()
+
+            # Verify old classification cleared
+            mock_pipeline.delete.assert_awaited_once()
+
+            # Verify hot/cold servers added
+            assert mock_pipeline.sadd.await_count == 2  # hot and cold sets
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_empty_sets(self):
+        """Test publishing classification with empty hot or cold sets."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock()
+        mock_pipeline.delete = AsyncMock()
+        mock_pipeline.sadd = AsyncMock()
+        mock_pipeline.set = AsyncMock()
+        mock_pipeline.execute = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        metadata = ClassificationMetadata(total_servers=2, hot_cap=0, hot_actual=0, eligible_count=0, timestamp=time.time())
+        result = ClassificationResult(hot_servers=[], cold_servers=["http://cold1:8080", "http://cold2:8080"], metadata=metadata)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 300
+
+            await service._publish_classification_to_redis(result)
+
+            # Should only add cold servers (hot is empty)
+            await_calls = [call for call in mock_pipeline.sadd.await_args_list]
+            assert len(await_calls) == 1  # Only cold set
+
+    @pytest.mark.asyncio
+    async def test_get_server_classification_hot(self):
+        """Test retrieving hot server classification."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # hot=True
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        classification = await service.get_server_classification("http://test:8080")
+
+        assert classification == "hot"
+
+    @pytest.mark.asyncio
+    async def test_get_server_classification_cold(self):
+        """Test retrieving cold server classification."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[False, True])  # hot=False, cold=True
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        classification = await service.get_server_classification("http://test:8080")
+
+        assert classification == "cold"
+
+    @pytest.mark.asyncio
+    async def test_get_server_classification_not_classified(self):
+        """Test retrieving classification for unclassified server."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(return_value=False)  # Not in any set
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        classification = await service.get_server_classification("http://test:8080")
+
+        assert classification is None
+
+    @pytest.mark.asyncio
+    async def test_get_server_classification_without_redis(self):
+        """Test classification retrieval without Redis."""
+        service = ServerClassificationService(redis_client=None)
+        classification = await service.get_server_classification("http://test:8080")
+
+        assert classification is None
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_updates_timestamp(self):
+        """Test mark_poll_completed writes timestamp to Redis."""
+        mock_redis = AsyncMock()
+        # Server is hot
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            await service.mark_poll_completed("http://test:8080", "health")
+
+            # Should set timestamp with 2x interval expiry
+            mock_redis.set.assert_awaited_once()
+            args = mock_redis.set.await_args
+            import hashlib
+            url_hash = hashlib.sha256(b"http://test:8080").hexdigest()[:32]
+            expected_key = f"mcpgateway:server_poll_state:{url_hash}:last_health"
+            assert args[0][0] == expected_key
+            assert args[1]["ex"] == 600  # 2x interval
+
+
+class TestServiceLifecycle:
+    """Tests for service start/stop lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_start_when_disabled(self):
+        """Test service start when feature is disabled."""
+        service = ServerClassificationService(redis_client=None)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = False
+
+            await service.start()
+
+            assert service._running is False
+            assert service._classification_task is None
+
+    @pytest.mark.asyncio
+    async def test_start_when_enabled(self):
+        """Test service start when feature is enabled."""
+        service = ServerClassificationService(redis_client=None)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            try:
+                await service.start()
+
+                assert service._running is True
+                assert service._classification_task is not None
+                assert isinstance(service._classification_task, asyncio.Task)
+            finally:
+                await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_when_already_running(self):
+        """Test service start when already running (idempotent)."""
+        service = ServerClassificationService(redis_client=None)
+        service._running = True
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            await service.start()
+
+            # Should log warning but not crash
+            assert service._running is True
+
+    @pytest.mark.asyncio
+    async def test_stop_service(self):
+        """Test service stop."""
+        service = ServerClassificationService(redis_client=None)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            await service.start()
+            await service.stop()
+
+            assert service._running is False
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_running(self):
+        """Test stop when service not running."""
+        service = ServerClassificationService(redis_client=None)
+
+        await service.stop()
+
+        # Should complete without error
+        assert service._running is False
+
+    @pytest.mark.asyncio
+    async def test_stop_after_task_died_with_exception(self):
+        """Stop must not crash when the background task already died with an error."""
+        service = ServerClassificationService(redis_client=None)
+
+        # Simulate a task that already finished with an exception
+        async def _boom():
+            raise RuntimeError("unexpected crash")
+
+        service._classification_task = asyncio.create_task(_boom())
+        # Let the task fail
+        await asyncio.sleep(0.05)
+
+        # stop() must not propagate the RuntimeError
+        await service.stop()
+        assert service._running is False
+
+
+    @pytest.mark.asyncio
+    async def test_on_classification_task_done_with_exception(self):
+        """_on_classification_task_done logs error and sets _running=False when task dies."""
+        service = ServerClassificationService(redis_client=None)
+        service._running = True
+
+        async def _fail():
+            raise RuntimeError("boom")
+
+        task = asyncio.create_task(_fail())
+        await asyncio.sleep(0.05)
+
+        service._on_classification_task_done(task)
+        assert service._running is False
+
+    @pytest.mark.asyncio
+    async def test_on_classification_task_done_cancelled_is_noop(self):
+        """_on_classification_task_done is a no-op when the task was cancelled."""
+        service = ServerClassificationService(redis_client=None)
+        service._running = True
+
+        async def _sleep():
+            await asyncio.sleep(999)
+
+        task = asyncio.create_task(_sleep())
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        service._on_classification_task_done(task)
+        # _running should NOT be changed for cancellation
+        assert service._running is True
+
+    @pytest.mark.asyncio
+    async def test_classification_timeout(self):
+        """Classification that exceeds timeout is cancelled, loop continues."""
+        service = ServerClassificationService(redis_client=None)
+        service._running = True
+        service._leader_ttl = 1  # 0.8s timeout
+
+        call_count = 0
+
+        async def slow_classify():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(10)  # Will be cancelled by timeout
+
+        with (
+            patch.object(service, "_try_acquire_leader_lock", AsyncMock(return_value=True)),
+            patch.object(service, "_perform_classification", side_effect=slow_classify),
+            patch("mcpgateway.services.server_classification_service.settings") as mock_settings,
+        ):
+            mock_settings.gateway_auto_refresh_interval = 0.05
+
+            task = asyncio.create_task(service._run_classification_loop())
+            await asyncio.sleep(1.5)
+            service._running = False
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_noscript_recovery(self):
+        """NOSCRIPT error triggers script re-registration and retry."""
+        mock_redis = AsyncMock()
+        mock_redis.script_load = AsyncMock(return_value="sha_new")
+
+        # First evalsha raises NOSCRIPT, second succeeds
+        mock_redis.evalsha = AsyncMock(side_effect=[Exception("NOSCRIPT No matching script"), 1])
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 60
+            service = ServerClassificationService(redis_client=mock_redis)
+
+            is_leader = await service._try_acquire_leader_lock()
+
+            assert is_leader is True
+            # script_load called twice: initial + recovery
+            assert mock_redis.script_load.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_leader_lock_non_noscript_error_reraises(self):
+        """Non-NOSCRIPT evalsha errors are reraised and caught by outer handler."""
+        mock_redis = AsyncMock()
+        mock_redis.script_load = AsyncMock(return_value="sha123")
+        mock_redis.evalsha = AsyncMock(side_effect=Exception("connection refused"))
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 60
+            service = ServerClassificationService(redis_client=mock_redis)
+
+            # Should fail safe (False), not crash
+            is_leader = await service._try_acquire_leader_lock()
+            assert is_leader is False
+
+    def test_accumulate_session_creates_metrics_entry_for_new_url(self):
+        """_accumulate_session in _classify_servers_from_pool creates ServerUsageMetrics for unseen URLs."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Active-only: session only in _active, not in _pools idle queue
+        url = "http://active-only:8080"
+        pool_key = ("anon", url, "h1", "sse", "")
+
+        active_session = MagicMock()
+        active_session.last_used = now
+        active_session.use_count = 3
+
+        pool = MagicMock()
+        pool._pools = {}  # Empty idle queue — no pool key at all
+        pool._active = {pool_key: {active_session}}
+
+        result = service._classify_servers_from_pool(pool, [url])
+
+        # Session from _active should have created metrics and made server eligible
+        assert url in result.hot_servers or url in result.cold_servers
+
+
+class TestIntegrationWithGatewayService:
+    """Integration tests with GatewayService health checks."""
+
+    @pytest.mark.asyncio
+    async def test_gateway_service_respects_hot_polling(self):
+        """Test GatewayService health check respects hot server polling interval."""
+        # This test verifies integration points between GatewayService and ServerClassificationService
+        # The actual integration is tested via the should_poll_server calls in gateway_service.py
+
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # Server is hot
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 100))  # Recently polled
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            # Simulate GatewayService calling should_poll_server before health check
+            should_check = await service.should_poll_server("http://test:8080", "health")
+
+            # Should skip health check (too recent)
+            assert should_check is False
+
+    @pytest.mark.asyncio
+    async def test_gateway_service_respects_cold_polling(self):
+        """Test GatewayService health check respects cold server polling interval."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[False, True])  # Server is cold
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 400))  # Polled 400s ago
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.cold_server_check_interval = 900  # 15 minutes
+
+            # Cold server polled 400s ago, should wait longer
+            should_check = await service.should_poll_server("http://test:8080", "health")
+
+            assert should_check is False
+
+
+class TestErrorHandling:
+    """Tests for error handling in ServerClassificationService."""
+
+    @pytest.mark.asyncio
+    async def test_classification_loop_handles_no_leader(self):
+        """Test classification loop skips when not leader."""
+        mock_redis = AsyncMock()
+        service = ServerClassificationService(redis_client=mock_redis)
+        service._running = True
+
+        with patch.object(service, "_try_acquire_leader_lock", AsyncMock(return_value=False)):
+            with patch.object(service, "_perform_classification", AsyncMock()) as mock_perform:
+                # Run one iteration
+                service._running = False  # Stop after one iteration
+
+                # Start loop - it should exit without performing classification
+                with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+                    mock_settings.gateway_auto_refresh_interval = 0.1
+                    try:
+                        await asyncio.wait_for(service._run_classification_loop(), timeout=0.5)
+                    except asyncio.TimeoutError:
+                        pass
+
+                # Classification should not have been performed
+                mock_perform.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classification_loop_handles_general_error(self):
+        """Test classification loop continues after general error."""
+        mock_redis = AsyncMock()
+        service = ServerClassificationService(redis_client=mock_redis)
+        service._running = True
+
+        call_count = 0
+
+        async def mock_acquire():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("Unexpected error")
+            return False  # Not leader on subsequent calls
+
+        # Override error backoff to avoid 30s delay in tests
+        service._error_backoff_seconds = 0.001
+
+        with patch.object(service, "_try_acquire_leader_lock", side_effect=mock_acquire):
+            with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+                mock_settings.gateway_auto_refresh_interval = 0.05
+
+                # Start loop
+                task = asyncio.create_task(service._run_classification_loop())
+
+                # Wait long enough for error to occur and loop to continue
+                await asyncio.sleep(0.3)
+
+                service._running = False
+                await asyncio.sleep(0.15)
+                task.cancel()
+
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+                # Verify loop continued after error (call_count > 1)
+                assert call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_perform_classification_handles_no_gateways(self):
+        """Test _perform_classification handles no gateways gracefully."""
+        mock_redis = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        # _get_gateway_url_map is a method on the service instance
+        with patch.object(service, "_get_gateway_url_map", AsyncMock(return_value={})):
+            # get_mcp_session_pool is imported lazily inside _perform_classification
+            with patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=MagicMock()):
+                # Should return early without error
+                await service._perform_classification()
+
+                # Redis should not be called (no classification to publish)
+                mock_redis.pipeline.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extract_metrics_handles_missing_url_in_active(self):
+        """Test metric extraction handles missing URLs in active dict."""
+        from collections import defaultdict
+
+        mock_pool = MagicMock()
+        mock_pool._idle = defaultdict(lambda: deque())  # Empty idle queue
+        mock_pool._active = {
+            ("user@example.com", "http://test:8080"): set([MagicMock()]),
+            ("user@example.com", "http://unknown:8080"): set([MagicMock()]),
+        }
+
+        service = ServerClassificationService(redis_client=None)
+
+        # Should not raise error when processing active sessions with unknown URLs
+        result = service._classify_servers_from_pool(
+            pool=mock_pool,
+            all_gateway_urls=["http://test:8080"]  # Only one URL in all_gateway_urls
+        )
+
+        # Should complete without error
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_extract_metrics_handles_session_attribute_error(self):
+        """Test metric extraction handles sessions with missing attributes."""
+        mock_session = MagicMock()
+        # Remove use_count attribute to trigger AttributeError path
+        del mock_session.use_count
+        mock_session.last_used = time.time()
+
+        mock_pool = MagicMock()
+        mock_pool._idle = {
+            ("user@example.com", "http://test:8080"): deque([mock_session])
+        }
+        mock_pool._active = {}
+
+        service = ServerClassificationService(redis_client=None)
+
+        # Should handle missing use_count attribute gracefully
+        result = service._classify_servers_from_pool(
+            pool=mock_pool,
+            all_gateway_urls=["http://test:8080"]
+        )
+
+        # Should complete without error
+        assert result is not None
+        assert "http://test:8080" in result.hot_servers or "http://test:8080" in result.cold_servers
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_handles_redis_error(self):
+        """Test _publish_classification_to_redis handles Redis errors."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_pipeline.execute = AsyncMock(side_effect=Exception("Redis error"))
+        mock_redis.pipeline.return_value.__aenter__.return_value = mock_pipeline
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        metadata = ClassificationMetadata(
+            total_servers=2,
+            hot_cap=1,
+            hot_actual=1,
+            eligible_count=2,
+            timestamp=time.time()
+        )
+        result = ClassificationResult(
+            hot_servers=["http://hot:8080"],
+            cold_servers=["http://cold:8080"],
+            metadata=metadata
+        )
+
+        # Should not raise exception, just log error
+        await service._publish_classification_to_redis(result)
+
+    @pytest.mark.asyncio
+    async def test_classification_loop_as_leader_calls_perform(self):
+        """Test classification loop calls _perform_classification when leader (lines 147-148)."""
+        mock_redis = AsyncMock()
+        service = ServerClassificationService(redis_client=mock_redis)
+        service._running = True
+
+        perform_called = asyncio.Event()
+
+        async def mock_perform():
+            perform_called.set()
+            service._running = False  # Stop after first call
+
+        with patch.object(service, "_try_acquire_leader_lock", AsyncMock(return_value=True)):
+            with patch.object(service, "_perform_classification", side_effect=mock_perform):
+                with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+                    mock_settings.gateway_auto_refresh_interval = 0.05
+                    await asyncio.wait_for(service._run_classification_loop(), timeout=2.0)
+
+        assert perform_called.is_set()
+
+    @pytest.mark.asyncio
+    async def test_classification_loop_cancelled_error(self):
+        """Test classification loop handles CancelledError cleanly (lines 155-156)."""
+        mock_redis = AsyncMock()
+        service = ServerClassificationService(redis_client=mock_redis)
+        service._running = True
+
+        with patch.object(service, "_try_acquire_leader_lock", AsyncMock(return_value=False)):
+            with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+                mock_settings.gateway_auto_refresh_interval = 10  # Long sleep so we can cancel
+
+                task = asyncio.create_task(service._run_classification_loop())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass  # CancelledError propagates from asyncio.sleep, not the break
+
+    @pytest.mark.asyncio
+    async def test_perform_classification_pool_not_initialized(self):
+        """Test _perform_classification returns early when pool not initialized (lines 188-190)."""
+        service = ServerClassificationService(redis_client=None)
+
+        with patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", side_effect=RuntimeError("pool not initialized")):
+            # Should return early without error
+            await service._perform_classification()
+
+    @pytest.mark.asyncio
+    async def test_perform_classification_logs_underutilized_reason(self):
+        """Test _perform_classification logs underutilized_reason when present (line 210)."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock(return_value=False)
+        mock_pipeline.execute = AsyncMock(return_value=None)
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        # Use 20 URLs so hot_cap=4, but only 1 has session activity → underutilized
+        all_urls = [f"http://server{i}:8080" for i in range(20)]
+        mock_pool = MagicMock()
+        pool_key = ("anonymous", all_urls[0], "hash123", TransportType.STREAMABLE_HTTP, None)
+        mock_queue = MagicMock()
+        active_session = MagicMock()
+        active_session.last_used = time.time()
+        active_session.use_count = 5
+        mock_queue._queue = deque([active_session])
+        mock_pool._pools = {pool_key: mock_queue}
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+            mock_settings.cold_server_check_interval = 900
+            mock_settings.gateway_auto_refresh_interval = 60
+
+            with patch.object(service, "_get_gateway_url_map", AsyncMock(return_value={f"gw-{i}": u for i, u in enumerate(all_urls)})):
+                with patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=mock_pool):
+                    await service._perform_classification()
+
+        mock_redis.pipeline.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_perform_classification_full_happy_path(self):
+        """Test _perform_classification runs classification and publishes to Redis (lines 199-213)."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock(return_value=False)
+        mock_pipeline.execute = AsyncMock(return_value=None)
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        mock_pool = MagicMock()
+        mock_pool._pools = {}  # Empty pool — all servers will be cold
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+            mock_settings.cold_server_check_interval = 900
+            mock_settings.gateway_auto_refresh_interval = 60
+
+            with patch.object(service, "_get_gateway_url_map", AsyncMock(return_value={"gw-1": "http://test:8080"})):
+                with patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=mock_pool):
+                    await service._perform_classification()
+
+        # Redis pipeline should have been called to publish classification
+        mock_redis.pipeline.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_perform_classification_exception_path(self):
+        """Test _perform_classification catches and logs unexpected exceptions (line 212-213)."""
+        service = ServerClassificationService(redis_client=None)
+
+        with patch.object(service, "_get_gateway_url_map", AsyncMock(side_effect=RuntimeError("unexpected"))):
+            with patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=MagicMock()):
+                # Should not raise — exception is caught inside _perform_classification
+                await service._perform_classification()
+
+    @pytest.mark.asyncio
+    async def test_classify_servers_queue_missing_queue_attr(self):
+        """Test _classify_servers_from_pool handles queue without _queue attribute (lines 254-255)."""
+        mock_pool = MagicMock()
+        pool_key = ("anonymous", "http://test:8080", "hash123", TransportType.STREAMABLE_HTTP, None)
+
+        # Queue that does NOT have _queue attribute
+        mock_queue = MagicMock(spec=[])  # spec=[] means no attributes allowed
+        mock_pool._pools = {pool_key: mock_queue}
+
+        service = ServerClassificationService(redis_client=None)
+        result = service._classify_servers_from_pool(mock_pool, ["http://test:8080"])
+
+        # Should complete without error, server goes cold (no session data)
+        assert result is not None
+        assert "http://test:8080" in result.cold_servers
+
+    @pytest.mark.asyncio
+    async def test_get_gateway_url_map_handles_db_error(self):
+        """Test _get_gateway_url_map handles database errors."""
+        # _get_gateway_url_map is a method on ServerClassificationService
+        # SessionLocal is imported lazily inside the method from mcpgateway.db
+        service = ServerClassificationService(redis_client=None)
+        with patch("mcpgateway.db.SessionLocal") as mock_session_local:
+            mock_session_local.return_value.__enter__.return_value.execute.side_effect = Exception("Database error")
+
+            # Should return empty dict on error, not raise exception
+            result = await service._get_gateway_url_map()
+            assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_server_classification_handles_redis_error(self):
+        """Test get_server_classification handles Redis errors gracefully."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=Exception("Redis error"))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        # Should return None on error (fail-open)
+        result = await service.get_server_classification("http://test:8080")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_poll_server_handles_redis_error(self):
+        """Test should_poll_server returns True on Redis error (fail-open)."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=Exception("Redis error"))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            # Should return True on error (fail-open)
+            result = await service.should_poll_server("http://test:8080", "health")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_handles_redis_error(self):
+        """Test mark_poll_completed handles Redis errors gracefully."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # hot server
+        mock_redis.set = AsyncMock(side_effect=Exception("Redis error"))
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            # Should not raise exception, just log warning
+            await service.mark_poll_completed("http://test:8080", "health")
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_with_no_redis(self):
+        """Test mark_poll_completed returns early when Redis is None."""
+        service = ServerClassificationService(redis_client=None)
+
+        # Should return early without error
+        await service.mark_poll_completed("http://test:8080", "health")
+
+
+class TestBoundsAndEdgeCases:
+    """Tests for boundary conditions and edge cases introduced by security fixes."""
+
+    # ------------------------------------------------------------------
+    # Finding #3: Redis timestamp bounds validation
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_should_poll_server_with_future_timestamp(self):
+        """Future timestamp in Redis (e.g. clock skew / tampering) is treated as never polled."""
+        import hashlib
+
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # Server is hot
+
+        far_future = str(time.time() + 9_000_000)  # ~100 days in future
+        mock_redis.get = AsyncMock(return_value=far_future)
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            # Future timestamp should be reset → elapsed treated as 0 → should poll now
+            result = await service.should_poll_server("http://test:8080", "health")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_should_poll_server_with_timestamp_at_bounds_boundary(self):
+        """Timestamp exactly at now+60 is accepted; now+61 is rejected."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False, True, False])
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        now = time.time()
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            mock_redis.set = AsyncMock()
+
+            # Timestamp 61s in future → beyond bound → treated as 0 → elapsed = now → should poll
+            mock_redis.get = AsyncMock(return_value=str(now + 61))
+            result = await service.should_poll_server("http://test:8080", "health")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_should_poll_redis_returns_non_numeric_timestamp(self):
+        """Non-numeric value in Redis timestamp key triggers fail-open (return True)."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])
+        mock_redis.get = AsyncMock(return_value="not-a-number")
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+
+            # float("not-a-number") raises ValueError → exception handler → fail open
+            result = await service.should_poll_server("http://test:8080", "health")
+            assert result is True
+
+    # ------------------------------------------------------------------
+    # Finding #5: URL-hashed Redis keys
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_should_poll_url_hash_key_used_not_raw_url(self):
+        """Redis key for poll state uses SHA-256 hash of URL, not raw URL."""
+        import hashlib
+
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])
+        url = "http://test:8080"
+        now = time.time()
+        mock_redis.get = AsyncMock(return_value=str(now - 1000))  # Long ago → should poll
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            await service.should_poll_server(url, "health")
+
+            # Verify the get was called with the hashed key, not the raw URL
+            url_hash = hashlib.sha256(url.encode()).hexdigest()[:32]
+            expected_key = f"mcpgateway:server_poll_state:{url_hash}:last_health"
+            mock_redis.get.assert_awaited_with(expected_key)
+
+    @pytest.mark.asyncio
+    async def test_mark_poll_completed_url_hash_key(self):
+        """mark_poll_completed uses SHA-256 hashed URL in the Redis key."""
+        import hashlib
+
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # hot server
+        mock_redis.set = AsyncMock()
+        url = "http://example.com:9000/path?query=1"
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+
+            await service.mark_poll_completed(url, "tool_discovery")
+
+            url_hash = hashlib.sha256(url.encode()).hexdigest()[:32]
+            expected_key = f"mcpgateway:server_poll_state:{url_hash}:last_tool_discovery"
+            args = mock_redis.set.await_args
+            assert args[0][0] == expected_key
+
+    # ------------------------------------------------------------------
+    # Finding #1: ORM is_(True) correctness
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_get_gateway_url_map_filters_disabled_gateways(self):
+        """Only enabled=True gateways are included; disabled gateways are excluded."""
+        service = ServerClassificationService(redis_client=None)
+
+        # Mock DB execution to return (id, url) tuples for enabled gateways only
+        mock_session = MagicMock()
+        mock_session.execute.return_value = [("gw-1", "http://enabled1:8080"), ("gw-2", "http://enabled2:8080")]
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        with patch("mcpgateway.db.SessionLocal", return_value=mock_ctx):
+            result = await service._get_gateway_url_map()
+
+        assert set(result.values()) == {"http://enabled1:8080", "http://enabled2:8080"}
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_gateway_url_map_returns_empty_when_none_enabled(self):
+        """Returns empty dict when no gateways are enabled."""
+        service = ServerClassificationService(redis_client=None)
+
+        mock_session = MagicMock()
+        mock_session.execute.return_value = []  # No enabled gateways
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        with patch("mcpgateway.db.SessionLocal", return_value=mock_ctx):
+            result = await service._get_gateway_url_map()
+
+        assert result == {}
+
+    # ------------------------------------------------------------------
+    # Classification correctness edge cases
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_classification_server_in_both_hot_and_cold_sets(self):
+        """Data corruption: server in both hot+cold — hot set takes priority."""
+        mock_redis = AsyncMock()
+        # Server returns True for hot check (first sismember call)
+        mock_redis.sismember = AsyncMock(side_effect=[True, True])
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        classification = await service.get_server_classification("http://test:8080")
+
+        # hot check runs first → returns "hot" immediately (cold never queried)
+        assert classification == "hot"
+        # Only one sismember call needed (short-circuits on hot=True)
+        assert mock_redis.sismember.await_count == 1
+
+    def test_classify_servers_url_in_active_not_in_pools(self):
+        """Gracefully handles URL present in _active but absent from _pools."""
+        service = ServerClassificationService(redis_client=None)
+
+        pool = MagicMock()
+        pool._pools = {}  # No pooled sessions
+        pool._active = {
+            ("anon", "http://ghost:8080", "h", None, None): {MagicMock()},
+        }
+
+        # Should not raise; ghost URL contributes no metrics
+        result = service._classify_servers_from_pool(pool, ["http://ghost:8080"])
+        assert result.metadata.eligible_count == 0
+        assert "http://ghost:8080" in result.cold_servers
+
+    def test_classify_servers_all_identical_metrics_url_tie_break(self):
+        """When all servers share identical metrics, URL (alphabetical) is tie-breaker."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # 5 servers, identical last_used/active/use_count — differ only by URL
+        urls = ["http://server-e:8080", "http://server-a:8080", "http://server-c:8080",
+                "http://server-b:8080", "http://server-d:8080"]
+
+        pool = MagicMock()
+        pool._active = {}
+
+        sessions = {}
+        for url in urls:
+            session = MagicMock()
+            session.last_used = now
+            session.use_count = 5
+            queue = MagicMock()
+            queue._queue = deque([session])
+            pool_key = ("anon", url, "hash", None, None)
+            sessions[pool_key] = queue
+
+        pool._pools = sessions
+
+        result = service._classify_servers_from_pool(pool, urls)
+
+        # hot_cap = floor(0.2 * 5) = 1 → 1 hot server
+        assert len(result.hot_servers) == 1
+        # Ascending URL sort → "a" sorts first → should NOT be hot (primary sort is -last_used desc)
+        # All have same last_used → tie broken by URL ascending → "server-a" first when sorted asc
+        # But sort key is m.url ASCENDING as tie-breaker, so server-a comes first in sorted list
+        assert result.hot_servers[0] == "http://server-a:8080"
+
+    def test_classify_servers_empty_pool_all_cold(self):
+        """When pool has no sessions, all provided gateway URLs are cold."""
+        service = ServerClassificationService(redis_client=None)
+
+        pool = MagicMock()
+        pool._pools = {}  # Empty pool
+        pool._active = {}
+
+        all_urls = ["http://server1:8080", "http://server2:8080", "http://server3:8080"]
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        assert result.hot_servers == []
+        assert set(result.cold_servers) == set(all_urls)
+        assert result.metadata.eligible_count == 0
+        assert result.metadata.hot_actual == 0
+
+    # ------------------------------------------------------------------
+    # Finding #4: Redis TTL on hot/cold sets
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_hot_cold_sets_have_ttl(self):
+        """Hot and cold Redis Sets must have a TTL set to prevent stale data."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock()
+        mock_pipeline.delete = AsyncMock()
+        mock_pipeline.sadd = AsyncMock()
+        mock_pipeline.expire = AsyncMock()
+        mock_pipeline.set = AsyncMock()
+        mock_pipeline.execute = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        metadata = ClassificationMetadata(total_servers=5, hot_cap=1, hot_actual=1, eligible_count=3, timestamp=time.time())
+        result = ClassificationResult(
+            hot_servers=["http://hot:8080"],
+            cold_servers=["http://cold1:8080", "http://cold2:8080", "http://cold3:8080", "http://cold4:8080"],
+            metadata=metadata,
+        )
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 300
+
+            await service._publish_classification_to_redis(result)
+
+        # expire must be called for HOT_KEY and COLD_KEY (sadd has no TTL parameter)
+        expire_keys = [call.args[0] for call in mock_pipeline.expire.await_args_list]
+        assert ServerClassificationService.CLASSIFICATION_HOT_KEY in expire_keys
+        assert ServerClassificationService.CLASSIFICATION_COLD_KEY in expire_keys
+        # TIMESTAMP_KEY gets its TTL via set(..., ex=ttl) — verify at least 2 expire calls
+        assert len(expire_keys) >= 2
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_ttl_is_two_x_interval(self):
+        """TTL applied to hot/cold sets equals 2× the gateway_auto_refresh_interval."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock()
+        mock_pipeline.delete = AsyncMock()
+        mock_pipeline.sadd = AsyncMock()
+        mock_pipeline.expire = AsyncMock()
+        mock_pipeline.set = AsyncMock()
+        mock_pipeline.execute = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        interval = 120
+
+        metadata = ClassificationMetadata(total_servers=2, hot_cap=1, hot_actual=1, eligible_count=1, timestamp=time.time())
+        result = ClassificationResult(hot_servers=["http://hot:8080"], cold_servers=["http://cold:8080"], metadata=metadata)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = interval
+            await service._publish_classification_to_redis(result)
+
+        expected_ttl = interval * 2
+        for call in mock_pipeline.expire.await_args_list:
+            assert call.args[1] == expected_ttl
+
+    # ------------------------------------------------------------------
+    # should_poll_server: interval boundary condition
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_should_poll_server_interval_exact_boundary(self):
+        """Elapsed time equal to the interval means should_poll is True (>= comparison)."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # hot
+        mock_redis.set = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        interval = 300
+        now = time.time()
+        # Set last_poll such that elapsed == exactly interval
+        mock_redis.get = AsyncMock(return_value=str(now - interval))
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = interval
+
+            with patch("mcpgateway.services.server_classification_service.time") as mock_time:
+                mock_time.time = MagicMock(return_value=now)
+                result = await service.should_poll_server("http://test:8080", "health")
+
+        assert result is True  # elapsed == interval → should poll
+
+    @pytest.mark.asyncio
+    async def test_should_poll_server_one_second_before_interval(self):
+        """Elapsed time one second less than interval means should_poll is False."""
+        mock_redis = AsyncMock()
+        mock_redis.sismember = AsyncMock(side_effect=[True, False])  # hot
+
+        service = ServerClassificationService(redis_client=mock_redis)
+        interval = 300
+        now = time.time()
+        # elapsed = interval - 1 → should NOT poll
+        mock_redis.get = AsyncMock(return_value=str(now - interval + 1))
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = interval
+
+            with patch("mcpgateway.services.server_classification_service.time") as mock_time:
+                mock_time.time = MagicMock(return_value=now)
+                result = await service.should_poll_server("http://test:8080", "health")
+
+        assert result is False
+
+
+class TestMissingBranchCoverage:
+    """Tests targeting uncovered branches in server_classification_service.py."""
+
+    # ------------------------------------------------------------------
+    # Branch 202->205: _perform_classification without Redis (skip publish, still log)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_perform_classification_without_redis_skips_publish(self):
+        """_perform_classification with redis_client=None skips Redis publish but still logs."""
+        service = ServerClassificationService(redis_client=None)
+
+        mock_pool = MagicMock()
+        mock_pool._pools = {}
+        mock_pool._active = {}
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.hot_cold_classification_enabled = True
+            mock_settings.hot_server_check_interval = 300
+            mock_settings.cold_server_check_interval = 900
+            mock_settings.gateway_auto_refresh_interval = 60
+
+            with patch.object(service, "_get_gateway_url_map", AsyncMock(return_value={"gw-1": "http://server1:8080"})):
+                with patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=mock_pool):
+                    # Must not raise; no Redis publish occurs (line 202->False->205)
+                    await service._perform_classification()
+
+        # No Redis set means no assertion needed; the test verifies it completes without error
+
+    # ------------------------------------------------------------------
+    # Branch 245->249: URL already present in server_metrics (second pool key, same URL)
+    # ------------------------------------------------------------------
+
+    def test_classify_servers_second_pool_key_same_url(self):
+        """Two pool keys with the same URL reuse the existing ServerUsageMetrics entry."""
+        service = ServerClassificationService(redis_client=None)
+
+        mock_pool = MagicMock()
+        url = "http://shared-url:8080"
+        now = time.time()
+
+        # Two different pool keys pointing to the same upstream URL
+        key_a = ("user_a", url, "hash_a", "sse", "gw-1")
+        key_b = ("user_b", url, "hash_b", "sse", "gw-1")
+
+        session_a = MagicMock()
+        session_a.last_used = now - 10
+        session_a.use_count = 5
+
+        session_b = MagicMock()
+        session_b.last_used = now - 5
+        session_b.use_count = 3
+
+        queue_a = MagicMock()
+        queue_a._queue = deque([session_a])
+        queue_b = MagicMock()
+        queue_b._queue = deque([session_b])
+
+        mock_pool._pools = {key_a: queue_a, key_b: queue_b}
+        mock_pool._active = {}
+
+        result = service._classify_servers_from_pool(mock_pool, [url])
+
+        # Both sessions counted under the single URL entry
+        assert url in result.hot_servers or url in result.cold_servers
+        # use_count should be cumulative across both pool keys
+        # (5 + 3 = 8 for the shared url)
+
+    # ------------------------------------------------------------------
+    # Branch 259->257: session.last_used == 0 (inactive session skipped)
+    # ------------------------------------------------------------------
+
+    def test_classify_servers_session_with_zero_last_used_skipped(self):
+        """Sessions with last_used == 0.0 are excluded from hot eligibility."""
+        service = ServerClassificationService(redis_client=None)
+
+        mock_pool = MagicMock()
+        url = "http://inactive-server:8080"
+
+        pool_key = ("anon", url, "h1", "sse", "gw-1")
+
+        inactive_session = MagicMock()
+        inactive_session.last_used = 0.0  # Never used — branch 259 False path
+        inactive_session.use_count = 0
+
+        queue = MagicMock()
+        queue._queue = deque([inactive_session])
+
+        mock_pool._pools = {pool_key: queue}
+        mock_pool._active = {}
+
+        result = service._classify_servers_from_pool(mock_pool, [url])
+
+        # Server has no valid last_used, so it stays cold
+        assert url in result.cold_servers
+        assert url not in result.hot_servers
+
+    # ------------------------------------------------------------------
+    # Branch 352->356: cold_servers is empty (all servers classified hot)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_publish_classification_empty_cold_servers(self):
+        """Publishing a result with no cold servers skips sadd for the cold set."""
+        mock_redis = AsyncMock()
+        mock_pipeline = AsyncMock()
+        mock_redis.pipeline = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__aenter__ = AsyncMock(return_value=mock_pipeline)
+        mock_pipeline.__aexit__ = AsyncMock(return_value=False)
+        mock_pipeline.delete = AsyncMock()
+        mock_pipeline.sadd = AsyncMock()
+        mock_pipeline.set = AsyncMock()
+        mock_pipeline.expire = AsyncMock()
+        mock_pipeline.execute = AsyncMock()
+
+        service = ServerClassificationService(redis_client=mock_redis)
+
+        metadata = ClassificationMetadata(total_servers=1, hot_cap=1, hot_actual=1, eligible_count=1, timestamp=time.time())
+        # hot has members; cold is empty — exercises the False branch of line 352
+        result = ClassificationResult(hot_servers=["http://hot1:8080"], cold_servers=[], metadata=metadata)
+
+        with patch("mcpgateway.services.server_classification_service.settings") as mock_settings:
+            mock_settings.gateway_auto_refresh_interval = 300
+
+            await service._publish_classification_to_redis(result)
+
+        # sadd should only be called once (for the hot set), not twice
+        sadd_calls = mock_pipeline.sadd.await_args_list
+        assert len(sadd_calls) == 1
+        assert sadd_calls[0].args[0] == ServerClassificationService.CLASSIFICATION_HOT_KEY
+
+    # ------------------------------------------------------------------
+    # URL normalization via gateway_id
+    # ------------------------------------------------------------------
+
+    def test_classify_resolves_canonical_url_via_gateway_id(self):
+        """Pool keys with auth-mutated URLs are resolved to canonical URL via gateway_id."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        canonical_url = "http://server:8080"
+        auth_url = "http://server:8080?tok=val"
+
+        # Pool key has auth-mutated URL but a valid gateway_id
+        pool_key = ("anon", auth_url, "h1", "sse", "gw-1")
+        session = MagicMock()
+        session.last_used = now
+        session.use_count = 5
+        queue = MagicMock()
+        queue._queue = deque([session])
+
+        pool = MagicMock()
+        pool._pools = {pool_key: queue}
+        pool._active = {}
+
+        gateway_url_map = {"gw-1": canonical_url}
+
+        result = service._classify_servers_from_pool(pool, [canonical_url], gateway_url_map)
+
+        # Auth URL must NOT appear in hot or cold sets
+        assert auth_url not in result.hot_servers
+        assert auth_url not in result.cold_servers
+        # Canonical URL should be classified
+        assert canonical_url in result.hot_servers or canonical_url in result.cold_servers
+
+    def test_classify_skips_pool_entries_with_unknown_gateway(self):
+        """Pool entries whose URL doesn't match any known gateway are skipped."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        # Pool has a session for an unknown URL
+        pool_key = ("anon", "http://unknown:9999", "h1", "sse", "")
+        session = MagicMock()
+        session.last_used = now
+        session.use_count = 10
+        queue = MagicMock()
+        queue._queue = deque([session])
+
+        pool = MagicMock()
+        pool._pools = {pool_key: queue}
+        pool._active = {}
+
+        # Only known gateway
+        result = service._classify_servers_from_pool(pool, ["http://known:8080"])
+
+        assert "http://unknown:9999" not in result.hot_servers
+        assert "http://unknown:9999" not in result.cold_servers
+        assert "http://known:8080" in result.cold_servers
+
+    def test_classify_active_only_server_eligible_for_hot(self):
+        """A server with all sessions in _active (empty idle queue) is still eligible."""
+        service = ServerClassificationService(redis_client=None)
+        now = time.time()
+
+        url = "http://busy-server:8080"
+        pool_key = ("anon", url, "h1", "sse", "gw-1")
+
+        # Empty idle queue but active sessions with valid last_used
+        queue = MagicMock()
+        queue._queue = deque()  # Empty — all sessions checked out
+
+        active_session = MagicMock()
+        active_session.last_used = now
+        active_session.use_count = 50
+
+        pool = MagicMock()
+        pool._pools = {pool_key: queue}
+        pool._active = {pool_key: {active_session}}
+
+        # 5 servers → hot_cap = 1, busy-server should be hot
+        all_urls = [url] + [f"http://idle{i}:8080" for i in range(4)]
+        result = service._classify_servers_from_pool(pool, all_urls)
+
+        assert url in result.hot_servers

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -1234,3 +1234,12 @@ def test_reverse_proxy_feature_default_false():
     """mcpgateway_reverse_proxy_enabled should default to False."""
     s = Settings(_env_file=None)
     assert s.mcpgateway_reverse_proxy_enabled is False
+
+
+def test_hot_server_check_interval_property():
+    """hot_server_check_interval should be auto-derived from gateway_auto_refresh_interval."""
+    from mcpgateway.config import Settings
+
+    s = Settings(gateway_auto_refresh_interval=60, _env_file=None)
+    # hot_server_check_interval defaults to gateway_auto_refresh_interval
+    assert s.hot_server_check_interval == 60


### PR DESCRIPTION
Closes #3734

> **Note:** This branch also includes the Layer 2 RBAC token-narrowing fix from #3919 (session-token team narrowing in permission checks).

---

## Overview

This PR implements **automatic tool discovery** for upstream MCP servers via usage-aware adaptive polling. The gateway now continuously synchronises tool lists from registered servers without any manual intervention — polling frequently-used servers at 1× the base interval and deprioritising idle servers to 3× — reducing unnecessary load while keeping active integrations fresh.

Previously, tool lists were only refreshed on demand or via manual admin action. With this change, the gateway discovers new, updated, and removed tools automatically, reflecting upstream changes within one poll cycle.

---

## Design Rationale: Polling vs. Push Notifications

The MCP spec defines `notifications/tools/list_changed` as the canonical mechanism for dynamic tool discovery, and it is a reasonable default for single-session clients. For a gateway operating at scale, persistent-connection notifications introduce a set of problems that polling sidesteps cleanly — this section explains that tradeoff honestly.

### Why persistent notifications don't fit the gateway model

**Notifications require a live transport stream.** The MCP SDK delivers notifications through a `_receive_loop` tied to the open connection. The gateway's refresh path (`_initialize_gateway` → `connect_to_sse_server` / `connect_to_streamablehttp_server`) uses ephemeral connections — open, fetch tools/list, close. No `message_handler` is registered and the notification window is effectively zero.

**Session pools are demand-driven, not proactive.** `MCPSessionPool` does maintain persistent sessions with notification handlers, but sessions are only created when users invoke tools. If no tools have been called against a gateway, no session exists and no notifications are received. Idle sessions are evicted after 600 s (`MCP_SESSION_POOL_IDLE_EVICTION`). The pool covers active user traffic, not passive server monitoring.

**The connection cost scales poorly.** Listening to N upstream servers requires N open TCP sockets and 2N asyncio tasks per worker, plus keepalive traffic and reconnect logic. At realistic deployment sizes:

| Scale | Persistent Notifications | Ephemeral Polling |
|---|---|---|
| Connections at rest | N per worker | 0 |
| asyncio tasks at rest | 2N per worker | 0 |
| Multi-worker support | ✗ (each worker needs own connections) | ✓ (leader election) |
| Server restart recovery | Requires explicit reconnect | Next poll picks it up |
| 1K servers, 4 workers | ~8K connections, ~8K tasks | 0 at rest |
| 10K servers, 4 workers | ~80K persistent connections | ~10K ephemeral calls/interval, batched |

Polling holds zero file descriptors at rest, works across workers via leader election (`FILELOCK_NAME`), and self-heals automatically when upstream servers restart. The existing health-check infrastructure already provides semaphore-based concurrency control, chunked batching with inter-batch pauses, and per-gateway throttling — this PR builds on that foundation rather than replacing it.

> If the MCP spec's push model becomes viable for large-scale gateway deployments in the future (e.g. via a dedicated notification broker), this polling layer can be replaced without touching the rest of the refresh pipeline.

---

## Background: What Already Exists

The gateway's health check system already implements:

- ✅ Semaphore-based concurrency control (adaptive limit)
- ✅ Chunked processing with 50 ms pauses between batches
- ✅ Per-gateway throttling via `last_refresh_at` timestamps
- ✅ Lock-based conflict prevention (manual vs. auto-refresh)
- ✅ Configurable intervals (`HEALTH_CHECK_INTERVAL`, `GATEWAY_AUTO_REFRESH_INTERVAL`)

> **Example:** 100 gateways → 10 concurrent batches with 50 ms pauses = ~5–10 s total check time

---

## Problem

Despite those safeguards, automatic tool discovery was not enabled and all servers were treated equally:

- No automatic synchronisation of tool lists from upstream servers
- A server receiving 1,000+ requests/day → checked every 300 s
- A server idle for weeks → also checked every 300 s
- No differentiation based on real usage patterns
- Unnecessary polling of servers that rarely if ever change

---

## Solution

### 1. Automatic Tool Discovery via Polling

The gateway now runs a background polling loop that periodically calls `tools/list` on every registered upstream server. Discovered tools are reconciled against the local registry — additions, updates, and removals are applied automatically. No manual refresh or admin action is required.

### 2. Hot/Cold Server Classification

To make automatic polling efficient at scale, the gateway analyses the MCP session pool to classify each server into one of two tiers:

| Tier | Criteria | Poll Interval |
|---|---|---|
| **Hot** (top 20%) | Recent active sessions, high use count | 1× base interval (300 s default) |
| **Cold** (remaining 80%) | No recent sessions or low usage | 3× base interval (900 s default) |

**Classification algorithm:**

1. Extract per-server metrics from pooled sessions: `server_last_used`, `active_session_count`, `total_use_count`
2. Filter to servers with a valid pooled session
3. Sort by recency (most recently used first); ties broken deterministically
4. Top 20% (`floor(0.20 × N)`) → **hot**
5. Remainder → **cold**

Classification is deterministic and grounded entirely in observed usage — no heuristics or guesswork.

### 3. Intelligent Interval Selection

Each server's tier determines its poll frequency:

```python
# Hot server (top 20% by usage)
should_poll = elapsed >= settings.hot_server_check_interval   # 300 s (1× base)

# Cold server (remaining 80%)
should_poll = elapsed >= settings.cold_server_check_interval  # 900 s (3× base)
```

### 4. Multi-Worker Coordination

- **With Redis:** Leader election ensures a single worker classifies servers; all workers read the shared classification from Redis.
- **Without Redis (`make dev`):** Single-worker mode; classification runs locally — no Redis dependency required for local development.

---

## Configuration

To enable automatic tool discovery and health checks:

```env
AUTO_REFRESH_SERVERS=true            # Master switch — enables automatic tool/resource/prompt sync during health checks
GATEWAY_AUTO_REFRESH_INTERVAL=300    # Tool list refresh interval in seconds (default: 300, minimum: 60)
```

Optional tuning:

```env
HOT_COLD_CLASSIFICATION_ENABLED=true    # Hot/cold classification (default: false, requires Redis for multi-worker)
```

All poll intervals are derived automatically from `GATEWAY_AUTO_REFRESH_INTERVAL`:

| Server tier | Poll interval |
|---|---|
| Hot (top 20% by usage) | 1× base (300 s) |
| Cold (remaining 80%) | 3× base (900 s) |
