### PR TITLE
fix: honor default mask strategy in Rust PII detector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock",
     "lines": null
   },
-  "generated_at": "2026-04-08T16:53:59Z",
+  "generated_at": "2026-04-10T08:19:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8604,7 +8604,7 @@
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 505,
+        "line_number": 506,
         "type": "AWS Access Key",
         "verified_result": null
       }

--- a/plugins_rust/pii_filter/src/detector.rs
+++ b/plugins_rust/pii_filter/src/detector.rs
@@ -719,7 +719,7 @@ mod tests {
     }
 
     #[test]
-    fn test_built_in_patterns_keep_explicit_mask_strategy() {
+    fn test_built_in_patterns_follow_global_default_mask_strategy() {
         let config = PIIConfig {
             detect_ssn: true,
             detect_email: true,
@@ -736,16 +736,16 @@ mod tests {
 
         assert_eq!(
             detections[&PIIType::Ssn][0].mask_strategy,
-            MaskingStrategy::Partial
+            MaskingStrategy::Redact
         );
         assert_eq!(
             detections[&PIIType::Email][0].mask_strategy,
-            MaskingStrategy::Partial
+            MaskingStrategy::Redact
         );
     }
 
     #[test]
-    fn test_built_in_mask_strategy_matrix_survives_global_override() {
+    fn test_built_in_mask_strategy_matrix_follows_global_override() {
         let config = PIIConfig {
             detect_ssn: true,
             detect_credit_card: true,
@@ -763,23 +763,23 @@ mod tests {
 
         assert_eq!(
             detections[&PIIType::Ssn][0].mask_strategy,
-            MaskingStrategy::Partial
+            MaskingStrategy::Hash
         );
         assert_eq!(
             detections[&PIIType::CreditCard][0].mask_strategy,
-            MaskingStrategy::Partial
+            MaskingStrategy::Hash
         );
         assert_eq!(
             detections[&PIIType::Email][0].mask_strategy,
-            MaskingStrategy::Partial
+            MaskingStrategy::Hash
         );
         assert_eq!(
             detections[&PIIType::Phone][0].mask_strategy,
-            MaskingStrategy::Partial
+            MaskingStrategy::Hash
         );
         assert_eq!(
             detections[&PIIType::IpAddress][0].mask_strategy,
-            MaskingStrategy::Redact
+            MaskingStrategy::Hash
         );
     }
 

--- a/plugins_rust/pii_filter/src/patterns.rs
+++ b/plugins_rust/pii_filter/src/patterns.rs
@@ -26,8 +26,8 @@ pub struct CompiledPatterns {
     pub whitelist: Vec<Regex>,
 }
 
-/// Pattern definitions (pattern, description, explicit masking strategy)
-type PatternDef = (&'static str, &'static str, MaskingStrategy);
+/// Pattern definitions (pattern, description, optional explicit masking strategy)
+type PatternDef = (&'static str, &'static str, Option<MaskingStrategy>);
 
 const VALID_SSN_DASHED_PATTERN: &str = r"\b(?:00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6(?:[0-5][0-9]|6[0-57-9]|[7-9][0-9])|[7-8][0-9]{2})-(?:0[1-9]|[1-9][0-9])-(?:000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})\b";
 const VALID_SSN_CONTEXTUAL_PATTERN: &str = r"\b(?:SSN|Social\s+Security(?:\s+Number)?)[:\s#-]*(?:00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6(?:[0-5][0-9]|6[0-57-9]|[7-9][0-9])|[7-8][0-9]{2})(?:0[1-9]|[1-9][0-9])(?:000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})\b";
@@ -38,12 +38,12 @@ static SSN_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
         (
             VALID_SSN_DASHED_PATTERN,
             "US Social Security Number",
-            MaskingStrategy::Partial,
+            None,
         ),
         (
             VALID_SSN_CONTEXTUAL_PATTERN,
             "US Social Security Number with explicit context",
-            MaskingStrategy::Partial,
+            None,
         ),
     ]
 });
@@ -55,12 +55,12 @@ static BSN_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
         (
             r"\b(?:BSN|Citizen\s+ID|Citizen\s+Service\s+Number|Burgerservicenummer)[:\s#]*\d{9}\b",
             "Dutch BSN with explicit context",
-            MaskingStrategy::Partial,
+            None,
         ),
         (
             r"\b(?:My\s+)?BSN\s+(?:is\s+)?\d{9}\b",
             "BSN with 'is' context",
-            MaskingStrategy::Partial,
+            None,
         ),
     ]
 });
