### PR TITLE
feat(auth): add token time restriction validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|Cargo.lock|^.secrets.baseline$|scripts/sign_image.sh|scripts/zap|sonar-project.properties|^/Users/brian/dev/github.ibm.com/contextforge-org/sps-pipeline-config/.secrets.baseline$|^./.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-02T15:29:25Z",
+  "generated_at": "2026-04-02T17:00:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -366,11 +366,11 @@
       },
       {
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1485,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
@@ -1094,27 +1094,27 @@
     "docker-compose.with-langfuse.yml": [
       {
         "hashed_secret": "cb58df830a45cc33df1a313e616ecad78cd796c5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 125,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "2e0c522bfe4e7885492862df2e0b987c0ca02623",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 148,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d9d007c8de197b3f36a3a0ba4f13c0f7df175d5a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 312,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docker-compose.yml": [
@@ -2638,11 +2638,11 @@
     "docs/docs/manage/observability/langfuse.md": [
       {
         "hashed_secret": "0c6e5ac9cb218c0a666019d0814c5029b374fb17",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 221,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/docs/manage/observability/observability.md": [
@@ -5398,11 +5398,11 @@
     "mcpgateway/alembic/versions/a7f3c9e1b2d4_add_title_to_tools_resources_prompts.py": [
       {
         "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 17,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "mcpgateway/alembic/versions/a8f3b2c1d4e5_add_gateway_refresh_fields.py": [
@@ -6486,7 +6486,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 564,
+        "line_number": 568,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6574,19 +6574,19 @@
     "plugins/encoded_exfil_detection/README.md": [
       {
         "hashed_secret": "f7f877c24a4ebef314009a2e79314797bae91bb6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 149,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5f2fe4f03b2314fa3a217f1e1f0ab2e3f5b1b49f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 178,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/examples/custom_auth_example/README.md": [
@@ -6836,27 +6836,27 @@
       },
       {
         "hashed_secret": "532fdeccb155dce5b528ba039b9a5d201b817e3b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 932,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 969,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ff1a7ebc241b8eefe9e75e13f20cc22c365ab626",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 969,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins_rust/secrets_detection/benches/secrets_detection.rs": [
@@ -10794,11 +10794,11 @@
     "tests/unit/mcpgateway/test_observability.py": [
       {
         "hashed_secret": "8f1b63868b5d31deb06a0ff740b192aa490e8950",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 326,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1fb844731bf1e5928ae606915b54e21264da4768",
@@ -11076,11 +11076,11 @@
     "tests/unit/mcpgateway/utils/test_trace_redaction.py": [
       {
         "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/utils/test_url_auth.py": [
@@ -11204,43 +11204,43 @@
       },
       {
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 538,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 582,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 595,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 971,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1288,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/unit/plugins/test_jwt_claims_extraction.py": [
@@ -11294,19 +11294,19 @@
     "tools_rust/mcp_runtime/src/observability.rs": [
       {
         "hashed_secret": "b7dd0ec3dc49487982011219e66db3716b6669c6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 596,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d2b1620ca7a5314280e595624e8b13c185f8a2e1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 785,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tools_rust/mcp_runtime/tests/runtime.rs": [

--- a/mcpgateway/utils/time_restrictions.py
+++ b/mcpgateway/utils/time_restrictions.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/time_restrictions.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Sebastian Iozu
+
+Time restriction validation utilities for token access control.
+This module provides functions to validate time-based access restrictions
+on API tokens, ensuring tokens can only be used during specified time windows.
+"""
+
+# Standard
+from datetime import datetime
+import logging
+from typing import Any, Dict
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Third-Party
+from fastapi import HTTPException, status
+
+# Initialize logging
+logger = logging.getLogger(__name__)
+
+# Valid day names for day restrictions
+VALID_DAYS = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+
+
+def validate_time_restrictions(payload: Dict[str, Any]) -> None:
+    """Validate time restrictions from JWT token payload.
+
+    Checks if the current time falls within the allowed time windows and days
+    specified in the token's time_restrictions. Raises HTTPException if the
+    token is being used outside of its allowed time periods.
+
+    Time restrictions format in JWT payload:
+    {
+        "scopes": {
+            "time_restrictions": {
+                "start_time": "09:00",
+                "end_time": "17:00",
+                "timezone": "UTC",
+                "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+            }
+        }
+    }
+
+    Args:
+        payload: Decoded JWT payload containing time_restrictions in scopes
+
+    Raises:
+        HTTPException: 403 if current time is outside allowed windows
+
+    Examples:
+        >>> payload = {
+        ...     "sub": "user@example.com",
+        ...     "scopes": {
+        ...         "time_restrictions": {
+        ...             "start_time": "09:00",
+        ...             "end_time": "17:00",
+        ...             "timezone": "UTC",
+        ...             "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+        ...         }
+        ...     }
+        ... }
+        >>> # Will raise HTTPException if called outside business hours
+        >>> # validate_time_restrictions(payload)
+    """
+    # Extract time restrictions from token scopes
+    scopes = payload.get("scopes", {})
+    if not isinstance(scopes, dict):
+        return  # No restrictions to validate
+
+    time_restrictions = scopes.get("time_restrictions", {})
+    if not time_restrictions or not isinstance(time_restrictions, dict):
+        return  # No time restrictions configured
+
+    # Get restriction parameters
+    start_time_str = time_restrictions.get("start_time")
+    end_time_str = time_restrictions.get("end_time")
+    timezone_str = time_restrictions.get("timezone", "UTC")
+    allowed_days = time_restrictions.get("days", [])
+
+    # If no restrictions are actually set, allow access
+    if not (start_time_str or end_time_str or allowed_days):
+        return
+
+    # Validate day names if day restrictions are present
+    if allowed_days:
+        invalid_days = set(allowed_days) - VALID_DAYS
+        if invalid_days:
+            logger.warning(
+                f"Invalid day names in time_restrictions: {invalid_days}",
+                extra={
+                    "security_event": "time_restriction_validation_error",
+                    "error_type": "invalid_day_names",
+                    "invalid_days": list(invalid_days),
+                    "user": payload.get("sub"),
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Token has invalid day names in time restrictions: {', '.join(sorted(invalid_days))}",
+            )
+
+    # Get current time in the specified timezone
+    try:
+        tz = ZoneInfo(timezone_str)
+    except (ZoneInfoNotFoundError, KeyError) as e:
+        logger.warning(
+            f"Invalid timezone in time_restrictions: {timezone_str}",
+            extra={
+                "security_event": "time_restriction_validation_error",
+                "error_type": "invalid_timezone",
+                "timezone": timezone_str,
+                "user": payload.get("sub"),
+            },
+        )
+        # SECURITY: Fail closed - deny access on invalid timezone to prevent bypass
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Token has invalid timezone in time restrictions: {timezone_str}",
+        )
+
+    now = datetime.now(tz)
+    current_day = now.strftime("%A")  # e.g., "Monday", "Tuesday", etc.
+    current_time = now.time()
+
+    # Check day restriction
+    if allowed_days and current_day not in allowed_days:
+        logger.warning(
+            f"Token access denied: current day '{current_day}' not in allowed days {allowed_days}",
+            extra={
+                "security_event": "time_restriction_violation",
+                "violation_type": "day_restriction",
+                "current_day": current_day,
+                "allowed_days": allowed_days,
+                "user": payload.get("sub"),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Token access is restricted to specific days. Current day: {current_day}. Allowed days: {', '.join(allowed_days)}",
+        )
+
+    # Check time range restriction
+    if start_time_str and end_time_str:
+        try:
+            # Parse time strings (format: "HH:MM" or "HH:MM:SS")
+            # Try HH:MM:SS first, then HH:MM as fallback
+            start_time = None
+            for fmt in ["%H:%M:%S", "%H:%M"]:
+                try:
+                    start_time = datetime.strptime(start_time_str, fmt).time()
+                    break
+                except ValueError:
+                    continue
+
+            if start_time is None:
+                raise ValueError(f"Invalid start_time format: {start_time_str}")
+
+            end_time = None
+            for fmt in ["%H:%M:%S", "%H:%M"]:
+                try:
+                    end_time = datetime.strptime(end_time_str, fmt).time()
+                    break
+                except ValueError:
+                    continue
+
+            if end_time is None:
+                raise ValueError(f"Invalid end_time format: {end_time_str}")
+
+            # Handle time ranges that cross midnight
+            if start_time <= end_time:
+                # Normal range (e.g., 09:00 - 17:00)
+                time_allowed = start_time <= current_time <= end_time
+            else:
+                # Range crosses midnight (e.g., 22:00 - 06:00)
+                time_allowed = current_time >= start_time or current_time <= end_time
+
+            if not time_allowed:
+                logger.warning(
+                    f"Token access denied: current time {current_time.strftime('%H:%M')} outside allowed range {start_time_str} - {end_time_str}",
+                    extra={
+                        "security_event": "time_restriction_violation",
+                        "violation_type": "time_range_restriction",
+                        "current_time": current_time.isoformat(),
+                        "start_time": start_time_str,
+                        "end_time": end_time_str,
+                        "timezone": timezone_str,
+                        "user": payload.get("sub"),
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Token access is restricted to {start_time_str} - {end_time_str} {timezone_str}. Current time: {current_time.strftime('%H:%M')} {timezone_str}",
+                )
+        except ValueError as e:
+            logger.error(
+                f"Invalid time format in time_restrictions: {e}",
+                extra={
+                    "security_event": "time_restriction_validation_error",
+                    "error_type": "invalid_time_format",
+                    "start_time": start_time_str,
+                    "end_time": end_time_str,
+                    "user": payload.get("sub"),
+                },
+            )
+            # SECURITY: Fail closed - deny access on parsing errors to prevent bypass
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Token has invalid time format in time restrictions: {e}",
+            )

--- a/mcpgateway/utils/time_restrictions.py
+++ b/mcpgateway/utils/time_restrictions.py
@@ -115,7 +115,7 @@ def validate_time_restrictions(payload: Dict[str, Any]) -> None:
             detail="Token has invalid time restriction format: timezone must be a string",
         )
 
-    if not isinstance(allowed_days, list):
+    if not isinstance(allowed_days, list) or not all(isinstance(d, str) for d in allowed_days):
         logger.warning(
             "Invalid type for days in time_restrictions",
             extra={
@@ -126,7 +126,7 @@ def validate_time_restrictions(payload: Dict[str, Any]) -> None:
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Token has invalid time restriction format: days must be a list",
+            detail="Token has invalid time restriction format: days must be a list of strings",
         )
 
     # SECURITY: Fail closed on half-configured time windows.

--- a/mcpgateway/utils/time_restrictions.py
+++ b/mcpgateway/utils/time_restrictions.py
@@ -84,6 +84,69 @@ def validate_time_restrictions(payload: Dict[str, Any]) -> None:
     if not (start_time_str or end_time_str or allowed_days):
         return
 
+    # SECURITY: Type-validate all fields before processing.
+    # Malformed types (e.g. start_time=123, days="Monday") would cause
+    # TypeError in strptime/set operations; fail closed to prevent bypass.
+    if (start_time_str is not None and not isinstance(start_time_str, str)) or (end_time_str is not None and not isinstance(end_time_str, str)):
+        logger.warning(
+            "Invalid type for start_time or end_time in time_restrictions",
+            extra={
+                "security_event": "time_restriction_validation_error",
+                "error_type": "invalid_field_type",
+                "user": payload.get("sub"),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token has invalid time restriction format: start_time and end_time must be strings",
+        )
+
+    if not isinstance(timezone_str, str):
+        logger.warning(
+            "Invalid type for timezone in time_restrictions",
+            extra={
+                "security_event": "time_restriction_validation_error",
+                "error_type": "invalid_field_type",
+                "user": payload.get("sub"),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token has invalid time restriction format: timezone must be a string",
+        )
+
+    if not isinstance(allowed_days, list):
+        logger.warning(
+            "Invalid type for days in time_restrictions",
+            extra={
+                "security_event": "time_restriction_validation_error",
+                "error_type": "invalid_field_type",
+                "user": payload.get("sub"),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token has invalid time restriction format: days must be a list",
+        )
+
+    # SECURITY: Fail closed on half-configured time windows.
+    # Only start_time or only end_time is malformed — deny to prevent bypass.
+    if bool(start_time_str) != bool(end_time_str):
+        logger.warning(
+            f"Incomplete time window in time_restrictions: start_time={start_time_str!r}, end_time={end_time_str!r}",
+            extra={
+                "security_event": "time_restriction_validation_error",
+                "error_type": "incomplete_time_window",
+                "start_time": start_time_str,
+                "end_time": end_time_str,
+                "user": payload.get("sub"),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token has incomplete time restriction: both start_time and end_time are required",
+        )
+
     # Validate day names if day restrictions are present
     if allowed_days:
         invalid_days = set(allowed_days) - VALID_DAYS
@@ -105,7 +168,7 @@ def validate_time_restrictions(payload: Dict[str, Any]) -> None:
     # Get current time in the specified timezone
     try:
         tz = ZoneInfo(timezone_str)
-    except (ZoneInfoNotFoundError, KeyError) as e:
+    except (ZoneInfoNotFoundError, KeyError):
         logger.warning(
             f"Invalid timezone in time_restrictions: {timezone_str}",
             extra={

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -67,6 +67,7 @@ import jwt
 from mcpgateway.config import settings
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.jwt_config_helper import validate_jwt_algo_and_keys
+from mcpgateway.utils.time_restrictions import validate_time_restrictions
 
 basic_security = HTTPBasic(auto_error=False)
 security = HTTPBearer(auto_error=False)
@@ -204,6 +205,9 @@ async def verify_jwt_token(token: str) -> dict:
                     detail=f"Token environment mismatch: token is for '{token_env}', server is '{settings.environment}'",
                     headers={"WWW-Authenticate": "Bearer"},
                 )
+
+        # Validate time restrictions if present in token scopes
+        validate_time_restrictions(payload)
 
         return payload
 

--- a/tests/unit/mcpgateway/utils/test_time_restrictions.py
+++ b/tests/unit/mcpgateway/utils/test_time_restrictions.py
@@ -368,7 +368,7 @@ class TestValidateTimeRestrictions:
             validate_time_restrictions(payload)
 
         assert exc_info.value.status_code == 403
-        assert "days must be a list" in exc_info.value.detail
+        assert "days must be a list of strings" in exc_info.value.detail
 
     def test_int_days_denies(self):
         """Test that integer days is rejected."""
@@ -378,7 +378,27 @@ class TestValidateTimeRestrictions:
             validate_time_restrictions(payload)
 
         assert exc_info.value.status_code == 403
-        assert "days must be a list" in exc_info.value.detail
+        assert "days must be a list of strings" in exc_info.value.detail
+
+    def test_non_string_entries_in_days_denies(self):
+        """Test that non-string entries inside days list are rejected (fail-closed)."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": [123, None]}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "days must be a list of strings" in exc_info.value.detail
+
+    def test_mixed_valid_and_invalid_type_in_days_denies(self):
+        """Test that a mix of strings and non-strings in days is rejected."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": ["Monday", 123]}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "days must be a list of strings" in exc_info.value.detail
 
     # --- Overnight window + days semantics ---
 

--- a/tests/unit/mcpgateway/utils/test_time_restrictions.py
+++ b/tests/unit/mcpgateway/utils/test_time_restrictions.py
@@ -1,0 +1,321 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/utils/test_time_restrictions.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Sebastian Iozu
+
+Unit tests for time restriction validation.
+
+This module tests the time_restrictions validation function to ensure:
+- Valid time windows and day restrictions allow access
+- Invalid time windows and day restrictions deny access
+- Midnight crossing time ranges work correctly
+- Both HH:MM and HH:MM:SS formats are supported
+- Invalid formats and day names are rejected (fail-closed)
+- Empty/missing restrictions allow access
+- Timezone handling works correctly
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+
+# First-Party
+from mcpgateway.utils.time_restrictions import VALID_DAYS, validate_time_restrictions
+
+
+class TestValidateTimeRestrictions:
+    """Test time restriction validation."""
+
+    def test_no_restrictions_passes(self):
+        """Test that tokens without time_restrictions pass through."""
+        payload = {"sub": "user@example.com", "scopes": {}}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    def test_empty_time_restrictions_passes(self):
+        """Test that empty time_restrictions dict passes through."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {}}}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    def test_no_actual_restrictions_passes(self):
+        """Test that time_restrictions with no actual constraints passes through."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": None, "end_time": None, "timezone": "UTC", "days": []}}}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_valid_time_window_passes(self, mock_datetime):
+        """Test that access within allowed time window passes."""
+        # Mock current time to Wednesday 2026-03-25 10:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime  # Keep original strptime
+
+        payload = {
+            "sub": "user@example.com",
+            "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]}},
+        }
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_invalid_time_window_denies(self, mock_datetime):
+        """Test that access outside allowed time window is denied."""
+        # Mock current time to Wednesday 2026-03-25 18:00:00 UTC (after end_time)
+        mock_now = datetime(2026, 3, 25, 18, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {
+            "sub": "user@example.com",
+            "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]}},
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "outside allowed range" in exc_info.value.detail or "restricted to" in exc_info.value.detail
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_wrong_day_denies(self, mock_datetime):
+        """Test that access on non-allowed day is denied."""
+        # Mock current time to Saturday 2026-03-28 10:00:00 UTC
+        mock_now = datetime(2026, 3, 28, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {
+            "sub": "user@example.com",
+            "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]}},
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "Saturday" in exc_info.value.detail
+        assert "restricted to specific days" in exc_info.value.detail
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_midnight_crossing_before_midnight(self, mock_datetime):
+        """Test midnight crossing time range (e.g., 22:00-06:00) before midnight."""
+        # Mock current time to Wednesday 2026-03-25 23:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 23, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "22:00", "end_time": "06:00", "timezone": "UTC", "days": []}}}
+        # Should not raise (23:00 is within 22:00-06:00 range)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_midnight_crossing_after_midnight(self, mock_datetime):
+        """Test midnight crossing time range (e.g., 22:00-06:00) after midnight."""
+        # Mock current time to Thursday 2026-03-26 02:00:00 UTC
+        mock_now = datetime(2026, 3, 26, 2, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "22:00", "end_time": "06:00", "timezone": "UTC", "days": []}}}
+        # Should not raise (02:00 is within 22:00-06:00 range)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_midnight_crossing_outside_range(self, mock_datetime):
+        """Test midnight crossing rejects time outside range."""
+        # Mock current time to Thursday 2026-03-26 10:00:00 UTC
+        mock_now = datetime(2026, 3, 26, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "22:00", "end_time": "06:00", "timezone": "UTC", "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_hhmm_format_supported(self, mock_datetime):
+        """Test that HH:MM format is supported."""
+        # Mock current time to Wednesday 2026-03-25 10:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": []}}}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_hhmmss_format_supported(self, mock_datetime):
+        """Test that HH:MM:SS format is supported."""
+        # Mock current time to Wednesday 2026-03-25 10:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00:00", "end_time": "17:00:00", "timezone": "UTC", "days": []}}}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    def test_invalid_time_format_denies(self):
+        """Test that invalid time format is rejected (fail-closed)."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "9am", "end_time": "5pm", "timezone": "UTC", "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "invalid time format" in exc_info.value.detail.lower()
+
+    def test_invalid_end_time_format_denies(self):
+        """Test that invalid end_time format is rejected when start_time is valid."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "5pm", "timezone": "UTC", "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "invalid time format" in exc_info.value.detail.lower()
+
+    def test_invalid_day_names_denies(self):
+        """Test that invalid day names are rejected."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": ["Monday", "Moonday", "Fireday"]}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "invalid day names" in exc_info.value.detail.lower()
+        assert "Moonday" in exc_info.value.detail or "Fireday" in exc_info.value.detail
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_different_timezone(self, mock_datetime):
+        """Test that timezone handling works correctly."""
+        # Mock current time to Wednesday 2026-03-25 10:00:00 EST (15:00 UTC)
+        est = ZoneInfo("America/New_York")
+        mock_now = datetime(2026, 3, 25, 10, 0, 0, tzinfo=est)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "America/New_York", "days": ["Wednesday"]}}}
+        # Should not raise (10:00 EST is within 09:00-17:00 EST)
+        validate_time_restrictions(payload)
+
+    def test_invalid_timezone_denies(self):
+        """Test that invalid timezone is rejected (fail-closed)."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "Invalid/Timezone", "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "invalid timezone" in exc_info.value.detail.lower()
+
+    def test_only_start_time_no_restriction(self):
+        """Test that only start_time without end_time results in no restriction."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": None, "timezone": "UTC", "days": []}}}
+        # Should not raise (no restriction applied when end_time is missing)
+        validate_time_restrictions(payload)
+
+    def test_only_end_time_no_restriction(self):
+        """Test that only end_time without start_time results in no restriction."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": None, "end_time": "17:00", "timezone": "UTC", "days": []}}}
+        # Should not raise (no restriction applied when start_time is missing)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_only_days_restriction(self, mock_datetime):
+        """Test that day-only restriction works without time range."""
+        # Mock current time to Wednesday 2026-03-25 10:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": None, "end_time": None, "timezone": "UTC", "days": ["Monday", "Wednesday", "Friday"]}}}
+        # Should not raise (Wednesday is in allowed days)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_only_days_restriction_denies(self, mock_datetime):
+        """Test that day-only restriction denies access on wrong day."""
+        # Mock current time to Saturday 2026-03-28 10:00:00 UTC
+        mock_now = datetime(2026, 3, 28, 10, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": None, "end_time": None, "timezone": "UTC", "days": ["Monday", "Wednesday", "Friday"]}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "Saturday" in exc_info.value.detail
+
+    def test_scopes_not_dict_passes(self):
+        """Test that non-dict scopes field passes through."""
+        payload = {"sub": "user@example.com", "scopes": "invalid"}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    def test_time_restrictions_not_dict_passes(self):
+        """Test that non-dict time_restrictions passes through."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": "invalid"}}
+        # Should not raise
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_boundary_exact_start_time(self, mock_datetime):
+        """Test that exact start_time boundary is allowed."""
+        # Mock current time to Wednesday 2026-03-25 09:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 9, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": []}}}
+        # Should not raise (09:00 is exactly at start_time)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_boundary_exact_end_time(self, mock_datetime):
+        """Test that exact end_time boundary is allowed."""
+        # Mock current time to Wednesday 2026-03-25 17:00:00 UTC
+        mock_now = datetime(2026, 3, 25, 17, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": []}}}
+        # Should not raise (17:00 is exactly at end_time)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_seconds_precision_within_range(self, mock_datetime):
+        """Test that HH:MM:SS format with seconds precision works."""
+        # Mock current time to Wednesday 2026-03-25 09:30:45 UTC
+        mock_now = datetime(2026, 3, 25, 9, 30, 45, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00:00", "end_time": "17:00:00", "timezone": "UTC", "days": []}}}
+        # Should not raise (09:30:45 is within 09:00:00-17:00:00)
+        validate_time_restrictions(payload)
+
+    def test_valid_days_constant(self):
+        """Test that VALID_DAYS constant contains all 7 days."""
+        assert len(VALID_DAYS) == 7
+        assert "Monday" in VALID_DAYS
+        assert "Tuesday" in VALID_DAYS
+        assert "Wednesday" in VALID_DAYS
+        assert "Thursday" in VALID_DAYS
+        assert "Friday" in VALID_DAYS
+        assert "Saturday" in VALID_DAYS
+        assert "Sunday" in VALID_DAYS

--- a/tests/unit/mcpgateway/utils/test_time_restrictions.py
+++ b/tests/unit/mcpgateway/utils/test_time_restrictions.py
@@ -221,17 +221,25 @@ class TestValidateTimeRestrictions:
         assert exc_info.value.status_code == 403
         assert "invalid timezone" in exc_info.value.detail.lower()
 
-    def test_only_start_time_no_restriction(self):
-        """Test that only start_time without end_time results in no restriction."""
+    def test_only_start_time_denies(self):
+        """Test that only start_time without end_time is rejected (fail-closed)."""
         payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": None, "timezone": "UTC", "days": []}}}
-        # Should not raise (no restriction applied when end_time is missing)
-        validate_time_restrictions(payload)
 
-    def test_only_end_time_no_restriction(self):
-        """Test that only end_time without start_time results in no restriction."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "incomplete time restriction" in exc_info.value.detail.lower()
+
+    def test_only_end_time_denies(self):
+        """Test that only end_time without start_time is rejected (fail-closed)."""
         payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": None, "end_time": "17:00", "timezone": "UTC", "days": []}}}
-        # Should not raise (no restriction applied when start_time is missing)
-        validate_time_restrictions(payload)
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "incomplete time restriction" in exc_info.value.detail.lower()
 
     @patch("mcpgateway.utils.time_restrictions.datetime")
     def test_only_days_restriction(self, mock_datetime):
@@ -319,3 +327,95 @@ class TestValidateTimeRestrictions:
         assert "Friday" in VALID_DAYS
         assert "Saturday" in VALID_DAYS
         assert "Sunday" in VALID_DAYS
+
+    # --- Type guard tests (fail-closed on wrong inner types) ---
+
+    def test_non_string_start_time_denies(self):
+        """Test that non-string start_time is rejected."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": 123, "end_time": "17:00", "timezone": "UTC", "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "start_time and end_time must be strings" in exc_info.value.detail
+
+    def test_non_string_end_time_denies(self):
+        """Test that non-string end_time is rejected."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": 1700, "timezone": "UTC", "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "start_time and end_time must be strings" in exc_info.value.detail
+
+    def test_non_string_timezone_denies(self):
+        """Test that non-string timezone is rejected."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": 123, "days": []}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "timezone must be a string" in exc_info.value.detail
+
+    def test_non_list_days_denies(self):
+        """Test that non-list days is rejected (e.g. string iterates chars)."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": "Monday"}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "days must be a list" in exc_info.value.detail
+
+    def test_int_days_denies(self):
+        """Test that integer days is rejected."""
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "09:00", "end_time": "17:00", "timezone": "UTC", "days": 1}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "days must be a list" in exc_info.value.detail
+
+    # --- Overnight window + days semantics ---
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_overnight_window_with_days_allows_same_calendar_day(self, mock_datetime):
+        """Test that overnight window allows access on the starting calendar day.
+
+        With days=["Monday"] and window 22:00-06:00, Monday 23:00 is allowed
+        because the day check applies to the current calendar day.
+        """
+        # Monday 23:00 UTC
+        mock_now = datetime(2026, 3, 23, 23, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "22:00", "end_time": "06:00", "timezone": "UTC", "days": ["Monday"]}}}
+        # Should not raise (Monday is allowed, 23:00 is in 22:00-06:00 range)
+        validate_time_restrictions(payload)
+
+    @patch("mcpgateway.utils.time_restrictions.datetime")
+    def test_overnight_window_with_days_denies_next_calendar_day(self, mock_datetime):
+        """Test that overnight window denies access on the next calendar day.
+
+        With days=["Monday"] and window 22:00-06:00, Tuesday 02:00 is denied
+        because the day check applies to the current calendar day (Tuesday),
+        which is not in the allowed list. To allow overnight continuation,
+        include both Monday and Tuesday in the days list.
+        """
+        # Tuesday 02:00 UTC
+        mock_now = datetime(2026, 3, 24, 2, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.strptime = datetime.strptime
+
+        payload = {"sub": "user@example.com", "scopes": {"time_restrictions": {"start_time": "22:00", "end_time": "06:00", "timezone": "UTC", "days": ["Monday"]}}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_time_restrictions(payload)
+
+        assert exc_info.value.status_code == 403
+        assert "Tuesday" in exc_info.value.detail


### PR DESCRIPTION
## 🔗 Related Issue

Implements feature: https://github.com/IBM/mcp-context-forge/issues/3920

---

## 📝 Summary

The time restriction validation feature (added in this branch) enforces temporal access control on API tokens by restricting usage to specific time windows and days. The implementation uses stdlib zoneinfo.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    passed    |
| Unit tests                | `make test`     |    passed   |
| Coverage ≥ 80%            | `make coverage` |   99%     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---
