### PR TITLE
feat(openshift): add OpenShift deployment commands for TLS cert fetching and image building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8589,3 +8589,91 @@ linting-workflow-commitlint:         ## 📝  Conventional Commits linting (togg
 .PHONY: conc-01-gateways
 conc-01-gateways:                    ## Run CONC-01 gateways manual matrix (manual env/token setup required)
 	@/bin/bash tests/manual/concurrency/run_conc_01_gateways.sh
+
+# =============================================================================
+# 🔴 OPENSHIFT DEPLOYMENT
+# =============================================================================
+# help: 🔴 OPENSHIFT DEPLOYMENT
+# help: oc-tls                      - Fetch OpenShift registry TLS cert via oc extract and trust it inside Colima VM
+# help: oc-image                    - Build mcpgateway image locally (no-cache, Rust) and push to OpenShift internal registry
+
+REGISTRY_URL    ?=
+OC_TAG          ?= rust
+OC_NAMESPACE    ?= contextforge
+OC_TOKEN        ?=
+
+.PHONY: oc-tls
+oc-tls: ## 🔐 Fetch OpenShift registry TLS cert (oc extract) and trust it inside the Colima VM
+	@/bin/bash -c "set -euo pipefail; \
+		if ! command -v oc >/dev/null 2>&1; then echo '❌ oc CLI not found. Install from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/'; exit 1; fi; \
+		if ! command -v colima >/dev/null 2>&1; then echo '❌ colima not found. Install with: brew install colima'; exit 1; fi; \
+		echo '📥 Fetching OpenShift router TLS certificate via oc extract...'; \
+		oc extract secret/router-certs-default -n openshift-ingress --to=/tmp/oc-router-certs/ --confirm; \
+		cp /tmp/oc-router-certs/tls.crt ~/openshift-registry.crt; \
+		COUNT=\$$(grep -c 'BEGIN CERTIFICATE' ~/openshift-registry.crt 2>/dev/null || echo 0); \
+		if [ \"\$$COUNT\" -lt 1 ]; then \
+			echo '❌ Certificate capture failed — no BEGIN CERTIFICATE blocks found in ~/openshift-registry.crt'; \
+			exit 1; \
+		fi; \
+		echo \"✅ Certificate captured successfully (\$$COUNT cert block(s) in ~/openshift-registry.crt)\"; \
+		if [ -z \"$(REGISTRY_URL)\" ]; then \
+			echo ''; \
+			echo '❌ REGISTRY_URL is not set. Please set it and re-run:'; \
+			echo ''; \
+			echo '     export REGISTRY_URL=\$$(oc get route default-route -n openshift-image-registry -o jsonpath=\"{.spec.host}\")'; \
+			echo '     make oc-tls'; \
+			exit 1; \
+		fi; \
+		echo ''; \
+		echo '🐳 Trusting certificate inside the Colima VM (REGISTRY_URL=$(REGISTRY_URL))...'; \
+		colima ssh -- sudo mkdir -p /etc/docker/certs.d/$(REGISTRY_URL); \
+		cat ~/openshift-registry.crt | colima ssh -- sudo tee /etc/docker/certs.d/$(REGISTRY_URL)/ca.crt >/dev/null; \
+		cat ~/openshift-registry.crt | colima ssh -- sudo tee /usr/local/share/ca-certificates/openshift-registry.crt >/dev/null; \
+		colima ssh -- sudo update-ca-certificates; \
+		colima ssh -- sudo systemctl restart docker; \
+		echo ''; \
+		echo '✅ TLS certificate trusted inside Colima VM. Docker daemon restarted.'; \
+		echo '   You can now push to $(REGISTRY_URL) without x509 errors.'"
+
+.PHONY: oc-image
+oc-image: ## 🚀 Build mcpgateway image (no-cache, Rust) and push to OpenShift internal registry (requires REGISTRY_URL, OC_TOKEN)
+	@/bin/bash -c "set -euo pipefail; \
+		MISSING=0; \
+		if [ -z \"$(REGISTRY_URL)\" ]; then \
+			echo ''; \
+			echo '❌ REGISTRY_URL is not set. Please enter REGISTRY_URL and re-run this command:'; \
+			echo ''; \
+			echo '     export REGISTRY_URL=\$\$$(oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")'; \
+			echo '     make oc-image'; \
+			MISSING=1; \
+		fi; \
+		if [ -z \"$(OC_TOKEN)\" ]; then \
+			echo ''; \
+			echo '❌ OC_TOKEN is not set. Please enter OC_TOKEN and re-run this command:'; \
+			echo ''; \
+			echo '     export OC_TOKEN=\$\$$(oc whoami -t)'; \
+			echo '     make oc-image'; \
+			MISSING=1; \
+		fi; \
+		if [ \"\$$MISSING\" -eq 1 ]; then \
+			exit 1; \
+		fi; \
+		echo '🔨 Building mcpgateway image with Rust MCP runtime (no-cache)...'; \
+		$(MAKE) docker-prod; \
+		echo ''; \
+		echo '🏷️  Tagging image as $(REGISTRY_URL)/$(OC_NAMESPACE)/mcpgateway:$(OC_TAG)...'; \
+		docker tag $(IMAGE_BASE):$(IMAGE_TAG) $(REGISTRY_URL)/$(OC_NAMESPACE)/mcpgateway:$(OC_TAG); \
+		echo ''; \
+		echo '🔐 Logging in to OpenShift registry...'; \
+		docker login -u \$$$(oc whoami) -p $(OC_TOKEN) $(REGISTRY_URL); \
+		echo ''; \
+		echo '📦 Pre-creating ImageStream (required before first push)...'; \
+		oc create imagestream mcpgateway -n $(OC_NAMESPACE) 2>/dev/null || true; \
+		echo ''; \
+		echo '⬆️  Pushing $(REGISTRY_URL)/$(OC_NAMESPACE)/mcpgateway:$(OC_TAG)...'; \
+		docker push $(REGISTRY_URL)/$(OC_NAMESPACE)/mcpgateway:$(OC_TAG); \
+		echo ''; \
+		echo '✅ Push complete. Verify with:'; \
+		echo '   oc get imagestream mcpgateway -n $(OC_NAMESPACE)'"
+
+

