### PR TITLE
feat(gateway): add tools_include and tools_exclude filters

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -979,6 +979,19 @@ async def _parse_gateway_data_from_request(request: Request) -> dict[str, Any]:
         if oauth_config:
             data["oauth_config"] = oauth_config
 
+        # Normalize tools_include / tools_exclude (JSON list or comma-separated string)
+        for key in ("tools_include", "tools_exclude"):
+            if key in data and isinstance(data[key], str):
+                raw = data[key].strip()
+                if not raw:
+                    data[key] = None
+                    continue
+                try:
+                    parsed = orjson.loads(raw)
+                    data[key] = parsed if isinstance(parsed, list) else [str(parsed)]
+                except (orjson.JSONDecodeError, ValueError):
+                    data[key] = [p.strip() for p in raw.split(",") if p.strip()]
+
         return data
 
     else:
@@ -12825,6 +12838,25 @@ async def admin_edit_gateway(
         else:
             passthrough_headers = None
 
+        # Handle tools_include filter
+        # Use [] (empty list) to signal "user cleared the filter" vs None (not provided)
+        tools_include_str = str(form.get("tools_include", ""))
+        tools_include: Optional[List[str]] = []
+        if tools_include_str and tools_include_str.strip():
+            try:
+                tools_include = orjson.loads(tools_include_str)
+            except (orjson.JSONDecodeError, ValueError):
+                tools_include = [p.strip() for p in tools_include_str.split(",") if p.strip()]
+
+        # Handle tools_exclude filter
+        tools_exclude_str = str(form.get("tools_exclude", ""))
+        tools_exclude: Optional[List[str]] = []
+        if tools_exclude_str and tools_exclude_str.strip():
+            try:
+                tools_exclude = orjson.loads(tools_exclude_str)
+            except (orjson.JSONDecodeError, ValueError):
+                tools_exclude = [p.strip() for p in tools_exclude_str.split(",") if p.strip()]
+
         # Parse OAuth configuration - support both JSON string and individual form fields
         oauth_config_json = str(form.get("oauth_config"))
         oauth_config: Optional[dict[str, Any]] = None
@@ -12931,6 +12963,8 @@ async def admin_edit_gateway(
             auth_query_param_value=str(form.get("auth_query_param_value", "")) or None,
             one_time_auth=form.get("one_time_auth", False),
             passthrough_headers=passthrough_headers,
+            tools_include=tools_include,
+            tools_exclude=tools_exclude,
             oauth_config=oauth_config,
             visibility=visibility,
             owner_email=user_email,

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -797,6 +797,28 @@ export const handleEditGatewayFormSubmit = async function (e) {
 
     formData.append("passthrough_headers", JSON.stringify(passthroughHeaders));
 
+    // Process tools_include - convert comma-separated string to JSON array
+    const toolsIncludeString = formData.get("tools_include") || "";
+    const toolsInclude = toolsIncludeString
+      .split(",")
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern.length > 0);
+    if (toolsInclude.length > 0) {
+      formData.delete("tools_include");
+      formData.append("tools_include", JSON.stringify(toolsInclude));
+    }
+
+    // Process tools_exclude - convert comma-separated string to JSON array
+    const toolsExcludeString = formData.get("tools_exclude") || "";
+    const toolsExclude = toolsExcludeString
+      .split(",")
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern.length > 0);
+    if (toolsExclude.length > 0) {
+      formData.delete("tools_exclude");
+      formData.append("tools_exclude", JSON.stringify(toolsExclude));
+    }
+
     // Handle OAuth configuration
     // NOTE: OAuth config assembly is now handled by the backend (mcpgateway/admin.py)
     // The backend assembles individual form fields into oauth_config with proper field names
@@ -893,6 +915,28 @@ export const handleEditA2AAgentFormSubmit = async function (e) {
     }
 
     formData.append("passthrough_headers", JSON.stringify(passthroughHeaders));
+
+    // Process tools_include - convert comma-separated string to JSON array
+    const editToolsIncludeString = formData.get("tools_include") || "";
+    const editToolsInclude = editToolsIncludeString
+      .split(",")
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern.length > 0);
+    if (editToolsInclude.length > 0) {
+      formData.delete("tools_include");
+      formData.append("tools_include", JSON.stringify(editToolsInclude));
+    }
+
+    // Process tools_exclude - convert comma-separated string to JSON array
+    const editToolsExcludeString = formData.get("tools_exclude") || "";
+    const editToolsExclude = editToolsExcludeString
+      .split(",")
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern.length > 0);
+    if (editToolsExclude.length > 0) {
+      formData.delete("tools_exclude");
+      formData.append("tools_exclude", JSON.stringify(editToolsExclude));
+    }
 
     // Handle auth_headers JSON field
     const authHeadersJson = formData.get("auth_headers");

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -576,6 +576,26 @@ export const editGateway = async function (gatewayId) {
       }
     }
 
