### PR TITLE
fix(ui): remove duplicate disabled badge and tag/hook truncation on plugin cards

### DIFF
--- a/mcpgateway/templates/plugins_partial.html
+++ b/mcpgateway/templates/plugins_partial.html
@@ -319,12 +319,6 @@
         >
           Permissive
         </span>
-        {% else %}
-        <span
-          class="px-2 py-1 bg-gray-100 text-gray-800 text-xs font-medium rounded dark:bg-gray-700 dark:text-gray-300"
-        >
-          Disabled
-        </span>
         {% endif %}
 
         <!-- Implementation Badge -->
@@ -348,17 +342,13 @@
       <!-- Tags -->
       {% if plugin.tags %}
       <div class="flex flex-wrap gap-1 mb-4">
-        {% for tag in plugin.tags[:3] %}
+        {% for tag in plugin.tags %}
         <span
           class="px-2 py-1 bg-gray-100 text-gray-700 text-xs rounded dark:bg-gray-700 dark:text-gray-300"
         >
           {% if tag is mapping %}{{ tag.id }}{% else %}{{ tag }}{% endif %}
         </span>
-        {% endfor %} {% if plugin.tags|length > 3 %}
-        <span class="px-2 py-1 text-gray-500 text-xs">
-          +{{ plugin.tags|length - 3 }} more
-        </span>
-        {% endif %}
+        {% endfor %}
       </div>
       {% endif %}
 
@@ -367,12 +357,10 @@
       <div class="text-xs text-gray-500 dark:text-gray-400 mb-4">
         <div class="font-medium mb-1">Hooks:</div>
         <div class="flex flex-wrap gap-1">
-          {% for hook in plugin.hooks[:2] %}
+          {% for hook in plugin.hooks %}
           <span class="text-xs">{{ hook.replace('_', ' ') }}</span>
-          {% if not loop.last %}<span>,</span>{% endif %} {% endfor %} {% if
-          plugin.hooks|length > 2 %}
-          <span>... ({{ plugin.hooks|length }} total)</span>
-          {% endif %}
+          {% if not loop.last %}<span>,</span>{% endif %}
+          {% endfor %}
         </div>
       </div>
       {% endif %}


### PR DESCRIPTION
# Bug-fix PR

## 📌 Summary
Plugin cards on the Plugins page showed the word "Disabled" twice for disabled plugins, and truncated tag and hook lists to arbitrary limits (3 tags, 2 hooks) even when space was available to render them in full.

## 🔗 Related Issue
Closes: #3842

## 🔁 Reproduction Steps
**Duplicate "Disabled":**
1. Navigate to Admin UI → Plugins page
2. Observe any plugin card with `status=disabled` and `mode=disabled`
3. Both the status dot and the mode badge rendered "Disabled"

**Tag/hook truncation:**
1. Navigate to Admin UI → Plugins page
2. Observe any plugin card with more than 3 tags or more than 2 hooks
3. Tags beyond 3 showed `+N more`; hooks beyond 2 showed `...(N total)`

## 🐞 Root Cause
In `mcpgateway/templates/plugins_partial.html`:

1. The mode badge block used an `{% else %}` catch-all that rendered a "Disabled" badge for any mode that wasn't `enforce`, `enforce_ignore_error`, or `permissive` — including `mode=disabled`. This duplicated the status dot's "Disabled" text.
2. Tags were iterated as `plugin.tags[:3]` with an overflow `+{{ plugin.tags|length - 3 }} more` span — a hardcoded limit with no relation to available card space.
3. Hooks were similarly iterated as `plugin.hooks[:2]` with a `...(N total)` overflow span.

## 💡 Fix Description
All changes are confined to `mcpgateway/templates/plugins_partial.html`:

- **Mode badge:** removed the `{% else %}` catch-all; the mode block now only renders a badge for the three active modes (`enforce`, `enforce_ignore_error`, `permissive`). `mode=disabled` produces no badge — the status dot already conveys the disabled state.
- **Tags:** removed `[:3]` slice and the `+N more` overflow span; all tags render in the existing `flex-wrap` container.
- **Hooks:** removed `[:2]` slice and the `...(N total)` overflow span; all hooks render inline.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |     Pass   |
| Unit tests                            | `make test`          |    Pass    |
| Coverage ≥ 90 %                       | `make coverage`      |    Pass    |
| Manual regression no longer fails     | Disabled plugins show single "Disabled" label; all tags and hooks visible on cards |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed