### PR TITLE
refactor: standardize root_path access to settings.app_root_path

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -10362,7 +10362,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14062,
+        "line_number": 14065,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10370,7 +10370,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16819,
+        "line_number": 16822,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10378,7 +10378,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16838,
+        "line_number": 16841,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10386,7 +10386,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20496,
+        "line_number": 20393,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -10796,7 +10796,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2439,
+        "line_number": 2444,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -10804,7 +10804,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2727,
+        "line_number": 2731,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,6 +4,7 @@
     "lines": null
   },
   "generated_at": "2026-04-08T16:53:59Z",
+  "generated_at": "2026-04-09T06:15:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -10362,7 +10363,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14065,
+        "line_number": 14062,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10370,7 +10371,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16822,
+        "line_number": 16819,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10378,7 +10379,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16841,
+        "line_number": 16838,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -10386,7 +10387,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20393,
+        "line_number": 20496,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -10796,7 +10797,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2444,
+        "line_number": 2439,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -10804,7 +10805,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2731,
+        "line_number": 2727,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4171,7 +4171,7 @@ async def admin_login_page(request: Request) -> Response:
     # Check if email auth is enabled
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     root_path = settings.app_root_path
 
@@ -4190,7 +4190,7 @@ async def admin_login_page(request: Request) -> Response:
                     # creating an infinite redirect loop.
                     is_admin = payload.get("is_admin", False) or payload.get("user", {}).get("is_admin", False)
                     if is_admin:
-                        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
             except (HTTPException, jwt.PyJWTError):
                 # Token is invalid or expired - mark for clearing to prevent redirect loop
                 clear_invalid_cookies = True
@@ -4271,7 +4271,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
     """
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     try:
         form = await request.form()
@@ -4371,7 +4371,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
 
             # Create redirect response
             root_path = _resolve_root_path(request)
-            response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+            response = RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
             # Set JWT token as secure cookie
             try:
@@ -4812,7 +4812,7 @@ async def change_password_required_page(request: Request) -> HTMLResponse:
     """
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     # Get root path for template
     root_path = _resolve_root_path(request)
