### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/docs/docs/using/clients/llm-chat.md
+++ b/docs/docs/using/clients/llm-chat.md
@@ -35,6 +35,7 @@ All LLM providers are configured via the Admin UI's LLM Settings. Navigate to **
 | `ollama` | Local Ollama | Base URL (default: http://localhost:11434) |
 | `watsonx` | IBM watsonx.ai | API Key, project_id in additional_config |
 | `openai_compatible` | OpenAI-compatible APIs (vLLM, LocalAI, etc.) | Base URL, optional API Key |
+| `minimax` | MiniMax AI models (MiniMax-M2.7, etc.) | API Key |
 
 ### 🗄️ Redis Configurations for Multi Worker Environment
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6018,6 +6018,7 @@ class LLMProviderType:
     MISTRAL = "mistral"
     GROQ = "groq"
     TOGETHER = "together"
+    MINIMAX = "minimax"
 
     @classmethod
     def get_all_types(cls) -> List[str]:
@@ -6039,6 +6040,7 @@ class LLMProviderType:
             cls.MISTRAL,
             cls.GROQ,
             cls.TOGETHER,
+            cls.MINIMAX,
         ]
 
     @classmethod
@@ -6139,6 +6141,14 @@ class LLMProviderType:
                 "supports_model_list": False,
                 "requires_api_key": True,
                 "description": "IBM watsonx.ai",
+            },
+            cls.MINIMAX: {
+                "api_base": "https://api.minimax.io/v1",
+                "default_model": "MiniMax-M2.7",
+                "supports_model_list": True,
+                "models_endpoint": "/models",
+                "requires_api_key": True,
+                "description": "MiniMax AI models (MiniMax-M2.7, etc.)",
             },
         }
 

--- a/mcpgateway/llm_provider_configs.py
+++ b/mcpgateway/llm_provider_configs.py
@@ -505,6 +505,18 @@ PROVIDER_CONFIGS: Dict[str, ProviderConfigDefinition] = {
         api_base_default="https://api.together.xyz/v1",
         config_fields=[],
     ),
+    "minimax": ProviderConfigDefinition(
+        provider_type="minimax",
+        display_name="MiniMax",
+        description="MiniMax AI models (MiniMax-M2.7, etc.)",
+        requires_api_key=True,
+        api_key_label="MiniMax API Key",
+        api_key_help="Get your API key from https://platform.minimaxi.com/",
+        requires_api_base=True,
+        api_base_default="https://api.minimax.io/v1",
+        api_base_help="Default: https://api.minimax.io/v1",
+        config_fields=[],
+    ),
 }
 
 

