### PR TITLE
fix: restore runtime metric writeback and cover mcp_runtime in CI

### DIFF
--- a/.github/workflows/rust-tools.yml
+++ b/.github/workflows/rust-tools.yml
@@ -73,8 +73,28 @@ jobs:
         working-directory: tools_rust/wrapper
         run: make test
 
+      - name: Check formatting (mcp_runtime)
+        working-directory: tools_rust/mcp_runtime
+        run: cargo fmt --check
+
+      - name: Run cargo check (mcp_runtime)
+        working-directory: tools_rust/mcp_runtime
+        run: make check
+
+      - name: Run clippy (mcp_runtime)
+        working-directory: tools_rust/mcp_runtime
+        run: make clippy
+
+      - name: Run tests (mcp_runtime)
+        working-directory: tools_rust/mcp_runtime
+        run: make test
+
       - name: Build release
         working-directory: tools_rust/wrapper
+        run: make build-release
+
+      - name: Build release (mcp_runtime)
+        working-directory: tools_rust/mcp_runtime
         run: make build-release
 
   security-audit:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-11T00:25:04Z",
+  "generated_at": "2026-04-11T08:02:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -10944,7 +10944,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10450,
+        "line_number": 10447,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -8388,6 +8388,125 @@ rust-ensure-deps:                       ## Ensure Rust toolchain is installed
 		exit 1; \
 	fi
 	@rustup component add rustfmt clippy 2>/dev/null || true
