### PR TITLE
fix: handle missing expires_in in OAuth token response

### DIFF
--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -573,13 +573,18 @@ class OAuthManager:
 
         # Store tokens if storage service is available
         if self.token_storage:
+            # Use provider's expires_in if present; None means the provider
+            # does not specify token expiration (e.g. GitHub OAuth Apps).
+            raw_expires = token_response.get("expires_in")
+            expires_in = int(raw_expires) if raw_expires is not None else None
+
             token_record = await self.token_storage.store_tokens(
                 gateway_id=gateway_id,
                 user_id=user_id,
                 app_user_email=app_user_email,  # User from state
                 access_token=token_response["access_token"],
                 refresh_token=token_response.get("refresh_token"),
-                expires_in=token_response.get("expires_in", self.settings.oauth_default_timeout),
+                expires_in=expires_in,
                 scopes=token_response.get("scope", "").split(),
             )
 

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -74,7 +74,7 @@ class TokenStorageService:
             logger.warning("OAuth encryption not available, using plain text storage")
             self.encryption = None
 
-    async def store_tokens(self, gateway_id: str, user_id: str, app_user_email: str, access_token: str, refresh_token: Optional[str], expires_in: int, scopes: List[str]) -> OAuthToken:
+    async def store_tokens(self, gateway_id: str, user_id: str, app_user_email: str, access_token: str, refresh_token: Optional[str], expires_in: Optional[int], scopes: List[str]) -> OAuthToken:
         """Store OAuth tokens for a gateway-user combination.
 
         Args:
@@ -83,7 +83,7 @@ class TokenStorageService:
             app_user_email: ContextForge user email (required)
             access_token: Access token from OAuth provider
             refresh_token: Refresh token from OAuth provider (optional)
-            expires_in: Token expiration time in seconds
+            expires_in: Token expiration time in seconds, or None if the provider does not specify expiration
             scopes: List of OAuth scopes granted
 
         Returns:
@@ -102,8 +102,12 @@ class TokenStorageService:
                 if refresh_token:
                     encrypted_refresh = await self.encryption.encrypt_secret_async(refresh_token)
 
-            # Calculate expiration
-            expires_at = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+            # Calculate expiration (None if provider does not specify expires_in)
+            if expires_in is not None:
+                expires_at = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+            else:
+                logger.info(f"No expires_in from OAuth provider for gateway {SecurityValidator.sanitize_log_message(gateway_id)} — token will not auto-expire")
+                expires_at = None
             # Create or update token record - now scoped by app_user_email
             token_record = self.db.execute(select(OAuthToken).where(OAuthToken.gateway_id == gateway_id, OAuthToken.app_user_email == app_user_email)).scalar_one_or_none()
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

When an OAuth2 provider omits the `expires_in` field from the token response, the gateway crashes with a `TypeError` during token storage. The `expires_in` parameter is **RECOMMENDED** but not **REQUIRED** per [RFC 6749 Section 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1), so providers may legitimately omit it (e.g., GitHub OAuth Apps, some Azure AD configurations).

Fixes #3989

## 🔁 Reproduction Steps

1. Configure a gateway with OAuth2 pointing to a provider that does not return `expires_in` in the token response
2. Trigger the OAuth authorization code flow
3. Token exchange succeeds, but storing the token fails with `TypeError: unsupported operand type(s) for +: 'datetime' and 'NoneType'`

## 🐞 Root Cause

In `oauth_manager.py`, `token_response.get("expires_in", self.settings.oauth_default_timeout)` always returns a value, which hides the issue. However, when the provider returns `expires_in: null` or omits it entirely and the fallback default is also `None`, the code in `token_storage_service.py` tries to compute `datetime.now() + timedelta(seconds=int(None))` which raises `TypeError`.

More importantly, the current code papers over the absence of `expires_in` by substituting `oauth_default_timeout`, which may not reflect the actual token lifetime — the token could be valid indefinitely.

## 💡 Fix Description

**`oauth_manager.py`**: Extract `expires_in` with `.get()` and explicitly convert to `int` only when present. Pass `None` when the provider does not specify expiration.

**`token_storage_service.py`**: 
- Change `expires_in` parameter type from `int` to `Optional[int]`
- When `expires_in is None`, set `expires_at = None` and log an informational message
- When `expires_in` is provided, compute `expires_at` as before

The existing `_is_token_expired()` method already handles `expires_at=None` correctly (returns `False`, treating the token as non-expired).

## 🧪 Verification

| Check | Command | Status |
| --- | --- | --- |
| Lint suite | `make lint` | ⚠️ Not run (no local dev env) |
| Unit tests | `make test` | ⚠️ Not run (no local dev env) |
| Coverage ≥ 80 % | `make coverage` | ⚠️ Not run (no local dev env) |
| Manual regression no longer fails | Tested in production (Kubernetes) for 2+ weeks with Freshservice OAuth (which returns expires_in) and verified graceful handling when expires_in is absent | ✅ |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted
- [x] No secrets/credentials committed
- [x] DCO Signed-off-by included