### PR TITLE
feat: include full URL in OAuth authorization error messages

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -13949,7 +13949,7 @@ async def admin_test_gateway(
                     else:
                         latency_ms = int((time.monotonic() - start_time) * 1000)
                         return GatewayTestResponse(
-                            status_code=401, latency_ms=latency_ms, body={"error": f"Please authorize {gateway.name} first. Visit /oauth/authorize/{gateway.id} to complete OAuth flow."}
+                            status_code=401, latency_ms=latency_ms, body={"error": f"Please authorize {gateway.name} first. Visit {settings.app_domain}oauth/authorize/{gateway.id} to complete OAuth flow."}
                         )
                 except Exception as e:
                     LOGGER.error(f"Failed to obtain stored OAuth token for gateway {gateway.name}: {e}")

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1570,7 +1570,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
             if not access_token:
                 raise GatewayConnectionError(
-                    f"No OAuth tokens found for user {app_user_email} on gateway {gateway.name}. Please complete the OAuth authorization flow first at /oauth/authorize/{gateway.id}"
+                    f"No OAuth tokens found for user {app_user_email} on gateway {gateway.name}. Please complete the OAuth authorization flow first at {settings.app_domain}oauth/authorize/{gateway.id}"
                 )
 
             # Debug: Check if token was decrypted

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4024,7 +4024,7 @@ class ToolService(BaseService):
         # while still allowing legitimate plugin-injected auth (e.g. Vault) to satisfy
         # the requirement.
         if oauth_authcode_no_db_token and not any(hk.lower() == "authorization" for hk in runtime_headers):
-            raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit /oauth/authorize/{gateway_id_str} to complete OAuth flow.")
+            raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit {settings.app_domain}oauth/authorize/{gateway_id_str} to complete OAuth flow.")
 
         runtime_headers = inject_trace_context_headers(runtime_headers)
 
@@ -5671,7 +5671,7 @@ class ToolService(BaseService):
                     # while still allowing legitimate plugin-injected auth (e.g. Vault) to satisfy
                     # the requirement.
                     if oauth_authcode_no_db_token and not any(hk.lower() == "authorization" for hk in headers):
-                        raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit /oauth/authorize/{gateway_id_str} to complete OAuth flow.")
+                        raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit {settings.app_domain}oauth/authorize/{gateway_id_str} to complete OAuth flow.")
 
                     with create_child_span("tool.gateway_call", {"tool.name": name, "tool.id": tool_id, "tool.integration_type": "MCP"}):
                         tool_call_result = ToolResult(content=[TextContent(text="", type="text")])


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4054 

---

## 📝 Summary
OAuth authorization error messages now include the full URL (using `settings.app_domain`) instead of a relative path.

**Before:** `Visit /oauth/authorize/{id} to complete OAuth flow.`
**After:** `Visit https://gateway.example.com/oauth/authorize/{id} to complete OAuth flow.`

MCP clients (Claude Code, Cursor, etc.) display errors as plain text — relative paths are not clickable. This makes the link actionable

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   pass     |
| Unit tests                | `make test`     |   pass     |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
- `app_domain` (`APP_DOMAIN` env var) is defined in `config.py:754` as `HttpUrl`, which always includes a trailing slash
- Previously only used for CORS `allowed_origins` calculation — now also used in error messages
- No new dependencies or config changes required — just set `APP_DOMAIN` (most deployments already do)
