### PR TITLE
feat(oauth): add extra_auth_params support for OAuth authorization URL

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12851,8 +12851,6 @@ async def admin_edit_gateway(
                 extra_auth_params_raw = str(form.get("oauth_extra_auth_params", "")).strip()
                 if extra_auth_params_raw:
                     try:
-                        # Standard
-                        import json
                         extra_auth_params = json.loads(extra_auth_params_raw)
                         if isinstance(extra_auth_params, dict):
                             oauth_config["extra_auth_params"] = extra_auth_params

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -945,6 +945,7 @@ async def _parse_gateway_data_from_request(request: Request) -> dict[str, Any]:
             oauth_password = str(data.get("oauth_password", ""))
             oauth_scopes_str = str(data.get("oauth_scopes", ""))
             oauth_audience = str(data.get("oauth_audience", ""))
+            oauth_extra_auth_params = str(data.get("oauth_extra_auth_params", ""))
 
             # If any OAuth field is provided, assemble oauth_config
             if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
@@ -974,6 +975,14 @@ async def _parse_gateway_data_from_request(request: Request) -> dict[str, Any]:
                     scopes = [s.strip() for s in oauth_scopes_str.replace(",", " ").split() if s.strip()]
                     if scopes:
                         oauth_config["scopes"] = scopes
+                # Additional authorization URL parameters (e.g. Google access_type=offline, prompt=consent)
+                if oauth_extra_auth_params:
+                    try:
+                        parsed_extra = orjson.loads(oauth_extra_auth_params)
+                        if isinstance(parsed_extra, dict):
+                            oauth_config["extra_auth_params"] = parsed_extra
+                    except (orjson.JSONDecodeError, ValueError):
+                        pass
 
         # Only set oauth_config if it's a non-empty dict
         if oauth_config:
@@ -12837,6 +12846,18 @@ async def admin_edit_gateway(
                     scopes = [s.strip() for s in oauth_scopes_str.replace(",", " ").split() if s.strip()]
                     if scopes:
                         oauth_config["scopes"] = scopes
+
+                # Parse extra authorization parameters (JSON)
+                extra_auth_params_raw = str(form.get("oauth_extra_auth_params", "")).strip()
+                if extra_auth_params_raw:
+                    try:
+                        # Standard
+                        import json
+                        extra_auth_params = json.loads(extra_auth_params_raw)
+                        if isinstance(extra_auth_params, dict):
+                            oauth_config["extra_auth_params"] = extra_auth_params
+                    except (json.JSONDecodeError, ValueError):
+                        pass  # silently ignore invalid JSON
 
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_grant_type}, issuer={oauth_issuer}")
 

--- a/mcpgateway/admin_ui/admin.js
+++ b/mcpgateway/admin_ui/admin.js
@@ -166,8 +166,9 @@ Admin.handleSubmitWithConfirmation = handleSubmitWithConfirmation;
 Admin.handleDeleteSubmit = handleDeleteSubmit;
 
 // Gateways
-import { editGateway, refreshGatewayTools, refreshToolsForSelectedGateways, testGateway, viewGateway } from "./gateways.js";
+import { addExtraAuthParam, editGateway, refreshGatewayTools, refreshToolsForSelectedGateways, testGateway, viewGateway } from "./gateways.js";
 
+Admin.addExtraAuthParam = addExtraAuthParam;
 Admin.editGateway = editGateway;
 Admin.refreshGatewayTools = refreshGatewayTools;
 Admin.refreshToolsForSelectedGateways = refreshToolsForSelectedGateways;

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -29,6 +29,127 @@ import {
   showSuccessMessage,
 } from "./utils.js";
 
+// ===================================================================
+// EXTRA AUTH PARAMS (Key-Value UI)
+// ===================================================================
+let _extraAuthParamCounter = 0;
+
+/**
+ * Add a new extra auth param row to the specified container.
+ * @param {string} containerId - ID of the container div
+ * @param {string} [key=""] - Pre-populated key
+ * @param {string} [value=""] - Pre-populated value
+ * @param {boolean} [focus=true] - Whether to focus the key input
+ */
+export function addExtraAuthParam(containerId, key = "", value = "", focus = true) {
+  const container = safeGetElement(containerId);
+  if (!container) {
+    console.error(`Container with ID ${containerId} not found`);
+    return;
+  }
+
+  const rowId = `extra-param-row-${++_extraAuthParamCounter}`;
+  const row = document.createElement("div");
+  row.id = rowId;
+  row.className = "flex items-center space-x-2";
+
+  row.innerHTML = `
+    <div class="flex-1">
+      <input
+        type="text"
+        placeholder="Parameter Key (e.g., access_type)"
+        class="extra-auth-param-key block w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 text-sm"
+      />
+    </div>
+    <div class="flex-1">
+      <input
+        type="text"
+        placeholder="Parameter Value (e.g., offline)"
+        class="extra-auth-param-value block w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 text-sm"
+      />
+    </div>
+    <button
+      type="button"
+      class="inline-flex items-center px-2 py-1 border border-transparent text-sm leading-4 font-medium rounded-md text-red-700 bg-red-100 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:bg-red-900 dark:text-red-300 dark:hover:bg-red-800"
+      title="Remove parameter"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+      </svg>
+    </button>
+  `;
+
+  const keyInput = row.querySelector(".extra-auth-param-key");
+  const valueInput = row.querySelector(".extra-auth-param-value");
+  const removeBtn = row.querySelector("button");
+
+  keyInput.value = key;
+  valueInput.value = value;
+
+  keyInput.addEventListener("input", () => updateExtraAuthParamsJSON(containerId));
+  valueInput.addEventListener("input", () => updateExtraAuthParamsJSON(containerId));
+  removeBtn.addEventListener("click", () => {
+    row.remove();
+    updateExtraAuthParamsJSON(containerId);
+  });
+
+  container.appendChild(row);
+  updateExtraAuthParamsJSON(containerId);
+
+  if (focus && keyInput) {
+    keyInput.focus();
+  }
+}
+
+/**
+ * Sync all extra auth param rows into the hidden JSON input.
+ * @param {string} containerId - ID of the container div
+ */
+export function updateExtraAuthParamsJSON(containerId) {
+  const container = safeGetElement(containerId);
+  if (!container) return;
+
+  const result = {};
+  const rows = container.querySelectorAll('[id^="extra-param-row-"]');
+  rows.forEach((row) => {
+    const key = row.querySelector(".extra-auth-param-key")?.value?.trim();
+    const value = row.querySelector(".extra-auth-param-value")?.value?.trim() ?? "";
+    if (key) {
+      result[key] = value;
+    }
+  });
+
+  const hiddenId = containerId.replace("-container", "-json");
+  const hiddenInput = safeGetElement(hiddenId);
+  if (hiddenInput) {
+    hiddenInput.value = Object.keys(result).length > 0 ? JSON.stringify(result) : "";
+  }
+}
+
+/**
+ * Populate extra auth param rows from an existing object.
+ * @param {string} containerId - ID of the container div
+ * @param {Object} params - Key-value pairs to populate
+ */
+export function loadExtraAuthParams(containerId, params) {
+  const container = safeGetElement(containerId);
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  if (!params || typeof params !== "object") {
+    updateExtraAuthParamsJSON(containerId);
+    return;
+  }
+
+  Object.entries(params).forEach(([key, value]) => {
+    addExtraAuthParam(containerId, key, String(value ?? ""), false);
+  });
+
+  updateExtraAuthParamsJSON(containerId);
+}
+
+
 /**
  * SECURE: View Gateway function
  */
@@ -526,6 +647,10 @@ export const editGateway = async function (gatewayId) {
               ? config.scopes.join(" ")
               : "";
           }
+          loadExtraAuthParams(
+            "extra-auth-params-container-gw-edit",
+            config.extra_auth_params || {}
+          );
         }
         break;
       case "query_param":

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2850,7 +2850,8 @@ class GatewayCreate(BaseModelWithConfigDict):
 
     # OAuth 2.0 configuration
     oauth_config: Optional[Dict[str, Any]] = Field(
-        None, description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), and resource (RFC 8707)"
+        None,
+        description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), resource (RFC 8707), and extra_auth_params (optional dict of additional authorization URL parameters, e.g. {'access_type': 'offline', 'prompt': 'consent'})",
     )
 
     # Query Parameter Authentication (INSECURE)
@@ -3209,7 +3210,8 @@ class GatewayUpdate(BaseModelWithConfigDict):
 
     # OAuth 2.0 configuration
     oauth_config: Optional[Dict[str, Any]] = Field(
-        None, description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), and resource (RFC 8707)"
+        None,
+        description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), resource (RFC 8707), and extra_auth_params (optional dict of additional authorization URL parameters, e.g. {'access_type': 'offline', 'prompt': 'consent'})",
     )
 
     # Query Parameter Authentication (INSECURE)
@@ -3564,7 +3566,8 @@ class GatewayRead(BaseModelWithConfigDict):
 
     # OAuth 2.0 configuration
     oauth_config: Optional[Dict[str, Any]] = Field(
-        None, description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), and resource (RFC 8707)"
+        None,
+        description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), resource (RFC 8707), and extra_auth_params (optional dict of additional authorization URL parameters, e.g. {'access_type': 'offline', 'prompt': 'consent'})",
     )
 
     # Query Parameter Authentication (masked for security)

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -653,7 +653,12 @@ class OAuthManager:
         oauth = OAuth2Session(client_id, redirect_uri=redirect_uri, scope=scopes)
 
         # Generate authorization URL with state for CSRF protection
-        auth_url, state = oauth.authorization_url(authorization_url)
+        # Include extra_auth_params if provided (e.g. Google's access_type, Auth0's audience)
+        extra = credentials.get("extra_auth_params", {})
+        if extra and isinstance(extra, dict):
+            auth_url, state = oauth.authorization_url(authorization_url, **extra)
+        else:
+            auth_url, state = oauth.authorization_url(authorization_url)
 
         logger.info(f"Generated authorization URL for client {client_id}")
 