@@ -4881,7 +4881,7 @@ async def change_password_required_handler(request: Request, db: Session = Depen
     """
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     try:
         form = await request.form()
@@ -4956,7 +4956,7 @@ async def change_password_required_handler(request: Request, db: Session = Depen
 
                 # Create redirect response to admin panel
                 root_path = _resolve_root_path(request)
-                response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                response = RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
                 # Update JWT token cookie
                 try:
@@ -15681,7 +15681,7 @@ async def admin_set_a2a_agent_state(
     """
     if not a2a_service or not settings.mcpgateway_a2a_enabled:
         root_path = _resolve_root_path(request)
-        return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
+        return RedirectResponse(f"{root_path}/admin/#a2a-agents", status_code=303)
 
     user_email = get_user_email(user)
     error_message = None
@@ -15735,7 +15735,7 @@ async def admin_delete_a2a_agent(
     """
     if not a2a_service or not settings.mcpgateway_a2a_enabled:
         root_path = _resolve_root_path(request)
-        return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
+        return RedirectResponse(f"{root_path}/admin/#a2a-agents", status_code=303)
 
     error_message = None
     is_inactive_checked = "false"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2628,7 +2628,7 @@ class DocsAuthMiddleware(BaseHTTPMiddleware):
 
         # Get path from scope to handle root_path correctly
         scope_path = request.scope.get("path", request.url.path)
-        root_path = request.scope.get("root_path", "")
+        root_path = settings.app_root_path
         scope_path = _normalize_scope_path(scope_path, root_path)
 
         is_protected = any(scope_path.startswith(p) for p in protected_paths)
@@ -2718,7 +2718,7 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
 
         # Get path from scope to handle root_path correctly
         scope_path = request.scope.get("path", request.url.path)
-        root_path = request.scope.get("root_path", "")
+        root_path = settings.app_root_path
         scope_path = _normalize_scope_path(scope_path, root_path)
 
         # Allow OPTIONS requests for CORS preflight (RFC 7231)

--- a/mcpgateway/routers/llm_admin_router.py
+++ b/mcpgateway/routers/llm_admin_router.py
@@ -111,7 +111,7 @@ async def get_providers_partial(
             "providers": provider_data,
             "provider_types": LLMProviderType.get_all_types(),
             "pagination": pagination,
-            "root_path": request.scope.get("root_path", ""),
+            "root_path": settings.app_root_path,
         },
     )
 
@@ -210,7 +210,7 @@ async def get_models_partial(
             "providers": provider_options,
             "selected_provider_id": provider_id,
             "pagination": pagination,
-            "root_path": request.scope.get("root_path", ""),
+            "root_path": settings.app_root_path,
         },
     )
 
@@ -260,7 +260,7 @@ async def set_provider_state_html(
                     "health_status": provider.health_status,
                     "model_count": len(provider.models),
                 },
-                "root_path": request.scope.get("root_path", ""),
+                "root_path": settings.app_root_path,
             },
         )
     except LLMProviderNotFoundError as e:
@@ -383,7 +383,7 @@ async def set_model_state_html(
                     "enabled": model.enabled,
                     "deprecated": model.deprecated,
                 },
-                "root_path": request.scope.get("root_path", ""),
+                "root_path": settings.app_root_path,
             },
         )
     except LLMModelNotFoundError as e:
@@ -481,7 +481,7 @@ async def get_api_info_partial(
             "models": model_data,
             "stats": stats,
             "llmchat_enabled": settings.llmchat_enabled,
-            "root_path": request.scope.get("root_path", ""),
+            "root_path": settings.app_root_path,
         },
     )
 

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -446,7 +446,7 @@ async def oauth_callback(
 
     try:
         # Get root path for URL construction
-        root_path = request.scope.get("root_path", "") if request else ""
+        root_path = settings.app_root_path if request else ""
         safe_root_path = escape(str(root_path), quote=True)
 
         # RFC 6749 Section 4.1.2.1: provider may return error instead of code

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -334,7 +334,33 @@ async def handle_sso_callback(
         raise HTTPException(status_code=404, detail="SSO authentication is disabled")
 
     # Get root path for URL construction
-    root_path = request.scope.get("root_path", "") if request else ""
+    root_path = settings.app_root_path if request else ""
+
+    # Handle OAuth error responses from provider (RFC 6749 Section 4.1.2.1)
+    if error:
+        error_msg = error_description or error
+        logger.warning("SSO callback error from provider '%s': %s - %s", provider_id, error, error_msg)
+
+        error_mappings = {
+            "access_denied": "sso_cancelled",
+            "invalid_request": "sso_invalid_request",
+            "unauthorized_client": "sso_unauthorized",
+            "unsupported_response_type": "sso_config_error",
+            "invalid_scope": "sso_invalid_scope",
+            "server_error": "sso_server_error",
+            "temporarily_unavailable": "sso_unavailable",
+        }
+        error_code = error_mappings.get(error, "sso_failed")
+        return RedirectResponse(url=f"{root_path}/admin/login?error={error_code}", status_code=302)
+
+    # Code and state are required if no error was returned
+    if not code:
+        logger.warning("SSO callback for provider '%s' missing both code and error parameters", provider_id)
+        return RedirectResponse(url=f"{root_path}/admin/login?error=sso_failed", status_code=302)
+
+    if not state:
+        logger.warning("SSO callback for provider '%s' missing required state parameter", provider_id)
+        return RedirectResponse(url=f"{root_path}/admin/login?error=sso_failed", status_code=302)
 
     # Handle OAuth error responses from provider (RFC 6749 Section 4.1.2.1)
     if error:
@@ -385,7 +411,7 @@ async def handle_sso_callback(
         return RedirectResponse(url=f"{root_path}/admin/login?error=user_creation_failed", status_code=302)
 
     # Create redirect response
-    redirect_response = RedirectResponse(url=f"{root_path}/admin", status_code=302)
+    redirect_response = RedirectResponse(url=f"{root_path}/admin/", status_code=302)
 
     # Set secure HTTP-only cookie using the same method as email auth
     # First-Party

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -1163,7 +1163,7 @@ async def require_admin_auth(
                             accept_header = request.headers.get("accept", "")
                             if "text/html" in accept_header:
                                 # Redirect browser to login page with error
-                                root_path = request.scope.get("root_path", "")
+                                root_path = settings.app_root_path
                                 raise HTTPException(status_code=status.HTTP_302_FOUND, detail="Admin privileges required", headers={"Location": f"{root_path}/admin/login?error=admin_required"})
                             else:
                                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
@@ -1180,7 +1180,7 @@ async def require_admin_auth(
             # For 401, check if we should redirect browser users
             accept_header = request.headers.get("accept", "")
             if "text/html" in accept_header:
-                root_path = request.scope.get("root_path", "")
+                root_path = settings.app_root_path
                 raise HTTPException(status_code=status.HTTP_302_FOUND, detail="Authentication required", headers={"Location": f"{root_path}/admin/login"})
             # If JWT auth fails, fall back to basic auth for backward compatibility
         except Exception:
@@ -1210,7 +1210,7 @@ async def require_admin_auth(
             accept_header = request.headers.get("accept", "")
             is_htmx = request.headers.get("hx-request") == "true"
             if "text/html" in accept_header or is_htmx:
-                root_path = request.scope.get("root_path", "")
+                root_path = settings.app_root_path
                 raise HTTPException(status_code=status.HTTP_302_FOUND, detail="Authentication required", headers={"Location": f"{root_path}/admin/login"})
             else:
                 raise HTTPException(

--- a/tests/unit/mcpgateway/routers/test_sso_router.py
+++ b/tests/unit/mcpgateway/routers/test_sso_router.py
@@ -309,7 +309,7 @@ async def test_handle_sso_callback_success_sets_cookie(monkeypatch: pytest.Monke
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "").endswith("/admin/")
     assert set_cookie.called
 
 
@@ -347,7 +347,7 @@ async def test_handle_sso_callback_keycloak_sets_id_token_hint_cookie(monkeypatc
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "").endswith("/admin/")
     assert "sso_id_token_hint=id-token-hint" in response.headers.get("set-cookie", "")
     assert set_cookie.called
 
@@ -387,7 +387,7 @@ async def test_handle_sso_callback_keycloak_oversized_id_token_skips_hint_cookie
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "").endswith("/admin/")
     assert "sso_id_token_hint=" not in response.headers.get("set-cookie", "")
     assert "id_token too large for cookie storage" in caplog.text
     assert set_cookie.called

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -5291,7 +5291,7 @@ class TestA2AAgentManagement:
         result = await admin_set_a2a_agent_state("agent-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/root/admin#a2a-agents"
+        assert result.headers["location"] == "/root/admin/#a2a-agents"
 
     @patch.object(A2AAgentService, "delete_agent")
     async def test_admin_delete_a2a_agent_success(self, mock_delete_agent, mock_request, mock_db):
@@ -5367,7 +5367,7 @@ class TestA2AAgentManagement:
         result = await admin_delete_a2a_agent("agent-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#a2a-agents"
+        assert result.headers["location"] == "/admin/#a2a-agents"
 
     @patch.object(A2AAgentService, "get_agent")
     @patch.object(A2AAgentService, "invoke_agent")
@@ -13899,6 +13899,7 @@ async def test_change_password_required_handler_paths(monkeypatch, mock_db):
 @pytest.mark.asyncio
 async def test_change_password_required_handler_success(monkeypatch, mock_db):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
+    monkeypatch.setattr(settings, "app_root_path", "/root")
 
     request = MagicMock(spec=Request)
     request.scope = {"root_path": "/root"}
@@ -13919,17 +13920,19 @@ async def test_change_password_required_handler_success(monkeypatch, mock_db):
 
     response = await change_password_required_handler(request, db=mock_db)
     assert isinstance(response, RedirectResponse)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
 async def test_change_password_required_handler_email_auth_disabled(monkeypatch, mock_db):
     monkeypatch.setattr(settings, "email_auth_enabled", False)
+    monkeypatch.setattr(settings, "app_root_path", "/root")
+
     request = MagicMock(spec=Request)
     request.scope = {"root_path": "/root"}
     response = await change_password_required_handler(request, db=mock_db)
     assert isinstance(response, RedirectResponse)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -16411,7 +16414,7 @@ class TestAuthLogin:
         # Should redirect to admin dashboard, not show login page
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_shows_form_for_invalid_token(self, monkeypatch):
@@ -16513,7 +16516,7 @@ class TestAuthLogin:
         # Should redirect to admin dashboard
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_access_token_cookie_invalid_shows_form(self, monkeypatch):
@@ -16821,7 +16824,7 @@ class TestAuthLogin:
         result = await admin_login_handler(request, mock_db)
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"].endswith("/admin")
+        assert result.headers["location"].endswith("/admin/")
 
     @pytest.mark.asyncio
     async def test_admin_login_handler_auth_failure(self, monkeypatch, mock_db):

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -436,7 +436,7 @@ async def test_admin_login_handler_paths(monkeypatch):
     user.password_change_required = False
     monkeypatch.setattr(admin.settings, "password_change_enforcement_enabled", False)
     response = await admin.admin_login_handler(request, mock_db)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -1120,7 +1120,7 @@ async def test_change_password_required_handler(monkeypatch):
     with patch("sqlalchemy.inspect", return_value=SimpleNamespace(transient=False, detached=False)):
         response = await admin.change_password_required_handler(request, mock_db)
 
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
     assert set_cookie.called
 
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -1781,8 +1781,10 @@ class TestDocsAuthMiddleware:
         call_next.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_docs_auth_normalizes_prefixed_scope_path(self):
+    async def test_docs_auth_normalizes_prefixed_scope_path(self, monkeypatch):
         """When proxy forwards full path, scope_path includes root_path prefix and must be stripped."""
+        monkeypatch.setattr(settings, "app_root_path", "/qa/gateway")
+
         middleware = DocsAuthMiddleware(None)
         request = _make_request("/qa/gateway/docs", root_path="/qa/gateway")
         call_next = AsyncMock(return_value=StarletteResponse("ok"))
@@ -1832,8 +1834,10 @@ class TestDocsAuthMiddleware:
         call_next.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_docs_auth_trailing_slash_root_path(self):
+    async def test_docs_auth_trailing_slash_root_path(self, monkeypatch):
         """root_path with trailing slash must still strip prefix correctly."""
+        monkeypatch.setattr(settings, "app_root_path", "/qa/gateway")
+
         middleware = DocsAuthMiddleware(None)
         request = _make_request("/qa/gateway/docs", root_path="/qa/gateway/")
         call_next = AsyncMock(return_value=StarletteResponse("ok"))
@@ -2172,6 +2176,7 @@ class TestAdminAuthMiddleware:
         call_next = AsyncMock(return_value="ok")
 
         monkeypatch.setattr(settings, "auth_required", True)
+        monkeypatch.setattr(settings, "app_root_path", "/qa/gateway")
 
         response = await middleware.dispatch(request, call_next)
         # /admin/login is exempt; leading slash must not be stripped
@@ -2186,6 +2191,7 @@ class TestAdminAuthMiddleware:
         call_next = AsyncMock(return_value="ok")
 
         monkeypatch.setattr(settings, "auth_required", True)
+        monkeypatch.setattr(settings, "app_root_path", "/qa/gateway")
 
         response = await middleware.dispatch(request, call_next)
         # No credentials: should redirect to login (302), not pass through
@@ -2199,7 +2205,7 @@ class TestAdminAuthMiddleware:
         middleware = AdminAuthMiddleware(None)
         request = _make_request("/qa/gateway/admin/tools", root_path="/qa/gateway/", headers={"accept": "text/html"})
         call_next = AsyncMock(return_value="ok")
-
+        monkeypatch.setattr(settings, "app_root_path", "/qa/gateway")
         monkeypatch.setattr(settings, "auth_required", True)
 
         response = await middleware.dispatch(request, call_next)

--- a/tests/unit/mcpgateway/utils/test_verify_credentials.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials.py
@@ -1399,6 +1399,7 @@ async def test_require_admin_auth_email_auth_missing_username_falls_back_to_basi
 @pytest.mark.asyncio
 async def test_require_admin_auth_email_auth_get_db_http_401_redirects_html(monkeypatch):
     monkeypatch.setattr(vc.settings, "email_auth_enabled", True, raising=False)
+    monkeypatch.setattr(vc.settings, "app_root_path", "/root", raising=False)
 
     def get_db_raises():
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="boom")


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #1588

---

## 📝 Summary
_What does this PR do and why?_
Replaces all **request.scope.get("root_path", "")** calls with **settings.app_root_path** across files.

Redirect URLs to `/admin` were also updated to use a consistent trailing slash (`/admin/`) to avoid unnecessary 307 redirects from FastAPI's path normalization.

Tests were updated to patch `settings.app_root_path` directly instead of injecting root_path via the request scope, which aligns with the new standardized pattern and makes tests easier to maintain.

The existing _resolve_root_path helper in admin.py was preserved as-is since it intentionally reads from the request scope first (for proxy/mounted deployments) and falls back to settings.app_root_path — this links to PR #1547.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |     ✅    |
| Unit tests                | `make test`     |    ✅     |
| Coverage ≥ 80%            | `make coverage` |     ✅    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---