### PR TITLE
fix(ui): harden ensureNoResultsElement() against stale DOM IDs

### DIFF
--- a/mcpgateway/admin_ui/search.js
+++ b/mcpgateway/admin_ui/search.js
@@ -405,16 +405,16 @@ export const ensureNoResultsElement = function (
   msg.id = msgId;
   msg.className = "text-gray-700 dark:text-gray-300 mt-2";
   msg.style.display = "none";
-  const span = document.createElement("span");
-  span.id = spanId;
+  const newSpan = document.createElement("span");
+  newSpan.id = spanId;
   msg.appendChild(
     document.createTextNode(`No ${entityLabel} found containing \u201C`)
   );
-  msg.appendChild(span);
+  msg.appendChild(newSpan);
   msg.appendChild(document.createTextNode("\u201D"));
   // Insert right after the container
   container.parentNode.insertBefore(msg, container.nextSibling);
-  return { msg, span };
+  return { msg, span: newSpan };
 };
 
 /**

--- a/mcpgateway/admin_ui/search.js
+++ b/mcpgateway/admin_ui/search.js
@@ -386,13 +386,15 @@ export const ensureNoResultsElement = function (
   entityLabel
 ) {
   let msg = document.getElementById(msgId);
-  let span = document.getElementById(spanId);
   if (msg) {
-    // Element already in the DOM – just return references
-    if (!span) {
-      span = msg.querySelector("span");
-    }
-    return { msg, span };
+    // Scope span lookup to inside msg — guard against global ID collisions
+    const span = document.getElementById(spanId);
+    return { msg, span: span && msg.contains(span) ? span : msg.querySelector("span") };
+  }
+  // Remove any stale element holding spanId before creating a new one
+  const staleSpan = document.getElementById(spanId);
+  if (staleSpan) {
+    staleSpan.removeAttribute("id");
   }
   // Create the message element dynamically
   const container = document.getElementById(containerId);
@@ -403,7 +405,7 @@ export const ensureNoResultsElement = function (
   msg.id = msgId;
   msg.className = "text-gray-700 dark:text-gray-300 mt-2";
   msg.style.display = "none";
-  span = document.createElement("span");
+  const span = document.createElement("span");
   span.id = spanId;
   msg.appendChild(
     document.createTextNode(`No ${entityLabel} found containing \u201C`)

--- a/tests/js/admin-edit-server-selection.test.js
+++ b/tests/js/admin-edit-server-selection.test.js
@@ -2233,6 +2233,59 @@ describe("ensureNoResultsElement", () => {
     expect(result.msg).toBeNull();
     expect(result.span).toBeNull();
   });
+
+  // Edge case: span found globally but not a descendant of msg — should fall back to querySelector
+  test("falls back to querySelector when globally-found span is not inside msg", () => {
+    // msg exists in the DOM with its own inner span (no id)
+    const container = makeContainer("ctr3326a");
+    const msg = doc.createElement("p");
+    msg.id = "noMsg3326a";
+    const innerSpan = doc.createElement("span");
+    msg.appendChild(innerSpan);
+    container.parentNode.insertBefore(msg, container.nextSibling);
+
+    // A rogue span elsewhere in the DOM has the same id
+    const rogueSpan = doc.createElement("span");
+    rogueSpan.id = "querySpan3326a";
+    doc.body.appendChild(rogueSpan);
+
+    const result = win.ensureNoResultsElement(
+      "ctr3326a",
+      "noMsg3326a",
+      "querySpan3326a",
+      "item",
+    );
+
+    // Should return the inner span, not the rogue one
+    expect(result.msg).toBe(msg);
+    expect(result.span).toBe(innerSpan);
+    expect(result.span).not.toBe(rogueSpan);
+    expect(msg.contains(result.span)).toBe(true);
+  });
+
+  // Edge case: msg absent but a stale span with the same id exists — must strip it to prevent duplicate IDs
+  test("removes stale span id before creating new elements to prevent duplicate IDs", () => {
+    const container = makeContainer("ctr3326b");
+
+    // Orphaned span with the target id already in the DOM (msg is absent)
+    const orphanSpan = doc.createElement("span");
+    orphanSpan.id = "querySpan3326b";
+    doc.body.appendChild(orphanSpan);
+
+    const result = win.ensureNoResultsElement(
+      "ctr3326b",
+      "noMsg3326b",
+      "querySpan3326b",
+      "tool",
+    );
+
+    // The newly created span should have the id
+    expect(result.span.id).toBe("querySpan3326b");
+    // The orphan must have had its id stripped to avoid duplicates
+    expect(orphanSpan.id).toBe("");
+    // Only one element with that id should exist
+    expect(doc.querySelectorAll("#querySpan3326b").length).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -1337,8 +1337,7 @@ describe("initGatewaySelect - extended", () => {
       </div>
       <div id="gw-pills"></div>
       <div id="gw-warn"></div>
-      <div id="noGatewayMessage" style="display:none"></div>
-      <span id="searchQueryServers"></span>
+      <p id="noGatewayMessage" style="display:none">No MCP server found containing "<span id="searchQueryServers"></span>"</p>
     `;
 
     initGatewaySelect("gw-select", "gw-pills", "gw-warn", 12, null, null, "searchGateways");


### PR DESCRIPTION
# Bug-fix PR

## 📌 Summary

`ensureNoResultsElement()` in `mcpgateway/admin_ui/search.js` resolved the `spanId` parameter via a global `document.getElementById()` call without verifying that the found element actually belonged to the expected `msg` parent. This could return a span from an entirely different part of the DOM, causing the "no results" query text to be written into the wrong element. Additionally, when `msg` was absent (e.g., after an HTMX partial re-render), the create branch unconditionally stamped a new `<span id=spanId>` without checking for a pre-existing stale element with the same ID, producing duplicate `id` attributes in the DOM — a violation of the HTML spec that makes subsequent `getElementById` calls non-deterministic.

## 🔗 Related Issue

Closes: #3326

## 🔁 Reproduction Steps

See issue #3326 for full reproduction steps. In brief:

**Edge case 1 — wrong span returned:**
```js
// A rogue span elsewhere in the DOM shares the spanId
const rogueSpan = document.createElement("span");
rogueSpan.id = "searchQueryTools";
document.body.appendChild(rogueSpan);

const { msg, span } = ensureNoResultsElement(
    "associatedTools", "noToolsMessage", "searchQueryTools", "tool"
);
console.log(msg.contains(span)); // false — wrong element returned
```

**Edge case 2 — duplicate IDs:**
```js
// msg is absent but an orphaned span with the same id exists
const orphanSpan = document.createElement("span");
orphanSpan.id = "searchQueryTools";
document.body.appendChild(orphanSpan);

ensureNoResultsElement("associatedTools", "noToolsMessage", "searchQueryTools", "tool");
console.log(document.querySelectorAll("#searchQueryTools").length); // 2 — duplicate id
```

## 🐞 Root Cause

In `mcpgateway/admin_ui/search.js` — `ensureNoResultsElement()`:

1. `document.getElementById(spanId)` was called globally at the top of the function with no subsequent check that the found element was a descendant of `msg`. If another element in the DOM happened to carry the same `id` (e.g., a stale element left by HTMX or a browser extension), that foreign element was returned to callers.

2. In the create branch (when `msg` is absent), `span.id = spanId` was assigned unconditionally without first checking for an existing element with that ID, producing duplicate `id` attributes.

## 💡 Fix Description

Two targeted changes to `ensureNoResultsElement()`:

**Fix 1 — Scope span lookup to `msg`:**
```js
// Before
let span = document.getElementById(spanId); // global, no parent check
if (msg) {
    if (!span) { span = msg.querySelector("span"); }
    return { msg, span }; // span may NOT be inside msg
}

// After
if (msg) {
    const span = document.getElementById(spanId);
    return { msg, span: span && msg.contains(span) ? span : msg.querySelector("span") };
}
```
The `msg.contains(span)` guard ensures the globally-found span is actually a descendant of `msg`. If not, it falls back to `msg.querySelector("span")` — the same safe fallback already used when `span` was null.

**Fix 2 — Strip stale ID before creating new elements:**
```js
// Before (create branch)
span = document.createElement("span");
span.id = spanId; // no duplicate check

// After
const staleSpan = document.getElementById(spanId);
if (staleSpan) { staleSpan.removeAttribute("id"); } // dedup guard
// ... then create fresh span
const span = document.createElement("span");
span.id = spanId;
```
Any orphaned element that already holds `spanId` has its `id` stripped before the new element is created, maintaining the HTML uniqueness invariant.

Two regression tests were added to `tests/js/admin-edit-server-selection.test.js` directly targeting each edge case.

Also corrected `tests/unit/js/gateway.test.js`: an existing test had `searchQueryServers` as a sibling element instead of nested inside `noGatewayMessage`, which didn't match the real template DOM structure. Updated to reflect the actual layout.

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | ✅ |
| Unit tests (JS) | `make test-js` | ✅ |
| Edge case 1: wrong span | New test `falls back to querySelector when globally-found span is not inside msg` | ✅ |
| Edge case 2: duplicate ID | New test `removes stale span id before creating new elements to prevent duplicate IDs` | ✅ |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed