### PR TITLE
chore: Add a minimum release age of 10 days for npm packages

### DIFF
--- a/.github/workflows/lint-web.yml
+++ b/.github/workflows/lint-web.yml
@@ -118,8 +118,11 @@ jobs:
           node-version: '20'
 
       # -----------------------------------------------------------
-      # 🔧  Configure npm registry
+      # 🔧  Configure npm
       # -----------------------------------------------------------
+      - name: 🔧  Upgrade npm to minimum required version
+        run: npm install -g npm@^11.10.0
+
       - name: 🔧  Configure npm registry
         run: npm config set registry https://registry.npmjs.org/
 

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -62,13 +62,19 @@ jobs:
           cache: npm
 
       # -----------------------------------------------------------
-      # 2️⃣  Install Dependencies
+      # 2️⃣  Upgrade npm to minimum required version
+      # -----------------------------------------------------------
+      - name: 🔧  Upgrade npm to minimum required version
+        run: npm install -g npm@^11.10.0
+
+      # -----------------------------------------------------------
+      # 3️⃣  Install Dependencies
       # -----------------------------------------------------------
       - name: 📥  Install dependencies
         run: npm ci
 
       # -----------------------------------------------------------
-      # 3️⃣  Run Vitest
+      # 4️⃣  Run Vitest
       # -----------------------------------------------------------
       - name: 🧪  Run Vitest
         run: npx vitest run

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=10


### PR DESCRIPTION
## 🔗 Related Issue
Closes #3940

---

## 📝 Summary
With the recent supply chain attacks, the safest approach is updating npm packages to their latest versions, but limit to versions older than 10 days (to allow time for any CVEs to get flagged).

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [X] Chore (deps, CI, tooling)
- [ ] Other (describe below)

