### PR TITLE
fix(transport): skip outputSchema validation for isError tool responses

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1683,6 +1683,14 @@ async def call_tool(name: str, arguments: dict) -> Union[
             if structured:
                 return (unstructured, structured)
 
+            # When the upstream tool returned an error (isError: true), return a
+            # CallToolResult directly so the MCP SDK skips outputSchema validation.
+            # Without this, the SDK replaces the original error message with
+            # "outputSchema defined but no structured output returned".
+            is_error = getattr(result, "is_error", None)
+            if is_error is True:
+                return types.CallToolResult(content=unstructured, isError=True)
+
             return unstructured
     except Exception as e:
         logger.exception("Error calling tool '%s': %s", name, e)

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -13550,3 +13550,142 @@ async def test_handle_streamable_http_initialize_span_exits_with_exception(monke
     assert exc_type is ValueError
     assert isinstance(exc_val, ValueError)
     assert str(exc_val) == "initialize failed"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# isError + outputSchema validation bypass
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_call_tool_is_error_returns_call_tool_result(monkeypatch):
+    """When tool result has is_error=True, call_tool should return CallToolResult(isError=True)
+    directly so the MCP SDK skips outputSchema validation."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = "Upstream tool error: resource not found"
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.is_error = True  # Explicitly set to bool True
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("mytool", {"foo": "bar"})
+
+    # Should return CallToolResult directly (not a list), so SDK skips validation
+    assert isinstance(result, types.CallToolResult)
+    assert result.isError is True
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], types.TextContent)
+    assert result.content[0].text == "Upstream tool error: resource not found"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_is_error_false_returns_list(monkeypatch):
+    """When tool result has is_error=False, call_tool should return a list (normal path)."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = "success result"
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.is_error = False
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("mytool", {"foo": "bar"})
+
+    # Should return list (normal unstructured path)
+    assert isinstance(result, list)
+    assert isinstance(result[0], types.TextContent)
+    assert result[0].text == "success result"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_is_error_preserves_content(monkeypatch):
+    """Error message content should be preserved exactly, not replaced by validation errors."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = "Access denied: insufficient permissions for this resource"
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.is_error = True
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("mytool", {})
+
+    assert isinstance(result, types.CallToolResult)
+    assert result.isError is True
+    # Original error message must be preserved, not replaced by SDK validation error
+    assert result.content[0].text == "Access denied: insufficient permissions for this resource"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_is_error_with_structured_returns_tuple(monkeypatch):
+    """When is_error=True but structured_content exists, structured path takes precedence."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = '{"error": "something"}'
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.is_error = True
+    mock_result.structured_content = {"error": "something"}
+    mock_result.model_dump = lambda by_alias=True: {"structuredContent": {"error": "something"}}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("mytool", {})
+
+    # Structured content path takes precedence (returned as tuple)
+    assert isinstance(result, tuple)
+    assert len(result) == 2


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4135 

---

## 📝 Summary

When an upstream MCP tool with outputSchema defined returns an error (isError: true) without structuredContent, the MCP Python SDK's server-side validation replaces the original error message with a generic "outputSchema defined but no structured output returned". 

This hides the actual error cause from the user.

This PR bypasses the SDK validation by returning a CallToolResult(isError=True) directly when is_error is True, which triggers the SDK's early-return path and skips outputSchema validation. This uses the same pattern already established in the codebase (lines 1451, 1468).

The root cause is in the MCP Python SDK v1.x (mcp/server/lowlevel/server.py), where outputSchema validation runs unconditionally regardless of isError.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |   pass     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Implementation detail

The fix is placed after the structuredContent check in streamablehttp_transport.py:call_tool():

1. if structured → return (unstructured, structured)   # SDK validates against outputSchema
2. if is_error is True → return CallToolResult(isError=True)  # SDK early-return, no validation
3. return unstructured                                  # normal path

This ordering is intentional: if an error response does include structuredContent, the existing validation path is preserved. We have not observed any MCP server returning both isError: true and structuredContent simultaneously, and the MCP spec does not define this combination. If it does occur, validating the structured content is arguably the correct behavior — the server explicitly provided it, so schema conformance should be checked.

is_error is True (strict identity check)

We use getattr(result, "is_error", None) with is True rather than a truthy check. This prevents false positives when result is a MagicMock in unit tests (where unset attributes return truthy MagicMock objects).

Manual E2E verification

To validate this fix end-to-end, we added a lookup_calculation tool to the existing output_schema_test_server that raises ToolError for unknown IDs (producing isError: true with outputSchema defined). Using the docker-compose stack:

- Before fix: "Output validation error: outputSchema defined but no structured output returned" ❌
- After fix: "Calculation 'nonexistent-id' not found. Only 'calc-001' is available." ✅

The test server change is not included in this PR — unit tests provide sufficient coverage for the transport-layer logic. The E2E setup can be formalized in a follow-up if needed.
