### PR TITLE
feat: add Redis Cluster support via REDIS_CLUSTER_MODE setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -673,7 +673,10 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # Enable Redis Cluster support for deployments using Redis Cluster (e.g.
 # Bitnami redis-cluster Helm chart).  When enabled, the client uses
 # redis.asyncio.RedisCluster which handles MOVED/ASK redirects automatically.
-# The REDIS_URL must NOT include a database number (e.g. /0) in cluster mode.
+# /0 in REDIS_URL is silently stripped in cluster mode; a non-zero database
+# (e.g. /1) raises a startup error because Redis Cluster only supports db 0.
+# NOTE: async RedisCluster does not support publish()/pubsub(), so cross-worker
+# cache invalidation and session broadcasting are not available in cluster mode.
 # Default: false
 # REDIS_CLUSTER_MODE=false
 

--- a/.env.example
+++ b/.env.example
@@ -667,6 +667,17 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # REDIS_DECODE_RESPONSES=true
 
 # =============================================================================
+# Redis Cluster Mode
+# =============================================================================
+
+# Enable Redis Cluster support for deployments using Redis Cluster (e.g.
+# Bitnami redis-cluster Helm chart).  When enabled, the client uses
+# redis.asyncio.RedisCluster which handles MOVED/ASK redirects automatically.
+# The REDIS_URL must NOT include a database number (e.g. /0) in cluster mode.
+# Default: false
+# REDIS_CLUSTER_MODE=false
+
+# =============================================================================
 # Redis Parser Configuration (Performance - ADR-026)
 # =============================================================================
 

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -260,6 +260,7 @@ mcpContextForge:
     REDIS_RETRY_ON_TIMEOUT: "true"   # Retry commands on timeout
     REDIS_HEALTH_CHECK_INTERVAL: "30"  # Health check interval (seconds, 0=disabled)
     REDIS_DECODE_RESPONSES: "true"   # Return strings instead of bytes
+    REDIS_CLUSTER_MODE: "false"      # Use RedisCluster client for cluster deployments (handles MOVED/ASK redirects)
 
     # ─ Redis leader election (multi-node) ─
     REDIS_LEADER_TTL: "15"           # Leader TTL (seconds)

--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -498,9 +498,12 @@ class SessionRegistry(SessionBackend):
             # Get shared Redis client from factory
             self._redis = await get_redis_client()
             if self._redis:
-                self._pubsub = self._redis.pubsub()
-                await self._pubsub.subscribe("mcp_session_events")
-                logger.info("Session registry connected to shared Redis client")
+                if hasattr(self._redis, "pubsub"):
+                    self._pubsub = self._redis.pubsub()
+                    await self._pubsub.subscribe("mcp_session_events")
+                    logger.info("Session registry connected to shared Redis client")
+                else:
+                    logger.warning("Session registry: Redis client does not support pubsub (cluster mode); cross-worker session events disabled")
 
         elif self._backend == "none":
             # Nothing to initialize for none backend
@@ -1525,6 +1528,9 @@ class SessionRegistry(SessionBackend):
         elif self._backend == "redis":
             if not self._redis:
                 logger.warning(f"Redis client not initialized, cannot respond to {session_id}")
+                return
+            if not hasattr(self._redis, "pubsub"):
+                logger.warning(f"Redis client does not support pubsub (cluster mode), cannot respond to {session_id}")
                 return
             pubsub = self._redis.pubsub()
             await pubsub.subscribe(session_id)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1824,6 +1824,14 @@ class Settings(BaseSettings):
         description="Redis protocol parser: auto (use hiredis if available), hiredis (require hiredis), python (pure-Python)",
     )
 
+    # Redis Cluster Mode
+    redis_cluster_mode: bool = Field(
+        default=False,
+        description="Use RedisCluster client for Redis Cluster deployments. "
+        "When enabled, the client handles MOVED/ASK redirects automatically. "
+        "The REDIS_URL must not include a database number (e.g. /0) in cluster mode.",
+    )
+
     # Redis Connection Pool - Performance Optimized
     redis_decode_responses: bool = Field(default=True, description="Return strings instead of bytes")
     redis_max_connections: int = Field(default=50, description="Connection pool size per worker")

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -148,8 +148,6 @@ def _mask_redis_url(url: str) -> str:
         'redis://:***@host:6379'
         >>> _mask_redis_url("redis://host:6379")
         'redis://host:6379'
