### PR TITLE
[FIX]: Stabilize CI workflow checks

### DIFF
--- a/.github/workflows/linting-full.yml
+++ b/.github/workflows/linting-full.yml
@@ -40,7 +40,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.x"
+          go-version: "1.25.8"
+          cache-dependency-path: |
+            a2a-agents/go/a2a-echo-agent/go.sum
+            mcp-servers/go/benchmark-server/go.sum
+            mcp-servers/go/fast-time-server/go.sum
+            mcp-servers/go/slow-time-server/go.sum
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/rust-plugins.yml
+++ b/.github/workflows/rust-plugins.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: wheels-build
+          name: wheels-build-${{ matrix.os }}
           path: plugins_rust/*/dist/*.whl
 
   # Security audit (all plugins in one job)
@@ -140,10 +140,10 @@ jobs:
       - name: Run cargo-deny policy checks on all plugins
         run: make rust-deny
 
-  # Benchmark tests (verify benchmarks compile and run)
-  benchmark-tests:
+  # Benchmark build verification (compile benchmark targets without running them)
+  release-build-verification:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    name: Benchmark Tests
+    name: Benchmark Build Verification
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -171,10 +171,10 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: plugins_rust/*/target
-          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-benchmark-build-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run benchmarks for all plugins
-        run: make rust-bench
+      - name: Compile Rust plugin benchmarks without running them
+        run: make rust-bench-build
 
   # Coverage report (all plugins in one job)
   coverage:

--- a/Makefile
+++ b/Makefile
@@ -3294,7 +3294,7 @@ LINT_GO_ROOT ?= $(LINT_TMP_ROOT)/go
 LINT_HELM_ROOT ?= $(LINT_TMP_ROOT)/helm
 LINT_NODE_ROOT ?= $(LINT_TMP_ROOT)/node
 LINT_PY_VENV ?= $(LINT_TMP_ROOT)/py-venv
-LINT_GO_TOOLCHAIN ?= go1.25.7
+LINT_GO_TOOLCHAIN ?= go1.25.8
 
 # Tool target defaults
 LINT_ZIZMOR_TARGET ?= .github/workflows
@@ -8075,6 +8075,7 @@ upgrade-validate:                         ## Validate fresh + upgrade DB startup
 # help: rust-test-integration                 - Run Rust integration tests
 # help: rust-test-all                         - Run all Rust and Python integration tests
 # help: rust-bench                            - Run Rust plugin benchmarks
+# help: rust-bench-build                      - Compile Rust plugin benchmarks without running them
 # help: rust-bench-compare                    - Compare Rust vs Python performance (with benchmarks)
 # help: rust-compare                          - Run compare_performance.py only (skip benchmarks)
 # help: rust-check                            - Run all Rust checks (format, lint, test)
@@ -8093,7 +8094,7 @@ upgrade-validate:                         ## Validate fresh + upgrade DB startup
 # help: rust-mcp-runtime-test                 - Run tests for the experimental Rust MCP runtime
 # help: rust-mcp-runtime-run                  - Run the experimental Rust MCP runtime against local gateway /rpc
 
-.PHONY: rust-build rust-dev rust-test rust-test-integration rust-python-test rust-test-all rust-bench rust-bench-compare rust-compare rust-check rust-clean rust-verify rust-verify-stubs
+.PHONY: rust-build rust-dev rust-test rust-test-integration rust-python-test rust-test-all rust-bench rust-bench-build rust-bench-compare rust-compare rust-check rust-clean rust-verify rust-verify-stubs
 .PHONY: rust-ensure-deps rust-install-deps rust-install-targets rust-install
 .PHONY: rust-build-all-linux rust-build-all-platforms rust-cross rust-cross-install-build
 .PHONY: rust-mcp-runtime-build rust-mcp-runtime-test rust-mcp-runtime-run
@@ -8143,6 +8144,9 @@ rust-test-all: rust-test rust-python-test  ## Run all Rust and Python tests
 
 rust-bench: rust-ensure-deps            ## Run Rust benchmarks
 	@$(MAKE) -C plugins_rust bench
+
+rust-bench-build: rust-ensure-deps      ## Compile Rust plugin benchmarks without running them
+	@$(MAKE) -C plugins_rust bench-build
 
 rust-bench-compare: rust-ensure-deps    ## Compare Rust vs Python performance
 	@$(MAKE) -C plugins_rust bench-compare

--- a/plugins_rust/Makefile
+++ b/plugins_rust/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Rust Plugins
 # Automatically discovers and installs all plugins (subdirectories with Cargo.toml)
 
-.PHONY: install clean list help build test fmt clippy doc test-python test-verbose clean-all fmt-check doc-open bench bench-compare compare check verify verify-stubs clean-stubs test-integration test-all uninstall deny
+.PHONY: install clean list help build test fmt clippy doc test-python test-verbose clean-all fmt-check doc-open bench bench-build bench-compare compare check verify verify-stubs clean-stubs test-integration test-all uninstall deny
 
 # Discover all plugin directories containing Cargo.toml
 PLUGIN_DIRS := $(shell find . -mindepth 1 -maxdepth 1 -type d -exec test -f {}/Cargo.toml \; -print | sed 's|^\./||' | sort)
