### PR TITLE
Benchmark docker compose deployment fix

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1289,8 +1289,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
                 invalidate_passthrough_header_caches()
 
-            # Invalidate registry cache and tool lookup cache for newly registered gateway tools/resources/prompts
-            # This ensures that subsequent list_tools and invoke_tool calls see the newly discovered items
+            # Invalidate caches for new gateway items
             cache = _get_registry_cache()
             if tools:
                 await cache.invalidate_tools()
@@ -1299,7 +1298,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             if db_prompts:
                 await cache.invalidate_prompts()
 
-            # Invalidate tool lookup cache for this gateway
+            # Invalidate tool lookup cache
             tool_lookup_cache = _get_tool_lookup_cache()
             await tool_lookup_cache.invalidate_gateway(str(db_gateway.id))
 


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
-->

## 🔗 Related Issue
The deployment and benchmark creates situation when tools not found:
```
make testing-rebuild-rust-full
```
As a result of this one cannot test with `make benchmark-mcp-tools`


---

## 📝 Summary
The PR fixes the gateway deployment issue, the tools list is empty when deployed with : `make testing-up-rust-full`

---

## 🏷️ Type of Change
- [x] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
