### PR TITLE
fix: Fix team join RBAC permissions

### DIFF
--- a/mcpgateway/services/permission_service.py
+++ b/mcpgateway/services/permission_service.py
@@ -516,7 +516,7 @@ class PermissionService:
             # When team_id is out of scope, we skip adding team-scoped roles but still
             # return global and personal roles (needed for join endpoint and other operations).
             if token_teams is not None and (len(token_teams) == 0 or team_id not in token_teams):
-                logger.warning(
+                logger.debug(
                     f"[RBAC] Team {SecurityValidator.sanitize_log_message(team_id)} not in token scope "
                     f"{SecurityValidator.sanitize_log_message(token_teams)} for {SecurityValidator.sanitize_log_message(user_email)}: "
                     f"excluding team-scoped roles but keeping global/personal roles"

--- a/tests/unit/mcpgateway/services/test_permission_service.py
+++ b/tests/unit/mcpgateway/services/test_permission_service.py
@@ -667,8 +667,7 @@ async def test_get_user_roles_out_of_scope_team_preserves_global_roles(svc, mock
     # User has token scoped to team-a, but requests roles for team-b (out of scope)
     roles = await svc._get_user_roles("user@test.com", team_id="team-b", token_teams=["team-a"])
 
-    # Should return empty list because team-b is out of scope
-    # But the fix ensures global roles are still included via scope_conditions
+    # Team-scoped roles for team-b are excluded, but global roles are preserved
     assert len(roles) == 1
     assert roles[0].scope == "global"
 

--- a/tests/unit/mcpgateway/services/test_permission_service_token_narrowing.py
+++ b/tests/unit/mcpgateway/services/test_permission_service_token_narrowing.py
@@ -568,6 +568,34 @@ async def test_explicit_team_id_excludes_out_of_scope_narrowed_token(svc, mock_d
 
 
 @pytest.mark.asyncio
+async def test_explicit_team_id_includes_team_roles_when_token_unrestricted(svc, mock_db):
+    """_get_user_roles includes team-scoped roles when token_teams is None (unrestricted).
+
+    Unrestricted tokens (token_teams=None) skip the narrowing guard entirely,
+    so team-scoped roles for the explicit team_id must appear in the query.
+    """
+    role = SimpleNamespace(name="developer", permissions=["tools.read"], get_effective_permissions=lambda: ["tools.read"])
+    team_user_role = SimpleNamespace(role=role, role_id="r1", scope="team", scope_id="team-a")
+    mock_db.execute.return_value.unique.return_value.scalars.return_value.all.return_value = [team_user_role]
+
+    result = await svc._get_user_roles(
+        "user@test.com",
+        team_id="team-a",
+        include_all_teams=False,
+        token_teams=None,  # Unrestricted
+    )
+
+    assert len(result) == 1
+    assert result[0].scope == "team"
+    assert result[0].scope_id == "team-a"
+
+    # Verify the compiled query includes team-scoped condition for team-a
+    query_arg = mock_db.execute.call_args[0][0]
+    compiled = str(query_arg.compile(compile_kwargs={"literal_binds": True}))
+    assert "team-a" in compiled, "Unrestricted token must include team-scoped roles for the requested team"
+
+
+@pytest.mark.asyncio
 async def test_has_admin_permission_suppresses_bypass_for_public_only(svc):
     """has_admin_permission suppresses admin bypass for token_teams=[].
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

<img width="391" height="193" alt="Screenshot 2026-04-02 at 00 00 57" src="https://github.com/user-attachments/assets/681ff39f-5893-4dc9-a0c3-bbdabff248c5" />

Closes #3980

## 🔁 Reproduction Steps
1. Login as an Admin user in the Admin UI
2. Create a public team
3. Create a non-admin user
4. Logout, then login as the new (non-admin) user
5. Request to create the public team

## 🐞 Root Cause
The team permission check returned `[]` when `team_id` was out of token scope, incorrectly discarding global and personal roles needed for the join endpoint.

## 💡 Fix Description                                                                                                                                                                                                                                                    Changed the guard to skip adding out-of-scope team roles while preserving global and personal roles in the scope conditions.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |    ✅    |
| Manual regression no longer fails     | steps / screenshots  |    ✅    |

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [X] No secrets/credentials committed