--- a/Makefile
+++ b/Makefile
@@ -8594,7 +8594,7 @@ conc-01-gateways:                    ## Run CONC-01 gateways manual matrix (manu
 # 🔴 OPENSHIFT DEPLOYMENT
 # =============================================================================
 # help: 🔴 OPENSHIFT DEPLOYMENT
-# help: oc-tls                      - Fetch OpenShift registry TLS cert via oc extract and trust it inside Colima VM
+# help: oc-tls                      - Fetch OpenShift registry TLS cert via oc extract and trust it (Colima/Docker Desktop/Linux Docker)
 # help: oc-image                    - Build mcpgateway image locally (no-cache, Rust) and push to OpenShift internal registry
 
 REGISTRY_URL    ?=
@@ -8603,10 +8603,9 @@ OC_NAMESPACE    ?= contextforge
 OC_TOKEN        ?=
 
 .PHONY: oc-tls
-oc-tls: ## 🔐 Fetch OpenShift registry TLS cert (oc extract) and trust it inside the Colima VM
+oc-tls: ## 🔐 Fetch OpenShift registry TLS cert (oc extract) and trust it (auto-detects Colima / Docker Desktop / Linux Docker)
 	@/bin/bash -c "set -euo pipefail; \
 		if ! command -v oc >/dev/null 2>&1; then echo '❌ oc CLI not found. Install from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/'; exit 1; fi; \
-		if ! command -v colima >/dev/null 2>&1; then echo '❌ colima not found. Install with: brew install colima'; exit 1; fi; \
 		echo '📥 Fetching OpenShift router TLS certificate via oc extract...'; \
 		oc extract secret/router-certs-default -n openshift-ingress --to=/tmp/oc-router-certs/ --confirm; \
 		cp /tmp/oc-router-certs/tls.crt ~/openshift-registry.crt; \
@@ -8624,19 +8623,38 @@ oc-tls: ## 🔐 Fetch OpenShift registry TLS cert (oc extract) and trust it insi
 			echo '     make oc-tls'; \
 			exit 1; \
 		fi; \
