### PR TITLE
fix: convert schema PromptArgument to mcp types in prompts/list handler

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1804,7 +1804,17 @@ async def list_prompts() -> List[types.Prompt]:
         try:
             async with get_db() as db:
                 prompts = await prompt_service.list_server_prompts(db, server_id, user_email=user_email, token_teams=token_teams)
-                return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
+                return [
+                    types.Prompt(
+                        name=prompt.name,
+                        description=prompt.description,
+                        arguments=[
+                            types.PromptArgument(name=arg.name, description=arg.description, required=arg.required)
+                            for arg in (prompt.arguments or [])
+                        ],
+                    )
+                    for prompt in prompts
+                ]
         except Exception as e:
             logger.exception("Error listing Prompts:%s", e)
             return []
@@ -1812,7 +1822,17 @@ async def list_prompts() -> List[types.Prompt]:
         try:
             async with get_db() as db:
                 prompts, _ = await prompt_service.list_prompts(db, include_inactive=False, limit=0, user_email=user_email, token_teams=token_teams)
-                return [types.Prompt(name=prompt.name, description=prompt.description, arguments=prompt.arguments) for prompt in prompts]
+                return [
+                    types.Prompt(
+                        name=prompt.name,
+                        description=prompt.description,
+                        arguments=[
+                            types.PromptArgument(name=arg.name, description=arg.description, required=arg.required)
+                            for arg in (prompt.arguments or [])
+                        ],
+                    )
+                    for prompt in prompts
+                ]
         except Exception as e:
             logger.exception("Error listing prompts:%s", e)
             return []


### PR DESCRIPTION
## Problem

The `prompts/list` MCP JSON-RPC method always returns an empty array through the gateway's MCP protocol endpoints (`/servers/{UUID}/mcp/` and `/mcp/`), even when prompts are correctly registered in the database.

The root cause is a Pydantic v2 type mismatch: `prompt_service.list_server_prompts()` returns `PromptRead` objects whose `arguments` field contains `mcpgateway.schemas.PromptArgument` instances, but `mcp.types.Prompt()` expects `mcp.types.PromptArgument`. Pydantic v2 strict validation rejects the foreign model and the exception is silently caught, resulting in an empty list.

`tools/list` and `resources/list` work correctly — only `prompts/list` is affected.

## Solution

Explicitly convert each `mcpgateway.schemas.PromptArgument` to `mcp.types.PromptArgument` when constructing the `types.Prompt` response in both code paths (server-scoped and global).

## Changes

- 1 file modified (`mcpgateway/transports/streamablehttp_transport.py`)
- 22 lines changed (2 list comprehensions expanded)
- No breaking changes

Closes #3939