### PR TITLE
Set TCP_NODELAY on socket in order to speed up statefull mcp server and make it comparable with rest api call rps.

### DIFF
--- a/mcp-servers/rust/fast-test-server/src/main.rs
+++ b/mcp-servers/rust/fast-test-server/src/main.rs
@@ -31,7 +31,7 @@ use std::env;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
-use tracing::log::trace;
+use tracing::trace;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:9080";
@@ -348,8 +348,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Bind and serve
     let tcp_listener = tokio::net::TcpListener::bind(&bind_address)
-        .await
-        .unwrap()
+        .await?
         .tap_io(|tcp_stream| {
             if let Err(err) = tcp_stream.set_nodelay(true) {
                 trace!("failed to set TCP_NODELAY on incoming connection: {err:#}");
@@ -505,5 +504,10 @@ mod tests {
     fn test_unknown_timezone() {
         let result = parse_timezone("Invalid/Timezone");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_server() {
+        let _server = FastTestServer::default();
     }
 }


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes # Slow benchmark results on fast-test-server.

---

## 📝 Summary
_Disables Nagle's algorithm (TCP_NODELAY) in the Rust fast-test-server to reduce latency and significantly improve throughput for MCP protocol operations._

The optimization sets `TCP_NODELAY` on the server socket before passing it to tokio's async runtime, eliminating the TCP buffering delay that was impacting small, frequent MCP JSON-RPC messages.

**Performance improvements** (benchmark source: https://github.com/sco3/mcp-benchmark):

```
cargo run --release --bin sdk-benchmark -- -s http://localhost:9080/mcp -t get_system_time  -u 16 -r 100
```

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Init** | 9,355 req/s (1.69ms) | 10,348 req/s (1.52ms) | **+10.6%** |
| **Tool/list** | 384 req/s (41.46ms) | 67,809 req/s (0.22ms) | **+176x** |
| **Tool call** | 382 req/s (40.59ms) | 71,687 req/s (0.21ms) | **+187x** |

The dramatic improvement in tool/list and tool call operations indicates that Nagle's algorithm was causing significant batching delays for small MCP protocol messages.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Technical details:**
- Added `socket2` crate dependency for low-level socket configuration
- Socket is configured with `TCP_NODELAY=true` before being converted to tokio's `TcpListener`
- This is a common optimization for latency-sensitive applications using request/response patterns with small messages

**Files changed:**
- `mcp-servers/rust/fast-test-server/Cargo.toml` - Added socket2 dependency
- `mcp-servers/rust/fast-test-server/Cargo.lock` - Updated lock file
- `mcp-servers/rust/fast-test-server/src/main.rs` - Socket configuration and minor formatting