@@ -70,7 +70,7 @@ static CREDIT_CARD_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
     vec![(
         r"\b(?:\d{4}[-\s]?){3}\d{4}\b",
         "Credit card number",
-        MaskingStrategy::Partial,
+        None,
     )]
 });
 
@@ -79,7 +79,7 @@ static EMAIL_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
     vec![(
         r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
         "Email address",
-        MaskingStrategy::Partial,
+        None,
     )]
 });
 
@@ -89,12 +89,12 @@ static PHONE_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
         (
             r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b",
             "US phone number",
-            MaskingStrategy::Partial,
+            None,
         ),
         (
             r"\+[1-9]\d{9,14}\b",
             "International phone number",
-            MaskingStrategy::Partial,
+            None,
         ),
     ]
 });
@@ -105,12 +105,12 @@ static IP_ADDRESS_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
         (
             r"\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b",
             "IPv4 address",
-            MaskingStrategy::Redact,
+            None,
         ),
         (
             r"\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b",
             "IPv6 address",
-            MaskingStrategy::Redact,
+            None,
         ),
     ]
 });
@@ -121,12 +121,12 @@ static DOB_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
         (
             r"\b(?:DOB|Date of Birth|Born|Birthday)[:\s]+\d{1,2}[-/]\d{1,2}[-/]\d{2,4}\b",
             "Date of birth with label",
-            MaskingStrategy::Redact,
+            None,
         ),
         (
             r"\b(?:0[1-9]|1[0-2])[-/](?:0[1-9]|[12]\d|3[01])[-/](?:19|20)\d{2}\b",
             "Date in MM/DD/YYYY format",
-            MaskingStrategy::Redact,
+            None,
         ),
     ]
 });
@@ -136,7 +136,7 @@ static PASSPORT_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
     vec![(
         r"\b(?:Passport\s+Number|Passport\s+No|Passport)[#:\s-]+[A-Z0-9]{6,9}\b",
         "Passport number with explicit context",
-        MaskingStrategy::Redact,
+        None,
     )]
 });
 
@@ -145,7 +145,7 @@ static DRIVER_LICENSE_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
     vec![(
         r"\b(?:DL|License|Driver'?s? License)[#:\s]+[A-Z0-9]{5,20}\b",
         "Driver's license number",
-        MaskingStrategy::Redact,
+        None,
     )]
 });
 
@@ -155,12 +155,12 @@ static BANK_ACCOUNT_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
         (
             r"\b(?:Account|Acct|Bank\s+Account|Account\s+Number|Routing\s+Account)[#:\s-]*\d{8,17}\b",
             "Bank account number with explicit context",
-            MaskingStrategy::Redact,
+            None,
         ),
         (
             r"\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:\d{3})?\b",
             "IBAN",
-            MaskingStrategy::Partial,
+            None,
         ),
     ]
 });
@@ -170,7 +170,7 @@ static MEDICAL_RECORD_PATTERNS: Lazy<Vec<PatternDef>> = Lazy::new(|| {
     vec![(
         r"\b(?:MRN|Medical Record)[#:\s]+[A-Z0-9]{6,12}\b",
         "Medical record number",
-        MaskingStrategy::Redact,
+        None,
     )]
 });
 
@@ -193,7 +193,7 @@ pub fn compile_patterns(config: &PIIConfig) -> Result<CompiledPatterns, String> 
                     patterns.push(CompiledPattern {
                         pii_type: $pii_type,
                         regex,
-                        mask_strategy: Some(*mask_strategy),
+                        mask_strategy: *mask_strategy,
                         description: description.to_string(),
                     });
                 }

