### PR TITLE
test: speed up slow docker-entrypoint and sensitive-logging tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -94,7 +94,7 @@ jobs:
       - name: 🧪  Run pytest
         run: |
           uv run --extra plugins pytest -n auto \
-            --durations=5 \
+            --durations=10 \
             --ignore=tests/fuzz \
             --ignore=tests/e2e/test_entra_id_integration.py \
             --cov=mcpgateway \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -433,6 +433,10 @@ install_plugin_requirements() {
 
     local max_retries=3
     local retry_delay="${PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS:-2}"
+    if [[ ! "${retry_delay}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        echo "⚠️  PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS=${retry_delay} is not a non-negative number; falling back to 2s"
+        retry_delay=2
+    fi
     local attempt=1
     while (( attempt <= max_retries )); do
         if "${app_root}/.venv/bin/pip" install --no-cache-dir -r "${resolved_path}"; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -432,6 +432,7 @@ install_plugin_requirements() {
     echo "🧩 Installing ${requirement_count} plugin package requirement(s) from ${resolved_path}"
 
     local max_retries=3
+    local retry_delay="${PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS:-2}"
     local attempt=1
     while (( attempt <= max_retries )); do
         if "${app_root}/.venv/bin/pip" install --no-cache-dir -r "${resolved_path}"; then
@@ -439,7 +440,7 @@ install_plugin_requirements() {
         fi
         echo "⚠️  Plugin package install attempt ${attempt}/${max_retries} failed"
         (( attempt++ ))
-        (( attempt <= max_retries )) && sleep 2
+        (( attempt <= max_retries )) && sleep "${retry_delay}"
     done
     echo "❌ Plugin package install failed after ${max_retries} attempts; refusing to start with incomplete plugin dependencies"
     return 1

--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -2189,10 +2189,15 @@ class TestSensitiveLoggingRegressions:
         """Scan runtime logger calls to ensure sensitive values are not interpolated."""
         source_root = Path(__file__).resolve().parents[2] / "mcpgateway"
         violations = []
+        sensitive_needles = tuple(self.SENSITIVE_IDENTIFIERS) + ("credentials",)
 
         for file_path in source_root.rglob("*.py"):
             source = file_path.read_text(encoding="utf-8")
             if "logger." not in source:
+                continue
+            # Cheap text pre-filter: only parse files that could plausibly
+            # log a sensitive identifier. Avoids ~100 AST parses per run.
+            if not any(needle in source for needle in sensitive_needles):
                 continue
             tree = ast.parse(source, filename=str(file_path))
             for node in ast.walk(tree):

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -30,6 +30,7 @@ export APP_ROOT="{app_root}"
 source "{ENTRYPOINT}"
 export RELOAD_PLUGIN_REQUIREMENTS_TXT=true
 export PLUGIN_REQUIREMENTS_TXT_PATH="{requirements_path or app_root / 'plugins' / 'requirements.txt'}"
+export PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS=0
 install_plugin_requirements
 """
     return subprocess.run(

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -84,6 +84,39 @@ exit 1
     assert "failed after 3 attempts" in result.stdout
 
 
+def test_install_plugin_requirements_rejects_invalid_retry_delay(tmp_path: Path) -> None:
+    app_root = _make_app_root(tmp_path)
+    requirements = app_root / "plugins" / "requirements.txt"
+    requirements.write_text("cpex-rate-limiter==0.0.3\n", encoding="utf-8")
+    _write_executable(
+        app_root / ".venv" / "bin" / "pip",
+        """#!/usr/bin/env bash
+exit 0
+""",
+    )
+    command = f"""
+set -euo pipefail
+export CONTEXTFORGE_TEST_ONLY_SOURCE=true
+export APP_ROOT="{app_root}"
+source "{ENTRYPOINT}"
+export RELOAD_PLUGIN_REQUIREMENTS_TXT=true
+export PLUGIN_REQUIREMENTS_TXT_PATH="{requirements}"
+export PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS="not-a-number"
+install_plugin_requirements
+"""
+
+    result = subprocess.run(
+        ["bash", "-lc", command],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "is not a non-negative number; falling back to 2s" in result.stdout
+
+
 def test_install_plugin_requirements_succeeds_after_retry(tmp_path: Path) -> None:
     app_root = _make_app_root(tmp_path)
     requirements = app_root / "plugins" / "requirements.txt"


### PR DESCRIPTION
## Summary

Two CI test-runtime wins from analyzing the pytest `--durations` output:

- **`test_install_plugin_requirements_retries_three_times_then_fails`**: ~4.2s → ~0.04s. The test forces three pip failures, and `docker-entrypoint.sh` slept 2s between retries. Made the delay configurable via `PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS` (default `2`, preserving production behavior), and the test sets it to `0`.
- **`test_runtime_logger_calls_do_not_embed_sensitive_values`**: ~3.7s → ~0.6s. The scan was `ast.parse()`-ing every `mcpgateway/**/*.py` file containing `logger.` (~150 files). Added a cheap substring pre-filter so only files that mention a sensitive identifier (`token`, `password`, `credentials`, etc.) are parsed.

Also audited the rest of `tests/` for similar patterns. Remaining `asyncio.sleep(N)` calls in unit tests are inside mock coroutines that get cancelled by the test harness (idiomatic cancellation/timeout pattern), and the other `rglob("*.py")` scan in `test_policies.py` is narrowly scoped to the framework directory.

## Test plan

- [x] `uv run pytest tests/unit/test_docker_entrypoint.py` — 5 passed, retry test at 0.04s
- [x] `uv run pytest tests/security/test_input_validation.py::TestSensitiveLoggingRegressions` — 5 passed, scan test at 0.56s
- [x] Production default preserved: `sleep 2` still applies when `PLUGIN_REQUIREMENTS_RETRY_DELAY_SECONDS` is unset