+	@if ! command -v maturin > /dev/null 2>&1; then \
+		if [ -f "$(VENV_DIR)/bin/activate" ]; then \
+			echo "📦 Installing maturin into venv..."; \
+			/bin/bash -c "source $(VENV_DIR)/bin/activate && $(UV_BIN) pip install maturin"; \
+		elif command -v pip > /dev/null 2>&1; then \
+			echo "📦 Installing maturin globally (venv not found)..."; \
+			pip install maturin; \
+		else \
+			echo "⚠️  maturin not found and cannot be installed (no venv or pip available)"; \
+			echo "   For building wheels, install maturin: pip install maturin"; \
+		fi; \
+	fi
+
+rust-install: rust-ensure-deps          ## Install all Rust plugins into venv
+	@$(MAKE) -C plugins_rust install
+
+rust-build: rust-ensure-deps            ## Build Rust plugins (release)
+	@$(MAKE) -C plugins_rust build
+
+rust-dev: rust-ensure-deps              ## Build and install Rust plugins (development mode)
+	@$(MAKE) -C plugins_rust install
+
+rust-test: rust-ensure-deps             ## Run Rust plugin and MCP runtime tests
+	@$(MAKE) -C plugins_rust test
+	@$(MAKE) -C tools_rust/mcp_runtime test
+
+rust-python-test: rust-install          ## Run Python tests for Rust plugins (installs plugins first)
+	@$(MAKE) -C plugins_rust test-python
+
+rust-test-all: rust-test rust-python-test  ## Run all Rust and Python tests
+
+rust-bench: rust-ensure-deps            ## Run Rust benchmarks
+	@$(MAKE) -C plugins_rust bench
+
+rust-bench-build: rust-ensure-deps      ## Compile Rust plugin benchmarks without running them
+	@$(MAKE) -C plugins_rust bench-build
+
+rust-bench-compare: rust-ensure-deps    ## Compare Rust vs Python performance
+	@$(MAKE) -C plugins_rust bench-compare
+
+rust-compare: rust-ensure-deps          ## Run compare_performance.py only (skip Rust benchmarks)
+	@$(MAKE) -C plugins_rust compare
+
+rust-check: rust-ensure-deps            ## Run all Rust checks (plugins and MCP runtime)
+	@$(MAKE) -C plugins_rust check
+	@$(MAKE) -C tools_rust/mcp_runtime lint
+
+rust-doc: rust-ensure-deps              ## Build Rust documentation
+	@$(MAKE) -C plugins_rust doc
+
+rust-build-wheels: rust-ensure-deps     ## Build Python wheels for all Rust plugins
+	@$(MAKE) -C plugins_rust build-wheels
+
+rust-audit: rust-ensure-deps            ## Run security audit on all Rust plugins
+	@$(MAKE) -C plugins_rust audit
+
+rust-deny: rust-ensure-deps             ## Run cargo-deny policy checks on all Rust plugins
+	@$(MAKE) -C plugins_rust deny
+
+rust-coverage: rust-ensure-deps         ## Run coverage for all Rust plugins
+	@$(MAKE) -C plugins_rust coverage
+
+rust-release: rust-ensure-deps          ## Build release wheels for all Rust plugins
+	@$(MAKE) -C plugins_rust release
+
+rust-release-publish: rust-ensure-deps  ## Publish release wheels to PyPI
+	@$(MAKE) -C plugins_rust release-publish
+
+rust-uninstall-plugins: rust-ensure-deps ## Uninstall all Rust plugins from Python environment
+	@$(MAKE) -C plugins_rust uninstall
+
+rust-clean: rust-ensure-deps            ## Clean Rust build artifacts and uninstall plugins
+	@$(MAKE) -C plugins_rust uninstall
+	@$(MAKE) -C plugins_rust clean
+
+rust-verify: rust-ensure-deps           ## Verify Rust plugin installation
+	@$(MAKE) -C plugins_rust verify
+
+rust-verify-stubs: rust-ensure-deps     ## Verify stub generation and pyproject.toml for all Rust plugins
+	@$(MAKE) -C plugins_rust verify-stubs
+
+rust-clean-stubs: rust-ensure-deps      ## Remove all generated stub files from Rust plugins
+	@$(MAKE) -C plugins_rust clean-stubs
+
+rust-install-deps: rust-ensure-deps     ## Install all Rust build dependencies
+	@echo "✅ Rust build dependencies installed"
+
+rust-install-targets: rust-ensure-deps  ## Install all Rust cross-compilation targets
+	@echo "🎯 Installing Rust cross-compilation targets..."
+	@rustup target add x86_64-unknown-linux-gnu
+	@rustup target add aarch64-unknown-linux-gnu
+	@rustup target add armv7-unknown-linux-gnueabihf
+	@rustup target add s390x-unknown-linux-gnu
+	@rustup target add powerpc64le-unknown-linux-gnu
+	@rustup target add x86_64-apple-darwin
+	@rustup target add aarch64-apple-darwin
+	@rustup target add x86_64-pc-windows-msvc
+
+rust-build-%: rust-ensure-deps               ## Build for specific target (use rust-build-<TARGET>)
+	@echo "🎯 Ensuring Rust target $* is installed..."
+	@rustup target add $*
+	@$(MAKE) -C plugins_rust build-target-$*
+
+rust-build-all-linux: rust-build-x86_64-unknown-linux-gnu rust-build-aarch64-unknown-linux-gnu rust-build-armv7-unknown-linux-gnueabihf rust-build-s390x-unknown-linux-gnu rust-build-powerpc64le-unknown-linux-gnu  ## Build for all Linux architectures
+	@echo "✅ Built for all Linux architectures"
+
+rust-build-all-platforms: rust-build-all-linux  ## Build for all platforms (Linux, macOS, Windows)
+	@echo "🦀 Building for macOS..."
+	@$(MAKE) -C plugins_rust build-target-x86_64-apple-darwin || echo "⚠️  macOS x86_64 build skipped"
+	@$(MAKE) -C plugins_rust build-target-aarch64-apple-darwin || echo "⚠️  macOS ARM64 build skipped"
+	@echo "🦀 Building for Windows..."
+	@$(MAKE) -C plugins_rust build-target-x86_64-pc-windows-msvc || echo "⚠️  Windows build skipped"
+	@echo "✅ Built for all platforms"
+
+rust-cross: rust-install-targets rust-build-all-linux  ## Install targets + build all Linux (convenience)
+	@echo "✅ Cross-compilation complete"
+
+rust-cross-install-build: rust-install-deps rust-install-targets rust-build-all-platforms  ## Install targets + build all platforms (one command)
+	@echo "✅ Full cross-compilation setup and build complete"
 
 rust-mcp-runtime-build:                    ## Build the experimental Rust MCP runtime
 	@echo "🦀 Building experimental Rust MCP runtime..."

--- a/tools_rust/mcp_runtime/src/lib.rs
+++ b/tools_rust/mcp_runtime/src/lib.rs
@@ -8440,7 +8440,7 @@ fn tools_call_error_type_from_payload(payload: &Value) -> &'static str {
     }
 }
 