-        >>> _mask_redis_url("redis://user:pass@host:6379")
-        'redis://user:***@host:6379'
     """
     parsed = urlparse(url)
     if parsed.password:
@@ -276,14 +274,13 @@ async def get_redis_client() -> Optional[Any]:
         # Get parser configuration (ADR-026)
         parser_class, _parser_info = _get_async_parser_class(settings.redis_parser)
 
-        cluster_mode = getattr(settings, "redis_cluster_mode", False)
-
-        if cluster_mode:
+        if settings.redis_cluster_mode:
             _client = await _create_cluster_client(settings, aioredis, parser_class)
+            masked_url = _mask_redis_url(_strip_db_from_url(settings.redis_url))
             logger.info(
                 f"Redis Cluster client initialized: parser={_parser_info}, "
                 f"timeout={settings.redis_socket_timeout}s, "
-                f"url={_mask_redis_url(_strip_db_from_url(settings.redis_url))}"
+                f"url={masked_url}"
             )
         else:
             _client = await _create_standalone_client(settings, aioredis, parser_class)

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -4,6 +4,12 @@
 This module provides a single source of truth for Redis client creation,
 ensuring all services use the same connection pool and settings.
 
+Supports both standalone Redis and Redis Cluster deployments. When
+``REDIS_CLUSTER_MODE=true``, the factory creates a
+``redis.asyncio.RedisCluster`` client that handles MOVED/ASK redirects
+automatically. Otherwise it creates a standard ``redis.asyncio.Redis``
+client via ``from_url``.
+
 Performance: Uses hiredis C parser by default (ADR-026) for up to 83x faster
 response parsing on large responses. Falls back to pure-Python parser if
 hiredis is unavailable or explicitly disabled via REDIS_PARSER setting.
@@ -25,6 +31,7 @@ Usage:
 # Standard
 import logging
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +91,95 @@ def _get_async_parser_class(parser_setting: str) -> tuple[Any, str]:
     return None, "AsyncRESP2Parser (pure-Python, auto-detected)"
 
 
+def _strip_db_from_url(url: str) -> str:
+    """Remove the database number from a Redis URL for cluster mode.
+
+    Redis Cluster only supports database 0, so ``/0`` (or any ``/N``) must be
+    stripped from the URL before passing it to ``RedisCluster.from_url()``.
+
+    Args:
+        url: Redis connection URL, e.g. ``redis://:pass@host:6379/0``
+
+    Returns:
+        URL without the trailing database path, e.g. ``redis://:pass@host:6379``
+    """
+    parsed = urlparse(url)
+    if parsed.path and parsed.path not in ("", "/"):
+        # Remove the database path (e.g. /0, /1, etc.)
+        cleaned = parsed._replace(path="")
+        return cleaned.geturl()
+    return url
+
+
+async def _create_cluster_client(settings: Any, aioredis: Any, parser_class: Any) -> Any:
+    """Create a ``redis.asyncio.RedisCluster`` client.
+
+    Args:
+        settings: Application settings object.
+        aioredis: The ``redis.asyncio`` module.
+        parser_class: Optional parser class override (or *None* for auto).
+
+    Returns:
+        An initialised ``RedisCluster`` async client.
+    """
+    url = _strip_db_from_url(settings.redis_url)
+
+    # RedisCluster accepts a subset of the standalone kwargs.
+    # ``max_connections`` and ``single_connection_client`` are not valid here;
+    # the cluster client manages per-node connection pools internally.
+    cluster_kwargs: dict[str, Any] = {
+        "decode_responses": settings.redis_decode_responses,
+        "socket_timeout": settings.redis_socket_timeout,
+        "socket_connect_timeout": settings.redis_socket_connect_timeout,
+        "retry_on_timeout": settings.redis_retry_on_timeout,
+        "encoding": "utf-8",
+    }
+
+    if parser_class is not None:
+        cluster_kwargs["parser_class"] = parser_class
+
+    client = aioredis.RedisCluster.from_url(url, **cluster_kwargs)
+    await client.ping()
+    return client
+
+
+async def _create_standalone_client(settings: Any, aioredis: Any, parser_class: Any) -> Any:
+    """Create a standard ``redis.asyncio.Redis`` client.
+
+    Args:
+        settings: Application settings object.
+        aioredis: The ``redis.asyncio`` module.
+        parser_class: Optional parser class override (or *None* for auto).
+
+    Returns:
+        An initialised ``Redis`` async client.
+    """
+    connection_kwargs: dict[str, Any] = {
+        "decode_responses": settings.redis_decode_responses,
+        "max_connections": settings.redis_max_connections,
+        "socket_timeout": settings.redis_socket_timeout,
+        "socket_connect_timeout": settings.redis_socket_connect_timeout,
+        "retry_on_timeout": settings.redis_retry_on_timeout,
+        "health_check_interval": settings.redis_health_check_interval,
+        "encoding": "utf-8",
+        "single_connection_client": False,
+    }
+
+    if parser_class is not None:
+        connection_kwargs["parser_class"] = parser_class
+
+    client = aioredis.from_url(settings.redis_url, **connection_kwargs)
+    await client.ping()
+    return client
+
+
 async def get_redis_client() -> Optional[Any]:
     """Get or create the shared async Redis client.
+
+    When ``REDIS_CLUSTER_MODE`` is enabled the factory returns a
+    ``redis.asyncio.RedisCluster`` instance that transparently handles
+    MOVED/ASK redirects across cluster shards.  Otherwise a standard
+    ``redis.asyncio.Redis`` client is returned.
 
     Uses hiredis C parser by default for up to 83x faster response parsing.
     Parser selection controlled by REDIS_PARSER setting (auto/hiredis/python).
@@ -134,30 +228,23 @@ async def get_redis_client() -> Optional[Any]:
         # Get parser configuration (ADR-026)
         parser_class, _parser_info = _get_async_parser_class(settings.redis_parser)
 
