### PR TITLE
fix(ui): token revoke button sends DELETE with empty token ID (#4046)

### DIFF
--- a/mcpgateway/templates/tokens_partial.html
+++ b/mcpgateway/templates/tokens_partial.html
@@ -101,8 +101,7 @@
       </button>
       {% if token.is_active and not token.is_revoked %}
       <button
-        hx-delete="{{ root_path }}/admin/tokens/{{token_id}}"
-        hx-swap="none"
+        data-action="token-revoke"
         data-token-id="{{ token.id }}"
         data-token-name="{{ token.name }}"
         class="px-3 py-1 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 border border-red-300 dark:border-red-600 hover:border-red-500 dark:hover:border-red-400 rounded-md"

--- a/tests/playwright/security/test_token_lifecycle.py
+++ b/tests/playwright/security/test_token_lifecycle.py
@@ -117,6 +117,91 @@ class TestTokenLifecycle:
 # ---------------------------------------------------------------------------
 
 
+class TestTokenRevokeUI:
+    """Regression tests for token revoke via the admin UI.
+
+    The revoke button previously used a broken HTMX hx-delete attribute with
+    an undefined template variable (``{{token_id}}`` instead of ``{{token.id}}``),
+    resulting in ``DELETE /admin/tokens/`` (missing ID) → 404.
+
+    These tests verify the fix: the button now delegates to the JS ``revokeToken()``
+    function via ``data-action="token-revoke"``, which calls the correct endpoint.
+
+    """
+
+    def test_revoke_button_triggers_correct_api_call(self, admin_api: APIRequestContext, tokens_page):
+        """Revoke button in UI must send DELETE /tokens/{token_id} (not /admin/tokens/)."""
+        token_name = f"ui-revoke-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post("/tokens", data={"name": token_name, "expires_in_days": 1})
+        assert create_resp.status in (200, 201), f"Setup failed: {create_resp.status}"
+        token_id = _get_token_id(create_resp.json())
+
+        try:
+            # Navigate to tokens tab and wait for the token to appear
+            tokens_page.navigate_to_tokens_tab()
+            tokens_page.wait_for_token_visible(token_name, timeout=15000)
+
+            # Verify the revoke button is actually visible in the UI
+            # (prevents the revoke_token() fallback API path from masking UI bugs)
+            revoke_btn = tokens_page.get_token_revoke_btn(token_name)
+            assert revoke_btn.count() > 0 and revoke_btn.first.is_visible(), (
+                "Revoke button must be visible for an active token"
+            )
+
+            # Click revoke via UI button directly — bypasses the fallback path
+            with tokens_page.page.expect_response(
+                lambda r: f"/tokens/{token_id}" in r.url and r.request.method == "DELETE",
+                timeout=10000,
+            ) as response_info:
+                tokens_page.page.once("dialog", lambda dialog: dialog.accept())
+                revoke_btn.first.click()
+
+            response = response_info.value
+            assert response.status in (200, 204), (
+                f"Revoke should succeed (got {response.status}). "
+                "If 404, the button may still be using the broken hx-delete path."
+            )
+        finally:
+            # Cleanup: ensure token is revoked even if UI test fails
+            try:
+                admin_api.delete(f"/tokens/{token_id}")
+            except Exception:
+                pass
+
+    def test_revoke_button_not_shown_for_revoked_token(self, admin_api: APIRequestContext, tokens_page):
+        """Already-revoked tokens must not show a revoke button even when listed."""
+        token_name = f"already-revoked-{uuid.uuid4().hex[:8]}"
+        create_resp = admin_api.post("/tokens", data={"name": token_name, "expires_in_days": 1})
+        assert create_resp.status in (200, 201)
+        token_id = _get_token_id(create_resp.json())
+
+        # Revoke via API first
+        revoke_resp = admin_api.delete(f"/tokens/{token_id}")
+        assert revoke_resp.status in (200, 204)
+
+        # Navigate to tokens tab with include_inactive=true so revoked token IS listed
+        tokens_page.navigate_to_tokens_tab()
+        # Enable "Show inactive" to make revoked tokens visible in the list
+        inactive_checkbox = tokens_page.page.locator("#tokens-inactive-toggle, [name='include_inactive']")
+        if inactive_checkbox.count() > 0 and not inactive_checkbox.first.is_checked():
+            inactive_checkbox.first.click()
+            tokens_page.page.wait_for_timeout(2000)
+
+        # Verify the token card IS rendered (not vacuously absent)
+        token_card = tokens_page.page.locator(f"text={token_name}")
+        if token_card.count() > 0:
+            # Token is visible — the revoke button must NOT be present
+            revoke_btn = tokens_page.get_token_revoke_btn(token_name)
+            assert revoke_btn.count() == 0, "Revoke button should be hidden for already-revoked tokens"
+        else:
+            # If include_inactive toggle is not available, verify via API that token is truly revoked
+            resp = admin_api.get(f"/tokens/{token_id}")
+            if resp.status == 200:
+                token_data = resp.json()
+                token_obj = token_data.get("token", token_data)
+                assert not token_obj.get("is_active", True), "Token should be inactive after revocation"
+
+
 class TestTokenPermissions:
     """Test that non-admin users have limited token access."""
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -19316,6 +19316,109 @@ class TestTemplateButtonGating:
         assert "editA2AAgent" not in html
         assert "/delete" not in html
 
+    # -- tokens_partial.html button tests --
+
+    def _render_tokens_partial(self, jinja_env, token_data_list, current_user_email="user@example.com", is_admin=False, user_team_roles=None):
+        """Helper to render tokens_partial.html with given context."""
+        template = jinja_env.get_template("tokens_partial.html")
+        return template.render(
+            data=token_data_list,
+            pagination={"page": 1, "per_page": 10, "total_items": 1, "total_pages": 1, "has_next": False, "has_prev": False},
+            links=None,
+            root_path="",
+            include_inactive=False,
+            team_id=None,
+            current_user_email=current_user_email,
+            is_admin=is_admin,
+            user_team_roles=user_team_roles or {},
+        )
+
+    def test_tokens_revoke_button_uses_data_action_not_hx_delete(self, jinja_env):
+        """Revoke button must use data-action='token-revoke' (JS path), not hx-delete (broken HTMX path)."""
+        token_data = {
+            "id": "tok-abc-123",
+            "name": "My Token",
+            "description": None,
+            "user_email": "user@example.com",
+            "team_id": None,
+            "team_name": None,
+            "created_at": "2026-04-01T00:00:00",
+            "expires_at": None,
+            "last_used": None,
+            "is_active": True,
+            "is_revoked": False,
+            "revoked_at": None,
+            "revoked_by": None,
+            "revocation_reason": None,
+            "tags": [],
+            "server_id": None,
+            "resource_scopes": [],
+            "ip_restrictions": [],
+            "time_restrictions": {},
+            "usage_limits": {},
+            "_json": "{}",
+        }
+        html = self._render_tokens_partial(jinja_env, [token_data])
+        assert 'data-action="token-revoke"' in html
+        assert 'data-token-id="tok-abc-123"' in html
+        assert "hx-delete" not in html
+
+    def test_tokens_revoke_button_hidden_for_inactive_token(self, jinja_env):
+        """Revoke button must be hidden when token is inactive."""
+        token_data = {
+            "id": "tok-inactive",
+            "name": "Inactive Token",
+            "description": None,
+            "user_email": "user@example.com",
+            "team_id": None,
+            "team_name": None,
+            "created_at": "2026-04-01T00:00:00",
+            "expires_at": None,
+            "last_used": None,
+            "is_active": False,
+            "is_revoked": False,
+            "revoked_at": None,
+            "revoked_by": None,
+            "revocation_reason": None,
+            "tags": [],
+            "server_id": None,
+            "resource_scopes": [],
+            "ip_restrictions": [],
+            "time_restrictions": {},
+            "usage_limits": {},
+            "_json": "{}",
+        }
+        html = self._render_tokens_partial(jinja_env, [token_data])
+        assert 'data-action="token-revoke"' not in html
+
+    def test_tokens_revoke_button_hidden_for_revoked_token(self, jinja_env):
+        """Revoke button must be hidden when token is already revoked."""
+        token_data = {
+            "id": "tok-revoked",
+            "name": "Revoked Token",
+            "description": None,
+            "user_email": "user@example.com",
+            "team_id": None,
+            "team_name": None,
+            "created_at": "2026-04-01T00:00:00",
+            "expires_at": None,
+            "last_used": None,
+            "is_active": True,
+            "is_revoked": True,
+            "revoked_at": "2026-04-02T00:00:00",
+            "revoked_by": "admin@example.com",
+            "revocation_reason": "Test",
+            "tags": [],
+            "server_id": None,
+            "resource_scopes": [],
+            "ip_restrictions": [],
+            "time_restrictions": {},
+            "usage_limits": {},
+            "_json": "{}",
+        }
+        html = self._render_tokens_partial(jinja_env, [token_data])
+        assert 'data-action="token-revoke"' not in html
+
 
 class TestAdminGetToolPassesTeamRoles:
     """Tests that admin_get_tool and admin_list_tools pass requesting_user_team_roles."""


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4046

---

## 📝 Summary
The token revoke button in the admin UI used an undefined Jinja2 variable `{{token_id}}` in its `hx-delete` attribute, causing `DELETE /admin/tokens/` (missing ID) → 404. Additionally, no `DELETE /admin/tokens/{id}` endpoint exists in `admin.py`.

Fixed by replacing the broken HTMX `hx-delete` with `data-action="token-revoke"`, delegating to the existing JS `revokeToken()` handler which calls the correct `DELETE /tokens/{token_id}` endpoint. This also adds the missing confirmation dialog that the HTMX path lacked.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |   pass     |

Also I've done Playwright E2E test `pytest tests/playwright/security/test_token_lifecycle.py` (passed)

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Root cause:** `tokens_partial.html:104` — `{{token_id}}` is not a valid template variable in the `{% for token in data %}` loop. The correct variable is `{{token.id}}`, which is used correctly on the adjacent line 106 (`data-token-id="{{ token.id }}"`). 

This bug was introduced in #2833 and was never caught because:

1. Unit tests only checked `isinstance(response, HTMLResponse)` without parsing the rendered HTML
2. Playwright's `revoke_token()` helper has a fallback API path that silently bypasses the broken UI button

**Changes:**
- `tokens_partial.html` — Replace `hx-delete`/`hx-swap` with `data-action="token-revoke"`
- `test_admin.py` — 3 unit tests verifying button attributes and visibility gating
- `test_token_lifecycle.py` — 2 Playwright E2E tests for UI revoke flow regression
