### PR TITLE
Feature/plugin multi tenancy with per tool plugin config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T19:59:03Z",
+  "generated_at": "2026-04-06T22:28:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1276,7 +1276,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 13,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9166,7 +9166,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2221,
+        "line_number": 2179,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -18920,7 +18920,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3792,
+        "line_number": 3784,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -18928,7 +18928,7 @@
         "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6635,
+        "line_number": 6627,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -18936,7 +18936,7 @@
         "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6991,
+        "line_number": 6983,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -18944,7 +18944,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7015,
+        "line_number": 7007,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -19658,7 +19658,7 @@
         "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1390,
+        "line_number": 1387,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19666,7 +19666,7 @@
         "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1477,
+        "line_number": 1474,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -19832,7 +19832,7 @@
         "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 593,
+        "line_number": 616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19840,7 +19840,7 @@
         "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 760,
+        "line_number": 801,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19848,7 +19848,7 @@
         "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 774,
+        "line_number": 815,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -21436,7 +21436,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2871,
+        "line_number": 2870,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21444,7 +21444,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3499,
+        "line_number": 3498,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21452,7 +21452,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5778,
+        "line_number": 5793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21460,7 +21460,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6270,
+        "line_number": 6285,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21468,7 +21468,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7515,
+        "line_number": 7495,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21476,7 +21476,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7653,
+        "line_number": 7633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21484,7 +21484,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8030,
+        "line_number": 8009,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -21494,7 +21494,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2238,
+        "line_number": 2242,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21502,7 +21502,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2926,
+        "line_number": 2929,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21510,7 +21510,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2935,
+        "line_number": 2938,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21518,7 +21518,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3326,
+        "line_number": 3329,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -21526,7 +21526,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5611,
+        "line_number": 5613,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21534,7 +21534,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5629,
+        "line_number": 5631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21542,7 +21542,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5653,
+        "line_number": 5655,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21550,7 +21550,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5717,
+        "line_number": 5719,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21558,7 +21558,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5728,
+        "line_number": 5730,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21566,7 +21566,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5769,
+        "line_number": 5771,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21574,7 +21574,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5775,
+        "line_number": 5777,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21582,7 +21582,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6902,
+        "line_number": 6900,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -22114,7 +22114,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2444,
+        "line_number": 2447,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -22122,7 +22122,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2731,
+        "line_number": 2735,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -22719,6 +22719,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "83719d2d8284b30dee2823349c2d7f600e237d8c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "d9ea801e3f4d913d0b6721b819f2b90c35f2303b",
         "is_secret": false,
         "is_verified": false,
@@ -22740,6 +22748,14 @@
         "is_verified": false,
         "line_number": 103,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "04a1a3194c674cd1244ae336e0fe7054fb9bc64f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -22788,6 +22804,22 @@
         "is_verified": false,
         "line_number": 159,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ab5e8c5a013b4ea054a281a403fd0b7ab4917bc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "831b1f0f0af506c6b1b5c2de459b9b4b4f3ac633",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -22847,6 +22879,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "d1837f7e31117d99b0cbffd82e7eabcea851a94c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 250,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad1a0238d69b8c5443fa6d9abd6cdca087349517",
         "is_secret": false,
         "is_verified": false,
@@ -22860,6 +22900,14 @@
         "is_verified": false,
         "line_number": 259,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8773b28b7ba6a12c738b3cdd1b980ae660b3c0de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 262,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -22991,6 +23039,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "d146f9686c9c372d5c5f3d85c964777ce5a583f0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 444,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "088b03c54e39344f385c72c0d648cb5b98a63a02",
         "is_secret": false,
         "is_verified": false,
@@ -23004,6 +23060,14 @@
         "is_verified": false,
         "line_number": 455,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b85b391225b20c3137322bcc23c7e2c31320a83e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 465,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23036,6 +23100,14 @@
         "is_verified": false,
         "line_number": 502,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee7f4bf6e85139039bdd2af2df821dde5a5138d1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 503,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23191,6 +23263,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "604edf3bd2202bebf89e23895a6ef68088f57e42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 659,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "2ebad4ca4792566abd1ba0d665249302119cb457",
         "is_secret": false,
         "is_verified": false,
@@ -23271,6 +23351,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "84195544d364bd618a1ff2934f7820b59206d21a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 773,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "f3d3c26ed24a648081ced9182bb1b19f7d78e68d",
         "is_secret": false,
         "is_verified": false,
@@ -23284,6 +23372,14 @@
         "is_verified": false,
         "line_number": 786,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de230a3c66580155ba845c7202e7fc4158d1c82b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 787,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23383,11 +23479,27 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "788b34ba07c35e639f6e3e82f608189791e3239f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 938,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "9bfd048ce5ceb106ba035489cea34b77d79814e4",
         "is_secret": false,
         "is_verified": false,
         "line_number": 943,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbd62b2fef0566cbd4adcae3c005b9fb1d23170d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 944,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -24711,102 +24823,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "83719d2d8284b30dee2823349c2d7f600e237d8c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2697,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "04a1a3194c674cd1244ae336e0fe7054fb9bc64f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2703,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "788b34ba07c35e639f6e3e82f608189791e3239f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2714,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbd62b2fef0566cbd4adcae3c005b9fb1d23170d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2720,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5ab5e8c5a013b4ea054a281a403fd0b7ab4917bc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2726,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "831b1f0f0af506c6b1b5c2de459b9b4b4f3ac633",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2736,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d1837f7e31117d99b0cbffd82e7eabcea851a94c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2745,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8773b28b7ba6a12c738b3cdd1b980ae660b3c0de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2751,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d146f9686c9c372d5c5f3d85c964777ce5a583f0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2760,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b85b391225b20c3137322bcc23c7e2c31320a83e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2769,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee7f4bf6e85139039bdd2af2df821dde5a5138d1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2778,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "604edf3bd2202bebf89e23895a6ef68088f57e42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2787,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "a98f930ed9e869e7534be3e4b8ca121b2f46b3cc",
         "is_secret": false,
         "is_verified": false,
@@ -24971,22 +24987,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 3016,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "84195544d364bd618a1ff2934f7820b59206d21a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3025,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de230a3c66580155ba845c7202e7fc4158d1c82b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3034,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -25903,11 +25903,35 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "f2ceefa876785b2d7376d2af71e760c71ec0109e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 502,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ea76a6819e6c7b642a58ff2639e061e2303fc28d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 503,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "8ee82c36fc0af17f1fdeb940d2bca6424bf2e453",
         "is_secret": false,
         "is_verified": false,
         "line_number": 507,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "20b3b413826d61a82664d755aaaa4a180123d161",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 519,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -26447,190 +26471,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "f2ceefa876785b2d7376d2af71e760c71ec0109e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1243,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ea76a6819e6c7b642a58ff2639e061e2303fc28d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1249,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "20b3b413826d61a82664d755aaaa4a180123d161",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1255,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "56397d9a520742406189d71ac27362811f4eb3f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1264,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "978bcf06dc12b74b1579b446ae082265db1358f6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1270,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8cc69a0306a6b8f4c32428f44505f11eaebb3ebf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1279,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6538f9a3e2204f918d5719f17a23367f4d2105c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1289,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff70e2022b5f305d9d30b5604b3d3fef49158de5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1298,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b4259ea178dd7cb0249df5d8feb7d13a2d6fd820",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1312,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fb82e6c6c8d3ed2486ef8249d7e59336b5c86610",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1321,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ba44f293d24fbbcbe1ef98385355f7fed4f8419d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1327,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bfdcf12c00b303dde9a57ba3e08927a60a89c6b8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1333,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8be0eab839d1133fc403dcc2790b84d4dfff3381",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1343,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "891ddfb5f57f136198961b98f8014e3c7bc9e602",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1353,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "19c50b4f711d39a10ac1890b58e609934e3e7ff6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1362,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "74ac836ae646fd72c7c162ace0d10d50d81af86b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1371,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "852251ba1e8919a04b1d4678fbf9ba2a73e82a19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1380,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0675b70f52618de044d1d1703b6c8849b407c83a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1391,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c63addae2503bfe26923f0460158bb2fc674b928",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1403,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9f7a7461ae8d5e27458e899b4e84416483680a51",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1414,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5b35b10ce4ffd9e769dc5edeb91e3717ca35a110",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1420,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de655789d424d5a5631a8000892feda124ff3528",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1460,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bbf2c697167fb0954886a726005d59a7548b75e6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1474,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "639bd69cb045a98edcce33e331b9ac85691c5fda",
         "is_secret": false,
         "is_verified": false,
@@ -26991,6 +26831,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "56397d9a520742406189d71ac27362811f4eb3f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1934,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "7794fee4eaeafc705f8eeba3b4d69cba7869dab0",
         "is_secret": false,
         "is_verified": false,
@@ -27127,22 +26975,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "611ee95376df586616103d908ee6f0e50de5ce6f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2119,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8792035d236f541da7fcdacf04647f5050fd4f37",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2130,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "1c7d5dc44e70c25f3c80013f6b1fcf41995ed951",
         "is_secret": false,
         "is_verified": false,
@@ -27247,6 +27079,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "bfdcf12c00b303dde9a57ba3e08927a60a89c6b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2242,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "040278ead73fc50f601174bf24cfe3552915a67e",
         "is_secret": false,
         "is_verified": false,
@@ -27275,6 +27115,14 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2275,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "611ee95376df586616103d908ee6f0e50de5ce6f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2283,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -27519,6 +27367,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "8792035d236f541da7fcdacf04647f5050fd4f37",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2570,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "e67b0b7e7387fa4b492322f78c37bbae56f8aede",
         "is_secret": false,
         "is_verified": false,
@@ -27607,6 +27463,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "978bcf06dc12b74b1579b446ae082265db1358f6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2702,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "fb3ffd7b8e0ef97a3b404c2db1b91868d28b0298",
         "is_secret": false,
         "is_verified": false,
@@ -27668,6 +27532,142 @@
         "is_verified": false,
         "line_number": 2773,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8be0eab839d1133fc403dcc2790b84d4dfff3381",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2929,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "891ddfb5f57f136198961b98f8014e3c7bc9e602",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2938,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "19c50b4f711d39a10ac1890b58e609934e3e7ff6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3329,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8cc69a0306a6b8f4c32428f44505f11eaebb3ebf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3330,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74ac836ae646fd72c7c162ace0d10d50d81af86b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5613,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "852251ba1e8919a04b1d4678fbf9ba2a73e82a19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5631,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0675b70f52618de044d1d1703b6c8849b407c83a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5655,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c63addae2503bfe26923f0460158bb2fc674b928",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5719,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9f7a7461ae8d5e27458e899b4e84416483680a51",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5730,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5b35b10ce4ffd9e769dc5edeb91e3717ca35a110",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5771,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de655789d424d5a5631a8000892feda124ff3528",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5777,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6538f9a3e2204f918d5719f17a23367f4d2105c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5792,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff70e2022b5f305d9d30b5604b3d3fef49158de5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6284,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bbf2c697167fb0954886a726005d59a7548b75e6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6900,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b4259ea178dd7cb0249df5d8feb7d13a2d6fd820",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7494,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb82e6c6c8d3ed2486ef8249d7e59336b5c86610",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7632,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ba44f293d24fbbcbe1ef98385355f7fed4f8419d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8008,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T08:18:36Z",
+  "generated_at": "2026-04-07T08:48:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -9480,7 +9480,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 297,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9488,7 +9488,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3404,
+        "line_number": 3380,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-06T22:28:33Z",
+  "generated_at": "2026-04-07T08:00:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -22058,7 +22058,7 @@
         "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 222,
+        "line_number": 203,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T10:28:26Z",
+  "generated_at": "2026-04-07T13:08:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1276,7 +1276,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13,
+        "line_number": 14,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8893,6 +8893,24 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 39,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/c2d3e4f5a6b7_add_manage_plugins_to_team_admin.py": [
+      {
+        "hashed_secret": "a25d3ab3a62142e06a5940fb9eac04c77bec7919",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "67e71f59c479818d8d271427edeaee49eae77ffe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T13:08:12Z",
+  "generated_at": "2026-04-07T18:52:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -21488,7 +21488,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5793,
+        "line_number": 5791,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21496,7 +21496,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6285,
+        "line_number": 6283,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21504,7 +21504,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7495,
+        "line_number": 7493,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21512,7 +21512,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7633,
+        "line_number": 7631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21520,7 +21520,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8009,
+        "line_number": 8007,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T08:48:54Z",
+  "generated_at": "2026-04-07T09:02:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -19558,7 +19558,7 @@
         "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 82,
+        "line_number": 83,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19566,7 +19566,7 @@
         "hashed_secret": "35e6ca489e73a8991165cdcfc2b79eb0d25ed0a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19574,7 +19574,7 @@
         "hashed_secret": "59df6723fb54fd8dde6dcf51034e51491bfbff24",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 909,
+        "line_number": 947,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19582,7 +19582,7 @@
         "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 915,
+        "line_number": 955,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -19592,7 +19592,7 @@
         "hashed_secret": "6f865e7e20c773e3483eaa74a07d03cec02bde2e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19600,7 +19600,7 @@
         "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 202,
+        "line_number": 180,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19608,7 +19608,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 250,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19616,7 +19616,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 284,
+        "line_number": 262,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19624,7 +19624,7 @@
         "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 466,
+        "line_number": 450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19632,7 +19632,7 @@
         "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 487,
+        "line_number": 472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19640,7 +19640,7 @@
         "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 525,
+        "line_number": 512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -19648,7 +19648,7 @@
         "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 674,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -22719,14 +22719,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "83719d2d8284b30dee2823349c2d7f600e237d8c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 83,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "d9ea801e3f4d913d0b6721b819f2b90c35f2303b",
         "is_secret": false,
         "is_verified": false,
@@ -22748,14 +22740,6 @@
         "is_verified": false,
         "line_number": 103,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "04a1a3194c674cd1244ae336e0fe7054fb9bc64f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 105,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -22804,22 +22788,6 @@
         "is_verified": false,
         "line_number": 159,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5ab5e8c5a013b4ea054a281a403fd0b7ab4917bc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 159,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "831b1f0f0af506c6b1b5c2de459b9b4b4f3ac633",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 180,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -22879,14 +22847,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "d1837f7e31117d99b0cbffd82e7eabcea851a94c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 250,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "ad1a0238d69b8c5443fa6d9abd6cdca087349517",
         "is_secret": false,
         "is_verified": false,
@@ -22900,14 +22860,6 @@
         "is_verified": false,
         "line_number": 259,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8773b28b7ba6a12c738b3cdd1b980ae660b3c0de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 262,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23039,14 +22991,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "d146f9686c9c372d5c5f3d85c964777ce5a583f0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 444,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "088b03c54e39344f385c72c0d648cb5b98a63a02",
         "is_secret": false,
         "is_verified": false,
@@ -23060,14 +23004,6 @@
         "is_verified": false,
         "line_number": 455,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b85b391225b20c3137322bcc23c7e2c31320a83e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 465,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23100,14 +23036,6 @@
         "is_verified": false,
         "line_number": 502,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee7f4bf6e85139039bdd2af2df821dde5a5138d1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 503,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23263,14 +23191,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "604edf3bd2202bebf89e23895a6ef68088f57e42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 659,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "2ebad4ca4792566abd1ba0d665249302119cb457",
         "is_secret": false,
         "is_verified": false,
@@ -23351,14 +23271,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "84195544d364bd618a1ff2934f7820b59206d21a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 773,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "f3d3c26ed24a648081ced9182bb1b19f7d78e68d",
         "is_secret": false,
         "is_verified": false,
@@ -23372,14 +23284,6 @@
         "is_verified": false,
         "line_number": 786,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de230a3c66580155ba845c7202e7fc4158d1c82b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 787,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -23479,27 +23383,11 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "788b34ba07c35e639f6e3e82f608189791e3239f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 938,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "9bfd048ce5ceb106ba035489cea34b77d79814e4",
         "is_secret": false,
         "is_verified": false,
         "line_number": 943,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbd62b2fef0566cbd4adcae3c005b9fb1d23170d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 944,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -24823,6 +24711,102 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "83719d2d8284b30dee2823349c2d7f600e237d8c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2697,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "04a1a3194c674cd1244ae336e0fe7054fb9bc64f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2703,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "788b34ba07c35e639f6e3e82f608189791e3239f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2714,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbd62b2fef0566cbd4adcae3c005b9fb1d23170d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2720,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ab5e8c5a013b4ea054a281a403fd0b7ab4917bc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2726,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "831b1f0f0af506c6b1b5c2de459b9b4b4f3ac633",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2736,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d1837f7e31117d99b0cbffd82e7eabcea851a94c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2745,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8773b28b7ba6a12c738b3cdd1b980ae660b3c0de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2751,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d146f9686c9c372d5c5f3d85c964777ce5a583f0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2760,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b85b391225b20c3137322bcc23c7e2c31320a83e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2769,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee7f4bf6e85139039bdd2af2df821dde5a5138d1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2778,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "604edf3bd2202bebf89e23895a6ef68088f57e42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2787,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "a98f930ed9e869e7534be3e4b8ca121b2f46b3cc",
         "is_secret": false,
         "is_verified": false,
@@ -24987,6 +24971,22 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 3016,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "84195544d364bd618a1ff2934f7820b59206d21a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3025,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de230a3c66580155ba845c7202e7fc4158d1c82b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3034,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -25903,35 +25903,11 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "f2ceefa876785b2d7376d2af71e760c71ec0109e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 502,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ea76a6819e6c7b642a58ff2639e061e2303fc28d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 503,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "8ee82c36fc0af17f1fdeb940d2bca6424bf2e453",
         "is_secret": false,
         "is_verified": false,
         "line_number": 507,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "20b3b413826d61a82664d755aaaa4a180123d161",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 519,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
@@ -26471,6 +26447,190 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "f2ceefa876785b2d7376d2af71e760c71ec0109e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1243,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ea76a6819e6c7b642a58ff2639e061e2303fc28d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1249,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "20b3b413826d61a82664d755aaaa4a180123d161",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1255,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "56397d9a520742406189d71ac27362811f4eb3f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1264,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "978bcf06dc12b74b1579b446ae082265db1358f6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1270,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8cc69a0306a6b8f4c32428f44505f11eaebb3ebf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1279,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6538f9a3e2204f918d5719f17a23367f4d2105c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1289,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff70e2022b5f305d9d30b5604b3d3fef49158de5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1298,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b4259ea178dd7cb0249df5d8feb7d13a2d6fd820",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1312,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb82e6c6c8d3ed2486ef8249d7e59336b5c86610",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1321,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ba44f293d24fbbcbe1ef98385355f7fed4f8419d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1327,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfdcf12c00b303dde9a57ba3e08927a60a89c6b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1333,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8be0eab839d1133fc403dcc2790b84d4dfff3381",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1343,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "891ddfb5f57f136198961b98f8014e3c7bc9e602",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1353,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "19c50b4f711d39a10ac1890b58e609934e3e7ff6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1362,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74ac836ae646fd72c7c162ace0d10d50d81af86b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1371,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "852251ba1e8919a04b1d4678fbf9ba2a73e82a19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1380,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0675b70f52618de044d1d1703b6c8849b407c83a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1391,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c63addae2503bfe26923f0460158bb2fc674b928",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1403,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9f7a7461ae8d5e27458e899b4e84416483680a51",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1414,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5b35b10ce4ffd9e769dc5edeb91e3717ca35a110",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1420,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de655789d424d5a5631a8000892feda124ff3528",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1460,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bbf2c697167fb0954886a726005d59a7548b75e6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1474,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "639bd69cb045a98edcce33e331b9ac85691c5fda",
         "is_secret": false,
         "is_verified": false,
@@ -26831,14 +26991,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "56397d9a520742406189d71ac27362811f4eb3f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1934,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "7794fee4eaeafc705f8eeba3b4d69cba7869dab0",
         "is_secret": false,
         "is_verified": false,
@@ -26975,6 +27127,22 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "611ee95376df586616103d908ee6f0e50de5ce6f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2119,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8792035d236f541da7fcdacf04647f5050fd4f37",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2130,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "1c7d5dc44e70c25f3c80013f6b1fcf41995ed951",
         "is_secret": false,
         "is_verified": false,
@@ -27079,14 +27247,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "bfdcf12c00b303dde9a57ba3e08927a60a89c6b8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2242,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "040278ead73fc50f601174bf24cfe3552915a67e",
         "is_secret": false,
         "is_verified": false,
@@ -27115,14 +27275,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2275,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "611ee95376df586616103d908ee6f0e50de5ce6f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2283,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -27367,14 +27519,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "8792035d236f541da7fcdacf04647f5050fd4f37",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2570,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "e67b0b7e7387fa4b492322f78c37bbae56f8aede",
         "is_secret": false,
         "is_verified": false,
@@ -27463,14 +27607,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "978bcf06dc12b74b1579b446ae082265db1358f6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2702,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "fb3ffd7b8e0ef97a3b404c2db1b91868d28b0298",
         "is_secret": false,
         "is_verified": false,
@@ -27532,142 +27668,6 @@
         "is_verified": false,
         "line_number": 2773,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8be0eab839d1133fc403dcc2790b84d4dfff3381",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2929,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "891ddfb5f57f136198961b98f8014e3c7bc9e602",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2938,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "19c50b4f711d39a10ac1890b58e609934e3e7ff6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3329,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8cc69a0306a6b8f4c32428f44505f11eaebb3ebf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3330,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "74ac836ae646fd72c7c162ace0d10d50d81af86b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5613,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "852251ba1e8919a04b1d4678fbf9ba2a73e82a19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5631,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0675b70f52618de044d1d1703b6c8849b407c83a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5655,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c63addae2503bfe26923f0460158bb2fc674b928",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5719,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9f7a7461ae8d5e27458e899b4e84416483680a51",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5730,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5b35b10ce4ffd9e769dc5edeb91e3717ca35a110",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5771,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de655789d424d5a5631a8000892feda124ff3528",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5777,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6538f9a3e2204f918d5719f17a23367f4d2105c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5792,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff70e2022b5f305d9d30b5604b3d3fef49158de5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6284,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bbf2c697167fb0954886a726005d59a7548b75e6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6900,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b4259ea178dd7cb0249df5d8feb7d13a2d6fd820",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7494,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fb82e6c6c8d3ed2486ef8249d7e59336b5c86610",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7632,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ba44f293d24fbbcbe1ef98385355f7fed4f8419d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8008,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T08:00:49Z",
+  "generated_at": "2026-04-07T08:18:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -22114,7 +22114,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2447,
+        "line_number": 2439,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -22122,7 +22122,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2735,
+        "line_number": 2727,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -8844,6 +8844,7 @@
     "mcpgateway/alembic/versions/b1c2d3e4f5a6_add_tool_plugin_bindings_table.py": [
       {
         "hashed_secret": "67e71f59c479818d8d271427edeaee49eae77ffe",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 15,
         "type": "Hex High Entropy String",
@@ -8851,6 +8852,7 @@
       },
       {
         "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 16,
         "type": "Hex High Entropy String",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T18:52:43Z",
+  "generated_at": "2026-04-07T20:27:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -9202,7 +9202,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2179,
+        "line_number": 2221,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -18956,7 +18956,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3784,
+        "line_number": 3792,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -18964,7 +18964,7 @@
         "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6627,
+        "line_number": 6635,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -18972,7 +18972,7 @@
         "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6983,
+        "line_number": 6991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -18980,7 +18980,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7007,
+        "line_number": 7015,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -21472,7 +21472,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2870,
+        "line_number": 2871,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21480,7 +21480,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3498,
+        "line_number": 3499,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21488,7 +21488,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5791,
+        "line_number": 5792,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21496,7 +21496,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6283,
+        "line_number": 6284,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21504,7 +21504,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7493,
+        "line_number": 7494,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21512,7 +21512,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7631,
+        "line_number": 7632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -21520,7 +21520,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8007,
+        "line_number": 8008,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T09:02:54Z",
+  "generated_at": "2026-04-07T10:28:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8837,6 +8837,22 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/b1c2d3e4f5a6_add_tool_plugin_bindings_table.py": [
+      {
+        "hashed_secret": "67e71f59c479818d8d271427edeaee49eae77ffe",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
+        "is_verified": false,
+        "line_number": 16,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/architecture-plugin-multi-tenancy.md
+++ b/docs/architecture-plugin-multi-tenancy.md
@@ -1,0 +1,238 @@
+# Plugin Manager Multi-Tenancy Architecture
+
+## Overview
+
+The plugin subsystem now supports **context-scoped isolation** through a shared `TenantPluginManagerFactory`. Each resolved context gets its own `TenantPluginManager` instance with an independently merged plugin configuration, while the default `__global__` context continues to serve non-context-aware call sites.
+
+The factory is intentionally **context-agnostic**. The identifier passed to `get_manager()` can represent a virtual server, tenant, tool, user, or another scoping key. The factory does not interpret the value; it only uses it to:
+- look up an existing cached manager,
+- fetch optional configuration overrides via `get_config_from_db(context_id)`,
+- build and initialize a `TenantPluginManager`,
+- cache the result for reuse.
+
+In the current gateway wiring, the primary runtime usage is:
+- `get_plugin_manager()` or `get_plugin_manager("__global__")` for shared/global plugin execution
+- `get_plugin_manager(server_id)` for server-scoped execution in services such as tools, prompts, and resources
+
+---
+
+## Architecture Summary
+
+```mermaid
+flowchart TD
+    A["Application lifespan"]
+    F["TenantPluginManagerFactory<br/>singleton in framework.__init__"]
+    G["TenantPluginManager<br/>context='__global__'"]
+    S["TenantPluginManager<br/>context='<server_id>'"]
+
+    A --> F
+    F --> G
+    F --> S
+```
+
+### Main components
+
+- **`PluginManager`**: legacy Borg-style manager with shared state across instances.
+- **`TenantPluginManager`**: `PluginManager` subclass that disables Borg behavior and keeps fully independent state per instance.
+- **`TenantPluginManagerFactory`**: async-safe cache/factory for per-context managers.
+- **`get_plugin_manager()`**: global accessor in `mcpgateway.plugins.framework.__init__` that returns a context manager from the singleton factory when plugins are enabled.
+
+---
+
+## Current Runtime Behavior
+
+### Startup
+
+At startup, `mcpgateway.main.lifespan()`:
+
+1. enables the plugin subsystem when configured,
+2. initializes the global `TenantPluginManagerFactory` with:
+   - YAML config path,
+   - plugin timeout,
+   - hook payload policies,
+   - optional observability provider,
+3. calls `await get_plugin_manager()` to resolve the default `__global__` manager,
+4. leaves additional context-specific managers to be created lazily on first use.
+
+This means the factory is initialized eagerly, but most tenant/server managers are initialized on demand.
+
+### Request-time resolution
+
+Services that support context scoping call `get_plugin_manager(server_id)` and receive:
+- a cached `TenantPluginManager`, or
+- a newly built and initialized one for that context.
+
+Call sites that do not provide a context ID continue to use the default global manager.
+
+---
+
+## Core Types
+
+### `PluginManager`
+
+`PluginManager` remains the base implementation and still uses the Borg pattern.
+
+| Property | Current behavior |
+| --- | --- |
+| State model | Shared `__dict__` across instances |
+| Primary role | Legacy/global compatibility |
+| Initialization | Loads YAML config and shares registry/executor state |
+| Reset path | `PluginManager.reset()` clears shared Borg state |
+
+### `TenantPluginManager`
+
+`TenantPluginManager` inherits the public API from `PluginManager` but bypasses the Borg initialization path.
+
+| Property | Current behavior |
+| --- | --- |
+| State model | Independent per instance |
+| Config source | Either a `Config` object or YAML path |
+| Registry | Dedicated `PluginInstanceRegistry` per manager |
+| Executor | Dedicated `PluginExecutor` per manager |
+| Locking | Own async init/shutdown lock per manager |
+
+`enable_borg()` is overridden as a no-op, so tenant managers do not share state.
+
+### `TenantPluginManagerFactory`
+
+Defined in `mcpgateway/plugins/framework/manager.py`.
+
+| Method | Current behavior |
+| --- | --- |
+| `get_manager(context_id=None)` | Returns cached manager or creates one; defaults to `__global__` |
+| `_build_manager(context_id)` | Fetches overrides, merges config, initializes manager, swaps cache entry |
+| `_merge_tenant_config(overrides)` | Applies per-plugin override values on top of base YAML config |
+| `reload_tenant(context_id)` | Evicts cached manager, rebuilds it, and shuts down the old one |
+| `shutdown()` | Cancels in-flight builds and shuts down all cached managers |
+| `get_config_from_db(context_id)` | Extension hook; returns `None` in the base implementation |
+
+---
+
+## Accessor Layer
+
+The public accessor lives in `mcpgateway/plugins/framework/__init__.py`.
+
+| Function | Current behavior |
+| --- | --- |
+| `enable_plugins(toggle)` | Enables or disables the plugin subsystem globally |
+| `init_plugin_manager_factory(...)` | Creates the singleton factory explicitly during startup |
+| `get_plugin_manager(server_id="__global__")` | Returns a context manager when plugins are enabled and the factory exists |
+| `shutdown_plugin_manager_factory()` | Shuts down the factory and clears the singleton reference |
+| `reset_plugin_manager_factory()` | Clears the singleton reference for tests |
+
+### Important clarification
+
+The accessor **does not lazy-initialize the factory anymore**. If the factory was not initialized during startup, `get_plugin_manager()` simply returns `None`.
+
+---
+
+## Configuration Merge Model
+
+Each context starts from the base YAML plugin config and optionally applies a list of `PluginConfigOverride` objects returned by `get_config_from_db(context_id)`.
+
+Only plugins already present in the base config participate in the merge.
+
+For each matching plugin:
+- `config` is shallow-merged: `{**base.config, **override.config}`
+- `mode` is replaced only if provided in the override
+- `priority` is replaced only if provided in the override
+
+Plugins not mentioned in the override list remain unchanged.
+
+```mermaid
+flowchart LR
+    B["Base YAML config"]
+    O["Overrides for context_id"]
+    M["_merge_tenant_config()"]
+    R["Merged context config"]
+
+    B --> M
+    O --> M
+    M --> R
+```
+
+### Notes
+
+- `None` overrides mean: use the base config as-is.
+- The factory itself does not query the database directly beyond the overridable `get_config_from_db()` hook.
+- The base implementation of `get_config_from_db()` currently returns `None`, so subclassing or integration wiring is required for DB-backed overrides.
+
+---
+
+## Concurrency Model
+
+Manager creation is deduplicated per context through `_inflight`.
+
+When multiple coroutines ask for the same context manager concurrently:
+
+1. the first caller creates `_build_manager(context_id)` as an `asyncio.Task`,
+2. the task is stored in `_inflight[context_id]`,
+3. later callers await the same task,
+4. the task is removed from `_inflight` in a `finally` block.
+
+This ensures that only one initialization path runs per context at a time.
+
+```mermaid
+sequenceDiagram
+    participant C1 as Caller 1
+    participant C2 as Caller 2
+    participant F as Factory
+    participant T as _build_manager task
+
+    C1->>F: get_manager("server-1")
+    F->>T: create task
+    C2->>F: get_manager("server-1")
+    C1-->>T: await
+    C2-->>T: await
+    T-->>C1: manager
+    T-->>C2: same manager
+```
+
+---
+
+## Reload and Shutdown Semantics
+
+### Reload
+
+`reload_tenant(context_id)`:
+1. removes the cached manager for the context,
+2. creates or reuses an in-flight rebuild task,
+3. shuts down the old manager outside the lock,
+4. returns the rebuilt manager.
+
+### Shutdown
+
+`shutdown()`:
+1. snapshots cached managers and in-flight tasks under the lock,
+2. clears both caches,
+3. cancels in-flight tasks,
+4. awaits their completion,
+5. shuts down each cached manager.
+
+This keeps teardown orderly without leaving active manager instances behind.
+
+---
+
+## Backward Compatibility
+
+The current design preserves compatibility in a few important ways:
+
+- `PluginManager` still exists for Borg-based shared-state behavior.
+- `TenantPluginManager` keeps the same public lifecycle and hook invocation API as `PluginManager`.
+- `get_plugin_manager()` without arguments still resolves the global `__global__` manager.
+- Call sites that are not context-aware continue to function against the global manager.
+
+What changed is the wiring: the system now routes plugin access through the factory instead of a single shared manager instance.
+
+---
+
+## Recommended Mental Model
+
+Use the following model when reasoning about the architecture:
+
+- **one factory per process**
+- **one cached manager per context ID**
+- **one independent registry/executor per manager**
+- **one shared base config, optionally merged with per-context overrides**
+
+That is the current architecture implemented by the code, without requiring every request path to understand how plugin configuration is stored internally.

--- a/docs/architecture-plugin-multi-tenancy.md
+++ b/docs/architecture-plugin-multi-tenancy.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The plugin subsystem now supports **context-scoped isolation** through a shared `TenantPluginManagerFactory`. Each resolved context gets its own `TenantPluginManager` instance with an independently merged plugin configuration, while the default `__global__` context continues to serve non-context-aware call sites.
+The plugin subsystem supports **context-scoped isolation** through a shared `TenantPluginManagerFactory`. Each resolved context gets its own `TenantPluginManager` instance with an independently merged plugin configuration, while the default `__global__` context continues to serve non-context-aware call sites.
 
 The factory is intentionally **context-agnostic**. The identifier passed to `get_manager()` can represent a virtual server, tenant, tool, user, or another scoping key. The factory does not interpret the value; it only uses it to:
 - look up an existing cached manager,
@@ -16,18 +16,85 @@ In the current gateway wiring, the primary runtime usage is:
 
 ---
 
+## Plugin Configuration Lifecycle
+
+### Startup: YAML is the source of truth
+
+Plugins must be **declared in the YAML configuration file at startup**. The YAML defines which plugins exist, their default `mode`, `priority`, and plugin-specific `config` keys. This base configuration is loaded once by `TenantPluginManagerFactory` and is **immutable at runtime** — it cannot be changed without a restart.
+
+```yaml
+plugins/config.yaml
+  └─ plugin A  (mode: enforce, priority: 10, config: {...})
+  └─ plugin B  (mode: permissive, priority: 20, config: {...})
+```
+
+Only plugins listed in the YAML participate in any context. There is no mechanism to introduce entirely new plugins at runtime.
+
+### Runtime: per-context overrides via `PluginConfigOverride`
+
+For each context (e.g. a virtual server), the factory may apply a list of `PluginConfigOverride` objects on top of the base YAML config. An override can:
+
+- **change a plugin's `mode`** (e.g. promote from `permissive` to `enforce` for a specific server)
+- **change a plugin's `priority`** (re-order execution within the chain)
+- **add or replace keys in the plugin's `config` dict** (deep custom configuration)
+
+Overrides are **additive and selective**: only the fields explicitly set in an override are applied; everything else inherits the YAML base. A plugin not mentioned in the override list is used as-is.
+
+```yaml
+PluginConfigOverride
+  └─ name: "plugin A"
+  └─ mode: permissive       # overrides YAML value for this context
+  └─ config: {threshold: 5} # merged on top of base config
+```
+
+### Fetch hook: `get_config_from_db`
+
+`get_config_from_db(context_id)` is the extension point that translates a context identifier into a list of `PluginConfigOverride` objects fetched from persistent storage.
+
+The base implementation always returns `None` (no overrides). Subclasses override this method to query the database — or any other store — for the per-context plugin settings associated with `context_id`.
+
+The returned overrides are passed directly to `_merge_tenant_config`, which walks the base config's plugin list and applies each override: per-plugin `config` dicts are shallow-merged (override keys win), and optional `mode` and `priority` fields replace the base values when present. The result is a new `Config` object used to construct an isolated `TenantPluginManager` for that context.
+
+In summary: `get_config_from_db` is the seam between the factory and your persistence layer — override it to make per-context plugin configuration dynamic.
+
+```mermaid
+flowchart TD
+    Y["YAML config file\n(loaded at startup, immutable)"]
+    DB["Persistence layer\n(DB, config store, etc.)"]
+    H["get_config_from_db(context_id)\n[override this in subclass]"]
+    O["list[PluginConfigOverride]\n(mode / priority / config keys)"]
+    M["_merge_tenant_config()"]
+    C["Merged Config\n(per-context)"]
+    T["TenantPluginManager\n(per-context instance)"]
+
+    Y --> M
+    DB --> H
+    H --> O
+    O --> M
+    M --> C
+    C --> T
+```
+
+---
+
 ## Architecture Summary
 
 ```mermaid
 flowchart TD
-    A["Application lifespan"]
-    F["TenantPluginManagerFactory<br/>singleton in framework.__init__"]
-    G["TenantPluginManager<br/>context='__global__'"]
-    S["TenantPluginManager<br/>context='<server_id>'"]
+    APP["Application lifespan\n(mcpgateway.main)"]
+    F["TenantPluginManagerFactory\n(singleton, holds base YAML config)"]
+    G["TenantPluginManager\ncontext = '__global__'\n(backward-compat global manager)"]
+    S1["TenantPluginManager\ncontext = 'server-id-1'"]
+    S2["TenantPluginManager\ncontext = 'server-id-2'"]
+    DB["get_config_from_db(context_id)\n(fetch per-context overrides)"]
+    YAML["plugins/config.yaml\n(base plugin config)"]
 
-    A --> F
-    F --> G
-    F --> S
+    APP -->|"init_plugin_manager_factory()"| F
+    YAML -->|"loaded once at startup"| F
+    F -->|"eager: get_manager()"| G
+    F -->|"lazy: get_manager(server_id)"| S1
+    F -->|"lazy: get_manager(server_id)"| S2
+    F <-->|"override fetch"| DB
 ```
 
 ### Main components
@@ -104,7 +171,7 @@ Defined in `mcpgateway/plugins/framework/manager.py`.
 | `_merge_tenant_config(overrides)` | Applies per-plugin override values on top of base YAML config |
 | `reload_tenant(context_id)` | Evicts cached manager, rebuilds it, and shuts down the old one |
 | `shutdown()` | Cancels in-flight builds and shuts down all cached managers |
-| `get_config_from_db(context_id)` | Extension hook; returns `None` in the base implementation |
+| `get_config_from_db(context_id)` | Extension hook; returns `None` in the base implementation — **subclass to enable DB-backed overrides** |
 
 ---
 
@@ -122,7 +189,7 @@ The public accessor lives in `mcpgateway/plugins/framework/__init__.py`.
 
 ### Important clarification
 
-The accessor **does not lazy-initialize the factory anymore**. If the factory was not initialized during startup, `get_plugin_manager()` simply returns `None`.
+The accessor **does not lazy-initialize the factory**. If the factory was not initialized during startup, `get_plugin_manager()` returns `None`.
 
 ---
 
@@ -130,32 +197,27 @@ The accessor **does not lazy-initialize the factory anymore**. If the factory wa
 
 Each context starts from the base YAML plugin config and optionally applies a list of `PluginConfigOverride` objects returned by `get_config_from_db(context_id)`.
 
-Only plugins already present in the base config participate in the merge.
+Only plugins already present in the base config participate in the merge. There is no mechanism to introduce new plugins at runtime; the YAML is the canonical plugin registry.
 
 For each matching plugin:
-- `config` is shallow-merged: `{**base.config, **override.config}`
+
+- `config` is shallow-merged: `{**base.config, **override.config}` — override keys win
 - `mode` is replaced only if provided in the override
 - `priority` is replaced only if provided in the override
 
-Plugins not mentioned in the override list remain unchanged.
+Plugins not mentioned in the override list remain unchanged. Passing `None` overrides means: use the base config as-is.
 
 ```mermaid
 flowchart LR
-    B["Base YAML config"]
-    O["Overrides for context_id"]
+    B["Base YAML config\n(plugin A, plugin B, plugin C)"]
+    O["PluginConfigOverride list\nfrom get_config_from_db(context_id)"]
     M["_merge_tenant_config()"]
-    R["Merged context config"]
+    R["Merged context Config\n(used to build TenantPluginManager)"]
 
-    B --> M
-    O --> M
+    B -->|"all plugins"| M
+    O -->|"selective overrides\nmode / priority / config keys"| M
     M --> R
 ```
-
-### Notes
-
-- `None` overrides mean: use the base config as-is.
-- The factory itself does not query the database directly beyond the overridable `get_config_from_db()` hook.
-- The base implementation of `get_config_from_db()` currently returns `None`, so subclassing or integration wiring is required for DB-backed overrides.
 
 ---
 
@@ -165,27 +227,32 @@ Manager creation is deduplicated per context through `_inflight`.
 
 When multiple coroutines ask for the same context manager concurrently:
 
-1. the first caller creates `_build_manager(context_id)` as an `asyncio.Task`,
-2. the task is stored in `_inflight[context_id]`,
-3. later callers await the same task,
-4. the task is removed from `_inflight` in a `finally` block.
+1. the first caller acquires the lock and creates `_build_manager(context_id)` as an `asyncio.Task`,
+2. the task is stored in `_inflight[context_id]` and the lock is released,
+3. later callers acquiring the lock find the existing task and await it,
+4. once the task completes, `_build_manager` stores the result in `_managers` under the lock,
+5. `get_manager` re-checks `_managers` after the await to pick up any replacement triggered by a concurrent `reload_tenant`,
+6. the task is removed from `_inflight` in a `finally` block.
 
-This ensures that only one initialization path runs per context at a time.
+This ensures only one initialization path runs per context at a time, and concurrent callers share the result rather than racing to build duplicate managers.
 
 ```mermaid
 sequenceDiagram
     participant C1 as Caller 1
     participant C2 as Caller 2
-    participant F as Factory
+    participant F as Factory (lock)
     participant T as _build_manager task
 
     C1->>F: get_manager("server-1")
-    F->>T: create task
+    F->>F: cache miss → create task
+    F->>T: asyncio.create_task(_build_manager)
+    F-->>C1: release lock, await task
     C2->>F: get_manager("server-1")
-    C1-->>T: await
-    C2-->>T: await
-    T-->>C1: manager
-    T-->>C2: same manager
+    F->>F: cache miss → inflight task found
+    F-->>C2: release lock, await same task
+    T-->>F: initialize manager, store in _managers
+    T-->>C1: return manager
+    T-->>C2: return same manager
 ```
 
 ---
@@ -195,18 +262,21 @@ sequenceDiagram
 ### Reload
 
 `reload_tenant(context_id)`:
-1. removes the cached manager for the context,
-2. creates or reuses an in-flight rebuild task,
-3. shuts down the old manager outside the lock,
-4. returns the rebuilt manager.
+
+1. acquires the lock and removes the cached manager for the context,
+2. cancels any existing in-flight build task for the same context,
+3. creates a fresh `_build_manager` task and stores it in `_inflight`,
+4. releases the lock and shuts down the old manager outside it,
+5. awaits the new task and returns the rebuilt manager.
 
 ### Shutdown
 
 `shutdown()`:
+
 1. snapshots cached managers and in-flight tasks under the lock,
-2. clears both caches,
-3. cancels in-flight tasks,
-4. awaits their completion,
+2. clears both caches atomically,
+3. cancels all in-flight tasks,
+4. awaits their completion (collecting exceptions),
 5. shuts down each cached manager.
 
 This keeps teardown orderly without leaving active manager instances behind.
@@ -230,9 +300,10 @@ What changed is the wiring: the system now routes plugin access through the fact
 
 Use the following model when reasoning about the architecture:
 
-- **one factory per process**
-- **one cached manager per context ID**
-- **one independent registry/executor per manager**
-- **one shared base config, optionally merged with per-context overrides**
+- **one factory per process** — holds the base YAML config and the manager cache
+- **one cached manager per context ID** — each with an independent registry and executor
+- **plugins declared once in YAML at startup** — the YAML is the canonical plugin registry
+- **per-context overrides fetched at manager-build time** — via `get_config_from_db`; subclass to wire to your DB
+- **one shared base config, optionally merged with per-context overrides** — override keys win; unknown plugins are ignored
 
 That is the current architecture implemented by the code, without requiring every request path to understand how plugin configuration is stored internally.

--- a/mcpgateway/alembic/versions/b1c2d3e4f5a6_add_tool_plugin_bindings_table.py
+++ b/mcpgateway/alembic/versions/b1c2d3e4f5a6_add_tool_plugin_bindings_table.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Add tool_plugin_bindings table for per-tool per-tenant plugin policies
+
+Revision ID: b1c2d3e4f5a6
+Revises: a7f3c9e1b2d4
+Create Date: 2026-04-03 00:00:00.000000
+
+"""
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision = "a7f3c9e1b2d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create tool_plugin_bindings table if it does not already exist."""
+    inspector = sa.inspect(op.get_bind())
+
+    if "tool_plugin_bindings" in inspector.get_table_names():
+        return
+
+    op.create_table(
+        "tool_plugin_bindings",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("team_id", sa.String(36), sa.ForeignKey("email_teams.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("tool_name", sa.String(255), nullable=False),
+        sa.Column("plugin_id", sa.String(64), nullable=False),
+        sa.Column("mode", sa.String(20), nullable=False, server_default="enforce"),
+        sa.Column("priority", sa.Integer(), nullable=False, server_default="50"),
+        sa.Column("config", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("created_by", sa.String(255), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_by", sa.String(255), nullable=False),
+        sa.UniqueConstraint("team_id", "tool_name", "plugin_id", name="uq_tool_plugin_binding"),
+    )
+
+    op.create_index("ix_tool_plugin_bindings_team_id", "tool_plugin_bindings", ["team_id"])
+    op.create_index("ix_tool_plugin_bindings_tool_name", "tool_plugin_bindings", ["tool_name"])
+
+
+def downgrade() -> None:
+    """Drop tool_plugin_bindings table."""
+    inspector = sa.inspect(op.get_bind())
+
+    if "tool_plugin_bindings" not in inspector.get_table_names():
+        return
+
+    op.drop_index("ix_tool_plugin_bindings_tool_name", table_name="tool_plugin_bindings")
+    op.drop_index("ix_tool_plugin_bindings_team_id", table_name="tool_plugin_bindings")
+    op.drop_table("tool_plugin_bindings")

--- a/mcpgateway/alembic/versions/b1c2d3e4f5a6_add_tool_plugin_bindings_table.py
+++ b/mcpgateway/alembic/versions/b1c2d3e4f5a6_add_tool_plugin_bindings_table.py
@@ -2,7 +2,7 @@
 """Add tool_plugin_bindings table for per-tool per-tenant plugin policies
 
 Revision ID: b1c2d3e4f5a6
-Revises: a7f3c9e1b2d4
+Revises: cbedf4e580e0
 Create Date: 2026-04-03 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "b1c2d3e4f5a6"
-down_revision = "a7f3c9e1b2d4"
+down_revision = "cbedf4e580e0"
 branch_labels = None
 depends_on = None
 

--- a/mcpgateway/alembic/versions/c2d3e4f5a6b7_add_manage_plugins_to_team_admin.py
+++ b/mcpgateway/alembic/versions/c2d3e4f5a6b7_add_manage_plugins_to_team_admin.py
@@ -1,0 +1,146 @@
+# pylint: disable=no-member
+"""Add tools.manage_plugins permission to team_admin role.
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2025-07-01 00:00:00.000000
+
+Backfills the tools.manage_plugins permission into the team-scoped team_admin role
+so that team administrators can configure per-tool plugin policies for their teams
+without requiring a platform_admin account.
+
+Note: platform_admin already has wildcard permissions and is unaffected.
+"""
+
+# Standard
+from datetime import datetime, timezone
+import json
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ROLE_PERMISSION_ADDITIONS: list[tuple[str, str, list[str]]] = [
+    # (role_name, scope, permissions_to_add)
+    ("team_admin", "team", ["tools.manage_plugins"]),
+]
+
+
+def _load_permissions(raw_permissions: object) -> list[str]:
+    """Normalize stored role permissions into a list of strings.
+
+    Args:
+        raw_permissions: Raw permissions value from the role row.
+
+    Returns:
+        list[str]: Normalized list of permission strings.
+    """
+    if not raw_permissions:
+        return []
+
+    parsed = raw_permissions
+    if isinstance(parsed, (bytes, bytearray)):
+        parsed = parsed.decode("utf-8")
+
+    if isinstance(parsed, str):
+        try:
+            parsed = json.loads(parsed)
+        except json.JSONDecodeError:
+            return []
+
+    if isinstance(parsed, list):
+        return [perm for perm in parsed if isinstance(perm, str)]
+
+    return []
+
+
+def _update_role_permissions(conn, role_name: str, scope: str, permissions: list[str], add: bool) -> None:
+    """Add or remove permissions from a role, idempotently.
+
+    Args:
+        conn: Active Alembic connection.
+        role_name: Role name to update.
+        scope: Role scope ('team' or 'global') to disambiguate roles with the same name.
+        permissions: Permission values to add or remove.
+        add: When True, add permissions; when False, remove permissions.
+    """
+    row = conn.execute(
+        text("SELECT id, permissions FROM roles WHERE name = :name AND scope = :scope LIMIT 1"),
+        {"name": role_name, "scope": scope},
+    ).fetchone()
+
+    if not row:
+        print(f"{role_name} role not found. Skipping.")
+        return
+
+    role_id = row[0]
+    current_permissions = _load_permissions(row[1])
+
+    if add:
+        updated_permissions = list(current_permissions)
+        for permission in permissions:
+            if permission not in updated_permissions:
+                updated_permissions.append(permission)
+    else:
+        updated_permissions = [permission for permission in current_permissions if permission not in permissions]
+
+    if updated_permissions == current_permissions:
+        print(f"{role_name} role already has the required permissions. Skipping.")
+        return
+
+    dialect_name = conn.dialect.name
+    if dialect_name == "postgresql":
+        update_query = text("""
+            UPDATE roles
+            SET permissions = CAST(:permissions AS JSONB), updated_at = :updated_at
+            WHERE id = :role_id
+            """)
+    else:
+        update_query = text("""
+            UPDATE roles
+            SET permissions = :permissions, updated_at = :updated_at
+            WHERE id = :role_id
+            """)
+
+    conn.execute(
+        update_query,
+        {
+            "permissions": json.dumps(updated_permissions),
+            "updated_at": datetime.now(timezone.utc),
+            "role_id": role_id,
+        },
+    )
+    print(f"Updated role '{role_name}' permissions.")
+
+
+def upgrade() -> None:
+    """Backfill tools.manage_plugins permission into the team_admin role."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "roles" not in inspector.get_table_names():
+        print("roles table not found. Skipping migration.")
+        return
+
+    for role_name, scope, permissions in ROLE_PERMISSION_ADDITIONS:
+        _update_role_permissions(conn, role_name, scope, permissions, add=True)
+
+
+def downgrade() -> None:
+    """Remove tools.manage_plugins permission from the team_admin role."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "roles" not in inspector.get_table_names():
+        print("roles table not found. Skipping migration.")
+        return
+
+    for role_name, scope, permissions in ROLE_PERMISSION_ADDITIONS:
+        _update_role_permissions(conn, role_name, scope, permissions, add=False)

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1150,7 +1150,7 @@ async def get_current_user(
     # This hook is invoked BEFORE standard JWT/API token validation
     try:
         # Get plugin manager singleton
-        plugin_manager = get_plugin_manager()
+        plugin_manager = await get_plugin_manager()
 
         if plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_AUTH_RESOLVE_USER):
             # Extract client information
@@ -1248,7 +1248,7 @@ async def get_current_user(
                 if request and global_context:
                     request.state.plugin_global_context = global_context
 
-                if plugin_manager and plugin_manager.config.plugin_settings.include_user_info:
+                if plugin_manager and plugin_manager.config and plugin_manager.config.plugin_settings.include_user_info:
                     _inject_userinfo_instate(request, user)
                 _propagate_tenant_id(request)
 
@@ -1378,7 +1378,7 @@ async def get_current_user(
                                     headers={"WWW-Authenticate": "Bearer"},
                                 )
 
-                        if plugin_manager and plugin_manager.config.plugin_settings.include_user_info:
+                        if plugin_manager and plugin_manager.config and plugin_manager.config.plugin_settings.include_user_info:
                             _inject_userinfo_instate(request, _user_from_cached_dict(cached_ctx.user))
                         _propagate_tenant_id(request)
 
@@ -1517,7 +1517,7 @@ async def get_current_user(
                             headers={"WWW-Authenticate": "Bearer"},
                         )
 
-                if plugin_manager and plugin_manager.config.plugin_settings.include_user_info:
+                if plugin_manager and plugin_manager.config and plugin_manager.config.plugin_settings.include_user_info:
                     _inject_userinfo_instate(request, _batched_user)
                 _propagate_tenant_id(request)
 
@@ -1699,7 +1699,7 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if plugin_manager and plugin_manager.config.plugin_settings.include_user_info:
+    if plugin_manager and plugin_manager.config and plugin_manager.config.plugin_settings.include_user_info:
         _inject_userinfo_instate(request, user)
     _propagate_tenant_id(request)
 

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -305,6 +305,7 @@ async def bootstrap_default_roles(conn: Connection) -> None:
                         "tokens.read",
                         "tokens.update",
                         "tokens.revoke",
+                        "tools.manage_plugins",
                     ],
                     "is_system_role": True,
                 },

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6547,3 +6547,84 @@ def set_prompt_name_and_slug(mapper, connection, target):  # pylint: disable=unu
         target.name = f"{gateway_slug}{sep}{target.custom_name_slug}"
     else:
         target.name = target.custom_name_slug
+
+
+# ---------------------------------------------------------------------------
+# ToolPluginBinding — per-tool per-tenant plugin policy bindings
+# ---------------------------------------------------------------------------
+
+
+class ToolPluginBinding(Base):
+    """ORM model for per-tool per-tenant plugin policy bindings.
+
+    Each row represents a single plugin policy applied to a specific tool
+    within a specific team.  Multiple rows for the same (team, tool) pair
+    are allowed as long as the plugin_id differs — each plugin type may only
+    appear once per (team_id, tool_name, plugin_id) triple (enforced via
+    UniqueConstraint).  A POST with an existing triple performs an upsert
+    (updates the existing row's config/mode/priority).
+
+    Supported plugin_id values:
+        - ``OUTPUT_LENGTH_GUARD`` — truncate/block responses exceeding a char limit.
+        - ``RATE_LIMITER``        — per-user / per-tenant / per-tool rate gating.
+        - ``SECRETS_DETECTION``   — redact or block secret patterns in output.
+
+    Attributes:
+        id (str): UUID primary key.
+        team_id (str): FK to ``email_teams.id``.
+        tool_name (str): Name of the tool the policy applies to; ``"*"`` means all team tools.
+        plugin_id (str): One of the supported plugin identifiers.
+        mode (str): ``"enforce"`` | ``"permissive"`` | ``"disabled"``.
+        priority (int): Execution priority — lower numbers run first.
+        config (dict): Plugin-specific JSON configuration blob.
+        created_at (datetime): Row creation timestamp (UTC).
+        created_by (str): Email of the user who created the binding.
+        updated_at (datetime): Last update timestamp (UTC).
+        updated_by (str): Email of the user who last updated the binding.
+
+    Examples:
+        >>> binding = ToolPluginBinding(
+        ...     team_id="abc123",
+        ...     tool_name="*",
+        ...     plugin_id="OUTPUT_LENGTH_GUARD",
+        ...     mode="enforce",
+        ...     priority=10,
+        ...     config={"max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+        ...     created_by="admin@example.com",
+        ... )
+        >>> binding.plugin_id
+        'OUTPUT_LENGTH_GUARD'
+        >>> binding.mode
+        'enforce'
+    """
+
+    __tablename__ = "tool_plugin_bindings"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: uuid.uuid4().hex)
+    team_id: Mapped[str] = mapped_column(String(36), ForeignKey("email_teams.id", ondelete="CASCADE"), nullable=False)
+    tool_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    plugin_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    mode: Mapped[str] = mapped_column(String(20), nullable=False, default="enforce")
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=50)
+    config: Mapped[Dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    updated_by: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # Relationship back to team
+    team: Mapped["EmailTeam"] = relationship("EmailTeam", foreign_keys=[team_id])
+
+    __table_args__ = (
+        UniqueConstraint("team_id", "tool_name", "plugin_id", name="uq_tool_plugin_binding"),
+        Index("ix_tool_plugin_bindings_team_id", "team_id"),
+        Index("ix_tool_plugin_bindings_tool_name", "tool_name"),
+    )
+
+    def __repr__(self) -> str:
+        """String representation.
+
+        Returns:
+            str: String representation of ToolPluginBinding instance.
+        """
+        return f"<ToolPluginBinding(id='{self.id}', team_id='{self.team_id}', tool_name='{self.tool_name}', plugin_id='{self.plugin_id}')>"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11014,6 +11014,15 @@ app.include_router(metrics_router)
 app.include_router(tag_router)
 app.include_router(export_import_router)
 
+# Tool plugin bindings router
+try:
+    from mcpgateway.routers.tool_plugin_bindings import router as tool_plugin_bindings_router  # pylint: disable=import-outside-toplevel
+
+    app.include_router(tool_plugin_bindings_router)
+    logger.info("Tool plugin bindings router included")
+except ImportError as e:
+    logger.error(f"Tool plugin bindings router not available: {e}")
+
 # Include log search router if structured logging is enabled
 if getattr(settings, "structured_logging_enabled", True):
     try:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -96,7 +96,17 @@ from mcpgateway.middleware.security_headers import SecurityHeadersMiddleware
 from mcpgateway.middleware.token_scoping import token_scoping_middleware
 from mcpgateway.middleware.validation_middleware import ValidationMiddleware
 from mcpgateway.observability import init_telemetry, OpenTelemetryRequestMiddleware, otel_tracing_enabled
-from mcpgateway.plugins.framework import HttpHookType, PluginError, PluginManager, PluginViolationError, PromptHookType, ResourceHookType
+from mcpgateway.plugins.framework import (
+    enable_plugins,
+    get_plugin_manager,
+    HttpHookType,
+    init_plugin_manager_factory,
+    PluginError,
+    PluginViolationError,
+    PromptHookType,
+    ResourceHookType,
+    shutdown_plugin_manager_factory,
+)
 from mcpgateway.plugins.framework.constants import PLUGIN_VIOLATION_CODE_MAPPING, PluginViolationCode, VALID_HTTP_STATUS_CODES
 from mcpgateway.routers.server_well_known import router as server_well_known_router
 from mcpgateway.routers.well_known import router as well_known_router
@@ -199,17 +209,11 @@ except RuntimeError:
 else:
     loop.create_task(bootstrap_db())
 
-# Initialize plugin manager as a singleton.
-_PLUGINS_ENABLED = settings.plugins.enabled
-if _PLUGINS_ENABLED:
-    _plugin_settings = settings.plugins
-    # First-Party
-    from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # noqa: E402
-
-    plugin_manager: PluginManager | None = PluginManager(_plugin_settings.config_file, timeout=_plugin_settings.plugin_timeout, hook_policies=HOOK_PAYLOAD_POLICIES)
-else:
-    plugin_manager = None  # pylint: disable=invalid-name
-
+# Enable plugin subsystem at module load time, mirroring the old singleton pattern.
+# get_plugin_manager() guards on this flag, so it must be set before lifespan runs.
+if settings.plugins.enabled:
+    enable_plugins(True)
+    logger.info("Plugin subsystem enabled (factory will be initialized in lifespan)")
 
 # First-Party
 # First-Party - import module-level service singletons
@@ -591,6 +595,7 @@ async def _run_internal_mcp_authentication(
     """
     # Run pre-request plugin hooks (e.g. WXO JWT → team token exchange)
     # before building the auth scope, so plugins can transform headers.
+    plugin_manager = await get_plugin_manager()
     if plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_PRE_REQUEST):
         headers, _, _ = await run_pre_request_hooks(
             plugin_manager=plugin_manager,
@@ -1718,14 +1723,41 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # Validate security configuration
         validate_security_configuration()
 
-        if plugin_manager:
-            logger.debug("plugin_manager.initialize() starting...")
-            try:
-                await plugin_manager.initialize()
+        # Initialize plugin manager factory if plugins are enabled
+        if settings.plugins.enabled:
+            # First-Party
+            from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # pylint: disable=import-outside-toplevel
+
+            init_plugin_manager_factory(
+                yaml_path=settings.plugins.config_file,
+                timeout=settings.plugins.plugin_timeout,
+                hook_policies=HOOK_PAYLOAD_POLICIES,
+                observability=None,  # Will be set later if needed
+            )
+            logger.info("Plugin manager factory initialized")
+
+        try:
+            plugin_manager = await get_plugin_manager()
+            if plugin_manager:
                 logger.info(f"Plugin manager initialized with {plugin_manager.plugin_count} plugins")
-            except Exception as diag_exc:
-                logger.error(f"plugin_manager.initialize() failed: {diag_exc}", exc_info=True)
-                raise
+                # Wire plugin manager to plugin service for admin endpoints
+                # First-Party
+                from mcpgateway.services.plugin_service import get_plugin_service  # pylint: disable=import-outside-toplevel
+
+                plugin_service = get_plugin_service()
+                plugin_service.set_plugin_manager(plugin_manager)
+        except Exception as diag_exc:
+            logger.error(f"Plugin manager initialization failed: {diag_exc}", exc_info=True)
+            raise
+
+        # Wire observability adapter to plugin manager if observability is enabled
+        if settings.observability_enabled and _service is not None:  # pylint: disable=possibly-used-before-assignment
+            # First-Party
+            from mcpgateway.plugins.framework import set_global_observability  # pylint: disable=import-outside-toplevel
+            from mcpgateway.plugins.observability_adapter import ObservabilityServiceAdapter  # pylint: disable=import-outside-toplevel
+
+            set_global_observability(ObservabilityServiceAdapter(service=_service))
+            logger.info("🔍 Plugin observability adapter wired to ObservabilityService")
 
         if settings.enable_header_passthrough:
             await setup_passthrough_headers()
@@ -1906,13 +1938,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 with suppress(asyncio.CancelledError):
                     await task
 
-        # Shutdown plugin manager
-        if plugin_manager:
-            try:
-                await plugin_manager.shutdown()
-                logger.info("Plugin manager shutdown complete")
-            except Exception as e:
-                logger.error(f"Error shutting down plugin manager: {str(e)}")
+        # Shutdown global plugin manager factory (no-op when plugins were never initialised)
+        try:
+            await shutdown_plugin_manager_factory()
+            logger.info("Plugin manager shutdown complete")
+        except Exception as e:
+            logger.error(f"Error shutting down plugin manager: {str(e)}")
 
         # Stop cache invalidation subscriber
         try:
@@ -3059,9 +3090,8 @@ else:
     app.add_middleware(MCPPathRewriteMiddleware)
 
 # Add HTTP authentication hook middleware for plugins (before auth dependencies)
-if plugin_manager:
-    app.add_middleware(HttpAuthMiddleware, plugin_manager=plugin_manager)
-    logger.info("🔌 HTTP authentication hooks enabled for plugins")
+# Middleware will get the global plugin manager at request time if factory exists
+app.add_middleware(HttpAuthMiddleware)
 
 # Add request logging middleware FIRST (always enabled for gateway boundary logging)
 # IMPORTANT: Must be registered BEFORE CorrelationIDMiddleware so it executes AFTER correlation ID is set
@@ -3126,13 +3156,11 @@ else:
 if settings.observability_enabled:
     # First-Party
     from mcpgateway.middleware.observability_middleware import ObservabilityMiddleware
-    from mcpgateway.plugins.observability_adapter import ObservabilityServiceAdapter
     from mcpgateway.services.observability_service import ObservabilityService
 
     _service = ObservabilityService()
     app.add_middleware(ObservabilityMiddleware, enabled=True, service=_service)
-    if plugin_manager:
-        plugin_manager.observability = ObservabilityServiceAdapter(service=_service)
+    # Plugin observability adapter will be set in lifespan after plugin_manager is initialized
     logger.info("🔍 Observability middleware enabled - tracing include-listed requests")
 else:
     logger.info("🔍 Observability middleware disabled")
@@ -3237,16 +3265,10 @@ if not settings.templates_auto_reload:
     logger.info("🎨 Template auto-reload disabled (production mode)")
 app.state.templates = templates
 
-# Store plugin manager in app state for access in routes
-app.state.plugin_manager = plugin_manager
+# Plugin manager is obtained from factory at request time via get_plugin_manager()
+# No need to store in app state; routes will get it from the factory when needed
 
-# Initialize plugin service with plugin manager
-if plugin_manager:
-    # First-Party
-    from mcpgateway.services.plugin_service import get_plugin_service
-
-    plugin_service = get_plugin_service()
-    plugin_service.set_plugin_manager(plugin_manager)
+# Plugin service will be initialized in lifespan after plugin manager is ready
 
 # Create API routers
 protocol_router = APIRouter(prefix="/protocol", tags=["Protocol"])
@@ -8691,7 +8713,8 @@ async def _authorize_internal_mcp_server_scoped_method(
         )
         if db.is_active and db.in_transaction() is not None:
             db.commit()
-        fallback_reason = _server_scoped_direct_execution_fallback_reason(method)
+        plugin_manager = await get_plugin_manager()
+        fallback_reason = _server_scoped_direct_execution_fallback_reason(method, plugin_manager)
         if fallback_reason:
             return ORJSONResponse(
                 status_code=status.HTTP_200_OK,
@@ -8716,7 +8739,7 @@ async def _authorize_internal_mcp_server_scoped_method(
         db.close()
 
 
-def _server_scoped_direct_execution_fallback_reason(method: str) -> Optional[str]:
+def _server_scoped_direct_execution_fallback_reason(method: str, plugin_manager) -> Optional[str]:
     """Return a direct-execution fallback reason for server-scoped Rust MCP calls.
 
     This fail-closed helper lets Python remain the source of truth for plugin
@@ -8725,6 +8748,7 @@ def _server_scoped_direct_execution_fallback_reason(method: str) -> Optional[str
 
     Args:
         method: MCP method name being considered for Rust direct execution.
+        plugin_manager: Plugin manager instance to check for configured hooks.
 
     Returns:
         A stable fallback reason when Python must handle the request to preserve

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1733,6 +1733,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 timeout=settings.plugins.plugin_timeout,
                 hook_policies=HOOK_PAYLOAD_POLICIES,
                 observability=None,  # Will be set later if needed
+                db_factory=SessionLocal,
             )
             logger.info("Plugin manager factory initialized")
 
@@ -1746,6 +1747,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
                 plugin_service = get_plugin_service()
                 plugin_service.set_plugin_manager(plugin_manager)
+                # Expose on app.state so the admin UI can show the correct enabled status
+                app.state.plugin_manager = plugin_manager
         except Exception as diag_exc:
             logger.error(f"Plugin manager initialization failed: {diag_exc}", exc_info=True)
             raise

--- a/mcpgateway/middleware/http_auth_middleware.py
+++ b/mcpgateway/middleware/http_auth_middleware.py
@@ -17,14 +17,14 @@ from starlette.types import ASGIApp
 
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpHookType, HttpPostRequestPayload, HttpPreRequestPayload, PluginManager
+from mcpgateway.plugins.framework import get_plugin_manager, GlobalContext, HttpHeaderPayload, HttpHookType, HttpPostRequestPayload, HttpPreRequestPayload, PluginManager
 from mcpgateway.utils.correlation_id import generate_correlation_id, get_correlation_id
 
 logger = logging.getLogger(__name__)
 
 
 async def run_pre_request_hooks(
-    plugin_manager: PluginManager,
+    plugin_manager: PluginManager,  # Base class type annotation is intentional - accepts both PluginManager and TenantPluginManager
     headers: dict[str, str],
     path: str,
     method: str,
@@ -121,15 +121,13 @@ class HttpAuthMiddleware(BaseHTTPMiddleware):
     - Log response status and headers
     """
 
-    def __init__(self, app: ASGIApp, plugin_manager: PluginManager | None = None):
+    def __init__(self, app: ASGIApp):
         """Initialize the HTTP auth middleware.
 
         Args:
             app: The ASGI application
-            plugin_manager: Optional plugin manager for hook invocation
         """
         super().__init__(app)
-        self.plugin_manager = plugin_manager
 
     async def dispatch(self, request: Request, call_next):
         """Process request through plugin hooks.
@@ -141,14 +139,19 @@ class HttpAuthMiddleware(BaseHTTPMiddleware):
         Returns:
             The response from the application
         """
-        # Skip hook invocation if no plugin manager
-        if not self.plugin_manager:
+        # Note: HTTP hooks always use global config (__global__ context) because
+        # this middleware runs before virtual server routing. Per-tenant HTTP hooks
+        # would require extracting server_id from the request path, which is not
+        # currently implemented. This is acceptable for auth-layer middleware.
+        plugin_manager = await get_plugin_manager()
+        if not plugin_manager:
             logger.debug("HttpAuthMiddleware: no plugin_manager, skipping hooks")
             return await call_next(request)
+        logger.debug("HTTP authentication hooks enabled for plugins")
 
         # Skip payload creation if no HTTP hooks registered
-        has_pre = self.plugin_manager.has_hooks_for(HttpHookType.HTTP_PRE_REQUEST)
-        has_post = self.plugin_manager.has_hooks_for(HttpHookType.HTTP_POST_REQUEST)
+        has_pre = plugin_manager.has_hooks_for(HttpHookType.HTTP_PRE_REQUEST)
+        has_post = plugin_manager.has_hooks_for(HttpHookType.HTTP_POST_REQUEST)
 
         if not has_pre and not has_post:
             logger.debug("HttpAuthMiddleware: has_pre=%s has_post=%s, skipping hooks", has_pre, has_post)
@@ -179,7 +182,7 @@ class HttpAuthMiddleware(BaseHTTPMiddleware):
         # PRE-REQUEST HOOK: Allow plugins to transform headers before authentication
         if has_pre:
             merged_headers, global_context, context_table = await run_pre_request_hooks(
-                plugin_manager=self.plugin_manager,
+                plugin_manager=plugin_manager,
                 headers=dict(request.headers),
                 path=str(request.url.path),
                 method=request.method,
@@ -204,7 +207,7 @@ class HttpAuthMiddleware(BaseHTTPMiddleware):
             try:
                 response_headers = HttpHeaderPayload(root=dict(response.headers))
 
-                post_result, _ = await self.plugin_manager.invoke_hook(
+                post_result, _ = await plugin_manager.invoke_hook(
                     HttpHookType.HTTP_POST_REQUEST,
                     payload=HttpPostRequestPayload(
                         path=str(request.url.path),

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -646,7 +646,7 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
             # First-Party
             from mcpgateway.plugins.framework import get_plugin_manager, GlobalContext, HttpAuthCheckPermissionPayload, HttpHookType  # pylint: disable=import-outside-toplevel
 
-            plugin_manager = get_plugin_manager()
+            plugin_manager = await get_plugin_manager()
             if plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_AUTH_CHECK_PERMISSION):
                 # Get plugin contexts from user_context (stored in request.state by HttpAuthMiddleware)
                 # These enable cross-hook context sharing between HTTP_PRE_REQUEST and HTTP_AUTH_CHECK_PERMISSION

--- a/mcpgateway/plugins/framework/__init__.py
+++ b/mcpgateway/plugins/framework/__init__.py
@@ -14,7 +14,7 @@ Exposes core ContextForge plugin components:
 """
 
 # Standard
-from typing import Optional
+from typing import Callable, Optional
 
 # First-Party
 from mcpgateway.plugins.framework.base import Plugin
@@ -85,6 +85,7 @@ def init_plugin_manager_factory(
     timeout: float,
     hook_policies: dict,
     observability: Optional[ObservabilityProvider] = None,
+    db_factory: Optional[Callable] = None,
 ) -> None:
     """Explicitly initialise the global plugin manager factory.
 
@@ -98,16 +99,35 @@ def init_plugin_manager_factory(
         timeout: Per-plugin call timeout in seconds.
         hook_policies: Hook payload policy map from ``mcpgateway.plugins.policy``.
         observability: Optional observability provider to attach to the factory.
+        db_factory: Zero-argument callable returning a SQLAlchemy Session
+            (e.g. ``SessionLocal``).  When provided the factory uses
+            :class:`~mcpgateway.plugins.gateway_plugin_manager.GatewayTenantPluginManagerFactory`
+            so per-tool plugin bindings stored in the DB are applied.
+            When ``None`` the base :class:`TenantPluginManagerFactory` is used
+            (no DB overrides).
     """
     global _plugin_manager_factory
     global _observability_service
     _observability_service = observability
-    _plugin_manager_factory = TenantPluginManagerFactory(
-        yaml_path=yaml_path,
-        timeout=timeout,
-        hook_policies=hook_policies,
-        observability=observability,
-    )
+    if db_factory is not None:
+        # Lazy import to avoid circular dependency:
+        # framework/__init__ → gateway_plugin_manager → services → base_service → framework/__init__
+        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory  # pylint: disable=import-outside-toplevel
+
+        _plugin_manager_factory = GatewayTenantPluginManagerFactory(
+            yaml_path=yaml_path,
+            timeout=timeout,
+            hook_policies=hook_policies,
+            observability=observability,
+            db_factory=db_factory,
+        )
+    else:
+        _plugin_manager_factory = TenantPluginManagerFactory(
+            yaml_path=yaml_path,
+            timeout=timeout,
+            hook_policies=hook_policies,
+            observability=observability,
+        )
 
 
 async def get_plugin_manager(server_id: str = DEFAULT_SERVER_ID) -> Optional[TenantPluginManager]:
@@ -165,6 +185,21 @@ def reset_plugin_manager_factory() -> None:
     _plugin_manager_factory = None
 
 
+async def reload_plugin_context(context_id: str) -> None:
+    """Invalidate and rebuild the cached plugin manager for *context_id*.
+
+    No-op when plugins are disabled or the factory is not initialised.
+    Call this after persisting a ToolPluginBinding change so the next tool
+    invocation picks up the updated DB overrides.
+
+    Args:
+        context_id: Context key to evict and rebuild (e.g. ``"<team_id>::<tool_name>"``).
+    """
+    if not _PLUGINS_ENABLED or _plugin_manager_factory is None:
+        return
+    await _plugin_manager_factory.reload_tenant(context_id)
+
+
 __all__ = [
     "AgentHookType",
     "AgentPostInvokePayload",
@@ -181,6 +216,7 @@ __all__ = [
     "get_plugin_manager",
     "shutdown_plugin_manager_factory",
     "reset_plugin_manager_factory",
+    "reload_plugin_context",
     "GlobalContext",
     "HookRegistry",
     "HttpAuthCheckPermissionPayload",

--- a/mcpgateway/plugins/framework/__init__.py
+++ b/mcpgateway/plugins/framework/__init__.py
@@ -20,11 +20,7 @@ from typing import Optional
 from mcpgateway.plugins.framework.base import Plugin
 from mcpgateway.plugins.framework.errors import PluginError, PluginViolationError
 from mcpgateway.plugins.framework.external.mcp.server import ExternalPluginServer
-from mcpgateway.plugins.framework.hooks.registry import HookRegistry, get_hook_registry
-from mcpgateway.plugins.framework.loader.config import ConfigLoader
-from mcpgateway.plugins.framework.loader.plugin import PluginLoader
-from mcpgateway.plugins.framework.manager import PluginManager
-from mcpgateway.plugins.framework.observability import ObservabilityProvider
+from mcpgateway.plugins.framework.hooks.agents import AgentHookType, AgentPostInvokePayload, AgentPostInvokeResult, AgentPreInvokePayload, AgentPreInvokeResult
 from mcpgateway.plugins.framework.hooks.http import (
     HttpAuthCheckPermissionPayload,
     HttpAuthCheckPermissionResult,
@@ -38,8 +34,6 @@ from mcpgateway.plugins.framework.hooks.http import (
     HttpPreRequestPayload,
     HttpPreRequestResult,
 )
-from mcpgateway.plugins.framework.hooks.agents import AgentHookType, AgentPostInvokePayload, AgentPostInvokeResult, AgentPreInvokePayload, AgentPreInvokeResult
-from mcpgateway.plugins.framework.hooks.resources import ResourceHookType, ResourcePostFetchPayload, ResourcePostFetchResult, ResourcePreFetchPayload, ResourcePreFetchResult
 from mcpgateway.plugins.framework.hooks.prompts import (
     PromptHookType,
     PromptPosthookPayload,
@@ -47,7 +41,12 @@ from mcpgateway.plugins.framework.hooks.prompts import (
     PromptPrehookPayload,
     PromptPrehookResult,
 )
-from mcpgateway.plugins.framework.hooks.tools import ToolHookType, ToolPostInvokePayload, ToolPostInvokeResult, ToolPreInvokeResult, ToolPreInvokePayload
+from mcpgateway.plugins.framework.hooks.registry import get_hook_registry, HookRegistry
+from mcpgateway.plugins.framework.hooks.resources import ResourceHookType, ResourcePostFetchPayload, ResourcePostFetchResult, ResourcePreFetchPayload, ResourcePreFetchResult
+from mcpgateway.plugins.framework.hooks.tools import ToolHookType, ToolPostInvokePayload, ToolPostInvokeResult, ToolPreInvokePayload, ToolPreInvokeResult
+from mcpgateway.plugins.framework.loader.config import ConfigLoader
+from mcpgateway.plugins.framework.loader.plugin import PluginLoader
+from mcpgateway.plugins.framework.manager import PluginManager, TenantPluginManager, TenantPluginManagerFactory
 from mcpgateway.plugins.framework.models import (
     GlobalContext,
     MCPServerConfig,
@@ -61,47 +60,109 @@ from mcpgateway.plugins.framework.models import (
     PluginResult,
     PluginViolation,
 )
+from mcpgateway.plugins.framework.observability import ObservabilityProvider
 from mcpgateway.plugins.framework.utils import get_attr
 
-# Plugin manager singleton (lazy initialization)
-_plugin_manager: Optional[PluginManager] = None
+# --- Global plugin manager factory singleton ---
+_PLUGINS_ENABLED = False
+_plugin_manager_factory: Optional[TenantPluginManagerFactory] = None
+_observability_service: Optional[ObservabilityProvider] = None
+DEFAULT_SERVER_ID = "__global__"
 
 
-def get_plugin_manager(observability: Optional[ObservabilityProvider] = None) -> Optional[PluginManager]:
-    """Get or initialize the plugin manager singleton.
-
-    This is the public API for accessing the plugin manager from anywhere in the application.
-    The plugin manager is lazily initialized on first access if plugins are enabled.
+def enable_plugins(toggle: bool) -> None:
+    """Enable or disable the plugin subsystem globally.
 
     Args:
-        observability: Optional observability provider implementing ObservabilityProvider protocol.
+        toggle: Pass ``True`` to activate plugins, ``False`` to deactivate.
+    """
+    global _PLUGINS_ENABLED
+    _PLUGINS_ENABLED = toggle
+
+
+def init_plugin_manager_factory(
+    yaml_path: str,
+    timeout: float,
+    hook_policies: dict,
+    observability: Optional[ObservabilityProvider] = None,
+) -> None:
+    """Explicitly initialise the global plugin manager factory.
+
+    Called from ``main.py`` lifespan startup after all dependencies
+    (observability, settings) are ready.  Prefer this over the lazy
+    initialisation path inside :func:`get_plugin_manager` so that the
+    factory is always created with a fully-wired dependency set.
+
+    Args:
+        yaml_path: Path to the plugins YAML config file.
+        timeout: Per-plugin call timeout in seconds.
+        hook_policies: Hook payload policy map from ``mcpgateway.plugins.policy``.
+        observability: Optional observability provider to attach to the factory.
+    """
+    global _plugin_manager_factory
+    global _observability_service
+    _observability_service = observability
+    _plugin_manager_factory = TenantPluginManagerFactory(
+        yaml_path=yaml_path,
+        timeout=timeout,
+        hook_policies=hook_policies,
+        observability=observability,
+    )
+
+
+async def get_plugin_manager(server_id: str = DEFAULT_SERVER_ID) -> Optional[TenantPluginManager]:
+    """Return a context-scoped plugin manager from the global async factory.
+
+    Args:
+        server_id: Context identifier used to resolve a specific manager instance.
 
     Returns:
-        PluginManager instance if plugins are enabled, None otherwise.
-
-    Examples:
-        >>> from mcpgateway.plugins.framework import get_plugin_manager
-        >>> pm = get_plugin_manager()
-        >>> # Returns PluginManager if plugins are enabled, None otherwise
-        >>> pm is None or isinstance(pm, PluginManager)
-        True
+        Optional[TenantPluginManager]: Context-specific manager when plugins are
+            enabled and the factory is initialized, otherwise ``None``.
     """
-    global _plugin_manager  # pylint: disable=global-statement
-    if _plugin_manager is None:
-        # Use plugin framework's own settings instead of mcpgateway.config
-        from mcpgateway.plugins.framework.settings import settings  # pylint: disable=import-outside-toplevel
+    if not _PLUGINS_ENABLED:
+        return None
 
-        if settings.enabled:
-            # Import concrete policies from the gateway side
-            from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # pylint: disable=import-outside-toplevel
+    if _plugin_manager_factory is None:
+        return None
 
-            _plugin_manager = PluginManager(
-                settings.config_file,
-                timeout=settings.plugin_timeout,
-                observability=observability,
-                hook_policies=HOOK_PAYLOAD_POLICIES,
-            )
-    return _plugin_manager
+    return await _plugin_manager_factory.get_manager(server_id)
+
+
+def set_global_observability(observability: ObservabilityProvider) -> None:
+    """Set the global observability provider and propagate it to the active factory.
+
+    Args:
+        observability: The observability provider to attach.
+    """
+    global _observability_service
+    _observability_service = observability
+    if _plugin_manager_factory is not None:
+        _plugin_manager_factory.observability = observability
+
+
+async def shutdown_plugin_manager_factory() -> None:
+    """Shutdown and reset the global plugin manager factory.
+
+    Calls :meth:`TenantPluginManagerFactory.shutdown` on the singleton factory (if one has
+    been initialised) and then clears the reference so the next call to
+    :func:`get_plugin_manager` will create a fresh factory.  Primarily used during
+    application lifespan teardown.
+    """
+    global _plugin_manager_factory  # pylint: disable=global-statement
+
+    if not _PLUGINS_ENABLED:
+        return
+    factory = _plugin_manager_factory
+    _plugin_manager_factory = None
+    if factory is not None:
+        await factory.shutdown()
+
+
+def reset_plugin_manager_factory() -> None:
+    """Reset the global factory and all per-server managers (primarily for tests)."""
+    global _plugin_manager_factory
+    _plugin_manager_factory = None
 
 
 __all__ = [
@@ -110,11 +171,16 @@ __all__ = [
     "AgentPostInvokeResult",
     "AgentPreInvokePayload",
     "AgentPreInvokeResult",
+    "enable_plugins",
+    "init_plugin_manager_factory",
+    "set_global_observability",
     "ConfigLoader",
     "ExternalPluginServer",
     "get_attr",
     "get_hook_registry",
     "get_plugin_manager",
+    "shutdown_plugin_manager_factory",
+    "reset_plugin_manager_factory",
     "GlobalContext",
     "HookRegistry",
     "HttpAuthCheckPermissionPayload",
@@ -139,6 +205,8 @@ __all__ = [
     "PluginErrorModel",
     "PluginLoader",
     "PluginManager",
+    "TenantPluginManager",
+    "TenantPluginManagerFactory",
     "PluginMode",
     "PluginPayload",
     "PluginResult",

--- a/mcpgateway/plugins/framework/manager.py
+++ b/mcpgateway/plugins/framework/manager.py
@@ -45,7 +45,7 @@ from mcpgateway.plugins.framework.hooks.policies import apply_policy, DefaultHoo
 from mcpgateway.plugins.framework.loader.config import ConfigLoader
 from mcpgateway.plugins.framework.loader.plugin import PluginLoader
 from mcpgateway.plugins.framework.memory import copyonwrite
-from mcpgateway.plugins.framework.models import Config, GlobalContext, PluginContext, PluginContextTable, PluginErrorModel, PluginMode, PluginPayload, PluginResult
+from mcpgateway.plugins.framework.models import Config, GlobalContext, PluginConfigOverride, PluginContext, PluginContextTable, PluginErrorModel, PluginMode, PluginPayload, PluginResult
 from mcpgateway.plugins.framework.observability import current_trace_id, ObservabilityProvider
 from mcpgateway.plugins.framework.registry import PluginInstanceRegistry
 from mcpgateway.plugins.framework.settings import settings
@@ -62,6 +62,7 @@ CONTEXT_MAX_AGE = 3600  # 1 hour
 HTTP_AUTH_CHECK_PERMISSION_HOOK = "http_auth_check_permission"
 DECISION_PLUGIN_METADATA_KEY = "_decision_plugin"
 RESERVED_INTERNAL_METADATA_KEYS = frozenset({DECISION_PLUGIN_METADATA_KEY})
+_DEFAULT_CONTEXT_ID = "__global__"
 
 
 class PluginTimeoutError(Exception):
@@ -126,7 +127,7 @@ class PluginExecutor:
         """Execute plugins in priority order with timeout protection.
 
         Args:
-            hook_refs: List of hook references to execute, sorted by priority.
+            hook_refs: list of hook references to execute, sorted by priority.
             payload: The payload to be processed by plugins.
             global_context: Shared context for all plugins containing request metadata.
             hook_type: The hook type identifier (e.g., "tool_pre_invoke").
@@ -596,7 +597,7 @@ class PluginManager:
             >>> # Initialize with custom timeout
             >>> manager = PluginManager("plugins/config.yaml", timeout=60)
         """
-        self.__dict__ = self.__shared_state
+        self.enable_borg()
 
         # Only initialize once (first instance when shared state is empty)
         # Use lock to prevent race condition in multi-threaded environments
@@ -635,6 +636,10 @@ class PluginManager:
             with self.__lock:
                 if self._executor is None:
                     self._executor = PluginExecutor(config=self._config, timeout=timeout, observability=observability)
+
+    def enable_borg(self) -> None:
+        """Activate Borg singleton — share state dict across all PluginManager instances."""
+        self.__dict__ = self.__shared_state
 
     def _get_executor(self) -> PluginExecutor:
         """Get plugin executor, creating it lazily if necessary.
@@ -979,3 +984,305 @@ class PluginManager:
         if not isinstance(payload, PluginPayload):
             raise ValueError(f"When payload_as_json=False, payload must be a PluginPayload, got {type(payload)}")
         return await self._get_executor().execute_plugin(hook_ref, payload, context, violations_as_exceptions)
+
+
+class TenantPluginManager(PluginManager):
+    """
+    PluginManager with per-server configuration overrides.
+    Each instance has independent state (Borg pattern is disabled).
+    Fully compatible with PluginManager API.
+    """
+
+    def enable_borg(self) -> None:
+        """Opt out of Borg singleton — each tenant instance manages its own state."""
+
+    def __init__(  # pylint: disable=super-init-not-called
+        self,
+        config: Union[str, Config],
+        timeout: int = DEFAULT_PLUGIN_TIMEOUT,
+        observability: Optional[ObservabilityProvider] = None,
+        hook_policies: Optional[dict[str, HookPayloadPolicy]] = None,
+    ):
+        """Initialize a TenantPluginManager with independent state.
+
+        Bypasses PluginManager.__init__ entirely — Borg logic doesn't apply here.
+        Each TenantPluginManager is fully independent.
+
+        Args:
+            config: Plugin configuration (path or Config object).
+            timeout: Per-plugin call timeout in seconds.
+            observability: Optional observability provider.
+            hook_policies: Optional hook payload policy map.
+        """
+        if isinstance(config, Config):
+            self._config_path = None
+            self._config = config
+        else:
+            self._config_path = config
+            self._config = ConfigLoader.load_config(config)
+
+        self._executor = PluginExecutor(
+            config=self._config,
+            timeout=timeout,
+            observability=observability,
+            hook_policies=hook_policies,
+        )
+        self._initialized = False
+        self._registry = PluginInstanceRegistry()
+        self._loader = PluginLoader()
+        self._async_lock: asyncio.Lock | None = None
+
+
+class TenantPluginManagerFactory:
+    """
+    Factory for context-scoped TenantPluginManager instances.
+
+    Caches per-context instances and ensures async-safe initialization.
+    The context can represent any scoping mechanism: server, tenant, user,
+    organization, or any other identifier requiring isolated plugin configuration.
+    """
+
+    def __init__(
+        self,
+        yaml_path: str,
+        timeout: int = DEFAULT_PLUGIN_TIMEOUT,
+        observability: Optional[ObservabilityProvider] = None,
+        hook_policies: Optional[dict[str, HookPayloadPolicy]] = None,
+    ):
+        """Initialize the TenantPluginManagerFactory.
+
+        Args:
+            yaml_path: Path to the base plugin configuration YAML file.
+            timeout: Per-plugin call timeout in seconds.
+            observability: Optional observability provider.
+            hook_policies: Optional hook payload policy map.
+        """
+        self._base_config = ConfigLoader.load_config(yaml_path)
+        self._timeout = timeout
+        self._observability = observability
+        self._hook_policies = hook_policies
+        self._managers: dict[str, TenantPluginManager] = {}
+        self._inflight: dict[str, asyncio.Task[TenantPluginManager]] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def observability(self) -> Optional[ObservabilityProvider]:
+        """Get the current observability provider.
+
+        Returns:
+            Optional[ObservabilityProvider]: The current observability provider, or None if not set.
+        """
+        return self._observability
+
+    @observability.setter
+    def observability(self, value: Optional[ObservabilityProvider]) -> None:
+        """Set the observability provider for all future tenant managers.
+
+        Args:
+            value: The observability provider to set, or None to clear.
+        """
+        self._observability = value
+
+    async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
+        """Get or create a TenantPluginManager for the given context.
+
+        Args:
+            context_id: Context identifier (server, tenant, etc.). Defaults to __global__.
+
+        Returns:
+            TenantPluginManager: The manager instance for this context.
+        """
+        context_id = context_id or _DEFAULT_CONTEXT_ID
+
+        async with self._lock:
+            existing = self._managers.get(context_id)
+            if existing is not None:
+                return existing
+
+            inflight = self._inflight.get(context_id)
+            if inflight is None:
+                inflight = asyncio.create_task(self._build_manager(context_id))
+                self._inflight[context_id] = inflight
+
+        try:
+            manager = await inflight
+
+            # Re-check cache under the lock: reload_tenant may have evicted
+            # and replaced the entry between the await completing and here.
+            # Returning a shut-down manager (the pre-eviction one) would be
+            # incorrect, so always prefer whatever is currently in the cache.
+            async with self._lock:
+                return self._managers.get(context_id, manager)
+
+        finally:
+            # Cleanup only - no return to avoid suppressing exceptions
+            async with self._lock:
+                if self._inflight.get(context_id) is inflight:
+                    self._inflight.pop(context_id, None)
+
+    async def _build_manager(self, context_id: str) -> TenantPluginManager:
+        """Build, initialise, and cache a TenantPluginManager for the given context.
+
+        Fetches any DB overrides for ``context_id``, merges them with the base
+        config, constructs a :class:`TenantPluginManager`, and stores it in the
+        cache.  Shuts down any previously cached manager for the same context.
+
+        Args:
+            context_id: Identifier for the tenant/server context.
+
+        Returns:
+            TenantPluginManager: Manager for ``context_id``.
+
+        Raises:
+            asyncio.CancelledError: If the manager build task is cancelled.
+            Exception: If manager initialization fails, the manager is shut down before re-raising.
+        """
+        manager = None
+        try:
+            new_config = await self.get_config_from_db(context_id)
+            config = self._merge_tenant_config(new_config)
+
+            manager = TenantPluginManager(
+                config=config,
+                timeout=self._timeout,
+                observability=self._observability,
+                hook_policies=self._hook_policies,
+            )
+            await manager.initialize()
+
+            async with self._lock:
+                old = self._managers.get(context_id)
+                self._managers[context_id] = manager
+
+            if old is not None and old is not manager:
+                try:
+                    await old.shutdown()
+                except Exception:
+                    logger.warning("Failed to shutdown old manager for context_id=%s", context_id)
+
+            return manager
+
+        except asyncio.CancelledError:
+            if manager is not None:
+                try:
+                    await manager.shutdown()
+                except Exception:
+                    logger.warning("Failed to shutdown cancelled manager for context_id=%s", context_id)
+            raise
+        except Exception:
+            if manager is not None:
+                try:
+                    await manager.shutdown()
+                except Exception:
+                    logger.warning("Failed to shutdown manager after error for context_id=%s", context_id)
+            raise
+
+    def _merge_tenant_config(self, tenant_cfg_override: Optional[list[PluginConfigOverride]]) -> Config:
+        """Merge context-specific plugin configuration overrides with base configuration.
+
+        Args:
+            tenant_cfg_override: List of plugin configuration overrides for this context
+                (server, tenant, user, organization, etc.).
+
+        Returns:
+            Config: Merged configuration with context-specific overrides applied.
+        """
+        if tenant_cfg_override is None:
+            return self._base_config
+
+        override_map = {p.name: p for p in tenant_cfg_override}
+        merged_plugins = []
+
+        for plugin in self._base_config.plugins or []:
+            override = override_map.get(plugin.name)
+            if not override:
+                merged_plugins.append(plugin)
+                continue
+            merged_config = {**(plugin.config or {}), **(override.config or {})}
+            merged_plugins.append(
+                plugin.model_copy(
+                    update={
+                        "config": merged_config,
+                        "mode": override.mode if override.mode is not None else plugin.mode,
+                        "priority": override.priority if override.priority is not None else plugin.priority,
+                    }
+                )
+            )
+        return self._base_config.model_copy(update={"plugins": merged_plugins}, deep=True)
+
+    async def reload_tenant(self, context_id: str) -> TenantPluginManager:
+        """Evict and rebuild the cached manager for the given context.
+
+        Removes the existing manager from the cache, triggers a fresh build,
+        and shuts down the old instance once the new one is ready.
+
+        Args:
+            context_id: Identifier for the tenant/server context to reload.
+
+        Returns:
+            TenantPluginManager: Rebuilt manager for ``context_id``.
+        """
+        async with self._lock:
+            old = self._managers.pop(context_id, None)
+
+            # Cancel any existing inflight task to force fresh DB fetch
+            inflight = self._inflight.get(context_id)
+            if inflight is not None:
+                inflight.cancel()
+                self._inflight.pop(context_id, None)
+
+            inflight = asyncio.create_task(self._build_manager(context_id))
+            self._inflight[context_id] = inflight
+
+        if old is not None:
+            try:
+                await old.shutdown()
+            except Exception:
+                logger.exception("Failed to shutdown old manager for context_id=%s", context_id)
+
+        try:
+            return await inflight
+        finally:
+            async with self._lock:
+                if self._inflight.get(context_id) is inflight:
+                    self._inflight.pop(context_id, None)
+
+    async def shutdown(self) -> None:
+        """Shut down all cached managers and cancel any in-flight build tasks."""
+        async with self._lock:
+            managers = list(self._managers.values())
+            inflight = list(self._inflight.values())
+            self._managers.clear()
+            self._inflight.clear()
+
+        for task in inflight:
+            task.cancel()
+
+        if inflight:
+            await asyncio.gather(*inflight, return_exceptions=True)
+
+        for manager in managers:
+            try:
+                await manager.shutdown()
+            except Exception:
+                logger.exception("Failed to shutdown plugin manager")
+
+    async def get_config_from_db(self, context_id: str) -> Optional[list[PluginConfigOverride]]:  # pylint: disable=unused-argument
+        """Get plugin configuration overrides from database for a specific context.
+
+        This method should be overridden by subclasses to fetch context-specific
+        plugin configuration overrides from the database. The returned overrides will
+        be merged with the base configuration.
+
+        The context_id can represent any scoping mechanism: server, tenant, user,
+        organization, or any other identifier that requires isolated plugin configuration.
+
+        Args:
+            context_id: The context identifier to fetch overrides for (e.g., server ID,
+                tenant ID, user ID, organization ID).
+
+        Returns:
+            Optional[list[PluginConfigOverride]]: List of plugin configuration overrides,
+                or None if no overrides exist for this context.
+        """
+        return None

--- a/mcpgateway/plugins/framework/models.py
+++ b/mcpgateway/plugins/framework/models.py
@@ -1187,6 +1187,38 @@ class PluginConfig(BaseModel):
         return self
 
 
+class PluginConfigOverride(BaseModel):
+    """Plugin configuration override for tenant/server-specific customization.
+
+    This model represents the subset of PluginConfig fields that can be overridden
+    on a per-tenant or per-server basis. It's used to customize plugin behavior
+    without modifying the base configuration.
+
+    Attributes:
+        name (str): The name of the plugin to override (must match base plugin name).
+        config (Optional[dict[str, Any]]): Plugin-specific configuration overrides.
+        mode (Optional[PluginMode]): Override for plugin execution mode.
+        priority (Optional[int]): Override for plugin execution priority.
+
+    Examples:
+        >>> override = PluginConfigOverride(
+        ...     name="pii_filter",
+        ...     config={"sensitivity": "high"},
+        ...     mode=PluginMode.ENFORCE,
+        ...     priority=50
+        ... )
+        >>> override.name
+        'pii_filter'
+        >>> override.mode
+        <PluginMode.ENFORCE: 'enforce'>
+    """
+
+    name: str
+    config: Optional[dict[str, Any]] = None
+    mode: Optional[PluginMode] = None
+    priority: Optional[int] = None
+
+
 class PluginManifest(BaseModel):
     """Plugin manifest.
 

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -119,6 +119,6 @@ def make_context_id(team_id: str, tool_name: str) -> str:
         tool_name: Tool name (use ``"*"`` for team-wide wildcard lookups).
 
     Returns:
-        ``"<team_id>::<tool_name>"``
+        str: ``"<team_id>CONTEXT_ID_SEPARATOR<tool_name>"``
     """
     return f"{team_id}{CONTEXT_ID_SEPARATOR}{tool_name}"

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/plugins/gateway_plugin_manager.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhumohan Jaishankar
+
+Gateway-specific subclass of TenantPluginManagerFactory.
+
+Bridges the ToolPluginBinding DB table with the plugin framework by
+implementing get_config_from_db() to translate stored bindings into
+PluginConfigOverride objects the framework merges with base YAML config.
+
+Context ID convention: ``"<team_id>::<tool_name>"``
+"""
+
+# Standard
+import logging
+from typing import Callable, Optional
+
+# Third-Party
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+from mcpgateway.plugins.framework.models import PluginConfigOverride, PluginMode
+from mcpgateway.schemas import PLUGIN_ID_TO_NAME
+from mcpgateway.services.tool_plugin_binding_service import get_bindings_for_tool
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_ID_SEPARATOR = "::"
+
+
+class GatewayTenantPluginManagerFactory(TenantPluginManagerFactory):
+    """TenantPluginManagerFactory wired to the gateway's ToolPluginBinding table.
+
+    Context IDs must follow the ``"<team_id>::<tool_name>"`` convention.
+    Call sites should use :func:`make_context_id` to construct them.
+
+    When ``get_config_from_db`` is invoked for a context:
+
+    * Wildcard bindings (``tool_name == "*"``) provide team-wide defaults.
+    * Exact ``tool_name`` bindings override wildcards for the same plugin_id
+      (last-write-wins by ``updated_at``).
+    * Bindings whose ``plugin_id`` is not in :data:`~mcpgateway.schemas.PLUGIN_ID_TO_NAME`
+      are silently skipped (forward-compatibility guard).
+    * Returns ``None`` (not an empty list) when no bindings are found so the
+      framework falls back to the unmodified base YAML config.
+    """
+
+    def __init__(self, *args: object, db_factory: Callable[[], Session], **kwargs: object) -> None:
+        """Initialise the factory with a DB session factory.
+
+        Args:
+            *args: Forwarded to :class:`TenantPluginManagerFactory`.
+            db_factory: Zero-argument callable that returns a fresh
+                ``Session`` (e.g. ``SessionLocal``).  The session is opened
+                and closed within each ``get_config_from_db`` call.
+            **kwargs: Forwarded to :class:`TenantPluginManagerFactory`.
+        """
+        super().__init__(*args, **kwargs)
+        self._db_factory = db_factory
+
+    async def get_config_from_db(self, context_id: str) -> Optional[list[PluginConfigOverride]]:
+        """Fetch per-tool plugin overrides from the DB for *context_id*.
+
+        Args:
+            context_id: Must be ``"<team_id>::<tool_name>"``.  Any other
+                format is treated as having no overrides (returns ``None``).
+
+        Returns:
+            List of :class:`~mcpgateway.plugins.framework.models.PluginConfigOverride`
+            for this tool, or ``None`` if no bindings exist.
+        """
+        if CONTEXT_ID_SEPARATOR not in context_id:
+            logger.debug("get_config_from_db: unrecognised context_id format %r, skipping", context_id)
+            return None
+
+        team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
+
+        db: Session = self._db_factory()
+        try:
+            bindings = get_bindings_for_tool(db, team_id, tool_name)
+        finally:
+            db.close()
+
+        if not bindings:
+            return None
+
+        overrides: list[PluginConfigOverride] = []
+        for binding in bindings:
+            plugin_name = PLUGIN_ID_TO_NAME.get(binding.plugin_id)
+            if plugin_name is None:
+                logger.warning(
+                    "get_config_from_db: unknown plugin_id %r for binding %s, skipping",
+                    binding.plugin_id,
+                    binding.id,
+                )
+                continue
+
+            mode: Optional[PluginMode] = PluginMode(binding.mode) if binding.mode else None
+            overrides.append(
+                PluginConfigOverride(
+                    name=plugin_name,
+                    config=binding.config or {},
+                    mode=mode,
+                    priority=binding.priority,
+                )
+            )
+
+        return overrides if overrides else None
+
+
+def make_context_id(team_id: str, tool_name: str) -> str:
+    """Build the context_id string expected by GatewayTenantPluginManagerFactory.
+
+    Args:
+        team_id: Team identifier.
+        tool_name: Tool name (use ``"*"`` for team-wide wildcard lookups).
+
+    Returns:
+        ``"<team_id>::<tool_name>"``
+    """
+    return f"{team_id}{CONTEXT_ID_SEPARATOR}{tool_name}"

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -77,7 +77,7 @@ async def upsert_tool_plugin_bindings(
         caller_email: str = current_user_ctx["email"]
         bindings = _service.upsert_bindings(db, request, caller_email=caller_email)
         return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
-    except Exception as exc:
+    except ValueError as exc:
         logger.error("Failed to upsert tool plugin bindings: %s", exc)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -75,6 +75,17 @@ async def upsert_tool_plugin_bindings(
     """
     try:
         caller_email: str = current_user_ctx["email"]
+        is_admin: bool = current_user_ctx.get("is_admin", False)
+        user_teams: list = current_user_ctx.get("teams", []) or []
+
+        if not is_admin:
+            unauthorized = [tid for tid in request.teams if tid not in user_teams]
+            if unauthorized:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Not authorized to configure bindings for team(s): {', '.join(unauthorized)}",
+                )
+
         bindings = _service.upsert_bindings(db, request, caller_email=caller_email)
         return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
     except ValueError as exc:

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/tool_plugin_bindings.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhumohan Jaishankar
+
+Tool Plugin Bindings Router.
+Provides endpoints for configuring per-tool per-tenant plugin policies.
+
+Endpoints:
+    POST   /v1/tools/plugin_bindings          — Create or update bindings (upsert)
+    GET    /v1/tools/plugin_bindings           — List all bindings
+    GET    /v1/tools/plugin_bindings/{team_id} — List bindings for a specific team
+    DELETE /v1/tools/plugin_bindings/{id}      — Delete a binding by ID
+"""
+
+# Standard
+from typing import Any, Dict
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import get_db
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
+from mcpgateway.schemas import ToolPluginBindingListResponse, ToolPluginBindingRequest, ToolPluginBindingResponse
+from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError, ToolPluginBindingService
+
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+router = APIRouter(prefix="/v1/tools/plugin_bindings", tags=["Tool Plugin Bindings"])
+
+_service = ToolPluginBindingService()
+
+
+# ---------------------------------------------------------------------------
+# POST — upsert bindings
+# ---------------------------------------------------------------------------
+
+
+@router.post("/", response_model=ToolPluginBindingListResponse, status_code=status.HTTP_200_OK)
+@require_permission("tools.manage_plugins")
+async def upsert_tool_plugin_bindings(
+    request: ToolPluginBindingRequest,
+    current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ToolPluginBindingListResponse:
+    """Create or update tool plugin bindings.
+
+    Each (team_id, tool_name, plugin_id) triple is upserted:
+    - Existing rows are updated in place (id and created_* fields preserved).
+    - New rows are inserted.
+
+    Multiple teams and multiple tools per policy can be configured in a single request.
+
+    Args:
+        request: Validated binding payload keyed by team_id.
+        current_user_ctx: Authenticated user context.
+        db: Database session.
+
+    Returns:
+        ToolPluginBindingListResponse: All created/updated bindings.
+
+    Raises:
+        HTTPException 400: If the request payload is invalid.
+        HTTPException 403: If the caller lacks permission.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(upsert_tool_plugin_bindings)
+        True
+    """
+    try:
+        caller_email: str = current_user_ctx["email"]
+        bindings = _service.upsert_bindings(db, request, caller_email=caller_email)
+        return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
+    except Exception as exc:
+        logger.error("Failed to upsert tool plugin bindings: %s", exc)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# GET — list all bindings
+# ---------------------------------------------------------------------------
+
+
+@router.get("/", response_model=ToolPluginBindingListResponse)
+@require_permission("tools.read")
+async def list_tool_plugin_bindings(
+    current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ToolPluginBindingListResponse:
+    """List all tool plugin bindings across all teams.
+
+    Args:
+        current_user_ctx: Authenticated user context.
+        db: Database session.
+
+    Returns:
+        ToolPluginBindingListResponse: All bindings.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(list_tool_plugin_bindings)
+        True
+    """
+    bindings = _service.list_bindings(db, team_id=None)
+    return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
+
+
+# ---------------------------------------------------------------------------
+# GET /{team_id} — list bindings for a team
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{team_id}", response_model=ToolPluginBindingListResponse)
+@require_permission("tools.read")
+async def list_tool_plugin_bindings_for_team(
+    team_id: str,
+    current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ToolPluginBindingListResponse:
+    """List all tool plugin bindings for a specific team.
+
+    Args:
+        team_id: Team identifier to filter by.
+        current_user_ctx: Authenticated user context.
+        db: Database session.
+
+    Returns:
+        ToolPluginBindingListResponse: Bindings for the specified team.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(list_tool_plugin_bindings_for_team)
+        True
+    """
+    bindings = _service.list_bindings(db, team_id=team_id)
+    return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
+
+
+# ---------------------------------------------------------------------------
+# DELETE /{id} — remove a binding by its UUID
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/{binding_id}", response_model=ToolPluginBindingResponse, status_code=status.HTTP_200_OK)
+@require_permission("tools.manage_plugins")
+async def delete_tool_plugin_binding(
+    binding_id: str,
+    current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ToolPluginBindingResponse:
+    """Delete a tool plugin binding by its unique ID.
+
+    Returns the full details of the deleted binding so callers can
+    confirm exactly what was removed without a prior GET.
+
+    Args:
+        binding_id: UUID of the binding to delete.
+        current_user_ctx: Authenticated user context.
+        db: Database session.
+
+    Returns:
+        ToolPluginBindingResponse: The deleted binding record.
+
+    Raises:
+        HTTPException 404: If no binding with the given ID exists.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(delete_tool_plugin_binding)
+        True
+    """
+    try:
+        return _service.delete_binding(db, binding_id)
+    except ToolPluginBindingNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -24,6 +24,8 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
+from mcpgateway.plugins.framework import reload_plugin_context
+from mcpgateway.plugins.gateway_plugin_manager import make_context_id
 from mcpgateway.schemas import ToolPluginBindingListResponse, ToolPluginBindingRequest, ToolPluginBindingResponse
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError, ToolPluginBindingService
@@ -87,6 +89,11 @@ async def upsert_tool_plugin_bindings(
                 )
 
         bindings = _service.upsert_bindings(db, request, caller_email=caller_email)
+        # Commit before invalidating cache so the new session opened by reload
+        # reads committed data. The get_db() cleanup commit is then a safe no-op.
+        db.commit()
+        for ctx_id in {make_context_id(b.team_id, b.tool_name) for b in bindings}:
+            await reload_plugin_context(ctx_id)
         return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
     except ValueError as exc:
         logger.error("Failed to upsert tool plugin bindings: %s", exc)
@@ -187,6 +194,9 @@ async def delete_tool_plugin_binding(
         True
     """
     try:
-        return _service.delete_binding(db, binding_id)
+        deleted = _service.delete_binding(db, binding_id)
+        db.commit()
+        await reload_plugin_context(make_context_id(deleted.team_id, deleted.tool_name))
+        return deleted
     except ToolPluginBindingNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -67,8 +67,7 @@ async def upsert_tool_plugin_bindings(
         ToolPluginBindingListResponse: All created/updated bindings.
 
     Raises:
-        HTTPException 400: If the request payload is invalid.
-        HTTPException 403: If the caller lacks permission.
+        HTTPException: 400 if the request payload is invalid, 403 if the caller lacks permission.
 
     Examples:
         >>> import asyncio
@@ -186,7 +185,7 @@ async def delete_tool_plugin_binding(
         ToolPluginBindingResponse: The deleted binding record.
 
     Raises:
-        HTTPException 404: If no binding with the given ID exists.
+        HTTPException: 404 if no binding with the given ID exists.
 
     Examples:
         >>> import asyncio

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7865,6 +7865,15 @@ class PluginId(str, Enum):
     SECRETS_DETECTION = "SECRETS_DETECTION"
 
 
+# Maps PluginId enum values (stored in DB) to plugin class names used by the
+# plugin framework's PluginConfigOverride.name field.
+PLUGIN_ID_TO_NAME: dict[str, str] = {
+    PluginId.OUTPUT_LENGTH_GUARD: "OutputLengthGuardPlugin",
+    PluginId.RATE_LIMITER: "RateLimiterPlugin",
+    PluginId.SECRETS_DETECTION: "SecretsDetection",
+}
+
+
 class PluginBindingMode(str, Enum):
     """Plugin execution mode for tool plugin bindings."""
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -30,7 +30,7 @@ from urllib.parse import urlparse
 
 # Third-Party
 import orjson
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, EmailStr, Field, field_serializer, field_validator, model_serializer, model_validator, SecretStr, ValidationInfo
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, EmailStr, Field, ValidationError, field_serializer, field_validator, model_serializer, model_validator, SecretStr, ValidationInfo
 
 # First-Party
 from mcpgateway.common.models import Annotations, ImageContent
@@ -7850,3 +7850,270 @@ class PerformanceHistoryResponse(BaseModel):
     aggregates: List[PerformanceAggregateRead] = Field(default_factory=list, description="Historical aggregates")
     period_type: str = Field(..., description="Aggregation period type")
     total_count: int = Field(0, description="Total matching records")
+
+
+# ---------------------------------------------------------------------------
+# Tool Plugin Binding Schemas
+# ---------------------------------------------------------------------------
+
+
+class PluginId(str, Enum):
+    """Supported plugin identifiers for tool plugin bindings."""
+
+    OUTPUT_LENGTH_GUARD = "OUTPUT_LENGTH_GUARD"
+    RATE_LIMITER = "RATE_LIMITER"
+    SECRETS_DETECTION = "SECRETS_DETECTION"
+
+
+class PluginBindingMode(str, Enum):
+    """Plugin execution mode for tool plugin bindings."""
+
+    ENFORCE = "enforce"
+    PERMISSIVE = "permissive"
+    DISABLED = "disabled"
+
+
+# --- Plugin-specific config schemas ---
+
+
+class OutputLengthGuardConfig(BaseModel):
+    """Config schema for OUTPUT_LENGTH_GUARD plugin.
+
+    Attributes:
+        min_chars: Minimum character count (>= 0).
+        max_chars: Maximum character count (> 1).
+        strategy: What to do when limit is exceeded.
+        ellipsis: Suffix appended when truncating.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    min_chars: int = Field(0, ge=0, description="Minimum character count, must be >= 0")
+    max_chars: int = Field(2000, gt=1, description="Maximum character count, must be > 1")
+    strategy: Literal["truncate", "block"] = Field("truncate", description="Action when limit exceeded")
+    ellipsis: str = Field("...", max_length=20, description="Suffix appended on truncation")
+
+    @model_validator(mode="after")
+    def min_less_than_max(self) -> "OutputLengthGuardConfig":
+        """Validate min_chars < max_chars.
+
+        Returns:
+            self after validation.
+
+        Raises:
+            ValueError: If min_chars >= max_chars.
+        """
+        if self.min_chars >= self.max_chars:
+            raise ValueError("min_chars must be less than max_chars")
+        return self
+
+
+class RateLimiterConfig(BaseModel):
+    """Config schema for RATE_LIMITER plugin.
+
+    Rate strings use the format ``<count>/<period>`` where period is
+    ``s`` (second) or ``m`` (minute), e.g. ``60/m``, ``10/s``.
+
+    Attributes:
+        by_user: Rate limit per user.
+        by_tenant: Rate limit per tenant.
+        by_tool: Rate limit per tool.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    by_user: Optional[str] = Field(None, description="Rate limit per user, e.g. '60/m' or '10/s'")
+    by_tenant: Optional[str] = Field(None, description="Rate limit per tenant, e.g. '600/m'")
+    by_tool: Optional[str] = Field(None, description="Rate limit per tool, e.g. '10/m'")
+
+    @field_validator("by_user", "by_tenant", "by_tool", mode="before")
+    @classmethod
+    def validate_rate_string(cls, v: Optional[str]) -> Optional[str]:
+        """Validate rate string format <count>/<s|m>.
+
+        Args:
+            v: Rate string to validate.
+
+        Returns:
+            Validated rate string or None.
+
+        Raises:
+            ValueError: If format is invalid.
+        """
+        if v is None:
+            return v
+        if not re.match(r"^\d+/[sm]$", v):
+            raise ValueError(f"Rate string '{v}' is invalid. Use format '<count>/s' or '<count>/m'")
+        return v
+
+
+class SecretsDetectionConfig(BaseModel):
+    """Config schema for SECRETS_DETECTION plugin.
+
+    Attributes:
+        enabled: Map of pattern names to whether they are active.
+        redact: Whether to redact detected secrets from output.
+        redaction_text: Text used to replace redacted secrets.
+        block_on_detection: Whether to block the response when secrets are found.
+        min_findings_to_block: Minimum number of findings required to trigger a block.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: Dict[str, bool] = Field(default_factory=dict, description="Map of pattern names to enabled flag, e.g. {'aws_key': true}")
+    redact: bool = Field(True, description="Whether to redact detected secrets")
+    redaction_text: str = Field("[REDACTED]", max_length=50, description="Text to replace secrets with when redacting")
+    block_on_detection: bool = Field(False, description="Whether to block the response when secrets are detected")
+    min_findings_to_block: int = Field(1, ge=1, description="Minimum number of findings required to block")
+
+
+# Map of plugin_id → config schema class for validation
+_PLUGIN_CONFIG_MAP: Dict[str, type] = {
+    PluginId.OUTPUT_LENGTH_GUARD: OutputLengthGuardConfig,
+    PluginId.RATE_LIMITER: RateLimiterConfig,
+    PluginId.SECRETS_DETECTION: SecretsDetectionConfig,
+}
+
+
+# --- Policy item (one plugin, one or more tools) ---
+
+
+class PluginPolicyItem(BaseModel):
+    """A single plugin policy entry within a team's binding payload.
+
+    Attributes:
+        tool_names: List of tool names this policy applies to. Use ``["*"]`` for all tools.
+        plugin_id: The plugin to bind.
+        mode: Execution mode.
+        priority: Execution order — lower numbers run first.
+        config: Plugin-specific configuration.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tool_names: List[str] = Field(..., min_length=1, description="Tool names to apply the policy to; use ['*'] for all tools in the team")
+    plugin_id: PluginId = Field(..., description="Plugin to bind")
+    mode: PluginBindingMode = Field(PluginBindingMode.ENFORCE, description="Execution mode: enforce, permissive, or disabled")
+    priority: int = Field(50, ge=1, le=1000, description="Execution priority; lower numbers run first")
+    config: Dict[str, Any] = Field(..., description="Plugin-specific configuration; always provide all fields you care about — on upsert the config is fully replaced, so any key you omit reverts to the plugin's default value")
+
+    @model_validator(mode="after")
+    def validate_config_for_plugin(self) -> "PluginPolicyItem":
+        """Validate config against the schema for the selected plugin_id.
+
+        Returns:
+            self after validation.
+
+        Raises:
+            ValueError: If config is invalid for the chosen plugin.
+        """
+        config_cls = _PLUGIN_CONFIG_MAP.get(self.plugin_id)
+        if config_cls:
+            expected = set(config_cls.model_fields.keys())
+            provided = set(self.config.keys())
+            missing = expected - provided
+            if missing:
+                raise ValueError(f"Missing config fields for {self.plugin_id.value}: {sorted(missing)}")
+            try:
+                config_cls(**self.config)
+            except ValidationError as exc:
+                parts = []
+                for e in exc.errors():
+                    loc = ".".join(str(p) for p in e["loc"])
+                    parts.append(f"{loc}: {e['msg']}" if loc else e["msg"])
+                raise ValueError(f"Invalid {self.plugin_id.value} config: [{', '.join(parts)}]") from exc
+        return self
+
+
+# --- Per-team policies wrapper ---
+
+
+class TeamPolicies(BaseModel):
+    """Policies for a single team."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    policies: List[PluginPolicyItem] = Field(..., min_length=1, description="List of plugin policies for this team")
+
+
+# --- Top-level request body ---
+
+
+class ToolPluginBindingRequest(BaseModel):
+    """Request body for POST /v1/tools/plugin_bindings.
+
+    The payload is a dict keyed by team_id, each value being a ``TeamPolicies``
+    object.  Multiple teams can be configured in a single request.  If a
+    (team_id, tool_name, plugin_id) triple already exists the row is updated
+    in place (upsert); otherwise a new row is inserted.
+
+    Example::
+
+        {
+            "team_abc": {
+                "policies": [
+                    {
+                        "tool_names": ["tool_a", "tool_b"],
+                        "plugin_id": "OUTPUT_LENGTH_GUARD",
+                        "mode": "enforce",
+                        "priority": 10,
+                        "config": {"max_chars": 2000, "strategy": "truncate"}
+                    }
+                ]
+            }
+        }
+    """
+
+    teams: Dict[str, TeamPolicies] = Field(..., min_length=1, description="Map of team_id to its plugin policies")
+
+
+# --- Response schemas ---
+
+
+class ToolPluginBindingResponse(BaseModelWithConfigDict):
+    """A single tool plugin binding record returned from the API.
+
+    Attributes:
+        id: Unique binding identifier (UUID).
+        team_id: Team the binding belongs to.
+        tool_name: Tool name the policy applies to.
+        plugin_id: Plugin identifier.
+        mode: Execution mode.
+        priority: Execution priority.
+        config: Plugin-specific configuration.
+        created_at: Creation timestamp.
+        created_by: Email of creator.
+        updated_at: Last update timestamp.
+        updated_by: Email of last updater.
+    """
+
+    id: str = Field(..., description="Unique binding identifier")
+    team_id: str = Field(..., description="Team the binding belongs to")
+    tool_name: str = Field(..., description="Tool name the policy applies to")
+    plugin_id: str = Field(..., description="Plugin identifier")
+    mode: str = Field(..., description="Execution mode")
+    priority: int = Field(..., description="Execution priority")
+    config: Dict[str, Any] = Field(..., description="Plugin-specific configuration")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    created_by: str = Field(..., description="Email of creator")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+    updated_by: str = Field(..., description="Email of last updater")
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, v: datetime) -> str:
+        """Serialize datetime fields to ISO 8601.
+
+        Args:
+            v: Datetime to serialize.
+
+        Returns:
+            ISO 8601 string.
+        """
+        return encode_datetime(v)
+
+
+class ToolPluginBindingListResponse(BaseModelWithConfigDict):
+    """Response for GET /v1/tools/plugin_bindings[/{team_id}]."""
+
+    bindings: List[ToolPluginBindingResponse] = Field(default_factory=list, description="List of tool plugin bindings")
+    total: int = Field(0, description="Total number of bindings returned")

--- a/mcpgateway/services/base_service.py
+++ b/mcpgateway/services/base_service.py
@@ -14,6 +14,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.plugins.framework import get_plugin_manager
 from mcpgateway.services.team_management_service import TeamManagementService
 
 
@@ -149,3 +150,14 @@ class BaseService(ABC):
             access_conditions.append(and_(model_cls.team_id.in_(token_teams), model_cls.visibility.in_(["team", "public"])))
 
         return query.where(or_(*access_conditions))
+
+    async def _get_plugin_manager(self, server_id: str | None) -> Any:
+        """Return the context-scoped plugin manager from the global factory.
+
+        Args:
+            server_id: Context identifier used to resolve a specific plugin manager.
+
+        Returns:
+            Plugin manager instance when plugins are enabled, otherwise ``None``.
+        """
+        return await get_plugin_manager(server_id)

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -44,7 +44,7 @@ from mcpgateway.db import get_for_update
 from mcpgateway.db import Prompt as DbPrompt
 from mcpgateway.db import PromptMetric, PromptMetricsHourly, server_prompt_association
 from mcpgateway.observability import create_span, set_span_attribute, set_span_error
-from mcpgateway.plugins.framework import get_plugin_manager, GlobalContext, PluginContextTable, PluginManager, PromptHookType, PromptPosthookPayload, PromptPrehookPayload
+from mcpgateway.plugins.framework import GlobalContext, PluginContextTable, PromptHookType, PromptPosthookPayload, PromptPrehookPayload
 from mcpgateway.schemas import PromptCreate, PromptMetrics, PromptRead, PromptUpdate, TopPerformer
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
@@ -283,7 +283,6 @@ class PromptService(BaseService):
         self._event_service = EventService(channel_name="mcpgateway:prompt_events")
         # Use the module-level singleton for template caching
         self._jinja_env = _get_jinja_env()
-        self._plugin_manager: PluginManager | None = get_plugin_manager()
 
     @staticmethod
     def _should_fetch_gateway_prompt(prompt: DbPrompt) -> bool:
@@ -1854,8 +1853,9 @@ class PromptService(BaseService):
         with create_span("prompt.render", span_attributes) as span:
             try:
                 # Check if any prompt hooks are registered to avoid unnecessary context creation
-                has_pre_fetch = self._plugin_manager and self._plugin_manager.has_hooks_for(PromptHookType.PROMPT_PRE_FETCH)
-                has_post_fetch = self._plugin_manager and self._plugin_manager.has_hooks_for(PromptHookType.PROMPT_POST_FETCH)
+                plugin_manager = await self._get_plugin_manager(server_id)
+                has_pre_fetch = plugin_manager and plugin_manager.has_hooks_for(PromptHookType.PROMPT_PRE_FETCH)
+                has_post_fetch = plugin_manager and plugin_manager.has_hooks_for(PromptHookType.PROMPT_POST_FETCH)
 
                 # Initialize plugin context variables only if hooks are registered
                 context_table = None
@@ -1878,7 +1878,7 @@ class PromptService(BaseService):
                         global_context = GlobalContext(request_id=request_id, user=user, server_id=server_id, tenant_id=tenant_id)
 
                 if has_pre_fetch:
-                    pre_result, context_table = await self._plugin_manager.invoke_hook(
+                    pre_result, context_table = await plugin_manager.invoke_hook(
                         PromptHookType.PROMPT_PRE_FETCH,
                         payload=PromptPrehookPayload(prompt_id=prompt_id, args=arguments),
                         global_context=global_context,
@@ -1966,7 +1966,7 @@ class PromptService(BaseService):
                         raise PromptError(f"Failed to process prompt: {str(e)}")
 
                 if has_post_fetch:
-                    post_result, _ = await self._plugin_manager.invoke_hook(
+                    post_result, _ = await plugin_manager.invoke_hook(
                         PromptHookType.PROMPT_POST_FETCH,
                         payload=PromptPosthookPayload(prompt_id=prompt.name, result=result),
                         global_context=global_context,

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -58,6 +58,7 @@ from mcpgateway.db import ResourceMetric, ResourceMetricsHourly
 from mcpgateway.db import ResourceSubscription as DbSubscription
 from mcpgateway.db import server_resource_association
 from mcpgateway.observability import create_span, set_span_attribute, set_span_error
+from mcpgateway.plugins.framework import GlobalContext, PluginContextTable, ResourceHookType, ResourcePostFetchPayload, ResourcePreFetchPayload
 from mcpgateway.schemas import ResourceCreate, ResourceMetrics, ResourceRead, ResourceSubscription, ResourceUpdate, TopPerformer
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
@@ -80,15 +81,6 @@ from mcpgateway.utils.trace_context import format_trace_team_scope
 from mcpgateway.utils.trace_redaction import is_input_capture_enabled, is_output_capture_enabled, serialize_trace_payload
 from mcpgateway.utils.url_auth import apply_query_param_auth, sanitize_exception_message
 from mcpgateway.utils.validate_signature import validate_signature
-
-# Plugin support imports (conditional)
-try:
-    # First-Party
-    from mcpgateway.plugins.framework import get_plugin_manager, GlobalContext, PluginContextTable, ResourceHookType, ResourcePostFetchPayload, ResourcePreFetchPayload
-
-    PLUGINS_AVAILABLE = True
-except ImportError:
-    PLUGINS_AVAILABLE = False
 
 # Cache import (lazy to avoid circular dependencies)
 _REGISTRY_CACHE = None
@@ -210,17 +202,6 @@ class ResourceService(BaseService):
         self._event_service = EventService(channel_name="mcpgateway:resource_events")
         self._template_cache: Dict[str, ResourceTemplate] = {}
         self.oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=int(os.getenv("OAUTH_MAX_RETRIES", "3")))
-
-        # Initialize plugin manager if plugins are enabled in settings
-        self._plugin_manager = None
-        if PLUGINS_AVAILABLE:
-            try:
-                self._plugin_manager = get_plugin_manager()
-                if self._plugin_manager:
-                    logger.info("Plugin manager initialized for ResourceService with config: %s", settings.plugins.config_file)
-            except Exception as e:
-                logger.warning("Plugin manager initialization failed in ResourceService: %s", e)
-                self._plugin_manager = None
 
         # Initialize mime types
         mimetypes.init()
@@ -2223,17 +2204,12 @@ class ResourceService(BaseService):
                 contexts = None
 
                 # Check if plugin manager is available and eligible for this request
-                plugin_eligible = bool(self._plugin_manager and PLUGINS_AVAILABLE and uri and ("://" in uri))
-
-                # Initialize plugin manager if needed (lazy init must happen before has_hooks_for check)
-                # pylint: disable=protected-access
-                if plugin_eligible and not self._plugin_manager._initialized:
-                    await self._plugin_manager.initialize()
-                # pylint: enable=protected-access
+                plugin_manager = await self._get_plugin_manager(server_id)
+                plugin_eligible = bool(plugin_manager and uri and ("://" in uri))
 
                 # Check if any resource hooks are registered to avoid unnecessary context creation
-                has_pre_fetch = plugin_eligible and self._plugin_manager.has_hooks_for(ResourceHookType.RESOURCE_PRE_FETCH)
-                has_post_fetch = plugin_eligible and self._plugin_manager.has_hooks_for(ResourceHookType.RESOURCE_POST_FETCH)
+                has_pre_fetch = plugin_eligible and plugin_manager.has_hooks_for(ResourceHookType.RESOURCE_PRE_FETCH)
+                has_post_fetch = plugin_eligible and plugin_manager.has_hooks_for(ResourceHookType.RESOURCE_POST_FETCH)
 
                 # Initialize plugin context variables only if hooks are registered
                 global_context = None
@@ -2268,7 +2244,7 @@ class ResourceService(BaseService):
                     pre_payload = ResourcePreFetchPayload(uri=uri, metadata={})
 
                     # Execute pre-fetch hooks with context from previous hooks
-                    pre_result, contexts = await self._plugin_manager.invoke_hook(
+                    pre_result, contexts = await plugin_manager.invoke_hook(
                         ResourceHookType.RESOURCE_PRE_FETCH,
                         pre_payload,
                         global_context,
@@ -2541,7 +2517,7 @@ class ResourceService(BaseService):
                 # ═══════════════════════════════════════════════════════════════════════════
                 if has_post_fetch:
                     post_payload = ResourcePostFetchPayload(uri=original_uri, content=content)
-                    post_result, _ = await self._plugin_manager.invoke_hook(ResourceHookType.RESOURCE_POST_FETCH, post_payload, global_context, contexts, violations_as_exceptions=True)
+                    post_result, _ = await plugin_manager.invoke_hook(ResourceHookType.RESOURCE_POST_FETCH, post_payload, global_context, contexts, violations_as_exceptions=True)
                     if post_result.modified_payload:
                         content = post_result.modified_payload.content
 

--- a/mcpgateway/services/server_classification_service.py
+++ b/mcpgateway/services/server_classification_service.py
@@ -321,6 +321,13 @@ class ServerClassificationService:
 
         # Helper to accumulate metrics from a single PooledSession
         def _accumulate_session(url: str, session: object) -> None:
+            """Accumulate metrics from a single pooled session into server_metrics.
+
+            Args:
+                url: Server URL
+                session: PooledSession object with last_used and use_count attributes
+            """
+
             if url not in server_metrics:
                 server_metrics[url] = ServerUsageMetrics(url=url)
             if hasattr(session, "last_used") and session.last_used > 0:

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -11,6 +11,7 @@ Handles upsert, retrieval, and deletion of per-tool per-tenant plugin policy bin
 # Standard
 import logging
 from typing import List, Optional
+import uuid
 
 # Third-Party
 from sqlalchemy.orm import Session
@@ -95,18 +96,16 @@ class ToolPluginBindingService:
         results: List[ToolPluginBindingResponse] = []
         now = utc_now()
 
+        # Prefetch all existing bindings for the requested teams in a single query
+        # rather than issuing one SELECT per (team_id, tool_name, plugin_id) triple.
+        team_ids = list(request.teams.keys())
+        existing_rows = db.query(ToolPluginBinding).filter(ToolPluginBinding.team_id.in_(team_ids)).all()
+        existing_map: dict = {(b.team_id, b.tool_name, b.plugin_id): b for b in existing_rows}
+
         for team_id, team_policies in request.teams.items():
             for policy in team_policies.policies:
                 for tool_name in policy.tool_names:
-                    existing = (
-                        db.query(ToolPluginBinding)
-                        .filter(
-                            ToolPluginBinding.team_id == team_id,
-                            ToolPluginBinding.tool_name == tool_name,
-                            ToolPluginBinding.plugin_id == policy.plugin_id.value,
-                        )
-                        .first()
-                    )
+                    existing = existing_map.get((team_id, tool_name, policy.plugin_id.value))
 
                     if existing:
                         # Upsert — update mutable fields only
@@ -115,7 +114,6 @@ class ToolPluginBindingService:
                         existing.config = policy.config
                         existing.updated_at = now
                         existing.updated_by = caller_email
-                        db.flush()
                         results.append(self._to_response(existing))
                         logger.debug(
                             "Updated tool plugin binding id=%s team=%s tool=%s plugin=%s",
@@ -126,6 +124,7 @@ class ToolPluginBindingService:
                         )
                     else:
                         new_binding = ToolPluginBinding(
+                            id=uuid.uuid4().hex,
                             team_id=team_id,
                             tool_name=tool_name,
                             plugin_id=policy.plugin_id.value,
@@ -138,7 +137,6 @@ class ToolPluginBindingService:
                             updated_by=caller_email,
                         )
                         db.add(new_binding)
-                        db.flush()
                         results.append(self._to_response(new_binding))
                         logger.debug(
                             "Created tool plugin binding id=%s team=%s tool=%s plugin=%s",
@@ -148,6 +146,7 @@ class ToolPluginBindingService:
                             policy.plugin_id.value,
                         )
 
+        db.flush()  # single flush for all inserts/updates
         return results
 
     # ------------------------------------------------------------------
@@ -199,6 +198,6 @@ class ToolPluginBindingService:
             raise ToolPluginBindingNotFoundError(f"Tool plugin binding '{binding_id}' not found")
         response = self._to_response(binding)
         db.delete(binding)
-        db.flush()
+        db.flush()  # flush so the DELETE is sent before the caller's commit
         logger.debug("Deleted tool plugin binding id=%s", binding_id)
         return response

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/tool_plugin_binding_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhumohan Jaishankar
+
+Tool Plugin Binding Service.
+Handles upsert, retrieval, and deletion of per-tool per-tenant plugin policy bindings.
+"""
+
+# Standard
+import logging
+from typing import List, Optional
+
+# Third-Party
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import ToolPluginBinding, utc_now
+from mcpgateway.schemas import ToolPluginBindingRequest, ToolPluginBindingResponse
+
+logger = logging.getLogger(__name__)
+
+
+class ToolPluginBindingNotFoundError(Exception):
+    """Raised when a binding with the given ID does not exist."""
+
+
+class ToolPluginBindingService:
+    """Service for managing tool plugin bindings.
+
+    All write operations follow an upsert pattern keyed on
+    (team_id, tool_name, plugin_id) — a re-POST for an existing triple
+    updates the existing row without changing its ``id`` or ``created_*`` fields.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_response(binding: ToolPluginBinding) -> ToolPluginBindingResponse:
+        """Convert an ORM row to a response schema.
+
+        Args:
+            binding: ORM instance to convert.
+
+        Returns:
+            ToolPluginBindingResponse: Pydantic response model.
+        """
+        return ToolPluginBindingResponse(
+            id=binding.id,
+            team_id=binding.team_id,
+            tool_name=binding.tool_name,
+            plugin_id=binding.plugin_id,
+            mode=binding.mode,
+            priority=binding.priority,
+            config=binding.config,
+            created_at=binding.created_at,
+            created_by=binding.created_by,
+            updated_at=binding.updated_at,
+            updated_by=binding.updated_by,
+        )
+
+    # ------------------------------------------------------------------
+    # Write — upsert
+    # ------------------------------------------------------------------
+
+    def upsert_bindings(
+        self,
+        db: Session,
+        request: ToolPluginBindingRequest,
+        caller_email: str,
+    ) -> List[ToolPluginBindingResponse]:
+        """Create or update plugin bindings from a POST request payload.
+
+        Iterates over every (team_id, policy) combination in the request.
+        For each (team_id, tool_name, plugin_id) triple:
+        - If a row already exists → update mode/priority/config/updated_by/updated_at.
+        - If no row exists → insert a new row.
+
+        **Config replacement policy**: ``config`` is always fully replaced on
+        update — it is NOT merged with the stored value.  To preserve existing
+        keys the caller must include them in the new request payload.
+
+        Args:
+            db: SQLAlchemy session.
+            request: Validated request payload.
+            caller_email: Email of the authenticated user making the request.
+                Must be a non-empty string — sourced from the auth middleware.
+
+        Returns:
+            List[ToolPluginBindingResponse]: All created/updated bindings, flattened.
+        """
+        results: List[ToolPluginBindingResponse] = []
+        now = utc_now()
+
+        for team_id, team_policies in request.teams.items():
+            for policy in team_policies.policies:
+                for tool_name in policy.tool_names:
+                    existing = (
+                        db.query(ToolPluginBinding)
+                        .filter(
+                            ToolPluginBinding.team_id == team_id,
+                            ToolPluginBinding.tool_name == tool_name,
+                            ToolPluginBinding.plugin_id == policy.plugin_id.value,
+                        )
+                        .first()
+                    )
+
+                    if existing:
+                        # Upsert — update mutable fields only
+                        existing.mode = policy.mode.value
+                        existing.priority = policy.priority
+                        existing.config = policy.config
+                        existing.updated_at = now
+                        existing.updated_by = caller_email
+                        db.flush()
+                        results.append(self._to_response(existing))
+                        logger.debug(
+                            "Updated tool plugin binding id=%s team=%s tool=%s plugin=%s",
+                            existing.id,
+                            team_id,
+                            tool_name,
+                            policy.plugin_id.value,
+                        )
+                    else:
+                        new_binding = ToolPluginBinding(
+                            team_id=team_id,
+                            tool_name=tool_name,
+                            plugin_id=policy.plugin_id.value,
+                            mode=policy.mode.value,
+                            priority=policy.priority,
+                            config=policy.config,
+                            created_at=now,
+                            created_by=caller_email,
+                            updated_at=now,
+                            updated_by=caller_email,
+                        )
+                        db.add(new_binding)
+                        db.flush()
+                        results.append(self._to_response(new_binding))
+                        logger.debug(
+                            "Created tool plugin binding id=%s team=%s tool=%s plugin=%s",
+                            new_binding.id,
+                            team_id,
+                            tool_name,
+                            policy.plugin_id.value,
+                        )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def list_bindings(
+        self,
+        db: Session,
+        team_id: Optional[str] = None,
+    ) -> List[ToolPluginBindingResponse]:
+        """Return all bindings, optionally filtered by team.
+
+        Args:
+            db: SQLAlchemy session.
+            team_id: If provided, return only bindings for this team.
+
+        Returns:
+            List[ToolPluginBindingResponse]: Matching bindings.
+        """
+        query = db.query(ToolPluginBinding)
+        if team_id:
+            query = query.filter(ToolPluginBinding.team_id == team_id)
+        bindings = query.order_by(ToolPluginBinding.team_id, ToolPluginBinding.priority).all()
+        return [self._to_response(b) for b in bindings]
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    def delete_binding(self, db: Session, binding_id: str) -> ToolPluginBindingResponse:
+        """Delete a binding by its primary key and return its details.
+
+        The response is captured before the row is removed so the caller
+        receives the full record that was deleted.
+
+        Args:
+            db: SQLAlchemy session.
+            binding_id: UUID of the binding to delete.
+
+        Returns:
+            ToolPluginBindingResponse: Details of the deleted binding.
+
+        Raises:
+            ToolPluginBindingNotFoundError: If no binding with the given ID exists.
+        """
+        binding = db.query(ToolPluginBinding).filter(ToolPluginBinding.id == binding_id).first()
+        if not binding:
+            raise ToolPluginBindingNotFoundError(f"Tool plugin binding '{binding_id}' not found")
+        response = self._to_response(binding)
+        db.delete(binding)
+        db.flush()
+        logger.debug("Deleted tool plugin binding id=%s", binding_id)
+        return response

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -18,13 +18,50 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import ToolPluginBinding, utc_now
-from mcpgateway.schemas import ToolPluginBindingRequest, ToolPluginBindingResponse
+from mcpgateway.schemas import PLUGIN_ID_TO_NAME, ToolPluginBindingRequest, ToolPluginBindingResponse
 
 logger = logging.getLogger(__name__)
 
 
 class ToolPluginBindingNotFoundError(Exception):
     """Raised when a binding with the given ID does not exist."""
+
+
+def get_bindings_for_tool(
+    db: Session,
+    team_id: str,
+    tool_name: str,
+) -> List[ToolPluginBinding]:
+    """Return deduplicated plugin bindings for a (team_id, tool_name) pair.
+
+    Includes wildcard ``"*"`` bindings alongside exact-match bindings.
+    For duplicate plugin_ids, the most recently updated binding wins
+    (last-write-wins) so a specific tool_name entry overrides a ``"*"`` entry
+    when both exist for the same plugin.
+
+    Args:
+        db: SQLAlchemy session.
+        team_id: Team whose bindings to query.
+        tool_name: Exact tool name, or ``"*"`` to fetch only wildcard rows.
+
+    Returns:
+        List of ORM ``ToolPluginBinding`` instances, one per unique plugin_id.
+    """
+    rows = (
+        db.query(ToolPluginBinding)
+        .filter(
+            ToolPluginBinding.team_id == team_id,
+            ToolPluginBinding.tool_name.in_([tool_name, "*"]),
+        )
+        .order_by(ToolPluginBinding.updated_at.asc())
+        .all()
+    )
+    # Last-write-wins: iterate ascending updated_at so exact matches (later)
+    # overwrite wildcard matches (earlier) for the same plugin_id.
+    seen: dict[str, ToolPluginBinding] = {}
+    for binding in rows:
+        seen[binding.plugin_id] = binding
+    return list(seen.values())
 
 
 class ToolPluginBindingService:

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import ToolPluginBinding, utc_now
-from mcpgateway.schemas import PLUGIN_ID_TO_NAME, ToolPluginBindingRequest, ToolPluginBindingResponse
+from mcpgateway.schemas import ToolPluginBindingRequest, ToolPluginBindingResponse
 
 logger = logging.getLogger(__name__)
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3873,7 +3873,18 @@ class ToolService(BaseService):
         # This prevents lazy loading during HTTP calls
         tool_metadata: Optional[PydanticTool] = None
         gateway_metadata: Optional[PydanticGateway] = None
-        plugin_manager = await self._get_plugin_manager(server_id)
+        # Resolve per-tool context_id so DB plugin bindings (ToolPluginBinding) are applied.
+        # Lazy import avoids circular: gateway_plugin_manager → services.__init__ → tool_service.
+        from mcpgateway.plugins.gateway_plugin_manager import make_context_id  # pylint: disable=import-outside-toplevel
+
+        _tool_team_id = tool_payload.get("team_id")
+        # Use original_name (the MCP server's tool name, e.g. "echo_text") as the binding key,
+        # not the gateway-prefixed display name (e.g. "plugin-tools-echo_text").
+        # Users create bindings against the original name they see in the MCP server.
+        _binding_tool_name = tool_payload.get("original_name") or name
+        plugin_context_id = make_context_id(str(_tool_team_id), _binding_tool_name) if _tool_team_id else server_id
+        plugin_manager = await self._get_plugin_manager(plugin_context_id)
+        logger.debug("invoke_tool: plugin_context_id=%r plugin_manager=%r", plugin_context_id, plugin_manager)
         if plugin_manager:
             if tool is not None:
                 tool_metadata = PydanticTool.model_validate(tool)
@@ -4721,7 +4732,7 @@ class ToolService(BaseService):
                     # REMOVED: Redundant gateway query - gateway already eager-loaded via joinedload
                     # tool_gateway = db.execute(select(DbGateway).where(DbGateway.id == tool_gateway_id)...)
 
-                    plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                    plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         # Use pre-created Pydantic models from Phase 2 (no ORM access)
                         if tool_metadata:
@@ -4774,7 +4785,7 @@ class ToolService(BaseService):
                     headers = {"Content-Type": "application/json"}
 
                     # Plugin hook: tool pre-invoke for A2A
-                    plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                    plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
@@ -4894,7 +4905,7 @@ class ToolService(BaseService):
                 with create_child_span("tool.post_process", {"tool.name": name, "tool.id": tool_id}):
                     post_result = None
                     # Plugin hook: tool post-invoke
-                    plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                    plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
                         post_result, _ = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_POST_INVOKE,
@@ -4989,7 +5000,7 @@ class ToolService(BaseService):
                 # include it in structuredContent so the retry plugin can honour retry_on_status
                 # instead of blindly retrying every exception.
                 exc_post_result = None
-                plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                plugin_manager = await self._get_plugin_manager(plugin_context_id)
                 if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
                     try:
                         exc_structured: Optional[Dict[str, Any]] = None

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -60,12 +60,10 @@ from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import ToolMetric, ToolMetricsHourly
 from mcpgateway.observability import create_child_span, create_span, inject_trace_context_headers, otel_context_active, set_span_attribute, set_span_error
 from mcpgateway.plugins.framework import (
-    get_plugin_manager,
     GlobalContext,
     HttpHeaderPayload,
     PluginContextTable,
     PluginError,
-    PluginManager,
     PluginViolationError,
     ToolHookType,
     ToolPostInvokePayload,
@@ -590,7 +588,6 @@ class ToolService(BaseService):
         """
         self._event_service = EventService(channel_name="mcpgateway:tool_events")
         self._http_client = ResilientHttpClient(client_args={"timeout": settings.federation_timeout, "verify": not settings.skip_ssl_verify})
-        self._plugin_manager: PluginManager | None = get_plugin_manager()
         self.oauth_manager = OAuthManager(
             request_timeout=int(settings.oauth_request_timeout if hasattr(settings, "oauth_request_timeout") else 30),
             max_retries=int(settings.oauth_max_retries if hasattr(settings, "oauth_max_retries") else 3),
@@ -2974,8 +2971,9 @@ class ToolService(BaseService):
             ToolNotFoundError: If the requested tool is not visible or invocable.
             ToolInvocationError: If gateway auth preparation fails or the tool name is ambiguous.
         """
-        has_pre_invoke = self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE)
-        has_post_invoke = self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE)
+        plugin_manager = await self._get_plugin_manager(server_id)
+        has_pre_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE)
+        has_post_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE)
 
         gateway_id_from_header = extract_gateway_id_from_headers(request_headers)
         is_direct_proxy = False
@@ -3234,7 +3232,7 @@ class ToolService(BaseService):
 
         native_post_invoke_retry_policy = None
         if has_post_invoke:
-            native_post_invoke_retry_policy, requires_python_fallback = self._build_rust_native_tool_post_invoke_retry_policy(name, hook_global_context)
+            native_post_invoke_retry_policy, requires_python_fallback = self._build_rust_native_tool_post_invoke_retry_policy(plugin_manager, name, hook_global_context)
             if requires_python_fallback:
                 return {"eligible": False, "fallbackReason": "post-invoke-hooks-configured"}
 
@@ -3242,7 +3240,7 @@ class ToolService(BaseService):
         # inject credentials and clean arguments before the Rust direct call.
         modified_args = arguments
         if has_pre_invoke and arguments is not None:
-            pre_result, _ = await self._plugin_manager.invoke_hook(
+            pre_result, _ = await plugin_manager.invoke_hook(
                 ToolHookType.TOOL_PRE_INVOKE,
                 payload=ToolPreInvokePayload(name=name, args=arguments, headers=HttpHeaderPayload(root=dict(runtime_headers))),
                 global_context=hook_global_context,
@@ -3325,6 +3323,7 @@ class ToolService(BaseService):
 
     def _build_rust_native_tool_post_invoke_retry_policy(
         self,
+        plugin_manager: Optional[Any],
         tool_name: str,
         hook_global_context: Optional[GlobalContext],
     ) -> Tuple[Optional[Dict[str, Any]], bool]:
@@ -3335,13 +3334,14 @@ class ToolService(BaseService):
         hook must still force the call back to Python to preserve plugin semantics.
 
         Args:
+            plugin_manager: Plugin manager instance (may be None).
             tool_name: Requested tool name.
             hook_global_context: Resolved plugin context for condition matching.
 
         Returns:
             Tuple of `(policy, requires_python_fallback)`.
         """
-        if not self._plugin_manager or not self._plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
+        if not plugin_manager or not plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
             return (None, False)
 
         # First-Party
@@ -3353,7 +3353,7 @@ class ToolService(BaseService):
 
         global_context = hook_global_context or GlobalContext(request_id=get_correlation_id() or uuid.uuid4().hex)
         payload = ToolPostInvokePayload(name=tool_name, result={})
-        hook_refs = self._plugin_manager._registry.get_hook_refs_for_hook(hook_type=ToolHookType.TOOL_POST_INVOKE)  # pylint: disable=protected-access
+        hook_refs = plugin_manager._registry.get_hook_refs_for_hook(hook_type=ToolHookType.TOOL_POST_INVOKE)  # pylint: disable=protected-access
 
         active_hook_refs = []
         for hook_ref in hook_refs:
@@ -3425,6 +3425,7 @@ class ToolService(BaseService):
         effective_timeout: float,
         global_context: Any,
         context_table: Any,
+        plugin_manager: Any = None,
     ) -> None:
         """Invoke post-invoke plugins after a timeout and raise with retry signal if requested.
 
@@ -3439,6 +3440,7 @@ class ToolService(BaseService):
             effective_timeout: Timeout duration in seconds.
             global_context: Plugin global context for cross-hook state.
             context_table: Plugin local context table for per-plugin state.
+            plugin_manager: Optional pre-fetched plugin manager to avoid redundant lookups.
 
         Raises:
             ToolTimeoutError: When the retry plugin requests a delayed retry.
@@ -3447,12 +3449,12 @@ class ToolService(BaseService):
             for ctx in context_table.values():
                 ctx.set_state("cb_timeout_failure", True)
 
-        if not self._plugin_manager:
-            return
+        if plugin_manager is None:
+            plugin_manager = await self._get_plugin_manager(global_context.server_id if global_context else None)
 
-        if self._plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
+        if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
             timeout_error_result = ToolResult(content=[TextContent(type="text", text=f"Tool invocation timed out after {effective_timeout}s")], is_error=True)
-            timeout_post_result, _ = await self._plugin_manager.invoke_hook(
+            timeout_post_result, _ = await plugin_manager.invoke_hook(
                 ToolHookType.TOOL_POST_INVOKE,
                 payload=ToolPostInvokePayload(name=name, result=timeout_error_result.model_dump(by_alias=True)),
                 global_context=global_context,
@@ -3871,7 +3873,8 @@ class ToolService(BaseService):
         # This prevents lazy loading during HTTP calls
         tool_metadata: Optional[PydanticTool] = None
         gateway_metadata: Optional[PydanticGateway] = None
-        if self._plugin_manager:
+        plugin_manager = await self._get_plugin_manager(server_id)
+        if plugin_manager:
             if tool is not None:
                 tool_metadata = PydanticTool.model_validate(tool)
                 if has_gateway and gateway is not None:
@@ -4054,11 +4057,11 @@ class ToolService(BaseService):
                             session_short = mcp_session_id[:8] if len(mcp_session_id) >= 8 else mcp_session_id
                             logger.debug(f"[AFFINITY] Worker {worker_id} | Session {session_short}... | Tool: {name} | Normalized MCP-Session-Id → x-mcp-session-id for pool affinity")
 
-                    if self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
+                    if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         # Use pre-created Pydantic model from Phase 2 (no ORM access)
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
-                        pre_result, context_table = await self._plugin_manager.invoke_hook(
+                        pre_result, context_table = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_PRE_INVOKE,
                             payload=ToolPreInvokePayload(name=name, args=arguments, headers=HttpHeaderPayload(root=headers)),
                             global_context=global_context,
@@ -4131,8 +4134,8 @@ class ToolService(BaseService):
                                     exc,
                                     exc_info=True,
                                 )
-                            if self._plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table)
+                            if plugin_manager:
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         response.raise_for_status()
@@ -4501,8 +4504,8 @@ class ToolService(BaseService):
                                     exc_info=True,
                                 )
 
-                            if self._plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table)
+                            if plugin_manager:
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         except BaseException as e:
@@ -4689,8 +4692,8 @@ class ToolService(BaseService):
                                     exc_info=True,
                                 )
 
-                            if self._plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table)
+                            if plugin_manager:
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         except BaseException as e:
@@ -4718,13 +4721,14 @@ class ToolService(BaseService):
                     # REMOVED: Redundant gateway query - gateway already eager-loaded via joinedload
                     # tool_gateway = db.execute(select(DbGateway).where(DbGateway.id == tool_gateway_id)...)
 
-                    if self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
+                    plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                    if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         # Use pre-created Pydantic models from Phase 2 (no ORM access)
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
                         if gateway_metadata:
                             global_context.metadata[GATEWAY_METADATA] = gateway_metadata
-                        pre_result, context_table = await self._plugin_manager.invoke_hook(
+                        pre_result, context_table = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_PRE_INVOKE,
                             payload=ToolPreInvokePayload(name=name, args=arguments, headers=HttpHeaderPayload(root=headers)),
                             global_context=global_context,
@@ -4770,10 +4774,11 @@ class ToolService(BaseService):
                     headers = {"Content-Type": "application/json"}
 
                     # Plugin hook: tool pre-invoke for A2A
-                    if self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
+                    plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                    if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
-                        pre_result, context_table = await self._plugin_manager.invoke_hook(
+                        pre_result, context_table = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_PRE_INVOKE,
                             payload=ToolPreInvokePayload(name=name, args=arguments, headers=HttpHeaderPayload(root=headers)),
                             global_context=global_context,
@@ -4865,8 +4870,8 @@ class ToolService(BaseService):
                                 logger.debug("Failed to increment tool_timeout_counter for %s: %s", name, exc, exc_info=True)
 
                             # Trigger circuit breaker on timeout
-                            if self._plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table)
+                            if plugin_manager:
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
 
@@ -4889,8 +4894,9 @@ class ToolService(BaseService):
                 with create_child_span("tool.post_process", {"tool.name": name, "tool.id": tool_id}):
                     post_result = None
                     # Plugin hook: tool post-invoke
-                    if self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
-                        post_result, _ = await self._plugin_manager.invoke_hook(
+                    plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                    if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
+                        post_result, _ = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_POST_INVOKE,
                             payload=ToolPostInvokePayload(name=name, result=tool_result.model_dump(by_alias=True)),
                             global_context=global_context,
@@ -4983,13 +4989,14 @@ class ToolService(BaseService):
                 # include it in structuredContent so the retry plugin can honour retry_on_status
                 # instead of blindly retrying every exception.
                 exc_post_result = None
-                if self._plugin_manager and self._plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
+                plugin_manager = await self._get_plugin_manager(global_context.server_id)
+                if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
                     try:
                         exc_structured: Optional[Dict[str, Any]] = None
                         if isinstance(root_cause, httpx.HTTPStatusError):
                             exc_structured = {"status_code": root_cause.response.status_code}
                         exception_error_result = ToolResult(content=[TextContent(type="text", text=f"Tool invocation failed: {error_message}")], is_error=True, structured_content=exc_structured)
-                        exc_post_result, _ = await self._plugin_manager.invoke_hook(
+                        exc_post_result, _ = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_POST_INVOKE,
                             payload=ToolPostInvokePayload(name=name, result=exception_error_result.model_dump(by_alias=True)),
                             global_context=global_context,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -2971,9 +2971,6 @@ class ToolService(BaseService):
             ToolNotFoundError: If the requested tool is not visible or invocable.
             ToolInvocationError: If gateway auth preparation fails or the tool name is ambiguous.
         """
-        plugin_manager = await self._get_plugin_manager(server_id)
-        has_pre_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE)
-        has_post_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE)
 
         gateway_id_from_header = extract_gateway_id_from_headers(request_headers)
         is_direct_proxy = False
@@ -3117,6 +3114,16 @@ class ToolService(BaseService):
         tool_gateway_id = tool_payload.get("gateway_id")
         tool_timeout_ms = tool_payload.get("timeout_ms")
         effective_timeout = (tool_timeout_ms / 1000) if tool_timeout_ms else settings.tool_timeout
+
+        # Resolve per-tool context_id for plugin manager (same pattern as invoke_tool)
+        from mcpgateway.plugins.gateway_plugin_manager import make_context_id  # pylint: disable=import-outside-toplevel
+
+        _tool_team_id = tool_payload.get("team_id")
+        _binding_tool_name = tool_payload.get("original_name") or name
+        plugin_context_id = make_context_id(str(_tool_team_id), _binding_tool_name) if _tool_team_id else server_id
+        plugin_manager = await self._get_plugin_manager(plugin_context_id)
+        has_pre_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE)
+        has_post_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE)
 
         has_gateway = gateway_payload is not None
         gateway_url = gateway_payload.get("url") if has_gateway else None
@@ -3448,9 +3455,6 @@ class ToolService(BaseService):
         if context_table:
             for ctx in context_table.values():
                 ctx.set_state("cb_timeout_failure", True)
-
-        if plugin_manager is None:
-            plugin_manager = await self._get_plugin_manager(global_context.server_id if global_context else None)
 
         if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
             timeout_error_result = ToolResult(content=[TextContent(type="text", text=f"Tool invocation timed out after {effective_timeout}s")], is_error=True)
@@ -3875,6 +3879,7 @@ class ToolService(BaseService):
         gateway_metadata: Optional[PydanticGateway] = None
         # Resolve per-tool context_id so DB plugin bindings (ToolPluginBinding) are applied.
         # Lazy import avoids circular: gateway_plugin_manager → services.__init__ → tool_service.
+        # First-Party
         from mcpgateway.plugins.gateway_plugin_manager import make_context_id  # pylint: disable=import-outside-toplevel
 
         _tool_team_id = tool_payload.get("team_id")

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -97,13 +97,13 @@ plugins:
     author: "Mihai Criveti"
     hooks: ["prompt_pre_fetch", "prompt_post_fetch", "tool_pre_invoke", "tool_post_invoke"]
     tags: ["plugin", "transformer", "regex", "search-and-replace", "pre-post"]
-    mode: "disabled"  # enforce | enforce_ignore_error | permissive | disabled
+    mode: "enforce"  # enforce | enforce_ignore_error | permissive | disabled
     priority: 150
-    conditions:
-      # Apply to specific tools/servers
-      - prompts: ["test_prompt"]
-        server_ids: []  # Apply to all servers
-        tenant_ids: []  # Apply to all tenants
+    # conditions:
+    #   # Apply to specific tools/servers
+    #   - prompts: ["test_prompt"]
+    #     server_ids: []  # Apply to all servers
+    #     tenant_ids: []  # Apply to all tenants
     config:
       words:
         - search: crap

--- a/tests/unit/mcpgateway/middleware/test_http_auth_headers.py
+++ b/tests/unit/mcpgateway/middleware/test_http_auth_headers.py
@@ -13,7 +13,7 @@ These tests verify the low-level header modification works correctly:
 """
 
 # Standard
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import Depends, FastAPI, Request
@@ -39,7 +39,7 @@ class TestRequestScopeHeaderModification:
         app = FastAPI()
 
         # Create mock plugin manager that transforms X-API-Key → Authorization
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             if hook_type == HttpHookType.HTTP_PRE_REQUEST:
@@ -51,9 +51,9 @@ class TestRequestScopeHeaderModification:
             return PluginResult(continue_processing=True), {}
 
         mock_plugin_manager.invoke_hook = mock_invoke_hook
+        mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
 
-        # Add middleware
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        app.add_middleware(HttpAuthMiddleware)
 
         # Add bearer scheme
         bearer_scheme = HTTPBearer(auto_error=False)
@@ -70,7 +70,8 @@ class TestRequestScopeHeaderModification:
                 }
             return {"credentials": None, "headers_transformed": False}
 
-        return app
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            yield app
 
     def test_x_api_key_transformed_to_authorization_bearer(self, simple_app_with_header_transform):
         """Test that X-API-Key header is transformed and visible to HTTPBearer."""
@@ -83,6 +84,7 @@ class TestRequestScopeHeaderModification:
         )
 
         # Should succeed
+
         assert response.status_code == 200
 
         # The endpoint should have received credentials from the transformed Authorization header
@@ -133,7 +135,7 @@ class TestRequestScopeInspection:
         app = FastAPI()
 
         # Mock plugin manager
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             if hook_type == HttpHookType.HTTP_PRE_REQUEST:
@@ -144,7 +146,9 @@ class TestRequestScopeInspection:
             return PluginResult(continue_processing=True), {}
 
         mock_plugin_manager.invoke_hook = mock_invoke_hook
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/inspect-scope")
         async def inspect_scope(request: Request):
@@ -155,7 +159,8 @@ class TestRequestScopeInspection:
                 headers_dict[name.decode()] = value.decode()
             return {"scope_headers": headers_dict, "request_headers": dict(request.headers)}
 
-        return app
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            yield app
 
     def test_scope_headers_contain_transformed_header(self, app_with_scope_inspection):
         """Test that request.scope['headers'] contains the transformed header."""
@@ -205,7 +210,7 @@ class TestRequestStateRequestId:
         # Mock plugin manager that records request IDs
         request_ids_seen = []
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             # Record the request_id from global_context
@@ -213,7 +218,9 @@ class TestRequestStateRequestId:
             return PluginResult(continue_processing=True), {}
 
         mock_plugin_manager.invoke_hook = mock_invoke_hook
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test-request-id")
         async def test_endpoint(request: Request):
@@ -227,7 +234,8 @@ class TestRequestStateRequestId:
         # Store request_ids_seen so we can access it
         app.state.request_ids_seen = request_ids_seen
 
-        return app
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            yield app
 
     def test_request_id_consistent_across_hooks(self, app_with_request_id_tracking):
         """Test that same request_id is used in all hooks for a single request."""
@@ -280,7 +288,7 @@ class TestHeaderMergingBehavior:
         app = FastAPI()
 
         # Mock plugin manager that modifies and adds headers
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             if hook_type == HttpHookType.HTTP_PRE_REQUEST:
@@ -292,14 +300,17 @@ class TestHeaderMergingBehavior:
             return PluginResult(continue_processing=True), {}
 
         mock_plugin_manager.invoke_hook = mock_invoke_hook
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test-merge")
         async def test_endpoint(request: Request):
             """Return the headers seen by the endpoint."""
             return {"headers": dict(request.headers)}
 
-        return app
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            yield app
 
     def test_modified_headers_take_precedence(self, app_with_header_merging):
         """Test that plugin-modified headers override original headers in middleware."""
@@ -342,7 +353,7 @@ class TestHeaderMergingBehavior:
         """Test that middleware properly converts headers to ASGI format (lowercase bytes) in request.scope."""
         app = FastAPI()
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             if hook_type == HttpHookType.HTTP_PRE_REQUEST:
@@ -353,7 +364,9 @@ class TestHeaderMergingBehavior:
             return PluginResult(continue_processing=True), {}
 
         mock_plugin_manager.invoke_hook = mock_invoke_hook
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test-asgi-format")
         async def test_endpoint(request: Request):
@@ -363,8 +376,9 @@ class TestHeaderMergingBehavior:
             headers_dict = {name.decode(): value.decode() for name, value in scope_headers}
             return {"scope_headers_lowercase": all(name == name.lower() for name, _ in scope_headers), "headers": headers_dict}
 
-        client = TestClient(app)
-        response = client.get("/test-asgi-format")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            client = TestClient(app)
+            response = client.get("/test-asgi-format")
 
         assert response.status_code == 200
         data = response.json()
@@ -390,7 +404,7 @@ class TestHasHooksForOptimization:
         # Track which hooks are actually invoked
         hooks_invoked = []
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             hooks_invoked.append(hook_type)
@@ -401,7 +415,7 @@ class TestHasHooksForOptimization:
         # Default: both hooks registered
         mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
 
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
@@ -409,7 +423,9 @@ class TestHasHooksForOptimization:
 
         app.state.hooks_invoked = hooks_invoked
         app.state.mock_plugin_manager = mock_plugin_manager
-        return app
+
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            yield app
 
     def test_no_hooks_invoked_when_neither_registered(self, app_with_hook_tracking):
         """Test that no hooks are invoked when neither PRE nor POST is registered."""
@@ -535,7 +551,7 @@ class TestHasHooksForPerformance:
 
         invoke_calls = []
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             invoke_calls.append({"hook_type": hook_type, "payload_type": type(payload).__name__})
@@ -549,15 +565,16 @@ class TestHasHooksForPerformance:
 
         mock_plugin_manager.has_hooks_for = MagicMock(side_effect=has_hooks_side_effect)
 
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
             return {"status": "ok"}
 
-        client = TestClient(app)
-        invoke_calls.clear()
-        response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            client = TestClient(app)
+            invoke_calls.clear()
+            response = client.get("/test")
 
         assert response.status_code == 200
         # Only POST hook should have been invoked
@@ -571,7 +588,7 @@ class TestHasHooksForPerformance:
 
         invoke_calls = []
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             invoke_calls.append({"hook_type": hook_type, "payload_type": type(payload).__name__})
@@ -585,15 +602,16 @@ class TestHasHooksForPerformance:
 
         mock_plugin_manager.has_hooks_for = MagicMock(side_effect=has_hooks_side_effect)
 
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
             return {"status": "ok"}
 
-        client = TestClient(app)
-        invoke_calls.clear()
-        response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            client = TestClient(app)
+            invoke_calls.clear()
+            response = client.get("/test")
 
         assert response.status_code == 200
         # Only PRE hook should have been invoked
@@ -607,7 +625,7 @@ class TestHasHooksForPerformance:
 
         invoke_calls = []
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             invoke_calls.append({"hook_type": hook_type, "payload_type": type(payload).__name__})
@@ -618,15 +636,16 @@ class TestHasHooksForPerformance:
         # No hooks registered
         mock_plugin_manager.has_hooks_for = MagicMock(return_value=False)
 
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
             return {"status": "ok"}
 
-        client = TestClient(app)
-        invoke_calls.clear()
-        response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            client = TestClient(app)
+            invoke_calls.clear()
+            response = client.get("/test")
 
         assert response.status_code == 200
         # No hooks should have been invoked
@@ -644,7 +663,7 @@ class TestNoPluginManager:
     def test_dispatch_without_plugin_manager(self):
         """Middleware returns immediately when plugin_manager is None."""
         app = FastAPI()
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=None)
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
@@ -665,22 +684,24 @@ class TestCorrelationIdExists:
         from unittest.mock import patch as _patch
 
         app = FastAPI()
-        mock_pm = MagicMock()
+        mock_pm = AsyncMock()
         mock_pm.has_hooks_for = MagicMock(return_value=True)
 
         async def mock_invoke(*args, **kwargs):
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_pm)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint(request: Request):
             return {"request_id": getattr(request.state, "request_id", None)}
 
         client = TestClient(app)
-        with _patch("mcpgateway.middleware.http_auth_middleware.get_correlation_id", return_value="existing-id"):
-            response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_pm):
+            with _patch("mcpgateway.middleware.http_auth_middleware.get_correlation_id", return_value="existing-id"):
+                response = client.get("/test")
 
         assert response.status_code == 200
         assert response.json()["request_id"] == "existing-id"
@@ -696,7 +717,7 @@ class TestNoRequestClient:
 
         app = FastAPI()
         captured_payloads = []
-        mock_pm = MagicMock()
+        mock_pm = AsyncMock()
         mock_pm.has_hooks_for = MagicMock(return_value=True)
 
         async def mock_invoke(hook_type, payload, **kwargs):
@@ -705,7 +726,8 @@ class TestNoRequestClient:
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_pm)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
@@ -713,8 +735,9 @@ class TestNoRequestClient:
 
         client = TestClient(app)
         # TestClient always sets client, so we patch the request to have no client
-        with _patch("mcpgateway.middleware.http_auth_middleware.get_correlation_id", return_value="id"):
-            response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_pm):
+            with _patch("mcpgateway.middleware.http_auth_middleware.get_correlation_id", return_value="id"):
+                response = client.get("/test")
 
         # The test client always has a client, but we can verify behavior works.
         # For a stricter test, we'd need to override the ASGI scope.
@@ -727,7 +750,7 @@ class TestPreHookException:
     def test_pre_hook_exception_does_not_block_request(self):
         """Pre-request hook failure is logged but request proceeds."""
         app = FastAPI()
-        mock_pm = MagicMock()
+        mock_pm = AsyncMock()
 
         def has_hooks_side_effect(hook_type):
             return hook_type == HttpHookType.HTTP_PRE_REQUEST
@@ -738,14 +761,16 @@ class TestPreHookException:
             raise RuntimeError("plugin crash")
 
         mock_pm.invoke_hook = mock_invoke
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_pm)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
             return {"ok": True}
 
-        client = TestClient(app)
-        response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_pm):
+            client = TestClient(app)
+            response = client.get("/test")
         assert response.status_code == 200
         assert response.json() == {"ok": True}
 
@@ -756,7 +781,7 @@ class TestPostHookResponseHeaders:
     def test_post_hook_modifies_response_headers(self):
         """Post-request hook can add/modify response headers."""
         app = FastAPI()
-        mock_pm = MagicMock()
+        mock_pm = AsyncMock()
 
         def has_hooks_side_effect(hook_type):
             return hook_type == HttpHookType.HTTP_POST_REQUEST
@@ -770,21 +795,23 @@ class TestPostHookResponseHeaders:
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_pm)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
             return {"ok": True}
 
-        client = TestClient(app)
-        response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_pm):
+            client = TestClient(app)
+            response = client.get("/test")
         assert response.status_code == 200
         assert response.headers.get("x-custom-response") == "added-by-plugin"
 
     def test_post_hook_exception_does_not_block_response(self):
         """Post-request hook failure is logged but response is returned."""
         app = FastAPI()
-        mock_pm = MagicMock()
+        mock_pm = AsyncMock()
 
         def has_hooks_side_effect(hook_type):
             return hook_type == HttpHookType.HTTP_POST_REQUEST
@@ -795,14 +822,16 @@ class TestPostHookResponseHeaders:
             raise RuntimeError("post-hook crash")
 
         mock_pm.invoke_hook = mock_invoke
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_pm)
+
+        app.add_middleware(HttpAuthMiddleware)
 
         @app.get("/test")
         async def test_endpoint():
             return {"ok": True}
 
-        client = TestClient(app)
-        response = client.get("/test")
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_pm):
+            client = TestClient(app)
+            response = client.get("/test")
         assert response.status_code == 200
         assert response.json() == {"ok": True}
 
@@ -817,6 +846,7 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_returns_original_headers_when_no_hooks_registered(self):
         """No hooks registered => original headers returned unchanged."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
@@ -832,6 +862,7 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_returns_modified_headers_from_plugin(self):
         """Plugin that adds a header should produce merged output."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
@@ -855,6 +886,7 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_no_modification_when_plugin_returns_no_payload(self):
         """Plugin that returns no modified_payload should leave headers unchanged."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
@@ -873,16 +905,20 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_auth_header_override_stripped_by_default(self):
         """Default config prevents plugins from overriding existing auth headers."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
         pm.has_hooks_for.return_value = True
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
-            return PluginResult(
-                modified_payload=HttpHeaderPayload({"authorization": "Bearer HIJACKED", "x-new": "allowed"}),
-                continue_processing=True,
-            ), {}
+            return (
+                PluginResult(
+                    modified_payload=HttpHeaderPayload({"authorization": "Bearer HIJACKED", "x-new": "allowed"}),
+                    continue_processing=True,
+                ),
+                {},
+            )
 
         pm.invoke_hook = mock_invoke_hook
 
@@ -899,16 +935,20 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_auth_header_override_stripped_mixed_case(self):
         """Mixed-case auth header keys from plugins are also stripped (deny-path)."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
         pm.has_hooks_for.return_value = True
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
-            return PluginResult(
-                modified_payload=HttpHeaderPayload({"Authorization": "Bearer HIJACKED", "X-Api-Key": "stolen", "x-new": "ok"}),
-                continue_processing=True,
-            ), {}
+            return (
+                PluginResult(
+                    modified_payload=HttpHeaderPayload({"Authorization": "Bearer HIJACKED", "X-Api-Key": "stolen", "x-new": "ok"}),
+                    continue_processing=True,
+                ),
+                {},
+            )
 
         pm.invoke_hook = mock_invoke_hook
 
@@ -926,16 +966,20 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_auth_header_override_allowed_when_enabled(self):
         """plugins_can_override_auth_headers=True allows plugins to rewrite auth headers."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
         pm.has_hooks_for.return_value = True
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
-            return PluginResult(
-                modified_payload=HttpHeaderPayload({"authorization": "Bearer EXCHANGED"}),
-                continue_processing=True,
-            ), {}
+            return (
+                PluginResult(
+                    modified_payload=HttpHeaderPayload({"authorization": "Bearer EXCHANGED"}),
+                    continue_processing=True,
+                ),
+                {},
+            )
 
         pm.invoke_hook = mock_invoke_hook
 
@@ -949,6 +993,7 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_exception_returns_original_headers(self):
         """Hook failure should return original headers, not crash."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
@@ -968,16 +1013,20 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_headers_normalized_to_lowercase(self):
         """Merged headers should have lowercase keys to prevent duplicates."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 
         pm = MagicMock()
         pm.has_hooks_for.return_value = True
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
-            return PluginResult(
-                modified_payload=HttpHeaderPayload({"X-Plugin-Header": "value"}),
-                continue_processing=True,
-            ), {}
+            return (
+                PluginResult(
+                    modified_payload=HttpHeaderPayload({"X-Plugin-Header": "value"}),
+                    continue_processing=True,
+                ),
+                {},
+            )
 
         pm.invoke_hook = mock_invoke_hook
 
@@ -994,6 +1043,7 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_creates_global_context_when_not_provided(self):
         """When no global_context is passed, the function should create one."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
         from mcpgateway.plugins.framework import GlobalContext
 
@@ -1012,6 +1062,7 @@ class TestRunPreRequestHooks:
     @pytest.mark.asyncio
     async def test_reuses_provided_global_context(self):
         """When a global_context is passed, the function should reuse it."""
+        # First-Party
         from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
         from mcpgateway.plugins.framework import GlobalContext
 
@@ -1036,7 +1087,7 @@ class TestPluginsCanOverrideAuthHeaders:
         """Create app where plugin attempts to override the Authorization header."""
         app = FastAPI()
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             if hook_type == HttpHookType.HTTP_PRE_REQUEST:
@@ -1049,7 +1100,7 @@ class TestPluginsCanOverrideAuthHeaders:
         mock_plugin_manager.invoke_hook = mock_invoke_hook
         mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
 
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        app.add_middleware(HttpAuthMiddleware)
 
         bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -1060,7 +1111,8 @@ class TestPluginsCanOverrideAuthHeaders:
                 return {"scheme": credentials.scheme, "credentials": credentials.credentials}
             return {"credentials": None}
 
-        return app
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            yield app
 
     def test_auth_header_override_blocked_by_default(self, app_with_auth_override_plugin):
         """Deny-path: plugin override of existing Authorization header is stripped when setting is False (default)."""
@@ -1085,7 +1137,7 @@ class TestPluginsCanOverrideAuthHeaders:
         """Deny-path: plugin cannot bypass protection by returning a differently-cased header key."""
         app = FastAPI()
 
-        mock_plugin_manager = MagicMock()
+        mock_plugin_manager = AsyncMock()
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
             if hook_type == HttpHookType.HTTP_PRE_REQUEST:
@@ -1098,7 +1150,8 @@ class TestPluginsCanOverrideAuthHeaders:
         mock_plugin_manager.invoke_hook = mock_invoke_hook
         mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)
 
-        app.add_middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager)
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", return_value=mock_plugin_manager):
+            app.add_middleware(HttpAuthMiddleware)
 
         bearer_scheme = HTTPBearer(auto_error=False)
 

--- a/tests/unit/mcpgateway/middleware/test_http_auth_integration.py
+++ b/tests/unit/mcpgateway/middleware/test_http_auth_integration.py
@@ -14,13 +14,14 @@ Tests the complete flow:
 
 # Standard
 from datetime import datetime, timezone
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi.testclient import TestClient
 import pytest
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.plugins.framework import (
     HttpHeaderPayload,
     HttpHookType,
@@ -28,7 +29,6 @@ from mcpgateway.plugins.framework import (
     PluginViolation,
     PluginViolationError,
 )
-from mcpgateway.config import settings
 
 
 @pytest.mark.skipif(not settings.plugins.enabled, reason="Plugins must be enabled for HTTP auth integration tests")
@@ -108,33 +108,11 @@ class TestHttpAuthMiddlewareIntegration:
         mock_plugin_manager.invoke_hook = mock_invoke_hook
         mock_plugin_manager.has_hooks_for = MagicMock(return_value=True)  # Enable hook invocation
 
-        # Patch where get_plugin_manager is USED (in auth.py)
-        with patch("mcpgateway.auth.get_plugin_manager", return_value=mock_plugin_manager):
-            # Ensure HttpAuthMiddleware is in the middleware list with our mock
-            from starlette.middleware import Middleware
-            from mcpgateway.middleware.http_auth_middleware import HttpAuthMiddleware
-
-            found = False
-            for middleware in app.user_middleware:
-                if hasattr(middleware, "cls") and middleware.cls.__name__ == "HttpAuthMiddleware":
-                    middleware.kwargs["plugin_manager"] = mock_plugin_manager
-                    found = True
-
-            if not found:
-                app.user_middleware.insert(0, Middleware(HttpAuthMiddleware, plugin_manager=mock_plugin_manager))
-
-            # Force Starlette to rebuild the middleware stack so our changes take effect.
-            # The cached middleware_stack holds already-instantiated middleware objects,
-            # so modifying user_middleware alone has no effect without this reset.
-            saved_stack = app.middleware_stack
-            app.middleware_stack = None
-
-            try:
+        # Patch get_plugin_manager wherever it is used during request dispatch
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
+            with patch("mcpgateway.auth.get_plugin_manager", new_callable=AsyncMock, return_value=mock_plugin_manager):
                 client = TestClient(app)
                 yield client
-            finally:
-                # Restore original middleware stack to avoid affecting other tests
-                app.middleware_stack = saved_stack
 
     def test_x_api_key_transformation_and_authentication(self, test_client_with_http_auth):
         """Test that X-API-Key is transformed to Authorization and user is authenticated."""
@@ -242,7 +220,7 @@ class TestHttpAuthMiddlewareWithoutPlugins:
         # This should fall back to standard JWT/API token validation
 
         # Patch _get_plugin_manager to return None (no plugins)
-        with patch("mcpgateway.plugins.framework.get_plugin_manager", return_value=None):
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=None):
             client = TestClient(app)
 
             # Request without authentication should fail (use POST for initialize)
@@ -253,7 +231,7 @@ class TestHttpAuthMiddlewareWithoutPlugins:
 
     def test_health_endpoint_accessible_without_auth(self, app):
         """Test that health endpoint is accessible without authentication."""
-        with patch("mcpgateway.plugins.framework.get_plugin_manager", return_value=None):
+        with patch("mcpgateway.middleware.http_auth_middleware.get_plugin_manager", new_callable=AsyncMock, return_value=None):
             client = TestClient(app)
 
             response = client.get("/health")
@@ -313,6 +291,7 @@ class TestCustomAuthExamplePlugin:
     @pytest.fixture
     def plugin_config(self):
         """Plugin configuration for testing."""
+        # First-Party
         from mcpgateway.plugins.framework import PluginConfig
 
         return PluginConfig(
@@ -342,6 +321,7 @@ class TestCustomAuthExamplePlugin:
     @pytest.fixture
     def plugin(self, plugin_config):
         """Create plugin instance."""
+        # First-Party
         from plugins.examples.custom_auth_example.custom_auth import CustomAuthPlugin
 
         return CustomAuthPlugin(plugin_config)
@@ -349,6 +329,7 @@ class TestCustomAuthExamplePlugin:
     @pytest.fixture
     def strict_mode_plugin(self):
         """Create plugin instance with strict_mode enabled."""
+        # First-Party
         from mcpgateway.plugins.framework import PluginConfig
         from plugins.examples.custom_auth_example.custom_auth import CustomAuthPlugin
 
@@ -374,6 +355,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_pre_request_transforms_x_api_key(self, plugin):
         """Test that X-API-Key header is transformed to Authorization: Bearer."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPreRequestPayload, PluginContext
 
         payload = HttpPreRequestPayload(
@@ -396,14 +378,13 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_pre_request_does_not_override_existing_authorization(self, plugin):
         """Test that existing Authorization header is not overridden by X-API-Key."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPreRequestPayload, PluginContext
 
         payload = HttpPreRequestPayload(
             path="/protocol/initialize",
             method="POST",
-            headers=HttpHeaderPayload(
-                {"x-api-key": "valid-key-12345", "authorization": "Bearer existing-token", "content-type": "application/json"}
-            ),
+            headers=HttpHeaderPayload({"x-api-key": "valid-key-12345", "authorization": "Bearer existing-token", "content-type": "application/json"}),
             client_host="192.168.1.100",
             client_port=54321,
         )
@@ -417,6 +398,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_pre_request_no_transformation_without_x_api_key(self, plugin):
         """Test that no transformation occurs without X-API-Key header."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPreRequestPayload, PluginContext
 
         payload = HttpPreRequestPayload(
@@ -437,6 +419,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_auth_resolve_user_valid_api_key(self, plugin):
         """Test successful user authentication with valid API key."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, PluginContext
 
         payload = HttpAuthResolveUserPayload(
@@ -460,6 +443,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_auth_resolve_user_admin_api_key(self, plugin):
         """Test admin user authentication with admin API key."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, PluginContext
 
         payload = HttpAuthResolveUserPayload(
@@ -481,6 +465,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_auth_resolve_user_blocked_api_key(self, plugin):
         """Test that blocked API key raises PluginViolationError."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, PluginContext, PluginViolationError
 
         payload = HttpAuthResolveUserPayload(
@@ -500,6 +485,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_auth_resolve_user_invalid_api_key_fallback(self, plugin):
         """Test that invalid API key falls back to standard authentication (non-strict mode)."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, PluginContext
 
         payload = HttpAuthResolveUserPayload(
@@ -519,6 +505,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_auth_resolve_user_invalid_api_key_strict_mode(self, strict_mode_plugin):
         """Test that invalid API key raises error in strict mode."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, PluginContext, PluginViolationError
 
         payload = HttpAuthResolveUserPayload(
@@ -539,6 +526,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_auth_resolve_user_no_credentials_fallback(self, plugin):
         """Test that missing credentials falls back to standard authentication."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, PluginContext
 
         payload = HttpAuthResolveUserPayload(
@@ -557,6 +545,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_post_request_adds_correlation_id(self, plugin):
         """Test that correlation ID is propagated from request to response."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPostRequestPayload, PluginContext
 
         payload = HttpPostRequestPayload(
@@ -578,6 +567,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_post_request_adds_auth_status_success(self, plugin):
         """Test that x-auth-status header is set to 'authenticated' on successful requests."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPostRequestPayload, PluginContext
 
         payload = HttpPostRequestPayload(
@@ -599,6 +589,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_post_request_adds_auth_status_failure(self, plugin):
         """Test that x-auth-status header is set to 'failed' on failed requests."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPostRequestPayload, PluginContext
 
         payload = HttpPostRequestPayload(
@@ -620,6 +611,7 @@ class TestCustomAuthExamplePlugin:
 
     async def test_http_post_request_adds_auth_method_from_context(self, plugin):
         """Test that auth method from local context is added to response headers."""
+        # First-Party
         from mcpgateway.plugins.framework import GlobalContext, HttpHeaderPayload, HttpPostRequestPayload, PluginContext
 
         payload = HttpPostRequestPayload(
@@ -649,6 +641,7 @@ class TestCustomAuthExamplePlugin:
         2. HTTP_AUTH_RESOLVE_USER: Validate API key and return user
         3. HTTP_POST_REQUEST: Add response headers
         """
+        # First-Party
         from mcpgateway.plugins.framework import (
             GlobalContext,
             HttpAuthResolveUserPayload,

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Standard
-import asyncio
 from contextlib import contextmanager
 import importlib
 from types import SimpleNamespace
@@ -385,9 +384,7 @@ async def test_require_admin_permission_forwards_token_teams(monkeypatch):
         await dummy_endpoint(user=user_ctx)
 
     assert exc_info.value.status_code == 403
-    mock_perm_service.check_admin_permission.assert_called_once_with(
-        "user@example.com", token_teams=[]
-    )
+    mock_perm_service.check_admin_permission.assert_called_once_with("user@example.com", token_teams=[])
 
 
 # ============================================================================
@@ -2463,6 +2460,7 @@ def test_get_resource_param_to_model_builds_mapping():
 
 def test_rbac_get_db_emits_deprecation_warning():
     """Verify deprecated get_db() emits DeprecationWarning."""
+    # Standard
     import warnings
 
     with warnings.catch_warnings(record=True) as w:

--- a/tests/unit/mcpgateway/plugins/framework/test_observability.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_observability.py
@@ -503,6 +503,7 @@ async def test_get_plugin_manager_creates_manager_when_enabled():
 @pytest.mark.asyncio
 async def test_get_plugin_manager_returns_none_when_disabled():
     """get_plugin_manager returns None immediately when _PLUGINS_ENABLED is False (line 119)."""
+    # First-Party
     import mcpgateway.plugins.framework as fw
 
     fw.enable_plugins(False)
@@ -513,6 +514,7 @@ async def test_get_plugin_manager_returns_none_when_disabled():
 @pytest.mark.asyncio
 async def test_get_plugin_manager_returns_none_when_factory_missing():
     """get_plugin_manager returns None when enabled but factory not yet initialised (line 122)."""
+    # First-Party
     import mcpgateway.plugins.framework as fw
 
     fw.enable_plugins(True)
@@ -524,8 +526,11 @@ async def test_get_plugin_manager_returns_none_when_factory_missing():
 
 def test_set_global_observability_updates_factory():
     """set_global_observability propagates to the factory when one exists (lines 129-131)."""
-    import mcpgateway.plugins.framework as fw
+    # Standard
     from unittest.mock import MagicMock
+
+    # First-Party
+    import mcpgateway.plugins.framework as fw
 
     mock_factory = MagicMock()
     fw._plugin_manager_factory = mock_factory
@@ -540,8 +545,11 @@ def test_set_global_observability_updates_factory():
 
 def test_reset_plugin_manager_factory_clears_reference():
     """reset_plugin_manager_factory sets the factory to None (line 155)."""
-    import mcpgateway.plugins.framework as fw
+    # Standard
     from unittest.mock import MagicMock
+
+    # First-Party
+    import mcpgateway.plugins.framework as fw
 
     fw._plugin_manager_factory = MagicMock()
     fw.reset_plugin_manager_factory()
@@ -551,8 +559,11 @@ def test_reset_plugin_manager_factory_clears_reference():
 @pytest.mark.asyncio
 async def test_shutdown_plugin_manager_factory_when_disabled():
     """shutdown_plugin_manager_factory is a no-op when _PLUGINS_ENABLED is False (line 145)."""
-    import mcpgateway.plugins.framework as fw
+    # Standard
     from unittest.mock import AsyncMock, MagicMock
+
+    # First-Party
+    import mcpgateway.plugins.framework as fw
 
     mock_factory = MagicMock()
     mock_factory.shutdown = AsyncMock()
@@ -570,8 +581,11 @@ async def test_shutdown_plugin_manager_factory_when_disabled():
 @pytest.mark.asyncio
 async def test_shutdown_plugin_manager_factory_when_enabled():
     """shutdown_plugin_manager_factory calls factory.shutdown() when plugins enabled (lines 144-149)."""
-    import mcpgateway.plugins.framework as fw
+    # Standard
     from unittest.mock import AsyncMock, MagicMock
+
+    # First-Party
+    import mcpgateway.plugins.framework as fw
 
     mock_factory = MagicMock()
     mock_factory.shutdown = AsyncMock()

--- a/tests/unit/mcpgateway/plugins/framework/test_observability.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_observability.py
@@ -478,24 +478,108 @@ def test_protocol_method_bodies():
     assert result2 is None
 
 
-def test_get_plugin_manager_creates_manager_when_enabled():
-    """Test that get_plugin_manager creates a PluginManager when plugins_enabled is True."""
+@pytest.mark.asyncio
+async def test_get_plugin_manager_creates_manager_when_enabled():
+    """Test that get_plugin_manager creates a TenantPluginManager when plugins_enabled is True."""
     # First-Party
     import mcpgateway.plugins.framework as fw
+    from mcpgateway.plugins.framework.manager import TenantPluginManager
 
     recorder = RecordingObservability()
 
-    # Reset the module-level singleton
-    original = fw._plugin_manager
-    fw._plugin_manager = None
-    try:
-        with patch("mcpgateway.plugins.framework.settings.settings") as mock_settings:
-            mock_settings.enabled = True
-            mock_settings.config_file = "./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml"
-            pm = fw.get_plugin_manager(observability=recorder)
+    fw.enable_plugins(True)
+    fw.init_plugin_manager_factory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+        timeout=30,
+        hook_policies={},
+        observability=recorder,
+    )
+    pm = await fw.get_plugin_manager()
 
-        assert pm is not None
-        assert isinstance(pm, PluginManager)
-    finally:
-        fw._plugin_manager = original
-        PluginManager.reset()
+    assert pm is not None
+    assert isinstance(pm, TenantPluginManager)
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_manager_returns_none_when_disabled():
+    """get_plugin_manager returns None immediately when _PLUGINS_ENABLED is False (line 119)."""
+    import mcpgateway.plugins.framework as fw
+
+    fw.enable_plugins(False)
+    result = await fw.get_plugin_manager("any-server")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_manager_returns_none_when_factory_missing():
+    """get_plugin_manager returns None when enabled but factory not yet initialised (line 122)."""
+    import mcpgateway.plugins.framework as fw
+
+    fw.enable_plugins(True)
+    fw.reset_plugin_manager_factory()  # ensures factory is None
+    result = await fw.get_plugin_manager("any-server")
+    assert result is None
+    fw.enable_plugins(False)  # restore default
+
+
+def test_set_global_observability_updates_factory():
+    """set_global_observability propagates to the factory when one exists (lines 129-131)."""
+    import mcpgateway.plugins.framework as fw
+    from unittest.mock import MagicMock
+
+    mock_factory = MagicMock()
+    fw._plugin_manager_factory = mock_factory
+    mock_obs = MagicMock()
+
+    fw.set_global_observability(mock_obs)
+
+    assert fw._observability_service is mock_obs
+    assert mock_factory.observability == mock_obs
+    fw.reset_plugin_manager_factory()
+
+
+def test_reset_plugin_manager_factory_clears_reference():
+    """reset_plugin_manager_factory sets the factory to None (line 155)."""
+    import mcpgateway.plugins.framework as fw
+    from unittest.mock import MagicMock
+
+    fw._plugin_manager_factory = MagicMock()
+    fw.reset_plugin_manager_factory()
+    assert fw._plugin_manager_factory is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_plugin_manager_factory_when_disabled():
+    """shutdown_plugin_manager_factory is a no-op when _PLUGINS_ENABLED is False (line 145)."""
+    import mcpgateway.plugins.framework as fw
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_factory = MagicMock()
+    mock_factory.shutdown = AsyncMock()
+    fw._plugin_manager_factory = mock_factory
+    fw.enable_plugins(False)
+
+    await fw.shutdown_plugin_manager_factory()
+
+    mock_factory.shutdown.assert_not_awaited()
+    # factory reference unchanged since we returned early
+    assert fw._plugin_manager_factory is mock_factory
+    fw.reset_plugin_manager_factory()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_plugin_manager_factory_when_enabled():
+    """shutdown_plugin_manager_factory calls factory.shutdown() when plugins enabled (lines 144-149)."""
+    import mcpgateway.plugins.framework as fw
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_factory = MagicMock()
+    mock_factory.shutdown = AsyncMock()
+    fw._plugin_manager_factory = mock_factory
+    fw.enable_plugins(True)
+
+    await fw.shutdown_plugin_manager_factory()
+
+    mock_factory.shutdown.assert_awaited_once()
+    assert fw._plugin_manager_factory is None
+    fw.enable_plugins(False)  # restore default

--- a/tests/unit/mcpgateway/plugins/framework/test_policies.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_policies.py
@@ -11,8 +11,8 @@ Tests for hook payload policies.
 from unittest.mock import patch
 
 # Third-Party
-import pytest
 from pydantic import BaseModel, Field, ValidationError
+import pytest
 
 # First-Party
 from mcpgateway.plugins.framework.hooks.policies import apply_policy, DefaultHookPolicy, HookPayloadPolicy
@@ -191,6 +191,7 @@ class TestConcreteGatewayPolicies:
     """Tests for the gateway-side HOOK_PAYLOAD_POLICIES."""
 
     def test_all_hook_types_have_policies(self):
+        # First-Party
         from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
 
         expected_hooks = {
@@ -210,6 +211,7 @@ class TestConcreteGatewayPolicies:
         assert set(HOOK_PAYLOAD_POLICIES.keys()) == expected_hooks
 
     def test_tool_pre_invoke_writable_fields(self):
+        # First-Party
         from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
 
         policy = HOOK_PAYLOAD_POLICIES["tool_pre_invoke"]
@@ -218,12 +220,14 @@ class TestConcreteGatewayPolicies:
         assert "headers" in policy.writable_fields
 
     def test_tool_post_invoke_writable_fields(self):
+        # First-Party
         from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
 
         policy = HOOK_PAYLOAD_POLICIES["tool_post_invoke"]
         assert policy.writable_fields == frozenset({"result"})
 
     def test_agent_pre_invoke_includes_agent_id(self):
+        # First-Party
         from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
 
         policy = HOOK_PAYLOAD_POLICIES["agent_pre_invoke"]
@@ -234,6 +238,7 @@ class TestAgentMessageCoercion:
     """Tests for _coerce_messages field validator on agent payloads."""
 
     def test_pre_invoke_dict_messages_coerced(self):
+        # First-Party
         from mcpgateway.plugins.framework.hooks.agents import AgentPreInvokePayload
         from mcpgateway.plugins.framework.utils import StructuredData
 
@@ -246,6 +251,7 @@ class TestAgentMessageCoercion:
         assert payload.messages[0].content.text == "hello"
 
     def test_post_invoke_dict_messages_coerced(self):
+        # First-Party
         from mcpgateway.plugins.framework.hooks.agents import AgentPostInvokePayload
         from mcpgateway.plugins.framework.utils import StructuredData
 
@@ -257,6 +263,7 @@ class TestAgentMessageCoercion:
         assert payload.messages[0].content.text == "world"
 
     def test_real_message_objects_pass_through(self):
+        # First-Party
         from mcpgateway.common.models import Message, Role, TextContent
         from mcpgateway.plugins.framework.hooks.agents import AgentPreInvokePayload
 
@@ -265,6 +272,7 @@ class TestAgentMessageCoercion:
         assert payload.messages[0] is msg
 
     def test_empty_messages_list(self):
+        # First-Party
         from mcpgateway.plugins.framework.hooks.agents import AgentPreInvokePayload
 
         payload = AgentPreInvokePayload(agent_id="agent-1", messages=[])
@@ -275,6 +283,7 @@ class TestProtocolConformance:
     """Verify gateway concrete types satisfy framework protocols."""
 
     def test_message_satisfies_message_like(self):
+        # First-Party
         from mcpgateway.common.models import Message, Role, TextContent
         from mcpgateway.plugins.framework.protocols import MessageLike
 
@@ -282,6 +291,7 @@ class TestProtocolConformance:
         assert isinstance(msg, MessageLike)
 
     def test_prompt_result_satisfies_prompt_result_like(self):
+        # First-Party
         from mcpgateway.common.models import Message, PromptResult, Role, TextContent
         from mcpgateway.plugins.framework.protocols import PromptResultLike
 
@@ -292,8 +302,10 @@ class TestProtocolConformance:
         assert isinstance(result, PromptResultLike)
 
     def test_simple_namespace_satisfies_message_like(self):
+        # Standard
         from types import SimpleNamespace
 
+        # First-Party
         from mcpgateway.plugins.framework.protocols import MessageLike
 
         msg = SimpleNamespace(role="user", content="hello")
@@ -304,6 +316,7 @@ class TestPromptPosthookCoercion:
     """Tests for PromptPosthookPayload._coerce_result field validator."""
 
     def test_dict_result_coerced_to_structured_data(self):
+        # First-Party
         from mcpgateway.plugins.framework.hooks.prompts import PromptPosthookPayload
         from mcpgateway.plugins.framework.utils import StructuredData
 
@@ -315,8 +328,10 @@ class TestPromptPosthookCoercion:
         assert payload.result.messages[0].content.text == "hi"
 
     def test_non_dict_result_passthrough(self):
+        # Standard
         from types import SimpleNamespace
 
+        # First-Party
         from mcpgateway.plugins.framework.hooks.prompts import PromptPosthookPayload
 
         ns = SimpleNamespace(messages=[], description=None)
@@ -324,6 +339,7 @@ class TestPromptPosthookCoercion:
         assert payload.result is ns
 
     def test_pydantic_model_result_passthrough(self):
+        # First-Party
         from mcpgateway.plugins.framework.hooks.prompts import PromptPosthookPayload
 
         class FakeResult(BaseModel):
@@ -340,6 +356,7 @@ class TestExecutorPolicyEnforcement:
 
     @pytest.mark.asyncio
     async def test_explicit_policy_filters_writable_fields(self):
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -372,6 +389,7 @@ class TestExecutorPolicyEnforcement:
 
     @pytest.mark.asyncio
     async def test_default_deny_rejects_modifications(self):
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -405,6 +423,7 @@ class TestExecutorPolicyEnforcement:
 
     @pytest.mark.asyncio
     async def test_explicit_policy_no_effective_change(self):
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -438,6 +457,7 @@ class TestExecutorPolicyEnforcement:
     @pytest.mark.asyncio
     async def test_in_place_nested_mutation_caught_by_policy(self):
         """Plugins that mutate nested dicts in place should not bypass policy filtering."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -483,6 +503,7 @@ class TestExecutorPolicyEnforcement:
         """When an ENFORCE plugin short-circuits after a prior plugin made
         policy-approved modifications, the early return must carry those
         filtered modifications via current_payload — not the raw result."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginMode, PluginResult
@@ -530,6 +551,7 @@ class TestExecutorPolicyEnforcement:
     async def test_enforce_early_return_carries_metadata(self):
         """The early-return path must carry accumulated metadata from earlier
         plugins, consistent with the normal return path."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginMode, PluginResult
@@ -571,6 +593,7 @@ class TestExecutorPolicyEnforcement:
     async def test_enforce_early_return_deny_default_rejects_all(self):
         """When default=deny and an ENFORCE plugin short-circuits with modifications,
         all modifications must be rejected (modified_payload=None)."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginMode, PluginResult
@@ -610,6 +633,7 @@ class TestCrossTypePolicyHandling:
     async def test_cross_type_result_accepted_when_policy_exists(self):
         """When modified_payload is a different PluginPayload subtype from the
         input, the policy's presence authorises the hook and the result is accepted."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginPayload, PluginResult
@@ -640,6 +664,7 @@ class TestCrossTypePolicyHandling:
     @pytest.mark.asyncio
     async def test_cross_type_dict_result_accepted_when_policy_exists(self):
         """dict results (e.g. http_auth_resolve_user) are accepted when a policy exists."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -665,6 +690,7 @@ class TestCrossTypePolicyHandling:
     @pytest.mark.asyncio
     async def test_deny_default_snapshots_payload_for_in_place_isolation(self):
         """When default=deny, in-place nested mutations must not persist on the live payload."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -697,23 +723,27 @@ class TestCrossTypePolicyHandling:
 class TestBorgPolicyBackfill:
     """Tests for PluginManager Borg pattern policy injection."""
 
-    def test_get_plugin_manager_injects_policies(self, monkeypatch, tmp_path):
-        """Verify get_plugin_manager() always injects hook policies."""
+    @pytest.mark.asyncio
+    async def test_get_plugin_manager_injects_policies(self, monkeypatch, tmp_path):
+        """Verify get_plugin_manager() always injects hook policies into the DBPluginManager."""
+        # First-Party
         import mcpgateway.plugins.framework as fw
-        from mcpgateway.plugins.framework.settings import settings as plugin_settings
+        from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
 
         config_file = tmp_path / "plugins.yaml"
         config_file.write_text("plugin_settings:\n  plugin_timeout: 30\nplugin_dirs: []\nplugins: []\n")
 
-        monkeypatch.setenv("PLUGINS_ENABLED", "true")
+        fw.enable_plugins(True)
         monkeypatch.setenv("PLUGINS_CONFIG_FILE", str(config_file))
 
-        # Reset singleton state
-        fw.PluginManager.reset()
-        fw._plugin_manager = None
-        plugin_settings.cache_clear()
+        # Initialize factory with policies
+        fw.init_plugin_manager_factory(
+            yaml_path=str(config_file),
+            timeout=30,
+            hook_policies=HOOK_PAYLOAD_POLICIES,
+        )
 
-        pm = fw.get_plugin_manager()
+        pm = await fw.get_plugin_manager()
         assert pm is not None
         assert pm._executor.hook_policies, "get_plugin_manager() should inject hook policies"
 
@@ -721,27 +751,37 @@ class TestBorgPolicyBackfill:
         assert "tool_pre_invoke" in pm._executor.hook_policies
         assert "prompt_post_fetch" in pm._executor.hook_policies
 
-    def test_service_via_get_plugin_manager_has_policies(self, monkeypatch, tmp_path):
+    async def test_service_via_get_plugin_manager_has_policies(self, monkeypatch, tmp_path):
         """Verify that services using get_plugin_manager() get policies regardless of creation order."""
+        # First-Party
         import mcpgateway.plugins.framework as fw
         from mcpgateway.plugins.framework.settings import settings as plugin_settings
+        from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
 
         config_file = tmp_path / "plugins.yaml"
         config_file.write_text("plugin_settings:\n  plugin_timeout: 30\nplugin_dirs: []\nplugins: []\n")
 
-        monkeypatch.setenv("PLUGINS_ENABLED", "true")
+        fw.enable_plugins(True)
         monkeypatch.setenv("PLUGINS_CONFIG_FILE", str(config_file))
 
         # Reset state
-        fw.PluginManager.reset()
-        fw._plugin_manager = None
+        if fw._plugin_manager_factory is not None:
+            await fw._plugin_manager_factory.shutdown()
+        fw._plugin_manager_factory = None
         plugin_settings.cache_clear()
 
+        # Initialize factory with policies
+        fw.init_plugin_manager_factory(
+            yaml_path=str(config_file),
+            timeout=30,
+            hook_policies=HOOK_PAYLOAD_POLICIES,
+        )
+
         # Simulate service creating manager via get_plugin_manager
-        pm1 = fw.get_plugin_manager()
+        pm1 = await fw.get_plugin_manager()
 
         # Simulate another access (e.g. from another service)
-        pm2 = fw.get_plugin_manager()
+        pm2 = await fw.get_plugin_manager()
 
         # Both should share the same executor with policies
         assert pm1 is pm2
@@ -750,6 +790,7 @@ class TestBorgPolicyBackfill:
     @pytest.mark.asyncio
     async def test_policy_enforcement_through_manager(self, monkeypatch, tmp_path):
         """Integration test: policies enforced through PluginManager.execute flow."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.hooks.policies import HookPayloadPolicy
         from mcpgateway.plugins.framework.manager import PluginExecutor
@@ -791,6 +832,7 @@ class TestFrameworkImportIsolation:
     """Verify the plugin framework has no remaining imports from mcpgateway.common or mcpgateway.utils."""
 
     def test_no_common_or_utils_imports_in_framework(self):
+        # Standard
         import ast
         from pathlib import Path
 
@@ -823,6 +865,7 @@ class TestMultiPluginDictChain:
     async def test_dict_payload_deep_copied_for_next_plugin(self):
         """When plugin 1 returns a dict, the next plugin receives a deep-copied
         dict without crashing on model_copy (which dicts don't have)."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -861,6 +904,7 @@ class TestMultiPluginDictChain:
     async def test_dict_to_dict_accepted_without_apply_policy(self):
         """When effective_payload is a dict and plugin also returns a dict,
         the result is accepted directly (not routed through apply_policy)."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -895,6 +939,7 @@ class TestMultiPluginDictChain:
     async def test_empty_dict_payload_not_dropped_by_truthiness(self):
         """An empty dict returned by a plugin must not be replaced by the
         original payload due to falsy truthiness evaluation."""
+        # First-Party
         from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
         from mcpgateway.plugins.framework.manager import PluginExecutor
         from mcpgateway.plugins.framework.models import GlobalContext, PluginConfig, PluginResult
@@ -927,6 +972,7 @@ class TestMultiPluginDictChain:
 @pytest.mark.asyncio
 async def test_http_auth_permission_result_includes_decision_plugin_provenance():
     """Permission hook decisions should carry deciding plugin identity even with empty plugin metadata."""
+    # First-Party
     from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
     from mcpgateway.plugins.framework.hooks.http import HttpAuthCheckPermissionPayload, HttpAuthCheckPermissionResultPayload
     from mcpgateway.plugins.framework.manager import PluginExecutor
@@ -951,6 +997,7 @@ async def test_http_auth_permission_result_includes_decision_plugin_provenance()
 @pytest.mark.asyncio
 async def test_http_auth_permission_provenance_overrides_forged_metadata_from_decider():
     """Manager-owned provenance must overwrite forged plugin metadata keys."""
+    # First-Party
     from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
     from mcpgateway.plugins.framework.hooks.http import HttpAuthCheckPermissionPayload, HttpAuthCheckPermissionResultPayload
     from mcpgateway.plugins.framework.manager import PluginExecutor
@@ -978,6 +1025,7 @@ async def test_http_auth_permission_provenance_overrides_forged_metadata_from_de
 @pytest.mark.asyncio
 async def test_http_auth_permission_provenance_uses_actual_decider_in_multi_plugin_chain():
     """Metadata-only plugins must not control provenance when a later plugin decides."""
+    # First-Party
     from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
     from mcpgateway.plugins.framework.hooks.http import HttpAuthCheckPermissionPayload, HttpAuthCheckPermissionResultPayload
     from mcpgateway.plugins.framework.manager import PluginExecutor
@@ -1019,6 +1067,7 @@ async def test_http_auth_permission_provenance_uses_actual_decider_in_multi_plug
 @pytest.mark.asyncio
 async def test_http_auth_permission_enforce_short_circuit_records_decision_plugin():
     """ENFORCE short-circuit path should still persist authoritative decision provenance."""
+    # First-Party
     from mcpgateway.plugins.framework.base import HookRef, Plugin, PluginRef
     from mcpgateway.plugins.framework.hooks.http import HttpAuthCheckPermissionPayload, HttpAuthCheckPermissionResultPayload
     from mcpgateway.plugins.framework.manager import PluginExecutor

--- a/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
@@ -218,12 +218,14 @@ async def test_factory_tool_without_overrides():
 @pytest.mark.asyncio
 async def test_tenant_plugin_manager_with_config_object():
     """Test TenantPluginManager initialization with Config object instead of path."""
+    # First-Party
     from mcpgateway.plugins.framework.loader.config import ConfigLoader
 
     # Load config from file
     config = ConfigLoader.load_config("./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
 
     # Create manager with Config object
+    # First-Party
     from mcpgateway.plugins.framework.manager import TenantPluginManager
 
     manager = TenantPluginManager(config=config)
@@ -239,8 +241,11 @@ async def test_tenant_plugin_manager_with_config_object():
 @pytest.mark.asyncio
 async def test_factory_observability_setter():
     """Test that observability setter updates the provider."""
-    from mcpgateway.plugins.framework.observability import ObservabilityProvider
+    # Standard
     from unittest.mock import Mock
+
+    # First-Party
+    from mcpgateway.plugins.framework.observability import ObservabilityProvider
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
 
@@ -280,6 +285,7 @@ async def test_factory_concurrent_same_context():
 @pytest.mark.asyncio
 async def test_factory_build_manager_cancelled():
     """Test that cancelled build task properly cleans up."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -302,6 +308,7 @@ async def test_factory_build_manager_cancelled():
 @pytest.mark.asyncio
 async def test_factory_build_manager_exception():
     """Test that exception during build properly cleans up."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -337,6 +344,7 @@ async def test_factory_merge_tenant_config_none():
 @pytest.mark.asyncio
 async def test_factory_reload_shutdown_exception():
     """Test that reload handles old manager shutdown exception gracefully."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -361,6 +369,7 @@ async def test_factory_reload_shutdown_exception():
 @pytest.mark.asyncio
 async def test_factory_reload_cancels_inflight():
     """Test that reload cancels any existing inflight build task."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -392,6 +401,7 @@ async def test_factory_reload_cancels_inflight():
 @pytest.mark.asyncio
 async def test_factory_shutdown_with_exceptions():
     """Test that shutdown handles manager shutdown exceptions gracefully."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -414,6 +424,7 @@ async def test_factory_shutdown_with_exceptions():
 @pytest.mark.asyncio
 async def test_factory_shutdown_cancels_inflight():
     """Test that shutdown cancels all inflight build tasks."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -428,6 +439,7 @@ async def test_factory_shutdown_cancels_inflight():
 @pytest.mark.asyncio
 async def test_tenant_plugin_manager_with_string_path():
     """Test TenantPluginManager initialization with string path."""
+    # First-Party
     from mcpgateway.plugins.framework.manager import TenantPluginManager
 
     # Create manager with string path (not Config object)
@@ -471,6 +483,7 @@ async def test_factory_merge_with_overrides():
 @pytest.mark.asyncio
 async def test_factory_build_manager_old_shutdown_fails():
     """Test that _build_manager handles old manager shutdown failure."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -495,6 +508,7 @@ async def test_factory_build_manager_old_shutdown_fails():
 @pytest.mark.asyncio
 async def test_factory_reload_inflight_cleanup():
     """Test that reload properly cleans up inflight tasks."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -542,6 +556,7 @@ async def test_factory_shutdown_empty_inflight():
 @pytest.mark.asyncio
 async def test_factory_shutdown_with_active_inflight():
     """Test shutdown cancels active inflight build tasks."""
+    # Standard
     from unittest.mock import AsyncMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
@@ -569,11 +584,12 @@ async def test_factory_shutdown_with_active_inflight():
 @pytest.mark.asyncio
 async def test_factory_merge_with_plugin_config_override():
     """Test _merge_tenant_config properly merges plugin configurations."""
+    # First-Party
     from mcpgateway.plugins.framework.loader.config import ConfigLoader
 
     # Create a base config with a plugin
     base_yaml = "./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml"
-    base_config = ConfigLoader.load_config(base_yaml)
+    ConfigLoader.load_config(base_yaml)
 
     factory = ToolScopedPluginManagerFactory(yaml_path=base_yaml)
 
@@ -596,7 +612,8 @@ async def test_factory_merge_with_plugin_config_override():
 @pytest.mark.asyncio
 async def test_factory_build_manager_cancelled_with_shutdown_error():
     """Test _build_manager handles CancelledError with shutdown exception."""
-    from unittest.mock import AsyncMock, patch, MagicMock
+    # Standard
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
 
@@ -625,7 +642,8 @@ async def test_factory_build_manager_cancelled_with_shutdown_error():
 @pytest.mark.asyncio
 async def test_factory_build_manager_exception_with_shutdown_error():
     """Test _build_manager handles Exception with shutdown exception."""
-    from unittest.mock import AsyncMock, patch, MagicMock
+    # Standard
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
 
@@ -654,6 +672,7 @@ async def test_factory_build_manager_exception_with_shutdown_error():
 @pytest.mark.asyncio
 async def test_factory_merge_config_with_mode_and_priority():
     """Test _merge_tenant_config properly handles mode and priority overrides."""
+    # First-Party
     from mcpgateway.plugins.framework.loader.config import ConfigLoader
     from mcpgateway.plugins.framework.models import PluginConfig
 
@@ -701,6 +720,7 @@ async def test_factory_merge_config_with_mode_and_priority():
 @pytest.mark.asyncio
 async def test_factory_merge_config_no_override_for_plugin():
     """Test _merge_tenant_config keeps original plugin when no override exists."""
+    # First-Party
     from mcpgateway.plugins.framework.loader.config import ConfigLoader
     from mcpgateway.plugins.framework.models import PluginConfig
 

--- a/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
@@ -1,0 +1,756 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Tests for TenantPluginManagerFactory using tool_id as context scoping.
+
+This test suite demonstrates that the factory can be used with any context identifier,
+including tool IDs, to create isolated plugin manager instances per tool.
+"""
+
+# Standard
+import asyncio
+from typing import Optional
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+from mcpgateway.plugins.framework.models import PluginConfigOverride, PluginMode
+
+
+class ToolScopedPluginManagerFactory(TenantPluginManagerFactory):
+    """Factory that uses tool_id as context for plugin configuration."""
+
+    def __init__(self, yaml_path: str, tool_configs: Optional[dict[str, list[PluginConfigOverride]]] = None):
+        """Initialize factory with tool-specific configurations.
+
+        Args:
+            yaml_path: Path to base plugin configuration.
+            tool_configs: Dict mapping tool_id to list of plugin overrides.
+        """
+        super().__init__(yaml_path=yaml_path)
+        self._tool_configs = tool_configs or {}
+
+    async def get_config_from_db(self, context_id: str) -> Optional[list[PluginConfigOverride]]:
+        """Get plugin configuration overrides for a specific tool.
+
+        Args:
+            context_id: The tool_id to fetch overrides for.
+
+        Returns:
+            List of plugin configuration overrides for this tool, or None.
+        """
+        return self._tool_configs.get(context_id)
+
+
+@pytest.mark.asyncio
+async def test_factory_with_tool_id_scoping():
+    """Test that factory can use tool_id as context for isolated plugin managers."""
+    # Define tool-specific plugin configurations
+    tool_configs = {
+        "tool_calculator": [
+            PluginConfigOverride(
+                name="ArgumentNormalizer",
+                mode=PluginMode.ENFORCE,
+                priority=10,
+                config={"normalize_numbers": True},
+            )
+        ],
+        "tool_file_reader": [
+            PluginConfigOverride(
+                name="ArgumentNormalizer",
+                mode=PluginMode.PERMISSIVE,
+                priority=50,
+                config={"normalize_paths": True},
+            )
+        ],
+    }
+
+    # Create factory with tool-scoped configurations
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+        tool_configs=tool_configs,
+    )
+
+    try:
+        # Get manager for calculator tool
+        calc_manager = await factory.get_manager(context_id="tool_calculator")
+        assert calc_manager is not None
+        assert calc_manager.initialized
+
+        # Get manager for file reader tool
+        file_manager = await factory.get_manager(context_id="tool_file_reader")
+        assert file_manager is not None
+        assert file_manager.initialized
+
+        # Verify they are different instances
+        assert calc_manager is not file_manager
+
+        # Get calculator manager again - should return cached instance
+        calc_manager_2 = await factory.get_manager(context_id="tool_calculator")
+        assert calc_manager_2 is calc_manager
+
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_with_default_tool_context():
+    """Test that factory uses default context when no tool_id is provided."""
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Get manager without context_id - should use default
+        default_manager = await factory.get_manager()
+        assert default_manager is not None
+        assert default_manager.initialized
+
+        # Get manager with explicit None - should return same default
+        default_manager_2 = await factory.get_manager(context_id=None)
+        assert default_manager_2 is default_manager
+
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_tool_context():
+    """Test that factory can reload a tool-specific manager."""
+    tool_configs = {
+        "tool_api_client": [
+            PluginConfigOverride(
+                name="ArgumentNormalizer",
+                mode=PluginMode.ENFORCE,
+                priority=20,
+            )
+        ],
+    }
+
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+        tool_configs=tool_configs,
+    )
+
+    try:
+        # Get initial manager
+        manager1 = await factory.get_manager(context_id="tool_api_client")
+        assert manager1 is not None
+
+        # Reload the manager
+        manager2 = await factory.reload_tenant(context_id="tool_api_client")
+        assert manager2 is not None
+        assert manager2 is not manager1  # Should be a new instance
+
+        # Get manager again - should return the reloaded one
+        manager3 = await factory.get_manager(context_id="tool_api_client")
+        assert manager3 is manager2
+
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_concurrent_tool_access():
+    """Test that factory handles concurrent access to different tool contexts safely."""
+    tool_configs = {
+        f"tool_{i}": [
+            PluginConfigOverride(
+                name="ArgumentNormalizer",
+                mode=PluginMode.ENFORCE,
+                priority=i * 10,
+            )
+        ]
+        for i in range(5)
+    }
+
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+        tool_configs=tool_configs,
+    )
+
+    try:
+        # Concurrently request managers for different tools
+        tasks = [factory.get_manager(context_id=f"tool_{i}") for i in range(5)]
+        managers = await asyncio.gather(*tasks)
+
+        # Verify all managers were created
+        assert len(managers) == 5
+        assert all(m is not None for m in managers)
+        assert all(m.initialized for m in managers)
+
+        # Verify they are all different instances
+        assert len(set(id(m) for m in managers)) == 5
+
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_tool_without_overrides():
+    """Test that factory works for tools without specific overrides."""
+    tool_configs = {
+        "tool_with_config": [
+            PluginConfigOverride(
+                name="ArgumentNormalizer",
+                mode=PluginMode.ENFORCE,
+            )
+        ],
+    }
+
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+        tool_configs=tool_configs,
+    )
+
+    try:
+        # Get manager for tool without overrides - should use base config
+        manager = await factory.get_manager(context_id="tool_without_config")
+        assert manager is not None
+        assert manager.initialized
+
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_tenant_plugin_manager_with_config_object():
+    """Test TenantPluginManager initialization with Config object instead of path."""
+    from mcpgateway.plugins.framework.loader.config import ConfigLoader
+
+    # Load config from file
+    config = ConfigLoader.load_config("./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    # Create manager with Config object
+    from mcpgateway.plugins.framework.manager import TenantPluginManager
+
+    manager = TenantPluginManager(config=config)
+    try:
+        await manager.initialize()
+        assert manager.initialized
+        assert manager._config_path is None
+        assert manager._config is config
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_observability_setter():
+    """Test that observability setter updates the provider."""
+    from mcpgateway.plugins.framework.observability import ObservabilityProvider
+    from unittest.mock import Mock
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Initially None
+        assert factory.observability is None
+
+        # Set observability provider (mock it since it's a Protocol)
+        mock_provider = Mock(spec=ObservabilityProvider)
+        factory.observability = mock_provider
+        assert factory.observability is mock_provider
+
+        # Clear observability
+        factory.observability = None
+        assert factory.observability is None
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_concurrent_same_context():
+    """Test that concurrent requests for same context return same manager."""
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Request same context concurrently
+        tasks = [factory.get_manager(context_id="same_tool") for _ in range(5)]
+        managers = await asyncio.gather(*tasks)
+
+        # All should be the same instance
+        assert len(set(id(m) for m in managers)) == 1
+        assert all(m.initialized for m in managers)
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_build_manager_cancelled():
+    """Test that cancelled build task properly cleans up."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Mock initialize to simulate cancellation
+        with patch("mcpgateway.plugins.framework.manager.TenantPluginManager.initialize", new_callable=AsyncMock) as mock_init:
+            mock_init.side_effect = asyncio.CancelledError()
+
+            # Attempt to get manager - should raise CancelledError
+            with pytest.raises(asyncio.CancelledError):
+                await factory.get_manager(context_id="cancelled_tool")
+
+            # Verify inflight was cleaned up
+            assert "cancelled_tool" not in factory._inflight
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_build_manager_exception():
+    """Test that exception during build properly cleans up."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Mock initialize to raise exception
+        with patch("mcpgateway.plugins.framework.manager.TenantPluginManager.initialize", new_callable=AsyncMock) as mock_init:
+            mock_init.side_effect = RuntimeError("Init failed")
+
+            # Attempt to get manager - should raise RuntimeError
+            with pytest.raises(RuntimeError, match="Init failed"):
+                await factory.get_manager(context_id="error_tool")
+
+            # Verify inflight was cleaned up
+            assert "error_tool" not in factory._inflight
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_merge_tenant_config_none():
+    """Test _merge_tenant_config with None override returns base config."""
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Call with None should return base config
+        merged = factory._merge_tenant_config(None)
+        assert merged is factory._base_config
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_shutdown_exception():
+    """Test that reload handles old manager shutdown exception gracefully."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Get initial manager
+        manager1 = await factory.get_manager(context_id="reload_error_tool")
+        assert manager1 is not None
+
+        # Mock shutdown to raise exception
+        with patch.object(manager1, "shutdown", new_callable=AsyncMock) as mock_shutdown:
+            mock_shutdown.side_effect = RuntimeError("Shutdown failed")
+
+            # Reload should succeed despite shutdown error
+            manager2 = await factory.reload_tenant(context_id="reload_error_tool")
+            assert manager2 is not None
+            assert manager2 is not manager1
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_cancels_inflight():
+    """Test that reload cancels any existing inflight build task."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Start a slow build
+        with patch("mcpgateway.plugins.framework.manager.TenantPluginManager.initialize", new_callable=AsyncMock) as mock_init:
+            # Make initialize slow
+            async def slow_init():
+                await asyncio.sleep(1)
+
+            mock_init.side_effect = slow_init
+
+            # Start build in background
+            task = asyncio.create_task(factory.get_manager(context_id="slow_tool"))
+            await asyncio.sleep(0.1)  # Let it start
+
+            # Reload should cancel the inflight task
+            manager = await factory.reload_tenant(context_id="slow_tool")
+            assert manager is not None
+
+            # Original task should be cancelled
+            with pytest.raises(asyncio.CancelledError):
+                await task
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_shutdown_with_exceptions():
+    """Test that shutdown handles manager shutdown exceptions gracefully."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    # Create multiple managers
+    manager1 = await factory.get_manager(context_id="tool1")
+    manager2 = await factory.get_manager(context_id="tool2")
+
+    # Mock shutdown to raise exception for one manager
+    with patch.object(manager1, "shutdown", new_callable=AsyncMock) as mock_shutdown1:
+        mock_shutdown1.side_effect = RuntimeError("Shutdown failed")
+
+        # Shutdown should complete despite exception
+        await factory.shutdown()
+
+        # Verify both managers were attempted to shutdown
+        assert mock_shutdown1.called
+
+
+@pytest.mark.asyncio
+async def test_factory_shutdown_cancels_inflight():
+    """Test that shutdown cancels all inflight build tasks."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    # Start multiple slow builds
+    with patch("mcpgateway.plugins.framework.manager.TenantPluginManager.initialize", new_callable=AsyncMock) as mock_init:
+        # Make initialize slow
+        async def slow_init():
+            await asyncio.sleep(2)
+
+
+@pytest.mark.asyncio
+async def test_tenant_plugin_manager_with_string_path():
+    """Test TenantPluginManager initialization with string path."""
+    from mcpgateway.plugins.framework.manager import TenantPluginManager
+
+    # Create manager with string path (not Config object)
+    manager = TenantPluginManager(config="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+    try:
+        await manager.initialize()
+        assert manager.initialized
+        assert manager._config_path == "./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml"
+        assert manager._config is not None
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_merge_with_overrides():
+    """Test _merge_tenant_config with actual overrides."""
+    tool_configs = {
+        "tool_with_override": [
+            PluginConfigOverride(
+                name="TestPlugin",
+                mode=PluginMode.PERMISSIVE,
+                priority=99,
+                config={"new_setting": "value"},
+            )
+        ],
+    }
+
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+        tool_configs=tool_configs,
+    )
+
+    try:
+        # Get manager which will trigger merge
+        manager = await factory.get_manager(context_id="tool_with_override")
+        assert manager is not None
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_build_manager_old_shutdown_fails():
+    """Test that _build_manager handles old manager shutdown failure."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Get initial manager
+        manager1 = await factory.get_manager(context_id="test_old_shutdown")
+        assert manager1 is not None
+
+        # Mock shutdown to fail
+        with patch.object(manager1, "shutdown", new_callable=AsyncMock) as mock_shutdown:
+            mock_shutdown.side_effect = RuntimeError("Shutdown failed")
+
+            # Get manager again with different config to trigger replacement
+            # This should handle the shutdown exception gracefully
+            manager2 = await factory.get_manager(context_id="test_old_shutdown")
+            assert manager2 is not None
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_inflight_cleanup():
+    """Test that reload properly cleans up inflight tasks."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Start a slow build
+        with patch("mcpgateway.plugins.framework.manager.TenantPluginManager.initialize", new_callable=AsyncMock) as mock_init:
+            # Make initialize slow
+            async def slow_init():
+                await asyncio.sleep(2)
+
+            mock_init.side_effect = slow_init
+
+            # Start build in background
+            task = asyncio.create_task(factory.get_manager(context_id="slow_reload"))
+            await asyncio.sleep(0.1)  # Let it start
+
+            # Reload should cancel and clean up
+            manager = await factory.reload_tenant(context_id="slow_reload")
+            assert manager is not None
+
+            # Verify inflight was cleaned up in finally block
+            assert "slow_reload" not in factory._inflight
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_shutdown_empty_inflight():
+    """Test shutdown with no inflight tasks."""
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    # Create some managers
+    await factory.get_manager(context_id="tool1")
+    await factory.get_manager(context_id="tool2")
+
+    # Shutdown should handle empty inflight list
+    await factory.shutdown()
+
+    # Verify cleanup
+    assert len(factory._managers) == 0
+    assert len(factory._inflight) == 0
+
+
+@pytest.mark.asyncio
+async def test_factory_shutdown_with_active_inflight():
+    """Test shutdown cancels active inflight build tasks."""
+    from unittest.mock import AsyncMock, patch
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    # Start multiple slow builds
+    with patch("mcpgateway.plugins.framework.manager.TenantPluginManager.initialize", new_callable=AsyncMock) as mock_init:
+        # Make initialize slow
+        async def slow_init():
+            await asyncio.sleep(5)
+
+        mock_init.side_effect = slow_init
+
+        # Start builds in background
+        tasks = [asyncio.create_task(factory.get_manager(context_id=f"tool{i}")) for i in range(3)]
+        await asyncio.sleep(0.1)  # Let them start
+
+        # Shutdown should cancel all inflight tasks
+        await factory.shutdown()
+
+        # All tasks should be cancelled or done
+        for task in tasks:
+            assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_factory_merge_with_plugin_config_override():
+    """Test _merge_tenant_config properly merges plugin configurations."""
+    from mcpgateway.plugins.framework.loader.config import ConfigLoader
+
+    # Create a base config with a plugin
+    base_yaml = "./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml"
+    base_config = ConfigLoader.load_config(base_yaml)
+
+    factory = ToolScopedPluginManagerFactory(yaml_path=base_yaml)
+
+    try:
+        # Create override with config merge
+        override = PluginConfigOverride(
+            name="TestPlugin",
+            mode=PluginMode.PERMISSIVE,
+            priority=99,
+            config={"new_key": "new_value"},
+        )
+
+        # Test merge
+        merged = factory._merge_tenant_config([override])
+        assert merged is not None
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_build_manager_cancelled_with_shutdown_error():
+    """Test _build_manager handles CancelledError with shutdown exception."""
+    from unittest.mock import AsyncMock, patch, MagicMock
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Create a manager mock that will fail on shutdown
+        manager_mock = MagicMock()
+        manager_mock.shutdown = AsyncMock(side_effect=RuntimeError("Shutdown failed"))
+
+        with patch("mcpgateway.plugins.framework.manager.TenantPluginManager") as MockManager:
+            # Make the constructor return our mock
+            MockManager.return_value = manager_mock
+
+            # Make initialize raise CancelledError
+            manager_mock.initialize = AsyncMock(side_effect=asyncio.CancelledError())
+
+            # Attempt to get manager - should raise CancelledError
+            with pytest.raises(asyncio.CancelledError):
+                await factory.get_manager(context_id="cancelled_with_error")
+
+            # Verify shutdown was attempted despite the error
+            manager_mock.shutdown.assert_called_once()
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_build_manager_exception_with_shutdown_error():
+    """Test _build_manager handles Exception with shutdown exception."""
+    from unittest.mock import AsyncMock, patch, MagicMock
+
+    factory = ToolScopedPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Create a manager mock that will fail on shutdown
+        manager_mock = MagicMock()
+        manager_mock.shutdown = AsyncMock(side_effect=RuntimeError("Shutdown failed"))
+
+        with patch("mcpgateway.plugins.framework.manager.TenantPluginManager") as MockManager:
+            # Make the constructor return our mock
+            MockManager.return_value = manager_mock
+
+            # Make initialize raise a regular exception
+            manager_mock.initialize = AsyncMock(side_effect=ValueError("Init failed"))
+
+            # Attempt to get manager - should raise ValueError
+            with pytest.raises(ValueError, match="Init failed"):
+                await factory.get_manager(context_id="error_with_shutdown_error")
+
+            # Verify shutdown was attempted despite the error
+            manager_mock.shutdown.assert_called_once()
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_merge_config_with_mode_and_priority():
+    """Test _merge_tenant_config properly handles mode and priority overrides."""
+    from mcpgateway.plugins.framework.loader.config import ConfigLoader
+    from mcpgateway.plugins.framework.models import PluginConfig
+
+    # Create a base config with a plugin
+    base_yaml = "./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml"
+    base_config = ConfigLoader.load_config(base_yaml)
+
+    # Add a plugin to base config for testing
+    test_plugin = PluginConfig(
+        name="TestPlugin",
+        kind="test.plugin.TestPlugin",
+        hooks=["prompt_pre_fetch"],
+        mode=PluginMode.ENFORCE,
+        priority=50,
+        config={"base_key": "base_value"},
+    )
+    base_config.plugins = [test_plugin]
+
+    factory = ToolScopedPluginManagerFactory(yaml_path=base_yaml)
+    factory._base_config = base_config
+
+    try:
+        # Create override with mode, priority, and config
+        override = PluginConfigOverride(
+            name="TestPlugin",
+            mode=PluginMode.PERMISSIVE,
+            priority=99,
+            config={"override_key": "override_value"},
+        )
+
+        # Test merge
+        merged = factory._merge_tenant_config([override])
+        assert merged is not None
+        assert len(merged.plugins) == 1
+
+        merged_plugin = merged.plugins[0]
+        assert merged_plugin.mode == PluginMode.PERMISSIVE
+        assert merged_plugin.priority == 99
+        assert "base_key" in merged_plugin.config
+        assert "override_key" in merged_plugin.config
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_merge_config_no_override_for_plugin():
+    """Test _merge_tenant_config keeps original plugin when no override exists."""
+    from mcpgateway.plugins.framework.loader.config import ConfigLoader
+    from mcpgateway.plugins.framework.models import PluginConfig
+
+    # Create a base config with a plugin
+    base_yaml = "./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml"
+    base_config = ConfigLoader.load_config(base_yaml)
+
+    # Add a plugin to base config for testing
+    test_plugin = PluginConfig(
+        name="TestPlugin",
+        kind="test.plugin.TestPlugin",
+        hooks=["prompt_pre_fetch"],
+        mode=PluginMode.ENFORCE,
+        priority=50,
+        config={"base_key": "base_value"},
+    )
+    base_config.plugins = [test_plugin]
+
+    factory = ToolScopedPluginManagerFactory(yaml_path=base_yaml)
+    factory._base_config = base_config
+
+    try:
+        # Create override for a different plugin
+        override = PluginConfigOverride(
+            name="DifferentPlugin",
+            mode=PluginMode.PERMISSIVE,
+            priority=99,
+        )
+
+        # Test merge - TestPlugin should remain unchanged
+        merged = factory._merge_tenant_config([override])
+        assert merged is not None
+        assert len(merged.plugins) == 1
+
+        merged_plugin = merged.plugins[0]
+        assert merged_plugin.name == "TestPlugin"
+        assert merged_plugin.mode == PluginMode.ENFORCE
+        assert merged_plugin.priority == 50
+    finally:
+        await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_get_config_from_db_default():
+    """Test that default get_config_from_db returns None."""
+    factory = TenantPluginManagerFactory(yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml")
+
+    try:
+        # Default implementation should return None
+        result = await factory.get_config_from_db("any_context")
+        assert result is None
+    finally:
+        await factory.shutdown()

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhumohan Jaishankar
+
+Unit tests for GatewayTenantPluginManagerFactory and related helpers.
+
+Tests cover:
+    - make_context_id: correct format
+    - get_config_from_db: unrecognised format returns None
+    - get_config_from_db: unknown team / no bindings returns None
+    - get_config_from_db: bindings translated to PluginConfigOverride list
+    - get_config_from_db: unknown plugin_id is skipped (forward-compat guard)
+    - get_config_from_db: all bindings have unknown plugin_ids → returns None
+    - reload_plugin_context: no-op when plugins disabled or factory is None
+    - reload_plugin_context: delegates to factory.reload_tenant when factory exists
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base
+from mcpgateway.plugins.framework import reload_plugin_context
+from mcpgateway.plugins.gateway_plugin_manager import (
+    CONTEXT_ID_SEPARATOR,
+    GatewayTenantPluginManagerFactory,
+    make_context_id,
+)
+from mcpgateway.plugins.framework.models import PluginMode
+from mcpgateway.schemas import (
+    PluginBindingMode,
+    PluginId,
+    PluginPolicyItem,
+    TeamPolicies,
+    ToolPluginBindingRequest,
+)
+from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingService
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_session():
+    """Shared in-memory SQLite session backed by all ORM models."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _make_factory(db_session_fixture):
+    """Return a GatewayTenantPluginManagerFactory that skips YAML loading.
+
+    We mock ``_base_config`` after construction so tests don't need a real
+    plugins/config.yaml on disk.
+    """
+    # Patch ConfigLoader.load_config so __init__ succeeds without a real YAML file
+    with patch("mcpgateway.plugins.framework.manager.ConfigLoader.load_config", return_value=MagicMock(plugins=[])):
+        factory = GatewayTenantPluginManagerFactory(
+            yaml_path="/fake/config.yaml",
+            db_factory=lambda: db_session_fixture,
+        )
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# make_context_id
+# ---------------------------------------------------------------------------
+
+
+class TestMakeContextId:
+    def test_format(self):
+        assert make_context_id("team-abc", "echo_text") == "team-abc::echo_text"
+
+    def test_separator_constant(self):
+        assert CONTEXT_ID_SEPARATOR == "::"
+
+    def test_wildcard_tool(self):
+        assert make_context_id("t1", "*") == "t1::*"
+
+
+# ---------------------------------------------------------------------------
+# GatewayTenantPluginManagerFactory.get_config_from_db
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfigFromDb:
+    @pytest.mark.asyncio
+    async def test_unrecognised_context_id_returns_none(self, db_session):
+        """context_id without '::' separator returns None (graceful fallback)."""
+        factory = _make_factory(db_session)
+        result = await factory.get_config_from_db("just-a-server-id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_bindings_returns_none(self, db_session):
+        """Returns None when no DB rows exist for the given team+tool."""
+        factory = _make_factory(db_session)
+        result = await factory.get_config_from_db(make_context_id("no-such-team", "any_tool"))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_bindings_translated_to_overrides(self, db_session):
+        """DB bindings are converted to PluginConfigOverride objects correctly."""
+        # Seed one binding
+        svc = ToolPluginBindingService()
+        req = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["my_tool"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.ENFORCE,
+                            priority=42,
+                            config={"min_chars": 0, "max_chars": 500, "strategy": "truncate", "ellipsis": "..."},
+                        )
+                    ]
+                )
+            }
+        )
+        svc.upsert_bindings(db_session, req, caller_email="admin@example.com")
+
+        factory = _make_factory(db_session)
+        overrides = await factory.get_config_from_db(make_context_id("team-a", "my_tool"))
+
+        assert overrides is not None
+        assert len(overrides) == 1
+        o = overrides[0]
+        assert o.name == "OutputLengthGuardPlugin"
+        assert o.mode == PluginMode.ENFORCE
+        assert o.priority == 42
+        assert o.config == {"min_chars": 0, "max_chars": 500, "strategy": "truncate", "ellipsis": "..."}
+
+    @pytest.mark.asyncio
+    async def test_unknown_plugin_id_is_skipped(self, db_session):
+        """A binding with an unknown plugin_id is silently skipped (forward-compat)."""
+        from mcpgateway.db import ToolPluginBinding, utc_now
+        import uuid
+
+        # Insert a row with a plugin_id not present in PLUGIN_ID_TO_NAME
+        row = ToolPluginBinding(
+            id=uuid.uuid4().hex,
+            team_id="team-x",
+            tool_name="t",
+            plugin_id="FUTURE_PLUGIN_NOT_YET_KNOWN",
+            mode="enforce",
+            priority=1,
+            config={},
+            created_at=utc_now(),
+            created_by="admin@example.com",
+            updated_at=utc_now(),
+            updated_by="admin@example.com",
+        )
+        db_session.add(row)
+        db_session.flush()
+
+        factory = _make_factory(db_session)
+        result = await factory.get_config_from_db(make_context_id("team-x", "t"))
+        # The unknown plugin is skipped and no known plugins remain → None
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wildcard_binding_returned(self, db_session):
+        """A wildcard '*' binding for the team is returned even for exact-tool queries."""
+        svc = ToolPluginBindingService()
+        req = ToolPluginBindingRequest(
+            teams={
+                "team-w": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["*"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            mode=PluginBindingMode.PERMISSIVE,
+                            priority=5,
+                            config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+                        )
+                    ]
+                )
+            }
+        )
+        svc.upsert_bindings(db_session, req, caller_email="admin@example.com")
+
+        factory = _make_factory(db_session)
+        overrides = await factory.get_config_from_db(make_context_id("team-w", "any_specific_tool"))
+
+        assert overrides is not None
+        assert len(overrides) == 1
+        assert overrides[0].name == "RateLimiterPlugin"
+
+
+# ---------------------------------------------------------------------------
+# reload_plugin_context
+# ---------------------------------------------------------------------------
+
+
+class TestReloadPluginContext:
+    @pytest.mark.asyncio
+    async def test_noop_when_plugins_disabled(self):
+        """reload_plugin_context is a no-op when plugins are disabled."""
+        with (
+            patch("mcpgateway.plugins.framework._PLUGINS_ENABLED", False),
+            patch("mcpgateway.plugins.framework._plugin_manager_factory", None),
+        ):
+            # Should not raise
+            await reload_plugin_context("team-a::my_tool")
+
+    @pytest.mark.asyncio
+    async def test_noop_when_factory_is_none(self):
+        """reload_plugin_context is a no-op when the factory is not initialised."""
+        with (
+            patch("mcpgateway.plugins.framework._PLUGINS_ENABLED", True),
+            patch("mcpgateway.plugins.framework._plugin_manager_factory", None),
+        ):
+            await reload_plugin_context("team-a::my_tool")
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_factory_reload_tenant(self):
+        """reload_plugin_context calls factory.reload_tenant with the context_id."""
+        mock_factory = MagicMock()
+        mock_factory.reload_tenant = AsyncMock()
+
+        with (
+            patch("mcpgateway.plugins.framework._PLUGINS_ENABLED", True),
+            patch("mcpgateway.plugins.framework._plugin_manager_factory", mock_factory),
+        ):
+            await reload_plugin_context("team-a::echo_text")
+
+        mock_factory.reload_tenant.assert_awaited_once_with("team-a::echo_text")

--- a/tests/unit/mcpgateway/routers/test_cancellation_router.py
+++ b/tests/unit/mcpgateway/routers/test_cancellation_router.py
@@ -7,13 +7,15 @@ Authors: Mihai Criveti
 Unit tests for cancellation router endpoints.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+# Standard
+from unittest.mock import AsyncMock, MagicMock
 
+# Third-Party
+from fastapi import HTTPException
 import pytest
 
-from fastapi import HTTPException
-
-from mcpgateway.services.cancellation_service import CancellationService, cancellation_service
+# First-Party
+from mcpgateway.services.cancellation_service import CancellationService
 
 
 @pytest.fixture
@@ -31,7 +33,11 @@ def allow_permission(monkeypatch):
             return True
 
     monkeypatch.setattr(rbac_module, "PermissionService", DummyPermissionService)
-    monkeypatch.setattr(plugins_framework, "get_plugin_manager", lambda: None)
+
+    async def _no_plugin_manager():
+        return None
+
+    monkeypatch.setattr(plugins_framework, "get_plugin_manager", _no_plugin_manager)
 
 
 @pytest.mark.asyncio
@@ -159,7 +165,7 @@ async def test_cancel_callback_exception_is_handled():
 async def test_cancel_run_broadcasts_notifications(allow_permission, monkeypatch):
     """Ensure cancel_run broadcasts notifications to active sessions."""
     # First-Party
-    from mcpgateway.routers.cancellation_router import CancelRequest, cancel_run
+    from mcpgateway.routers.cancellation_router import cancel_run, CancelRequest
 
     mock_registry = MagicMock()
     mock_registry.get_all_session_ids = AsyncMock(return_value=["s1", "s2"])
@@ -179,7 +185,7 @@ async def test_cancel_run_broadcasts_notifications(allow_permission, monkeypatch
 async def test_cancel_run_handles_session_errors(allow_permission, monkeypatch):
     """Ensure cancel_run returns even when session registry fails."""
     # First-Party
-    from mcpgateway.routers.cancellation_router import CancelRequest, cancel_run
+    from mcpgateway.routers.cancellation_router import cancel_run, CancelRequest
 
     mock_registry = MagicMock()
     mock_registry.get_all_session_ids = AsyncMock(side_effect=Exception("boom"))
@@ -197,7 +203,7 @@ async def test_cancel_run_handles_session_errors(allow_permission, monkeypatch):
 async def test_cancel_run_handles_per_session_broadcast_errors(allow_permission, monkeypatch):
     """Ensure per-session broadcast failures are logged and ignored."""
     # First-Party
-    from mcpgateway.routers.cancellation_router import CancelRequest, cancel_run
+    from mcpgateway.routers.cancellation_router import cancel_run, CancelRequest
 
     mock_registry = MagicMock()
     mock_registry.get_all_session_ids = AsyncMock(return_value=["s1", "s2"])

--- a/tests/unit/mcpgateway/routers/test_log_search.py
+++ b/tests/unit/mcpgateway/routers/test_log_search.py
@@ -11,9 +11,9 @@ from fastapi import HTTPException
 import pytest
 
 # First-Party
-from mcpgateway.routers import log_search
 from mcpgateway.middleware import rbac as rbac_module
 import mcpgateway.plugins.framework as plugin_framework
+from mcpgateway.routers import log_search
 
 
 @pytest.fixture(autouse=True)
@@ -22,7 +22,11 @@ def allow_permissions(monkeypatch: pytest.MonkeyPatch):
         return True
 
     monkeypatch.setattr(rbac_module.PermissionService, "check_permission", _ok)
-    monkeypatch.setattr(plugin_framework, "get_plugin_manager", lambda: None)
+
+    async def _no_plugin_manager():
+        return None
+
+    monkeypatch.setattr(plugin_framework, "get_plugin_manager", _no_plugin_manager)
 
 
 def test_align_to_window_rounds_down():

--- a/tests/unit/mcpgateway/routers/test_observability_sql.py
+++ b/tests/unit/mcpgateway/routers/test_observability_sql.py
@@ -7,7 +7,7 @@ Tests SQL-based and Python-based computation paths for query performance metrics
 # Standard
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException
@@ -32,8 +32,7 @@ def allow_permission(monkeypatch):
             return True
 
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DummyPermissionService)
-    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", lambda: None)
-
+    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", AsyncMock(return_value=None))
 
 
 class TestQueryPerformancePostgresql:
@@ -164,6 +163,7 @@ class TestQueryPerformanceRouting:
             with patch("mcpgateway.routers.observability._get_query_performance_python") as mock_py:
                 mock_pg.return_value = {"total_traces": 100}
 
+                # First-Party
                 from mcpgateway.routers.observability import get_query_performance
 
                 result = await get_query_performance(
@@ -194,6 +194,7 @@ class TestQueryPerformanceRouting:
             with patch("mcpgateway.routers.observability._get_query_performance_python") as mock_py:
                 mock_py.return_value = {"total_traces": 50}
 
+                # First-Party
                 from mcpgateway.routers.observability import get_query_performance
 
                 result = await get_query_performance(
@@ -213,6 +214,7 @@ class TestObservabilityRouterEndpoints:
 
     def test_get_db_commit_and_close(self, monkeypatch):
         """get_db commits and closes on success."""
+        # First-Party
         from mcpgateway.routers.observability import get_db
 
         mock_db = MagicMock()
@@ -230,6 +232,7 @@ class TestObservabilityRouterEndpoints:
 
     def test_get_db_rollback_invalidate(self, monkeypatch):
         """get_db rolls back and invalidates on error."""
+        # First-Party
         from mcpgateway.routers.observability import get_db
 
         mock_db = MagicMock()
@@ -248,6 +251,7 @@ class TestObservabilityRouterEndpoints:
 
     def test_get_db_rollback_and_invalidate_failure_ignored(self, monkeypatch):
         """get_db suppresses invalidate failures during error cleanup."""
+        # First-Party
         from mcpgateway.routers.observability import get_db
 
         mock_db = MagicMock()
@@ -268,6 +272,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_list_traces_returns_service_results(self, allow_permission):
         """list_traces returns query results."""
+        # First-Party
         from mcpgateway.routers.observability import list_traces
 
         mock_db = MagicMock()
@@ -283,6 +288,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_query_traces_advanced_parses_dates(self, allow_permission):
         """query_traces_advanced parses ISO datetime strings."""
+        # First-Party
         from mcpgateway.routers.observability import query_traces_advanced
 
         mock_db = MagicMock()
@@ -305,6 +311,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_query_traces_advanced_invalid_date(self, allow_permission):
         """query_traces_advanced returns 400 on invalid date."""
+        # First-Party
         from mcpgateway.routers.observability import query_traces_advanced
 
         with pytest.raises(HTTPException) as exc_info:
@@ -315,6 +322,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_get_trace_missing(self, allow_permission):
         """get_trace returns 404 when missing."""
+        # First-Party
         from mcpgateway.routers.observability import get_trace
 
         mock_db = MagicMock()
@@ -329,6 +337,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_get_trace_found(self, allow_permission):
         """get_trace returns trace when found."""
+        # First-Party
         from mcpgateway.routers.observability import get_trace
 
         mock_db = MagicMock()
@@ -343,6 +352,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_list_spans_returns_service_results(self, allow_permission):
         """list_spans returns query results."""
+        # First-Party
         from mcpgateway.routers.observability import list_spans
 
         mock_db = MagicMock()
@@ -358,6 +368,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_cleanup_old_traces(self, allow_permission):
         """cleanup_old_traces returns deleted count."""
+        # First-Party
         from mcpgateway.routers.observability import cleanup_old_traces
 
         mock_db = MagicMock()
@@ -371,6 +382,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_get_stats(self, allow_permission):
         """get_stats returns aggregated counts and slowest endpoints."""
+        # First-Party
         from mcpgateway.routers.observability import get_stats
 
         mock_db = MagicMock()
@@ -399,6 +411,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_export_traces_invalid_format(self, allow_permission):
         """export_traces raises on invalid format."""
+        # First-Party
         from mcpgateway.routers.observability import export_traces
 
         with pytest.raises(HTTPException) as exc_info:
@@ -409,6 +422,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_export_traces_json_csv_ndjson(self, allow_permission):
         """export_traces supports json, csv, and ndjson formats."""
+        # First-Party
         from mcpgateway.routers.observability import export_traces
 
         mock_db = MagicMock()
@@ -443,6 +457,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_export_traces_parses_iso_start_end(self, allow_permission):
         """export_traces parses ISO datetime strings in request body."""
+        # First-Party
         from mcpgateway.routers.observability import export_traces
 
         mock_db = MagicMock()
@@ -463,6 +478,7 @@ class TestObservabilityRouterEndpoints:
     @pytest.mark.asyncio
     async def test_export_traces_wraps_failures_in_http_400(self, allow_permission):
         """export_traces returns HTTP 400 when service query fails."""
+        # First-Party
         from mcpgateway.routers.observability import export_traces
 
         with patch("mcpgateway.routers.observability.ObservabilityService") as mock_service:

--- a/tests/unit/mcpgateway/routers/test_tokens.py
+++ b/tests/unit/mcpgateway/routers/test_tokens.py
@@ -12,8 +12,8 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
-import pytest
 from fastapi import HTTPException, status
+import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -42,6 +42,7 @@ from mcpgateway.schemas import (
 )
 from mcpgateway.services.token_catalog_service import TokenScope
 
+# Local
 # Test utilities
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
 
@@ -1115,6 +1116,7 @@ class TestGetCallerPermissionsTokenNarrowing:
     @pytest.mark.asyncio
     async def test_unrestricted_admin_returns_wildcard(self):
         """Un-narrowed admin (token_teams=None) gets ['*']."""
+        # First-Party
         from mcpgateway.routers.tokens import _get_caller_permissions
 
         user = {"email": "admin@test.com", "is_admin": True, "token_teams": None}
@@ -1124,6 +1126,7 @@ class TestGetCallerPermissionsTokenNarrowing:
     @pytest.mark.asyncio
     async def test_narrowed_admin_does_not_get_wildcard(self):
         """Narrowed admin (token_teams=['team-a']) must NOT get ['*'] (Finding 1)."""
+        # First-Party
         from mcpgateway.routers.tokens import _get_caller_permissions
 
         user = {"email": "admin@test.com", "is_admin": True, "token_teams": ["team-a"]}
@@ -1134,13 +1137,12 @@ class TestGetCallerPermissionsTokenNarrowing:
             result = await _get_caller_permissions(MagicMock(), user, team_id="team-a")
 
             assert result != ["*"], "Narrowed admin must not receive wildcard permissions"
-            mock_ps.get_user_permissions.assert_awaited_once_with(
-                user_email="admin@test.com", team_id="team-a", token_teams=["team-a"]
-            )
+            mock_ps.get_user_permissions.assert_awaited_once_with(user_email="admin@test.com", team_id="team-a", token_teams=["team-a"])
 
     @pytest.mark.asyncio
     async def test_public_only_admin_does_not_get_wildcard(self):
         """Public-only admin (token_teams=[]) must NOT get ['*'] (Finding 1)."""
+        # First-Party
         from mcpgateway.routers.tokens import _get_caller_permissions
 
         user = {"email": "admin@test.com", "is_admin": True, "token_teams": []}

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -448,3 +448,71 @@ class TestToolPluginBindingsRouter:
         assert asyncio.iscoroutinefunction(list_tool_plugin_bindings)
         assert asyncio.iscoroutinefunction(list_tool_plugin_bindings_for_team)
         assert asyncio.iscoroutinefunction(delete_tool_plugin_binding)
+
+    # ------------------------------------------------------------------
+    # Cache invalidation — reload_plugin_context called after mutations
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_upsert_calls_reload_plugin_context(self, user_ctx, db_session):
+        """After a successful upsert the router calls reload_plugin_context with
+        the canonical context_id (team_id::tool_name) for every affected binding.
+        """
+        from unittest.mock import AsyncMock
+
+        with patch(
+            "mcpgateway.routers.tool_plugin_bindings.reload_plugin_context",
+            new_callable=AsyncMock,
+        ) as mock_reload:
+            await upsert_tool_plugin_bindings(
+                request=_simple_request(),
+                current_user_ctx=user_ctx,
+                db=db_session,
+            )
+
+        mock_reload.assert_awaited_once_with("team-a::tool_x")
+
+    @pytest.mark.asyncio
+    async def test_upsert_two_teams_calls_reload_for_each_context(self, user_ctx, db_session):
+        """Upsert with two teams calls reload_plugin_context once per unique context_id."""
+        from unittest.mock import AsyncMock
+
+        with patch(
+            "mcpgateway.routers.tool_plugin_bindings.reload_plugin_context",
+            new_callable=AsyncMock,
+        ) as mock_reload:
+            await upsert_tool_plugin_bindings(
+                request=_two_team_request(),
+                current_user_ctx=user_ctx,
+                db=db_session,
+            )
+
+        called_ids = {call.args[0] for call in mock_reload.await_args_list}
+        assert called_ids == {"team-a::tool_x", "team-b::tool_y"}
+
+    @pytest.mark.asyncio
+    async def test_delete_calls_reload_plugin_context(self, user_ctx, db_session):
+        """After a successful delete the router calls reload_plugin_context with
+        the canonical context_id for the deleted binding.
+        """
+        from unittest.mock import AsyncMock
+
+        # Seed a binding first (with real reload so it doesn't interfere)
+        upsert_result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        binding_id = upsert_result.bindings[0].id
+
+        with patch(
+            "mcpgateway.routers.tool_plugin_bindings.reload_plugin_context",
+            new_callable=AsyncMock,
+        ) as mock_reload:
+            await delete_tool_plugin_binding(
+                binding_id=binding_id,
+                current_user_ctx=user_ctx,
+                db=db_session,
+            )
+
+        mock_reload.assert_awaited_once_with("team-a::tool_x")

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhumohan Jaishankar
+
+Unit tests for the tool plugin bindings router.
+
+Tests cover:
+    - POST /  (upsert): success, service exception → 400
+    - GET /   (list all): success
+    - GET /{team_id} (list by team): success
+    - DELETE /{binding_id}: success → 204, not found → 404
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+# Third-Party
+from fastapi import HTTPException, status
+import pytest
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.schemas import (
+    PluginBindingMode,
+    PluginId,
+    PluginPolicyItem,
+    TeamPolicies,
+    ToolPluginBindingListResponse,
+    ToolPluginBindingRequest,
+    ToolPluginBindingResponse,
+)
+from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError
+
+from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_binding_response(
+    id_="binding-001",
+    team_id="team-a",
+    tool_name="tool_x",
+    plugin_id="OUTPUT_LENGTH_GUARD",
+    mode="enforce",
+    priority=50,
+) -> ToolPluginBindingResponse:
+    """Build a minimal ToolPluginBindingResponse."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return ToolPluginBindingResponse(
+        id=id_,
+        team_id=team_id,
+        tool_name=tool_name,
+        plugin_id=plugin_id,
+        mode=mode,
+        priority=priority,
+        config={"max_chars": 2000, "strategy": "truncate"},
+        created_at=now,
+        created_by="admin@example.com",
+        updated_at=now,
+        updated_by="admin@example.com",
+    )
+
+
+def _make_list_response(bindings=None) -> ToolPluginBindingListResponse:
+    """Build a ToolPluginBindingListResponse from a list of response objects."""
+    if bindings is None:
+        bindings = [_make_binding_response()]
+    return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
+
+
+def _simple_request() -> ToolPluginBindingRequest:
+    """Return a minimal single-team single-tool POST payload."""
+    return ToolPluginBindingRequest(
+        teams={
+            "team-a": TeamPolicies(
+                policies=[
+                    PluginPolicyItem(
+                        tool_names=["tool_x"],
+                        plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                        mode=PluginBindingMode.ENFORCE,
+                        priority=50,
+                        config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                    )
+                ]
+            )
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+class TestToolPluginBindingsRouter:
+    """Unit tests for the tool plugin bindings FastAPI router."""
+
+    @pytest.fixture(autouse=True)
+    def setup_rbac_mocks(self):
+        """Bypass RBAC decorators for every test in this class."""
+        originals = patch_rbac_decorators()
+        yield
+        restore_rbac_decorators(originals)
+
+    @pytest.fixture
+    def mock_db(self):
+        """Mock database session."""
+        return MagicMock(spec=Session)
+
+    @pytest.fixture
+    def mock_user_ctx(self, mock_db):
+        """Mock user context with plugin management permissions."""
+        return {
+            "email": "admin@example.com",
+            "full_name": "Admin User",
+            "is_admin": True,
+            "db": mock_db,
+            "permissions": ["tools.manage_plugins", "tools.read"],
+        }
+
+    # ------------------------------------------------------------------
+    # POST / — upsert_tool_plugin_bindings
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_upsert_success(self, mock_user_ctx, mock_db):
+        """POST with valid payload returns 200 with the upserted bindings."""
+        expected_response = _make_list_response()
+
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.upsert_bindings.return_value = expected_response.bindings
+
+            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
+
+            result = await upsert_tool_plugin_bindings(
+                request=_simple_request(),
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        assert isinstance(result, ToolPluginBindingListResponse)
+        assert result.total == 1
+        assert result.bindings[0].team_id == "team-a"
+        mock_svc.upsert_bindings.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_upsert_passes_caller_email(self, mock_user_ctx, mock_db):
+        """POST extracts caller email from user context and passes it to the service."""
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.upsert_bindings.return_value = [_make_binding_response()]
+
+            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
+
+            await upsert_tool_plugin_bindings(
+                request=_simple_request(),
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        _, call_kwargs = mock_svc.upsert_bindings.call_args
+        assert call_kwargs.get("caller_email") == "admin@example.com"
+
+    @pytest.mark.asyncio
+    async def test_upsert_service_exception_raises_400(self, mock_user_ctx, mock_db):
+        """POST raises HTTP 400 when the service layer throws an exception."""
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.upsert_bindings.side_effect = ValueError("team not found")
+
+            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
+
+            with pytest.raises(HTTPException) as exc_info:
+                await upsert_tool_plugin_bindings(
+                    request=_simple_request(),
+                    current_user_ctx=mock_user_ctx,
+                    db=mock_db,
+                )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "team not found" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_upsert_missing_email_in_context_raises_400(self, mock_db):
+        """POST raises HTTP 400 when 'email' key is absent from user context.
+
+        The auth middleware always populates 'email', so a missing key indicates
+        a broken auth pipeline. The router catches the resulting KeyError via
+        its broad except clause and surfaces it as 400.
+        """
+        user_ctx_no_email = {"is_admin": True, "db": mock_db}  # no 'email' key
+
+        with patch("mcpgateway.routers.tool_plugin_bindings._service"):
+            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
+
+            with pytest.raises(HTTPException) as exc_info:
+                await upsert_tool_plugin_bindings(
+                    request=_simple_request(),
+                    current_user_ctx=user_ctx_no_email,
+                    db=mock_db,
+                )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    # ------------------------------------------------------------------
+    # GET / — list_tool_plugin_bindings
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_list_all_success(self, mock_user_ctx, mock_db):
+        """GET / returns all bindings with correct total count."""
+        bindings = [_make_binding_response("b1"), _make_binding_response("b2")]
+
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.list_bindings.return_value = bindings
+
+            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings
+
+            result = await list_tool_plugin_bindings(
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        assert isinstance(result, ToolPluginBindingListResponse)
+        assert result.total == 2
+        assert len(result.bindings) == 2
+        mock_svc.list_bindings.assert_called_once_with(mock_db, team_id=None)
+
+    @pytest.mark.asyncio
+    async def test_list_all_empty(self, mock_user_ctx, mock_db):
+        """GET / returns total=0 when no bindings exist."""
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.list_bindings.return_value = []
+
+            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings
+
+            result = await list_tool_plugin_bindings(
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        assert result.total == 0
+        assert result.bindings == []
+
+    # ------------------------------------------------------------------
+    # GET /{team_id} — list_tool_plugin_bindings_for_team
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_list_by_team_success(self, mock_user_ctx, mock_db):
+        """GET /{team_id} filters bindings by team and returns correct results."""
+        binding = _make_binding_response(team_id="team-a")
+
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.list_bindings.return_value = [binding]
+
+            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings_for_team
+
+            result = await list_tool_plugin_bindings_for_team(
+                team_id="team-a",
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        assert result.total == 1
+        assert result.bindings[0].team_id == "team-a"
+        mock_svc.list_bindings.assert_called_once_with(mock_db, team_id="team-a")
+
+    @pytest.mark.asyncio
+    async def test_list_by_team_empty(self, mock_user_ctx, mock_db):
+        """GET /{team_id} returns empty list when team has no bindings."""
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.list_bindings.return_value = []
+
+            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings_for_team
+
+            result = await list_tool_plugin_bindings_for_team(
+                team_id="team-unknown",
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        assert result.total == 0
+        assert result.bindings == []
+
+    # ------------------------------------------------------------------
+    # DELETE /{binding_id} — delete_tool_plugin_binding
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, mock_user_ctx, mock_db):
+        """DELETE with valid ID returns the deleted binding details (200)."""
+        deleted_binding = _make_binding_response()
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.delete_binding.return_value = deleted_binding
+
+            from mcpgateway.routers.tool_plugin_bindings import delete_tool_plugin_binding
+
+            result = await delete_tool_plugin_binding(
+                binding_id="binding-001",
+                current_user_ctx=mock_user_ctx,
+                db=mock_db,
+            )
+
+        assert result.id == deleted_binding.id
+        assert result.team_id == deleted_binding.team_id
+        mock_svc.delete_binding.assert_called_once_with(mock_db, "binding-001")
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found_raises_404(self, mock_user_ctx, mock_db):
+        """DELETE raises HTTP 404 when the binding does not exist."""
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.delete_binding.side_effect = ToolPluginBindingNotFoundError("Tool plugin binding 'xyz' not found")
+
+            from mcpgateway.routers.tool_plugin_bindings import delete_tool_plugin_binding
+
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_tool_plugin_binding(
+                    binding_id="xyz",
+                    current_user_ctx=mock_user_ctx,
+                    db=mock_db,
+                )
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "xyz" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_is_coroutine(self):
+        """All router functions are async (coroutine functions)."""
+        import asyncio
+        from mcpgateway.routers.tool_plugin_bindings import (
+            delete_tool_plugin_binding,
+            list_tool_plugin_bindings,
+            list_tool_plugin_bindings_for_team,
+            upsert_tool_plugin_bindings,
+        )
+
+        assert asyncio.iscoroutinefunction(upsert_tool_plugin_bindings)
+        assert asyncio.iscoroutinefunction(list_tool_plugin_bindings)
+        assert asyncio.iscoroutinefunction(list_tool_plugin_bindings_for_team)
+        assert asyncio.iscoroutinefunction(delete_tool_plugin_binding)

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -6,23 +6,36 @@ Authors: Madhumohan Jaishankar
 
 Unit tests for the tool plugin bindings router.
 
+Uses an in-memory SQLite database and the real ToolPluginBindingService so
+tests exercise the full stack from router handler down to SQL, with no mocked
+service responses.
+
 Tests cover:
     - POST /  (upsert): success, service exception → 400
-    - GET /   (list all): success
-    - GET /{team_id} (list by team): success
-    - DELETE /{binding_id}: success → 204, not found → 404
+    - GET /   (list all): success, empty
+    - GET /{team_id}: filtered list, empty
+    - DELETE /{binding_id}: success → 200, not found → 404
 """
 
 # Standard
-from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import patch
 
 # Third-Party
 from fastapi import HTTPException, status
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # First-Party
+from mcpgateway.db import Base
+from mcpgateway.routers.tool_plugin_bindings import (
+    delete_tool_plugin_binding,
+    list_tool_plugin_bindings,
+    list_tool_plugin_bindings_for_team,
+    upsert_tool_plugin_bindings,
+)
 from mcpgateway.schemas import (
     PluginBindingMode,
     PluginId,
@@ -38,44 +51,42 @@ from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorator
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures
 # ---------------------------------------------------------------------------
 
 
-def _make_binding_response(
-    id_="binding-001",
-    team_id="team-a",
-    tool_name="tool_x",
-    plugin_id="OUTPUT_LENGTH_GUARD",
-    mode="enforce",
-    priority=50,
-) -> ToolPluginBindingResponse:
-    """Build a minimal ToolPluginBindingResponse."""
-    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    return ToolPluginBindingResponse(
-        id=id_,
-        team_id=team_id,
-        tool_name=tool_name,
-        plugin_id=plugin_id,
-        mode=mode,
-        priority=priority,
-        config={"max_chars": 2000, "strategy": "truncate"},
-        created_at=now,
-        created_by="admin@example.com",
-        updated_at=now,
-        updated_by="admin@example.com",
+@pytest.fixture
+def db_session():
+    """In-memory SQLite session shared across all connections within one test."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
 
 
-def _make_list_response(bindings=None) -> ToolPluginBindingListResponse:
-    """Build a ToolPluginBindingListResponse from a list of response objects."""
-    if bindings is None:
-        bindings = [_make_binding_response()]
-    return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
+@pytest.fixture
+def user_ctx(db_session):
+    """Authenticated admin user context wired to the real DB session."""
+    return {
+        "email": "admin@example.com",
+        "full_name": "Admin User",
+        "is_admin": True,
+        "db": db_session,
+        "permissions": ["tools.manage_plugins", "tools.read"],
+    }
 
 
 def _simple_request() -> ToolPluginBindingRequest:
-    """Return a minimal single-team single-tool POST payload."""
+    """Minimal single-team single-tool POST payload."""
     return ToolPluginBindingRequest(
         teams={
             "team-a": TeamPolicies(
@@ -93,13 +104,43 @@ def _simple_request() -> ToolPluginBindingRequest:
     )
 
 
+def _two_team_request() -> ToolPluginBindingRequest:
+    """Two-team two-tool POST payload for list/filter tests."""
+    return ToolPluginBindingRequest(
+        teams={
+            "team-a": TeamPolicies(
+                policies=[
+                    PluginPolicyItem(
+                        tool_names=["tool_x"],
+                        plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                        mode=PluginBindingMode.ENFORCE,
+                        priority=50,
+                        config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                    )
+                ]
+            ),
+            "team-b": TeamPolicies(
+                policies=[
+                    PluginPolicyItem(
+                        tool_names=["tool_y"],
+                        plugin_id=PluginId.RATE_LIMITER,
+                        mode=PluginBindingMode.PERMISSIVE,
+                        priority=30,
+                        config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+                    )
+                ]
+            ),
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test class
 # ---------------------------------------------------------------------------
 
 
 class TestToolPluginBindingsRouter:
-    """Unit tests for the tool plugin bindings FastAPI router."""
+    """Router tests using in-memory SQLite and the real service."""
 
     @pytest.fixture(autouse=True)
     def setup_rbac_mocks(self):
@@ -108,181 +149,197 @@ class TestToolPluginBindingsRouter:
         yield
         restore_rbac_decorators(originals)
 
-    @pytest.fixture
-    def mock_db(self):
-        """Mock database session."""
-        return MagicMock(spec=Session)
-
-    @pytest.fixture
-    def mock_user_ctx(self, mock_db):
-        """Mock user context with plugin management permissions."""
-        return {
-            "email": "admin@example.com",
-            "full_name": "Admin User",
-            "is_admin": True,
-            "db": mock_db,
-            "permissions": ["tools.manage_plugins", "tools.read"],
-        }
-
     # ------------------------------------------------------------------
     # POST / — upsert_tool_plugin_bindings
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_upsert_success(self, mock_user_ctx, mock_db):
-        """POST with valid payload returns 200 with the upserted bindings."""
-        expected_response = _make_list_response()
-
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.upsert_bindings.return_value = expected_response.bindings
-
-            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
-
-            result = await upsert_tool_plugin_bindings(
-                request=_simple_request(),
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
+    async def test_upsert_success(self, user_ctx, db_session):
+        """POST with valid payload inserts a row and returns it in the response."""
+        result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
         assert isinstance(result, ToolPluginBindingListResponse)
         assert result.total == 1
-        assert result.bindings[0].team_id == "team-a"
-        mock_svc.upsert_bindings.assert_called_once()
+        binding = result.bindings[0]
+        assert binding.team_id == "team-a"
+        assert binding.tool_name == "tool_x"
+        assert binding.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert binding.mode == "enforce"
+        assert binding.priority == 50
+        assert binding.created_by == "admin@example.com"
 
     @pytest.mark.asyncio
-    async def test_upsert_passes_caller_email(self, mock_user_ctx, mock_db):
-        """POST extracts caller email from user context and passes it to the service."""
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.upsert_bindings.return_value = [_make_binding_response()]
-
-            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
-
-            await upsert_tool_plugin_bindings(
-                request=_simple_request(),
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
-
-        _, call_kwargs = mock_svc.upsert_bindings.call_args
-        assert call_kwargs.get("caller_email") == "admin@example.com"
-
-    @pytest.mark.asyncio
-    async def test_upsert_service_exception_raises_400(self, mock_user_ctx, mock_db):
-        """POST raises HTTP 400 when the service layer throws an exception."""
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.upsert_bindings.side_effect = ValueError("team not found")
-
-            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
-
-            with pytest.raises(HTTPException) as exc_info:
-                await upsert_tool_plugin_bindings(
-                    request=_simple_request(),
-                    current_user_ctx=mock_user_ctx,
-                    db=mock_db,
+    async def test_upsert_idempotent_update(self, user_ctx, db_session):
+        """POST twice on the same (team, tool, plugin) updates in place — no duplicate rows."""
+        await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        updated_request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.PERMISSIVE,
+                            priority=99,
+                            config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."},
+                        )
+                    ]
                 )
+            }
+        )
+        result = await upsert_tool_plugin_bindings(
+            request=updated_request,
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
-        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-        assert "team not found" in str(exc_info.value.detail)
+        assert result.total == 1
+        binding = result.bindings[0]
+        assert binding.mode == "permissive"
+        assert binding.priority == 99
+        assert binding.config["max_chars"] == 500
 
     @pytest.mark.asyncio
-    async def test_upsert_missing_email_in_context_raises_400(self, mock_db):
-        """POST raises HTTP 400 when 'email' key is absent from user context.
+    async def test_upsert_service_value_error_raises_400(self, user_ctx, db_session):
+        """Router maps ValueError from the service layer to HTTP 400 Bad Request.
 
-        The auth middleware always populates 'email', so a missing key indicates
-        a broken auth pipeline. The router catches the resulting KeyError via
-        its broad except clause and surfaces it as 400.
+        ValueError signals bad input (e.g. invalid plugin config) — that is a
+        client error and 400 is correct. Other exception types are not caught
+        and propagate as 500, so only ValueError gets this treatment.
+        We patch the service singleton to inject a controlled ValueError since
+        there is no real data path that triggers it with a Pydantic-validated payload.
         """
-        user_ctx_no_email = {"is_admin": True, "db": mock_db}  # no 'email' key
-
-        with patch("mcpgateway.routers.tool_plugin_bindings._service"):
-            from mcpgateway.routers.tool_plugin_bindings import upsert_tool_plugin_bindings
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.upsert_bindings.side_effect = ValueError("invalid plugin config")
 
             with pytest.raises(HTTPException) as exc_info:
                 await upsert_tool_plugin_bindings(
                     request=_simple_request(),
-                    current_user_ctx=user_ctx_no_email,
-                    db=mock_db,
+                    current_user_ctx=user_ctx,
+                    db=db_session,
                 )
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "invalid plugin config" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_upsert_unexpected_exception_propagates_as_500(self, user_ctx, db_session):
+        """Unexpected exceptions from the service layer are NOT caught by the router.
+
+        Only ValueError is caught and mapped to 400. A RuntimeError (or any other
+        non-ValueError exception) propagates uncaught, which FastAPI renders as 500.
+        """
+        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
+            mock_svc.upsert_bindings.side_effect = RuntimeError("unexpected bug")
+
+            with pytest.raises(RuntimeError, match="unexpected bug"):
+                await upsert_tool_plugin_bindings(
+                    request=_simple_request(),
+                    current_user_ctx=user_ctx,
+                    db=db_session,
+                )
 
     # ------------------------------------------------------------------
     # GET / — list_tool_plugin_bindings
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_list_all_success(self, mock_user_ctx, mock_db):
-        """GET / returns all bindings with correct total count."""
-        bindings = [_make_binding_response("b1"), _make_binding_response("b2")]
-
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.list_bindings.return_value = bindings
-
-            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings
-
-            result = await list_tool_plugin_bindings(
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
+    async def test_list_all_empty(self, user_ctx, db_session):
+        """GET / returns total=0 when no bindings have been inserted."""
+        result = await list_tool_plugin_bindings(
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
         assert isinstance(result, ToolPluginBindingListResponse)
-        assert result.total == 2
-        assert len(result.bindings) == 2
-        mock_svc.list_bindings.assert_called_once_with(mock_db, team_id=None)
-
-    @pytest.mark.asyncio
-    async def test_list_all_empty(self, mock_user_ctx, mock_db):
-        """GET / returns total=0 when no bindings exist."""
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.list_bindings.return_value = []
-
-            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings
-
-            result = await list_tool_plugin_bindings(
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
-
         assert result.total == 0
         assert result.bindings == []
+
+    @pytest.mark.asyncio
+    async def test_list_all_returns_all_bindings(self, user_ctx, db_session):
+        """GET / returns all bindings across all teams with correct field values."""
+        await upsert_tool_plugin_bindings(
+            request=_two_team_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        result = await list_tool_plugin_bindings(
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        assert result.total == 2
+        by_team = {b.team_id: b for b in result.bindings}
+        assert set(by_team.keys()) == {"team-a", "team-b"}
+
+        team_a = by_team["team-a"]
+        assert team_a.tool_name == "tool_x"
+        assert team_a.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert team_a.mode == "enforce"
+        assert team_a.priority == 50
+        assert team_a.config == {"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."}
+        assert team_a.created_by == "admin@example.com"
+
+        team_b = by_team["team-b"]
+        assert team_b.tool_name == "tool_y"
+        assert team_b.plugin_id == "RATE_LIMITER"
+        assert team_b.mode == "permissive"
+        assert team_b.priority == 30
+        assert team_b.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
+        assert team_b.created_by == "admin@example.com"
 
     # ------------------------------------------------------------------
     # GET /{team_id} — list_tool_plugin_bindings_for_team
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_list_by_team_success(self, mock_user_ctx, mock_db):
-        """GET /{team_id} filters bindings by team and returns correct results."""
-        binding = _make_binding_response(team_id="team-a")
+    async def test_list_by_team_filters_correctly(self, user_ctx, db_session):
+        """GET /{team_id} returns only bindings for that team with correct field values."""
+        await upsert_tool_plugin_bindings(
+            request=_two_team_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.list_bindings.return_value = [binding]
-
-            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings_for_team
-
-            result = await list_tool_plugin_bindings_for_team(
-                team_id="team-a",
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
+        result = await list_tool_plugin_bindings_for_team(
+            team_id="team-a",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
         assert result.total == 1
-        assert result.bindings[0].team_id == "team-a"
-        mock_svc.list_bindings.assert_called_once_with(mock_db, team_id="team-a")
+        binding = result.bindings[0]
+        assert binding.team_id == "team-a"
+        assert binding.tool_name == "tool_x"
+        assert binding.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert binding.mode == "enforce"
+        assert binding.priority == 50
+        assert binding.config == {"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."}
+        assert binding.created_by == "admin@example.com"
 
     @pytest.mark.asyncio
-    async def test_list_by_team_empty(self, mock_user_ctx, mock_db):
-        """GET /{team_id} returns empty list when team has no bindings."""
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.list_bindings.return_value = []
+    async def test_list_by_team_empty_for_unknown_team(self, user_ctx, db_session):
+        """GET /{team_id} returns empty list for a team with no bindings."""
+        await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
-            from mcpgateway.routers.tool_plugin_bindings import list_tool_plugin_bindings_for_team
-
-            result = await list_tool_plugin_bindings_for_team(
-                team_id="team-unknown",
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
+        result = await list_tool_plugin_bindings_for_team(
+            team_id="team-unknown",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
 
         assert result.total == 0
         assert result.bindings == []
@@ -292,53 +349,52 @@ class TestToolPluginBindingsRouter:
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_delete_success(self, mock_user_ctx, mock_db):
-        """DELETE with valid ID returns the deleted binding details (200)."""
-        deleted_binding = _make_binding_response()
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.delete_binding.return_value = deleted_binding
+    async def test_delete_success(self, user_ctx, db_session):
+        """DELETE removes the binding and returns its details."""
+        upsert_result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        binding_id = upsert_result.bindings[0].id
 
-            from mcpgateway.routers.tool_plugin_bindings import delete_tool_plugin_binding
-
-            result = await delete_tool_plugin_binding(
-                binding_id="binding-001",
-                current_user_ctx=mock_user_ctx,
-                db=mock_db,
-            )
-
-        assert result.id == deleted_binding.id
-        assert result.team_id == deleted_binding.team_id
-        mock_svc.delete_binding.assert_called_once_with(mock_db, "binding-001")
-
-    @pytest.mark.asyncio
-    async def test_delete_not_found_raises_404(self, mock_user_ctx, mock_db):
-        """DELETE raises HTTP 404 when the binding does not exist."""
-        with patch("mcpgateway.routers.tool_plugin_bindings._service") as mock_svc:
-            mock_svc.delete_binding.side_effect = ToolPluginBindingNotFoundError("Tool plugin binding 'xyz' not found")
-
-            from mcpgateway.routers.tool_plugin_bindings import delete_tool_plugin_binding
-
-            with pytest.raises(HTTPException) as exc_info:
-                await delete_tool_plugin_binding(
-                    binding_id="xyz",
-                    current_user_ctx=mock_user_ctx,
-                    db=mock_db,
-                )
-
-        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-        assert "xyz" in str(exc_info.value.detail)
-
-    @pytest.mark.asyncio
-    async def test_is_coroutine(self):
-        """All router functions are async (coroutine functions)."""
-        import asyncio
-        from mcpgateway.routers.tool_plugin_bindings import (
-            delete_tool_plugin_binding,
-            list_tool_plugin_bindings,
-            list_tool_plugin_bindings_for_team,
-            upsert_tool_plugin_bindings,
+        result = await delete_tool_plugin_binding(
+            binding_id=binding_id,
+            current_user_ctx=user_ctx,
+            db=db_session,
         )
 
+        assert isinstance(result, ToolPluginBindingResponse)
+        assert result.id == binding_id
+        assert result.team_id == "team-a"
+        assert result.tool_name == "tool_x"
+
+        # Confirm it's gone
+        after = await list_tool_plugin_bindings(
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        assert after.total == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found_raises_404(self, user_ctx, db_session):
+        """DELETE raises HTTP 404 when the binding ID does not exist."""
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_tool_plugin_binding(
+                binding_id="nonexistent-id",
+                current_user_ctx=user_ctx,
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "nonexistent-id" in str(exc_info.value.detail)
+
+    # ------------------------------------------------------------------
+    # Structural
+    # ------------------------------------------------------------------
+
+    def test_all_handlers_are_coroutines(self):
+        """All router handler functions are async coroutine functions."""
         assert asyncio.iscoroutinefunction(upsert_tool_plugin_bindings)
         assert asyncio.iscoroutinefunction(list_tool_plugin_bindings)
         assert asyncio.iscoroutinefunction(list_tool_plugin_bindings_for_team)

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -247,6 +247,55 @@ class TestToolPluginBindingsRouter:
                     db=db_session,
                 )
 
+    @pytest.mark.asyncio
+    async def test_upsert_non_admin_own_team_succeeds(self, db_session):
+        """Non-admin with membership in the target team can create bindings."""
+        non_admin_ctx = {
+            "email": "member@example.com",
+            "full_name": "Team Member",
+            "is_admin": False,
+            "teams": ["team-a"],
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=non_admin_ctx,
+            db=db_session,
+        )
+        assert result.total == 1
+        assert result.bindings[0].team_id == "team-a"
+
+    @pytest.mark.asyncio
+    async def test_upsert_non_admin_foreign_team_raises_403(self, db_session):
+        """Non-admin cannot create bindings for a team they don't belong to."""
+        non_admin_ctx = {
+            "email": "outsider@example.com",
+            "full_name": "Outsider",
+            "is_admin": False,
+            "teams": ["team-b"],
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            await upsert_tool_plugin_bindings(
+                request=_simple_request(),  # targets team-a
+                current_user_ctx=non_admin_ctx,
+                db=db_session,
+            )
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        assert exc_info.value.detail == "Not authorized to configure bindings for team(s): team-a"
+
+    @pytest.mark.asyncio
+    async def test_upsert_admin_can_target_any_team(self, user_ctx, db_session):
+        """Platform admin (is_admin=True) bypasses team membership check."""
+        result = await upsert_tool_plugin_bindings(
+            request=_two_team_request(),
+            current_user_ctx=user_ctx,  # is_admin=True, no explicit team list
+            db=db_session,
+        )
+        assert result.total == 2
+
     # ------------------------------------------------------------------
     # GET / — list_tool_plugin_bindings
     # ------------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
+++ b/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
@@ -3579,7 +3579,9 @@ class TestMaxTotalKeysLimit:
 
         # Create 8 pool keys to reach 80% threshold (warning at 8/10)
         # Patch the logger at the module level where it's imported
+        # First-Party
         import mcpgateway.services.mcp_session_pool as pool_module
+
         with patch.object(pool_module, "logger") as mock_logger:
             # Warning fires when len(self._pools) BEFORE adding the new key >= threshold (8).
             # Creating 9 keys means the 9th call sees len=8 >= 8 and emits the warning.
@@ -3588,8 +3590,7 @@ class TestMaxTotalKeysLimit:
                 await pool._get_or_create_pool(key)
 
             # Check that warning was logged when the pool count reached 80% of 10
-            warning_calls = [call for call in mock_logger.warning.call_args_list
-                           if "approaching limit" in str(call).lower()]
+            warning_calls = [call for call in mock_logger.warning.call_args_list if "approaching limit" in str(call).lower()]
             assert len(warning_calls) > 0, f"Expected warning about approaching limit. Got calls: {mock_logger.warning.call_args_list}"
 
         await pool.close_all()
@@ -3676,6 +3677,7 @@ class TestMaxTotalSessionsLimit:
 
         # Mock _create_session to return fake sessions quickly
         call_count = [0]
+
         async def mock_create(url, *args, **kwargs):
             call_count[0] += 1
             mock_session = MagicMock()
@@ -3708,6 +3710,7 @@ class TestMaxTotalSessionsLimit:
 
         # Mock _create_session to return fake sessions quickly
         call_count = [0]
+
         async def mock_create(url, *args, **kwargs):
             call_count[0] += 1
             mock_session = MagicMock()
@@ -3751,6 +3754,7 @@ class TestJwtIdentityExtractorNone:
     @pytest.mark.asyncio
     async def test_jwt_identity_extractor_returns_none_on_invalid_token(self):
         """When jwt_identity_extractor returns None, should fall back to header hash."""
+
         def extractor_returns_none(headers: dict) -> Optional[str]:
             return None
 
@@ -3767,6 +3771,7 @@ class TestJwtIdentityExtractorNone:
     @pytest.mark.asyncio
     async def test_jwt_identity_extractor_exception_falls_back(self):
         """When jwt_identity_extractor raises, should fall back to header hash."""
+
         def extractor_raises(headers: dict) -> Optional[str]:
             raise ValueError("Invalid JWT")
 
@@ -3803,7 +3808,7 @@ class TestJwtIdentityExtractorNone:
     @pytest.mark.asyncio
     async def test_jwt_identity_extractor_with_real_jwt_decode_failure(self):
         """Test the actual jwt_identity_extractor implementation with invalid JWT."""
-        # Standard
+        # Third-Party
         import jwt
 
         def jwt_identity_extractor(headers: dict) -> Optional[str]:
@@ -3817,11 +3822,7 @@ class TestJwtIdentityExtractorNone:
                 return None
 
             try:
-                claims = jwt.decode(
-                    token,
-                    options={"verify_signature": False},
-                    algorithms=["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
-                )
+                claims = jwt.decode(token, options={"verify_signature": False}, algorithms=["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"])
                 return claims.get("sub") or claims.get("email") or claims.get("user_id")
             except Exception:
                 return None

--- a/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
+++ b/tests/unit/mcpgateway/services/test_mcp_session_pool_coverage.py
@@ -22,7 +22,6 @@ from mcpgateway.services.mcp_session_pool import (
     _get_cleanup_timeout,
     close_mcp_session_pool,
     drain_mcp_session_pool,
-    get_mcp_session_pool,
     init_mcp_session_pool,
     MCPSessionPool,
     PooledSession,

--- a/tests/unit/mcpgateway/services/test_metrics_exception_coverage.py
+++ b/tests/unit/mcpgateway/services/test_metrics_exception_coverage.py
@@ -223,6 +223,7 @@ class TestToolServiceMetricsException:
             patch("mcpgateway.services.http_client_service.get_http_client") as mock_http_client,
             patch("mcpgateway.services.tool_service.PydanticTool.model_validate", return_value=valid_tool),
             patch("mcpgateway.services.tool_service.PydanticGateway.model_validate", return_value=MagicMock()),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
 
             mock_client = AsyncMock()

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -212,11 +212,11 @@ class TestPromptServiceInit:
     async def test_plugins_enabled_env_flag_false_disables_plugin_manager(self, monkeypatch):
         """Cover env-override parsing in PromptService._get_plugin_manager (PLUGINS_ENABLED)."""
         from mcpgateway.plugins.framework import enable_plugins, reset_plugin_manager_factory
-        
+
         monkeypatch.setenv("PLUGINS_ENABLED", "false")
         enable_plugins(False)
         reset_plugin_manager_factory()
-        
+
         svc = PromptService()
         result = await svc._get_plugin_manager(None)
         assert not result

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -208,11 +208,13 @@ def prompt_service():
 
 
 class TestPromptServiceInit:
-    def test_plugins_enabled_env_flag_false_disables_plugin_manager(self, monkeypatch):
-        """Cover env-override parsing in PromptService.__init__ (PLUGINS_ENABLED)."""
+    @pytest.mark.asyncio
+    async def test_plugins_enabled_env_flag_false_disables_plugin_manager(self, monkeypatch):
+        """Cover env-override parsing in PromptService._get_plugin_manager (PLUGINS_ENABLED)."""
         monkeypatch.setenv("PLUGINS_ENABLED", "false")
         svc = PromptService()
-        assert svc._plugin_manager is None
+        result = await svc._get_plugin_manager(None)
+        assert not result
 
 
 class TestPromptService:
@@ -413,11 +415,7 @@ class TestPromptService:
 
         # Mock get_content_security_service to return a mock that raises ContentSizeError
         mock_security_service = Mock()
-        mock_security_service.validate_prompt_size.side_effect = ContentSizeError(
-            content_type="Prompt template",
-            actual_size=15000,
-            max_size=10240
-        )
+        mock_security_service.validate_prompt_size.side_effect = ContentSizeError(content_type="Prompt template", actual_size=15000, max_size=10240)
 
         with patch("mcpgateway.services.prompt_service.get_content_security_service", return_value=mock_security_service):
             # Use 15KB template - passes Pydantic (65KB limit) but fails ContentSizeError (10KB limit)
@@ -904,8 +902,6 @@ class TestPromptService:
 
         plugin_mgr.invoke_hook = AsyncMock(side_effect=[(pre_result, {"ctx": 1}), (post_result, {"ctx": 1})])
 
-        prompt_service._plugin_manager = plugin_mgr
-
         @contextmanager
         def _no_span(*_a, **_kw):
             yield None
@@ -915,6 +911,7 @@ class TestPromptService:
         with (
             patch("mcpgateway.services.prompt_service.create_span", _no_span),
             patch("mcpgateway.services.prompt_service.metrics_buffer") as mock_get_buf,
+            patch.object(prompt_service, "_get_plugin_manager", AsyncMock(return_value=plugin_mgr)),
         ):
             mock_get_buf.record_prompt_metric = Mock()
             result = await prompt_service.get_prompt(
@@ -953,8 +950,6 @@ class TestPromptService:
         pre_result = SimpleNamespace(modified_payload=pre_payload)
         plugin_mgr.invoke_hook = AsyncMock(return_value=(pre_result, {"ctx": 1}))
 
-        prompt_service._plugin_manager = plugin_mgr
-
         @contextmanager
         def _no_span(*_a, **_kw):
             yield None
@@ -962,6 +957,7 @@ class TestPromptService:
         with (
             patch("mcpgateway.services.prompt_service.create_span", _no_span),
             patch("mcpgateway.services.prompt_service.metrics_buffer") as mock_get_buf,
+            patch.object(prompt_service, "_get_plugin_manager", AsyncMock(return_value=plugin_mgr)),
         ):
             mock_get_buf.record_prompt_metric = Mock()
             result = await prompt_service.get_prompt(test_db, "1", {"name": "Bob"}, user="user@test.com")
@@ -1157,11 +1153,7 @@ class TestPromptService:
 
         # Mock get_content_security_service to return a mock that raises ContentSizeError
         mock_security_service = Mock()
-        mock_security_service.validate_prompt_size.side_effect = ContentSizeError(
-            content_type="Prompt template",
-            actual_size=15000,
-            max_size=10240
-        )
+        mock_security_service.validate_prompt_size.side_effect = ContentSizeError(content_type="Prompt template", actual_size=15000, max_size=10240)
 
         with patch("mcpgateway.services.prompt_service.get_content_security_service", return_value=mock_security_service):
             # Use 15KB template - passes Pydantic (65KB limit) but fails ContentSizeError (10KB limit)

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -211,7 +211,12 @@ class TestPromptServiceInit:
     @pytest.mark.asyncio
     async def test_plugins_enabled_env_flag_false_disables_plugin_manager(self, monkeypatch):
         """Cover env-override parsing in PromptService._get_plugin_manager (PLUGINS_ENABLED)."""
+        from mcpgateway.plugins.framework import enable_plugins, reset_plugin_manager_factory
+        
         monkeypatch.setenv("PLUGINS_ENABLED", "false")
+        enable_plugins(False)
+        reset_plugin_manager_factory()
+        
         svc = PromptService()
         result = await svc._get_plugin_manager(None)
         assert not result

--- a/tests/unit/mcpgateway/services/test_prompt_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service_extended.py
@@ -13,8 +13,6 @@ including error handling, edge cases, and specific functionality scenarios.
 from __future__ import annotations
 
 # Standard
-import asyncio
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -22,11 +20,8 @@ import pytest
 
 # First-Party
 from mcpgateway.services.prompt_service import (
-    PromptError,
     PromptNameConflictError,
-    PromptNotFoundError,
     PromptService,
-    PromptValidationError,
 )
 
 
@@ -252,8 +247,8 @@ class TestPromptServiceExtended:
         """Test get_prompt method functionality (handles rendering)."""
         service = PromptService()
 
-        # Test plugin manager exists
-        assert hasattr(service, "_plugin_manager")
+        # Test plugin manager method exists
+        assert hasattr(service, "_get_plugin_manager")
 
         # Test method parameters
         # Standard

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1968,14 +1968,15 @@ class TestUtilityMethods:
         result = resource_service.convert_resource_to_read(mock_resource, include_metrics=False)
         assert result.tags == ["plain", "dict-label", "dict-name", "obj-label", "obj-name"]
 
-    def test_init_skips_plugin_manager_when_plugins_unavailable(self):
-        """Cover the PLUGINS_AVAILABLE=False init branch."""
+    def test_init_creates_service_with_expected_attributes(self):
+        """Cover ResourceService.__init__ — verify core attributes are set."""
         # First-Party
         from mcpgateway.services import resource_service as rs_mod
 
-        with patch.object(rs_mod, "PLUGINS_AVAILABLE", False):
-            svc = rs_mod.ResourceService()
-        assert svc._plugin_manager is None
+        svc = rs_mod.ResourceService()
+        assert hasattr(svc, "_event_service")
+        assert hasattr(svc, "_template_cache")
+        assert hasattr(svc, "oauth_manager")
 
 
 # --------------------------------------------------------------------------- #
@@ -2393,7 +2394,6 @@ class TestResourceUpdateMimeTypeDetection:
     async def test_update_resource_with_empty_mime_type_detects_from_uri(self, resource_service, mock_db):
         """Test that empty MIME type triggers detection from URI."""
         # Standard
-        from datetime import datetime, timezone
 
         # First-Party
         from mcpgateway.schemas import ResourceUpdate
@@ -5862,11 +5862,11 @@ class TestReadResourceCoverageEdges:
         )
         db.get.return_value = resource_db
 
-        plugin_manager = MagicMock()
+        plugin_manager = AsyncMock()
         plugin_manager._initialized = True
         plugin_manager.has_hooks_for.side_effect = lambda hook: hook == ResourceHookType.RESOURCE_PRE_FETCH
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None), None))
-        svc._plugin_manager = plugin_manager
+        svc._get_plugin_manager = AsyncMock(return_value=plugin_manager)
 
         global_ctx = SimpleNamespace(user=None, server_id=None)
 
@@ -5905,11 +5905,11 @@ class TestReadResourceCoverageEdges:
         )
         db.get.return_value = resource_db
 
-        plugin_manager = MagicMock()
+        plugin_manager = AsyncMock()
         plugin_manager._initialized = True
         plugin_manager.has_hooks_for.side_effect = lambda hook: hook == ResourceHookType.RESOURCE_PRE_FETCH
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None), None))
-        svc._plugin_manager = plugin_manager
+        svc._get_plugin_manager = AsyncMock(return_value=plugin_manager)
 
         global_ctx = SimpleNamespace(user=None, server_id=None)
 

--- a/tests/unit/mcpgateway/services/test_resource_service_plugins.py
+++ b/tests/unit/mcpgateway/services/test_resource_service_plugins.py
@@ -12,18 +12,17 @@ import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
+from fastapi import Request
+from fastapi.responses import HTMLResponse
 import pytest
 from sqlalchemy.orm import Session
-from fastapi.responses import HTMLResponse
-from fastapi import Request
 
 # First-Party
+from mcpgateway.admin import admin_add_resource
 from mcpgateway.common.models import ResourceContent
-from mcpgateway.plugins.framework import ResourceHookType
+from mcpgateway.plugins.framework import PluginError, PluginErrorModel, PluginViolation, PluginViolationError, ResourceHookType
 from mcpgateway.plugins.framework.models import PluginResult
 from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService
-from mcpgateway.plugins.framework import PluginError, PluginErrorModel, PluginViolation, PluginViolationError
-from mcpgateway.admin import admin_add_resource
 
 
 @pytest.fixture
@@ -117,10 +116,11 @@ class TestResourceServicePluginIntegration:
         mock_manager = MagicMock()
         mock_manager._initialized = False
         mock_manager.initialize = AsyncMock()
+        mock_manager.has_hooks_for = MagicMock(return_value=True)
         mock_manager.invoke_hook = AsyncMock(return_value=(PR(continue_processing=True, modified_payload=None), None))  # contexts
         with patch.dict(os.environ, {"PLUGINS_ENABLED": "false"}):
             service = ResourceService()
-        service._plugin_manager = mock_manager
+        service._get_plugin_manager = AsyncMock(return_value=mock_manager)
         return service
 
     @pytest.mark.asyncio
@@ -148,7 +148,7 @@ class TestResourceServicePluginIntegration:
         """Test read_resource executes pre-fetch hook and passes correct context."""
 
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         # Mock DB session
         mock_db: Session = MagicMock()
@@ -226,11 +226,12 @@ class TestResourceServicePluginIntegration:
     @pytest.mark.asyncio
     async def test_read_resource_blocked_by_plugin(self, resource_service_with_plugins, mock_db):
         """Test read_resource blocked by pre-fetch hook."""
+        # First-Party
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         # Setup mock resource
         mock_resource = MagicMock()
@@ -267,7 +268,8 @@ class TestResourceServicePluginIntegration:
         """Test read_resource with plugin modifying URI and a mocked SQLAlchemy Session."""
 
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+
+        mock_manager = await service._get_plugin_manager(None)
 
         # Fake resource content returned from DB
         fake_resource_content = ResourceContent(
@@ -328,14 +330,13 @@ class TestResourceServicePluginIntegration:
     async def test_read_resource_content_filtered_by_plugin(self, mock_ssl, resource_service_with_plugins, mock_db):
         """Test read_resource with content filtering by post-fetch hook."""
         # First-Party
-        from mcpgateway.plugins.framework.models import PluginResult
         from mcpgateway.plugins.framework import ResourceHookType
-
+        from mcpgateway.plugins.framework.models import PluginResult
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         mock_ctx = MagicMock()
         mock_ssl.return_value = mock_ctx
@@ -402,11 +403,12 @@ class TestResourceServicePluginIntegration:
     @pytest.mark.asyncio
     async def test_read_resource_plugin_error_handling(self, resource_service_with_plugins, mock_db):
         """Test read_resource handles plugin errors gracefully."""
+        # First-Party
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         # Setup mock resource
         mock_resource = MagicMock()
@@ -436,14 +438,13 @@ class TestResourceServicePluginIntegration:
     async def test_read_resource_post_fetch_blocking(self, resource_service_with_plugins, mock_db):
         """Test read_resource blocked by post-fetch hook."""
         # First-Party
-        from mcpgateway.plugins.framework.models import PluginResult
         from mcpgateway.plugins.framework import ResourceHookType
-
+        from mcpgateway.plugins.framework.models import PluginResult
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         # Setup mock resource
         mock_resource = MagicMock()
@@ -491,11 +492,12 @@ class TestResourceServicePluginIntegration:
     @patch("mcpgateway.services.resource_service.ssl.create_default_context")
     async def test_read_resource_with_template(self, mock_ssl, resource_service_with_plugins, mock_db):
         """Test read_resource with template resource and plugins."""
+        # First-Party
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         mock_ctx = MagicMock()
         mock_ssl.return_value = mock_ctx
@@ -532,14 +534,13 @@ class TestResourceServicePluginIntegration:
     async def test_read_resource_context_propagation(self, mock_ssl, resource_service_with_plugins, mock_db):
         """Test context propagation from pre-fetch to post-fetch."""
         # First-Party
-        from mcpgateway.plugins.framework.models import PluginResult
         from mcpgateway.plugins.framework import ResourceHookType
-
+        from mcpgateway.plugins.framework.models import PluginResult
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         mock_ctx = MagicMock()
         mock_ssl.return_value = mock_ctx
@@ -602,28 +603,31 @@ class TestResourceServicePluginIntegration:
 
     @pytest.mark.asyncio
     async def test_plugin_manager_initialization(self):
-        """Test plugin manager initialization in ResourceService."""
+        """_get_plugin_manager should return the manager from the framework factory."""
         mock_manager = MagicMock()
-        with patch("mcpgateway.services.resource_service.get_plugin_manager", return_value=mock_manager):
-            service = ResourceService()
-            assert service._plugin_manager is mock_manager
+        service = ResourceService()
+        with patch("mcpgateway.services.base_service.get_plugin_manager", AsyncMock(return_value=mock_manager)):
+            result = await service._get_plugin_manager("server-1")
+        assert result is mock_manager
 
     @pytest.mark.asyncio
     async def test_plugin_manager_initialization_failure(self):
-        """Test plugin manager initialization failure handling."""
-        with patch("mcpgateway.services.resource_service.get_plugin_manager", side_effect=ValueError("Invalid config")):
-            service = ResourceService()
-            assert service._plugin_manager is None  # Should fail gracefully
+        """_get_plugin_manager should propagate errors from the framework factory."""
+        service = ResourceService()
+        with patch("mcpgateway.services.base_service.get_plugin_manager", AsyncMock(side_effect=ValueError("Invalid config"))):
+            with pytest.raises(ValueError, match="Invalid config"):
+                await service._get_plugin_manager("server-1")
 
     @pytest.mark.asyncio
     @patch("mcpgateway.services.resource_service.ssl.create_default_context")
     async def test_read_resource_no_request_id(self, mock_ssl, resource_service_with_plugins, mock_db):
         """Test read_resource generates request_id if not provided."""
+        # First-Party
         import mcpgateway.services.resource_service as resource_service_mod
 
         resource_service_mod.PLUGINS_AVAILABLE = True
         service = resource_service_with_plugins
-        mock_manager = service._plugin_manager
+        mock_manager = await service._get_plugin_manager(None)
 
         mock_ctx = MagicMock()
         mock_ssl.return_value = mock_ctx

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -27,9 +27,12 @@ from sqlalchemy.pool import StaticPool
 # First-Party
 from mcpgateway.db import Base, ToolPluginBinding
 from mcpgateway.schemas import (
+    OutputLengthGuardConfig,
     PluginBindingMode,
     PluginId,
     PluginPolicyItem,
+    RateLimiterConfig,
+    SecretsDetectionConfig,
     TeamPolicies,
     ToolPluginBindingRequest,
     ToolPluginBindingResponse,
@@ -267,10 +270,24 @@ class TestUpsertBindings:
         results = service.upsert_bindings(db_session, request, caller_email="admin@example.com")
 
         assert len(results) == 2
-        assert {r.tool_name for r in results} == {"tool_a", "tool_b"}
-        for r in results:
-            assert r.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
         assert db_session.query(ToolPluginBinding).count() == 2
+
+        by_tool = {r.tool_name: r for r in results}
+        assert set(by_tool.keys()) == {"tool_a", "tool_b"}
+
+        tool_a = by_tool["tool_a"]
+        assert tool_a.team_id == "team-a"
+        assert tool_a.plugin_id == "RATE_LIMITER"
+        assert tool_a.mode == "permissive"
+        assert tool_a.priority == 20
+        assert tool_a.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
+
+        tool_b = by_tool["tool_b"]
+        assert tool_b.team_id == "team-a"
+        assert tool_b.plugin_id == "RATE_LIMITER"
+        assert tool_b.mode == "permissive"
+        assert tool_b.priority == 20
+        assert tool_b.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
 
     def test_multiple_teams(self, service, db_session):
         """A request spanning two teams produces one binding per team."""
@@ -287,8 +304,20 @@ class TestUpsertBindings:
         results = service.upsert_bindings(db_session, request, caller_email="admin@example.com")
 
         assert len(results) == 2
-        assert {r.team_id for r in results} == {"team-a", "team-b"}
         assert db_session.query(ToolPluginBinding).count() == 2
+
+        by_team = {r.team_id: r for r in results}
+        assert set(by_team.keys()) == {"team-a", "team-b"}
+
+        team_a = by_team["team-a"]
+        assert team_a.tool_name == "tool_x"
+        assert team_a.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert team_a.config == {"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."}
+
+        team_b = by_team["team-b"]
+        assert team_b.tool_name == "tool_y"
+        assert team_b.plugin_id == "SECRETS_DETECTION"
+        assert team_b.config == {"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 1}
 
     def test_caller_email_stored_in_audit_fields(self, service, db_session, simple_request):
         """caller_email is written to both created_by and updated_by on insert."""
@@ -394,8 +423,6 @@ class TestOutputLengthGuardConfig:
 
     def test_valid_defaults(self):
         """Default construction succeeds — schema defaults remain available for internal/plugin-manager use."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         cfg = OutputLengthGuardConfig()
         assert cfg.min_chars == 0
         assert cfg.max_chars == 2000
@@ -404,60 +431,44 @@ class TestOutputLengthGuardConfig:
 
     def test_valid_explicit(self):
         """Explicit valid values are accepted."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         cfg = OutputLengthGuardConfig(min_chars=100, max_chars=500, strategy="block", ellipsis="[cut]")
         assert cfg.min_chars == 100
         assert cfg.max_chars == 500
         assert cfg.strategy == "block"
         assert cfg.ellipsis == "[cut]"
 
-    def test_min_must_be_less_than_max(self):
-        """min_chars >= max_chars is rejected by the cross-validator."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
+    def test_min_equal_to_max_rejected(self):
+        """min_chars == max_chars is rejected by the cross-validator."""
         with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
             OutputLengthGuardConfig(min_chars=500, max_chars=500, strategy="truncate", ellipsis="...")
 
-    def test_min_greater_than_max_also_rejected(self):
-        """min_chars > max_chars is also rejected."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
+    def test_min_greater_than_max_rejected(self):
+        """min_chars > max_chars is rejected by the cross-validator."""
         with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
             OutputLengthGuardConfig(min_chars=1000, max_chars=100, strategy="truncate", ellipsis="...")
 
     def test_max_chars_must_be_greater_than_one(self):
         """max_chars=1 is rejected (must be > 1)."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         with pytest.raises(ValidationError, match=r"(?s)max_chars.*greater than 1"):
             OutputLengthGuardConfig(min_chars=0, max_chars=1, strategy="truncate", ellipsis="...")
 
     def test_min_chars_must_be_non_negative(self):
         """min_chars=-1 is rejected (must be >= 0)."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         with pytest.raises(ValidationError, match=r"(?s)min_chars.*greater than or equal to 0"):
             OutputLengthGuardConfig(min_chars=-1, max_chars=100, strategy="truncate", ellipsis="...")
 
     def test_invalid_strategy(self):
         """Strategy values other than 'truncate' or 'block' are rejected."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         with pytest.raises(ValidationError, match=r"(?s)strategy.*'truncate' or 'block'"):
             OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="drop", ellipsis="...")
 
     def test_ellipsis_too_long(self):
         """ellipsis longer than 20 characters is rejected."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         with pytest.raises(ValidationError, match=r"(?s)ellipsis.*at most 20 characters"):
             OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="truncate", ellipsis="x" * 21)
 
     def test_extra_fields_forbidden(self):
         """Unknown fields are rejected (extra='forbid')."""
-        from mcpgateway.schemas import OutputLengthGuardConfig
-
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="truncate", ellipsis="...", unknown_field="bad")
 
@@ -472,8 +483,6 @@ class TestRateLimiterConfig:
 
     def test_all_none_is_valid(self):
         """All-None construction is valid (no limits configured)."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         cfg = RateLimiterConfig()
         assert cfg.by_user is None
         assert cfg.by_tenant is None
@@ -481,51 +490,37 @@ class TestRateLimiterConfig:
 
     def test_valid_per_minute(self):
         """Rate strings ending in /m are accepted."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         cfg = RateLimiterConfig(by_user="60/m", by_tenant="600/m", by_tool="10/m")
         assert cfg.by_user == "60/m"
         assert cfg.by_tenant == "600/m"
 
     def test_valid_per_second(self):
         """Rate strings ending in /s are accepted."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         cfg = RateLimiterConfig(by_user="10/s")
         assert cfg.by_user == "10/s"
 
     def test_invalid_period_h(self):
         """Period /h is not accepted."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         with pytest.raises(ValidationError, match=r"Rate string '60/h' is invalid"):
             RateLimiterConfig(by_user="60/h")
 
     def test_invalid_no_slash(self):
         """Rate strings without a slash are rejected."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         with pytest.raises(ValidationError, match=r"Rate string '100' is invalid"):
             RateLimiterConfig(by_tool="100")
 
     def test_invalid_missing_count(self):
         """Rate strings missing the numeric count are rejected."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         with pytest.raises(ValidationError, match=r"Rate string '/m' is invalid"):
             RateLimiterConfig(by_tenant="/m")
 
     def test_invalid_non_numeric_count(self):
         """Non-numeric count is rejected."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         with pytest.raises(ValidationError, match=r"Rate string 'fast/m' is invalid"):
             RateLimiterConfig(by_user="fast/m")
 
     def test_extra_fields_forbidden(self):
         """Unknown fields are rejected (extra='forbid')."""
-        from mcpgateway.schemas import RateLimiterConfig
-
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             RateLimiterConfig(by_ip="10/m")
 
@@ -540,8 +535,6 @@ class TestSecretsDetectionConfig:
 
     def test_valid_defaults(self):
         """Default construction succeeds — schema defaults remain available for internal/plugin-manager use."""
-        from mcpgateway.schemas import SecretsDetectionConfig
-
         cfg = SecretsDetectionConfig()
         assert cfg.redact is True
         assert cfg.redaction_text == "[REDACTED]"
@@ -551,8 +544,6 @@ class TestSecretsDetectionConfig:
 
     def test_valid_explicit(self):
         """Explicit valid values are accepted."""
-        from mcpgateway.schemas import SecretsDetectionConfig
-
         cfg = SecretsDetectionConfig(
             enabled={"aws_key": True, "github_token": False},
             redact=True,
@@ -565,22 +556,16 @@ class TestSecretsDetectionConfig:
 
     def test_min_findings_must_be_at_least_one(self):
         """min_findings_to_block=0 is rejected (must be >= 1)."""
-        from mcpgateway.schemas import SecretsDetectionConfig
-
         with pytest.raises(ValidationError, match=r"(?s)min_findings_to_block.*greater than or equal to 1"):
             SecretsDetectionConfig(enabled={}, redact=True, redaction_text="[REDACTED]", block_on_detection=False, min_findings_to_block=0)
 
     def test_redaction_text_too_long(self):
         """redaction_text longer than 50 characters is rejected."""
-        from mcpgateway.schemas import SecretsDetectionConfig
-
         with pytest.raises(ValidationError, match=r"(?s)redaction_text.*at most 50 characters"):
             SecretsDetectionConfig(enabled={}, redact=True, redaction_text="x" * 51, block_on_detection=False, min_findings_to_block=1)
 
     def test_extra_fields_forbidden(self):
         """Unknown fields are rejected (extra='forbid')."""
-        from mcpgateway.schemas import SecretsDetectionConfig
-
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             SecretsDetectionConfig(enabled={}, redact=True, redaction_text="[REDACTED]", block_on_detection=False, min_findings_to_block=1, scan_mode="deep")
 
@@ -790,13 +775,15 @@ class TestTopLevelSchemas:
                 }
             )
         errors = exc_info.value.errors()
-        # Both items must be present — two separate value_error entries
         assert len(errors) == 2, f"Expected 2 errors, got {len(errors)}: {errors}"
-        # Locations include the list index so callers can pinpoint which binding was broken
-        locs = [e["loc"] for e in errors]
-        assert any(0 in loc for loc in locs), "Expected error location for policies[0]"
-        assert any(1 in loc for loc in locs), "Expected error location for policies[1]"
-        # Error text must name the offending plugin for easy diagnosis
-        all_msgs = " ".join(e["msg"] for e in errors)
-        assert "OUTPUT_LENGTH_GUARD" in all_msgs
-        assert "RATE_LIMITER" in all_msgs
+
+        # Sort by the integer index in the loc tuple so assertions are deterministic regardless of collection order
+        errors_by_index = sorted(errors, key=lambda e: next(x for x in e["loc"] if isinstance(x, int)))
+
+        # item 0: OLG — strategy field rejected
+        assert errors_by_index[0]["loc"] == ("teams", "team-a", "policies", 0)
+        assert errors_by_index[0]["msg"] == "Value error, Invalid OUTPUT_LENGTH_GUARD config: [strategy: Input should be 'truncate' or 'block']"
+
+        # item 1: RATE_LIMITER — missing all three fields (sorted alphabetically in the error)
+        assert errors_by_index[1]["loc"] == ("teams", "team-a", "policies", 1)
+        assert errors_by_index[1]["msg"] == "Value error, Missing config fields for RATE_LIMITER: ['by_tenant', 'by_tool', 'by_user']"

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -1,0 +1,802 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Madhumohan Jaishankar
+
+Unit tests for ToolPluginBindingService.
+
+Tests cover:
+    - _to_response: ORM → Pydantic conversion helper
+    - upsert_bindings: insert path, update path, multi-team, multi-tool
+    - list_bindings: unfiltered and team-filtered
+    - delete_binding: success and not-found error
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+# Third-Party
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, ToolPluginBinding
+from mcpgateway.schemas import (
+    PluginBindingMode,
+    PluginId,
+    PluginPolicyItem,
+    TeamPolicies,
+    ToolPluginBindingRequest,
+    ToolPluginBindingResponse,
+)
+from mcpgateway.services.tool_plugin_binding_service import (
+    ToolPluginBindingNotFoundError,
+    ToolPluginBindingService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_binding(
+    id_="binding-001",
+    team_id="team-a",
+    tool_name="tool_x",
+    plugin_id="OUTPUT_LENGTH_GUARD",
+    mode="enforce",
+    priority=50,
+    config=None,
+    created_by="admin@example.com",
+    updated_by="admin@example.com",
+):
+    """Build a MagicMock that quacks like a ToolPluginBinding ORM row."""
+    b = MagicMock()
+    b.id = id_
+    b.team_id = team_id
+    b.tool_name = tool_name
+    b.plugin_id = plugin_id
+    b.mode = mode
+    b.priority = priority
+    b.config = config if config is not None else {"max_chars": 2000, "strategy": "truncate"}
+    b.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    b.created_by = created_by
+    b.updated_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    b.updated_by = updated_by
+    return b
+
+
+@pytest.fixture
+def service():
+    """Return a fresh service instance."""
+    return ToolPluginBindingService()
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite session backed by all ORM models.
+
+    Uses StaticPool so the same in-memory database is shared across all
+    connections within the test, giving the service the same view of rows
+    it just inserted.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def simple_request():
+    """Minimal single-team single-tool POST payload."""
+    return ToolPluginBindingRequest(
+        teams={
+            "team-a": TeamPolicies(
+                policies=[
+                    PluginPolicyItem(
+                        tool_names=["tool_x"],
+                        plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                        mode=PluginBindingMode.ENFORCE,
+                        priority=50,
+                        config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                    )
+                ]
+            )
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# _to_response tests
+# ---------------------------------------------------------------------------
+
+
+class TestToResponse:
+    """Tests for ToolPluginBindingService._to_response."""
+
+    def test_to_response_fields(self, service):
+        """All ORM fields are mapped correctly to the response schema."""
+        binding = _make_binding()
+        result = service._to_response(binding)
+
+        assert isinstance(result, ToolPluginBindingResponse)
+        assert result.id == binding.id
+        assert result.team_id == binding.team_id
+        assert result.tool_name == binding.tool_name
+        assert result.plugin_id == binding.plugin_id
+        assert result.mode == binding.mode
+        assert result.priority == binding.priority
+        assert result.config == binding.config
+        assert result.created_at == binding.created_at
+        assert result.created_by == binding.created_by
+        assert result.updated_at == binding.updated_at
+        assert result.updated_by == binding.updated_by
+
+
+# ---------------------------------------------------------------------------
+# upsert_bindings tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertBindings:
+    """Tests for ToolPluginBindingService.upsert_bindings against a real in-memory SQLite DB."""
+
+    def test_insert_new_binding(self, service, db_session, simple_request):
+        """A new (team_id, tool_name, plugin_id) triple is persisted and all fields returned."""
+        results = service.upsert_bindings(db_session, simple_request, caller_email="admin@example.com")
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.team_id == "team-a"
+        assert r.tool_name == "tool_x"
+        assert r.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert r.mode == "enforce"
+        assert r.priority == 50
+        assert r.config == {"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."}
+        assert r.created_by == "admin@example.com"
+        assert r.updated_by == "admin@example.com"
+
+        # Verify the row was actually persisted in the DB
+        row = db_session.query(ToolPluginBinding).one()
+        assert row.tool_name == "tool_x"
+        assert row.team_id == "team-a"
+
+    def test_update_existing_binding(self, service, db_session):
+        """Re-upserting the same triple updates mutable fields; id and created_by are preserved."""
+        request_v1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.PERMISSIVE,
+                            priority=10,
+                            config={"min_chars": 0, "max_chars": 500, "strategy": "truncate", "ellipsis": "..."},
+                        )
+                    ]
+                )
+            }
+        )
+        inserted = service.upsert_bindings(db_session, request_v1, caller_email="creator@example.com")
+        original_id = inserted[0].id
+
+        request_v2 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.ENFORCE,
+                            priority=50,
+                            config={"min_chars": 0, "max_chars": 2000, "strategy": "block", "ellipsis": "..."},
+                        )
+                    ]
+                )
+            }
+        )
+        updated = service.upsert_bindings(db_session, request_v2, caller_email="updater@example.com")
+
+        assert db_session.query(ToolPluginBinding).count() == 1  # still one row
+
+        r = updated[0]
+        assert r.id == original_id                       # primary key preserved
+        assert r.mode == "enforce"
+        assert r.priority == 50
+        assert r.config == {"min_chars": 0, "max_chars": 2000, "strategy": "block", "ellipsis": "..."}
+        assert r.updated_by == "updater@example.com"
+        assert r.created_by == "creator@example.com"     # creation author unchanged
+
+    def test_config_is_fully_replaced_not_merged(self, service, db_session):
+        """On update, config is entirely replaced — values absent from the new payload do not survive."""
+        r1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": "10/s", "by_tenant": None, "by_tool": None})]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r1, caller_email="admin@example.com")
+
+        # Upsert with by_tenant set and by_user explicitly None — original by_user value must NOT survive
+        r2 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": None, "by_tenant": "600/m", "by_tool": None})]
+                )
+            }
+        )
+        results = service.upsert_bindings(db_session, r2, caller_email="admin@example.com")
+
+        assert results[0].config == {"by_user": None, "by_tenant": "600/m", "by_tool": None}
+        assert results[0].config["by_user"] is None  # original "10/s" is gone
+
+    def test_multiple_tool_names_in_one_policy(self, service, db_session):
+        """A policy with multiple tool_names produces one binding per tool, each with the full config."""
+        request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a", "tool_b"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            mode=PluginBindingMode.PERMISSIVE,
+                            priority=20,
+                            config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+                        )
+                    ]
+                )
+            }
+        )
+        results = service.upsert_bindings(db_session, request, caller_email="admin@example.com")
+
+        assert len(results) == 2
+        assert {r.tool_name for r in results} == {"tool_a", "tool_b"}
+        for r in results:
+            assert r.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
+        assert db_session.query(ToolPluginBinding).count() == 2
+
+    def test_multiple_teams(self, service, db_session):
+        """A request spanning two teams produces one binding per team."""
+        request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."})]
+                ),
+                "team-b": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config={"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 1})]
+                ),
+            }
+        )
+        results = service.upsert_bindings(db_session, request, caller_email="admin@example.com")
+
+        assert len(results) == 2
+        assert {r.team_id for r in results} == {"team-a", "team-b"}
+        assert db_session.query(ToolPluginBinding).count() == 2
+
+    def test_caller_email_stored_in_audit_fields(self, service, db_session, simple_request):
+        """caller_email is written to both created_by and updated_by on insert."""
+        results = service.upsert_bindings(db_session, simple_request, caller_email="admin@example.com")
+
+        assert results[0].created_by == "admin@example.com"
+        assert results[0].updated_by == "admin@example.com"
+
+
+# ---------------------------------------------------------------------------
+# list_bindings tests
+# ---------------------------------------------------------------------------
+
+
+class TestListBindings:
+    """Tests for ToolPluginBindingService.list_bindings against a real in-memory SQLite DB."""
+
+    @pytest.fixture(autouse=True)
+    def seed(self, service, db_session):
+        """Insert two bindings for different teams before each test."""
+        request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": None, "by_tenant": None, "by_tool": None})]),
+                "team-b": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config={"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 1})]),
+            }
+        )
+        service.upsert_bindings(db_session, request, caller_email="seeder@example.com")
+
+    def test_list_all_no_filter(self, service, db_session):
+        """team_id=None returns all bindings from all teams."""
+        results = service.list_bindings(db_session, team_id=None)
+        assert len(results) == 2
+        assert {r.team_id for r in results} == {"team-a", "team-b"}
+
+    def test_list_with_team_filter(self, service, db_session):
+        """team_id filter returns only bindings for that team."""
+        results = service.list_bindings(db_session, team_id="team-a")
+        assert len(results) == 1
+        assert results[0].team_id == "team-a"
+
+    def test_list_ordered_by_priority(self, service, db_session):
+        """Results are returned in ascending priority order within a team."""
+        # Add a second binding for team-a with a lower priority number (runs first)
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_z"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, priority=10, config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."})]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+
+        results = service.list_bindings(db_session, team_id="team-a")
+        assert len(results) == 2
+        priorities = [r.priority for r in results]
+        assert priorities == sorted(priorities)
+
+    def test_list_empty(self, service, db_session):
+        """Returns empty list when no bindings exist for the specified team."""
+        results = service.list_bindings(db_session, team_id="team-unknown")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# delete_binding tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBinding:
+    """Tests for ToolPluginBindingService.delete_binding against a real in-memory SQLite DB."""
+
+    def test_delete_success(self, service, db_session):
+        """delete_binding returns the deleted record's details and removes it from the DB."""
+        r = ToolPluginBindingRequest(
+            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": None, "by_tenant": None, "by_tool": None})])}
+        )
+        inserted = service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+        binding_id = inserted[0].id
+
+        deleted = service.delete_binding(db_session, binding_id)
+
+        assert deleted.id == binding_id
+        assert deleted.team_id == "team-a"
+        assert deleted.tool_name == "tool_x"
+        assert deleted.plugin_id == "RATE_LIMITER"
+        assert deleted.config == {"by_user": None, "by_tenant": None, "by_tool": None}
+        # Confirm the row is gone from the DB
+        assert db_session.query(ToolPluginBinding).filter_by(id=binding_id).first() is None
+
+    def test_delete_not_found(self, service, db_session):
+        """delete_binding raises ToolPluginBindingNotFoundError for an unknown ID."""
+        with pytest.raises(ToolPluginBindingNotFoundError, match="not found"):
+            service.delete_binding(db_session, "nonexistent-id")
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — OutputLengthGuardConfig
+# ---------------------------------------------------------------------------
+
+
+class TestOutputLengthGuardConfig:
+    """Pydantic validation for OutputLengthGuardConfig."""
+
+    def test_valid_defaults(self):
+        """Default construction succeeds — schema defaults remain available for internal/plugin-manager use."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        cfg = OutputLengthGuardConfig()
+        assert cfg.min_chars == 0
+        assert cfg.max_chars == 2000
+        assert cfg.strategy == "truncate"
+        assert cfg.ellipsis == "..."
+
+    def test_valid_explicit(self):
+        """Explicit valid values are accepted."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        cfg = OutputLengthGuardConfig(min_chars=100, max_chars=500, strategy="block", ellipsis="[cut]")
+        assert cfg.min_chars == 100
+        assert cfg.max_chars == 500
+        assert cfg.strategy == "block"
+        assert cfg.ellipsis == "[cut]"
+
+    def test_min_must_be_less_than_max(self):
+        """min_chars >= max_chars is rejected by the cross-validator."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
+            OutputLengthGuardConfig(min_chars=500, max_chars=500, strategy="truncate", ellipsis="...")
+
+    def test_min_greater_than_max_also_rejected(self):
+        """min_chars > max_chars is also rejected."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
+            OutputLengthGuardConfig(min_chars=1000, max_chars=100, strategy="truncate", ellipsis="...")
+
+    def test_max_chars_must_be_greater_than_one(self):
+        """max_chars=1 is rejected (must be > 1)."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match=r"(?s)max_chars.*greater than 1"):
+            OutputLengthGuardConfig(min_chars=0, max_chars=1, strategy="truncate", ellipsis="...")
+
+    def test_min_chars_must_be_non_negative(self):
+        """min_chars=-1 is rejected (must be >= 0)."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match=r"(?s)min_chars.*greater than or equal to 0"):
+            OutputLengthGuardConfig(min_chars=-1, max_chars=100, strategy="truncate", ellipsis="...")
+
+    def test_invalid_strategy(self):
+        """Strategy values other than 'truncate' or 'block' are rejected."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match=r"(?s)strategy.*'truncate' or 'block'"):
+            OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="drop", ellipsis="...")
+
+    def test_ellipsis_too_long(self):
+        """ellipsis longer than 20 characters is rejected."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match=r"(?s)ellipsis.*at most 20 characters"):
+            OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="truncate", ellipsis="x" * 21)
+
+    def test_extra_fields_forbidden(self):
+        """Unknown fields are rejected (extra='forbid')."""
+        from mcpgateway.schemas import OutputLengthGuardConfig
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="truncate", ellipsis="...", unknown_field="bad")
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — RateLimiterConfig
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiterConfig:
+    """Pydantic validation for RateLimiterConfig."""
+
+    def test_all_none_is_valid(self):
+        """All-None construction is valid (no limits configured)."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        cfg = RateLimiterConfig()
+        assert cfg.by_user is None
+        assert cfg.by_tenant is None
+        assert cfg.by_tool is None
+
+    def test_valid_per_minute(self):
+        """Rate strings ending in /m are accepted."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        cfg = RateLimiterConfig(by_user="60/m", by_tenant="600/m", by_tool="10/m")
+        assert cfg.by_user == "60/m"
+        assert cfg.by_tenant == "600/m"
+
+    def test_valid_per_second(self):
+        """Rate strings ending in /s are accepted."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        cfg = RateLimiterConfig(by_user="10/s")
+        assert cfg.by_user == "10/s"
+
+    def test_invalid_period_h(self):
+        """Period /h is not accepted."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        with pytest.raises(ValidationError, match=r"Rate string '60/h' is invalid"):
+            RateLimiterConfig(by_user="60/h")
+
+    def test_invalid_no_slash(self):
+        """Rate strings without a slash are rejected."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        with pytest.raises(ValidationError, match=r"Rate string '100' is invalid"):
+            RateLimiterConfig(by_tool="100")
+
+    def test_invalid_missing_count(self):
+        """Rate strings missing the numeric count are rejected."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        with pytest.raises(ValidationError, match=r"Rate string '/m' is invalid"):
+            RateLimiterConfig(by_tenant="/m")
+
+    def test_invalid_non_numeric_count(self):
+        """Non-numeric count is rejected."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        with pytest.raises(ValidationError, match=r"Rate string 'fast/m' is invalid"):
+            RateLimiterConfig(by_user="fast/m")
+
+    def test_extra_fields_forbidden(self):
+        """Unknown fields are rejected (extra='forbid')."""
+        from mcpgateway.schemas import RateLimiterConfig
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            RateLimiterConfig(by_ip="10/m")
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — SecretsDetectionConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsDetectionConfig:
+    """Pydantic validation for SecretsDetectionConfig."""
+
+    def test_valid_defaults(self):
+        """Default construction succeeds — schema defaults remain available for internal/plugin-manager use."""
+        from mcpgateway.schemas import SecretsDetectionConfig
+
+        cfg = SecretsDetectionConfig()
+        assert cfg.redact is True
+        assert cfg.redaction_text == "[REDACTED]"
+        assert cfg.block_on_detection is False
+        assert cfg.min_findings_to_block == 1
+        assert cfg.enabled == {}
+
+    def test_valid_explicit(self):
+        """Explicit valid values are accepted."""
+        from mcpgateway.schemas import SecretsDetectionConfig
+
+        cfg = SecretsDetectionConfig(
+            enabled={"aws_key": True, "github_token": False},
+            redact=True,
+            redaction_text="***",
+            block_on_detection=True,
+            min_findings_to_block=3,
+        )
+        assert cfg.enabled == {"aws_key": True, "github_token": False}
+        assert cfg.min_findings_to_block == 3
+
+    def test_min_findings_must_be_at_least_one(self):
+        """min_findings_to_block=0 is rejected (must be >= 1)."""
+        from mcpgateway.schemas import SecretsDetectionConfig
+
+        with pytest.raises(ValidationError, match=r"(?s)min_findings_to_block.*greater than or equal to 1"):
+            SecretsDetectionConfig(enabled={}, redact=True, redaction_text="[REDACTED]", block_on_detection=False, min_findings_to_block=0)
+
+    def test_redaction_text_too_long(self):
+        """redaction_text longer than 50 characters is rejected."""
+        from mcpgateway.schemas import SecretsDetectionConfig
+
+        with pytest.raises(ValidationError, match=r"(?s)redaction_text.*at most 50 characters"):
+            SecretsDetectionConfig(enabled={}, redact=True, redaction_text="x" * 51, block_on_detection=False, min_findings_to_block=1)
+
+    def test_extra_fields_forbidden(self):
+        """Unknown fields are rejected (extra='forbid')."""
+        from mcpgateway.schemas import SecretsDetectionConfig
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            SecretsDetectionConfig(enabled={}, redact=True, redaction_text="[REDACTED]", block_on_detection=False, min_findings_to_block=1, scan_mode="deep")
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — PluginPolicyItem cross-validation
+# ---------------------------------------------------------------------------
+
+
+class TestPluginPolicyItemValidation:
+    """Tests for PluginPolicyItem including config cross-validation per plugin."""
+
+    def test_defaults_mode_and_priority(self):
+        """PluginPolicyItem defaults for mode and priority; RATE_LIMITER accepts all-null config (explicit no-limit)."""
+        item = PluginPolicyItem(
+            tool_names=["tool_x"],
+            plugin_id=PluginId.RATE_LIMITER,
+            config={"by_user": None, "by_tenant": None, "by_tool": None},
+        )
+        assert item.mode == PluginBindingMode.ENFORCE
+        assert item.priority == 50
+
+    def test_output_length_guard_valid_config(self):
+        """OUTPUT_LENGTH_GUARD with all required fields passes cross-validation."""
+        item = PluginPolicyItem(
+            tool_names=["tool_x"],
+            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+            config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."},
+        )
+        assert item.plugin_id == PluginId.OUTPUT_LENGTH_GUARD
+
+    def test_output_length_guard_invalid_config_rejected(self):
+        """OUTPUT_LENGTH_GUARD with min >= max is caught by PluginPolicyItem validator."""
+        with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                config={"min_chars": 5000, "max_chars": 3000, "strategy": "truncate", "ellipsis": "..."},
+            )
+
+    def test_output_length_guard_rejects_empty_config(self):
+        """OUTPUT_LENGTH_GUARD with {} is rejected — all four fields are required."""
+        with pytest.raises(ValidationError, match="Missing config fields for OUTPUT_LENGTH_GUARD"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                config={},
+            )
+
+    def test_rate_limiter_valid_config(self):
+        """RATE_LIMITER with all three fields (some None) passes cross-validation."""
+        item = PluginPolicyItem(
+            tool_names=["tool_y"],
+            plugin_id=PluginId.RATE_LIMITER,
+            config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+        )
+        assert item.plugin_id == PluginId.RATE_LIMITER
+
+    def test_rate_limiter_invalid_config_rejected(self):
+        """RATE_LIMITER with invalid rate string format is caught by PluginPolicyItem validator."""
+        with pytest.raises(ValidationError, match=r"Rate string '60/h' is invalid"):
+            PluginPolicyItem(
+                tool_names=["tool_y"],
+                plugin_id=PluginId.RATE_LIMITER,
+                config={"by_user": "60/h", "by_tenant": None, "by_tool": None},  # /h not allowed
+            )
+
+    def test_secrets_detection_valid_config(self):
+        """SECRETS_DETECTION with all required fields passes cross-validation."""
+        item = PluginPolicyItem(
+            tool_names=["tool_z"],
+            plugin_id=PluginId.SECRETS_DETECTION,
+            config={"enabled": {"aws_key": True}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": True, "min_findings_to_block": 2},
+        )
+        assert item.plugin_id == PluginId.SECRETS_DETECTION
+
+    def test_secrets_detection_invalid_config_rejected(self):
+        """SECRETS_DETECTION with min_findings_to_block=0 is caught by PluginPolicyItem validator."""
+        with pytest.raises(ValidationError, match=r"(?s)min_findings_to_block.*greater than or equal to 1"):
+            PluginPolicyItem(
+                tool_names=["tool_z"],
+                plugin_id=PluginId.SECRETS_DETECTION,
+                config={"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 0},
+            )
+
+    def test_secrets_detection_rejects_empty_config(self):
+        """SECRETS_DETECTION with {} is rejected — all five fields are required."""
+        with pytest.raises(ValidationError, match="Missing config fields for SECRETS_DETECTION"):
+            PluginPolicyItem(
+                tool_names=["tool_z"],
+                plugin_id=PluginId.SECRETS_DETECTION,
+                config={},
+            )
+
+    def test_empty_tool_names_rejected(self):
+        """tool_names=[] is rejected (min_length=1)."""
+        with pytest.raises(ValidationError, match=r"(?s)tool_names.*at least 1 item"):
+            PluginPolicyItem(
+                tool_names=[],
+                plugin_id=PluginId.RATE_LIMITER,
+                config={"by_user": None, "by_tenant": None, "by_tool": None},
+            )
+
+    def test_priority_below_minimum_rejected(self):
+        """priority=0 is rejected (ge=1)."""
+        with pytest.raises(ValidationError, match=r"(?s)priority.*greater than or equal to 1"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.RATE_LIMITER,
+                priority=0,
+                config={"by_user": None, "by_tenant": None, "by_tool": None},
+            )
+
+    def test_priority_above_maximum_rejected(self):
+        """priority=1001 is rejected (le=1000)."""
+        with pytest.raises(ValidationError, match=r"(?s)priority.*less than or equal to 1000"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.RATE_LIMITER,
+                priority=1001,
+                config={"by_user": None, "by_tenant": None, "by_tool": None},
+            )
+
+    def test_invalid_plugin_id_rejected(self):
+        """An unrecognised plugin_id string is rejected by the PluginId enum."""
+        with pytest.raises(ValidationError, match=r"(?s)plugin_id.*Input should be"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id="UNKNOWN_PLUGIN",  # type: ignore[arg-type]
+                config={},
+            )
+
+    def test_extra_fields_forbidden(self):
+        """Unknown fields on PluginPolicyItem are rejected (extra='forbid')."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.RATE_LIMITER,
+                config={"by_user": None, "by_tenant": None, "by_tool": None},
+                unknown_key="bad",
+            )
+
+    def test_config_field_is_required(self):
+        """config is a required field — omitting it is rejected at schema validation time."""
+        with pytest.raises(ValidationError, match=r"(?s)config.*Field required"):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.RATE_LIMITER,
+                # config intentionally omitted
+            )
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — top-level request/enum invariants
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelSchemas:
+    """Tests for ToolPluginBindingRequest, TeamPolicies, and enum values."""
+
+    def test_request_requires_at_least_one_team(self):
+        """ToolPluginBindingRequest with empty teams dict is rejected."""
+        with pytest.raises(ValidationError, match=r"(?s)teams.*at least 1 item"):
+            ToolPluginBindingRequest(teams={})
+
+    def test_team_policies_requires_at_least_one_policy(self):
+        """TeamPolicies with an empty policies list is rejected."""
+        with pytest.raises(ValidationError, match=r"(?s)policies.*at least 1 item"):
+            TeamPolicies(policies=[])
+
+    def test_plugin_id_enum_values(self):
+        """PluginId enum covers all expected plugin identifiers."""
+        assert PluginId.OUTPUT_LENGTH_GUARD == "OUTPUT_LENGTH_GUARD"
+        assert PluginId.RATE_LIMITER == "RATE_LIMITER"
+        assert PluginId.SECRETS_DETECTION == "SECRETS_DETECTION"
+
+    def test_plugin_binding_mode_enum_values(self):
+        """PluginBindingMode enum covers all expected execution modes."""
+        assert PluginBindingMode.ENFORCE == "enforce"
+        assert PluginBindingMode.PERMISSIVE == "permissive"
+        assert PluginBindingMode.DISABLED == "disabled"
+
+    def test_all_plugin_errors_collected_across_list(self):
+        """When multiple PluginPolicyItems are invalid, all their errors appear in one ValidationError.
+
+        Previously, a ValidationError escaping from the model_validator would short-circuit
+        list validation and hide errors from subsequent items. After the fix, each item's
+        errors are wrapped as ValueError so Pydantic can collect every item.
+
+        NOTE: items must be passed as raw dicts so that Pydantic constructs each
+        PluginPolicyItem internally — if you pre-construct them with PluginPolicyItem(...),
+        Python evaluates each call before TeamPolicies() is reached, raising immediately.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            ToolPluginBindingRequest.model_validate(
+                {
+                    "teams": {
+                        "team-a": {
+                            "policies": [
+                                # item 0: OLG with an invalid value — triggers the new ValueError format
+                                {"tool_names": ["tool_x"], "plugin_id": "OUTPUT_LENGTH_GUARD", "config": {"min_chars": 0, "max_chars": 2000, "strategy": "drop", "ellipsis": "..."}},
+                                # item 1: RATE_LIMITER with missing fields — triggers the existing ValueError
+                                {"tool_names": ["tool_y"], "plugin_id": "RATE_LIMITER", "config": {}},
+                            ]
+                        }
+                    }
+                }
+            )
+        errors = exc_info.value.errors()
+        # Both items must be present — two separate value_error entries
+        assert len(errors) == 2, f"Expected 2 errors, got {len(errors)}: {errors}"
+        # Locations include the list index so callers can pinpoint which binding was broken
+        locs = [e["loc"] for e in errors]
+        assert any(0 in loc for loc in locs), "Expected error location for policies[0]"
+        assert any(1 in loc for loc in locs), "Expected error location for policies[1]"
+        # Error text must name the offending plugin for easy diagnosis
+        all_msgs = " ".join(e["msg"] for e in errors)
+        assert "OUTPUT_LENGTH_GUARD" in all_msgs
+        assert "RATE_LIMITER" in all_msgs

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -40,6 +40,7 @@ from mcpgateway.schemas import (
 from mcpgateway.services.tool_plugin_binding_service import (
     ToolPluginBindingNotFoundError,
     ToolPluginBindingService,
+    get_bindings_for_tool,
 )
 
 
@@ -787,3 +788,122 @@ class TestTopLevelSchemas:
         # item 1: RATE_LIMITER — missing all three fields (sorted alphabetically in the error)
         assert errors_by_index[1]["loc"] == ("teams", "team-a", "policies", 1)
         assert errors_by_index[1]["msg"] == "Value error, Missing config fields for RATE_LIMITER: ['by_tenant', 'by_tool', 'by_user']"
+
+
+# ---------------------------------------------------------------------------
+# get_bindings_for_tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetBindingsForTool:
+    """Tests for the module-level get_bindings_for_tool() query function."""
+
+    @pytest.fixture(autouse=True)
+    def _seed(self, service, db_session):
+        """Insert a known set of bindings used across tests."""
+        self._service = service
+        self._db = db_session
+
+        # Exact binding for (team-a, tool_x) — OUTPUT_LENGTH_GUARD
+        olg_req = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.ENFORCE,
+                            priority=50,
+                            config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, olg_req, caller_email="admin@example.com")
+
+        # Wildcard binding for (team-a, *) — RATE_LIMITER
+        rl_req = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["*"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            mode=PluginBindingMode.PERMISSIVE,
+                            priority=10,
+                            config={"by_user": "100/m", "by_tenant": "1000/m", "by_tool": None},
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, rl_req, caller_email="admin@example.com")
+
+    def test_returns_exact_and_wildcard_bindings(self):
+        """get_bindings_for_tool returns both the exact tool_name match and the '*' wildcard."""
+        results = get_bindings_for_tool(self._db, "team-a", "tool_x")
+        plugin_ids = {b.plugin_id for b in results}
+        assert plugin_ids == {"OUTPUT_LENGTH_GUARD", "RATE_LIMITER"}
+
+    def test_returns_only_wildcard_for_unknown_tool(self):
+        """A tool with no exact binding still gets the wildcard binding."""
+        results = get_bindings_for_tool(self._db, "team-a", "other_tool")
+        assert len(results) == 1
+        assert results[0].plugin_id == "RATE_LIMITER"
+
+    def test_returns_empty_for_unknown_team(self):
+        """An unknown team has no bindings."""
+        results = get_bindings_for_tool(self._db, "unknown-team", "tool_x")
+        assert results == []
+
+    def test_exact_overrides_wildcard_for_same_plugin(self, service, db_session):
+        """When both an exact and a wildcard binding exist for the same plugin_id,
+        the more recently updated one wins (exact was inserted after wildcard here)."""
+        # Insert a wildcard OUTPUT_LENGTH_GUARD first
+        wc_req = ToolPluginBindingRequest(
+            teams={
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["*"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.PERMISSIVE,
+                            priority=1,
+                            config={"min_chars": 0, "max_chars": 100, "strategy": "truncate", "ellipsis": "..."},
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, wc_req, caller_email="admin@example.com")
+
+        # Now insert an exact OUTPUT_LENGTH_GUARD for team-b/tool_z
+        exact_req = ToolPluginBindingRequest(
+            teams={
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_z"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            mode=PluginBindingMode.ENFORCE,
+                            priority=99,
+                            config={"min_chars": 0, "max_chars": 9999, "strategy": "truncate", "ellipsis": "..."},
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, exact_req, caller_email="admin@example.com")
+
+        results = get_bindings_for_tool(db_session, "team-b", "tool_z")
+        # Only one entry per plugin_id — the one with the higher updated_at wins
+        olg_results = [b for b in results if b.plugin_id == "OUTPUT_LENGTH_GUARD"]
+        assert len(olg_results) == 1
+        # The exact binding has priority=99 (inserted last → higher updated_at)
+        assert olg_results[0].priority == 99
+
+    def test_does_not_cross_team_boundaries(self):
+        """Bindings for a different team are not returned."""
+        results = get_bindings_for_tool(self._db, "team-b", "tool_x")
+        assert results == []

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -29,7 +29,7 @@ from mcpgateway.cache.tool_lookup_cache import tool_lookup_cache
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import Tool as DbTool
-from mcpgateway.plugins.framework import PluginManager
+from mcpgateway.plugins.framework import PluginManager, PluginMode
 from mcpgateway.plugins.framework.hooks.tools import ToolHookType
 from mcpgateway.plugins.framework.models import PluginResult
 from mcpgateway.schemas import AuthenticationValues, ToolCreate, ToolRead, ToolUpdate
@@ -217,30 +217,28 @@ class TestToolServiceHelpersExtended:
         assert result == [TextContent(type="text", text="Error applying jsonpath filter: boom")]
 
     def test_tool_service_plugin_env_override(self, monkeypatch):
-        """PLUGINS_ENABLED env flag should override settings."""
+        """PLUGINS_ENABLED env flag controls whether the plugin factory is available."""
         # First-Party
         import mcpgateway.plugins.framework as pf_mod  # pylint: disable=import-outside-toplevel
         from mcpgateway.plugins.framework.settings import settings as plugin_settings  # pylint: disable=import-outside-toplevel
 
-        # Reset singleton so get_plugin_manager() re-evaluates settings
-        monkeypatch.setattr(pf_mod, "_plugin_manager", None)
+        # Enabled case: pre-install a mock factory so get_plugin_manager_factory() returns it
+        mock_factory_instance = MagicMock()
+        mock_factory_instance._managers = {}
+        monkeypatch.setattr(pf_mod, "_plugin_manager_factory", mock_factory_instance)
         monkeypatch.setenv("PLUGINS_ENABLED", "yes")
         plugin_settings.cache_clear()
 
-        with patch("mcpgateway.plugins.framework.PluginManager") as mock_pm:
-            service = ToolService()
-        assert service._plugin_manager is not None
-        mock_pm.assert_called_once()
+        service = ToolService()  # noqa: F841
+        assert pf_mod._plugin_manager_factory is not None
 
-        # Reset singleton again for the disabled case
-        monkeypatch.setattr(pf_mod, "_plugin_manager", None)
+        # Disabled case: factory should be None
+        monkeypatch.setattr(pf_mod, "_plugin_manager_factory", None)
         monkeypatch.setenv("PLUGINS_ENABLED", "no")
         plugin_settings.cache_clear()
 
-        with patch("mcpgateway.plugins.framework.PluginManager") as mock_pm:
-            service = ToolService()
-        assert service._plugin_manager is None
-        mock_pm.assert_not_called()
+        service = ToolService()  # noqa: F841
+        assert pf_mod._plugin_manager_factory is None
 
     @pytest.mark.asyncio
     async def test_get_top_tools_returns_cached(self, monkeypatch):
@@ -325,6 +323,8 @@ def tool_service():
     """Create a tool service instance."""
     service = ToolService()
     service._http_client = AsyncMock()
+    service.get_plugin_manager = AsyncMock()
+    # service._plugin_manager = False  # Disable plugin manager to avoid real plugin execution in tests
 
     return service
 
@@ -3683,7 +3683,7 @@ class TestToolService:
         mock_post_result.modified_payload = None
         mock_post_result.retry_delay_ms = 0
 
-        tool_service._plugin_manager = Mock()
+        mock_pm = Mock()
 
         def invoke_hook_side_effect(hook_type, payload, global_context, local_contexts=None, **kwargs):
             if hook_type == ToolHookType.TOOL_PRE_INVOKE:
@@ -3691,16 +3691,17 @@ class TestToolService:
             # POST_INVOKE
             return (mock_post_result, None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         with (
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "original response"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
         # Verify plugin hooks were called
-        assert tool_service._plugin_manager.invoke_hook.call_count == 2  # Pre and post invoke
+        assert mock_pm.invoke_hook.call_count == 2  # Pre and post invoke
 
         # Verify result
         assert result.content[0].text == '{\n  "result": "original response"\n}'
@@ -3735,7 +3736,7 @@ class TestToolService:
         # First-Party
         from mcpgateway.plugins.framework import PluginResult, ToolHookType
 
-        tool_service._plugin_manager = Mock()
+        mock_pm = Mock()
 
         def invoke_hook_side_effect(hook_type, payload, global_context, local_contexts=None, **kwargs):
             if hook_type == ToolHookType.TOOL_PRE_INVOKE:
@@ -3743,16 +3744,17 @@ class TestToolService:
             # POST_INVOKE
             return (mock_post_result, None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         with (
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "original response"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
         # Verify plugin hooks were called
-        assert tool_service._plugin_manager.invoke_hook.call_count == 2  # Pre and post invoke
+        assert mock_pm.invoke_hook.call_count == 2  # Pre and post invoke
 
         # Verify result was modified by plugin
         assert result.content[0].text == "Modified by plugin"
@@ -3788,7 +3790,7 @@ class TestToolService:
         from mcpgateway.plugins.framework import ToolHookType
         from mcpgateway.plugins.framework.models import PluginResult
 
-        tool_service._plugin_manager = Mock()
+        mock_pm = Mock()
 
         def invoke_hook_side_effect(hook_type, payload, global_context, local_contexts=None, **kwargs):
             if hook_type == ToolHookType.TOOL_PRE_INVOKE:
@@ -3796,16 +3798,17 @@ class TestToolService:
             # POST_INVOKE
             return (mock_post_result, None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         with (
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "original response"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
         # Verify plugin hooks were called
-        assert tool_service._plugin_manager.invoke_hook.call_count == 2  # Pre and post invoke
+        assert mock_pm.invoke_hook.call_count == 2  # Pre and post invoke
 
         # Verify result was converted to string since format was invalid
         assert result.content[0].text == "Invalid format - not a dict"
@@ -3832,7 +3835,7 @@ class TestToolService:
         from mcpgateway.plugins.framework import ToolHookType
         from mcpgateway.plugins.framework.models import PluginResult
 
-        tool_service._plugin_manager = Mock()
+        mock_pm = Mock()
 
         def invoke_hook_side_effect(hook_type, payload, global_context, local_contexts=None, **kwargs):
             if hook_type == ToolHookType.TOOL_PRE_INVOKE:
@@ -3840,14 +3843,14 @@ class TestToolService:
             # POST_INVOKE - raise error
             raise Exception("Plugin error")
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         # Mock plugin config to fail on errors
         mock_plugin_settings = Mock()
         mock_plugin_settings.fail_on_plugin_error = True
         mock_config = Mock()
         mock_config.plugin_settings = mock_plugin_settings
-        tool_service._plugin_manager.config = mock_config
+        mock_pm.config = mock_config
 
         # Mock metrics recording
         tool_service._record_tool_metric_sync = Mock()
@@ -3855,6 +3858,7 @@ class TestToolService:
         with (
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "original response"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             with pytest.raises(Exception) as exc_info:
                 await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
@@ -3879,21 +3883,22 @@ class TestToolService:
         tool_service._http_client.request.return_value = mock_response
 
         # Mock plugin manager and post-invoke hook with error
-        tool_service._plugin_manager = PluginManager("./tests/unit/mcpgateway/plugins/fixtures/configs/tool_headers_metadata_plugin.yaml")
-        await tool_service._plugin_manager.initialize()
+        pm = PluginManager("./tests/unit/mcpgateway/plugins/fixtures/configs/tool_headers_metadata_plugin.yaml")
+        await pm.initialize()
         # Mock metrics recording
         tool_service._record_tool_metric_sync = Mock()
 
         with (
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "original response"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
         # Verify result still succeeded despite plugin error
         assert result.content[0].text == '{\n  "result": "original response"\n}'
 
-        await tool_service._plugin_manager.shutdown()
+        await pm.shutdown()
 
     async def test_invoke_tool_with_plugin_metadata_sse(self, tool_service, mock_tool, mock_gateway, test_db):
         """Test invoking tool with plugin post-invoke hook error when fail_on_plugin_error is True."""
@@ -3932,8 +3937,8 @@ class TestToolService:
         # Mock HTTP client response
 
         # Mock plugin manager and post-invoke hook with error
-        tool_service._plugin_manager = PluginManager("./tests/unit/mcpgateway/plugins/fixtures/configs/tool_headers_metadata_plugin.yaml")
-        await tool_service._plugin_manager.initialize()
+        pm = PluginManager("./tests/unit/mcpgateway/plugins/fixtures/configs/tool_headers_metadata_plugin.yaml")
+        await pm.initialize()
         # Mock metrics recording
         tool_service._record_tool_metric_sync = Mock()
 
@@ -3941,10 +3946,11 @@ class TestToolService:
             patch("mcpgateway.services.tool_service.sse_client", return_value=sse_ctx),
             patch("mcpgateway.services.tool_service.ClientSession", return_value=client_session_cm),
             patch("mcpgateway.services.tool_service.extract_using_jq", side_effect=lambda data, _filt: data),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=pm)),
         ):
             await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
-        await tool_service._plugin_manager.shutdown()
+        await pm.shutdown()
 
     @pytest.mark.asyncio
     async def test_invoke_tool_plugin_retry_delay_triggers_retry(self, tool_service, mock_tool, mock_global_config_obj, test_db):
@@ -3961,7 +3967,7 @@ class TestToolService:
         mock_response.json = Mock(return_value={"result": "first attempt"})
         tool_service._http_client.request.return_value = mock_response
 
-        tool_service._plugin_manager = Mock()
+        mock_pm = Mock()
 
         post_invoke_count = [0]
 
@@ -3973,7 +3979,7 @@ class TestToolService:
             delay = 100 if post_invoke_count[0] == 1 else 0
             return (PluginResult(continue_processing=True, violation=None, modified_payload=None, retry_delay_ms=delay), None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         # Intercept the recursive retry call so it returns immediately on retry_attempt > 0
         retry_result = ToolResult(content=[TextContent(type="text", text="retry succeeded")])
@@ -3989,6 +3995,7 @@ class TestToolService:
             patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "first attempt"}),
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch.object(tool_service, "invoke_tool", side_effect=spy_invoke),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
@@ -4010,8 +4017,8 @@ class TestToolService:
         # HTTP client raises an exception (simulates network error)
         tool_service._http_client.request.side_effect = RuntimeError("connection reset")
 
-        tool_service._plugin_manager = Mock()
-        tool_service._plugin_manager.has_hooks_for.return_value = True
+        mock_pm = Mock()
+        mock_pm.has_hooks_for.return_value = True
 
         # Plugin returns delay > 0 on first post-invoke, 0 on subsequent
         post_invoke_count = [0]
@@ -4023,7 +4030,7 @@ class TestToolService:
             delay = 50 if post_invoke_count[0] == 1 else 0
             return (PluginResult(continue_processing=True, violation=None, modified_payload=None, retry_delay_ms=delay), None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         retry_result = ToolResult(content=[TextContent(type="text", text="recovered after exception")])
         original_invoke = tool_service.invoke_tool
@@ -4037,6 +4044,7 @@ class TestToolService:
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch.object(tool_service, "invoke_tool", side_effect=spy_invoke),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
@@ -4047,6 +4055,7 @@ class TestToolService:
     @pytest.mark.asyncio
     async def test_invoke_tool_http_status_error_passes_status_to_plugin(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """When raise_for_status() raises HTTPStatusError the status code must be forwarded to the plugin in structuredContent."""
+        # Third-Party
         import httpx
 
         mock_tool.integration_type = "REST"
@@ -4061,8 +4070,8 @@ class TestToolService:
         mock_request = MagicMock()
         tool_service._http_client.request.side_effect = httpx.HTTPStatusError("Not Found", request=mock_request, response=mock_response)
 
-        tool_service._plugin_manager = Mock()
-        tool_service._plugin_manager.has_hooks_for.return_value = True
+        mock_pm = Mock()
+        mock_pm.has_hooks_for.return_value = True
 
         captured_payloads = []
 
@@ -4071,9 +4080,12 @@ class TestToolService:
                 captured_payloads.append(payload)
             return (PluginResult(continue_processing=True, violation=None, modified_payload=None, retry_delay_ms=0), None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
-        with patch("mcpgateway.services.tool_service.decode_auth", return_value={}):
+        with (
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
+        ):
             with pytest.raises(ToolInvocationError):
                 await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
@@ -4096,15 +4108,15 @@ class TestToolService:
         # the timeout handler having already called _run_timeout_post_invoke.
         tool_service._http_client.request.side_effect = ToolTimeoutError("timed out after 30s", retry_delay_ms=75)
 
-        tool_service._plugin_manager = Mock()
-        tool_service._plugin_manager.has_hooks_for.return_value = True
+        mock_pm = Mock()
+        mock_pm.has_hooks_for.return_value = True
 
         def invoke_hook_side_effect(hook_type, payload, global_context, local_contexts=None, **kwargs):
             if hook_type == ToolHookType.TOOL_PRE_INVOKE:
                 return (PluginResult(continue_processing=True, violation=None, modified_payload=None), None)
             return (PluginResult(continue_processing=True, violation=None, modified_payload=None, retry_delay_ms=0), None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         retry_result = ToolResult(content=[TextContent(type="text", text="recovered after timeout")])
         original_invoke = tool_service.invoke_tool
@@ -4118,6 +4130,7 @@ class TestToolService:
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch.object(tool_service, "invoke_tool", side_effect=spy_invoke),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
 
@@ -4136,19 +4149,20 @@ class TestToolService:
 
         tool_service._http_client.request.side_effect = ToolTimeoutError("timed out after 30s")
 
-        tool_service._plugin_manager = Mock()
-        tool_service._plugin_manager.has_hooks_for.return_value = True
+        mock_pm = Mock()
+        mock_pm.has_hooks_for.return_value = True
 
         def invoke_hook_side_effect(hook_type, payload, global_context, local_contexts=None, **kwargs):
             if hook_type == ToolHookType.TOOL_PRE_INVOKE:
                 return (PluginResult(continue_processing=True, violation=None, modified_payload=None), None)
             return (PluginResult(continue_processing=True, violation=None, modified_payload=None, retry_delay_ms=0), None)
 
-        tool_service._plugin_manager.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
+        mock_pm.invoke_hook = AsyncMock(side_effect=invoke_hook_side_effect)
 
         with (
             patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             with pytest.raises(ToolTimeoutError):
                 await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
@@ -4158,35 +4172,37 @@ class TestToolService:
     @pytest.mark.asyncio
     async def test_run_timeout_post_invoke_calls_hook(self, tool_service):
         """_run_timeout_post_invoke must invoke the post-invoke hook when the plugin manager has hooks."""
-        tool_service._plugin_manager = Mock()
-        tool_service._plugin_manager.has_hooks_for.return_value = True
-        tool_service._plugin_manager.invoke_hook = AsyncMock(return_value=(PluginResult(retry_delay_ms=0), None))
+        mock_pm = Mock()
+        mock_pm.has_hooks_for.return_value = True
+        mock_pm.invoke_hook = AsyncMock(return_value=(PluginResult(retry_delay_ms=0), None))
 
-        await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
+        with patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)):
+            await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
 
-        tool_service._plugin_manager.invoke_hook.assert_awaited_once()
-        call_kwargs = tool_service._plugin_manager.invoke_hook.call_args
+        mock_pm.invoke_hook.assert_awaited_once()
+        call_kwargs = mock_pm.invoke_hook.call_args
         assert call_kwargs[1]["payload"].name == "test_tool"
         assert call_kwargs[1]["payload"].result["isError"] is True
 
     @pytest.mark.asyncio
     async def test_run_timeout_post_invoke_raises_on_retry_signal(self, tool_service):
         """_run_timeout_post_invoke must raise ToolTimeoutError with retry_delay_ms when the plugin requests a retry."""
-        tool_service._plugin_manager = Mock()
-        tool_service._plugin_manager.has_hooks_for.return_value = True
-        tool_service._plugin_manager.invoke_hook = AsyncMock(return_value=(PluginResult(retry_delay_ms=250), None))
+        mock_pm = Mock()
+        mock_pm.has_hooks_for.return_value = True
+        mock_pm.invoke_hook = AsyncMock(return_value=(PluginResult(retry_delay_ms=250), None))
 
-        with pytest.raises(ToolTimeoutError) as exc_info:
-            await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
+        with patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)):
+            with pytest.raises(ToolTimeoutError) as exc_info:
+                await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
 
         assert exc_info.value.retry_delay_ms == 250
 
     @pytest.mark.asyncio
     async def test_run_timeout_post_invoke_noop_without_plugin_manager(self, tool_service):
         """_run_timeout_post_invoke must return immediately when plugin_manager is None."""
-        tool_service._plugin_manager = None
-        # Should not raise
-        await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
+        with patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)):
+            # Should not raise
+            await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
 
 
 # --------------------------------------------------------------------------- #
@@ -7097,63 +7113,29 @@ class TestRustMcpExecutionPlan:
         db.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_prepare_rust_mcp_tool_execution_retry_post_invoke_hook_keeps_eligible_plan(self, tool_service):
-        """The default retry post-invoke hook should stay eligible on the Rust fast path."""
-        cache = self._cache_mock(self._cache_payload(timeout_ms=2500))
-        plugin_manager = MagicMock()
-        retry_hook = MagicMock()
-        retry_hook.plugin_ref.mode = "permissive"
-        retry_hook.plugin_ref.name = "RetryWithBackoffPlugin"
-        retry_hook.plugin_ref.conditions = []
-        retry_hook.plugin_ref.plugin.config.config = {
-            "max_retries": 2,
-            "backoff_base_ms": 200,
-            "max_backoff_ms": 5000,
-            "retry_on_status": [429, 500, 502, 503, 504],
-            "jitter": True,
-            "check_text_content": False,
-            "tool_overrides": {},
-        }
-        plugin_manager.has_hooks_for = MagicMock(side_effect=lambda hook_type: hook_type == ToolHookType.TOOL_POST_INVOKE)
-        plugin_manager._registry.get_hook_refs_for_hook.return_value = [retry_hook]  # pylint: disable=protected-access
-        tool_service._plugin_manager = plugin_manager
+    async def test_prepare_rust_mcp_tool_execution_post_invoke_hooks_force_fallback(self, tool_service):
+        """Post-invoke hooks should force fallback even when pre-invoke hooks are also registered."""
+        # Create a mock plugin manager with proper registry structure
+        mock_hook_ref = MagicMock()
+        mock_hook_ref.plugin_ref.name = "SomeOtherPlugin"  # Not RetryWithBackoffPlugin
+        mock_hook_ref.plugin_ref.mode = PluginMode.ENFORCE
+        mock_hook_ref.plugin_ref.conditions = None
+
+        mock_registry = MagicMock()
+        mock_registry.get_hook_refs_for_hook = MagicMock(return_value=[mock_hook_ref])
+
+        mock_pm = MagicMock()
+        mock_pm.has_hooks_for = MagicMock(side_effect=lambda hook_type: hook_type in (ToolHookType.TOOL_PRE_INVOKE, ToolHookType.TOOL_POST_INVOKE))
+        mock_pm._registry = mock_registry
+
+        cache = self._cache_mock(self._cache_payload())
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
-            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
-        ):
-            plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
-
-        assert plan["eligible"] is True
-        assert plan["postInvokeRetryPolicy"] == {
-            "kind": "retry_with_backoff",
-            "maxRetries": 2,
-            "backoffBaseMs": 200,
-            "maxBackoffMs": 5000,
-            "retryOnStatus": [429, 500, 502, 503, 504],
-            "jitter": True,
-        }
-
-    @pytest.mark.asyncio
-    async def test_prepare_rust_mcp_tool_execution_unsupported_post_invoke_hooks_force_fallback(self, tool_service):
-        """Unsupported post-invoke hooks should still force Python fallback."""
-        cache = self._cache_mock(self._cache_payload(timeout_ms=2500))
-        tool_service._plugin_manager = MagicMock()
-        unsupported_hook = MagicMock()
-        unsupported_hook.plugin_ref.mode = "permissive"
-        unsupported_hook.plugin_ref.name = "TestToolOutputSentinelPlugin"
-        unsupported_hook.plugin_ref.conditions = []
-        tool_service._plugin_manager.has_hooks_for = MagicMock(side_effect=lambda hook_type: hook_type == ToolHookType.TOOL_POST_INVOKE)
-        tool_service._plugin_manager._registry.get_hook_refs_for_hook.return_value = [unsupported_hook]  # pylint: disable=protected-access
-
-        with (
-            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
-            patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
-            patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
-            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7161,16 +7143,16 @@ class TestRustMcpExecutionPlan:
         assert plan == {"eligible": False, "fallbackReason": "post-invoke-hooks-configured"}
 
     @pytest.mark.asyncio
-    async def test_prepare_rust_mcp_tool_execution_trace_id_keeps_eligible_plan(self, tool_service):
-        """Active observability trace should no longer force Python fallback."""
-        tool_service._plugin_manager = None
-        cache = self._cache_mock(self._cache_payload(timeout_ms=2500))
+    async def test_prepare_rust_mcp_tool_execution_trace_id_forces_fallback(self, tool_service):
+        """Active observability trace should bypass Rust direct execution."""
+        cache = self._cache_mock(self._cache_payload())
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value="trace-1"))),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7207,11 +7189,11 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_respects_negative_cache_entries(self, tool_service, status, error_match):
         """Negative cache entries should short-circuit with the expected error."""
         cache = self._cache_mock({"status": status})
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match=error_match):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7234,12 +7216,12 @@ class TestRustMcpExecutionPlan:
         )
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = gateway
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.settings.mcpgateway_direct_proxy_enabled", True),
             patch("mcpgateway.services.tool_service.check_gateway_access", new=AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 db,
@@ -7269,12 +7251,12 @@ class TestRustMcpExecutionPlan:
         )
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = gateway
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.settings.mcpgateway_direct_proxy_enabled", True),
             patch("mcpgateway.services.tool_service.check_gateway_access", new=AsyncMock(return_value=False)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="Tool not found"):
                 await tool_service.prepare_rust_mcp_tool_execution(
@@ -7289,12 +7271,12 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_loads_missing_tool_from_db(self, tool_service):
         """DB lookup should raise not-found when no invocable tool exists."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_load_invocable_tools", return_value=[]),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="Tool not found"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7303,7 +7285,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_rejects_ambiguous_accessible_tool_candidates(self, tool_service):
         """Multiple equally visible accessible tools should be treated as ambiguous."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         candidate_a = SimpleNamespace(
             enabled=True,
             reachable=True,
@@ -7326,6 +7307,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_load_invocable_tools", return_value=[candidate_a, candidate_b]),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolInvocationError, match="ambiguous"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", user_email="user@example.com", token_teams=["team-a"])
@@ -7334,7 +7316,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_selects_highest_priority_accessible_candidate(self, tool_service):
         """A single best-priority accessible candidate should be selected successfully."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         selected_gateway = SimpleNamespace(
             id="gw-1",
             name="gateway-one",
@@ -7374,6 +7355,7 @@ class TestRustMcpExecutionPlan:
             patch.object(tool_service, "_load_invocable_tools", return_value=[candidate_public, candidate_team]),
             patch.object(tool_service, "_check_tool_access", AsyncMock(side_effect=[True, True, True])),
             patch.object(tool_service, "_build_tool_cache_payload", return_value=self._cache_payload(id="tool-team", gateway_id="gw-1")),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -7390,7 +7372,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_rejects_inaccessible_db_candidates(self, tool_service):
         """DB-loaded candidates with no accessible match should surface as not-found."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         candidate_a = SimpleNamespace(enabled=True, reachable=True, visibility="team", team_id="team-a", owner_email="user@example.com", gateway=SimpleNamespace())
         candidate_b = SimpleNamespace(enabled=True, reachable=True, visibility="public", team_id=None, owner_email=None, gateway=SimpleNamespace())
 
@@ -7399,6 +7380,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_load_invocable_tools", return_value=[candidate_a, candidate_b]),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=False)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="Tool not found"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", user_email="user@example.com", token_teams=["team-a"])
@@ -7407,7 +7389,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_rejects_inactive_db_tool(self, tool_service):
         """Inactive DB-loaded tools should fail before plan generation."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         tool = SimpleNamespace(
             enabled=False,
             reachable=True,
@@ -7421,6 +7402,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_load_invocable_tools", return_value=[tool]),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="inactive"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7429,7 +7411,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_marks_unreachable_tools_offline_and_caches_negative_result(self, tool_service):
         """Unreachable DB-loaded tools should set a negative cache entry before failing."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         tool = SimpleNamespace(
             enabled=True,
             reachable=False,
@@ -7443,6 +7424,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_load_invocable_tools", return_value=[tool]),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="currently offline"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7460,11 +7442,11 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_rejects_inactive_or_offline_cached_payloads(self, tool_service, payload, error_match):
         """Cached payloads should honor enabled/reachable flags before plan generation."""
         cache = self._cache_mock(self._cache_payload(**payload))
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match=error_match):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7473,12 +7455,12 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_rejects_cached_payload_when_access_is_denied(self, tool_service):
         """Cached payloads should still pass through access checks."""
         cache = self._cache_mock(self._cache_payload())
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=False)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="Tool not found"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", user_email="user@example.com", token_teams=["team-a"])
@@ -7487,12 +7469,12 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_rejects_server_scoped_cached_payload_without_tool_id(self, tool_service):
         """Server-scoped cached payloads need a concrete tool id for membership checks."""
         cache = self._cache_mock(self._cache_payload(id=None))
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="Tool not found"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", server_id="srv-1")
@@ -7501,7 +7483,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_uses_live_gateway_auth_fields_for_loaded_tools(self, tool_service):
         """Loaded DB tools should prefer live gateway auth metadata over cached payload values."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         gateway = SimpleNamespace(
             id="gw-1",
             name="gateway-one",
@@ -7562,6 +7543,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.encode_auth", return_value="encoded-live-auth"),
             patch("mcpgateway.services.tool_service.decode_auth", return_value={"Authorization": "Bearer live-token"}),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"Authorization": "Bearer live-token"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
 
@@ -7573,7 +7555,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_uses_live_gateway_string_auth_values(self, tool_service):
         """Loaded DB tools should honor pre-encoded gateway auth strings."""
         cache = self._cache_mock(None)
-        tool_service._plugin_manager = None
         gateway = SimpleNamespace(
             id="gw-1",
             name="gateway-one",
@@ -7633,6 +7614,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.decode_auth", return_value={"Authorization": "Bearer string-token"}),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"Authorization": "Bearer string-token"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
 
@@ -7646,7 +7628,6 @@ class TestRustMcpExecutionPlan:
                 gateway={"auth_type": "basic", "auth_value": None, "auth_query_params": None, "oauth_config": None},
             )
         )
-        tool_service._plugin_manager = None
         tool_auth_row = SimpleNamespace(
             gateway=SimpleNamespace(
                 auth_value={"Authorization": "Bearer hydrated-token"},
@@ -7665,6 +7646,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.encode_auth", return_value="encoded-hydrated-auth"),
             patch("mcpgateway.services.tool_service.decode_auth", return_value={"Authorization": "Bearer hydrated-token"}),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"Authorization": "Bearer hydrated-token"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(db, "tool-one")
 
@@ -7679,7 +7661,6 @@ class TestRustMcpExecutionPlan:
                 gateway={"auth_type": "basic", "auth_value": None, "auth_query_params": None, "oauth_config": None},
             )
         )
-        tool_service._plugin_manager = None
         tool_auth_row = SimpleNamespace(
             gateway=SimpleNamespace(
                 auth_value="encoded-hydrated-string",
@@ -7697,6 +7678,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.decode_auth", return_value={"Authorization": "Bearer hydrated-string"}),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"Authorization": "Bearer hydrated-string"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(db, "tool-one")
 
@@ -7725,12 +7707,12 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_returns_expected_fallback_reasons(self, tool_service, tool_overrides, expected_reason):
         """Unsupported execution plans should report explicit fallback reasons."""
         cache = self._cache_mock(self._cache_payload(**tool_overrides))
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
 
@@ -7759,12 +7741,12 @@ class TestRustMcpExecutionPlan:
         cache = self._cache_mock(self._cache_payload())
         db = MagicMock()
         db.execute.return_value.first.return_value = None
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="Tool not found"):
                 await tool_service.prepare_rust_mcp_tool_execution(db, "tool-one", server_id="srv-1")
@@ -7784,8 +7766,6 @@ class TestRustMcpExecutionPlan:
                 }
             )
         )
-        tool_service._plugin_manager = None
-
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
@@ -7794,6 +7774,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.apply_query_param_auth", side_effect=lambda url, params: f"{url}?api_key={params['api_key']}"),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"X-Tenant-Id": "tenant-1"}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -7818,13 +7799,12 @@ class TestRustMcpExecutionPlan:
                 }
             )
         )
-        tool_service._plugin_manager = None
-
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolInvocationError, match="OAuth token retrieval failed"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7840,7 +7820,6 @@ class TestRustMcpExecutionPlan:
                 }
             )
         )
-        tool_service._plugin_manager = None
         tool_service.oauth_manager = MagicMock(get_access_token=AsyncMock(side_effect=RuntimeError("boom")))
 
         with (
@@ -7848,6 +7827,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolInvocationError, match="OAuth authentication failed"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
@@ -7866,7 +7846,6 @@ class TestRustMcpExecutionPlan:
         token_storage = MagicMock()
         token_storage.get_user_token = AsyncMock(return_value="stored-oauth-token")
         fresh_session = MagicMock()
-        tool_service._plugin_manager = None
 
         @contextmanager
         def _fresh_db_session():
@@ -7880,6 +7859,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.token_storage_service.TokenStorageService", return_value=token_storage),
             patch("mcpgateway.services.tool_service.fresh_db_session", _fresh_db_session),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", side_effect=lambda _request_headers, headers, *_args, **_kwargs: headers),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", app_user_email="user@example.com")
 
@@ -7900,7 +7880,6 @@ class TestRustMcpExecutionPlan:
         token_storage = MagicMock()
         token_storage.get_user_token = AsyncMock(return_value=None)
         fresh_session = MagicMock()
-        tool_service._plugin_manager = None
 
         @contextmanager
         def _fresh_db_session():
@@ -7913,6 +7892,7 @@ class TestRustMcpExecutionPlan:
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
             patch("mcpgateway.services.token_storage_service.TokenStorageService", return_value=token_storage),
             patch("mcpgateway.services.tool_service.fresh_db_session", _fresh_db_session),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolInvocationError, match="OAuth token retrieval failed"):
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", app_user_email="user@example.com")
@@ -7928,7 +7908,6 @@ class TestRustMcpExecutionPlan:
                 }
             )
         )
-        tool_service._plugin_manager = None
         tool_service.oauth_manager = MagicMock(get_access_token=AsyncMock(return_value="oauth-access-token"))
 
         with (
@@ -7937,6 +7916,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", side_effect=lambda _request_headers, headers, *_args, **_kwargs: headers),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
 
@@ -7947,7 +7927,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_tool_execution_returns_eligible_plan(self, tool_service):
         """Simple MCP streamable-http tools should produce an eligible Rust execution plan."""
         cache = self._cache_mock(self._cache_payload(timeout_ms=2500))
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
@@ -7955,6 +7934,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"Authorization": "Bearer abc"}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8032,7 +8012,6 @@ class TestRustMcpExecutionPlan:
             return PluginResult(modified_payload=modified, continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke_hook
-        tool_service._plugin_manager = mock_pm
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
@@ -8040,6 +8019,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"authorization": "Bearer abc"}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8073,7 +8053,6 @@ class TestRustMcpExecutionPlan:
             return PluginResult(modified_payload=modified, continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke_hook
-        tool_service._plugin_manager = mock_pm
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
@@ -8081,6 +8060,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8097,7 +8077,6 @@ class TestRustMcpExecutionPlan:
     async def test_prepare_rust_mcp_pre_invoke_no_hooks_omits_hook_fields(self, tool_service):
         """When no pre-invoke hooks are registered, plan should not contain hook fields."""
         cache = self._cache_mock(self._cache_payload())
-        tool_service._plugin_manager = None
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
@@ -8105,6 +8084,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             plan = await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8135,7 +8115,6 @@ class TestRustMcpExecutionPlan:
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke_hook
-        tool_service._plugin_manager = mock_pm
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
@@ -8143,6 +8122,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={"Authorization": "Bearer gateway-token"}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8180,7 +8160,6 @@ class TestRustMcpExecutionPlan:
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke_hook
-        tool_service._plugin_manager = mock_pm
 
         # Simulate middleware-provided context with JWT claims state
         provided_ctx = GlobalContext(request_id="corr-123", server_id="srv-1", tenant_id=None, user="jwt-user@example.com")
@@ -8193,6 +8172,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8230,7 +8210,6 @@ class TestRustMcpExecutionPlan:
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke_hook
-        tool_service._plugin_manager = mock_pm
 
         # Provide a context with user=None so the fallback injection fires
         provided_ctx = GlobalContext(request_id="corr-456", server_id="srv-1", tenant_id=None, user=None)
@@ -8241,6 +8220,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
         ):
             await tool_service.prepare_rust_mcp_tool_execution(
                 MagicMock(),
@@ -8277,9 +8257,13 @@ class TestRustMcpExecutionPlan:
             )
         )
 
-        received_metadata = {}
+        received_metadata = {
+            "has_tool": False,
+            "has_gateway": False,
+            "keys": [],
+        }
 
-        mock_pm = MagicMock()
+        mock_pm = AsyncMock()
         mock_pm.has_hooks_for = MagicMock(side_effect=lambda hook_type: hook_type == ToolHookType.TOOL_PRE_INVOKE)
 
         async def mock_invoke_hook(hook_type, payload, global_context, local_contexts=None, violations_as_exceptions=False):  # noqa: ARG001
@@ -8293,9 +8277,10 @@ class TestRustMcpExecutionPlan:
             return PluginResult(continue_processing=True), {}
 
         mock_pm.invoke_hook = mock_invoke_hook
-        tool_service._plugin_manager = mock_pm
 
         provided_ctx = GlobalContext(request_id="corr-789", server_id=None, tenant_id=None, user="user@example.com")
+
+        tool_service._get_plugin_manager = AsyncMock(return_value=mock_pm)
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -4176,8 +4176,7 @@ class TestToolService:
         mock_pm.has_hooks_for.return_value = True
         mock_pm.invoke_hook = AsyncMock(return_value=(PluginResult(retry_delay_ms=0), None))
 
-        with patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)):
-            await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
+        await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None, mock_pm)
 
         mock_pm.invoke_hook.assert_awaited_once()
         call_kwargs = mock_pm.invoke_hook.call_args
@@ -4191,9 +4190,8 @@ class TestToolService:
         mock_pm.has_hooks_for.return_value = True
         mock_pm.invoke_hook = AsyncMock(return_value=(PluginResult(retry_delay_ms=250), None))
 
-        with patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)):
-            with pytest.raises(ToolTimeoutError) as exc_info:
-                await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None)
+        with pytest.raises(ToolTimeoutError) as exc_info:
+            await tool_service._run_timeout_post_invoke("test_tool", 30.0, None, None, mock_pm)
 
         assert exc_info.value.retry_delay_ms == 250
 

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -392,18 +392,22 @@ class TestInitializeShutdown:
         service._http_client.aclose.assert_awaited_once()
         service._event_service.shutdown.assert_awaited_once()
 
-    def test_init_delegates_to_get_plugin_manager(self):
-        """ToolService.__init__ should assign whatever get_plugin_manager() returns."""
+    @pytest.mark.asyncio
+    async def test_init_delegates_to_get_plugin_manager(self):
+        """_get_plugin_manager should return the manager from the framework factory."""
         mock_pm = MagicMock()
-        with patch("mcpgateway.services.tool_service.get_plugin_manager", return_value=mock_pm):
-            service = ToolService()
-        assert service._plugin_manager is mock_pm
+        service = ToolService()
+        with patch("mcpgateway.services.base_service.get_plugin_manager", AsyncMock(return_value=mock_pm)):
+            result = await service._get_plugin_manager("server-1")
+        assert result is mock_pm
 
-    def test_init_plugin_manager_none_when_disabled(self):
-        """ToolService._plugin_manager should be None when get_plugin_manager() returns None."""
-        with patch("mcpgateway.services.tool_service.get_plugin_manager", return_value=None):
-            service = ToolService()
-        assert service._plugin_manager is None
+    @pytest.mark.asyncio
+    async def test_init_plugin_manager_none_when_disabled(self):
+        """_get_plugin_manager should return None when plugins are disabled."""
+        service = ToolService()
+        with patch("mcpgateway.services.base_service.get_plugin_manager", AsyncMock(return_value=None)):
+            result = await service._get_plugin_manager("server-1")
+        assert result is None
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -2903,7 +2907,6 @@ class TestCallA2AAgentCoverage:
         headers = mock_client.post.call_args[1]["headers"]
         assert headers["X-Custom-Auth"] == "custom-value"
 
-
     @pytest.mark.asyncio
     async def test_bearer_auth_decrypt_failure(self, tool_service):
         """Should raise ToolInvocationError when decode_auth fails."""
@@ -3852,7 +3855,7 @@ class TestListToolsBranches:
             mock_cache.set = AsyncMock()
             mock_cache_fn.return_value = mock_cache
 
-            result = await tool_service.list_tools(db)
+            await tool_service.list_tools(db)
         mock_cache.set.assert_called_once()
 
     @pytest.mark.asyncio
@@ -4406,7 +4409,7 @@ class TestUpdateToolBranches:
             patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
             patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
         ):
-            result = await tool_service.update_tool(db, "t1", tool_update)
+            await tool_service.update_tool(db, "t1", tool_update)
 
         assert tool.version == 1
 
@@ -5007,15 +5010,15 @@ class TestInvokeToolRestTimeout:
                 (SimpleNamespace(modified_payload=None, retry_delay_ms=0), context_table),  # post-invoke (timeout handler)
             ]
         )
-        tool_service._plugin_manager = plugin_manager
 
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
-            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+            patch("mcpgateway.services.tool_service.metrics_buffer", MagicMock()),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
             patch("mcpgateway.services.metrics.tool_timeout_counter") as mock_timeout_counter,
         ):
@@ -5023,7 +5026,6 @@ class TestInvokeToolRestTimeout:
             mock_trace.get = MagicMock(return_value=None)
             mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
             mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
-            mock_mbuf.return_value = MagicMock()
 
             # Make counter increment raise to hit the "except Exception as exc" branch.
             mock_timeout_counter.labels.return_value.inc.side_effect = RuntimeError("counter fail")
@@ -5050,11 +5052,11 @@ class TestInvokeToolRestTimeout:
 
         plugin_manager = MagicMock()
         plugin_manager.has_hooks_for = MagicMock(return_value=False)
-        tool_service._plugin_manager = plugin_manager
 
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -5165,7 +5167,6 @@ class TestInvokeToolRestPreInvokeModifiedPayload:
         plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
         modified_payload = SimpleNamespace(name="test_tool", args={"k": "v"}, headers=None)
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=modified_payload), {}))
-        tool_service._plugin_manager = plugin_manager
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -5175,6 +5176,7 @@ class TestInvokeToolRestPreInvokeModifiedPayload:
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -5977,11 +5979,11 @@ class TestInvokeToolPluginPostInvokeSerialization:
                 (SimpleNamespace(modified_payload=SimpleNamespace(result={"status": "transformed", "valid": False}), retry_delay_ms=0), {}),  # post-invoke
             ]
         )
-        tool_service._plugin_manager = plugin_manager
 
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -6007,9 +6009,6 @@ class TestInvokeToolPluginPostInvokeSerialization:
         assert parsed["valid"] is False
         assert "False" not in text  # Python repr would have capital False
 
-        # Cleanup
-        tool_service._plugin_manager = None
-
     @pytest.mark.asyncio
     async def test_plugin_post_invoke_unserializable_result_falls_back_to_str(self, tool_service):
         """When plugin post-invoke returns an unserializable value (e.g. set), it should fall back to str() instead of crashing."""
@@ -6033,11 +6032,11 @@ class TestInvokeToolPluginPostInvokeSerialization:
                 (SimpleNamespace(modified_payload=SimpleNamespace(result={"unserializable", "set", "values"}), retry_delay_ms=0), {}),  # post-invoke
             ]
         )
-        tool_service._plugin_manager = plugin_manager
 
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -6062,9 +6061,6 @@ class TestInvokeToolPluginPostInvokeSerialization:
         assert isinstance(text, str)
         assert len(text) > 0
 
-        # Cleanup
-        tool_service._plugin_manager = None
-
 
 class TestInvokeToolPluginMetadataFromPayload:
     @pytest.mark.asyncio
@@ -6083,12 +6079,13 @@ class TestInvokeToolPluginMetadataFromPayload:
             return mock_response
 
         # Ensure plugin hooks don't run; we only want metadata creation from payloads.
-        tool_service._plugin_manager = MagicMock()
-        tool_service._plugin_manager.has_hooks_for = MagicMock(return_value=False)
+        plugin_manager_no_hooks = MagicMock()
+        plugin_manager_no_hooks.has_hooks_for = MagicMock(return_value=False)
 
         with (
             _setup_cache_for_invoke(tp, gp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager_no_hooks)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -6141,12 +6138,13 @@ class TestInvokeToolPluginMetadataFromOrm:
         mock_response.json = MagicMock(return_value={"ok": True})
         mock_response.raise_for_status = MagicMock()
 
-        tool_service._plugin_manager = MagicMock()
-        tool_service._plugin_manager.has_hooks_for = MagicMock(return_value=False)
+        plugin_manager_no_hooks = MagicMock()
+        plugin_manager_no_hooks.has_hooks_for = MagicMock(return_value=False)
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=mock_cache),
             patch.object(tool_service, "_build_tool_cache_payload", return_value=built_payload),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager_no_hooks)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -6501,7 +6499,6 @@ class TestInvokeToolA2A:
             headers=SimpleNamespace(model_dump=lambda: {"Content-Type": "application/json", "X-Test": "1"}),
         )
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=modified_payload), {}))
-        tool_service._plugin_manager = plugin_manager
 
         captured = {}
         mock_http_response = MagicMock()
@@ -6517,6 +6514,7 @@ class TestInvokeToolA2A:
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -6971,11 +6969,11 @@ class TestInvokeToolA2A:
 
         plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None, retry_delay_ms=0), context_table))
-        tool_service._plugin_manager = plugin_manager
 
         with (
             _setup_cache_for_invoke(tp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -7280,6 +7278,7 @@ class TestInvokeToolMcpSse:
     @pytest.mark.asyncio
     async def test_mcp_https_url_decrypts_encrypted_client_key(self, tool_service):
         """Encrypted client_key in gateway payload is decrypted before SSL context creation."""
+        # First-Party
         from mcpgateway.services.encryption_service import get_encryption_service
 
         encryption = get_encryption_service(settings.auth_encryption_secret)
@@ -7645,7 +7644,6 @@ class TestInvokeToolMcpSseTimeoutAndErrors:
 
         plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None, retry_delay_ms=0), context_table))
-        tool_service._plugin_manager = plugin_manager
 
         def fake_sse_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             class _CM:
@@ -7671,6 +7669,7 @@ class TestInvokeToolMcpSseTimeoutAndErrors:
         with (
             _setup_cache_for_invoke(tp, gp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -7773,7 +7772,6 @@ class TestInvokeToolMcpStreamableHttpCoverage:
 
         plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None), {}))
-        tool_service._plugin_manager = plugin_manager
 
         def fake_streamablehttp_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             class _CM:
@@ -7799,6 +7797,7 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         with (
             _setup_cache_for_invoke(tp, gp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -7843,7 +7842,6 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
         modified_payload = SimpleNamespace(name="test_tool", args={}, headers=None)
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=modified_payload), {}))
-        tool_service._plugin_manager = plugin_manager
 
         pooled_session = AsyncMock()
         pooled_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
@@ -7861,6 +7859,7 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         with (
             _setup_cache_for_invoke(tp, gp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -7900,7 +7899,6 @@ class TestInvokeToolMcpStreamableHttpCoverage:
 
         plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
         plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None, retry_delay_ms=0), None))
-        tool_service._plugin_manager = plugin_manager
 
         def fake_streamablehttp_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             class _CM:
@@ -7926,6 +7924,7 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         with (
             _setup_cache_for_invoke(tp, gp),
             patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
             patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
             patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
             patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
@@ -8078,6 +8077,7 @@ class TestInvokeToolLookupLogic:
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=AsyncMock(get=AsyncMock(return_value=None))),
             patch.object(tool_service, "_build_tool_cache_payload", side_effect=_fake_build),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(), __exit__=MagicMock()))),
@@ -8086,7 +8086,6 @@ class TestInvokeToolLookupLogic:
         ):
             tool_service._http_client = AsyncMock()
             tool_service._http_client.get = AsyncMock(return_value=MagicMock(status_code=200, json=MagicMock(return_value={"ok": True})))
-            tool_service._plugin_manager = None
 
             await tool_service.invoke_tool(db, "test_tool", {}, user_email="me@test.com", token_teams=["team-A"])
 
@@ -8111,6 +8110,7 @@ class TestInvokeToolLookupLogic:
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=AsyncMock(get=AsyncMock(return_value=None))),
             patch.object(tool_service, "_build_tool_cache_payload", side_effect=_fake_build),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(), __exit__=MagicMock()))),
@@ -8119,7 +8119,6 @@ class TestInvokeToolLookupLogic:
         ):
             tool_service._http_client = AsyncMock()
             tool_service._http_client.get = AsyncMock(return_value=MagicMock(status_code=200, json=MagicMock(return_value={"ok": True})))
-            tool_service._plugin_manager = None
 
             await tool_service.invoke_tool(db, "test_tool", {}, user_email="me@test.com", token_teams=["team-A"])
 
@@ -8165,6 +8164,7 @@ class TestInvokeToolLookupLogic:
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=mock_cache),
             patch.object(tool_service, "_build_tool_cache_payload", side_effect=_fake_build),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
             patch("mcpgateway.services.tool_service.global_config_cache", MagicMock(get_passthrough_headers=MagicMock(return_value=[]))),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(), __exit__=MagicMock()))),
@@ -8173,7 +8173,6 @@ class TestInvokeToolLookupLogic:
         ):
             tool_service._http_client = AsyncMock()
             tool_service._http_client.get = AsyncMock(return_value=MagicMock(status_code=200, json=MagicMock(return_value={"ok": True})))
-            tool_service._plugin_manager = None
 
             await tool_service.invoke_tool(db, "test_tool", {}, user_email="me@test.com", token_teams=["team-A"])
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -382,7 +382,7 @@ def allow_permission(monkeypatch):
     mock_perm_service.check_permission = AsyncMock(return_value=True)
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
     monkeypatch.setattr("mcpgateway.admin.PermissionService", lambda db: mock_perm_service)
-    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", lambda: None)
+    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", AsyncMock(return_value=None))
     return mock_perm_service
 
 
@@ -21647,7 +21647,7 @@ class TestPublicVisibilityGuard:
         mock_perm_service.check_permission = AsyncMock(return_value=True)
         monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
         monkeypatch.setattr("mcpgateway.admin.PermissionService", lambda db: mock_perm_service)
-        monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", lambda: None)
+        monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", AsyncMock(return_value=None))
         return mock_perm_service
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin_error_handlers.py
+++ b/tests/unit/mcpgateway/test_admin_error_handlers.py
@@ -11,14 +11,13 @@ Tests for error handling paths in admin.py to improve coverage.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
-from pydantic import ValidationError
 from pydantic_core import ValidationError as CoreValidationError
+import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-import pytest
 
 # First-Party
-from mcpgateway.services.server_service import ServerError, ServerNameConflictError, ServerNotFoundError
+from mcpgateway.services.server_service import ServerError, ServerNameConflictError
 
 
 class FakeForm(dict):
@@ -77,7 +76,7 @@ def allow_permission(monkeypatch):
     mock_perm_service = MagicMock()
     mock_perm_service.check_permission = AsyncMock(return_value=True)
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
-    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", lambda: None)
+    monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", AsyncMock(return_value=None))
     return mock_perm_service
 
 

--- a/tests/unit/mcpgateway/test_final_coverage_push.py
+++ b/tests/unit/mcpgateway/test_final_coverage_push.py
@@ -35,7 +35,7 @@ async def _call_toolops(handler, monkeypatch, **kwargs):
             return True
 
     monkeypatch.setattr(rbac_module, "PermissionService", DummyPermissionService)
-    monkeypatch.setattr(plugins_framework, "get_plugin_manager", lambda: None)
+    monkeypatch.setattr(plugins_framework, "get_plugin_manager", AsyncMock(return_value=None))
     return await handler(**kwargs)
 
 
@@ -62,7 +62,7 @@ def test_log_level_enum_comprehensive():
         (LogLevel.ERROR, "error"),
         (LogLevel.CRITICAL, "critical"),
         (LogLevel.ALERT, "alert"),
-        (LogLevel.EMERGENCY, "emergency")
+        (LogLevel.EMERGENCY, "emergency"),
     ]
 
     for level, expected_value in levels:
@@ -71,6 +71,7 @@ def test_log_level_enum_comprehensive():
 
 def test_content_types():
     """Test content type models."""
+    # Standard
     import base64
 
     # Test TextContent
@@ -80,30 +81,28 @@ def test_content_types():
 
     # Test ImageContent - now uses base64-encoded string per MCP spec
     image_bytes = b"fake_image_bytes"
-    image_data = base64.b64encode(image_bytes).decode('utf-8')
+    image_data = base64.b64encode(image_bytes).decode("utf-8")
     image = ImageContent(type="image", data=image_data, mime_type="image/png")
     assert image.type == "image"
     assert image.data == image_data
     assert image.mime_type == "image/png"
 
     # Test ResourceContent
-    resource = ResourceContent(
-        type="resource",
-        id="res123",
-        uri="/api/data",
-        mime_type="application/json",
-        text="Sample content"
-    )
+    resource = ResourceContent(type="resource", id="res123", uri="/api/data", mime_type="application/json", text="Sample content")
     assert resource.type == "resource"
     assert resource.uri == "/api/data"
     assert resource.mime_type == "application/json"
     assert resource.text == "Sample content"
 
+
 def test_content_type_model_form_urlencoded():
     """
     Test that the system can parse/accept application/x-www-form-urlencoded.
     """
+    # Third-Party
     from fastapi.testclient import TestClient
+
+    # First-Party
     from mcpgateway.main import app
 
     client = TestClient(app)
@@ -112,8 +111,10 @@ def test_content_type_model_form_urlencoded():
     response = client.post("/admin/tools", data=data, headers=headers)
     assert response.status_code in [200, 201, 400, 401, 415, 422]
 
+
 def test_base_model_with_config_dict():
     """Test BaseModelWithConfigDict functionality."""
+
     # Create a simple test model
     class TestModel(BaseModelWithConfigDict):
         name: str
@@ -141,13 +142,13 @@ async def test_cli_export_import_main_flows():
     from mcpgateway.cli_export_import import main_with_subcommands
 
     # Test with no subcommands (should fall back to main CLI)
-    with patch.object(sys, 'argv', ['mcpgateway', '--version']):
-        with patch('mcpgateway.cli.main') as mock_main:
+    with patch.object(sys, "argv", ["mcpgateway", "--version"]):
+        with patch("mcpgateway.cli.main") as mock_main:
             main_with_subcommands()
             mock_main.assert_called_once()
 
     # Test with export command but invalid args
-    with patch.object(sys, 'argv', ['mcpgateway', 'export', '--invalid-option']):
+    with patch.object(sys, "argv", ["mcpgateway", "export", "--invalid-option"]):
         with pytest.raises(SystemExit):
             main_with_subcommands()
 
@@ -162,38 +163,26 @@ async def test_export_command_parameter_building():
     from mcpgateway.cli_export_import import export_command
 
     # Test with all parameters set
-    args = argparse.Namespace(
-        types="tools,gateways",
-        exclude_types="servers",
-        tags="production,api",
-        include_inactive=True,
-        include_dependencies=False,
-        output="test-output.json",
-        verbose=True
-    )
+    args = argparse.Namespace(types="tools,gateways", exclude_types="servers", tags="production,api", include_inactive=True, include_dependencies=False, output="test-output.json", verbose=True)
 
     # Mock the API call to just capture parameters
-    with patch('mcpgateway.cli_export_import.make_authenticated_request') as mock_request:
-        mock_request.return_value = {
-            "version": "2025-03-26",
-            "entities": {"tools": []},
-            "metadata": {"entity_counts": {"tools": 0}}
-        }
+    with patch("mcpgateway.cli_export_import.make_authenticated_request") as mock_request:
+        mock_request.return_value = {"version": "2025-03-26", "entities": {"tools": []}, "metadata": {"entity_counts": {"tools": 0}}}
 
-        with patch('mcpgateway.cli_export_import.Path.mkdir'):
-            with patch('pathlib.Path.write_bytes'):  # Changed from builtins.open for asyncio.to_thread
+        with patch("mcpgateway.cli_export_import.Path.mkdir"):
+            with patch("pathlib.Path.write_bytes"):  # Changed from builtins.open for asyncio.to_thread
                 await export_command(args)
 
         # Verify API was called with correct parameters
         mock_request.assert_called_once()
         call_args = mock_request.call_args
-        params = call_args[1]['params']
+        params = call_args[1]["params"]
 
-        assert params['types'] == "tools,gateways"
-        assert params['exclude_types'] == "servers"
-        assert params['tags'] == "production,api"
-        assert params['include_inactive'] == "true"
-        assert params['include_dependencies'] == "false"
+        assert params["types"] == "tools,gateways"
+        assert params["exclude_types"] == "servers"
+        assert params["tags"] == "production,api"
+        assert params["include_inactive"] == "true"
+        assert params["include_dependencies"] == "false"
 
 
 @pytest.mark.asyncio
@@ -206,45 +195,28 @@ async def test_import_command_parameter_parsing():
     from mcpgateway.cli_export_import import import_command
 
     # Create temp file with valid JSON
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-        test_data = {
-            "version": "2025-03-26",
-            "entities": {"tools": []},
-            "metadata": {"entity_counts": {"tools": 0}}
-        }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        test_data = {"version": "2025-03-26", "entities": {"tools": []}, "metadata": {"entity_counts": {"tools": 0}}}
         json.dump(test_data, f)
         temp_file = f.name
 
-    args = argparse.Namespace(
-        input_file=temp_file,
-        conflict_strategy='update',
-        dry_run=True,
-        rekey_secret='new-secret',
-        include='tools:tool1,tool2;servers:server1',
-        verbose=True
-    )
+    args = argparse.Namespace(input_file=temp_file, conflict_strategy="update", dry_run=True, rekey_secret="new-secret", include="tools:tool1,tool2;servers:server1", verbose=True)
 
     # Mock the API call
-    with patch('mcpgateway.cli_export_import.make_authenticated_request') as mock_request:
-        mock_request.return_value = {
-            "import_id": "test_123",
-            "status": "completed",
-            "progress": {"total": 1, "processed": 1, "created": 1, "failed": 0},
-            "warnings": [],
-            "errors": []
-        }
+    with patch("mcpgateway.cli_export_import.make_authenticated_request") as mock_request:
+        mock_request.return_value = {"import_id": "test_123", "status": "completed", "progress": {"total": 1, "processed": 1, "created": 1, "failed": 0}, "warnings": [], "errors": []}
 
         await import_command(args)
 
         # Verify API was called with correct data
         mock_request.assert_called_once()
         call_args = mock_request.call_args
-        request_data = call_args[1]['json_data']
+        request_data = call_args[1]["json_data"]
 
-        assert request_data['conflict_strategy'] == 'update'
-        assert request_data['dry_run'] == True
-        assert request_data['rekey_secret'] == 'new-secret'
-        assert 'selected_entities' in request_data
+        assert request_data["conflict_strategy"] == "update"
+        assert request_data["dry_run"] == True
+        assert request_data["rekey_secret"] == "new-secret"
+        assert "selected_entities" in request_data
 
 
 def test_utils_coverage():
@@ -253,13 +225,7 @@ def test_utils_coverage():
     from mcpgateway.utils.create_slug import slugify
 
     # Test slugify variations
-    test_cases = [
-        ("Simple Test", "simple-test"),
-        ("API_Gateway", "api-gateway"),
-        ("Multiple   Spaces", "multiple-spaces"),
-        ("", ""),
-        ("123Numbers", "123numbers")
-    ]
+    test_cases = [("Simple Test", "simple-test"), ("API_Gateway", "api-gateway"), ("Multiple   Spaces", "multiple-spaces"), ("", ""), ("123Numbers", "123numbers")]
 
     for input_text, expected in test_cases:
         result = slugify(input_text)
@@ -272,10 +238,10 @@ def test_config_properties():
     from mcpgateway.config import settings
 
     # Test basic properties exist
-    assert hasattr(settings, 'app_name')
-    assert hasattr(settings, 'host')
-    assert hasattr(settings, 'port')
-    assert hasattr(settings, 'database_url')
+    assert hasattr(settings, "app_name")
+    assert hasattr(settings, "host")
+    assert hasattr(settings, "port")
+    assert hasattr(settings, "database_url")
 
     # Test computed properties
     api_key = settings.api_key
@@ -333,15 +299,15 @@ def test_services_init():
 def test_cli_module_main_execution():
     """Test CLI module main execution path."""
     # Standard
-    import sys
 
     # First-Party
     # Test __main__ execution path exists
     from mcpgateway import cli_export_import
-    assert hasattr(cli_export_import, 'main_with_subcommands')
+
+    assert hasattr(cli_export_import, "main_with_subcommands")
 
     # Test module can be executed
-    assert cli_export_import.__name__ == 'mcpgateway.cli_export_import'
+    assert cli_export_import.__name__ == "mcpgateway.cli_export_import"
 
 
 def test_security_logger_threat_score_and_review():

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -11949,6 +11949,10 @@ class TestRemainingCoverageGaps:
         # First-Party
         import mcpgateway.plugins.framework as plugin_framework
 
+        # Reset plugin state before test
+        plugin_framework.enable_plugins(False)
+        plugin_framework.reset_plugin_manager_factory()
+
         _import_fresh_main_module(
             monkeypatch,
             env={

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -407,7 +407,7 @@ class TestJwtIdentityExtractor:
 
     def test_extractor_returns_none_on_jwt_decode_exception(self):
         """JWT decode raising an exception should return None and log debug message."""
-        # Third-Party
+        # Standard
         from unittest.mock import patch
 
         extractor = _create_jwt_identity_extractor()
@@ -424,11 +424,7 @@ class TestJwtIdentityExtractor:
         import jwt
 
         extractor = _create_jwt_identity_extractor()
-        token = jwt.encode(
-            {"sub": "user-sub", "email": "user@example.com", "user_id": "uid-123"},
-            "secret",
-            algorithm="HS256"
-        )
+        token = jwt.encode({"sub": "user-sub", "email": "user@example.com", "user_id": "uid-123"}, "secret", algorithm="HS256")
         headers = {"Authorization": f"Bearer {token}"}
 
         result = extractor(headers)
@@ -440,11 +436,7 @@ class TestJwtIdentityExtractor:
         import jwt
 
         extractor = _create_jwt_identity_extractor()
-        token = jwt.encode(
-            {"email": "user@example.com", "user_id": "uid-123"},
-            "secret",
-            algorithm="HS256"
-        )
+        token = jwt.encode({"email": "user@example.com", "user_id": "uid-123"}, "secret", algorithm="HS256")
         headers = {"Authorization": f"Bearer {token}"}
 
         result = extractor(headers)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -202,7 +202,10 @@ def _import_fresh_main_module(
         async def shutdown(self):  # noqa: D401 - trivial
             return None
 
-    monkeypatch.setattr("mcpgateway.plugins.framework.PluginManager", _DummyPluginManager)
+        def has_hooks_for(self, server_id):
+            return False
+
+    monkeypatch.setattr("mcpgateway.plugins.framework.TenantPluginManager", _DummyPluginManager)
 
     # Force selected module imports to fail to cover defensive ImportError paths.
     if force_import_error:
@@ -772,6 +775,7 @@ class TestInternalTrustedMcpTransportBridge:
 
         monkeypatch.setattr("mcpgateway.main.settings.email_auth_enabled", False)
         monkeypatch.setattr("mcpgateway.main.streamable_http_auth", _fake_streamable_http_auth)
+        monkeypatch.setattr("mcpgateway.main.get_plugin_manager", AsyncMock(return_value=None))
 
         error_response, auth_context = await _run_internal_mcp_authentication(
             method="POST",
@@ -802,7 +806,7 @@ class TestInternalTrustedMcpTransportBridge:
 
         mock_pm = MagicMock()
         mock_pm.has_hooks_for = MagicMock(side_effect=lambda ht: ht == HttpHookType.HTTP_PRE_REQUEST)
-        monkeypatch.setattr(main_mod, "plugin_manager", mock_pm)
+        monkeypatch.setattr(main_mod, "get_plugin_manager", AsyncMock(return_value=mock_pm))
 
         transformed_headers = {"authorization": "Bearer exchanged-token", "x-injected": "value"}
         original_headers = {"authorization": "Bearer original-token"}
@@ -907,6 +911,7 @@ class TestInternalTrustedMcpTransportBridge:
         monkeypatch.setattr("mcpgateway.main.settings.email_auth_enabled", True)
         monkeypatch.setattr("mcpgateway.main.streamable_http_auth", _fake_streamable_http_auth)
         monkeypatch.setattr("mcpgateway.main.token_scoping_middleware", _passthrough_middleware)
+        monkeypatch.setattr("mcpgateway.main.get_plugin_manager", AsyncMock(return_value=None))
 
         error_response, auth_context = await _run_internal_mcp_authentication(
             method="POST",
@@ -936,6 +941,7 @@ class TestInternalTrustedMcpTransportBridge:
         monkeypatch.setattr("mcpgateway.main.settings.email_auth_enabled", True)
         monkeypatch.setattr("mcpgateway.main.streamable_http_auth", _ignored_streamable_http_auth)
         monkeypatch.setattr("mcpgateway.main.token_scoping_middleware", _none_middleware)
+        monkeypatch.setattr("mcpgateway.main.get_plugin_manager", AsyncMock(return_value=None))
 
         error_response, auth_context = await _run_internal_mcp_authentication(
             method="GET",
@@ -1378,9 +1384,6 @@ class TestApplicationStartupPaths:
         # Standard
         from contextlib import ExitStack
 
-        # First-Party
-        import mcpgateway.main as main_mod
-
         mock_logging_service = MagicMock()
         mock_logging_service.initialize = AsyncMock()
         mock_logging_service.shutdown = AsyncMock()
@@ -1398,7 +1401,6 @@ class TestApplicationStartupPaths:
 
         monkeypatch.setattr(settings, "require_strong_secrets", False, raising=False)
         monkeypatch.setattr(settings, "dev_mode", True, raising=False)
-        monkeypatch.setattr(main_mod, "plugin_manager", None, raising=False)
 
         with ExitStack() as stack:
             stack.enter_context(patch("mcpgateway.main.logging_service", mock_logging_service))
@@ -2441,7 +2443,9 @@ class TestAdminAuthMiddleware:
 
         assert response == "ok"
         # Verify has_admin_permission was called with the validated team_id
-        mock_permission_service.has_admin_permission.assert_awaited_once_with("dev@example.com", team_id="a1b2c3d4e5f6789012345678abcdef01", token_teams=["a1b2c3d4e5f6789012345678abcdef01", "fedcba9876543210fedcba9876543210"])
+        mock_permission_service.has_admin_permission.assert_awaited_once_with(
+            "dev@example.com", team_id="a1b2c3d4e5f6789012345678abcdef01", token_teams=["a1b2c3d4e5f6789012345678abcdef01", "fedcba9876543210fedcba9876543210"]
+        )
 
     @pytest.mark.asyncio
     async def test_admin_auth_team_scoped_request_ignores_nonmember_team_id(self, monkeypatch):
@@ -4448,11 +4452,12 @@ class TestLifespanAdvanced:
         monkeypatch.setattr(main_mod.settings, "metrics_aggregation_backfill_hours", 1)
         monkeypatch.setattr(main_mod.settings, "metrics_aggregation_window_minutes", 0)
 
-        plugin = MagicMock()
-        plugin.initialize = AsyncMock()
-        plugin.shutdown = AsyncMock(side_effect=Exception("boom"))
-        plugin.plugin_count = 2
-        monkeypatch.setattr(main_mod, "plugin_manager", plugin)
+        _default_manager = MagicMock()
+        _default_manager.plugin_count = 2
+        mock_get_pm = AsyncMock(return_value=_default_manager)
+        mock_shutdown_factory = AsyncMock(side_effect=Exception("boom"))
+        monkeypatch.setattr(main_mod, "get_plugin_manager", mock_get_pm)
+        monkeypatch.setattr(main_mod, "shutdown_plugin_manager_factory", mock_shutdown_factory)
 
         logging_service = make_service()
         logging_service.configure_uvicorn_after_startup = MagicMock()
@@ -4558,8 +4563,8 @@ class TestLifespanAdvanced:
         async with main_mod.lifespan(main_mod.app):
             await asyncio.sleep(0)
 
-        plugin.initialize.assert_called_once()
-        plugin.shutdown.assert_called_once()
+        mock_get_pm.assert_awaited_once()
+        mock_shutdown_factory.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_lifespan_exits_on_plugin_initialization_failed(self, monkeypatch):
@@ -4626,18 +4631,14 @@ class TestLifespanAdvanced:
 
         monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
 
-        plugin = MagicMock()
-        plugin.initialize = AsyncMock(side_effect=Exception("Plugin initialization failed"))
-        plugin.shutdown = AsyncMock()
-        plugin.plugin_count = 1
-        monkeypatch.setattr(main_mod, "plugin_manager", plugin)
+        monkeypatch.setattr(main_mod, "get_plugin_manager", AsyncMock(side_effect=Exception("Plugin initialization failed")))
+        monkeypatch.setattr(main_mod, "shutdown_plugin_manager_factory", AsyncMock())
 
         with pytest.raises(SystemExit) as excinfo:
             async with main_mod.lifespan(main_mod.app):
                 pass
 
         assert excinfo.value.code == 1
-        plugin.shutdown.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_shutdown_services_continues_on_exception(self):
@@ -7259,7 +7260,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.plugin_manager", None),
+            patch("mcpgateway.main.get_plugin_manager", new=AsyncMock(return_value=None)),
         ):
             response = await handler(request)
 
@@ -7310,7 +7311,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.plugin_manager", mock_plugin_manager),
+            patch("mcpgateway.main.get_plugin_manager", new=AsyncMock(return_value=mock_plugin_manager)),
         ):
             response = await handler(request)
 
@@ -11953,18 +11954,23 @@ class TestRemainingCoverageGaps:
         )
 
     async def test_module_level_skips_plugin_settings_validation_when_plugins_disabled(self, monkeypatch):
-        mod = _import_fresh_main_module(
+        # First-Party
+        import mcpgateway.plugins.framework as plugin_framework
+
+        _import_fresh_main_module(
             monkeypatch,
             env={
                 "PLUGINS_ENABLED": "false",
                 "PLUGINS_SERVER_PORT": "abc",
             },
         )
-        await asyncio.sleep(0)
-        assert mod.plugin_manager is None
+        # settings.enabled is False → get_plugin_manager() short-circuits to None
+        result = await plugin_framework.get_plugin_manager()
+        assert result is None
 
     async def test_module_level_uses_settings_backed_plugin_enablement(self, monkeypatch):
         # First-Party
+        import mcpgateway.plugins.framework as plugin_framework
         import mcpgateway.plugins.framework.settings as plugin_settings_mod
 
         monkeypatch.delenv("PLUGINS_ENABLED", raising=False)
@@ -11979,9 +11985,26 @@ class TestRemainingCoverageGaps:
             lambda **_kwargs: SimpleNamespace(config_file="plugins/config.yaml", plugin_timeout=30),
         )
 
-        mod = _import_fresh_main_module(monkeypatch)
-        await asyncio.sleep(0)
-        assert mod.plugin_manager is not None
+        class _DummyFactory:
+            def __init__(self, *_a, **_k):
+                pass
+
+            async def get_manager(self, server_id=None):
+                return SimpleNamespace(plugin_count=0)
+
+        monkeypatch.setattr(plugin_framework, "TenantPluginManagerFactory", _DummyFactory)
+        plugin_framework.reset_plugin_manager_factory()
+        plugin_framework.enable_plugins(True)
+
+        # Create the factory instance
+        plugin_framework._plugin_manager_factory = _DummyFactory()
+
+        _import_fresh_main_module(monkeypatch)
+        # settings.enabled is True → get_plugin_manager() returns a manager
+        result = await plugin_framework.get_plugin_manager()
+        assert result is not None
+        # Clean up the global factory to avoid polluting subsequent tests
+        plugin_framework.reset_plugin_manager_factory()
 
 
 class TestHardeningHelperCoverage:

--- a/tests/unit/mcpgateway/test_main_pool_init.py
+++ b/tests/unit/mcpgateway/test_main_pool_init.py
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 # Standard
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # Third-Party
 import pytest
@@ -71,7 +71,6 @@ class TestPoolInitAutoAlignment:
         """Verify init_mcp_session_pool receives the calculated parameters."""
         # First-Party
         from mcpgateway.services.mcp_session_pool import (
-            MCPSessionPool,
             close_mcp_session_pool,
             init_mcp_session_pool,
         )

--- a/tests/unit/mcpgateway/test_main_sighup.py
+++ b/tests/unit/mcpgateway/test_main_sighup.py
@@ -101,8 +101,12 @@ def test_install_sighup_handler_skips_outside_main_thread(monkeypatch):
     # First-Party
     import mcpgateway.main as main_mod
 
-    monkeypatch.setattr(main_mod.threading, "current_thread", lambda: object())
-    monkeypatch.setattr(main_mod.threading, "main_thread", lambda: object())
+    mock_current = MagicMock()
+    mock_current.name = "TestThread"
+    mock_main = MagicMock()
+    mock_main.name = "MainThread"
+    monkeypatch.setattr(main_mod.threading, "current_thread", lambda: mock_current)
+    monkeypatch.setattr(main_mod.threading, "main_thread", lambda: mock_main)
     mock_signal = MagicMock()
     monkeypatch.setattr(main_mod.signal, "signal", mock_signal)
 
@@ -119,8 +123,12 @@ def test_restore_default_sighup_handler_skips_outside_main_thread(monkeypatch):
     # First-Party
     import mcpgateway.main as main_mod
 
-    monkeypatch.setattr(main_mod.threading, "current_thread", lambda: object())
-    monkeypatch.setattr(main_mod.threading, "main_thread", lambda: object())
+    mock_current = MagicMock()
+    mock_current.name = "TestThread"
+    mock_main = MagicMock()
+    mock_main.name = "MainThread"
+    monkeypatch.setattr(main_mod.threading, "current_thread", lambda: mock_current)
+    monkeypatch.setattr(main_mod.threading, "main_thread", lambda: mock_main)
     mock_signal = MagicMock()
     monkeypatch.setattr(main_mod.signal, "signal", mock_signal)
 

--- a/tests/unit/plugins/test_secrets_detection.py
+++ b/tests/unit/plugins/test_secrets_detection.py
@@ -103,7 +103,7 @@ async def test_resource_post_fetch_receives_resolved_content(use_rust):
         return MagicMock(modified_payload=None), None
 
     pm.invoke_hook = invoke_hook
-    service._plugin_manager = pm
+    service._get_plugin_manager = AsyncMock(return_value=pm)
 
     # Execute
     result = await service.read_resource(


### PR DESCRIPTION
## 🔗 Related Issue
Closes #

---

## 📝 Summary
This PR combines two related pieces of work that together form the foundation of plugin multi-tenancy in ContextForge.

**1. Per-tool plugin binding API (`/v1/tools/plugin_bindings`)**

Adds four new endpoints for configuring per-tool plugin policies on a per-team basis:

- `POST /v1/tools/plugin_bindings` — create or update bindings (upsert)
- `GET /v1/tools/plugin_bindings` — list all bindings
- `GET /v1/tools/plugin_bindings/{team_id}` — list bindings for a specific team
- `DELETE /v1/tools/plugin_bindings/{id}` — delete a binding by ID

Each binding is a `(team_id, tool_name, plugin_id)` triple stored in a new `tool_plugin_bindings` table. POSTing an existing triple performs an in-place upsert, preserving the original `id` and `created_*` fields. A single request can configure multiple teams and multiple tools at once.

Supported plugin types: `OUTPUT_LENGTH_GUARD`, `RATE_LIMITER`, `SECRETS_DETECTION`.

Security:
- Non-admin callers are restricted to teams they belong to — cross-team requests return HTTP 403.
- Platform admins and sidecar/automation tokens (`is_admin: true, teams: null`) bypass the team guard and can configure any team.
- `tools.manage_plugins` permission is required for write operations; `tools.read` for reads.
- `tools.manage_plugins` is seeded into the `team_admin` role on new installations and backfilled via migration for existing ones.

Performance: a single `team_id IN (...)` prefetch replaces the previous per-triple SELECT loop, and all inserts/updates are flushed in a single `db.flush()` call after the loop.

**2. Tenant plugin manager (`TenantPluginManagerFactory`)**

Adds a per-context plugin manager that dynamically loads and routes plugins per tenant/team at tool execution time. The `TenantPluginManagerFactory` resolves the correct plugin pipeline for the calling team rather than applying a single global plugin stack. The tool service, resource service, and prompt service are updated to use the tenant-aware manager when executing MCP operations.

Key changes:
- `plugins/framework/manager.py` — `TenantPluginManagerFactory` with per-team plugin loading and lifecycle management
- `plugins/framework/__init__.py` — factory registration and context propagation
- `plugins/framework/models.py` — tenant-scoped plugin model additions
- `services/tool_service.py`, `resource_service.py`, `prompt_service.py` — use tenant plugin manager at execution time
- `services/base_service.py` — base plumbing for tenant context propagation

Together these two pieces form a complete multi-tenancy plugin system: the API lets teams declare which plugins apply to which tools, and the tenant manager enforces those policies at runtime.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅     |
| Unit tests                | `make test`     | ✅ 69 new tests passing |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
New Alembic migrations (applied in order):
- `b1c2d3e4f5a6` — creates the `tool_plugin_bindings` table
- `c2d3e4f5a6b7` — backfills `tools.manage_plugins` into the `team_admin` role for existing installations

For sidecar/automated processes that need to configure bindings across all teams in a single request, use an API token with `is_admin: true, teams: null` and assign the `platform_admin` role.