### PR TITLE
virtual-servers-select-all-count

### DIFF
--- a/mcpgateway/static/admin.js
+++ b/mcpgateway/static/admin.js
@@ -10316,6 +10316,18 @@ function initResourceSelect(
             } else {
                 warnBox.textContent = "";
             }
+
+            // Update the Select All button text to show count
+            if (selectBtnId) {
+                const currentSelectBtn = document.getElementById(selectBtnId);
+                if (currentSelectBtn) {
+                    if (count > 0) {
+                        currentSelectBtn.textContent = `Select All (${count})`;
+                    } else {
+                        currentSelectBtn.textContent = "Select All";
+                    }
+                }
+            }
         } catch (error) {
             console.error("Error updating resource select:", error);
         }
@@ -10362,7 +10374,6 @@ function initResourceSelect(
         selectBtn.parentNode.replaceChild(newSelectBtn, selectBtn);
 
         newSelectBtn.addEventListener("click", async () => {
-            const originalText = newSelectBtn.textContent;
             newSelectBtn.disabled = true;
             newSelectBtn.textContent = "Selecting all resources...";
 
@@ -10445,14 +10456,11 @@ function initResourceSelect(
                 allIds.forEach((id) => editSel.add(String(id)));
 
                 update();
-
-                newSelectBtn.textContent = `✓ All ${allIds.length} resources selected`;
-                setTimeout(() => {
-                    newSelectBtn.textContent = originalText;
-                }, 2000);
             } catch (error) {
                 console.error("Error selecting all resources:", error);
                 alert("Failed to select all resources. Please try again.");
+                newSelectBtn.disabled = false;
+                update(); // Reset button text via update()
             } finally {
                 newSelectBtn.disabled = false;
             }
@@ -10731,6 +10739,18 @@ function initPromptSelect(
             } else {
                 warnBox.textContent = "";
             }
+
+            // Update the Select All button text to show count
+            if (selectBtnId) {
+                const currentSelectBtn = document.getElementById(selectBtnId);
+                if (currentSelectBtn) {
+                    if (count > 0) {
+                        currentSelectBtn.textContent = `Select All (${count})`;
+                    } else {
+                        currentSelectBtn.textContent = "Select All";
+                    }
+                }
+            }
         } catch (error) {
             console.error("Error updating prompt select:", error);
         }
@@ -10776,7 +10796,6 @@ function initPromptSelect(
         newSelectBtn.dataset.listenerAttached = "true";
         selectBtn.parentNode.replaceChild(newSelectBtn, selectBtn);
         newSelectBtn.addEventListener("click", async () => {
-            const originalText = newSelectBtn.textContent;
             newSelectBtn.disabled = true;
             newSelectBtn.textContent = "Selecting all prompts...";
 
@@ -10859,14 +10878,11 @@ function initPromptSelect(
                 allIds.forEach((id) => editSel.add(String(id)));
 
                 update();
-
-                newSelectBtn.textContent = `✓ All ${allIds.length} prompts selected`;
-                setTimeout(() => {
-                    newSelectBtn.textContent = originalText;
-                }, 2000);
             } catch (error) {
                 console.error("Error selecting all prompts:", error);
                 alert("Failed to select all prompts. Please try again.");
+                newSelectBtn.disabled = false;
+                update(); // Reset button text via update()
             } finally {
                 newSelectBtn.disabled = false;
             }
@@ -11125,6 +11141,18 @@ function initGatewaySelect(
             } else {
                 warnBox.textContent = "";
             }
+
+            // Update the Select All button text to show count
+            if (selectBtnId) {
+                const currentSelectBtn = document.getElementById(selectBtnId);
+                if (currentSelectBtn) {
+                    if (count > 0) {
+                        currentSelectBtn.textContent = `Select All (${count})`;
+                    } else {
+                        currentSelectBtn.textContent = "Select All";
+                    }
+                }
+            }
         } catch (error) {
             console.error("Error updating gateway select:", error);
         }
@@ -11172,7 +11200,6 @@ function initGatewaySelect(
 
         newSelectBtn.addEventListener("click", async () => {
             // Disable button and show loading state
-            const originalText = newSelectBtn.textContent;
             newSelectBtn.disabled = true;
             newSelectBtn.textContent = "Selecting all gateways...";
 
@@ -11265,18 +11292,13 @@ function initGatewaySelect(
 
                 update();
 
-                newSelectBtn.textContent = `✓ All ${allGatewayIds.length} gateways selected`;
-                setTimeout(() => {
-                    newSelectBtn.textContent = originalText;
-                }, 2000);
-
                 // Reload associated items after selecting all
                 reloadAssociatedItems();
             } catch (error) {
                 console.error("Error in Select All:", error);
                 alert("Failed to select all gateways. Please try again.");
                 newSelectBtn.disabled = false;
-                newSelectBtn.textContent = originalText;
+                update(); // Reset button text via update()
             } finally {
                 newSelectBtn.disabled = false;
             }

--- a/tests/js/admin-edit-server-selection.test.js
+++ b/tests/js/admin-edit-server-selection.test.js
@@ -2733,3 +2733,282 @@ describe("serverSideEditToolSearch — error catch visibility (#3314)", () => {
         }
     });
 });
+
+// ---------------------------------------------------------------------------
+// Select All button count display (#3833)
+// ---------------------------------------------------------------------------
+describe("Select All button shows count in update() (#3833)", () => {
+    beforeEach(() => {
+        win.initToolSelect = realInitToolSelect;
+    });
+
+    /**
+     * Helper: build the DOM scaffolding needed by initToolSelect and return
+     * references to the key elements.
+     */
+    function buildToolSelectDOM({
+        containerId,
+        pillsId,
+        warnId,
+        selectBtnId,
+        clearBtnId,
+    }) {
+        const wrapper = doc.createElement("div");
+        doc.body.appendChild(wrapper);
+
+        const container = doc.createElement("div");
+        container.id = containerId;
+        wrapper.appendChild(container);
+
+        const pills = doc.createElement("div");
+        pills.id = pillsId;
+        wrapper.appendChild(pills);
+
+        const warn = doc.createElement("div");
+        warn.id = warnId;
+        wrapper.appendChild(warn);
+
+        const selectBtn = doc.createElement("button");
+        selectBtn.id = selectBtnId;
+        selectBtn.textContent = "Select All";
+        wrapper.appendChild(selectBtn);
+
+        const clearBtn = doc.createElement("button");
+        clearBtn.id = clearBtnId;
+        wrapper.appendChild(clearBtn);
+
+        return { wrapper, container, pills, warn, selectBtn, clearBtn };
+    }
+
+    test("button text shows 'Select All (N)' after selecting tools", async () => {
+        const { container } = buildToolSelectDOM({
+            containerId: "edit-server-tools",
+            pillsId: "selectedEditToolsPills",
+            warnId: "selectedEditToolsWarning",
+            selectBtnId: "selectAllEditToolsBtn",
+            clearBtnId: "clearAllEditToolsBtn",
+        });
+
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t1",
+            checked: false,
+        });
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t2",
+            checked: false,
+        });
+
+        win.fetch = vi.fn().mockResolvedValue(
+            mockResponse({
+                ok: true,
+                contentType: "application/json",
+                body: { tool_ids: ["t1", "t2", "t3"] },
+            }),
+        );
+
+        win.initToolSelect(
+            "edit-server-tools",
+            "selectedEditToolsPills",
+            "selectedEditToolsWarning",
+            6,
+            "selectAllEditToolsBtn",
+            "clearAllEditToolsBtn",
+        );
+
+        // Click Select All
+        const newSelectBtn = doc.getElementById("selectAllEditToolsBtn");
+        newSelectBtn.click();
+
+        // Wait for async handler to settle
+        for (let i = 0; i < 20; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            if (win.getEditSelections("edit-server-tools").size >= 3) break;
+        }
+
+        // Button should display count
+        expect(newSelectBtn.textContent).toBe("Select All (3)");
+    });
+
+    test("button text resets to 'Select All' after Clear All", async () => {
+        const { container } = buildToolSelectDOM({
+            containerId: "edit-server-tools",
+            pillsId: "selectedEditToolsPills",
+            warnId: "selectedEditToolsWarning",
+            selectBtnId: "selectAllEditToolsBtn",
+            clearBtnId: "clearAllEditToolsBtn",
+        });
+
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t1",
+            checked: false,
+        });
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t2",
+            checked: false,
+        });
+
+        win.fetch = vi.fn().mockResolvedValue(
+            mockResponse({
+                ok: true,
+                contentType: "application/json",
+                body: { tool_ids: ["t1", "t2"] },
+            }),
+        );
+
+        win.initToolSelect(
+            "edit-server-tools",
+            "selectedEditToolsPills",
+            "selectedEditToolsWarning",
+            6,
+            "selectAllEditToolsBtn",
+            "clearAllEditToolsBtn",
+        );
+
+        // Select All
+        const selectBtn = doc.getElementById("selectAllEditToolsBtn");
+        selectBtn.click();
+
+        for (let i = 0; i < 20; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            if (win.getEditSelections("edit-server-tools").size >= 2) break;
+        }
+
+        expect(selectBtn.textContent).toBe("Select All (2)");
+
+        // Clear All
+        const clearBtn = doc.getElementById("clearAllEditToolsBtn");
+        clearBtn.click();
+
+        // update() is synchronous after clear — button should reset
+        expect(selectBtn.textContent).toBe("Select All");
+    });
+
+    test("button shows 'Select All' when no selectBtnId is provided", () => {
+        const wrapper = doc.createElement("div");
+        doc.body.appendChild(wrapper);
+
+        const container = doc.createElement("div");
+        container.id = "tools-no-btn";
+        wrapper.appendChild(container);
+
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t1",
+            checked: true,
+        });
+
+        const pills = doc.createElement("div");
+        pills.id = "pills-no-btn";
+        wrapper.appendChild(pills);
+
+        const warn = doc.createElement("div");
+        warn.id = "warn-no-btn";
+        wrapper.appendChild(warn);
+
+        // No selectBtnId — should not throw
+        win.initToolSelect(
+            "tools-no-btn",
+            "pills-no-btn",
+            "warn-no-btn",
+            6,
+            null,
+            null,
+        );
+    });
+
+    test("button text updates on individual checkbox change", () => {
+        const { container } = buildToolSelectDOM({
+            containerId: "edit-server-tools",
+            pillsId: "selectedEditToolsPills",
+            warnId: "selectedEditToolsWarning",
+            selectBtnId: "selectAllEditToolsBtn",
+            clearBtnId: "clearAllEditToolsBtn",
+        });
+
+        const cb1 = addCheckbox(container, {
+            name: "associatedTools",
+            value: "t1",
+            checked: false,
+        });
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t2",
+            checked: false,
+        });
+
+        win.initToolSelect(
+            "edit-server-tools",
+            "selectedEditToolsPills",
+            "selectedEditToolsWarning",
+            6,
+            "selectAllEditToolsBtn",
+            "clearAllEditToolsBtn",
+        );
+
+        const selectBtn = doc.getElementById("selectAllEditToolsBtn");
+
+        // Initially no selections
+        expect(selectBtn.textContent).toBe("Select All");
+
+        // Check one checkbox and fire change event from the checkbox (bubbles to container)
+        cb1.checked = true;
+        cb1.dispatchEvent(new win.Event("change", { bubbles: true }));
+
+        expect(selectBtn.textContent).toBe("Select All (1)");
+    });
+
+    test("button text shows count on error recovery via update()", async () => {
+        const { container } = buildToolSelectDOM({
+            containerId: "edit-server-tools",
+            pillsId: "selectedEditToolsPills",
+            warnId: "selectedEditToolsWarning",
+            selectBtnId: "selectAllEditToolsBtn",
+            clearBtnId: "clearAllEditToolsBtn",
+        });
+
+        addCheckbox(container, {
+            name: "associatedTools",
+            value: "t1",
+            checked: true,
+        });
+
+        // Mock fetch to fail
+        win.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+        // Suppress alert during test
+        const origAlert = win.alert;
+        win.alert = vi.fn();
+
+        win.initToolSelect(
+            "edit-server-tools",
+            "selectedEditToolsPills",
+            "selectedEditToolsWarning",
+            6,
+            "selectAllEditToolsBtn",
+            "clearAllEditToolsBtn",
+        );
+
+        const selectBtn = doc.getElementById("selectAllEditToolsBtn");
+
+        // There's 1 checked checkbox, so initial update() should show count
+        expect(selectBtn.textContent).toBe("Select All (1)");
+
+        // Click Select All — will fail due to mock fetch error
+        selectBtn.click();
+
+        for (let i = 0; i < 20; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            if (!selectBtn.disabled) break;
+        }
+
+        // After error, update() is called — button should still show count for checked items
+        expect(selectBtn.textContent).toBe("Select All (1)");
+        expect(selectBtn.disabled).toBe(false);
+
+        win.alert = origAlert;
+    });
+});