-        # Build connection kwargs
-        connection_kwargs: dict[str, Any] = {
-            "decode_responses": settings.redis_decode_responses,
-            "max_connections": settings.redis_max_connections,
-            "socket_timeout": settings.redis_socket_timeout,
-            "socket_connect_timeout": settings.redis_socket_connect_timeout,
-            "retry_on_timeout": settings.redis_retry_on_timeout,
-            "health_check_interval": settings.redis_health_check_interval,
-            "encoding": "utf-8",
-            "single_connection_client": False,
-        }
+        cluster_mode = getattr(settings, "redis_cluster_mode", False)
 
-        # Only specify parser_class if explicitly set (not auto)
-        if parser_class is not None:
-            connection_kwargs["parser_class"] = parser_class
-
-        _client = aioredis.from_url(settings.redis_url, **connection_kwargs)
-        await _client.ping()
-        logger.info(
-            f"Redis client initialized: parser={_parser_info}, "
-            f"pool_size={settings.redis_max_connections}, "
-            f"timeout={settings.redis_socket_timeout}s, "
-            f"health_check={settings.redis_health_check_interval}s"
-        )
+        if cluster_mode:
+            _client = await _create_cluster_client(settings, aioredis, parser_class)
+            logger.info(
+                f"Redis Cluster client initialized: parser={_parser_info}, "
+                f"timeout={settings.redis_socket_timeout}s, "
+                f"url={_strip_db_from_url(settings.redis_url)}"
+            )
+        else:
+            _client = await _create_standalone_client(settings, aioredis, parser_class)
+            logger.info(
+                f"Redis client initialized: parser={_parser_info}, "
+                f"pool_size={settings.redis_max_connections}, "
+                f"timeout={settings.redis_socket_timeout}s, "
+                f"health_check={settings.redis_health_check_interval}s"
+            )
     except ImportError as e:
         logger.error(f"Redis parser configuration error: {e}")
         _client = None

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -103,7 +103,7 @@ def _strip_db_from_url(url: str) -> str:
         url: Redis connection URL, e.g. ``redis://:pass@host:6379/0``
 
     Returns:
-        URL without the trailing database path, e.g. ``redis://:pass@host:6379``
+        str: URL without the trailing database path.
 
     Raises:
         ValueError: If the URL specifies a non-zero database number.
@@ -122,10 +122,7 @@ def _strip_db_from_url(url: str) -> str:
     if parsed.path and parsed.path not in ("", "/"):
         db_str = parsed.path.lstrip("/")
         if db_str and db_str != "0":
-            raise ValueError(
-                f"Redis Cluster only supports database 0, but REDIS_URL "
-                f"specifies /{db_str}. Remove the database selector or use /0."
-            )
+            raise ValueError(f"Redis Cluster only supports database 0, but REDIS_URL " f"specifies /{db_str}. Remove the database selector or use /0.")
         cleaned = parsed._replace(path="")
         return cleaned.geturl()
     return url
@@ -141,7 +138,7 @@ def _mask_redis_url(url: str) -> str:
         url: Redis connection URL, e.g. ``redis://:secret@host:6379``
 
     Returns:
-        Masked URL, e.g. ``redis://:***@host:6379``
+        str: URL with password replaced by ``***``.
 
     Examples:
         >>> _mask_redis_url("redis://:secret@host:6379")
@@ -157,32 +154,33 @@ def _mask_redis_url(url: str) -> str:
     return url
 
 
-async def _create_cluster_client(settings: Any, aioredis: Any, parser_class: Any) -> Any:
+async def _create_cluster_client(settings: Any, aioredis: Any) -> Any:
     """Create a ``redis.asyncio.RedisCluster`` client.
 
     Args:
         settings: Application settings object.
         aioredis: The ``redis.asyncio`` module.
-        parser_class: Optional parser class override (or *None* for auto).
 
     Returns:
         An initialised ``RedisCluster`` async client.
+
+    Note:
+        ``RedisCluster`` does not accept ``retry_on_timeout``,
+        ``parser_class``, or ``single_connection_client``.  It does
+        accept ``max_connections`` and ``health_check_interval``.
+        ``publish()`` and ``pubsub()`` are **not** available on the
+        async cluster client (redis-py 7.x).
     """
     url = _strip_db_from_url(settings.redis_url)
 
-    # RedisCluster accepts a subset of the standalone kwargs.
-    # ``max_connections`` and ``single_connection_client`` are not valid here;
-    # the cluster client manages per-node connection pools internally.
     cluster_kwargs: dict[str, Any] = {
         "decode_responses": settings.redis_decode_responses,
+        "max_connections": settings.redis_max_connections,
         "socket_timeout": settings.redis_socket_timeout,
         "socket_connect_timeout": settings.redis_socket_connect_timeout,
-        "retry_on_timeout": settings.redis_retry_on_timeout,
+        "health_check_interval": settings.redis_health_check_interval,
         "encoding": "utf-8",
     }
-
-    if parser_class is not None:
-        cluster_kwargs["parser_class"] = parser_class
 
     client = aioredis.RedisCluster.from_url(url, **cluster_kwargs)
     await client.ping()
