### PR TITLE
fix(ui): clarify MCP Servers and Virtual Servers naming in admin UI

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2401,7 +2401,7 @@
         {% endif %}
         <div class="flex justify-between items-center mb-4">
           <div class="flex items-center space-x-10">
-            <h2 class="text-2xl font-bold dark:text-gray-200">Virtual MCP Servers</h2>
+            <h2 class="text-2xl font-bold dark:text-gray-200">Virtual Servers (Federated MCP Endpoints)</h2>
             <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
               Virtual Servers let you combine Tools, Resources, and Prompts into
               an MCP Server with its own API key (see API Tokens).
@@ -4989,7 +4989,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
       <div id="gateways-panel" class="tab-panel hidden">
         <div class="flex justify-between items-center mb-4">
           <h2 class="text-2xl font-bold dark:text-gray-200">
-            MCP Servers & Federated Gateways (MCP Registry)
+            MCP Servers (Registry)
           </h2>
           <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
             Register external MCP Servers (SSE/HTTP) to retrieve their


### PR DESCRIPTION
## 🔗 Related Issue
N/A

---

## 📝 Summary
Clarify the Admin UI tab headers to reduce naming confusion between MCP Servers and Virtual Servers.

- "MCP Servers & Federated Gateways (MCP Registry)" → "MCP Servers (Registry)"
- "Virtual MCP Servers" → "Virtual Servers (Federated MCP Endpoints)"

The "Federated Gateways" label was misleading on the MCP Servers tab — federation is what Virtual Servers do (combining tools/resources from multiple MCP servers into a single endpoint), not what the MCP Servers registry does.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [X] Other (describe below)

Admin UI changes.

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   pass     |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |   pass     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

UI-only text change, 2 lines modified in admin.html. No logic or behavior changes.

