### PR TITLE
fix: use absolute OAuth authorize URL and allow non-admin users to authorize

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3772,7 +3772,8 @@ class ToolService(BaseService):
                     if access_token:
                         headers = {"Authorization": f"Bearer {access_token}"}
                     else:
-                        raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit /oauth/authorize/{gateway_id_str} to complete OAuth flow.")
+                        authorize_url = f"{str(settings.app_domain).rstrip('/')}{settings.app_root_path}/oauth/authorize/{gateway_id_str}"
+                        raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit {authorize_url} to complete OAuth flow.")
                 except Exception as e:
                     logger.error(f"Failed to obtain stored OAuth token for gateway {gateway_name}: {e}")
                     raise ToolInvocationError(f"OAuth token retrieval failed for gateway: {str(e)}")
@@ -4859,7 +4860,8 @@ class ToolService(BaseService):
                                     headers = {"Authorization": f"Bearer {access_token}"}
                                 else:
                                     # User hasn't authorized this gateway yet
-                                    raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit /oauth/authorize/{gateway_id_str} to complete OAuth flow.")
+                                    authorize_url = f"{str(settings.app_domain).rstrip('/')}{settings.app_root_path}/oauth/authorize/{gateway_id_str}"
+                                    raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit {authorize_url} to complete OAuth flow.")
                             except Exception as e:
                                 logger.error(f"Failed to obtain stored OAuth token for gateway {gateway_name}: {e}")
                                 raise ToolInvocationError(f"OAuth token retrieval failed for gateway: {str(e)}")

--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -68,8 +68,8 @@
                 class="w-full flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
               >Test</button>
 
-              {% if gateway.authType == 'oauth' and can_modify %}
-              <!-- OAuth Authorize -->
+              {% if gateway.authType == 'oauth' %}
+              <!-- OAuth Authorize (accessible to all authenticated users with gateway access) -->
               <a
                 href="{{ root_path }}/oauth/authorize/{{ gateway.id }}"
                 @click="menuOpen = false"


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Two related OAuth UX fixes for multi-user deployments:

1. **Relative authorize URL in error messages**: When a tool invocation fails due to a missing OAuth token, the `ToolInvocationError` message contains `/oauth/authorize/{id}` — a relative path that AI agents (VS Code Copilot, etc.) cannot use. Fixed to build an absolute URL using `settings.app_domain` + `settings.app_root_path`.

2. **Authorize button hidden for non-admin users**: In `gateways_partial.html`, the "Authorize" button is gated behind `can_modify` (admin/owner). Since OAuth authorization is a per-user action (each user needs their own token), any authenticated user with gateway access should be able to authorize. "Fetch/Refresh Tools" remains admin-only.

Fixes #3998

## 🔁 Reproduction Steps

**Bug 1:**
1. Configure a gateway with OAuth enabled
2. As a non-admin user, call a tool on that gateway via MCP client
3. Error: `"Visit /oauth/authorize/xxx to complete OAuth flow"` — relative path

**Bug 2:**
1. As a non-admin team member, open Admin UI gateways list
2. OAuth gateway the user has access to is visible
3. No "Authorize" button — only admins see it

## 🐞 Root Cause

1. `tool_service.py`: Uses hardcoded relative path `/oauth/authorize/{id}` in two `ToolInvocationError` messages (line ~3162 and ~4165)
2. `gateways_partial.html`: `{% if gateway.authType == 'oauth' and can_modify %}` groups the Authorize button with admin-only actions

## 💡 Fix Description

1. **`tool_service.py`**: Build `authorize_url` from `settings.app_domain` + `settings.app_root_path` + `/oauth/authorize/{id}`. Applied in both `invoke_tool` and `stream_invoke_tool` code paths.
2. **`gateways_partial.html`**: Change condition to `{% if gateway.authType == 'oauth' %}` (no `can_modify`) for the Authorize button. The `{% if can_modify %}` block now starts after the Authorize button, before Fetch/Refresh Tools.

## 🧪 Verification

| Check | Command | Status |
| --- | --- | --- |
| Lint suite | `make lint` | ⚠️ Not run (no local dev env) |
| Unit tests | `make test` | ⚠️ Not run (no local dev env) |
| Coverage ≥ 80 % | `make coverage` | ⚠️ Not run (no local dev env) |
| Manual regression | Tested in production Kubernetes (3+ weeks) — VS Code Copilot receives clickable absolute URLs, non-admin team members can authorize gateways | ✅ |

## 📐 MCP Compliance
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted
- [x] No secrets/credentials committed
- [x] DCO Signed-off-by included