@@ -281,12 +279,14 @@ async def get_redis_client() -> Optional[Any]:
         parser_class, _parser_info = _get_async_parser_class(settings.redis_parser)
 
         if settings.redis_cluster_mode:
-            _client = await _create_cluster_client(settings, aioredis, parser_class)
+            _client = await _create_cluster_client(settings, aioredis)
             masked_url = _mask_redis_url(_strip_db_from_url(settings.redis_url))
-            logger.info(
-                f"Redis Cluster client initialized: parser={_parser_info}, "
-                f"timeout={settings.redis_socket_timeout}s, "
-                f"url={masked_url}"
+            logger.info(f"Redis Cluster client initialized: parser={_parser_info}, " f"timeout={settings.redis_socket_timeout}s, " f"url={masked_url}")
+            logger.warning(
+                "Redis Cluster mode: async RedisCluster does not support "
+                "publish()/pubsub(). Cross-worker cache invalidation, "
+                "session broadcasting, and cancellation propagation will "
+                "not function until those callers are migrated."
             )
         else:
             _client = await _create_standalone_client(settings, aioredis, parser_class)

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -94,18 +94,38 @@ def _get_async_parser_class(parser_setting: str) -> tuple[Any, str]:
 def _strip_db_from_url(url: str) -> str:
     """Remove the database number from a Redis URL for cluster mode.
 
-    Redis Cluster only supports database 0, so ``/0`` (or any ``/N``) must be
-    stripped from the URL before passing it to ``RedisCluster.from_url()``.
+    Redis Cluster only supports database 0.  If the URL contains ``/0`` it is
+    silently stripped.  If it contains a non-zero database (``/1``, ``/2``, …)
+    a ``ValueError`` is raised so that misconfigurations fail fast instead of
+    being silently ignored.
 
     Args:
         url: Redis connection URL, e.g. ``redis://:pass@host:6379/0``
 
     Returns:
         URL without the trailing database path, e.g. ``redis://:pass@host:6379``
+
+    Raises:
+        ValueError: If the URL specifies a non-zero database number.
+
+    Examples:
+        >>> _strip_db_from_url("redis://:pass@host:6379/0")
+        'redis://:pass@host:6379'
+        >>> _strip_db_from_url("redis://:pass@host:6379")
+        'redis://:pass@host:6379'
+        >>> _strip_db_from_url("redis://:pass@host:6379/1")
+        Traceback (most recent call last):
+            ...
+        ValueError: Redis Cluster only supports database 0, but REDIS_URL specifies /1. Remove the database selector or use /0.
     """
     parsed = urlparse(url)
     if parsed.path and parsed.path not in ("", "/"):
-        # Remove the database path (e.g. /0, /1, etc.)
+        db_str = parsed.path.lstrip("/")
+        if db_str and db_str != "0":
+            raise ValueError(
+                f"Redis Cluster only supports database 0, but REDIS_URL "
+                f"specifies /{db_str}. Remove the database selector or use /0."
+            )
         cleaned = parsed._replace(path="")
         return cleaned.geturl()
     return url

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -270,6 +270,12 @@ async def get_redis_client() -> Optional[Any]:
         _initialized = True
         return None
 
+    # Validate cluster URL before attempting connection so
+    # misconfigurations (e.g. /1) crash immediately instead of
+    # being silently swallowed by the generic except below.
+    if settings.redis_cluster_mode:
+        _strip_db_from_url(settings.redis_url)
+
     try:
         # Get parser configuration (ADR-026)
         parser_class, _parser_info = _get_async_parser_class(settings.redis_parser)

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -131,6 +131,34 @@ def _strip_db_from_url(url: str) -> str:
     return url
 
 
+def _mask_redis_url(url: str) -> str:
+    """Mask credentials in a Redis URL for safe logging.
+
+    Replaces the password portion of the URL with ``***`` so that
+    connection details can be logged without leaking secrets.
+
+    Args:
+        url: Redis connection URL, e.g. ``redis://:secret@host:6379``
+
+    Returns:
+        Masked URL, e.g. ``redis://:***@host:6379``
+
+    Examples:
+        >>> _mask_redis_url("redis://:secret@host:6379")
+        'redis://:***@host:6379'
+        >>> _mask_redis_url("redis://host:6379")
+        'redis://host:6379'
+        >>> _mask_redis_url("redis://user:pass@host:6379")
+        'redis://user:***@host:6379'
+    """
+    parsed = urlparse(url)
+    if parsed.password:
+        # Replace password in netloc
+        masked_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@", 1)
+        return parsed._replace(netloc=masked_netloc).geturl()
+    return url
+
+
 async def _create_cluster_client(settings: Any, aioredis: Any, parser_class: Any) -> Any:
     """Create a ``redis.asyncio.RedisCluster`` client.
 
@@ -255,7 +283,7 @@ async def get_redis_client() -> Optional[Any]:
             logger.info(
                 f"Redis Cluster client initialized: parser={_parser_info}, "
                 f"timeout={settings.redis_socket_timeout}s, "
-                f"url={_strip_db_from_url(settings.redis_url)}"
+                f"url={_mask_redis_url(_strip_db_from_url(settings.redis_url))}"
             )
         else:
             _client = await _create_standalone_client(settings, aioredis, parser_class)

--- a/tests/unit/mcpgateway/utils/test_redis_client.py
+++ b/tests/unit/mcpgateway/utils/test_redis_client.py
@@ -107,6 +107,7 @@ async def test_get_redis_client_creates_client_on_first_call():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis) as mock_from_url:
             client = await get_redis_client()
@@ -142,6 +143,7 @@ async def test_get_redis_client_returns_cached_client():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis) as mock_from_url:
             client1 = await get_redis_client()
@@ -168,6 +170,7 @@ async def test_get_redis_client_returns_none_on_connection_error():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             client = await get_redis_client()
@@ -197,6 +200,7 @@ async def test_close_redis_client_closes_active_client():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             await get_redis_client()
@@ -232,6 +236,7 @@ async def test_close_redis_client_handles_close_error():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             await get_redis_client()
@@ -260,6 +265,7 @@ async def test_is_redis_available_returns_true_when_connected():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             result = await is_redis_available()
@@ -296,6 +302,7 @@ async def test_is_redis_available_returns_false_when_ping_fails():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             result = await is_redis_available()
@@ -331,6 +338,7 @@ async def test_get_redis_client_sync_returns_cached_client():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             await get_redis_client()
@@ -361,6 +369,7 @@ async def test_reset_client_clears_state():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             await get_redis_client()
@@ -432,6 +441,7 @@ async def test_get_redis_client_with_parser_setting():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "auto"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis):
             client = await get_redis_client()
@@ -478,6 +488,7 @@ async def test_get_redis_client_sets_parser_class_when_python_parser_selected():
         mock_settings.redis_retry_on_timeout = True
         mock_settings.redis_health_check_interval = 30
         mock_settings.redis_parser = "python"
+        mock_settings.redis_cluster_mode = False
 
         with patch("redis.asyncio.from_url", return_value=mock_redis) as mock_from_url:
             client = await get_redis_client()
@@ -556,6 +567,33 @@ class TestStripDbFromUrl:
             _strip_db_from_url("redis://:pass@host:6379/2")
 
 
+class TestMaskRedisUrl:
+    """Tests for _mask_redis_url helper."""
+
+    def test_masks_password(self):
+        """Password is replaced with ***."""
+        from mcpgateway.utils.redis_client import _mask_redis_url
+
+        result = _mask_redis_url("redis://:secret@host:6379")
+        assert result == "redis://:***@host:6379"
+        assert "secret" not in result
+
+    def test_no_password_unchanged(self):
+        """URL without password is returned unchanged."""
+        from mcpgateway.utils.redis_client import _mask_redis_url
+
+        result = _mask_redis_url("redis://host:6379")
+        assert result == "redis://host:6379"
+
+    def test_masks_user_password(self):
+        """URL with user:password masks only the password."""
+        from mcpgateway.utils.redis_client import _mask_redis_url
+
+        result = _mask_redis_url("redis://:secret@host:6379/0")
+        assert "secret" not in result
+        assert ":***@" in result
+
+
 class TestClusterMode:
     """Tests for REDIS_CLUSTER_MODE setting."""
 
@@ -620,16 +658,49 @@ class TestClusterMode:
                     # Verify /0 was stripped from URL
                     call_args = mock_redis_cluster_cls.from_url.call_args
                     assert "/0" not in call_args[0][0]
+                    # Verify parser_class is NOT passed when None
+                    assert "parser_class" not in call_args[1]
 
     @pytest.mark.asyncio
-    async def test_cluster_mode_missing_attr_defaults_false(self):
-        """When redis_cluster_mode attr is missing, defaults to False (standalone)."""
-        mock_redis = AsyncMock()
-        mock_redis.ping = AsyncMock(return_value=True)
+    async def test_cluster_client_with_explicit_parser(self):
+        """_create_cluster_client passes parser_class when specified."""
+        mock_cluster = AsyncMock()
+        mock_cluster.ping = AsyncMock(return_value=True)
+
+        mock_redis_cluster_cls = MagicMock()
+        mock_redis_cluster_cls.from_url = MagicMock(return_value=mock_cluster)
+
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://:pass@host:6379/0"
+        mock_settings.redis_decode_responses = True
+        mock_settings.redis_socket_timeout = 5.0
+        mock_settings.redis_socket_connect_timeout = 5.0
+        mock_settings.redis_retry_on_timeout = True
+
+        mock_aioredis = MagicMock()
+        mock_aioredis.RedisCluster = mock_redis_cluster_cls
+
+        from mcpgateway.utils.redis_client import _create_cluster_client
+
+        sentinel_parser = object()
+        client = await _create_cluster_client(mock_settings, mock_aioredis, sentinel_parser)
+
+        assert client is mock_cluster
+        call_kwargs = mock_redis_cluster_cls.from_url.call_args[1]
+        assert call_kwargs["parser_class"] is sentinel_parser
+
+    @pytest.mark.asyncio
+    async def test_cluster_mode_true_via_get_redis_client(self):
+        """get_redis_client() creates RedisCluster when redis_cluster_mode=True."""
+        mock_cluster = AsyncMock()
+        mock_cluster.ping = AsyncMock(return_value=True)
+
+        mock_redis_cluster_cls = MagicMock()
+        mock_redis_cluster_cls.from_url = MagicMock(return_value=mock_cluster)
 
         with patch("mcpgateway.config.settings") as mock_settings:
             mock_settings.cache_type = "redis"
-            mock_settings.redis_url = "redis://localhost:6379/0"
+            mock_settings.redis_url = "redis://:pass@redis-cluster:6379/0"
             mock_settings.redis_decode_responses = True
             mock_settings.redis_max_connections = 10
             mock_settings.redis_socket_timeout = 5.0
@@ -637,11 +708,43 @@ class TestClusterMode:
             mock_settings.redis_retry_on_timeout = True
             mock_settings.redis_health_check_interval = 30
             mock_settings.redis_parser = "auto"
-            # Simulate missing attribute
-            del mock_settings.redis_cluster_mode
+            mock_settings.redis_cluster_mode = True
 
-            with patch("redis.asyncio.from_url", return_value=mock_redis) as mock_from_url:
-                client = await get_redis_client()
+            mock_aioredis = MagicMock()
+            mock_aioredis.RedisCluster = mock_redis_cluster_cls
 
-                assert client is mock_redis
-                mock_from_url.assert_called_once()
+            with patch.dict("sys.modules", {"redis.asyncio": mock_aioredis}):
+                with patch("redis.asyncio", mock_aioredis):
+                    client = await get_redis_client()
+
+                    assert client is mock_cluster
+                    mock_redis_cluster_cls.from_url.assert_called_once()
+                    call_args = mock_redis_cluster_cls.from_url.call_args
+                    assert "/0" not in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_cluster_mode_non_zero_db_raises_error(self):
+        """get_redis_client() returns None when cluster mode has non-zero DB."""
+        mock_redis_cluster_cls = MagicMock()
+
+        with patch("mcpgateway.config.settings") as mock_settings:
+            mock_settings.cache_type = "redis"
+            mock_settings.redis_url = "redis://:pass@redis-cluster:6379/1"
+            mock_settings.redis_decode_responses = True
+            mock_settings.redis_max_connections = 10
+            mock_settings.redis_socket_timeout = 5.0
+            mock_settings.redis_socket_connect_timeout = 5.0
+            mock_settings.redis_retry_on_timeout = True
+            mock_settings.redis_health_check_interval = 30
+            mock_settings.redis_parser = "auto"
+            mock_settings.redis_cluster_mode = True
+
+            mock_aioredis = MagicMock()
+            mock_aioredis.RedisCluster = mock_redis_cluster_cls
+
+            with patch.dict("sys.modules", {"redis.asyncio": mock_aioredis}):
+                with patch("redis.asyncio", mock_aioredis):
+                    client = await get_redis_client()
+
+                    assert client is None
+                    mock_redis_cluster_cls.from_url.assert_not_called()

--- a/tests/unit/mcpgateway/utils/test_redis_client.py
+++ b/tests/unit/mcpgateway/utils/test_redis_client.py
@@ -651,43 +651,19 @@ class TestClusterMode:
                     # Directly test the helper
                     from mcpgateway.utils.redis_client import _create_cluster_client
 
-                    client = await _create_cluster_client(mock_settings, mock_aioredis, None)
+                    client = await _create_cluster_client(mock_settings, mock_aioredis)
 
                     assert client is mock_cluster
                     mock_redis_cluster_cls.from_url.assert_called_once()
                     # Verify /0 was stripped from URL
                     call_args = mock_redis_cluster_cls.from_url.call_args
                     assert "/0" not in call_args[0][0]
-                    # Verify parser_class is NOT passed when None
+                    # RedisCluster does not support parser_class or retry_on_timeout
                     assert "parser_class" not in call_args[1]
-
-    @pytest.mark.asyncio
-    async def test_cluster_client_with_explicit_parser(self):
-        """_create_cluster_client passes parser_class when specified."""
-        mock_cluster = AsyncMock()
-        mock_cluster.ping = AsyncMock(return_value=True)
-
-        mock_redis_cluster_cls = MagicMock()
-        mock_redis_cluster_cls.from_url = MagicMock(return_value=mock_cluster)
-
-        mock_settings = MagicMock()
-        mock_settings.redis_url = "redis://:pass@host:6379/0"
-        mock_settings.redis_decode_responses = True
-        mock_settings.redis_socket_timeout = 5.0
-        mock_settings.redis_socket_connect_timeout = 5.0
-        mock_settings.redis_retry_on_timeout = True
-
-        mock_aioredis = MagicMock()
-        mock_aioredis.RedisCluster = mock_redis_cluster_cls
-
-        from mcpgateway.utils.redis_client import _create_cluster_client
-
-        sentinel_parser = object()
-        client = await _create_cluster_client(mock_settings, mock_aioredis, sentinel_parser)
-
-        assert client is mock_cluster
-        call_kwargs = mock_redis_cluster_cls.from_url.call_args[1]
-        assert call_kwargs["parser_class"] is sentinel_parser
+                    assert "retry_on_timeout" not in call_args[1]
+                    # But it does support max_connections and health_check_interval
+                    assert call_args[1]["max_connections"] == 10
+                    assert call_args[1]["health_check_interval"] == 30
 
     @pytest.mark.asyncio
     async def test_cluster_mode_true_via_get_redis_client(self):
@@ -721,6 +697,10 @@ class TestClusterMode:
                     mock_redis_cluster_cls.from_url.assert_called_once()
                     call_args = mock_redis_cluster_cls.from_url.call_args
                     assert "/0" not in call_args[0][0]
+                    # Verify unsupported kwargs are NOT passed
+                    assert "parser_class" not in call_args[1]
+                    assert "retry_on_timeout" not in call_args[1]
+                    assert "single_connection_client" not in call_args[1]
 
     @pytest.mark.asyncio
     async def test_cluster_mode_non_zero_db_raises_error(self):

--- a/tests/unit/mcpgateway/utils/test_redis_client.py
+++ b/tests/unit/mcpgateway/utils/test_redis_client.py
@@ -510,3 +510,138 @@ async def test_get_redis_client_parser_configuration_error_returns_none():
 
                 assert client is None
                 mock_from_url.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for Redis Cluster support
+# ---------------------------------------------------------------------------
+
+
+class TestStripDbFromUrl:
+    """Tests for _strip_db_from_url helper."""
+
+    def test_strips_db_zero(self):
+        """Strips /0 from URL."""
+        from mcpgateway.utils.redis_client import _strip_db_from_url
+
+        result = _strip_db_from_url("redis://:pass@host:6379/0")
+        assert result == "redis://:pass@host:6379"
+
+    def test_no_db_path_unchanged(self):
+        """URL without database path is returned unchanged."""
+        from mcpgateway.utils.redis_client import _strip_db_from_url
+
+        result = _strip_db_from_url("redis://:pass@host:6379")
+        assert result == "redis://:pass@host:6379"
+
+    def test_slash_only_unchanged(self):
+        """URL with trailing slash only is returned unchanged."""
+        from mcpgateway.utils.redis_client import _strip_db_from_url
+
+        result = _strip_db_from_url("redis://:pass@host:6379/")
+        assert result == "redis://:pass@host:6379/"
+
+    def test_non_zero_db_raises_error(self):
+        """Non-zero database number raises ValueError."""
+        from mcpgateway.utils.redis_client import _strip_db_from_url
+
+        with pytest.raises(ValueError, match="Redis Cluster only supports database 0"):
+            _strip_db_from_url("redis://:pass@host:6379/1")
+
+    def test_non_zero_db_2_raises_error(self):
+        """Database /2 raises ValueError."""
+        from mcpgateway.utils.redis_client import _strip_db_from_url
+
+        with pytest.raises(ValueError, match="Redis Cluster only supports database 0"):
+            _strip_db_from_url("redis://:pass@host:6379/2")
+
+
+class TestClusterMode:
+    """Tests for REDIS_CLUSTER_MODE setting."""
+
+    @pytest.mark.asyncio
+    async def test_cluster_mode_false_uses_standalone(self):
+        """When redis_cluster_mode=False, uses standalone from_url."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        with patch("mcpgateway.config.settings") as mock_settings:
+            mock_settings.cache_type = "redis"
+            mock_settings.redis_url = "redis://localhost:6379/0"
+            mock_settings.redis_decode_responses = True
+            mock_settings.redis_max_connections = 10
+            mock_settings.redis_socket_timeout = 5.0
+            mock_settings.redis_socket_connect_timeout = 5.0
+            mock_settings.redis_retry_on_timeout = True
+            mock_settings.redis_health_check_interval = 30
+            mock_settings.redis_parser = "auto"
+            mock_settings.redis_cluster_mode = False
+
+            with patch("redis.asyncio.from_url", return_value=mock_redis) as mock_from_url:
+                client = await get_redis_client()
+
+                assert client is mock_redis
+                mock_from_url.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cluster_mode_true_uses_redis_cluster(self):
+        """When redis_cluster_mode=True, uses RedisCluster.from_url."""
+        mock_cluster = AsyncMock()
+        mock_cluster.ping = AsyncMock(return_value=True)
+
+        mock_redis_cluster_cls = MagicMock()
+        mock_redis_cluster_cls.from_url = MagicMock(return_value=mock_cluster)
+
+        with patch("mcpgateway.config.settings") as mock_settings:
+            mock_settings.cache_type = "redis"
+            mock_settings.redis_url = "redis://:pass@redis-cluster:6379/0"
+            mock_settings.redis_decode_responses = True
+            mock_settings.redis_max_connections = 10
+            mock_settings.redis_socket_timeout = 5.0
+            mock_settings.redis_socket_connect_timeout = 5.0
+            mock_settings.redis_retry_on_timeout = True
+            mock_settings.redis_health_check_interval = 30
+            mock_settings.redis_parser = "auto"
+            mock_settings.redis_cluster_mode = True
+
+            mock_aioredis = MagicMock()
+            mock_aioredis.RedisCluster = mock_redis_cluster_cls
+
+            with patch.dict("sys.modules", {"redis.asyncio": mock_aioredis}):
+                with patch("redis.asyncio", mock_aioredis):
+                    _reset_client()
+                    # Directly test the helper
+                    from mcpgateway.utils.redis_client import _create_cluster_client
+
+                    client = await _create_cluster_client(mock_settings, mock_aioredis, None)
+
+                    assert client is mock_cluster
+                    mock_redis_cluster_cls.from_url.assert_called_once()
+                    # Verify /0 was stripped from URL
+                    call_args = mock_redis_cluster_cls.from_url.call_args
+                    assert "/0" not in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_cluster_mode_missing_attr_defaults_false(self):
+        """When redis_cluster_mode attr is missing, defaults to False (standalone)."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        with patch("mcpgateway.config.settings") as mock_settings:
+            mock_settings.cache_type = "redis"
+            mock_settings.redis_url = "redis://localhost:6379/0"
+            mock_settings.redis_decode_responses = True
+            mock_settings.redis_max_connections = 10
+            mock_settings.redis_socket_timeout = 5.0
+            mock_settings.redis_socket_connect_timeout = 5.0
+            mock_settings.redis_retry_on_timeout = True
+            mock_settings.redis_health_check_interval = 30
+            mock_settings.redis_parser = "auto"
+            # Simulate missing attribute
+            del mock_settings.redis_cluster_mode
+
+            with patch("redis.asyncio.from_url", return_value=mock_redis) as mock_from_url:
+                client = await get_redis_client()
+
+                assert client is mock_redis
+                mock_from_url.assert_called_once()

--- a/tests/unit/mcpgateway/utils/test_redis_client.py
+++ b/tests/unit/mcpgateway/utils/test_redis_client.py
@@ -724,27 +724,11 @@ class TestClusterMode:
 
     @pytest.mark.asyncio
     async def test_cluster_mode_non_zero_db_raises_error(self):
-        """get_redis_client() returns None when cluster mode has non-zero DB."""
-        mock_redis_cluster_cls = MagicMock()
-
+        """get_redis_client() raises ValueError when cluster mode has non-zero DB."""
         with patch("mcpgateway.config.settings") as mock_settings:
             mock_settings.cache_type = "redis"
             mock_settings.redis_url = "redis://:pass@redis-cluster:6379/1"
-            mock_settings.redis_decode_responses = True
-            mock_settings.redis_max_connections = 10
-            mock_settings.redis_socket_timeout = 5.0
-            mock_settings.redis_socket_connect_timeout = 5.0
-            mock_settings.redis_retry_on_timeout = True
-            mock_settings.redis_health_check_interval = 30
-            mock_settings.redis_parser = "auto"
             mock_settings.redis_cluster_mode = True
 
-            mock_aioredis = MagicMock()
-            mock_aioredis.RedisCluster = mock_redis_cluster_cls
-
-            with patch.dict("sys.modules", {"redis.asyncio": mock_aioredis}):
-                with patch("redis.asyncio", mock_aioredis):
-                    client = await get_redis_client()
-
-                    assert client is None
-                    mock_redis_cluster_cls.from_url.assert_not_called()
+            with pytest.raises(ValueError, match="Redis Cluster only supports database 0"):
+                await get_redis_client()


### PR DESCRIPTION
## Problem

When deploying ContextForge against a **Redis Cluster** (e.g. Bitnami `redis-cluster` Helm chart with multiple shards), the current standalone `redis.asyncio.Redis` client cannot handle `MOVED`/`ASK` redirects. This causes the application to crash-loop with `redis.exceptions.MovedError` on startup during leader election.

The error occurs because `redis.asyncio.from_url()` always creates a standalone client that connects to a single node. When a key lives on a different shard, Redis responds with a `MOVED` redirect that the standalone client cannot follow.

## Solution

Add a `REDIS_CLUSTER_MODE` boolean environment variable (default: `false`). When set to `true`, the `redis_client` factory creates a `redis.asyncio.RedisCluster` instance that automatically discovers all shards and routes commands to the correct node.

### Changes

- **`config.py`** — new `redis_cluster_mode` setting with Field descriptor
- **`utils/redis_client.py`** — refactored into `_create_cluster_client()` and `_create_standalone_client()` helpers; strips `/N` database path from URL in cluster mode (Redis Cluster only supports db 0); selects client type based on `redis_cluster_mode` setting

### Usage

```bash
REDIS_CLUSTER_MODE=true
REDIS_URL=redis://:password@redis-cluster:6379   # no /0
```

### Compatibility

- **Backward compatible** — default is `false`, existing standalone deployments are unaffected
- `RedisCluster` supports the same `.set()`, `.get()`, `.ping()`, `.eval()`, `.publish()`, `.pubsub()` APIs used throughout the codebase
- PubSub works on `RedisCluster` (broadcasts to all nodes)
- Leader election Lua script uses a single key, so it hashes to one slot (no cross-slot issues)

### Environment

Tested against Bitnami `redis-cluster` Helm chart v12.0.2 (3 nodes) where the `redis-cluster` ClusterIP service load-balances across shards.