### PR TITLE
feat(sso): add SSO_OKTA_APIAM_ENABLED to support Okta Org Authorization Server

### DIFF
--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -896,6 +896,10 @@ mcpContextForge:
     SSO_GOOGLE_ENABLED: "false"
     SSO_IBM_VERIFY_ENABLED: "false"
     SSO_OKTA_ENABLED: "false"
+    # Set to "false" when Okta API Access Management add-on is not available.
+    # Uses the Org Authorization Server (/oauth2/v1/*) instead of the Custom
+    # Authorization Server (/oauth2/default/*). Default: "true".
+    SSO_OKTA_APIAM_ENABLED: "true"
     SSO_KEYCLOAK_ENABLED: "false"
     SSO_ENTRA_ENABLED: "false"
     SSO_GENERIC_ENABLED: "false"

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -327,8 +327,16 @@ class Settings(BaseSettings):
     sso_okta_enabled: bool = Field(default=False, description="Enable Okta OIDC authentication")
     sso_okta_client_id: Optional[str] = Field(default=None, description="Okta client ID")
     sso_okta_client_secret: Optional[SecretStr] = Field(default=None, description="Okta client secret")
-    sso_okta_issuer: Optional[str] = Field(default=None, description="Okta issuer URL")
+    sso_okta_issuer: Optional[str] = Field(default=None, description="Okta issuer URL (base URL, e.g. https://company.okta.com)")
     sso_okta_scope: str = Field(default="openid profile email", description="Okta OIDC scopes (space-separated)")
+    sso_okta_apiam_enabled: bool = Field(
+        default=True,
+        description=(
+            "Use Okta API Access Management (Custom Authorization Server, /oauth2/default/*). "
+            "Set to false to use the Okta Org Authorization Server (/oauth2/v1/*), which does not "
+            "require the API Access Management add-on."
+        ),
+    )
     okta_group_mapping: Optional[str] = Field(default=None, description="JSON mapping of Okta group names to team UUIDs")
 
     sso_keycloak_enabled: bool = Field(default=False, description="Enable Keycloak OIDC authentication")

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -64,11 +64,12 @@ def get_predefined_sso_providers() -> List[Dict]:
         >>> isinstance(result, list)
         True
 
-        Patch configuration to include Okta provider:
+        Patch configuration to include Okta provider (API Access Management / Custom Authorization Server):
         >>> cfg = SimpleNamespace(
         ...     sso_github_enabled=False, sso_github_client_id=None, sso_github_client_secret=None,
         ...     sso_trusted_domains=[], sso_auto_create_users=True,
         ...     sso_google_enabled=False, sso_okta_enabled=True, sso_okta_client_id='ok', sso_okta_client_secret='os', sso_okta_issuer='https://company.okta.com',
+        ...     sso_okta_apiam_enabled=True,
         ...     sso_ibm_verify_enabled=False, sso_entra_enabled=False
         ... )
         >>> with patch('mcpgateway.utils.sso_bootstrap.settings', cfg):
@@ -186,6 +187,20 @@ def get_predefined_sso_providers() -> List[Dict]:
                     logger.warning("OKTA_GROUP_MAPPING must be a JSON object (got %s); using empty team mapping", type(parsed).__name__)
             except (json.JSONDecodeError, TypeError):
                 logger.warning("Failed to parse OKTA_GROUP_MAPPING as JSON; using empty team mapping")
+        # SSO_OKTA_APIAM_ENABLED=true (default): Custom Authorization Server — requires the
+        # Okta API Access Management add-on (/oauth2/default/*).
+        # SSO_OKTA_APIAM_ENABLED=false: Org Authorization Server — no add-on required (/oauth2/v1/*).
+        apiam_enabled = getattr(settings, "sso_okta_apiam_enabled", True)
+        if apiam_enabled:
+            authorization_url = f"{base_url}/oauth2/default/v1/authorize"
+            token_url = f"{base_url}/oauth2/default/v1/token"
+            userinfo_url = f"{base_url}/oauth2/default/v1/userinfo"
+            issuer = f"{base_url}/oauth2/default"
+        else:
+            authorization_url = f"{base_url}/oauth2/v1/authorize"
+            token_url = f"{base_url}/oauth2/v1/token"
+            userinfo_url = f"{base_url}/oauth2/v1/userinfo"
+            issuer = base_url
         providers.append(
             {
                 "id": "okta",
@@ -194,10 +209,10 @@ def get_predefined_sso_providers() -> List[Dict]:
                 "provider_type": "oidc",
                 "client_id": settings.sso_okta_client_id,
                 "client_secret": settings.sso_okta_client_secret.get_secret_value() if settings.sso_okta_client_secret else "",
-                "authorization_url": f"{base_url}/oauth2/default/v1/authorize",
-                "token_url": f"{base_url}/oauth2/default/v1/token",
-                "userinfo_url": f"{base_url}/oauth2/default/v1/userinfo",
-                "issuer": f"{base_url}/oauth2/default",
+                "authorization_url": authorization_url,
+                "token_url": token_url,
+                "userinfo_url": userinfo_url,
+                "issuer": issuer,
                 "scope": settings.sso_okta_scope,
                 "trusted_domains": settings.sso_trusted_domains,
                 "auto_create_users": settings.sso_auto_create_users,


### PR DESCRIPTION
## Summary

Okta's **Custom Authorization Server** (`/oauth2/default/*`) requires the **API Access Management** add-on, which is not included in all Okta subscription tiers. Without it, the authorization request returns:

> `Your request resulted in an error. The requested feature is not enabled in this environment.`

The **Org Authorization Server** (`/oauth2/v1/*`) works without any add-on and supports the same OIDC flows for standard SSO use cases.

This PR adds `SSO_OKTA_APIAM_ENABLED` (default `true`, preserving existing behaviour) so operators can opt in to the Org Authorization Server without modifying the database manually after every pod restart.

## Changes

- **`mcpgateway/config.py`** — adds `sso_okta_apiam_enabled: bool` field (env var `SSO_OKTA_APIAM_ENABLED`, default `true`)
- **`mcpgateway/utils/sso_bootstrap.py`** — branches on `sso_okta_apiam_enabled` to write either Custom Authorization Server URLs (existing behaviour) or Org Authorization Server URLs to the DB on startup
- **`charts/mcp-stack/values.yaml`** — exposes `SSO_OKTA_APIAM_ENABLED: "true"` as a config key under `mcpContextForge.secret`

## URL mapping

| | Custom Authorization Server (`APIAM_ENABLED=true`, default) | Org Authorization Server (`APIAM_ENABLED=false`) |
|---|---|---|
| `authorization_url` | `{issuer}/oauth2/default/v1/authorize` | `{issuer}/oauth2/v1/authorize` |
| `token_url` | `{issuer}/oauth2/default/v1/token` | `{issuer}/oauth2/v1/token` |
| `userinfo_url` | `{issuer}/oauth2/default/v1/userinfo` | `{issuer}/oauth2/v1/userinfo` |
| `issuer` (DB) | `{issuer}/oauth2/default` | `{issuer}` |

## Behaviour

- **Default (`SSO_OKTA_APIAM_ENABLED=true`)**: no change to existing deployments.
- **`SSO_OKTA_APIAM_ENABLED=false`**: bootstrap writes Org Authorization Server URLs on every pod start, eliminating the need for manual DB patches after restarts.

## How to enable

```yaml
# charts/mcp-stack/values.yaml (or your wrapper chart override)
mcpContextForge:
  secret:
    SSO_OKTA_ENABLED: "true"
    SSO_OKTA_APIAM_ENABLED: "false"
    SSO_OKTA_CLIENT_ID: "<your-okta-client-id>"
    SSO_OKTA_CLIENT_SECRET: "<your-okta-client-secret>"
    SSO_OKTA_ISSUER: "https://<your-okta-domain>.okta.com"
```