--- a/tests/playwright/entities/test_servers_extended.py
+++ b/tests/playwright/entities/test_servers_extended.py
@@ -254,17 +254,12 @@ class TestServersExtended:
         first_checkbox = tool_checkboxes.first
         expect(first_checkbox).to_be_checked()
 
-        # Verify button text updates
-        button_text = servers_page.select_all_tools_btn.text_content()
-        assert "All" in button_text and "selected" in button_text.lower()
+        # Verify button text shows count — update() sets "Select All (N)"
+        button_text = servers_page.select_all_tools_btn.text_content() or ""
+        assert "Select All (" in button_text
 
     def test_clear_all_tools_button(self, servers_page: ServersPage):
-        """Test Clear All tools button functionality using Playwright's recommended approach.
-
-        Note: There's a known UI bug where the "Select All" button text
-        doesn't update after clicking "Clear All". The checkboxes are
-        correctly unchecked, but the button still shows "All X tools selected".
-        """
+        """Test Clear All tools button functionality using Playwright's recommended approach."""
         servers_page.navigate_to_servers_tab()
         servers_page.wait_for_visible(servers_page.add_server_form)
 
@@ -295,9 +290,9 @@ class TestServersExtended:
         # Use Playwright's recommended way to verify checkboxes are NOT checked
         expect(first_checkbox).not_to_be_checked()
 
-        # TODO: BUG - The "Select All" button text should update to "Select All"
-        # but it still shows "All X tools selected" after clicking "Clear All"
-        # This is a frontend JavaScript state management issue
+        # Verify button text resets to "Select All" after clearing
+        button_text = servers_page.select_all_tools_btn.text_content() or ""
+        assert button_text == "Select All"
 
     def test_search_tools_in_association(self, servers_page: ServersPage):
         """Test searching for tools in the association selector."""


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #3833 

## 💡 Fix Description
It re-fetches the button using document.getElementById to avoid stale references.
If the button exists:
When count > 0 → updates text to Select All (count)
When count === 0 → resets text to Select All
## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |Pass    |
| Unit tests                            | `make test`          |pass    |

## 📐 MCP Compliance (if relevant)
- [X] Matches current MCP spec
- [X] No breaking change to MCP clients

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
