### PR TITLE
fix: use parameterized query in cleanup_old_results (CWE-89)

### DIFF
--- a/mcp-servers/python/mcp_eval_server/mcp_eval_server/storage/results_store.py
+++ b/mcp-servers/python/mcp_eval_server/mcp_eval_server/storage/results_store.py
@@ -327,10 +327,11 @@ class ResultsStore:
         """
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(
-                f"""
+                """
                 DELETE FROM evaluation_results
-                WHERE created_at < datetime('now', '-{days_old} days')
-            """
+                WHERE created_at < datetime('now', '-' || CAST(? AS TEXT) || ' days')
+            """,
+                (days_old,),
             )
 
             # Steps are deleted automatically due to foreign key constraint


### PR DESCRIPTION
## Summary

Fixes #3898 — The `cleanup_old_results` method used an f-string to embed the `days_old` parameter directly into SQL, allowing SQL injection if the parameter bypasses type checking.

## Changes

- Replaced the f-string SQL interpolation with a parameterized query using `?` placeholder
- Used `CAST(? AS TEXT)` with string concatenation in the `datetime()` function to safely pass the parameter

## CWE Reference

- **CWE-89**: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
- **Severity**: Medium

## Testing

- Verify that `cleanup_old_results(days_old=30)` still correctly deletes results older than 30 days
- Verify that `cleanup_old_results(days_old=0)` works correctly
- Verify that the parameterized query produces the same results as the original for valid integer inputs

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*