--- a/mcpgateway/llm_schemas.py
+++ b/mcpgateway/llm_schemas.py
@@ -45,6 +45,7 @@ class LLMProviderTypeEnum(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     TOGETHER = "together"
+    MINIMAX = "minimax"
 
 
 class HealthStatus(str, Enum):

--- a/tests/integration/test_minimax_provider.py
+++ b/tests/integration/test_minimax_provider.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for MiniMax LLM provider support.
+
+These tests verify the end-to-end MiniMax provider integration by
+exercising the provider configuration, schema validation, and proxy
+request building in combination. They use mocked HTTP responses to
+simulate MiniMax API interactions without requiring a live API key.
+"""
+
+# Standard
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import LLMProviderType
+from mcpgateway.llm_provider_configs import get_provider_config
+from mcpgateway.llm_schemas import (
+    ChatCompletionRequest,
+    ChatMessage,
+    LLMModelCreate,
+    LLMProviderCreate,
+    LLMProviderTypeEnum,
+)
+from mcpgateway.services.llm_proxy_service import LLMProxyService
+
+
+def _make_minimax_provider(**overrides):
+    data = {
+        "id": "p-minimax-int",
+        "name": "MiniMax-Integration",
+        "provider_type": LLMProviderType.MINIMAX,
+        "enabled": True,
+        "api_key": None,
+        "api_base": "https://api.minimax.io/v1",
+        "default_temperature": 0.7,
+        "default_max_tokens": 4096,
+        "config": {},
+        "api_version": None,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _make_minimax_model(**overrides):
+    data = {
+        "id": "m-minimax-int",
+        "model_id": "MiniMax-M2.7",
+        "model_alias": None,
+        "enabled": True,
+        "provider_id": "p-minimax-int",
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+class TestMiniMaxProviderIntegration:
+    """Integration tests verifying MiniMax provider config + schema + proxy work together."""
+
+    def test_provider_config_matches_db_defaults(self):
+        """Provider config and DB defaults must agree on API base and key requirement."""
+        config = get_provider_config("minimax")
+        defaults = LLMProviderType.get_provider_defaults()[LLMProviderType.MINIMAX]
+
+        assert config.api_base_default == defaults["api_base"]
+        assert config.requires_api_key == defaults["requires_api_key"]
+
+    def test_schema_create_with_config_defaults(self):
+        """Creating a provider from config defaults should pass schema validation."""
+        config = get_provider_config("minimax")
+        defaults = LLMProviderType.get_provider_defaults()[LLMProviderType.MINIMAX]
+
+        provider = LLMProviderCreate(
+            name="MiniMax",
+            provider_type=LLMProviderTypeEnum.MINIMAX,
+            api_base=config.api_base_default,
+            default_model=defaults["default_model"],
+        )
+        provider.validate_provider_config()
+
+        assert provider.api_base == "https://api.minimax.io/v1"
+        assert provider.default_model == "MiniMax-M2.7"
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_chat_completion(self):
+        """Full chat completion flow: resolve model -> build request -> parse response."""
+        service = LLMProxyService()
+        provider = _make_minimax_provider()
+        model = _make_minimax_model()
+        service._resolve_model = MagicMock(return_value=(provider, model))
+
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[
+                ChatMessage(role="system", content="You are a helpful assistant."),
+                ChatMessage(role="user", content="What is 2+2?"),
+            ],
+            temperature=0.5,
+            max_tokens=100,
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "id": "chatcmpl-minimax-int-1",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": "MiniMax-M2.7",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "2+2 equals 4."},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 8, "total_tokens": 28},
+        }
+
+        service._client = AsyncMock()
+        service._client.post = AsyncMock(return_value=mock_response)
+
+        result = await service.chat_completion(MagicMock(), request)
+
+        assert result.id == "chatcmpl-minimax-int-1"
+        assert result.model == "MiniMax-M2.7"
+        assert result.choices[0].message.content == "2+2 equals 4."
+        assert result.choices[0].finish_reason == "stop"
+        assert result.usage.prompt_tokens == 20
+        assert result.usage.completion_tokens == 8
+
+        # Verify the request was sent to the correct URL
+        call_args = service._client.post.call_args
+        assert call_args[0][0] == "https://api.minimax.io/v1/chat/completions"
+        sent_body = call_args[1]["json"]
+        assert sent_body["model"] == "MiniMax-M2.7"
+        assert sent_body["temperature"] == 0.5
+        assert sent_body["max_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_minimax_m27_highspeed_model(self):
+        """MiniMax-M2.7-highspeed model should work the same way."""
+        service = LLMProxyService()
+        provider = _make_minimax_provider()
+        model = _make_minimax_model(model_id="MiniMax-M2.7-highspeed")
+        service._resolve_model = MagicMock(return_value=(provider, model))
+
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7-highspeed",
+            messages=[ChatMessage(role="user", content="Hi")],
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "id": "chatcmpl-hs-1",
+            "created": 1,
+            "model": "MiniMax-M2.7-highspeed",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi!"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
+        }
+
+        service._client = AsyncMock()
+        service._client.post = AsyncMock(return_value=mock_response)
+
+        result = await service.chat_completion(MagicMock(), request)
+
+        assert result.model == "MiniMax-M2.7-highspeed"
+        sent_body = service._client.post.call_args[1]["json"]
+        assert sent_body["model"] == "MiniMax-M2.7-highspeed"
+
+    def test_minimax_all_models_creatable(self):
+        """All known MiniMax models should be creatable as LLMModelCreate."""
+        models = [
+            ("MiniMax-M2.7", "MiniMax M2.7", 1000000),
+            ("MiniMax-M2.7-highspeed", "MiniMax M2.7 Highspeed", 1000000),
+            ("MiniMax-M2.5", "MiniMax M2.5", 204800),
+            ("MiniMax-M2.5-highspeed", "MiniMax M2.5 Highspeed", 204800),
+        ]
+        for model_id, model_name, context_window in models:
+            model = LLMModelCreate(
+                provider_id="minimax-provider",
+                model_id=model_id,
+                model_name=model_name,
+                supports_chat=True,
+                supports_streaming=True,
+                supports_function_calling=True,
+                context_window=context_window,
+            )
+            assert model.model_id == model_id

--- a/tests/unit/mcpgateway/test_minimax_provider.py
+++ b/tests/unit/mcpgateway/test_minimax_provider.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for MiniMax LLM provider support."""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import LLMProviderType
+from mcpgateway.llm_provider_configs import get_all_provider_configs, get_provider_config
+from mcpgateway.llm_schemas import (
+    ChatCompletionRequest,
+    ChatMessage,
+    LLMModelCreate,
+    LLMProviderCreate,
+    LLMProviderTypeEnum,
+)
+from mcpgateway.services.llm_proxy_service import LLMProxyService
+
+
+# ---------------------------------------------------------------------------
+# Enum and config registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxEnumRegistration:
+    """Verify MiniMax is registered in all provider enums and registries."""
+
+    def test_minimax_in_provider_type_enum(self):
+        """MiniMax must be a valid LLMProviderTypeEnum value."""
+        assert LLMProviderTypeEnum.MINIMAX == "minimax"
+
+    def test_minimax_in_db_provider_type(self):
+        """MiniMax must be a valid LLMProviderType constant."""
+        assert LLMProviderType.MINIMAX == "minimax"
+
+    def test_minimax_in_get_all_types(self):
+        """MiniMax must be included in LLMProviderType.get_all_types()."""
+        all_types = LLMProviderType.get_all_types()
+        assert "minimax" in all_types
+
+    def test_minimax_in_provider_defaults(self):
+        """MiniMax must have default configuration in get_provider_defaults()."""
+        defaults = LLMProviderType.get_provider_defaults()
+        assert LLMProviderType.MINIMAX in defaults
+        minimax_defaults = defaults[LLMProviderType.MINIMAX]
+        assert minimax_defaults["api_base"] == "https://api.minimax.io/v1"
+        assert minimax_defaults["default_model"] == "MiniMax-M2.7"
+        assert minimax_defaults["supports_model_list"] is True
+        assert minimax_defaults["requires_api_key"] is True
+
+
+class TestMiniMaxProviderConfig:
+    """Verify MiniMax provider configuration definition."""
+
+    def test_minimax_config_exists(self):
+        """MiniMax config must exist in provider configs."""
+        config = get_provider_config("minimax")
+        assert config is not None
+
+    def test_minimax_config_display_name(self):
+        """MiniMax display name must be correct."""
+        config = get_provider_config("minimax")
+        assert config.display_name == "MiniMax"
+
+    def test_minimax_config_requires_api_key(self):
+        """MiniMax must require an API key."""
+        config = get_provider_config("minimax")
+        assert config.requires_api_key is True
+
+    def test_minimax_config_api_base_default(self):
+        """MiniMax default API base must point to api.minimax.io."""
+        config = get_provider_config("minimax")
+        assert config.api_base_default == "https://api.minimax.io/v1"
+
+    def test_minimax_in_all_configs(self):
+        """MiniMax must be in get_all_provider_configs()."""
+        all_configs = get_all_provider_configs()
+        assert "minimax" in all_configs
+
+    def test_minimax_config_no_extra_fields(self):
+        """MiniMax should have no extra config fields (uses OpenAI-compat API)."""
+        config = get_provider_config("minimax")
+        assert config.config_fields == []
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxSchemas:
+    """Verify MiniMax works with LLM provider schemas."""
+
+    def test_create_minimax_provider(self):
+        """Creating a MiniMax provider with LLMProviderCreate should succeed."""
+        provider = LLMProviderCreate(
+            name="MiniMax-Provider",
+            provider_type=LLMProviderTypeEnum.MINIMAX,
+            api_key="test-minimax-key",
+            api_base="https://api.minimax.io/v1",
+        )
+        assert provider.provider_type == LLMProviderTypeEnum.MINIMAX
+        assert provider.api_key == "test-minimax-key"
+
+    def test_create_minimax_provider_minimal(self):
+        """Creating a MiniMax provider with minimal fields should succeed."""
+        provider = LLMProviderCreate(
+            name="MiniMax",
+            provider_type=LLMProviderTypeEnum.MINIMAX,
+        )
+        assert provider.provider_type == LLMProviderTypeEnum.MINIMAX
+        assert provider.enabled is True
+
+    def test_create_minimax_model(self):
+        """Creating a MiniMax model should succeed."""
+        model = LLMModelCreate(
+            provider_id="minimax-provider-id",
+            model_id="MiniMax-M2.7",
+            model_name="MiniMax M2.7",
+            supports_chat=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            context_window=1000000,
+        )
+        assert model.model_id == "MiniMax-M2.7"
+        assert model.context_window == 1000000
+
+    def test_validate_minimax_provider_config(self):
+        """MiniMax provider config validation should pass (no required fields)."""
+        provider = LLMProviderCreate(
+            name="MiniMax",
+            provider_type=LLMProviderTypeEnum.MINIMAX,
+        )
+        # Should not raise
+        provider.validate_provider_config()
+
+
+# ---------------------------------------------------------------------------
+# Proxy service tests
+# ---------------------------------------------------------------------------
+
+
+def _make_minimax_provider(**overrides):
+    data = {
+        "id": "p-minimax",
+        "name": "MiniMax",
+        "provider_type": LLMProviderType.MINIMAX,
+        "enabled": True,
+        "api_key": None,
+        "api_base": "https://api.minimax.io/v1",
+        "default_temperature": 0.7,
+        "default_max_tokens": 4096,
+        "config": {},
+        "api_version": None,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _make_minimax_model(**overrides):
+    data = {
+        "id": "m-minimax",
+        "model_id": "MiniMax-M2.7",
+        "model_alias": None,
+        "enabled": True,
+        "provider_id": "p-minimax",
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+class TestMiniMaxProxyRouting:
+    """Verify MiniMax routes through OpenAI-compatible request builder."""
+
+    def test_build_openai_request_for_minimax(self):
+        """MiniMax should use the OpenAI-compatible request builder."""
+        service = LLMProxyService()
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[ChatMessage(role="user", content="Hello")],
+        )
+        provider = _make_minimax_provider()
+        model = _make_minimax_model()
+
+        url, headers, body = service._build_openai_request(request, provider, model)
+
+        assert url == "https://api.minimax.io/v1/chat/completions"
+        assert headers["Content-Type"] == "application/json"
+        assert body["model"] == "MiniMax-M2.7"
+        assert body["messages"][0]["content"] == "Hello"
+
+    def test_minimax_request_includes_temperature(self):
+        """MiniMax request should include temperature from provider defaults."""
+        service = LLMProxyService()
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[ChatMessage(role="user", content="Hi")],
+        )
+        provider = _make_minimax_provider(default_temperature=0.9)
+        model = _make_minimax_model()
+
+        _, _, body = service._build_openai_request(request, provider, model)
+
+        assert body["temperature"] == 0.9
+
+    def test_minimax_request_explicit_temperature_overrides(self):
+        """Explicit request temperature should override provider default."""
+        service = LLMProxyService()
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[ChatMessage(role="user", content="Hi")],
+            temperature=0.3,
+        )
+        provider = _make_minimax_provider(default_temperature=0.9)
+        model = _make_minimax_model()
+
+        _, _, body = service._build_openai_request(request, provider, model)
+
+        assert body["temperature"] == 0.3
+
+    def test_minimax_streaming_request(self):
+        """MiniMax streaming should set stream=True in body."""
+        service = LLMProxyService()
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[ChatMessage(role="user", content="Hi")],
+            stream=True,
+        )
+        provider = _make_minimax_provider()
+        model = _make_minimax_model()
+
+        _, _, body = service._build_openai_request(request, provider, model)
+
+        assert body["stream"] is True
+
+    def test_minimax_with_tools(self):
+        """MiniMax request with tools should include them in body."""
+        from mcpgateway.llm_schemas import FunctionDefinition, ToolDefinition
+
+        service = LLMProxyService()
+        tool = ToolDefinition(
+            function=FunctionDefinition(name="get_weather", parameters={"type": "object"}),
+        )
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[ChatMessage(role="user", content="What is the weather?")],
+            tools=[tool],
+            tool_choice="auto",
+        )
+        provider = _make_minimax_provider()
+        model = _make_minimax_model()
+
+        _, _, body = service._build_openai_request(request, provider, model)
+
+        assert body["tools"] is not None
+        assert body["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_minimax_routes_to_openai(self):
+        """MiniMax chat completion should route through OpenAI-compat path."""
+        service = LLMProxyService()
+        provider = _make_minimax_provider()
+        model = _make_minimax_model()
+        service._resolve_model = MagicMock(return_value=(provider, model))
+
+        request = ChatCompletionRequest(
+            model="MiniMax-M2.7",
+            messages=[ChatMessage(role="user", content="Hi")],
+        )
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "id": "chatcmpl-minimax-1",
+            "created": 1,
+            "model": "MiniMax-M2.7",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        }
+
+        service._client = AsyncMock()
+        service._client.post = AsyncMock(return_value=response)
+
+        result = await service.chat_completion(MagicMock(), request)
+
+        assert result.model == "MiniMax-M2.7"
+        assert result.choices[0].message.content == "Hello!"
+        assert result.usage.total_tokens == 8
+
+
+# ---------------------------------------------------------------------------
+# Provider service tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxProviderService:
+    """Verify MiniMax works with the provider service layer."""
+
+    def test_create_minimax_provider_service(self):
+        """Creating a MiniMax provider through the service should succeed."""
+        from mcpgateway.services.llm_provider_service import LLMProviderService
+
+        service = LLMProviderService()
+        db = MagicMock()
+
+        # Mock no existing provider with same name
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db.execute.return_value = mock_result
+
+        provider_data = LLMProviderCreate(
+            name="MiniMax",
+            provider_type=LLMProviderTypeEnum.MINIMAX,
+            api_key="test-key",
+            api_base="https://api.minimax.io/v1",
+        )
+
+        from unittest.mock import patch
+
+        with patch("mcpgateway.services.llm_provider_service.encode_auth", return_value="encoded"):
+            provider = service.create_provider(db, provider_data, created_by="test-user")
+
+        assert provider.name == "MiniMax"
+        assert provider.provider_type == "minimax"
+        assert provider.api_key == "encoded"
+        db.add.assert_called_once()
+        db.commit.assert_called_once()