+		OS=\$$(uname -s); \
 		echo ''; \
-		echo '🐳 Trusting certificate inside the Colima VM (REGISTRY_URL=$(REGISTRY_URL))...'; \
-		colima ssh -- sudo mkdir -p /etc/docker/certs.d/$(REGISTRY_URL); \
-		cat ~/openshift-registry.crt | colima ssh -- sudo tee /etc/docker/certs.d/$(REGISTRY_URL)/ca.crt >/dev/null; \
-		cat ~/openshift-registry.crt | colima ssh -- sudo tee /usr/local/share/ca-certificates/openshift-registry.crt >/dev/null; \
-		colima ssh -- sudo update-ca-certificates; \
-		colima ssh -- sudo systemctl restart docker; \
-		echo ''; \
-		echo '✅ TLS certificate trusted inside Colima VM. Docker daemon restarted.'; \
+		if [ \"\$$OS\" = \"Darwin\" ] && command -v colima >/dev/null 2>&1 && colima status 2>&1 | grep -q 'running'; then \
+			echo '🐳 Detected: Colima (macOS) — trusting certificate inside the Colima VM (REGISTRY_URL=$(REGISTRY_URL))...'; \
+			colima ssh -- sudo mkdir -p /etc/docker/certs.d/$(REGISTRY_URL); \
+			cat ~/openshift-registry.crt | colima ssh -- sudo tee /etc/docker/certs.d/$(REGISTRY_URL)/ca.crt >/dev/null; \
+			cat ~/openshift-registry.crt | colima ssh -- sudo tee /usr/local/share/ca-certificates/openshift-registry.crt >/dev/null; \
+			colima ssh -- sudo update-ca-certificates; \
+			colima ssh -- sudo systemctl restart docker; \
+			echo ''; \
+			echo '✅ TLS certificate trusted inside Colima VM. Docker daemon restarted.'; \
+		elif [ \"\$$OS\" = \"Darwin\" ]; then \
+			echo '🐳 Detected: Docker Desktop (macOS) — installing certificate into ~/.docker/certs.d/$(REGISTRY_URL)/...'; \
+			mkdir -p ~/.docker/certs.d/$(REGISTRY_URL); \
+			cp ~/openshift-registry.crt ~/.docker/certs.d/$(REGISTRY_URL)/ca.crt; \
+			echo ''; \
+			echo '✅ TLS certificate installed for Docker Desktop.'; \
+			echo '⚠️  You may need to restart Docker Desktop manually for the certificate to take effect.'; \
+		else \
+			echo '🐳 Detected: Linux — installing certificate into /etc/docker/certs.d/$(REGISTRY_URL)/...'; \
+			sudo mkdir -p /etc/docker/certs.d/$(REGISTRY_URL); \
+			sudo cp ~/openshift-registry.crt /etc/docker/certs.d/$(REGISTRY_URL)/ca.crt; \
+			sudo cp ~/openshift-registry.crt /usr/local/share/ca-certificates/openshift-registry.crt; \
+			sudo update-ca-certificates; \
+			sudo systemctl restart docker; \
+			echo ''; \
+			echo '✅ TLS certificate trusted on Linux host. Docker daemon restarted.'; \
+		fi; \
 		echo '   You can now push to $(REGISTRY_URL) without x509 errors.'"
 
 .PHONY: oc-image
-oc-image: ## 🚀 Build mcpgateway image (no-cache, Rust) and push to OpenShift internal registry (requires REGISTRY_URL, OC_TOKEN)
+oc-image: ## 🚀 Build mcpgateway image (python core) and push to OpenShift internal registry (requires REGISTRY_URL, OC_TOKEN)
 	@/bin/bash -c "set -euo pipefail; \
 		MISSING=0; \
 		if [ -z \"$(REGISTRY_URL)\" ]; then \


### PR DESCRIPTION
## Summary

Adds two `make` targets (`oc-tls` and `oc-image`) that streamline deploying ContextForge to an OpenShift cluster from a macOS developer workstation running Colima as the local Docker runtime.

## Motivation

Pushing a locally-built container image to an OpenShift internal registry from macOS requires two friction-heavy manual steps:

1. Trusting the cluster's self-signed TLS certificate inside the Colima VM so Docker doesn't reject pushes with `x509: certificate signed by unknown authority`.
2. Building the production image, tagging it for the target registry, authenticating, pre-creating the ImageStream, and pushing — all in the correct order with correct environment variables.

Both steps had no automation and were undocumented, forcing developers to rediscover the process each time. These targets encode the steps as first-class, repeatable `make` commands.

## Changes

**`Makefile`** — 88 lines added, 0 deleted.

Added a new `OPENSHIFT DEPLOYMENT` section with:

### Variables

| Variable | Default | Purpose |
|---|---|---|
| `REGISTRY_URL` | _(required)_ | OpenShift internal registry host (e.g. `default-route-openshift-image-registry.apps.cluster.example.com`) |
| `OC_TAG` | `rust` | Image tag applied when pushing |
| `OC_NAMESPACE` | `contextforge` | Target OpenShift namespace / project |
| `OC_TOKEN` | _(required)_ | Token from `oc whoami -t` used for `docker login` |

### `oc-tls`

Fetches the cluster router TLS certificate via `oc extract secret/router-certs-default` and installs it inside the Colima VM so Docker trusts the OpenShift registry:

1. Validates `oc` and `colima` are available.
2. Extracts the cert to `~/openshift-registry.crt` and verifies it contains at least one `BEGIN CERTIFICATE` block.
3. Validates `REGISTRY_URL` is set (prints actionable export command if not).
4. Copies the cert into `/etc/docker/certs.d/<REGISTRY_URL>/` and `/usr/local/share/ca-certificates/` inside Colima.
5. Runs `update-ca-certificates` and restarts the Docker daemon.

### `oc-image`

Builds the production image and pushes it to the OpenShift internal registry:

1. Validates both `REGISTRY_URL` and `OC_TOKEN` are set (prints actionable export commands for each missing variable).
2. Calls `make docker-prod` (existing full Rust-enabled production build, no cache).
3. Tags the resulting image as `<REGISTRY_URL>/<OC_NAMESPACE>/mcpgateway:<OC_TAG>`.
4. Logs in to the registry with `docker login` using the `oc` token.
5. Pre-creates the ImageStream (`oc create imagestream`) idempotently (`|| true`).
6. Pushes the image and prints a verification command.

## Usage

```bash
# 1. Log in to your cluster
oc login --token=<token> --server=https://<api-server>

# 2. Set required variables
export REGISTRY_URL=$(oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")
export OC_TOKEN=$(oc whoami -t)

# 3. Trust the registry TLS cert inside Colima (once per cluster / cert rotation)
make oc-tls

# 4. Build and push
make oc-image

# Optional overrides
make oc-image OC_NAMESPACE=my-project OC_TAG=dev
```

## Testing

Validated end-to-end on an OpenShift 4.x cluster:

- `oc-tls` successfully extracts the cert, installs it in the Colima VM, and eliminates x509 errors on subsequent pushes.
- `oc-image` builds a fresh image via `docker-prod`, tags, authenticates, pre-creates the ImageStream, and pushes without error.
- Missing-variable guards (`REGISTRY_URL`, `OC_TOKEN`) print unambiguous export hints and exit non-zero when variables are absent.

## Notes

- No application code, schemas, or tests were modified. This is a pure developer-tooling addition.
- Requires `oc` CLI and `colima` to be installed on the developer machine.
- The `OC_TOKEN` variable should **never** be committed to source control; it is intended to be set in the shell environment only.

Relates to https://github.com/IBM/mcp-context-forge/issues/4952
