### PR TITLE
feat(plugin): add tool call anomaly detection plugin

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|Cargo.lock|^.secrets.baseline$|scripts/sign_image.sh|scripts/zap|sonar-project.properties|^/Users/brian/dev/github.ibm.com/contextforge-org/sps-pipeline-config/.secrets.baseline$|^./.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-05T09:07:27Z",
+  "generated_at": "2026-04-05T22:11:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 487,
+        "line_number": 493,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -250,7 +250,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 575,
+        "line_number": 581,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 931,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2291,
+        "line_number": 2297,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2382,
+        "line_number": 2388,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2425,
+        "line_number": 2431,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2430,
+        "line_number": 2436,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2435,
+        "line_number": 2441,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project **adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)**.
 
+## [Unreleased]
+
+### Added
+
+- **Tool Call Anomaly Detection Plugin** — Learns per-user tool-calling baselines and flags behavioral deviations: burst invocations, novel tool access, unusual frequency patterns, and off-hours activity. Runs on `tool_pre_invoke` and `tool_post_invoke` hooks with zero external dependencies. ([#3846](https://github.com/IBM/mcp-context-forge/pull/3846), closes [#3845](https://github.com/IBM/mcp-context-forge/issues/3845))
+
 ## [1.0.0] - 2026-03-31 - General Availability
 
 ### Overview

--- a/docs/docs/using/plugins/plugins.md
+++ b/docs/docs/using/plugins/plugins.md
@@ -31,6 +31,7 @@ Plugins for protecting against security threats, detecting sensitive data, and m
 | [VirusTotal Checker](https://github.com/IBM/mcp-context-forge/tree/main/plugins/virus_total_checker) | Native | Integrates with VirusTotal v3 to check URLs, domains, IPs, and file hashes before fetching with configurable blocking policies |
 | [LLMGuard](https://github.com/IBM/mcp-context-forge/tree/main/plugins/external/llmguard) | External | Comprehensive AI guardrails utilizing LLM Guard library with filters and sanitizers for input prompts and model outputs. Supports complex policy expressions and vault-based anonymization |
 | [ClamAV Remote](https://github.com/IBM/mcp-context-forge/tree/main/plugins/external/clamav_server) | External | External MCP server plugin that scans files and text content using ClamAV for malware detection in resources, prompts, and tool outputs |
+| [Tool Call Anomaly Detection](https://github.com/IBM/mcp-context-forge/tree/main/plugins/tool_call_anomaly_detection) | Native | Learns per-user tool-calling baselines and flags behavioral deviations: burst invocations, novel tool access, unusual frequency patterns, and off-hours activity |
 
 ## Reliability & Performance
 

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -1072,6 +1072,32 @@ plugins:
         timeout_ms: 1000
         parallel_evaluation: true
 
+  # Tool Call Anomaly Detection - behavioral baseline monitoring for agentic tool calls
+  - name: "ToolCallAnomalyDetection"
+    kind: "plugins.tool_call_anomaly_detection.tool_call_anomaly_detection.ToolCallAnomalyDetectionPlugin"
+    description: "Detects anomalous tool-calling patterns per user/agent using behavioral baselines"
+    version: "0.1.0"
+    author: "Anuj Shrivastava"
+    hooks: ["tool_pre_invoke", "tool_post_invoke"]
+    tags: ["security", "anomaly-detection", "behavioral", "audit"]
+    mode: "disabled"  # set to "permissive" to observe, "enforce" to block
+    priority: 201  # Run after telemetry exporter, before late-stage plugins
+    conditions: []
+    config:
+      learning_window_seconds: 3600
+      burst_window_seconds: 60
+      burst_threshold: 20
+      novelty_score_weight: 0.35
+      burst_score_weight: 0.35
+      frequency_score_weight: 0.15
+      block_threshold: 0.8
+      warn_threshold: 0.5
+      max_history_per_user: 1000
+      off_hours_start: 22
+      off_hours_end: 6
+      off_hours_score_bonus: 0.15
+      action: "warn"
+
   # JWT Claims Extraction — extracts claims for downstream Cedar/OPA authorization
   - name: "JwtClaimsExtractionPlugin"
     kind: "plugins.jwt_claims_extraction.jwt_claims_extraction.JwtClaimsExtractionPlugin"

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -1080,7 +1080,7 @@ plugins:
     author: "Anuj Shrivastava"
     hooks: ["tool_pre_invoke", "tool_post_invoke"]
     tags: ["security", "anomaly-detection", "behavioral", "audit"]
-    mode: "disabled"  # set to "permissive" to observe, "enforce" to block
+    mode: "disabled"  # set to "permissive" to observe; "enforce" + action: "block" to block
     priority: 201  # Run after telemetry exporter, before late-stage plugins
     conditions: []
     config:

--- a/plugins/tool_call_anomaly_detection/README.md
+++ b/plugins/tool_call_anomaly_detection/README.md
@@ -1,0 +1,67 @@
+# Tool Call Anomaly Detection Plugin
+
+> Author: Anuj Shrivastava
+> Version: 0.1.0
+
+Learns per-user/agent tool-calling baselines and flags behavioral anomalies in real time — burst invocations, access to unfamiliar tools, unusual frequency patterns, and off-hours activity.
+
+## Hooks
+- `tool_pre_invoke` — Scores the incoming call against the user's baseline; warns or blocks above threshold
+- `tool_post_invoke` — Records the call into the baseline and enriches response metadata with risk scores
+
+## Configuration
+
+```yaml
+- name: "ToolCallAnomalyDetection"
+  kind: "plugins.tool_call_anomaly_detection.tool_call_anomaly_detection.ToolCallAnomalyDetectionPlugin"
+  description: "Detects anomalous tool-calling patterns per user/agent using behavioral baselines"
+  version: "0.1.0"
+  author: "Anuj Shrivastava"
+  hooks: ["tool_pre_invoke", "tool_post_invoke"]
+  tags: ["security", "anomaly-detection", "behavioral", "audit"]
+  mode: "disabled"  # "permissive" to observe, "enforce" to block
+  priority: 201
+  conditions: []
+  config:
+    learning_window_seconds: 3600   # Baseline learning period per user
+    burst_window_seconds: 60        # Sliding window for burst detection
+    burst_threshold: 20             # Max calls in burst window before scoring
+    novelty_score_weight: 0.35      # Weight for never-seen-tool signal
+    burst_score_weight: 0.35        # Weight for burst-rate signal
+    frequency_score_weight: 0.15    # Weight for unusual frequency signal
+    block_threshold: 0.8            # Composite score to block (enforce mode)
+    warn_threshold: 0.5             # Composite score to warn
+    max_history_per_user: 1000      # Max call records kept per user
+    off_hours_start: 22             # Off-hours begin (24h)
+    off_hours_end: 6                # Off-hours end (24h)
+    off_hours_score_bonus: 0.15     # Extra score added during off-hours
+    action: "warn"                  # "warn" or "block"
+```
+
+## Features
+
+### Behavioral Baseline Learning
+During the configurable learning window, the plugin records each user's tool-calling patterns without scoring. After the window closes, deviations from the established baseline are flagged.
+
+### Anomaly Signals
+- **Novelty** — Tool name never seen in the user's history
+- **Burst** — Call rate exceeds threshold within the sliding window
+- **Frequency** — Tool called significantly more than its historical average
+- **Off-hours** — Activity outside normal working hours adds a score bonus
+
+### Operating Modes
+- **disabled** — Plugin inactive
+- **permissive** — Scores and logs anomalies but never blocks
+- **enforce** — Blocks calls that exceed `block_threshold`
+
+### Metadata Exposed
+- `anomaly_risk_score` — Composite risk score (0.0–1.0)
+- `anomaly_signals` — Dict of individual signal scores (novelty, burst, frequency)
+- `anomaly_off_hours` — Whether off-hours bonus was applied
+- `anomaly_action` — Action taken (allow / warn / block)
+
+## Testing
+
+```bash
+pytest tests/unit/plugins/test_tool_call_anomaly_detection.py -v
+```

--- a/plugins/tool_call_anomaly_detection/README.md
+++ b/plugins/tool_call_anomaly_detection/README.md
@@ -6,8 +6,8 @@
 Learns per-user/agent tool-calling baselines and flags behavioral anomalies in real time — burst invocations, access to unfamiliar tools, unusual frequency patterns, and off-hours activity.
 
 ## Hooks
-- `tool_pre_invoke` — Scores the incoming call against the user's baseline; warns or blocks above threshold
-- `tool_post_invoke` — Records the call into the baseline and enriches response metadata with risk scores
+- `tool_pre_invoke` — Scores the incoming call against the user's baseline, updates the baseline (allowed calls only), and may warn or block above threshold
+- `tool_post_invoke` — Reads anomaly metadata from context and enriches the tool response with risk scores
 
 ## Configuration
 
@@ -46,19 +46,22 @@ During the configurable learning window, the plugin records each user's tool-cal
 ### Anomaly Signals
 - **Novelty** — Tool name never seen in the user's history
 - **Burst** — Call rate exceeds threshold within the sliding window
-- **Frequency** — Tool called significantly more than its historical average
+- **Frequency** — Tool called significantly less than its historical average (unusually rare usage)
 - **Off-hours** — Activity outside normal working hours adds a score bonus
 
 ### Operating Modes
 - **disabled** — Plugin inactive
 - **permissive** — Scores and logs anomalies but never blocks
-- **enforce** — Blocks calls that exceed `block_threshold`
+- **enforce** — Enables blocking; calls are blocked only when `action: "block"` and the composite score exceeds `block_threshold`. Setting `action: "warn"` with enforce mode will still log but not block.
 
 ### Metadata Exposed
 - `anomaly_risk_score` — Composite risk score (0.0–1.0)
-- `anomaly_signals` — Dict of individual signal scores (novelty, burst, frequency)
-- `anomaly_off_hours` — Whether off-hours bonus was applied
-- `anomaly_action` — Action taken (allow / warn / block)
+- `anomaly_novelty` — Novelty signal score contributing to the composite risk
+- `anomaly_burst` — Burst-rate signal score contributing to the composite risk
+- `anomaly_frequency` — Frequency-pattern signal score contributing to the composite risk
+- `anomaly_off_hours` — Whether an off-hours bonus was applied when scoring
+- `anomaly_user` — The user identifier
+- `anomaly_tool` — The tool name
 
 ## Testing
 

--- a/plugins/tool_call_anomaly_detection/__init__.py
+++ b/plugins/tool_call_anomaly_detection/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/tool_call_anomaly_detection/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Anuj Shrivastava
+
+Tool Call Anomaly Detection Plugin package.
+"""

--- a/plugins/tool_call_anomaly_detection/plugin-manifest.yaml
+++ b/plugins/tool_call_anomaly_detection/plugin-manifest.yaml
@@ -1,0 +1,21 @@
+description: "Detects anomalous tool-calling patterns per user/agent using behavioral baselines — burst detection, novel tool access, frequency deviation, and off-hours scoring."
+author: "Anuj Shrivastava"
+version: "0.1.0"
+tags: ["security", "anomaly-detection", "behavioral", "audit"]
+available_hooks:
+  - "tool_pre_invoke"
+  - "tool_post_invoke"
+default_config:
+  learning_window_seconds: 3600
+  burst_window_seconds: 60
+  burst_threshold: 20
+  novelty_score_weight: 0.35
+  burst_score_weight: 0.35
+  frequency_score_weight: 0.15
+  block_threshold: 0.8
+  warn_threshold: 0.5
+  max_history_per_user: 1000
+  off_hours_start: 22
+  off_hours_end: 6
+  off_hours_score_bonus: 0.15
+  action: "warn"

--- a/plugins/tool_call_anomaly_detection/tool_call_anomaly_detection.py
+++ b/plugins/tool_call_anomaly_detection/tool_call_anomaly_detection.py
@@ -21,9 +21,9 @@ from __future__ import annotations
 import logging
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Literal, Set
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from mcpgateway.plugins.framework import (
     Plugin,
@@ -74,7 +74,15 @@ class AnomalyDetectionConfig(BaseModel):
     off_hours_start: int = Field(default=22, ge=0, le=23)
     off_hours_end: int = Field(default=6, ge=0, le=23)
     off_hours_score_bonus: float = Field(default=0.15, ge=0.0, le=1.0)
-    action: str = Field(default="warn")  # "warn" | "block"
+    action: Literal["warn", "block"] = Field(default="warn")
+
+    @model_validator(mode="after")
+    def _check_thresholds(self) -> "AnomalyDetectionConfig":
+        """Ensure warn_threshold <= block_threshold."""
+        if self.warn_threshold > self.block_threshold:
+            msg = f"warn_threshold ({self.warn_threshold}) must be <= block_threshold ({self.block_threshold})"
+            raise ValueError(msg)
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +209,7 @@ class ToolCallAnomalyDetectionPlugin(Plugin):
         return 0.0
 
     def _composite_score(
-        self, novelty: float, burst: float, frequency: float
+        self, novelty: float, burst: float, frequency: float, *, off_hours: bool
     ) -> float:
         """Compute the weighted composite risk score."""
         cfg = self._cfg
@@ -210,7 +218,7 @@ class ToolCallAnomalyDetectionPlugin(Plugin):
             + burst * cfg.burst_score_weight
             + frequency * cfg.frequency_score_weight
         )
-        if self._is_off_hours():
+        if off_hours:
             raw += cfg.off_hours_score_bonus
         return min(1.0, raw)
 
@@ -259,20 +267,18 @@ class ToolCallAnomalyDetectionPlugin(Plugin):
             )
 
         # Score the call
+        off_hours = self._is_off_hours()
         novelty = self._score_novelty(tool_name, arg_keys, baseline)
         burst = self._score_burst(baseline, now)
         frequency = self._score_frequency(tool_name, baseline)
-        risk_score = self._composite_score(novelty, burst, frequency)
-
-        # Always record (keeps baseline fresh)
-        self._record_call(user_id, tool_name, arg_keys, now)
+        risk_score = self._composite_score(novelty, burst, frequency, off_hours=off_hours)
 
         meta: Dict[str, Any] = {
             "anomaly_risk_score": round(risk_score, 4),
             "anomaly_novelty": round(novelty, 4),
             "anomaly_burst": round(burst, 4),
             "anomaly_frequency": round(frequency, 4),
-            "anomaly_off_hours": self._is_off_hours(),
+            "anomaly_off_hours": off_hours,
             "anomaly_user": user_id,
             "anomaly_tool": tool_name,
         }
@@ -300,6 +306,9 @@ class ToolCallAnomalyDetectionPlugin(Plugin):
                     details=meta,
                 ),
             )
+
+        # Record only after allowing — blocked calls should not train the baseline
+        self._record_call(user_id, tool_name, arg_keys, now)
 
         if risk_score >= self._cfg.warn_threshold:
             logger.info(

--- a/plugins/tool_call_anomaly_detection/tool_call_anomaly_detection.py
+++ b/plugins/tool_call_anomaly_detection/tool_call_anomaly_detection.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/tool_call_anomaly_detection/tool_call_anomaly_detection.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Anuj Shrivastava
+
+Tool Call Anomaly Detection Plugin.
+
+Learns baseline tool-calling patterns per user/agent and flags behavioral
+anomalies in real time — burst invocations, access to unfamiliar tools,
+off-hours activity, and unusual argument fingerprints.
+
+Applies database activity monitoring concepts to agentic MCP tool calls
+flowing through the gateway.
+
+Hooks: tool_pre_invoke, tool_post_invoke
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Set
+
+from pydantic import BaseModel, Field
+
+from mcpgateway.plugins.framework import (
+    Plugin,
+    PluginConfig,
+    PluginContext,
+    PluginViolation,
+    ToolPostInvokePayload,
+    ToolPostInvokeResult,
+    ToolPreInvokePayload,
+    ToolPreInvokeResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class AnomalyDetectionConfig(BaseModel):
+    """Configuration for tool call anomaly detection.
+
+    Attributes:
+        learning_window_seconds: Seconds of baseline learning before enforcement.
+        burst_window_seconds: Sliding window for burst detection.
+        burst_threshold: Max tool calls within burst window before flagging.
+        novelty_score_weight: Weight for novel-tool-access scoring (0-1).
+        burst_score_weight: Weight for burst-rate scoring (0-1).
+        frequency_score_weight: Weight for abnormal frequency scoring (0-1).
+        block_threshold: Composite risk score (0-1) above which to block.
+        warn_threshold: Composite risk score (0-1) above which to warn.
+        max_history_per_user: Maximum call records kept per user for baselines.
+        off_hours_start: UTC hour marking start of off-hours (0-23).
+        off_hours_end: UTC hour marking end of off-hours (0-23).
+        off_hours_score_bonus: Additional risk score during off-hours.
+        action: What to do on threshold breach — "warn" or "block".
+    """
+
+    learning_window_seconds: int = Field(default=3600, ge=0)
+    burst_window_seconds: int = Field(default=60, ge=1)
+    burst_threshold: int = Field(default=20, ge=1)
+    novelty_score_weight: float = Field(default=0.35, ge=0.0, le=1.0)
+    burst_score_weight: float = Field(default=0.35, ge=0.0, le=1.0)
+    frequency_score_weight: float = Field(default=0.15, ge=0.0, le=1.0)
+    block_threshold: float = Field(default=0.8, ge=0.0, le=1.0)
+    warn_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+    max_history_per_user: int = Field(default=1000, ge=10)
+    off_hours_start: int = Field(default=22, ge=0, le=23)
+    off_hours_end: int = Field(default=6, ge=0, le=23)
+    off_hours_score_bonus: float = Field(default=0.15, ge=0.0, le=1.0)
+    action: str = Field(default="warn")  # "warn" | "block"
+
+
+# ---------------------------------------------------------------------------
+# In-memory user baseline (lightweight, no external deps)
+# ---------------------------------------------------------------------------
+
+class _CallRecord:
+    """A single tool-call observation."""
+
+    __slots__ = ("tool_name", "timestamp", "arg_keys")
+
+    def __init__(self, tool_name: str, timestamp: float, arg_keys: frozenset[str]) -> None:
+        self.tool_name = tool_name
+        self.timestamp = timestamp
+        self.arg_keys = arg_keys
+
+
+class _UserBaseline:
+    """Per-user accumulated baseline statistics."""
+
+    __slots__ = (
+        "first_seen",
+        "known_tools",
+        "known_arg_signatures",
+        "call_history",
+        "tool_counts",
+    )
+
+    def __init__(self) -> None:
+        self.first_seen: float = time.time()
+        self.known_tools: Set[str] = set()
+        self.known_arg_signatures: Dict[str, Set[frozenset[str]]] = defaultdict(set)
+        self.call_history: List[_CallRecord] = []
+        self.tool_counts: Dict[str, int] = defaultdict(int)
+
+    @property
+    def total_calls(self) -> int:
+        """Return total number of tool calls observed."""
+        return sum(self.tool_counts.values())
+
+
+# ---------------------------------------------------------------------------
+# Plugin
+# ---------------------------------------------------------------------------
+
+class ToolCallAnomalyDetectionPlugin(Plugin):
+    """Detects anomalous tool-calling behaviour per user/agent.
+
+    During the learning window the plugin only observes and builds baselines.
+    After the window, every tool call is scored for risk and optionally
+    blocked or annotated with metadata.
+    """
+
+    def __init__(self, config: PluginConfig) -> None:
+        """Initialise plugin with anomaly detection configuration."""
+        super().__init__(config)
+        self._cfg = AnomalyDetectionConfig(**(config.config or {}))
+        self._baselines: Dict[str, _UserBaseline] = {}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_user_id(self, context: PluginContext) -> str:
+        """Extract user identifier from the plugin context."""
+        gc = context.global_context
+        if isinstance(gc.user, dict):
+            return gc.user.get("email", gc.user.get("sub", "anonymous"))
+        return gc.user or "anonymous"
+
+    def _get_baseline(self, user_id: str) -> _UserBaseline:
+        """Return the baseline for *user_id*, creating one if needed."""
+        if user_id not in self._baselines:
+            self._baselines[user_id] = _UserBaseline()
+        return self._baselines[user_id]
+
+    def _is_learning(self, baseline: _UserBaseline) -> bool:
+        """Check whether the baseline is still in the learning window."""
+        return (time.time() - baseline.first_seen) < self._cfg.learning_window_seconds
+
+    def _prune_history(self, baseline: _UserBaseline) -> None:
+        """Trim call history to the configured maximum."""
+        if len(baseline.call_history) > self._cfg.max_history_per_user:
+            baseline.call_history = baseline.call_history[-self._cfg.max_history_per_user:]
+
+    def _is_off_hours(self) -> bool:
+        """Return True if the current UTC hour falls within the off-hours window."""
+        import datetime  # noqa: E402 — deferred import (stdlib, lightweight)
+        hour = datetime.datetime.now(datetime.timezone.utc).hour
+        start, end = self._cfg.off_hours_start, self._cfg.off_hours_end
+        if start > end:  # overnight span, e.g. 22–06
+            return hour >= start or hour < end
+        return start <= hour < end
+
+    # ------------------------------------------------------------------
+    # Scoring
+    # ------------------------------------------------------------------
+
+    def _score_novelty(self, tool_name: str, arg_keys: frozenset[str], baseline: _UserBaseline) -> float:
+        """Score how novel this tool call is for the user."""
+        if tool_name not in baseline.known_tools:
+            return 1.0  # never-seen tool
+        known_sigs = baseline.known_arg_signatures.get(tool_name, set())
+        if known_sigs and arg_keys not in known_sigs:
+            return 0.5  # known tool, unknown argument shape
+        return 0.0
+
+    def _score_burst(self, baseline: _UserBaseline, now: float) -> float:
+        """Score burst rate within the sliding window."""
+        window_start = now - self._cfg.burst_window_seconds
+        recent = sum(1 for r in baseline.call_history if r.timestamp >= window_start)
+        if recent >= self._cfg.burst_threshold:
+            return min(1.0, recent / self._cfg.burst_threshold)
+        return recent / max(1, self._cfg.burst_threshold) * 0.5
+
+    def _score_frequency(self, tool_name: str, baseline: _UserBaseline) -> float:
+        """Score how far this tool's usage deviates from the user's normal distribution."""
+        total = baseline.total_calls
+        if total < 10:
+            return 0.0  # not enough data
+        tool_fraction = baseline.tool_counts.get(tool_name, 0) / total
+        if tool_fraction < 0.01:
+            return 0.6  # rarely used tool — moderate anomaly
+        return 0.0
+
+    def _composite_score(
+        self, novelty: float, burst: float, frequency: float
+    ) -> float:
+        """Compute the weighted composite risk score."""
+        cfg = self._cfg
+        raw = (
+            novelty * cfg.novelty_score_weight
+            + burst * cfg.burst_score_weight
+            + frequency * cfg.frequency_score_weight
+        )
+        if self._is_off_hours():
+            raw += cfg.off_hours_score_bonus
+        return min(1.0, raw)
+
+    # ------------------------------------------------------------------
+    # Record keeping
+    # ------------------------------------------------------------------
+
+    def _record_call(
+        self, user_id: str, tool_name: str, arg_keys: frozenset[str], now: float
+    ) -> None:
+        """Record a tool call in the user's baseline."""
+        baseline = self._get_baseline(user_id)
+        baseline.known_tools.add(tool_name)
+        baseline.known_arg_signatures[tool_name].add(arg_keys)
+        baseline.tool_counts[tool_name] += 1
+        baseline.call_history.append(_CallRecord(tool_name, now, arg_keys))
+        self._prune_history(baseline)
+
+    # ------------------------------------------------------------------
+    # Hook implementations
+    # ------------------------------------------------------------------
+
+    async def tool_pre_invoke(
+        self, payload: ToolPreInvokePayload, context: PluginContext
+    ) -> ToolPreInvokeResult:
+        """Evaluate risk score before tool execution.
+
+        Args:
+            payload: Tool invocation payload.
+            context: Plugin execution context.
+
+        Returns:
+            Result that may block the call if risk is too high.
+        """
+        now = time.time()
+        user_id = self._get_user_id(context)
+        tool_name = payload.name
+        arg_keys = frozenset((payload.args or {}).keys())
+        baseline = self._get_baseline(user_id)
+
+        # During learning window, just observe
+        if self._is_learning(baseline):
+            self._record_call(user_id, tool_name, arg_keys, now)
+            return ToolPreInvokeResult(
+                metadata={"anomaly_mode": "learning", "anomaly_user": user_id},
+            )
+
+        # Score the call
+        novelty = self._score_novelty(tool_name, arg_keys, baseline)
+        burst = self._score_burst(baseline, now)
+        frequency = self._score_frequency(tool_name, baseline)
+        risk_score = self._composite_score(novelty, burst, frequency)
+
+        # Always record (keeps baseline fresh)
+        self._record_call(user_id, tool_name, arg_keys, now)
+
+        meta: Dict[str, Any] = {
+            "anomaly_risk_score": round(risk_score, 4),
+            "anomaly_novelty": round(novelty, 4),
+            "anomaly_burst": round(burst, 4),
+            "anomaly_frequency": round(frequency, 4),
+            "anomaly_off_hours": self._is_off_hours(),
+            "anomaly_user": user_id,
+            "anomaly_tool": tool_name,
+        }
+
+        # Save for post_invoke enrichment
+        context.set_state("anomaly_meta", meta)
+        context.set_state("anomaly_risk_score", risk_score)
+
+        if risk_score >= self._cfg.block_threshold and self._cfg.action == "block":
+            logger.warning(
+                "Anomaly detection: blocking tool call %s for user %s (risk=%.2f)",
+                tool_name,
+                user_id,
+                risk_score,
+            )
+            return ToolPreInvokeResult(
+                continue_processing=False,
+                violation=PluginViolation(
+                    reason="Anomalous tool call detected",
+                    description=(
+                        f"Tool '{tool_name}' call by '{user_id}' scored "
+                        f"{risk_score:.2f} risk (threshold {self._cfg.block_threshold})"
+                    ),
+                    code="ANOMALY_BLOCKED",
+                    details=meta,
+                ),
+            )
+
+        if risk_score >= self._cfg.warn_threshold:
+            logger.info(
+                "Anomaly detection: elevated risk for tool %s by user %s (risk=%.2f)",
+                tool_name,
+                user_id,
+                risk_score,
+            )
+
+        return ToolPreInvokeResult(metadata=meta)
+
+    async def tool_post_invoke(
+        self, payload: ToolPostInvokePayload, context: PluginContext
+    ) -> ToolPostInvokeResult:
+        """Enrich post-invoke metadata with anomaly context.
+
+        Args:
+            payload: Tool result payload.
+            context: Plugin execution context.
+
+        Returns:
+            Result with anomaly metadata attached.
+        """
+        meta = context.get_state("anomaly_meta", {})
+        return ToolPostInvokeResult(metadata=meta)

--- a/tests/unit/plugins/test_tool_call_anomaly_detection.py
+++ b/tests/unit/plugins/test_tool_call_anomaly_detection.py
@@ -23,7 +23,6 @@ from mcpgateway.plugins.framework import (
 )
 from mcpgateway.plugins.framework.hooks.tools import ToolHookType
 from plugins.tool_call_anomaly_detection.tool_call_anomaly_detection import (
-    AnomalyDetectionConfig,
     ToolCallAnomalyDetectionPlugin,
 )
 
@@ -150,6 +149,7 @@ class TestDetectionPhase:
         plugin = self._build_trained_plugin(
             action="block",
             block_threshold=0.3,  # low threshold for testing
+            warn_threshold=0.1,
         )
         ctx = _make_context()
 
@@ -191,24 +191,25 @@ class TestDetectionPhase:
 class TestOffHours:
     @pytest.mark.asyncio
     async def test_off_hours_bonus(self):
-        plugin = ToolCallAnomalyDetectionPlugin(
-            _make_config(
-                learning_window_seconds=0,
-                off_hours_start=0,
-                off_hours_end=23,  # always off-hours
-                off_hours_score_bonus=0.15,
+        with patch.object(ToolCallAnomalyDetectionPlugin, "_is_off_hours", return_value=True):
+            plugin = ToolCallAnomalyDetectionPlugin(
+                _make_config(
+                    learning_window_seconds=0,
+                    off_hours_start=0,
+                    off_hours_end=23,
+                    off_hours_score_bonus=0.15,
+                )
             )
-        )
-        baseline = plugin._get_baseline("alice@example.com")
-        baseline.first_seen = time.time() - 7200
-        baseline.known_tools.add("db_query")
-        baseline.known_arg_signatures["db_query"].add(frozenset(["query"]))
-        baseline.tool_counts["db_query"] = 50
+            baseline = plugin._get_baseline("alice@example.com")
+            baseline.first_seen = time.time() - 7200
+            baseline.known_tools.add("db_query")
+            baseline.known_arg_signatures["db_query"].add(frozenset(["query"]))
+            baseline.tool_counts["db_query"] = 50
 
-        ctx = _make_context()
-        result = await plugin.tool_pre_invoke(_pre_payload("db_query", {"query": "x"}), ctx)
+            ctx = _make_context()
+            result = await plugin.tool_pre_invoke(_pre_payload("db_query", {"query": "x"}), ctx)
 
-        assert result.metadata["anomaly_off_hours"] is True
+            assert result.metadata["anomaly_off_hours"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +246,6 @@ class TestPruning:
         plugin = ToolCallAnomalyDetectionPlugin(
             _make_config(learning_window_seconds=9999, max_history_per_user=10)
         )
-        ctx = _make_context()
 
         for i in range(20):
             await plugin.tool_pre_invoke(_pre_payload(f"tool_{i}"), _make_context())

--- a/tests/unit/plugins/test_tool_call_anomaly_detection.py
+++ b/tests/unit/plugins/test_tool_call_anomaly_detection.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/test_tool_call_anomaly_detection.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Anuj Shrivastava
+
+Unit tests for tool call anomaly detection plugin.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from mcpgateway.plugins.framework import (
+    GlobalContext,
+    PluginConfig,
+    PluginContext,
+    ToolPostInvokePayload,
+    ToolPreInvokePayload,
+)
+from mcpgateway.plugins.framework.hooks.tools import ToolHookType
+from plugins.tool_call_anomaly_detection.tool_call_anomaly_detection import (
+    AnomalyDetectionConfig,
+    ToolCallAnomalyDetectionPlugin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides) -> PluginConfig:
+    return PluginConfig(
+        name="ToolCallAnomalyDetection",
+        kind="plugins.tool_call_anomaly_detection.tool_call_anomaly_detection.ToolCallAnomalyDetectionPlugin",
+        hooks=[ToolHookType.TOOL_PRE_INVOKE, ToolHookType.TOOL_POST_INVOKE],
+        priority=200,
+        config=overrides,
+    )
+
+
+def _make_context(user: str = "alice@example.com") -> PluginContext:
+    return PluginContext(
+        global_context=GlobalContext(
+            request_id="req-001",
+            server_id="srv-001",
+            user=user,
+        )
+    )
+
+
+def _pre_payload(name: str = "db_query", args: dict | None = None) -> ToolPreInvokePayload:
+    return ToolPreInvokePayload(name=name, args=args or {"query": "SELECT 1"})
+
+
+def _post_payload(name: str = "db_query") -> ToolPostInvokePayload:
+    return ToolPostInvokePayload(name=name, result={"content": [{"type": "text", "text": "ok"}]})
+
+
+# ---------------------------------------------------------------------------
+# Tests — learning mode
+# ---------------------------------------------------------------------------
+
+class TestLearningPhase:
+    """Tests for the baseline learning window."""
+
+    @pytest.mark.asyncio
+    async def test_learning_mode_always_allows(self):
+        plugin = ToolCallAnomalyDetectionPlugin(_make_config(learning_window_seconds=9999))
+        ctx = _make_context()
+
+        result = await plugin.tool_pre_invoke(_pre_payload(), ctx)
+
+        assert result.continue_processing is True
+        assert result.metadata["anomaly_mode"] == "learning"
+
+    @pytest.mark.asyncio
+    async def test_learning_builds_baseline(self):
+        plugin = ToolCallAnomalyDetectionPlugin(_make_config(learning_window_seconds=9999))
+        ctx = _make_context()
+
+        await plugin.tool_pre_invoke(_pre_payload("tool_a"), ctx)
+        await plugin.tool_pre_invoke(_pre_payload("tool_b"), ctx)
+
+        baseline = plugin._baselines["alice@example.com"]
+        assert "tool_a" in baseline.known_tools
+        assert "tool_b" in baseline.known_tools
+        assert baseline.total_calls == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests — detection mode
+# ---------------------------------------------------------------------------
+
+class TestDetectionPhase:
+    """Tests after learning window expires."""
+
+    def _build_trained_plugin(self, **config_overrides) -> ToolCallAnomalyDetectionPlugin:
+        """Create a plugin that has already passed learning phase."""
+        cfg = _make_config(learning_window_seconds=0, **config_overrides)
+        plugin = ToolCallAnomalyDetectionPlugin(cfg)
+        # Seed a baseline so first_seen is in the past
+        baseline = plugin._get_baseline("alice@example.com")
+        baseline.first_seen = time.time() - 7200
+        baseline.known_tools.update({"db_query", "list_files", "search"})
+        baseline.known_arg_signatures["db_query"].add(frozenset(["query"]))
+        baseline.known_arg_signatures["list_files"].add(frozenset(["path"]))
+        baseline.known_arg_signatures["search"].add(frozenset(["term"]))
+        for tool in ("db_query", "list_files", "search"):
+            baseline.tool_counts[tool] = 50
+        return plugin
+
+    @pytest.mark.asyncio
+    async def test_known_tool_low_risk(self):
+        plugin = self._build_trained_plugin()
+        ctx = _make_context()
+
+        result = await plugin.tool_pre_invoke(_pre_payload("db_query", {"query": "SELECT 1"}), ctx)
+
+        assert result.continue_processing is True
+        assert result.metadata["anomaly_risk_score"] < 0.5
+
+    @pytest.mark.asyncio
+    async def test_novel_tool_raises_risk(self):
+        plugin = self._build_trained_plugin()
+        ctx = _make_context()
+
+        result = await plugin.tool_pre_invoke(_pre_payload("delete_everything", {"confirm": "yes"}), ctx)
+
+        assert result.continue_processing is True
+        assert result.metadata["anomaly_novelty"] == 1.0
+        assert result.metadata["anomaly_risk_score"] >= 0.35
+
+    @pytest.mark.asyncio
+    async def test_burst_detection(self):
+        plugin = self._build_trained_plugin(burst_threshold=5, burst_window_seconds=60)
+        ctx = _make_context()
+
+        for _ in range(6):
+            result = await plugin.tool_pre_invoke(_pre_payload("db_query", {"query": "x"}), ctx)
+            ctx = _make_context()  # fresh context per call
+
+        assert result.metadata["anomaly_burst"] > 0
+
+    @pytest.mark.asyncio
+    async def test_block_action(self):
+        plugin = self._build_trained_plugin(
+            action="block",
+            block_threshold=0.3,  # low threshold for testing
+        )
+        ctx = _make_context()
+
+        # Novel tool should trigger block
+        result = await plugin.tool_pre_invoke(_pre_payload("hack_the_planet", {"target": "all"}), ctx)
+
+        assert result.continue_processing is False
+        assert result.violation is not None
+        assert result.violation.code == "ANOMALY_BLOCKED"
+
+    @pytest.mark.asyncio
+    async def test_warn_does_not_block(self):
+        plugin = self._build_trained_plugin(
+            action="warn",
+            warn_threshold=0.1,
+        )
+        ctx = _make_context()
+
+        result = await plugin.tool_pre_invoke(_pre_payload("unknown_tool"), ctx)
+
+        assert result.continue_processing is True
+        assert result.metadata["anomaly_risk_score"] >= 0.1
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_returns_metadata(self):
+        plugin = self._build_trained_plugin()
+        ctx = _make_context()
+
+        await plugin.tool_pre_invoke(_pre_payload("db_query", {"query": "x"}), ctx)
+        post_result = await plugin.tool_post_invoke(_post_payload("db_query"), ctx)
+
+        assert "anomaly_risk_score" in post_result.metadata
+
+
+# ---------------------------------------------------------------------------
+# Tests — off hours
+# ---------------------------------------------------------------------------
+
+class TestOffHours:
+    @pytest.mark.asyncio
+    async def test_off_hours_bonus(self):
+        plugin = ToolCallAnomalyDetectionPlugin(
+            _make_config(
+                learning_window_seconds=0,
+                off_hours_start=0,
+                off_hours_end=23,  # always off-hours
+                off_hours_score_bonus=0.15,
+            )
+        )
+        baseline = plugin._get_baseline("alice@example.com")
+        baseline.first_seen = time.time() - 7200
+        baseline.known_tools.add("db_query")
+        baseline.known_arg_signatures["db_query"].add(frozenset(["query"]))
+        baseline.tool_counts["db_query"] = 50
+
+        ctx = _make_context()
+        result = await plugin.tool_pre_invoke(_pre_payload("db_query", {"query": "x"}), ctx)
+
+        assert result.metadata["anomaly_off_hours"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — user identity extraction
+# ---------------------------------------------------------------------------
+
+class TestUserIdentity:
+    @pytest.mark.asyncio
+    async def test_dict_user_email(self):
+        plugin = ToolCallAnomalyDetectionPlugin(_make_config(learning_window_seconds=9999))
+        gc = GlobalContext(request_id="r", user={"email": "bob@co.com", "sub": "sub1"})
+        ctx = PluginContext(global_context=gc)
+
+        await plugin.tool_pre_invoke(_pre_payload(), ctx)
+        assert "bob@co.com" in plugin._baselines
+
+    @pytest.mark.asyncio
+    async def test_anonymous_fallback(self):
+        plugin = ToolCallAnomalyDetectionPlugin(_make_config(learning_window_seconds=9999))
+        gc = GlobalContext(request_id="r", user=None)
+        ctx = PluginContext(global_context=gc)
+
+        await plugin.tool_pre_invoke(_pre_payload(), ctx)
+        assert "anonymous" in plugin._baselines
+
+
+# ---------------------------------------------------------------------------
+# Tests — history pruning
+# ---------------------------------------------------------------------------
+
+class TestPruning:
+    @pytest.mark.asyncio
+    async def test_history_pruned(self):
+        plugin = ToolCallAnomalyDetectionPlugin(
+            _make_config(learning_window_seconds=9999, max_history_per_user=10)
+        )
+        ctx = _make_context()
+
+        for i in range(20):
+            await plugin.tool_pre_invoke(_pre_payload(f"tool_{i}"), _make_context())
+
+        baseline = plugin._baselines["alice@example.com"]
+        assert len(baseline.call_history) <= 10


### PR DESCRIPTION
# 🧱 New Plugin

## 🔗 Closes

Closes #3845

## 🚀 Summary

Add a tool call anomaly detection plugin that learns per-user tool-calling baselines and flags behavioral deviations: burst invocations, novel tool access, unusual frequency patterns, and off-hours activity. Runs on `tool_pre_invoke` and `tool_post_invoke` hooks with zero external dependencies.

## 🧪 Checks

- [ ] Plugin was [bootstrapped with the CLI](https://ibm.github.io/mcp-context-forge/using/plugins/lifecycle/) (native or external template)
- [x] Unit tests created for the new plugin
- [ ] `make lint plugins` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)
- [x] README documentation was created for the plugin
- [ ] New plugin added to the [documentation](https://ibm.github.io/mcp-context-forge/using/plugins/plugins/) linking to the README above
