### PR TITLE
fix: add /app to container PYTHONPATH for alternate entrypoints

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -117,8 +117,10 @@ EXPOSE 4444
 # Set the runtime user
 USER 1001
 
-# Ensure virtual environment binaries are in PATH
-ENV PATH="/app/.venv/bin:$PATH"
+# Ensure virtual environment binaries are in PATH and project modules resolve
+# even when containers run an alternate Python entrypoint.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH="/app"
 
 # HTTP server selection via HTTP_SERVER environment variable:
 #   - gunicorn : Python-based with Uvicorn workers (default)

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -318,6 +318,7 @@ COPY --from=builder --chown=1001:0 /app /app
 # - Disable pip version check to reduce startup time
 # ----------------------------------------------------------------------------
 ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONPATH="/app" \
     CONTEXTFORGE_ENABLE_RUST_BUILD=${ENABLE_RUST} \
     CONTEXTFORGE_ENABLE_RUST_MCP_RMCP_BUILD=${ENABLE_RUST_MCP_RMCP} \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/Containerfile.scratch
+++ b/Containerfile.scratch
@@ -321,6 +321,7 @@ COPY --from=builder ${ROOTFS_PATH}/ /
 # - Disable pip version check to reduce startup time
 # ----------------------------------------------------------------------------
 ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONPATH="/app" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONHASHSEED=random \


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 80 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Set `PYTHONPATH=/app` in the gateway runtime container images so Python imports keep working when the container is started with an entrypoint other than `./docker-entrypoint.sh`.

## 🔁 Reproduction Steps
Use one of the published gateway images with an alternate Python entrypoint or command that imports project modules directly from `/app`. Without `PYTHONPATH=/app`, imports depend on the launch context and can fail even though the code is present in the image.

## 🐞 Root Cause
The container images exported the virtualenv `bin` directory in `PATH`, but they did not export the application root in `PYTHONPATH`. That made module discovery fragile for alternate entrypoints.

## 💡 Fix Description
Add `PYTHONPATH=/app` to the shared runtime environment in `Containerfile`, `Containerfile.lite`, and `Containerfile.scratch`. This keeps imports stable across the standard entrypoint and alternate Python-based entrypoints without changing application startup logic.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Not run |
| Unit tests                            | `make test`          | Not run |
| Coverage ≥ 80 %                       | `make coverage`      | Not run |
| Manual regression no longer fails     | `git diff --check` and env review | Passed |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