### PR DESCRIPTION
## Summary

Add MiniMax AI as the 13th supported LLM provider in ContextForge Gateway. MiniMax provides an OpenAI-compatible API at `api.minimax.io`, offering models like **MiniMax-M2.7** and **MiniMax-M2.7-highspeed** with up to 1M token context windows, chat completion, streaming, and function calling support.

### Changes

- **`mcpgateway/llm_schemas.py`**: Add `MINIMAX = "minimax"` to `LLMProviderTypeEnum`
- **`mcpgateway/db.py`**: Add `MINIMAX` constant to `LLMProviderType`, include in `get_all_types()` and `get_provider_defaults()` with API base, default model, and model list endpoint
- **`mcpgateway/llm_provider_configs.py`**: Add MiniMax provider config definition with API key requirement and default base URL
- **`docs/docs/using/clients/llm-chat.md`**: Add MiniMax to the supported providers table
- **`tests/unit/mcpgateway/test_minimax_provider.py`**: 21 unit tests covering enum registration, config registry, schema validation, proxy routing, and provider service integration
- **`tests/integration/test_minimax_provider.py`**: 5 integration tests verifying end-to-end chat completion flow, config consistency, and multi-model support

### Why MiniMax?

[MiniMax](https://www.minimaxi.com/) is a leading AI company offering high-performance LLM models via an OpenAI-compatible API. Their M2.7 model features a 1M token context window, making it suitable for long-context applications. Since the API is OpenAI-compatible, MiniMax routes through the existing `_build_openai_request` path with zero changes to the proxy service.

### Testing

All 26 new tests pass, and all 181 existing LLM-related tests pass with no regressions:


