### PR TITLE
fix(rbac): unblock self-service public team join for non-admin users

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -72,7 +72,7 @@ from mcpgateway.common.models import LogLevel
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings, UI_HIDABLE_HEADER_ITEMS, UI_HIDABLE_SECTIONS, UI_HIDE_SECTION_ALIASES
 from mcpgateway.db import A2AAgent as DbA2AAgent
-from mcpgateway.db import EmailApiToken, EmailTeam, extract_json_field
+from mcpgateway.db import EmailApiToken, EmailTeam, EmailTeamJoinRequest, extract_json_field
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import get_db, GlobalConfig, ObservabilitySavedQuery, ObservabilitySpan, ObservabilityTrace
 from mcpgateway.db import Prompt as DbPrompt
@@ -6765,7 +6765,7 @@ async def admin_remove_team_member(
 
 
 @admin_router.post("/teams/{team_id}/leave")
-@require_permission("teams.join", allow_admin_bypass=False)  # Users who can join can also leave
+@require_permission("teams.join", allow_admin_bypass=False, check_globally=True)  # Users who can join can also leave
 async def admin_leave_team(
     team_id: str,
     request: Request,  # pylint: disable=unused-argument
@@ -6838,7 +6838,7 @@ async def admin_leave_team(
 
 
 @admin_router.post("/teams/{team_id}/join-request")
-@require_permission("teams.join", allow_admin_bypass=False)
+@require_permission("teams.join", allow_admin_bypass=False, check_globally=True)
 async def admin_create_join_request(
     team_id: str,
     request: Request,
@@ -6927,7 +6927,7 @@ async def admin_create_join_request(
 
 
 @admin_router.delete("/teams/{team_id}/join-request/{request_id}")
-@require_permission("teams.join", allow_admin_bypass=False)
+@require_permission("teams.join", allow_admin_bypass=False, check_globally=True)
 async def admin_cancel_join_request(
     team_id: str,
     request_id: str,
@@ -6951,6 +6951,11 @@ async def admin_cancel_join_request(
     try:
         team_service = TeamManagementService(db)
         user_email = get_user_email(user)
+
+        # Verify the join request belongs to this team before cancelling
+        join_request = db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id, EmailTeamJoinRequest.team_id == team_id).first()
+        if not join_request:
+            return HTMLResponse(content='<div class="text-red-500">Join request not found for this team</div>', status_code=404)
 
         # Cancel the join request
         success = await team_service.cancel_join_request(request_id, user_email)

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -553,7 +553,7 @@ def _is_mutate_permission(permission: str) -> bool:
     return parts[-1] in _MUTATE_PERMISSION_ACTIONS if len(parts) >= 2 else False
 
 
-def require_permission(permission: str, resource_type: Optional[str] = None, allow_admin_bypass: bool = True):
+def require_permission(permission: str, resource_type: Optional[str] = None, allow_admin_bypass: bool = True, check_globally: bool = False):
     """Decorator to require specific permission for accessing an endpoint.
 
     Args:
@@ -562,6 +562,10 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
         allow_admin_bypass: If True (default), admin users bypass all permission checks.
                            If False, even admins must have explicit permissions.
                            Use False for admin UI routes to enforce granular RBAC.
+        check_globally: If True, evaluate the permission against global/personal roles
+                        only, ignoring the request's team_id. Use for team-entry endpoints
+                        (e.g. join, leave) where the user needs a global permission but
+                        the URL contains a team_id they are not yet a member of.
 
     Returns:
         Callable: Decorated function that enforces the permission requirement
@@ -641,6 +645,13 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
                 # verify_team_for_user, token team membership checks).
                 if not team_id:
                     check_any_team = True
+
+            # check_globally: evaluate permission against global/personal roles only,
+            # ignoring the request's team_id.  Used for team-entry endpoints where the
+            # caller needs teams.join but is not yet a member of the target team.
+            if check_globally:
+                team_id = None
+                check_any_team = False
 
             # First, check if any plugins want to handle permission checking
             # First-Party
@@ -781,6 +792,7 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
         setattr(wrapper, "_required_permission", permission)
         setattr(wrapper, "_resource_type", resource_type)
         setattr(wrapper, "_allow_admin_bypass", allow_admin_bypass)
+        setattr(wrapper, "_check_globally", check_globally)
 
         return wrapper
 

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -886,7 +886,7 @@ async def cancel_team_invitation(invitation_id: str, current_user: dict = Depend
 
 
 @teams_router.post("/{team_id}/join", response_model=TeamJoinRequestResponse)
-@require_permission("teams.join")
+@require_permission("teams.join", check_globally=True)
 async def request_to_join_team(
     team_id: str,
     join_request: TeamJoinRequest,

--- a/tests/playwright/teams/conftest.py
+++ b/tests/playwright/teams/conftest.py
@@ -26,10 +26,13 @@ BASE_URL = os.getenv("TEST_BASE_URL", "http://localhost:8080")
 TEST_PASSWORD = "SecureTestPass123!"
 
 
-def _make_jwt(email: str, is_admin: bool = False, teams=None) -> str:
+def _make_jwt(email: str, is_admin: bool = False, teams=None, token_use: str = None) -> str:
     """Create a JWT token for testing."""
+    payload = {"sub": email}
+    if token_use:
+        payload["token_use"] = token_use
     return _create_jwt_token(
-        {"sub": email},
+        payload,
         user_data={"email": email, "is_admin": is_admin, "auth_provider": "local"},
         teams=teams,
     )

--- a/tests/playwright/teams/test_team_member_roles.py
+++ b/tests/playwright/teams/test_team_member_roles.py
@@ -100,8 +100,8 @@ class TestTeamMemberRoles:
         team_id = team_with_member["team"]["id"]
         member = team_with_member["member_email"]
 
-        # Leave as the member
-        member_jwt = _make_jwt(member, is_admin=False)
+        # Leave as the member (session token resolves DB team membership)
+        member_jwt = _make_jwt(member, is_admin=False, token_use="session")
         member_ctx = playwright.request.new_context(
             base_url=BASE_URL,
             extra_http_headers={"Authorization": f"Bearer {member_jwt}", "Accept": "application/json"},

--- a/tests/playwright/test_rbac_permissions.py
+++ b/tests/playwright/test_rbac_permissions.py
@@ -1467,11 +1467,12 @@ class TestSessionTokenCookieRBAC:
         logger.info("Developer cookie /rpc tools/list: error_code=%s — RBAC passed", error_code)
 
     def test_cross_team_tool_not_visible(self, playwright: Playwright, admin_api: APIRequestContext, rbac_developer_user: Dict):
-        """Developer must NOT see tools scoped to a different team (cross-team isolation).
+        """Developer must NOT access tools scoped to a different team (cross-team isolation).
 
         Creates a tool in a fresh team the developer does NOT belong to.
-        Verifies Layer 1 (token scoping) denies visibility even though
-        check_any_team=True grants the RBAC permission.
+        Verifies Layer 2 (RBAC) denies access when an explicit out-of-scope
+        team_id is provided.  The token-scoping guard in _get_user_roles()
+        rejects the request before Layer 1 filtering runs.
         """
         import json as _json  # noqa: PLC0415
 
@@ -1501,14 +1502,8 @@ class TestSessionTokenCookieRBAC:
             )
             try:
                 list_resp = dev_ctx.get(f"/tools?team_id={other_team_id}")
-                assert list_resp.status == 200
-                tools = list_resp.json()
-                names = [t.get("name") for t in (tools if isinstance(tools, list) else tools.get("tools", []))]
-                assert tool_name not in names, (
-                    f"Developer can see cross-team tool '{tool_name}' — Layer 1 isolation broken. "
-                    f"Visible: {names}"
-                )
-                logger.info("Cross-team tool '%s' correctly NOT visible to developer", tool_name)
+                assert list_resp.status == 403, f"Expected 403 for cross-team tool access, got {list_resp.status}"
+                logger.info("Cross-team tool access correctly denied with 403 for developer")
             finally:
                 dev_ctx.dispose()
         finally:

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -2633,3 +2633,63 @@ def test_rbac_get_db_backwards_compatibility():
                 pass
 
             mock_session.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# check_globally parameter tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_require_permission_check_globally_overrides_team_id(monkeypatch):
+    """check_globally=True must pass team_id=None to check_permission even when team_id kwarg is present."""
+
+    async def dummy_func(user=None, team_id=None):
+        return "ok"
+
+    mock_db = MagicMock()
+    mock_user = {"email": "user@example.com", "db": mock_db, "token_teams": []}
+    mock_perm_service = AsyncMock()
+    mock_perm_service.check_permission.return_value = True
+    monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+    decorated = rbac.require_permission("teams.join", check_globally=True)(dummy_func)
+    result = await decorated(user=mock_user, team_id="some-team-id")
+    assert result == "ok"
+    # team_id must be None, not "some-team-id"
+    assert mock_perm_service.check_permission.call_args.kwargs["team_id"] is None
+    # check_any_team must be False (global/personal roles only)
+    assert mock_perm_service.check_permission.call_args.kwargs["check_any_team"] is False
+
+
+@pytest.mark.asyncio
+async def test_require_permission_check_globally_false_preserves_team_id(monkeypatch):
+    """Default check_globally=False must NOT override team_id."""
+
+    async def dummy_func(user=None, team_id=None):
+        return "ok"
+
+    mock_db = MagicMock()
+    mock_user = {"email": "user@example.com", "db": mock_db, "token_teams": ["some-team-id"]}
+    mock_perm_service = AsyncMock()
+    mock_perm_service.check_permission.return_value = True
+    monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+    decorated = rbac.require_permission("teams.join")(dummy_func)
+    result = await decorated(user=mock_user, team_id="some-team-id")
+    assert result == "ok"
+    assert mock_perm_service.check_permission.call_args.kwargs["team_id"] == "some-team-id"
+
+
+@pytest.mark.asyncio
+async def test_require_permission_check_globally_metadata():
+    """check_globally value must be stored as function attribute for introspection."""
+
+    async def dummy_func(user=None):
+        return "ok"
+
+    decorated = rbac.require_permission("teams.join", check_globally=True)(dummy_func)
+    assert getattr(decorated, "_check_globally", None) is True
+
+    decorated_default = rbac.require_permission("teams.join")(dummy_func)
+    assert getattr(decorated_default, "_check_globally", None) is False

--- a/tests/unit/mcpgateway/routers/test_teams_coverage.py
+++ b/tests/unit/mcpgateway/routers/test_teams_coverage.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 
 # Patch RBAC decorators before importing teams module
-def _noop_decorator(permission: str, resource_type=None):
+def _noop_decorator(permission: str, resource_type=None, **kwargs):
     def decorator(func):
         return func
 

--- a/tests/unit/mcpgateway/routers/test_teams_v2.py
+++ b/tests/unit/mcpgateway/routers/test_teams_v2.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 
 
 # First, patch RBAC decorators before any mcpgateway imports
-def mock_require_permission_decorator(permission: str, resource_type=None):
+def mock_require_permission_decorator(permission: str, resource_type=None, **kwargs):
     """Mock decorator that bypasses permission checks."""
 
     def decorator(func):

--- a/tests/utils/rbac_mocks.py
+++ b/tests/utils/rbac_mocks.py
@@ -265,7 +265,7 @@ class RBACMockManager:
             self.app.dependency_overrides.update(self.original_overrides)
 
 
-def mock_require_permission_decorator(permission: str, resource_type: Optional[str] = None):
+def mock_require_permission_decorator(permission: str, resource_type: Optional[str] = None, **kwargs):
     """Mock version of the require_permission decorator that always allows access.
 
     This decorator bypasses all permission checks and simply executes the


### PR DESCRIPTION
## Summary

- Add `check_globally` parameter to `require_permission()` decorator to evaluate permissions against global/personal roles without binding to the request's `team_id`
- Apply to team-entry endpoints (`join`, `leave`, `join-request`, `cancel-join-request`) where users need `teams.join` but aren't yet members of the target team
- Add team_id validation to admin cancel-join-request to prevent cross-team cancellation
- Fix two Playwright test bugs (wrong token type, wrong assertion)

Closes #3960

## Test plan

- [ ] Unit tests: `pytest tests/unit/mcpgateway/middleware/test_rbac.py tests/unit/mcpgateway/services/test_permission_service_token_narrowing.py tests/unit/mcpgateway/services/test_rbac_cross_team_isolation.py -v` (335 pass)
- [ ] Full unit suite: 15,274 pass, 0 fail
- [ ] Pylint parallel: `make pylint` → 10.00/10
- [ ] Playwright: `test_request_to_join_public_team`, `test_member_leaves_team`, `test_cross_team_tool_not_visible`
- [ ] Manual: non-admin session token → `POST /teams/{public_team}/join` → 200