### PR TITLE
build: Support s390x and ppc64le architectures in lite container

### DIFF
--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -101,7 +101,7 @@ FROM rust-builder-base AS rust-builder
 ###########################
 # Frontend builder stage
 ###########################
-FROM node:lts-alpine AS frontend-builder
+FROM node:lts AS frontend-builder
 WORKDIR /app
 
 # Copy package.json and package-lock.json


### PR DESCRIPTION
## Summary

This PR updates the frontend builder stage in `Containerfile.lite` to support additional CPU architectures (s390x and ppc64le) by switching from the Alpine-based Node.js image to the standard Debian-based image.

## Changes

- Changed base image from `node:lts-alpine` to `node:lts` in the frontend builder stage
- Enables multi-architecture builds for s390x (IBM Z) and ppc64le (IBM Power) platforms

## Motivation

The Alpine-based Node.js image (`node:lts-alpine`) does not provide official builds for s390x and ppc64le architectures. By switching to the standard `node:lts` image (Debian-based), we enable support for these enterprise architectures while maintaining compatibility with existing x86_64 and arm64 builds.

## Testing

- [ ] Verify container builds successfully on s390x
- [ ] Verify container builds successfully on ppc64le
- [ ] Verify existing x86_64 and arm64 builds remain functional
- [ ] Confirm frontend assets are properly built and included

## Related Documentation

See `MULTIPLATFORM.md` for multi-architecture build guidance.

Signed-off-by: Jonathan Springer <jps@s390x.com>