--- a/tests/unit/mcpgateway/plugins/plugins/pii_filter/test_pii_filter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/pii_filter/test_pii_filter.py
@@ -34,6 +34,7 @@ from plugins.pii_filter.pii_filter import (
     PIIDetector,
     PIIFilterConfig,
     PIIFilterPlugin,
+    PIIPattern,
     PIIType,
 )
 from plugins.pii_filter import pii_filter as pii_filter_module
@@ -650,6 +651,7 @@ class TestRustPIIDetectorSpecific:
 
     def test_process_nested_dict(self, detector):
         """Test processing nested dictionary."""
+        detector = RustPIIDetector(PIIFilterConfig(default_mask_strategy=MaskingStrategy.PARTIAL))
         data = {"user": {"ssn": "123-45-6789", "email": "john@example.com", "name": "John Doe"}}
 
         modified, new_data, detections = detector.process_nested(data, "")
@@ -665,6 +667,7 @@ class TestRustPIIDetectorSpecific:
 
     def test_process_nested_list(self, detector):
         """Test processing list with PII."""
+        detector = RustPIIDetector(PIIFilterConfig(default_mask_strategy=MaskingStrategy.PARTIAL))
         data = ["SSN: 123-45-6789", "No PII here", "Email: test@example.com"]
 
         modified, new_data, detections = detector.process_nested(data, "")
@@ -676,6 +679,7 @@ class TestRustPIIDetectorSpecific:
 
     def test_process_nested_mixed_structure(self, detector):
         """Test processing mixed nested structure."""
+        detector = RustPIIDetector(PIIFilterConfig(default_mask_strategy=MaskingStrategy.PARTIAL))
         data = {"users": [{"ssn": "123-45-6789", "name": "Alice"}, {"ssn": "223-65-4321", "name": "Bob"}], "contact": {"email": "admin@example.com", "phone": "555-1234"}}
 
         modified, new_data, detections = detector.process_nested(data, "")
@@ -705,13 +709,13 @@ class TestRustPIIDetectorSpecific:
         detector = RustDet(config)
         assert detector is not None
 
-    def test_built_in_partial_masks_override_global_redaction_default(self):
-        """Built-in Rust detections should keep their explicit partial strategies."""
+    def test_built_in_partial_masks_follow_global_redaction_default(self):
+        """Built-in Rust detections should honor a global redact default."""
         detector = RustPIIDetector(PIIFilterConfig(detect_ssn=True, detect_email=True, detect_phone=False, detect_ip_address=False, default_mask_strategy=MaskingStrategy.REDACT))
         detections = detector.detect("SSN: 123-45-6789 Email: john@example.com")
 
-        assert detections["ssn"][0]["mask_strategy"] == "partial"
-        assert detections["email"][0]["mask_strategy"] == "partial"
+        assert detections["ssn"][0]["mask_strategy"] == "redact"
+        assert detections["email"][0]["mask_strategy"] == "redact"
 
     def test_rust_accepts_unformatted_contextual_ssn(self):
         """Rust should continue accepting labeled bare 9-digit SSNs."""
@@ -727,8 +731,8 @@ class TestRustPIIDetectorSpecific:
         detections = detector.detect("SSN: 123456789")
         assert "ssn" in detections
 