+    // Handle tools_include
+    const toolsIncludeField = safeGetElement("edit-gateway-tools-include");
+    if (toolsIncludeField) {
+      if (gateway.toolsInclude && Array.isArray(gateway.toolsInclude)) {
+        toolsIncludeField.value = gateway.toolsInclude.join(", ");
+      } else {
+        toolsIncludeField.value = "";
+      }
+    }
+
+    // Handle tools_exclude
+    const toolsExcludeField = safeGetElement("edit-gateway-tools-exclude");
+    if (toolsExcludeField) {
+      if (gateway.toolsExclude && Array.isArray(gateway.toolsExclude)) {
+        toolsExcludeField.value = gateway.toolsExclude.join(", ");
+      } else {
+        toolsExcludeField.value = "";
+      }
+    }
+
     openModal("gateway-edit-modal");
     applyVisibilityRestrictions(["edit-gateway-visibility"]); // Disable public radio if restricted, preserve checked state
     console.log("✓ Gateway edit modal loaded successfully");

--- a/mcpgateway/alembic/versions/b3c4d5e6f7a8_add_gateway_tool_filters.py
+++ b/mcpgateway/alembic/versions/b3c4d5e6f7a8_add_gateway_tool_filters.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+"""Add tools_include and tools_exclude columns to gateways table.
+
+Revision ID: b3c4d5e6f7a8
+Revises: a7f3c9e1b2d4
+Create Date: 2026-04-03 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "b3c4d5e6f7a8"
+down_revision = "a7f3c9e1b2d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add tool filter columns to gateways."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_columns = {col["name"] for col in inspector.get_columns("gateways")}
+
+    if "tools_include" not in existing_columns:
+        op.add_column("gateways", sa.Column("tools_include", sa.JSON(), nullable=True, comment="Glob patterns to include tools (whitelist)"))
+    if "tools_exclude" not in existing_columns:
+        op.add_column("gateways", sa.Column("tools_exclude", sa.JSON(), nullable=True, comment="Glob patterns to exclude tools (blacklist)"))
+
+
+def downgrade():
+    """Remove tool filter columns from gateways."""
+    with op.batch_alter_table("gateways", schema=None) as batch_op:
+        batch_op.drop_column("tools_exclude")
+        batch_op.drop_column("tools_include")

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -4739,6 +4739,13 @@ class Gateway(Base):
     # Overrides global settings when set: {enabled, mode, headers_prefix, sign_claims, allowed_attributes}
     identity_propagation: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True, comment="Per-gateway identity propagation config overrides")
 
+    # Tool filtering: include/exclude patterns (fnmatch glob syntax)
+    # - tools_include: only tools matching at least one pattern are imported (whitelist)
+    # - tools_exclude: tools matching any pattern are excluded (blacklist)
+    # - If both are set, include is applied first, then exclude
+    tools_include: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True, default=None, comment="Glob patterns to include tools (whitelist)")
+    tools_exclude: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True, default=None, comment="Glob patterns to exclude tools (blacklist)")
+
     # Relationship with OAuth tokens
     oauth_tokens: Mapped[List["OAuthToken"]] = relationship("OAuthToken", back_populates="gateway", cascade="all, delete-orphan")
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2939,6 +2939,10 @@ class GatewayCreate(BaseModelWithConfigDict):
     # Per-gateway identity propagation configuration
     identity_propagation: Optional[Dict[str, Any]] = Field(None, description="Per-gateway identity propagation config: {enabled, mode, headers_prefix, sign_claims, allowed_attributes}")
 
+    # Tool filtering: fnmatch glob patterns to include/exclude tools during refresh
+    tools_include: Optional[List[str]] = Field(None, description="Glob patterns to whitelist tools (only matching tools are imported)")
+    tools_exclude: Optional[List[str]] = Field(None, description="Glob patterns to blacklist tools (matching tools are excluded)")
+
     @field_validator("gateway_mode", mode="before")
     @classmethod
     def default_gateway_mode(cls, v: Optional[str]) -> str:
@@ -3322,6 +3326,10 @@ class GatewayUpdate(BaseModelWithConfigDict):
 
     # Gateway mode configuration
     gateway_mode: Optional[str] = Field(None, description="Gateway mode: 'cache' (database caching, default) or 'direct_proxy' (pass-through mode with no caching)", pattern="^(cache|direct_proxy)$")
+
+    # Tool filtering: fnmatch glob patterns to include/exclude tools during refresh
+    tools_include: Optional[List[str]] = Field(None, description="Glob patterns to whitelist tools (only matching tools are imported)")
+    tools_exclude: Optional[List[str]] = Field(None, description="Glob patterns to blacklist tools (matching tools are excluded)")
 
     # CA certificate configuration for custom TLS trust
     ca_certificate: Optional[str] = Field(None, description="Custom CA certificate for TLS verification")
@@ -3717,6 +3725,10 @@ class GatewayRead(BaseModelWithConfigDict):
 
     # Per-gateway identity propagation configuration
     identity_propagation: Optional[Dict[str, Any]] = Field(None, description="Per-gateway identity propagation config")
+
+    # Tool filtering: fnmatch glob patterns to include/exclude tools during refresh
+    tools_include: Optional[List[str]] = Field(None, description="Glob patterns to whitelist tools (only matching tools are imported)")
+    tools_exclude: Optional[List[str]] = Field(None, description="Glob patterns to blacklist tools (matching tools are excluded)")
 
     _normalize_visibility = field_validator("visibility", mode="before")(classmethod(lambda cls, v: _coerce_visibility(v)))
 

--- a/mcpgateway/services/export_service.py
+++ b/mcpgateway/services/export_service.py
@@ -512,6 +512,12 @@ class ExportService:
                 "passthrough_headers": gateway.passthrough_headers or [],
             }
 
+            # Tool filtering patterns
+            if gateway.tools_include:
+                gateway_data["tools_include"] = gateway.tools_include
+            if gateway.tools_exclude:
+                gateway_data["tools_exclude"] = gateway.tools_exclude
+
             # Handle authentication data securely - use batch-fetched values
             if gateway.auth_type and gateway.auth_value:
                 if gateway.auth_value == settings.masked_auth_value:
@@ -937,6 +943,12 @@ class ExportService:
                 "tags": db_gateway.tags or [],
                 "passthrough_headers": db_gateway.passthrough_headers or [],
             }
+
+            # Tool filtering patterns
+            if db_gateway.tools_include:
+                gateway_data["tools_include"] = db_gateway.tools_include
+            if db_gateway.tools_exclude:
+                gateway_data["tools_exclude"] = db_gateway.tools_exclude
 
             # Include auth data directly from DB (already have raw values)
             if db_gateway.auth_type:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -46,6 +46,7 @@ import asyncio
 import binascii
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import fnmatch
 import logging
 import mimetypes
 import os
@@ -181,6 +182,40 @@ def _resolve_tool_title(tool) -> Optional[str]:
         if isinstance(ann_title, str):
             return ann_title
     return None
+
+
+def _apply_tool_filters(
+    tools: List,
+    tools_include: Optional[List[str]],
+    tools_exclude: Optional[List[str]],
+) -> List:
+    """Filter a list of tools using fnmatch glob patterns.
+
+    If tools_include is set, only tools whose name matches at least one
+    include pattern are kept.  Then, if tools_exclude is set, tools whose
+    name matches any exclude pattern are removed.
+
+    Args:
+        tools: List of ToolCreate objects (must have a ``name`` attribute).
+        tools_include: Optional whitelist glob patterns.
+        tools_exclude: Optional blacklist glob patterns.
+
+    Returns:
+        Filtered list of tools.
+    """
+    if not tools_include and not tools_exclude:
+        return tools
+
+    filtered = tools
+    if tools_include:
+        filtered = [t for t in filtered if any(fnmatch.fnmatch(t.name, p) for p in tools_include)]
+    if tools_exclude:
+        filtered = [t for t in filtered if not any(fnmatch.fnmatch(t.name, p) for p in tools_exclude)]
+
+    if len(filtered) != len(tools):
+        logger.info(f"Tool filter applied: {len(tools)} discovered -> {len(filtered)} kept (include={tools_include}, exclude={tools_exclude})")
+
+    return filtered
 
 
 # Cache import (lazy to avoid circular dependencies)
@@ -1440,6 +1475,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 auth_value = preparation.auth_value
                 oauth_config = preparation.oauth_config
 
+            # Apply tool include/exclude filters (fnmatch glob patterns)
+            tools = _apply_tool_filters(tools, getattr(gateway, "tools_include", None), getattr(gateway, "tools_exclude", None))
+
             # DbTool.auth_value is Mapped[Optional[str]] (Text), so encode the dict before
             # storing it there. DbGateway.auth_value is Mapped[Optional[Dict]] (JSON) and
             # receives the plain dict directly (see assignment above).
@@ -1686,6 +1724,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 client_key=await self._encrypt_client_key(getattr(gateway, "client_key", None)),
                 # Gateway mode configuration
                 gateway_mode=preparation.gateway_mode,
+                # Tool filtering
+                tools_include=getattr(gateway, "tools_include", None),
+                tools_exclude=getattr(gateway, "tools_exclude", None),
             )
 
             # Add to DB and commit immediately so tools/resources/prompts are visible
@@ -2756,6 +2797,19 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         client_cert=connection_material.client_cert,
                         client_key=connection_material.client_key,
                     )
+
+                    # Apply NEW tool filters so this edit takes effect immediately
+                    # (must read from gateway_update BEFORE persisting to gateway)
+                    _upd_inc = getattr(gateway_update, "tools_include", None)
+                    _upd_exc = getattr(gateway_update, "tools_exclude", None)
+                    effective_include = _upd_inc if _upd_inc is not None else getattr(gateway, "tools_include", None)
+                    effective_exclude = _upd_exc if _upd_exc is not None else getattr(gateway, "tools_exclude", None)
+                    tools = _apply_tool_filters(tools, effective_include, effective_exclude)
+
+                    new_tool_names = [tool.name for tool in tools]
+                    new_resource_uris = [resource.uri for resource in resources]
+                    new_prompt_names = [prompt.name for prompt in prompts]
+
                     if gateway_update.one_time_auth:
                         # For one-time auth, clear auth_type and auth_value after initialization
                         gateway.auth_type = "one_time_auth"
@@ -2803,6 +2857,14 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     if gateway_update.gateway_mode == "direct_proxy" and not settings.mcpgateway_direct_proxy_enabled:
                         raise GatewayError("direct_proxy gateway mode is disabled. Set MCPGATEWAY_DIRECT_PROXY_ENABLED=true to enable.")
                     gateway.gateway_mode = gateway_update.gateway_mode
+
+                # Update tool filters if provided
+                # An empty list [] means "user cleared the filter" → store None
+                # None means "not provided in this update" → keep existing value
+                if hasattr(gateway_update, "tools_include") and gateway_update.tools_include is not None:
+                    gateway.tools_include = gateway_update.tools_include if gateway_update.tools_include else None
+                if hasattr(gateway_update, "tools_exclude") and gateway_update.tools_exclude is not None:
+                    gateway.tools_exclude = gateway_update.tools_exclude if gateway_update.tools_exclude else None
 
                 # Update metadata fields
                 gateway.updated_at = datetime.now(timezone.utc)
@@ -3255,6 +3317,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                             client_cert=act_client_cert,
                             client_key=act_client_key,
                         )
+                        # Apply tool include/exclude filters (fnmatch glob patterns)
+                        tools = _apply_tool_filters(tools, getattr(gateway, "tools_include", None), getattr(gateway, "tools_exclude", None))
+
                         catalog_sync = self._sync_gateway_catalog(
                             db,
                             gateway=gateway,
@@ -5752,6 +5817,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         gateway_auth_query_params = None
         refresh_client_cert = None
         refresh_client_key = None
+        gateway_tools_include = None
+        gateway_tools_exclude = None
 
         if gateway:
             if not gateway.enabled or not gateway.reachable:
@@ -5768,6 +5835,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             gateway_auth_query_params = gateway.auth_query_params
             refresh_client_cert = getattr(gateway, "client_cert", None)
             refresh_client_key = getattr(gateway, "client_key", None)
+            gateway_tools_include = getattr(gateway, "tools_include", None)
+            gateway_tools_exclude = getattr(gateway, "tools_exclude", None)
         else:
             with fresh_db_session() as db:
                 gateway_obj = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
@@ -5791,6 +5860,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 gateway_auth_query_params = gateway_obj.auth_query_params
                 refresh_client_cert = getattr(gateway_obj, "client_cert", None)
                 refresh_client_key = getattr(gateway_obj, "client_key", None)
+                gateway_tools_include = getattr(gateway_obj, "tools_include", None)
+                gateway_tools_exclude = getattr(gateway_obj, "tools_exclude", None)
 
         # Preserve base URL before auth mutation for classification poll-state keys
         gateway_base_url = gateway_url
@@ -5838,6 +5909,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             result["success"] = False
             result["error"] = str(e)
             return result
+
+        # Apply tool include/exclude filters (fnmatch glob patterns)
+        tools = _apply_tool_filters(tools, gateway_tools_include, gateway_tools_exclude)
 
         # For authorization_code OAuth gateways, empty responses may indicate incomplete auth flow
         # Skip only if it's an auth_code gateway with no data (user may not have completed authorization)

--- a/mcpgateway/services/import_service.py
+++ b/mcpgateway/services/import_service.py
@@ -1304,6 +1304,8 @@ class ImportService:
             description=gateway_data.get("description"),
             transport=gateway_data.get("transport", "SSE"),
             passthrough_headers=gateway_data.get("passthrough_headers"),
+            tools_include=gateway_data.get("tools_include"),
+            tools_exclude=gateway_data.get("tools_exclude"),
             tags=gateway_data.get("tags", []),
             **auth_kwargs,
         )
@@ -1368,6 +1370,8 @@ class ImportService:
             description=gateway_data.get("description"),
             transport=gateway_data.get("transport"),
             passthrough_headers=gateway_data.get("passthrough_headers"),
+            tools_include=gateway_data.get("tools_include"),
+            tools_exclude=gateway_data.get("tools_exclude"),
             tags=gateway_data.get("tags"),
             **auth_kwargs,
         )

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5930,6 +5930,40 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 />
               </div>
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                  >Tools Include Filter</label
+                >
+                <small class="text-gray-500 dark:text-gray-400 block mb-2">
+                  Glob patterns for tools to include (comma-separated, e.g.,
+                  "manage-ticket*, manage-task*"). Only matching tools will be
+                  imported. Leave empty to include all.
+                </small>
+                <input
+                  type="text"
+                  name="tools_include"
+                  placeholder="manage-ticket*, manage-task*"
+                  class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                />
+              </div>
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                  >Tools Exclude Filter</label
+                >
+                <small class="text-gray-500 dark:text-gray-400 block mb-2">
+                  Glob patterns for tools to exclude (comma-separated, e.g.,
+                  "manage-project*"). Matching tools will be skipped. Leave
+                  empty to exclude none.
+                </small>
+                <input
+                  type="text"
+                  name="tools_exclude"
+                  placeholder="manage-project*"
+                  class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                />
+              </div>
               <div id="add-gateway-loading" style="display: none">
                 <div class="spinner"></div>
               </div>
@@ -10371,6 +10405,46 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         name="passthrough_headers"
                         id="edit-gateway-passthrough-headers"
                         placeholder="Authorization, X-Tenant-Id, X-Trace-Id"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                        >Tools Include Filter</label
+                      >
+                      <small
+                        class="text-gray-500 dark:text-gray-400 block mb-2"
+                      >
+                        Glob patterns for tools to include (comma-separated,
+                        e.g., "manage-ticket*, manage-task*"). Only matching
+                        tools will be imported. Leave empty to include all.
+                      </small>
+                      <input
+                        type="text"
+                        name="tools_include"
+                        id="edit-gateway-tools-include"
+                        placeholder="manage-ticket*, manage-task*"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                        >Tools Exclude Filter</label
+                      >
+                      <small
+                        class="text-gray-500 dark:text-gray-400 block mb-2"
+                      >
+                        Glob patterns for tools to exclude (comma-separated,
+                        e.g., "manage-project*"). Matching tools will be
+                        skipped. Leave empty to exclude none.
+                      </small>
+                      <input
+                        type="text"
+                        name="tools_exclude"
+                        id="edit-gateway-tools-exclude"
+                        placeholder="manage-project*"
                         class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       />
                     </div>

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -214,6 +214,12 @@ def mock_gateway():
     gw.auth_value = {}
     gw.team_id = 1  # Ensure team_id is a real value, not a MagicMock
 
+    # Tool filter columns default to None on real DbGateway; without explicit
+    # assignment, MagicMock(spec=DbGateway) returns truthy Mocks that would
+    # trigger _apply_tool_filters and wipe the discovered tool list.
+    gw.tools_include = None
+    gw.tools_exclude = None
+
     # Mock email_team relationship and team property
     # Use instance-level assignment (MagicMock allows this)
     mock_email_team = MagicMock()


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #4021

---

## 🚀 Summary (1-2 sentences)
Add optional `tools_include` and `tools_exclude` fields to gateways that filter which tools are imported from a remote MCP server using fnmatch glob patterns.

---

## 🧪 Checks

- [x] `make lint` passes (ruff + black)
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes

### Use case

When connecting to a single MCP backend that exposes many tools (e.g. an ITSM API with 40+ endpoints), it is often useful to split it into multiple gateways with different tool subsets and different auth schemes:

- **Gateway A**: all tools except project management (`tools_exclude: ["*project*"]`) — OAuth auth
- **Gateway B**: only project management tools (`tools_include: ["*project*"]`) — API key auth

### Filtering logic

1. If `tools_include` is set, only tools whose name matches at least one include pattern are kept
2. If `tools_exclude` is set, tools matching any exclude pattern are removed
3. When both are set, include is applied first, then exclude
4. Empty/null means no filtering

Patterns use Python `fnmatch` syntax (`*project*`, `manage-ticket*`).

### Changes

| File | Change |
|------|--------|
| `db.py` | `tools_include`/`tools_exclude` JSON columns on `Gateway` |
| `schemas.py` | Fields on `GatewayCreate`, `GatewayUpdate`, `GatewayRead` |
| `gateway_service.py` | `_apply_tool_filters()` + 4 call sites (refresh, register, update, activate) |
| `export_service.py` | Export support |
| `import_service.py` | Import support |
| `admin.py` | Form parsing in create/edit flows |
| `formSubmitHandlers.js` | Comma→JSON array conversion |
| `gateways.js` | Edit modal population |
| `admin.html` | Input fields in create + edit forms |
| Alembic migration | New columns (`IF NOT EXISTS` guard) |
