### PR TITLE
feat(ui): allow non-owner users to authorize on accessible OAuth gateways

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-20T20:54:23Z",
+  "generated_at": "2026-04-21T09:41:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8946,7 +8946,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20819,
+        "line_number": 20917,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-21T09:41:21Z",
+  "generated_at": "2026-04-21T09:47:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8939,14 +8939,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 17161,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20917,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -19,6 +19,7 @@
     {% for gateway in data %}
       {% set gateway_label = gateway.name or gateway.id %}
       {% set can_modify = is_admin or gateway.ownerEmail == current_user_email or (gateway.visibility == 'team' and gateway.teamId and user_team_roles.get(gateway.teamId|string) == 'owner') %}
+      {% set can_authorize = can_modify or gateway.visibility == 'public' or (gateway.visibility == 'team' and gateway.teamId and gateway.teamId|string in user_team_roles) %}
       <tr id="gateway-row-{{ gateway.id }}" data-enabled="{{ gateway.enabled|lower }}" data-owner-email="{{ gateway.ownerEmail }}" data-team-id="{{ gateway.teamId or '' }}" data-visibility="{{ gateway.visibility }}">
         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
           <div class="relative"
@@ -68,7 +69,7 @@
                 class="w-full flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
               >Test</button>
 
-              {% if gateway.authType == 'oauth' and can_modify %}
+              {% if gateway.authType == 'oauth' and can_authorize %}
               <!-- OAuth Authorize -->
               <a
                 href="{{ root_path }}/oauth/authorize/{{ gateway.id }}"

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -20914,7 +20914,7 @@ class TestAdminTokensPartialSearch:
             response = await admin_mod.admin_reset_password_handler("token123", request, db=mock_db)
             assert "password_mismatch" in response.headers["location"]
 
-        request.form = AsyncMock(return_value=FakeForm({"password": "NewPassword123!", "confirm_password": "NewPassword123!"}))
+        request.form = AsyncMock(return_value=FakeForm({"password": "NewPassword123!", "confirm_password": "NewPassword123!"})) # pragma: allowlist secret
         with patch("mcpgateway.admin.settings") as mock_settings:
             mock_settings.email_auth_enabled = True
             mock_settings.password_reset_enabled = True

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -19490,6 +19490,104 @@ class TestTemplateButtonGating:
         assert "editGateway" not in html
         assert "/delete" not in html
 