-fn record_tools_call_metric(
+async fn record_tools_call_metric(
     state: &AppState,
     incoming_headers: &HeaderMap,
     plan: &ResolvedMcpToolCallPlan,
@@ -8460,15 +8460,9 @@ fn record_tools_call_metric(
         error_message,
     };
 
-    let state = state.clone();
-    let incoming_headers = incoming_headers.clone();
-    tokio::spawn(async move {
-        if let Err(err) =
-            send_tools_call_metric_to_backend(&state, &incoming_headers, &payload).await
-        {
-            warn!("{err}");
-        }
-    });
+    if let Err(err) = send_tools_call_metric_to_backend(state, incoming_headers, &payload).await {
+        warn!("{err}");
+    }
 }
 
 async fn execute_tools_call_direct(
@@ -8674,7 +8668,8 @@ async fn execute_tools_call_direct(
                         request_started.elapsed().as_secs_f64() * 1000.0,
                         false,
                         Some(err.clone()),
-                    );
+                    )
+                    .await;
                     set_span_attribute(&root_span, "success", false);
                     set_span_attribute(
                         &root_span,
@@ -8720,7 +8715,8 @@ async fn execute_tools_call_direct(
                     request_started.elapsed().as_secs_f64() * 1000.0,
                     success,
                     error_message.clone(),
-                );
+                )
+                .await;
 
                 if retry_attempt > 0 {
                     set_span_attribute(
@@ -8785,7 +8781,8 @@ async fn execute_tools_call_direct(
                         request_started.elapsed().as_secs_f64() * 1000.0,
                         success,
                         error_message.clone(),
-                    );
+                    )
+                    .await;
 
                     if retry_attempt > 0 {
                         set_span_attribute(


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
This fixes a Rust MCP runtime regression where direct `tools/call` requests could return before metric writeback completed, which made runtime metric accounting nondeterministic and caused the existing regression test to fail. It also closes the CI gap that let `main` stay green by adding `tools_rust/mcp_runtime` fmt/check/clippy/test/build steps to the Rust tools workflow and by including the runtime in the root Rust validation targets.

## 🔁 Reproduction Steps
Issue: direct runtime test failure not caught by CI.

Minimal repro:
1. Run `cargo test --manifest-path tools_rust/mcp_runtime/Cargo.toml`
2. Observe `tools_call_uses_rust_direct_execution_and_reuses_upstream_session` fail in `tools_rust/mcp_runtime/tests/runtime.rs`
3. Observe GitHub `Rust Tools CI/CD` remain green because it only exercised `tools_rust/wrapper`

## 🐞 Root Cause
`record_tools_call_metric()` in `tools_rust/mcp_runtime/src/lib.rs` was changed to fire-and-forget via `tokio::spawn`. That made metric delivery race with the request lifecycle, so the direct execution path could finish before the second metric was recorded. Separately, `.github/workflows/rust-tools.yml` did not run the `tools_rust/mcp_runtime` test suite at all.

## 💡 Fix Description
The runtime now awaits metric writeback again in the direct `tools/call` path, restoring deterministic behavior for the existing regression test and for request-scoped metric recording. CI was expanded to run `mcp_runtime` fmt/check/clippy/test/build steps directly, and the root `rust-test` and `rust-check` targets now include `tools_rust/mcp_runtime` so local validation matches the GitHub path more closely.

## 🧪 Verification

| Check                                 | Command                                                                                              | Status |
|---------------------------------------|------------------------------------------------------------------------------------------------------|--------|
| Runtime regression                    | `cargo test --manifest-path tools_rust/mcp_runtime/Cargo.toml --test runtime tools_call_uses_rust_direct_execution_and_reuses_upstream_session -- --exact` | Passed |
| Runtime format check                  | `make -C tools_rust/mcp_runtime fmt-check`                                                           | Passed |
| Runtime unit/integration tests        | `make -C tools_rust/mcp_runtime test`                                                                | Passed |
| Runtime clippy                        | `make -C tools_rust/mcp_runtime clippy`                                                              | Passed |
| Full repo lint suite                  | `make lint`                                                                                          | Not run |
| Full repo test suite                  | `make test`                                                                                          | Not run |
| Coverage ≥ 80 %                       | `make coverage`                                                                                      | Not run |
| Manual regression no longer fails     | Rust runtime regression test above                                                                   | Passed |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