@@ -1492,7 +1497,7 @@ class OAuthManager:
             Authorization URL string with PKCE parameters
         """
         # Standard
-        from urllib.parse import urlencode  # pylint: disable=import-outside-toplevel
+        from urllib.parse import parse_qs, urlencode, urlparse  # pylint: disable=import-outside-toplevel
 
         client_id = credentials["client_id"]
         redirect_uri = credentials["redirect_uri"]
@@ -1518,9 +1523,22 @@ class OAuthManager:
         if self._should_include_resource_parameter(credentials, scopes):
             params["resource"] = resource  # urlencode with doseq=True handles lists
 
-        # Build full URL (doseq=True handles list values like multiple resource params)
-        query_string = urlencode(params, doseq=True)
-        return f"{authorization_url}?{query_string}"
+        # Merge extra_auth_params (e.g. Google's access_type, Auth0's audience)
+        # without overriding core OAuth parameters
+        extra = credentials.get("extra_auth_params")
+        if extra and isinstance(extra, dict):
+            for k, v in extra.items():
+                if k not in params:
+                    params[k] = v
+
+        # Build full URL, preserving any existing query parameters in authorization_url
+        parsed = urlparse(authorization_url)
+        existing_params = parse_qs(parsed.query, keep_blank_values=True)
+        # New params override existing ones from the base URL
+        for k, v in params.items():
+            existing_params[k] = [v] if not isinstance(v, list) else v
+        query_string = urlencode(existing_params, doseq=True)
+        return f"{parsed.scheme}://{parsed.netloc}{parsed.path}?{query_string}"
 
     async def _exchange_code_for_tokens(
         self, credentials: Dict[str, Any], code: str, code_verifier: str = None, ca_certificate: Optional[str] = None, client_cert: Optional[str] = None, client_key: Optional[str] = None

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -654,9 +654,12 @@ class OAuthManager:
 
         # Generate authorization URL with state for CSRF protection
         # Include extra_auth_params if provided (e.g. Google's access_type, Auth0's audience)
+        # Filter out core OAuth parameters to prevent injection/override
         extra = credentials.get("extra_auth_params", {})
         if extra and isinstance(extra, dict):
-            auth_url, state = oauth.authorization_url(authorization_url, **extra)
+            core_params = {"client_id", "redirect_uri", "response_type", "scope", "state"}
+            safe_extra = {k: v for k, v in extra.items() if k not in core_params}
+            auth_url, state = oauth.authorization_url(authorization_url, **safe_extra)
         else:
             auth_url, state = oauth.authorization_url(authorization_url)
 
@@ -1497,7 +1500,7 @@ class OAuthManager:
             Authorization URL string with PKCE parameters
         """
         # Standard