-    def test_built_in_redaction_masks_ignore_global_partial_default(self):
-        """Built-in redaction-only detections should keep their explicit redact strategies."""
+    def test_built_in_redaction_masks_follow_global_partial_default(self):
+        """Built-in Rust detections should honor a global partial default."""
         detector = RustPIIDetector(
             PIIFilterConfig(
                 detect_ssn=False,
@@ -740,22 +744,22 @@ class TestRustPIIDetectorSpecific:
         )
         detections = detector.detect("IP 192.168.1.1")
 
-        assert detections["ip_address"][0]["mask_strategy"] == "redact"
+        assert detections["ip_address"][0]["mask_strategy"] == "partial"
 
     def test_custom_pattern_keeps_explicit_strategy_when_default_redacts(self):
         """Custom pattern overrides should win over the global default strategy."""
         detector = RustPIIDetector(
             PIIFilterConfig(
                 default_mask_strategy=MaskingStrategy.REDACT,
-                custom_patterns=[{"type": "custom", "pattern": r"\bEMP\d{6}\b", "description": "Employee ID", "mask_strategy": "partial", "enabled": True}],
+                custom_patterns=[PIIPattern(type=PIIType.CUSTOM, pattern=r"\bEMP\d{6}\b", description="Employee ID", mask_strategy=MaskingStrategy.PARTIAL)],
             )
         )
 
         detections = detector.detect("Employee ID EMP123456")
         assert detections["custom"][0]["mask_strategy"] == "partial"
 
-    def test_rust_mask_uses_built_in_partial_strategies_when_default_redacts(self):
-        """Live Rust masking should preserve built-in partial masking behavior."""
+    def test_rust_mask_uses_global_redaction_default_for_built_ins(self):
+        """Live Rust masking should redact built-ins when configured to do so."""
         detector = RustPIIDetector(
             PIIFilterConfig(
                 detect_ssn=True,
@@ -776,12 +780,12 @@ class TestRustPIIDetectorSpecific:
         detections = detector.detect(text)
         masked = detector.mask(text, detections)
 
-        assert "***-**-6789" in masked
-        assert "j***n@example.com" in masked
-        assert "[REDACTED]" not in masked
+        assert masked.count("[REDACTED]") == 2
+        assert "123-45-6789" not in masked
+        assert "john@example.com" not in masked
 
     def test_rust_mask_strategy_regression_matrix(self):
-        """Regression test: built-in Rust masks should ignore a global hash default."""
+        """Regression test: built-in Rust masks should honor a global hash default."""
         detector = RustPIIDetector(
             PIIFilterConfig(
                 detect_ssn=True,
@@ -803,18 +807,15 @@ class TestRustPIIDetectorSpecific:
         detections = detector.detect(text)
         masked = detector.mask(text, detections)
 
-        assert detections["ssn"][0]["mask_strategy"] == "partial"
-        assert detections["credit_card"][0]["mask_strategy"] == "partial"
-        assert detections["email"][0]["mask_strategy"] == "partial"
-        assert detections["phone"][0]["mask_strategy"] == "partial"
-        assert detections["ip_address"][0]["mask_strategy"] == "redact"
+        for pii_type in ["ssn", "credit_card", "email", "phone", "ip_address"]:
+            assert detections[pii_type][0]["mask_strategy"] == "hash"
 
-        assert "***-**-6789" in masked
-        assert "j***n@example.com" in masked
-        assert "***-***-4567" in masked
-        assert "****-****-****-1111" in masked
-        assert masked.count("[REDACTED]") == 1
-        assert "[HASH:" not in masked
+        assert masked.count("[HASH:") == 5
+        assert "123-45-6789" not in masked
+        assert "john@example.com" not in masked
+        assert "555-123-4567" not in masked
+        assert "4111-1111-1111-1111" not in masked
+        assert "192.168.1.1" not in masked
 
     def test_very_long_text_performance(self, detector):
         """Test performance with very long text."""


### PR DESCRIPTION
## Summary
This follow-up fixes the Rust-backed PII detector so built-in patterns honor `default_mask_strategy`, matching the Python implementation and the documented plugin configuration.

## What Changed
- Changed built-in Rust pattern definitions to inherit `config.default_mask_strategy`
- Kept explicit mask-strategy overrides for custom patterns
- Updated Rust unit tests to verify the new fallback behavior
- Added Python-side regression coverage for Rust parity, including nested-processing cases that now set `PARTIAL` explicitly when that behavior is under test

## Root Cause
The Rust implementation stored explicit per-pattern mask strategies for built-in PII types. Detection therefore never fell back to `default_mask_strategy`, so the global configuration was ignored whenever the Rust detector was active.

## Validation
- `uv run pytest -q tests/unit/mcpgateway/plugins/plugins/pii_filter/test_pii_filter.py`
- `cargo test` in `plugins_rust/pii_filter`

Closes #4120
Related to #3820