+    def test_gateways_oauth_authorize_visible_for_team_member(self, jinja_env):
+        """Team member (non-owner) can see Authorize button on OAuth team gateway."""
+        gw_data = {
+            "id": "gw-1",
+            "name": "Test Gateway",
+            "ownerEmail": "owner@example.com",
+            "teamId": "team-1",
+            "visibility": "team",
+            "enabled": True,
+            "url": "http://example.com",
+            "authType": "oauth",
+            "tags": [],
+            "lastSeen": None,
+            "team": None,
+        }
+        html = self._render_gateways_partial(
+            jinja_env, gw_data, current_user_email="member@example.com", user_team_roles={"team-1": "member"}
+        )
+        assert "Authorize" in html
+        assert "editGateway" not in html
+        assert "/delete" not in html
+
+    def test_gateways_oauth_authorize_visible_for_public_gateway(self, jinja_env):
+        """Any user can see Authorize button on public OAuth gateway."""
+        gw_data = {
+            "id": "gw-1",
+            "name": "Test Gateway",
+            "ownerEmail": "owner@example.com",
+            "teamId": "team-1",
+            "visibility": "public",
+            "enabled": True,
+            "url": "http://example.com",
+            "authType": "oauth",
+            "tags": [],
+            "lastSeen": None,
+            "team": None,
+        }
+        html = self._render_gateways_partial(jinja_env, gw_data, current_user_email="anyone@example.com")
+        assert "Authorize" in html
+        assert "editGateway" not in html
+        assert "/delete" not in html
+
+    def test_gateways_oauth_authorize_visible_for_owner(self, jinja_env):
+        """Regression: owner still sees Authorize button on OAuth gateway."""
+        gw_data = {
+            "id": "gw-1",
+            "name": "Test Gateway",
+            "ownerEmail": "owner@example.com",
+            "teamId": "team-1",
+            "visibility": "team",
+            "enabled": True,
+            "url": "http://example.com",
+            "authType": "oauth",
+            "tags": [],
+            "lastSeen": None,
+            "team": None,
+        }
+        html = self._render_gateways_partial(jinja_env, gw_data, current_user_email="owner@example.com")
+        assert "Authorize" in html
+        assert "editGateway" in html
+
+    def test_gateways_oauth_authorize_visible_for_admin(self, jinja_env):
+        """Regression: admin still sees Authorize button on OAuth gateway."""
+        gw_data = {
+            "id": "gw-1",
+            "name": "Test Gateway",
+            "ownerEmail": "owner@example.com",
+            "teamId": "team-1",
+            "visibility": "team",
+            "enabled": True,
+            "url": "http://example.com",
+            "authType": "oauth",
+            "tags": [],
+            "lastSeen": None,
+            "team": None,
+        }
+        html = self._render_gateways_partial(jinja_env, gw_data, current_user_email="admin@example.com", is_admin=True)
+        assert "Authorize" in html
+        assert "editGateway" in html
+
+    def test_gateways_oauth_authorize_hidden_for_non_member_team_gateway(self, jinja_env):
+        """Non-member cannot see Authorize button on team OAuth gateway."""
+        gw_data = {
+            "id": "gw-1",
+            "name": "Test Gateway",
+            "ownerEmail": "owner@example.com",
+            "teamId": "team-1",
+            "visibility": "team",
+            "enabled": True,
+            "url": "http://example.com",
+            "authType": "oauth",
+            "tags": [],
+            "lastSeen": None,
+            "team": None,
+        }
+        html = self._render_gateways_partial(jinja_env, gw_data, current_user_email="outsider@example.com")
+        assert "Authorize" not in html
+
     def test_servers_hides_buttons_for_non_owner(self, jinja_env):
         """Non-owner: no editServer in HTML."""
         server_data = {


### PR DESCRIPTION
## 🔗 Related Issue
Closes #3934

---

## 📝 Summary
Non-owner team members and public gateway users cannot see the "🔐 Authorize" button on OAuth gateways, preventing them from completing the OAuth flow. The backend already stores tokens per-user (oauth_tokens.app_user_email), so this is purely a UI visibility fix.

- Add can_authorize template variable (broader than can_modify) for Authorize/Fetch Tools buttons
- Keep can_modify for Edit/Deactivate/Delete (unchanged)
---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   pass     |
| Unit tests                | `make test`     |   pass    |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Changed files:
- gateways_partial.html: 1 line added + 1 line modified
- test_admin.py: 5 tests added (2 positive, 2 regression, 1 negative)

Visibility logic:

```
  ┌─────────────────────────────────┬───────────┬─────────────┐
  │            User type            │ Authorize │ Edit/Delete │
  ├─────────────────────────────────┼───────────┼─────────────┤
  │ Admin                           │    ✅     │     ✅      │
  ├─────────────────────────────────┼───────────┼─────────────┤
  │ Gateway owner                   │    ✅     │     ✅      │
  ├─────────────────────────────────┼───────────┼─────────────┤
  │ Team member (non-gateway-owner) │    ✅     │     ❌      │
  ├─────────────────────────────────┼───────────┼─────────────┤
  │ Any user (public gw)            │    ✅     │     ❌      │
  ├─────────────────────────────────┼───────────┼─────────────┤
  │ Non-member (team gw)            │    ❌     │     ❌      │
  └─────────────────────────────────┴───────────┴─────────────┘
```

Screenshot as team member but not the mcp owner.

<img width="549" height="372" alt="스크린샷 2026-03-31 오전 11 30 46" src="https://github.com/user-attachments/assets/676324a4-6d61-4998-81b6-19ce1e35ca48" />

(AWS Docs MCP set as no auth type)

E2E Verification (manual):
- Built and deployed from this commit to a live K8s cluster
- Tested as a team member who is not the gateway owner
- Confirmed Authorize button is visible and OAuth flow completes successfully
- As team owner: authorization, tool fetch, and tool invocation all work with the user's own token
- As team member: authorization works, but tool fetch/invocation is blocked due to missing tools.execute permission (pending #3882)