@@ -127,6 +127,13 @@ bench:
 	@for plugin in $(PLUGIN_DIRS); do \
 		echo "Benchmarking: $$plugin"; \
 		(cd $$plugin && $(MAKE) bench) || exit 1; \
+	done
+
+bench-build:
+	@echo "Compiling benchmarks for all Rust plugins without running them..."
+	@for plugin in $(PLUGIN_DIRS); do \
+		echo "Compiling benchmark targets: $$plugin"; \
+		(cd $$plugin && cargo bench --no-run) || exit 1; \
 	done
 
 bench-compare:

--- a/tests/unit/test_rust_plugins_workflow.py
+++ b/tests/unit/test_rust_plugins_workflow.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "rust-plugins.yml"
+LINTING_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "linting-full.yml"
+MAKEFILE_PATH = Path(__file__).resolve().parents[2] / "Makefile"
+
+
+def load_workflow() -> dict:
+    with WORKFLOW_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def load_linting_workflow() -> dict:
+    with LINTING_WORKFLOW_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_build_wheels_artifacts_are_unique_per_platform():
+    workflow = load_workflow()
+    build_wheels_job = workflow["jobs"]["build-wheels"]
+
+    upload_step = next(step for step in build_wheels_job["steps"] if step.get("name") == "Upload wheels as artifacts")
+
+    assert upload_step["with"]["name"] == "wheels-build-${{ matrix.os }}"
+
+
+def test_rust_ci_compiles_benchmarks_without_running_them():
+    workflow = load_workflow()
+    jobs = workflow["jobs"]
+
+    assert "benchmark-tests" not in jobs
+
+    release_build_job = jobs["release-build-verification"]
+    assert release_build_job["name"] == "Benchmark Build Verification"
+
+    build_step = next(step for step in release_build_job["steps"] if step.get("name") == "Compile Rust plugin benchmarks without running them")
+    assert build_step["run"] == "make rust-bench-build"
+
+
+def test_linting_full_uses_patched_go_and_module_cache_paths():
+    workflow = load_linting_workflow()
+    steps = workflow["jobs"]["linting-full"]["steps"]
+
+    setup_go_step = next(step for step in steps if step.get("name") == "Set up Go")
+    assert setup_go_step["with"]["go-version"] == "1.25.8"
+    assert setup_go_step["with"]["cache-dependency-path"].strip().splitlines() == [
+        "a2a-agents/go/a2a-echo-agent/go.sum",
+        "mcp-servers/go/benchmark-server/go.sum",
+        "mcp-servers/go/fast-time-server/go.sum",
+        "mcp-servers/go/slow-time-server/go.sum",
+    ]
+
+
+def test_linting_go_toolchain_is_patched_in_makefile():
+    makefile = MAKEFILE_PATH.read_text(encoding="utf-8")
+    assert "LINT_GO_TOOLCHAIN ?= go1.25.8" in makefile


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #3894

## 📌 Summary
This PR fixes three CI workflow regressions that were blocking GitHub Actions: Rust wheel artifact uploads were colliding across matrix platforms, the Rust plugin pipeline was running benchmarks instead of compile-only validation, and the Go lint workflow was pinned to a vulnerable toolchain patch release.

## 🔁 Reproduction Steps
- Trigger the Rust plugins workflow on a branch that builds wheels on multiple platforms and observe `upload-artifact@v4` fail with `409 Conflict` because all matrix jobs use the same artifact name.
- Trigger the Rust plugins workflow and observe the benchmark job execute `make rust-bench` instead of compiling bench targets only.
- Trigger the `linting-full` workflow and observe `govulncheck` fail on `GO-2026-4601` while using `go1.25.7`; the workflow also warns because `setup-go` cannot find a root-level `go.sum`.

## 🐞 Root Cause
- `.github/workflows/rust-plugins.yml` uploaded wheel artifacts under a single shared name, `wheels-build`, across all matrix OS jobs.
- The Rust workflow's benchmark validation job ran full benchmarks instead of a compile-only check.
- The linting path pinned `LINT_GO_TOOLCHAIN` to `go1.25.7`, which is the vulnerable stdlib version flagged by `govulncheck`, and the workflow did not point `setup-go` at the repo's actual Go module `go.sum` files.

## 💡 Fix Description
- Changed the Rust wheel artifact name to `wheels-build-${{ matrix.os }}` so matrix uploads are unique.
- Added `rust-bench-build` / `bench-build` make targets and updated the Rust workflow to compile benchmark targets with `cargo bench --no-run` instead of executing them.
- Updated the Go lint toolchain pin to `go1.25.8` and configured `linting-full.yml` with explicit Go module cache dependency paths.
- Added workflow regression tests that parse the Rust and linting workflow YAML plus the Makefile pin.

## 🧪 Verification

| Check                                 | Command                                  | Status |
|---------------------------------------|------------------------------------------|--------|
| Lint suite                            | `make linting-go-govulncheck`            | ✅ |
| Unit tests                            | `uv run pytest tests/unit/test_rust_plugins_workflow.py` | ✅ |
| Coverage ≥ 80 %                       | Not run                                  | n/a |
| Manual regression no longer fails     | `make rust-bench-build`                  | ✅ |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