-        from urllib.parse import parse_qs, urlencode, urlparse  # pylint: disable=import-outside-toplevel
+        from urllib.parse import parse_qs, urlencode  # pylint: disable=import-outside-toplevel
 
         client_id = credentials["client_id"]
         redirect_uri = credentials["redirect_uri"]

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5878,6 +5878,27 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       OAuth audience parameter (for Atlassian, Auth0, etc.)
                     </p>
                   </div>
+
+                  <div class="space-y-1">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Extra Authorization Parameters
+                      <span class="text-xs text-gray-400 font-normal ml-1">(additional query parameters for the OAuth authorization URL, e.g., access_type=offline, prompt=consent)</span>
+                    </label>
+                    <button
+                      type="button"
+                      onclick="Admin.addExtraAuthParam('extra-auth-params-container-gw')"
+                      class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    >
+                      <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                      </svg>
+                      Add Parameter
+                    </button>
+                  </div>
+                  <div id="extra-auth-params-container-gw" class="space-y-2 mt-2">
+                    <!-- Rows added dynamically -->
+                  </div>
+                  <input type="hidden" name="oauth_extra_auth_params" id="extra-auth-params-json-gw" value="" />
                 </div>
               </div>
 
@@ -10320,6 +10341,26 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                               read:user")
                             </p>
                           </div>
+                          <div class="space-y-1">
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                              Extra Authorization Parameters
+                              <span class="text-xs text-gray-400 font-normal ml-1">(additional query parameters for the OAuth authorization URL, e.g., access_type=offline, prompt=consent)</span>
+                            </label>
+                            <button
+                              type="button"
+                              onclick="Admin.addExtraAuthParam('extra-auth-params-container-gw-edit')"
+                              class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                            >
+                              <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                              </svg>
+                              Add Parameter
+                            </button>
+                          </div>
+                          <div id="extra-auth-params-container-gw-edit" class="space-y-2 mt-2">
+                            <!-- Rows added dynamically -->
+                          </div>
+                          <input type="hidden" name="oauth_extra_auth_params" id="extra-auth-params-json-gw-edit" value="" />
                         </div>
                       </div>
                     </div>

--- a/tests/unit/mcpgateway/services/test_oauth_manager_pkce.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager_pkce.py
@@ -581,6 +581,36 @@ class TestExtraAuthParamsNonPKCE:
         assert "state" in result
 
     @pytest.mark.asyncio
+    async def test_non_pkce_extra_auth_params_do_not_override_core_params(self):
+        """Test that extra_auth_params cannot override core OAuth parameters in non-PKCE flow."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "legitimate-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+            "extra_auth_params": {
+                "redirect_uri": "https://evil.com/steal",
+                "client_id": "attacker-client",
+                "state": "malicious-state",
+                "response_type": "token",
+                "access_type": "offline",
+            },
+        }
+
+        result = await manager.get_authorization_url(credentials)
+        url = result["authorization_url"]
+
+        # Core params must NOT be overridden
+        assert "evil.com" not in url
+        assert "attacker-client" not in url
+        assert "malicious-state" not in url
+        assert "response_type=token" not in url
+        # Safe extra param should still be included
+        assert "access_type=offline" in url
+
+    @pytest.mark.asyncio
     async def test_complete_authorization_code_flow_fails_with_invalid_state(self):
         """Test that invalid state causes flow to fail."""
         manager = OAuthManager()

--- a/tests/unit/mcpgateway/services/test_oauth_manager_pkce.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager_pkce.py
@@ -401,6 +401,185 @@ class TestCompleteAuthorizationCodeFlowWithPKCE:
         call_kwargs = mock_exchange.call_args[1]
         assert call_kwargs["code_verifier"] == "verifier-xyz"
 
+
+class TestExtraAuthParams:
+    """Test extra_auth_params support in authorization URL generation."""
+
+    def test_extra_auth_params_appear_in_pkce_url(self):
+        """Test that extra_auth_params are included in the PKCE authorization URL."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid", "email"],
+            "extra_auth_params": {"access_type": "offline", "prompt": "consent"},
+        }
+
+        auth_url = manager._create_authorization_url_with_pkce(credentials, "state", "challenge", "S256")
+
+        assert "access_type=offline" in auth_url
+        assert "prompt=consent" in auth_url
+
+    def test_extra_auth_params_do_not_override_core_params(self):
+        """Test that extra_auth_params cannot override core OAuth parameters."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "real-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": [],
+            "extra_auth_params": {
+                "client_id": "evil-client",
+                "response_type": "token",
+                "state": "malicious-state",
+            },
+        }
+
+        auth_url = manager._create_authorization_url_with_pkce(credentials, "legit-state", "challenge", "S256")
+
+        assert "client_id=real-client" in auth_url
+        assert "evil-client" not in auth_url
+        assert "response_type=code" in auth_url
+        assert "response_type=token" not in auth_url
+        assert "state=legit-state" in auth_url
+        assert "malicious-state" not in auth_url
+
+    def test_extra_auth_params_empty_dict_is_noop(self):
+        """Test that an empty extra_auth_params dict produces the same URL as no extra params."""
+        manager = OAuthManager()
+
+        base_credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+        }
+
+        url_without = manager._create_authorization_url_with_pkce(base_credentials, "state", "challenge", "S256")
+
+        credentials_with_empty = {**base_credentials, "extra_auth_params": {}}
+        url_with_empty = manager._create_authorization_url_with_pkce(credentials_with_empty, "state", "challenge", "S256")
+
+        assert url_without == url_with_empty
+
+    def test_extra_auth_params_none_is_noop(self):
+        """Test that extra_auth_params=None produces the same URL as no extra params."""
+        manager = OAuthManager()
+
+        base_credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+        }
+
+        url_without = manager._create_authorization_url_with_pkce(base_credentials, "state", "challenge", "S256")
+
+        credentials_with_none = {**base_credentials, "extra_auth_params": None}
+        url_with_none = manager._create_authorization_url_with_pkce(credentials_with_none, "state", "challenge", "S256")
+
+        assert url_without == url_with_none
+
+    def test_base_url_with_existing_query_params(self):
+        """Test that authorization URLs with existing query parameters are handled correctly."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://as.example.com/authorize?audience=https://api.example.com",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+        }
+
+        auth_url = manager._create_authorization_url_with_pkce(credentials, "state", "challenge", "S256")
+
+        # Both the existing param and the new params should be present
+        assert "audience=https" in auth_url
+        assert "client_id=test-client" in auth_url
+        assert "response_type=code" in auth_url
+        assert "code_challenge=challenge" in auth_url
+        # Bug fix verification: URL must have exactly one '?' separator
+        assert auth_url.count("?") == 1, f"Expected exactly one '?' in URL, got {auth_url.count('?')}: {auth_url}"
+
+    def test_extra_auth_params_non_dict_ignored(self):
+        """Test that non-dict extra_auth_params values are safely ignored."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": [],
+            "extra_auth_params": "not-a-dict",
+        }
+
+        # Should not raise, just ignore the invalid value
+        auth_url = manager._create_authorization_url_with_pkce(credentials, "state", "challenge", "S256")
+        assert "client_id=test-client" in auth_url
+
+
+class TestExtraAuthParamsNonPKCE:
+    """Test extra_auth_params support in non-PKCE authorization URL generation."""
+
+    @pytest.mark.asyncio
+    async def test_extra_auth_params_passed_via_oauth2session(self):
+        """Test that extra_auth_params are passed to OAuth2Session.authorization_url()."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+            "extra_auth_params": {"access_type": "offline", "prompt": "consent"},
+        }
+
+        result = await manager.get_authorization_url(credentials)
+
+        # The URL should contain the extra params
+        assert "access_type=offline" in result["authorization_url"]
+        assert "prompt=consent" in result["authorization_url"]
+        assert "state" in result
+
+    @pytest.mark.asyncio
+    async def test_non_pkce_without_extra_params(self):
+        """Test that get_authorization_url works without extra_auth_params."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+        }
+
+        result = await manager.get_authorization_url(credentials)
+
+        assert "authorization_url" in result
+        assert "state" in result
+        assert "client_id=test-client" in result["authorization_url"]
+
+    @pytest.mark.asyncio
+    async def test_non_pkce_empty_extra_params(self):
+        """Test that empty extra_auth_params dict is a no-op for non-PKCE flow."""
+        manager = OAuthManager()
+
+        credentials = {
+            "client_id": "test-client",
+            "authorization_url": "https://as.example.com/authorize",
+            "redirect_uri": "http://localhost:4444/callback",
+            "scopes": ["openid"],
+            "extra_auth_params": {},
+        }
+
+        result = await manager.get_authorization_url(credentials)
+
+        assert "authorization_url" in result
+        assert "state" in result
+
     @pytest.mark.asyncio
     async def test_complete_authorization_code_flow_fails_with_invalid_state(self):
         """Test that invalid state causes flow to fail."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -6606,6 +6606,96 @@ class TestOAuthFunctionality:
             assert gateway_create.oauth_config["scopes"] == ["read:jira-work", "write:jira-work"]
 
     @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_oauth_extra_auth_params_valid_json(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with valid extra_auth_params JSON from form fields."""
+        form_data = FakeForm(
+            {
+                "name": "OAuth_ExtraParams_Gateway",
+                "url": "https://extra.example.com",
+                "auth_type": "oauth",
+                "oauth_grant_type": "authorization_code",
+                "oauth_token_url": "https://issuer.example.com/token",
+                "oauth_authorization_url": "https://issuer.example.com/auth",
+                "oauth_client_id": "client-id",
+                "oauth_client_secret": "client-secret",
+                "oauth_extra_auth_params": '{"access_type": "offline", "prompt": "consent"}',
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_get_encryption,
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta,
+        ):
+            mock_encryption = MagicMock()
+            mock_encryption.encrypt_secret_async = AsyncMock(return_value="enc-secret")
+            mock_get_encryption.return_value = mock_encryption
+            mock_meta.return_value = {
+                "created_by": "u@example.com",
+                "created_from_ip": None,
+                "created_via": "ui",
+                "created_user_agent": None,
+                "import_batch_id": None,
+                "federation_source": None,
+            }
+
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 200
+
+            gateway_create = mock_register_gateway.call_args.args[1]
+            assert gateway_create.oauth_config["extra_auth_params"] == {"access_type": "offline", "prompt": "consent"}
+
+    @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_oauth_extra_auth_params_invalid_json_ignored(self, mock_register_gateway, mock_request, mock_db):
+        """Test that invalid JSON in extra_auth_params is silently ignored."""
+        form_data = FakeForm(
+            {
+                "name": "OAuth_BadExtra_Gateway",
+                "url": "https://badextra.example.com",
+                "auth_type": "oauth",
+                "oauth_grant_type": "authorization_code",
+                "oauth_token_url": "https://issuer.example.com/token",
+                "oauth_authorization_url": "https://issuer.example.com/auth",
+                "oauth_client_id": "client-id",
+                "oauth_client_secret": "client-secret",
+                "oauth_extra_auth_params": "not-valid-json{",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_get_encryption,
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta,
+        ):
+            mock_encryption = MagicMock()
+            mock_encryption.encrypt_secret_async = AsyncMock(return_value="enc-secret")
+            mock_get_encryption.return_value = mock_encryption
+            mock_meta.return_value = {
+                "created_by": "u@example.com",
+                "created_from_ip": None,
+                "created_via": "ui",
+                "created_user_agent": None,
+                "import_batch_id": None,
+                "federation_source": None,
+            }
+
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 200
+
+            gateway_create = mock_register_gateway.call_args.args[1]
+            assert "extra_auth_params" not in gateway_create.oauth_config
+
+    @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_oauth_assembled_minimal_fields_covers_false_branches(self, mock_register_gateway, mock_request, mock_db):
         """Cover false branches in the OAuth form-fields assembly logic."""
         form_data = FakeForm(
@@ -6798,6 +6888,78 @@ class TestOAuthFunctionality:
             assert gateway_update.oauth_config["client_id"] == "client-id"
             assert gateway_update.oauth_config["scopes"] == ["read:jira-work", "write:jira-work"]
 
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_edit_gateway_oauth_extra_auth_params_valid_json(self, mock_update_gateway, mock_request, mock_db):
+        """Test editing gateway with valid extra_auth_params JSON from form fields."""
+        form_data = FakeForm(
+            {
+                "name": "Edited_ExtraParams_Gateway",
+                "url": "https://edited-extra.example.com",
+                "oauth_grant_type": "authorization_code",
+                "oauth_token_url": "https://issuer.example.com/token",
+                "oauth_authorization_url": "https://issuer.example.com/auth",
+                "oauth_client_id": "client-id",
+                "oauth_client_secret": "client-secret",
+                "oauth_extra_auth_params": '{"access_type": "offline", "prompt": "consent"}',
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_get_encryption,
+            patch("mcpgateway.admin.MetadataCapture.extract_modification_metadata") as mock_meta,
+        ):
+            mock_encryption = MagicMock()
+            mock_encryption.encrypt_secret_async = AsyncMock(return_value="enc-secret")
+            mock_get_encryption.return_value = mock_encryption
+            mock_meta.return_value = {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None, "version": 1}
+
+            result = await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 200
+
+            gateway_update = mock_update_gateway.call_args.args[2]
+            assert gateway_update.oauth_config["extra_auth_params"] == {"access_type": "offline", "prompt": "consent"}
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_edit_gateway_oauth_extra_auth_params_invalid_json_ignored(self, mock_update_gateway, mock_request, mock_db):
+        """Test that invalid JSON in extra_auth_params is silently ignored during edit."""
+        form_data = FakeForm(
+            {
+                "name": "Edited_BadExtra_Gateway",
+                "url": "https://edited-badextra.example.com",
+                "oauth_grant_type": "authorization_code",
+                "oauth_token_url": "https://issuer.example.com/token",
+                "oauth_authorization_url": "https://issuer.example.com/auth",
+                "oauth_client_id": "client-id",
+                "oauth_client_secret": "client-secret",
+                "oauth_extra_auth_params": "{invalid json",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_get_encryption,
+            patch("mcpgateway.admin.MetadataCapture.extract_modification_metadata") as mock_meta,
+        ):
+            mock_encryption = MagicMock()
+            mock_encryption.encrypt_secret_async = AsyncMock(return_value="enc-secret")
+            mock_get_encryption.return_value = mock_encryption
+            mock_meta.return_value = {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None, "version": 1}
+
+            result = await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 200
+
+            gateway_update = mock_update_gateway.call_args.args[2]
+            assert "extra_auth_params" not in gateway_update.oauth_config
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_assembled_minimal_fields_covers_false_branches(self, mock_update_gateway, mock_request, mock_db, monkeypatch):


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4115

---

## 📝 Summary

Add `extra_auth_params` support for OAuth gateway configuration, allowing administrators to pass provider-specific query parameters to the OAuth authorization URL.

**Problem:** OAuth providers like Google require `access_type=offline` to issue refresh tokens, Auth0 requires `audience` for JWT access tokens, and Microsoft needs `domain_hint` — but Context Forge had no way to pass these parameters.

**Solution:** New `extra_auth_params` field (Dict[str, str]) in gateway OAuth config, with dynamic key-value UI in Admin and proper URL merging in both PKCE and non-PKCE paths.

Also fixes a pre-existing bug where the PKCE URL builder would produce invalid URLs if `authorization_url` already contained query parameters (`?` duplication).

---

## 🏷️ Type of Change
- [x] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   pass     |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |        |

I also tested with local docker-compose environment manually.

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Files changed (7):**
- `oauth_manager.py` — PKCE + non-PKCE path extra params merge + URL builder bug fix
- `admin.py` — form parsing for extra_auth_params
- `admin.html` — dynamic key-value UI (Add Parameter button, matching Custom Headers pattern)
- `gateways.js` + `admin.js` — JS functions for dynamic rows
- `schemas.py` — field description updates
- `test_oauth_manager_pkce.py` — 10 new tests (happy path, security/override protection, edge cases, bug fix)

**Test coverage:**
- Extra params appear in authorization URL (PKCE + non-PKCE)
- Core OAuth params (client_id, response_type, state) cannot be overridden
- Empty dict / None / non-dict safely ignored
- Base URL with existing query params produces valid URL (`?` count == 1)

<img width="1076" height="1194" alt="스크린샷 2026-04-10 오후 4 30 38" src="https://github.com/user-attachments/assets/51dc68b9-69aa-40e0-9992-5b8fb1bd41e4" />
