### PR TITLE
fix: Return proper JSON-RPC format for plugin exceptions in Rust internal endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-09T21:04:29Z",
+  "generated_at": "2026-05-09T21:23:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,9 +76,7 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(
-    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
-)
+_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -9595,11 +9595,12 @@ async def handle_internal_mcp_tools_call(request: Request):
         request: Trusted internal MCP tools/call request.
 
     Returns:
-        JSON-RPC response payload for the tools/call request.
+        dict: JSON-RPC response containing result on success,
+              or JSON-RPC error on plugin failures.
+              All plugin errors returned as structured JSON-RPC (never re-raised)
+              since this is an internal Rust↔Python interface.
 
     Raises:
-        PluginError: Re-raised so plugin middleware can preserve existing behavior.
-        PluginViolationError: Re-raised so plugin middleware can preserve existing behavior.
         Exception: Propagated after best-effort rollback when unexpected failures occur.
     """
     req_id = None
@@ -9825,9 +9826,11 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
             if hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
                 error_code = exc.violation.mcp_error_code
             if hasattr(exc.violation, "http_status_code") and isinstance(exc.violation.http_status_code, int):
-                http_status = exc.violation.http_status_code
+                candidate_status = exc.violation.http_status_code
+                if VALID_HTTP_STATUS_CODES.get(candidate_status):
+                    http_status = candidate_status
 
-        return ORJSONResponse(
+        response = ORJSONResponse(
             status_code=http_status,
             content={
                 "jsonrpc": "2.0",
@@ -9835,6 +9838,13 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
                 "id": request_id,
             },
         )
+        # Forward validated HTTP headers from violation if present
+        headers = exc.violation.http_headers if exc.violation and exc.violation.http_headers else None
+        if headers:
+            validated_headers = _validate_http_headers(headers)
+            if validated_headers:
+                response.headers.update(validated_headers)
+        return response
     except PluginError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
         error_code = -32603  # Internal error (JSON-RPC standard)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -9677,11 +9677,15 @@ async def handle_internal_mcp_tools_call(request: Request):
         return {"jsonrpc": "2.0", "result": result, "id": req_id}
     except PluginViolationError as exc:
         # Use violation's codes if present, otherwise JSON-RPC defaults
-        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
+        error_code = -32602  # Invalid params (JSON-RPC standard)
+        if exc.violation and hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
+            error_code = exc.violation.mcp_error_code
 
         return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
     except PluginError as exc:
-        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+        error_code = -32603  # Internal error (JSON-RPC standard)
+        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
+            error_code = exc.error.mcp_error_code
 
         return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
     except JSONRPCError as e:
@@ -9815,8 +9819,13 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
     except PluginViolationError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
         # Use violation's codes if present, otherwise JSON-RPC defaults
-        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
-        http_status = exc.violation.http_status_code if exc.violation and exc.violation.http_status_code else 422
+        error_code = -32602  # Invalid params (JSON-RPC standard)
+        http_status = 422
+        if exc.violation:
+            if hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
+                error_code = exc.violation.mcp_error_code
+            if hasattr(exc.violation, "http_status_code") and isinstance(exc.violation.http_status_code, int):
+                http_status = exc.violation.http_status_code
 
         return ORJSONResponse(
             status_code=http_status,
@@ -9828,7 +9837,9 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         )
     except PluginError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
-        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+        error_code = -32603  # Internal error (JSON-RPC standard)
+        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
+            error_code = exc.error.mcp_error_code
 
         return ORJSONResponse(
             status_code=500,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -9675,8 +9675,15 @@ async def handle_internal_mcp_tools_call(request: Request):
             db.close()
 
         return {"jsonrpc": "2.0", "result": result, "id": req_id}
-    except (PluginError, PluginViolationError):
-        raise
+    except PluginViolationError as exc:
+        # Use violation's codes if present, otherwise JSON-RPC defaults
+        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
+
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
+    except PluginError as exc:
+        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
     except JSONRPCError as e:
         error = e.to_dict()
         return {"jsonrpc": "2.0", "error": error["error"], "id": req_id}
@@ -9705,11 +9712,12 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         request: Trusted internal MCP tools/call resolve request.
 
     Returns:
-        JSON response containing either an execution plan or a JSON-RPC-visible error.
+        ORJSONResponse: JSON-RPC response containing execution plan on success,
+                        or JSON-RPC error on validation/permission/plugin failures.
+                        All errors returned as structured JSON-RPC (never re-raised)
+                        since this is an internal Rust↔Python interface.
 
     Raises:
-        PluginError: Re-raised so plugin middleware can preserve existing behavior.
-        PluginViolationError: Re-raised so plugin middleware can preserve existing behavior.
         Exception: Propagated after best-effort rollback when unexpected failures occur.
     """
     db = SessionLocal()
@@ -9804,8 +9812,32 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
                 "id": request_id,
             },
         )
-    except (PluginError, PluginViolationError):
-        raise
+    except PluginViolationError as exc:
+        request_id = body.get("id") if isinstance(body, dict) else None
+        # Use violation's codes if present, otherwise JSON-RPC defaults
+        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
+        http_status = exc.violation.http_status_code if exc.violation and exc.violation.http_status_code else 422
+
+        return ORJSONResponse(
+            status_code=http_status,
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": error_code, "message": str(exc)},
+                "id": request_id,
+            },
+        )
+    except PluginError as exc:
+        request_id = body.get("id") if isinstance(body, dict) else None
+        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+
+        return ORJSONResponse(
+            status_code=500,
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": error_code, "message": str(exc)},
+                "id": request_id,
+            },
+        )
     except JSONRPCError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
         return ORJSONResponse(

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -9196,11 +9196,15 @@ async def handle_internal_mcp_tools_call(request: Request):
         return {"jsonrpc": "2.0", "result": result, "id": req_id}
     except PluginViolationError as exc:
         # Use violation's codes if present, otherwise JSON-RPC defaults
-        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
+        error_code = -32602  # Invalid params (JSON-RPC standard)
+        if exc.violation and hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
+            error_code = exc.violation.mcp_error_code
 
         return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
     except PluginError as exc:
-        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+        error_code = -32603  # Internal error (JSON-RPC standard)
+        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
+            error_code = exc.error.mcp_error_code
 
         return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
     except JSONRPCError as e:
@@ -9334,8 +9338,13 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
     except PluginViolationError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
         # Use violation's codes if present, otherwise JSON-RPC defaults
-        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
-        http_status = exc.violation.http_status_code if exc.violation and exc.violation.http_status_code else 422
+        error_code = -32602  # Invalid params (JSON-RPC standard)
+        http_status = 422
+        if exc.violation:
+            if hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
+                error_code = exc.violation.mcp_error_code
+            if hasattr(exc.violation, "http_status_code") and isinstance(exc.violation.http_status_code, int):
+                http_status = exc.violation.http_status_code
 
         return ORJSONResponse(
             status_code=http_status,
@@ -9347,7 +9356,9 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         )
     except PluginError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
-        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+        error_code = -32603  # Internal error (JSON-RPC standard)
+        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
+            error_code = exc.error.mcp_error_code
 
         return ORJSONResponse(
             status_code=500,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -9194,8 +9194,15 @@ async def handle_internal_mcp_tools_call(request: Request):
             db.close()
 
         return {"jsonrpc": "2.0", "result": result, "id": req_id}
-    except (PluginError, PluginViolationError):
-        raise
+    except PluginViolationError as exc:
+        # Use violation's codes if present, otherwise JSON-RPC defaults
+        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
+
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
+    except PluginError as exc:
+        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
     except JSONRPCError as e:
         error = e.to_dict()
         return {"jsonrpc": "2.0", "error": error["error"], "id": req_id}
@@ -9224,11 +9231,12 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         request: Trusted internal MCP tools/call resolve request.
 
     Returns:
-        JSON response containing either an execution plan or a JSON-RPC-visible error.
+        ORJSONResponse: JSON-RPC response containing execution plan on success,
+                        or JSON-RPC error on validation/permission/plugin failures.
+                        All errors returned as structured JSON-RPC (never re-raised)
+                        since this is an internal Rust↔Python interface.
 
     Raises:
-        PluginError: Re-raised so plugin middleware can preserve existing behavior.
-        PluginViolationError: Re-raised so plugin middleware can preserve existing behavior.
         Exception: Propagated after best-effort rollback when unexpected failures occur.
     """
     db = SessionLocal()
@@ -9323,8 +9331,32 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
                 "id": request_id,
             },
         )
-    except (PluginError, PluginViolationError):
-        raise
+    except PluginViolationError as exc:
+        request_id = body.get("id") if isinstance(body, dict) else None
+        # Use violation's codes if present, otherwise JSON-RPC defaults
+        error_code = exc.violation.mcp_error_code if exc.violation and exc.violation.mcp_error_code else -32602
+        http_status = exc.violation.http_status_code if exc.violation and exc.violation.http_status_code else 422
+
+        return ORJSONResponse(
+            status_code=http_status,
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": error_code, "message": str(exc)},
+                "id": request_id,
+            },
+        )
+    except PluginError as exc:
+        request_id = body.get("id") if isinstance(body, dict) else None
+        error_code = exc.error.mcp_error_code if exc.error and exc.error.mcp_error_code else -32603
+
+        return ORJSONResponse(
+            status_code=500,
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": error_code, "message": str(exc)},
+                "id": request_id,
+            },
+        )
     except JSONRPCError as exc:
         request_id = body.get("id") if isinstance(body, dict) else None
         return ORJSONResponse(

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -839,22 +839,23 @@ class TestInternalMcpPluginExceptions:
     def mock_internal_auth(self):
         """Mock internal MCP authentication helpers."""
         with patch("mcpgateway.main._build_internal_mcp_forwarded_user") as mock_user, patch(
-            "mcpgateway.main._get_internal_mcp_auth_context"
-        ) as mock_auth, patch("mcpgateway.main._get_rpc_filter_context") as mock_filter, patch(
-            "mcpgateway.main._ensure_rpc_permission"
-        ) as mock_perm, patch("mcpgateway.main._enforce_internal_mcp_server_scope") as mock_scope:
+            "mcpgateway.main.get_internal_mcp_auth_context"
+        ) as mock_auth, patch("mcpgateway.main.get_rpc_filter_context") as mock_filter, patch(
+            "mcpgateway.main._ensure_rpc_permission", new=AsyncMock()
+        ) as mock_perm, patch(
+            "mcpgateway.main._enforce_internal_mcp_server_scope"
+        ) as mock_scope:
             mock_user.return_value = MagicMock(email="test@example.com")
             mock_auth.return_value = {"is_authenticated": True}
             mock_filter.return_value = ("test@example.com", [], False)
-            mock_perm.return_value = AsyncMock()
             mock_scope.return_value = None
             yield
 
     def test_resolve_plugin_violation_returns_jsonrpc_format(self, test_client, mock_internal_auth):
         """Resolve endpoint returns proper JSON-RPC format for PluginViolationError."""
         # First-Party
-        from mcpgateway.plugins.framework.errors import PluginViolationError
-        from mcpgateway.plugins.framework.models import PluginViolation
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
 
         # Setup: Mock prepare_rust_mcp_tool_execution to raise PluginViolationError
         violation = PluginViolation(
@@ -895,8 +896,8 @@ class TestInternalMcpPluginExceptions:
     def test_resolve_plugin_error_returns_jsonrpc_format(self, test_client, mock_internal_auth):
         """Resolve endpoint returns proper JSON-RPC format for PluginError."""
         # First-Party
-        from mcpgateway.plugins.framework.errors import PluginError
-        from mcpgateway.plugins.framework.models import PluginErrorModel
+        from cpex.framework.errors import PluginError
+        from cpex.framework.models import PluginErrorModel
 
         # Setup: Mock prepare_rust_mcp_tool_execution to raise PluginError
         error = PluginErrorModel(
@@ -934,8 +935,8 @@ class TestInternalMcpPluginExceptions:
     def test_call_plugin_violation_returns_jsonrpc_format(self, test_client, mock_internal_auth):
         """Tools/call endpoint returns proper JSON-RPC format for PluginViolationError."""
         # First-Party
-        from mcpgateway.plugins.framework.errors import PluginViolationError
-        from mcpgateway.plugins.framework.models import PluginViolation
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
 
         violation = PluginViolation(
             reason="Rate limit exceeded",
@@ -963,8 +964,8 @@ class TestInternalMcpPluginExceptions:
     def test_call_plugin_error_returns_jsonrpc_format(self, test_client, mock_internal_auth):
         """Tools/call endpoint returns proper JSON-RPC format for PluginError."""
         # First-Party
-        from mcpgateway.plugins.framework.errors import PluginError
-        from mcpgateway.plugins.framework.models import PluginErrorModel
+        from cpex.framework.errors import PluginError
+        from cpex.framework.models import PluginErrorModel
 
         error = PluginErrorModel(
             message="Plugin crashed",
@@ -992,8 +993,8 @@ class TestInternalMcpPluginExceptions:
     def test_resolve_preserves_request_id(self, test_client, mock_internal_auth):
         """Resolve endpoint preserves request ID from incoming JSON-RPC request."""
         # First-Party
-        from mcpgateway.plugins.framework.errors import PluginViolationError
-        from mcpgateway.plugins.framework.models import PluginViolation
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
 
         violation = PluginViolation(reason="test", description="test", code="TEST")
 

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -1010,3 +1010,126 @@ class TestInternalMcpPluginExceptions:
 
                 content = response.json()
                 assert content["id"] == test_id, f"Expected id {test_id}, got {content.get('id')}"
+
+    def test_resolve_defaults_when_violation_has_no_codes(self, test_client, mock_internal_auth):
+        """Resolve endpoint uses default JSON-RPC code/status when violation lacks them."""
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
+
+        # Violation with no mcp_error_code or http_status_code
+        violation = PluginViolation(reason="Bad input", description="Missing field", code="VALIDATION_ERROR")
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("Validation failed", violation=violation)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 10},
+            )
+
+            assert response.status_code == 422  # Default status
+            content = response.json()
+            assert content["error"]["code"] == -32602  # Default JSON-RPC code
+            assert content["id"] == 10
+
+    def test_resolve_rejects_invalid_http_status_code(self, test_client, mock_internal_auth):
+        """Resolve endpoint falls back to 422 when plugin provides invalid HTTP status."""
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
+
+        violation = PluginViolation(
+            reason="Blocked",
+            description="Blocked by policy",
+            code="BLOCKED",
+            http_status_code=999,  # Invalid status
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("Blocked", violation=violation)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 11},
+            )
+
+            assert response.status_code == 422  # Falls back to default
+            content = response.json()
+            assert content["error"]["code"] == -32602
+            assert content["id"] == 11
+
+    def test_call_defaults_when_plugin_error_has_no_code(self, test_client, mock_internal_auth):
+        """Tools/call endpoint uses default JSON-RPC code when PluginError lacks mcp_error_code."""
+        from cpex.framework.errors import PluginError
+        from cpex.framework.models import PluginErrorModel
+
+        error = PluginErrorModel(message="Generic failure", plugin_name="test_plugin")
+        error.mcp_error_code = None  # Force handler fallback branch
+
+        with patch("mcpgateway.main.tool_service.invoke_tool") as mock_invoke:
+            mock_invoke.side_effect = PluginError(error=error)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 12},
+            )
+
+            content = response.json()
+            assert content["error"]["code"] == -32603  # Default internal error
+            assert content["id"] == 12
+
+    def test_resolve_forwards_validated_violation_headers(self, test_client, mock_internal_auth):
+        """Resolve endpoint forwards validated HTTP headers from plugin violations."""
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
+
+        violation = PluginViolation(
+            reason="Rate limited",
+            description="Too many requests",
+            code="RATE_LIMIT",
+            mcp_error_code=-32000,
+            http_status_code=429,
+            http_headers={"Retry-After": "60", "X-RateLimit-Limit": "100"},
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("Rate limited", violation=violation)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 13},
+            )
+
+            assert response.status_code == 429
+            assert response.headers.get("Retry-After") == "60"
+            assert response.headers.get("X-RateLimit-Limit") == "100"
+            content = response.json()
+            assert content["error"]["code"] == -32000
+            assert content["id"] == 13
+
+    def test_resolve_drops_invalid_violation_headers(self, test_client, mock_internal_auth):
+        """Resolve endpoint drops malformed HTTP headers from plugin violations."""
+        from cpex.framework.errors import PluginViolationError
+        from cpex.framework.models import PluginViolation
+
+        violation = PluginViolation(
+            reason="Blocked",
+            description="Blocked",
+            code="BLOCKED",
+            http_status_code=403,
+            http_headers={"Bad Header\x00Name": "value", "Valid-Header": "ok"},
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("Blocked", violation=violation)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 14},
+            )
+
+            assert response.status_code == 403
+            # Invalid header with null byte should be dropped, valid one kept
+            assert response.headers.get("Valid-Header") == "ok"
+            assert "Bad Header" not in dict(response.headers)  # Null byte header was dropped
+            content = response.json()
+            assert content["id"] == 14

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -960,6 +960,35 @@ class TestInternalMcpPluginExceptions:
             assert content["error"]["code"] == -32000
             assert content["id"] == 4
 
+    def test_call_plugin_error_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Tools/call endpoint returns proper JSON-RPC format for PluginError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginError
+        from mcpgateway.plugins.framework.models import PluginErrorModel
+
+        error = PluginErrorModel(
+            message="Plugin crashed",
+            plugin_name="test_plugin",
+            code="CRASH",
+            mcp_error_code=-32603,
+        )
+
+        with patch("mcpgateway.main.tool_service.invoke_tool") as mock_invoke:
+            mock_invoke.side_effect = PluginError(error=error)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 5},
+            )
+
+            content = response.json()
+
+            # Verify JSON-RPC format (returns dict, not ORJSONResponse)
+            assert content["jsonrpc"] == "2.0"
+            assert "error" in content
+            assert content["error"]["code"] == -32603
+            assert content["id"] == 5
+
     def test_resolve_preserves_request_id(self, test_client, mock_internal_auth):
         """Resolve endpoint preserves request ID from incoming JSON-RPC request."""
         # First-Party

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -820,3 +820,163 @@ class TestAdminTemplateValidationErrorHandlers:
             assert "Template validation failed" in content["message"]
             assert content["template_name"] == "admin-edit-prompt"
             assert "Unbalanced template braces" in content["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Internal MCP Plugin Exception Tests (Issue #4103)                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestInternalMcpPluginExceptions:
+    """Test plugin exception handling in internal MCP endpoints.
+
+    These tests verify the fix for Issue #4103, ensuring that plugin exceptions
+    return proper JSON-RPC format instead of being re-raised, which caused the
+    Rust runtime to fall back to Python execution.
+    """
+
+    @pytest.fixture
+    def mock_internal_auth(self):
+        """Mock internal MCP authentication helpers."""
+        with patch("mcpgateway.main._build_internal_mcp_forwarded_user") as mock_user, patch(
+            "mcpgateway.main._get_internal_mcp_auth_context"
+        ) as mock_auth, patch("mcpgateway.main._get_rpc_filter_context") as mock_filter, patch(
+            "mcpgateway.main._ensure_rpc_permission"
+        ) as mock_perm, patch("mcpgateway.main._enforce_internal_mcp_server_scope") as mock_scope:
+            mock_user.return_value = MagicMock(email="test@example.com")
+            mock_auth.return_value = {"is_authenticated": True}
+            mock_filter.return_value = ("test@example.com", [], False)
+            mock_perm.return_value = AsyncMock()
+            mock_scope.return_value = None
+            yield
+
+    def test_resolve_plugin_violation_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Resolve endpoint returns proper JSON-RPC format for PluginViolationError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginViolationError
+        from mcpgateway.plugins.framework.models import PluginViolation
+
+        # Setup: Mock prepare_rust_mcp_tool_execution to raise PluginViolationError
+        violation = PluginViolation(
+            reason="Access Denied",
+            description="User lacks required license",
+            code="LICENSE_CHECK_FAILED",
+            plugin_name="license_check",
+            mcp_error_code=-32602,
+            http_status_code=403,
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("Plugin blocked tool execution", violation=violation)
+
+            # Execute: Call resolve endpoint
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 1},
+            )
+
+            # Verify: Response has complete JSON-RPC format
+            assert response.status_code == 403, f"Expected 403, got {response.status_code}"
+            content = response.json()
+
+            # CRITICAL: Must have "jsonrpc" field for Rust validation (lib.rs:8186-8188)
+            assert "jsonrpc" in content, "Missing 'jsonrpc' field - Rust will fallback to Python execution"
+            assert content["jsonrpc"] == "2.0", f"Expected 'jsonrpc': '2.0', got {content.get('jsonrpc')}"
+
+            # CRITICAL: Must have "error" field
+            assert "error" in content, "Missing 'error' field"
+            assert content["error"]["code"] == -32602, f"Expected error code -32602, got {content['error']['code']}"
+            assert "License" in content["error"]["message"] or "blocked" in content["error"]["message"]
+
+            # CRITICAL: Must have "id" field for JSON-RPC correlation
+            assert "id" in content, "Missing 'id' field - required for JSON-RPC correlation"
+            assert content["id"] == 1, f"Expected id 1, got {content.get('id')}"
+
+    def test_resolve_plugin_error_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Resolve endpoint returns proper JSON-RPC format for PluginError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginError
+        from mcpgateway.plugins.framework.models import PluginErrorModel
+
+        # Setup: Mock prepare_rust_mcp_tool_execution to raise PluginError
+        error = PluginErrorModel(
+            message="Plugin internal error",
+            plugin_name="test_plugin",
+            code="INTERNAL_ERROR",
+            mcp_error_code=-32603,
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginError(error=error)
+
+            # Execute: Call resolve endpoint
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 2},
+            )
+
+            # Verify: Response has complete JSON-RPC format
+            assert response.status_code == 500
+            content = response.json()
+
+            # CRITICAL: Must have "jsonrpc" field
+            assert "jsonrpc" in content
+            assert content["jsonrpc"] == "2.0"
+
+            # CRITICAL: Must have "error" field
+            assert "error" in content
+            assert content["error"]["code"] == -32603
+
+            # CRITICAL: Must have "id" field
+            assert "id" in content
+            assert content["id"] == 2
+
+    def test_call_plugin_violation_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Tools/call endpoint returns proper JSON-RPC format for PluginViolationError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginViolationError
+        from mcpgateway.plugins.framework.models import PluginViolation
+
+        violation = PluginViolation(
+            reason="Rate limit exceeded",
+            description="Too many requests",
+            code="RATE_LIMIT",
+            mcp_error_code=-32000,
+        )
+
+        with patch("mcpgateway.main.tool_service.invoke_tool") as mock_invoke:
+            mock_invoke.side_effect = PluginViolationError("Rate limited", violation=violation)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 4},
+            )
+
+            content = response.json()
+
+            # Verify JSON-RPC format (returns dict, not ORJSONResponse)
+            assert content["jsonrpc"] == "2.0"
+            assert "error" in content
+            assert content["error"]["code"] == -32000
+            assert content["id"] == 4
+
+    def test_resolve_preserves_request_id(self, test_client, mock_internal_auth):
+        """Resolve endpoint preserves request ID from incoming JSON-RPC request."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginViolationError
+        from mcpgateway.plugins.framework.models import PluginViolation
+
+        violation = PluginViolation(reason="test", description="test", code="TEST")
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("test", violation=violation)
+
+            # Test with various ID types
+            for test_id in [1, "string-id", 12345]:
+                response = test_client.post(
+                    "/_internal/mcp/tools/call/resolve",
+                    json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": test_id},
+                )
+
+                content = response.json()
+                assert content["id"] == test_id, f"Expected id {test_id}, got {content.get('id')}"

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -616,3 +616,163 @@ def test_content_type_exception_handler():
     assert result["detail"]["mime_type"] == "application/evil"
     assert "allowed_types" in result["detail"]
     assert len(result["detail"]["allowed_types"]) <= 5  # Limited to first 5
+
+
+# --------------------------------------------------------------------------- #
+# Internal MCP Plugin Exception Tests (Issue #4103)                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestInternalMcpPluginExceptions:
+    """Test plugin exception handling in internal MCP endpoints.
+
+    These tests verify the fix for Issue #4103, ensuring that plugin exceptions
+    return proper JSON-RPC format instead of being re-raised, which caused the
+    Rust runtime to fall back to Python execution.
+    """
+
+    @pytest.fixture
+    def mock_internal_auth(self):
+        """Mock internal MCP authentication helpers."""
+        with patch("mcpgateway.main._build_internal_mcp_forwarded_user") as mock_user, patch(
+            "mcpgateway.main._get_internal_mcp_auth_context"
+        ) as mock_auth, patch("mcpgateway.main._get_rpc_filter_context") as mock_filter, patch(
+            "mcpgateway.main._ensure_rpc_permission"
+        ) as mock_perm, patch("mcpgateway.main._enforce_internal_mcp_server_scope") as mock_scope:
+            mock_user.return_value = MagicMock(email="test@example.com")
+            mock_auth.return_value = {"is_authenticated": True}
+            mock_filter.return_value = ("test@example.com", [], False)
+            mock_perm.return_value = AsyncMock()
+            mock_scope.return_value = None
+            yield
+
+    def test_resolve_plugin_violation_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Resolve endpoint returns proper JSON-RPC format for PluginViolationError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginViolationError
+        from mcpgateway.plugins.framework.models import PluginViolation
+
+        # Setup: Mock prepare_rust_mcp_tool_execution to raise PluginViolationError
+        violation = PluginViolation(
+            reason="Access Denied",
+            description="User lacks required license",
+            code="LICENSE_CHECK_FAILED",
+            plugin_name="license_check",
+            mcp_error_code=-32602,
+            http_status_code=403,
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("Plugin blocked tool execution", violation=violation)
+
+            # Execute: Call resolve endpoint
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 1},
+            )
+
+            # Verify: Response has complete JSON-RPC format
+            assert response.status_code == 403, f"Expected 403, got {response.status_code}"
+            content = response.json()
+
+            # CRITICAL: Must have "jsonrpc" field for Rust validation (lib.rs:8186-8188)
+            assert "jsonrpc" in content, "Missing 'jsonrpc' field - Rust will fallback to Python execution"
+            assert content["jsonrpc"] == "2.0", f"Expected 'jsonrpc': '2.0', got {content.get('jsonrpc')}"
+
+            # CRITICAL: Must have "error" field
+            assert "error" in content, "Missing 'error' field"
+            assert content["error"]["code"] == -32602, f"Expected error code -32602, got {content['error']['code']}"
+            assert "License" in content["error"]["message"] or "blocked" in content["error"]["message"]
+
+            # CRITICAL: Must have "id" field for JSON-RPC correlation
+            assert "id" in content, "Missing 'id' field - required for JSON-RPC correlation"
+            assert content["id"] == 1, f"Expected id 1, got {content.get('id')}"
+
+    def test_resolve_plugin_error_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Resolve endpoint returns proper JSON-RPC format for PluginError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginError
+        from mcpgateway.plugins.framework.models import PluginErrorModel
+
+        # Setup: Mock prepare_rust_mcp_tool_execution to raise PluginError
+        error = PluginErrorModel(
+            message="Plugin internal error",
+            plugin_name="test_plugin",
+            code="INTERNAL_ERROR",
+            mcp_error_code=-32603,
+        )
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginError(error=error)
+
+            # Execute: Call resolve endpoint
+            response = test_client.post(
+                "/_internal/mcp/tools/call/resolve",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 2},
+            )
+
+            # Verify: Response has complete JSON-RPC format
+            assert response.status_code == 500
+            content = response.json()
+
+            # CRITICAL: Must have "jsonrpc" field
+            assert "jsonrpc" in content
+            assert content["jsonrpc"] == "2.0"
+
+            # CRITICAL: Must have "error" field
+            assert "error" in content
+            assert content["error"]["code"] == -32603
+
+            # CRITICAL: Must have "id" field
+            assert "id" in content
+            assert content["id"] == 2
+
+    def test_call_plugin_violation_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Tools/call endpoint returns proper JSON-RPC format for PluginViolationError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginViolationError
+        from mcpgateway.plugins.framework.models import PluginViolation
+
+        violation = PluginViolation(
+            reason="Rate limit exceeded",
+            description="Too many requests",
+            code="RATE_LIMIT",
+            mcp_error_code=-32000,
+        )
+
+        with patch("mcpgateway.main.tool_service.invoke_tool") as mock_invoke:
+            mock_invoke.side_effect = PluginViolationError("Rate limited", violation=violation)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 4},
+            )
+
+            content = response.json()
+
+            # Verify JSON-RPC format (returns dict, not ORJSONResponse)
+            assert content["jsonrpc"] == "2.0"
+            assert "error" in content
+            assert content["error"]["code"] == -32000
+            assert content["id"] == 4
+
+    def test_resolve_preserves_request_id(self, test_client, mock_internal_auth):
+        """Resolve endpoint preserves request ID from incoming JSON-RPC request."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginViolationError
+        from mcpgateway.plugins.framework.models import PluginViolation
+
+        violation = PluginViolation(reason="test", description="test", code="TEST")
+
+        with patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution") as mock_prepare:
+            mock_prepare.side_effect = PluginViolationError("test", violation=violation)
+
+            # Test with various ID types
+            for test_id in [1, "string-id", 12345]:
+                response = test_client.post(
+                    "/_internal/mcp/tools/call/resolve",
+                    json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": test_id},
+                )
+
+                content = response.json()
+                assert content["id"] == test_id, f"Expected id {test_id}, got {content.get('id')}"

--- a/tests/unit/mcpgateway/test_main_error_handlers.py
+++ b/tests/unit/mcpgateway/test_main_error_handlers.py
@@ -756,6 +756,35 @@ class TestInternalMcpPluginExceptions:
             assert content["error"]["code"] == -32000
             assert content["id"] == 4
 
+    def test_call_plugin_error_returns_jsonrpc_format(self, test_client, mock_internal_auth):
+        """Tools/call endpoint returns proper JSON-RPC format for PluginError."""
+        # First-Party
+        from mcpgateway.plugins.framework.errors import PluginError
+        from mcpgateway.plugins.framework.models import PluginErrorModel
+
+        error = PluginErrorModel(
+            message="Plugin crashed",
+            plugin_name="test_plugin",
+            code="CRASH",
+            mcp_error_code=-32603,
+        )
+
+        with patch("mcpgateway.main.tool_service.invoke_tool") as mock_invoke:
+            mock_invoke.side_effect = PluginError(error=error)
+
+            response = test_client.post(
+                "/_internal/mcp/tools/call",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}, "id": 5},
+            )
+
+            content = response.json()
+
+            # Verify JSON-RPC format (returns dict, not ORJSONResponse)
+            assert content["jsonrpc"] == "2.0"
+            assert "error" in content
+            assert content["error"]["code"] == -32603
+            assert content["id"] == 5
+
     def test_resolve_preserves_request_id(self, test_client, mock_internal_auth):
         """Resolve endpoint preserves request ID from incoming JSON-RPC request."""
         # First-Party

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -8762,7 +8762,7 @@ class TestRpcHandling:
         missing_name_result = await handle_internal_mcp_tools_call(missing_name_request)
         assert missing_name_result["error"]["code"] == -32602
 
-    async def test_handle_internal_mcp_tools_call_generates_id_and_reraises_plugin_error_while_ignoring_close_failures(self):
+    async def test_handle_internal_mcp_tools_call_generates_id_and_returns_jsonrpc_plugin_error_while_ignoring_close_failures(self):
         request = self._make_request({"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "echo"}})
         request.headers = {
             "x-contextforge-mcp-runtime": "rust",
@@ -8873,7 +8873,7 @@ class TestRpcHandling:
                 await handle_internal_mcp_tools_call_resolve(request_no_scope)
         public_db.invalidate.assert_called_once()
 
-    async def test_internal_mcp_tools_call_resolve_re_raises_plugin_errors_and_ignores_close_failures(self):
+    async def test_internal_mcp_tools_call_resolve_returns_jsonrpc_plugin_errors_and_ignores_close_failures(self):
         request = self._make_request({"jsonrpc": "2.0", "id": "plugin-err", "method": "tools/call", "params": {"name": "echo"}})
         request.headers = {
             "x-contextforge-mcp-runtime": "rust",

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -8779,8 +8779,15 @@ class TestRpcHandling:
             patch("mcpgateway.main._ensure_rpc_permission", new=AsyncMock()),
             patch("mcpgateway.main._execute_rpc_tools_call", new=AsyncMock(side_effect=PluginError(MagicMock(message="plugin boom")))),
         ):
-            with pytest.raises(PluginError):
-                await handle_internal_mcp_tools_call(request)
+            result = await handle_internal_mcp_tools_call(request)
+            # Verify JSON-RPC format is returned (not exception re-raised)
+            assert result["jsonrpc"] == "2.0"
+            assert "error" in result
+            assert result["error"]["code"] == -32603  # Internal error for PluginError
+            assert "plugin boom" in result["error"]["message"]
+            assert result["id"] is not None  # Generated ID
+            # Verify close() was called twice (once succeeded, once failed but ignored)
+            assert mock_db.close.call_count == 2
 
     async def test_handle_internal_mcp_tools_call_resolve_rejects_parse_error_invalid_method_missing_name_and_tool_error(self):
         base_headers = {
@@ -8881,8 +8888,17 @@ class TestRpcHandling:
             patch("mcpgateway.main._ensure_rpc_permission", new=AsyncMock()),
             patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution", new=AsyncMock(side_effect=PluginError(MagicMock(message="plugin boom")))),
         ):
-            with pytest.raises(PluginError):
-                await handle_internal_mcp_tools_call_resolve(request)
+            response = await handle_internal_mcp_tools_call_resolve(request)
+            # Verify JSON-RPC format is returned (not exception re-raised)
+            assert response.status_code == 500  # PluginError defaults to 500
+            content = json.loads(response.body)
+            assert content["jsonrpc"] == "2.0"
+            assert "error" in content
+            assert content["error"]["code"] == -32603  # Internal error for PluginError
+            assert "plugin boom" in content["error"]["message"]
+            assert content["id"] == "plugin-err"  # ID from request
+            # Verify close() was called (and failure was ignored)
+            assert mock_db.close.call_count == 1
 
     async def test_server_scoped_authz_missing_server_scope_and_jsonrpc_error(self):
         request = self._make_request({"jsonrpc": "2.0", "id": "authz", "method": "noop", "params": {}})

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -8358,8 +8358,15 @@ class TestRpcHandling:
             patch("mcpgateway.main._ensure_rpc_permission", new=AsyncMock()),
             patch("mcpgateway.main._execute_rpc_tools_call", new=AsyncMock(side_effect=PluginError(MagicMock(message="plugin boom")))),
         ):
-            with pytest.raises(PluginError):
-                await handle_internal_mcp_tools_call(request)
+            result = await handle_internal_mcp_tools_call(request)
+            # Verify JSON-RPC format is returned (not exception re-raised)
+            assert result["jsonrpc"] == "2.0"
+            assert "error" in result
+            assert result["error"]["code"] == -32603  # Internal error for PluginError
+            assert "plugin boom" in result["error"]["message"]
+            assert result["id"] is not None  # Generated ID
+            # Verify close() was called twice (once succeeded, once failed but ignored)
+            assert mock_db.close.call_count == 2
 
     async def test_handle_internal_mcp_tools_call_resolve_rejects_parse_error_invalid_method_missing_name_and_tool_error(self):
         base_headers = {
@@ -8460,8 +8467,17 @@ class TestRpcHandling:
             patch("mcpgateway.main._ensure_rpc_permission", new=AsyncMock()),
             patch("mcpgateway.main.tool_service.prepare_rust_mcp_tool_execution", new=AsyncMock(side_effect=PluginError(MagicMock(message="plugin boom")))),
         ):
-            with pytest.raises(PluginError):
-                await handle_internal_mcp_tools_call_resolve(request)
+            response = await handle_internal_mcp_tools_call_resolve(request)
+            # Verify JSON-RPC format is returned (not exception re-raised)
+            assert response.status_code == 500  # PluginError defaults to 500
+            content = json.loads(response.body)
+            assert content["jsonrpc"] == "2.0"
+            assert "error" in content
+            assert content["error"]["code"] == -32603  # Internal error for PluginError
+            assert "plugin boom" in content["error"]["message"]
+            assert content["id"] == "plugin-err"  # ID from request
+            # Verify close() was called (and failure was ignored)
+            assert mock_db.close.call_count == 1
 
     async def test_server_scoped_authz_missing_server_scope_and_jsonrpc_error(self):
         request = self._make_request({"jsonrpc": "2.0", "id": "authz", "method": "noop", "params": {}})


### PR DESCRIPTION
## Summary

Fixes plugin-based access control in Rust MCP runtime execution path by returning properly formatted JSON-RPC errors instead of re-raising plugin exceptions.

## Problem

When `tool_pre_invoke` plugins block tool execution (return `continue_processing=False`), the tool still executes via Rust fallback path instead of being properly blocked.

**Root Cause:** The `handle_internal_mcp_tools_call_resolve` endpoint re-raises `PluginError` and `PluginViolationError` exceptions, which get caught by the global exception handler. The global handler returns an incomplete JSON-RPC error format (missing "jsonrpc" and "id" fields), causing Rust to misinterpret the response as a fallback condition rather than a proper JSON-RPC error.

## Solution

Changed both internal endpoints (`/_internal/mcp/tools/call` and `/_internal/mcp/tools/call/resolve`) to:
- Catch `PluginError` and `PluginViolationError` inline
- Return complete JSON-RPC 2.0 format: `{"jsonrpc": "2.0", "error": {...}, "id": ...}`
- Extract error codes from plugin exceptions with defensive type checking
- Match the existing pattern used for `ToolError` and `JSONRPCError`

## Changes

### Production Code
- **mcpgateway/main.py**: Updated exception handlers in both internal MCP endpoints
  - Lines 9197-9208: `handle_internal_mcp_tools_call` 
  - Lines 9338-9368: `handle_internal_mcp_tools_call_resolve`
  - Added defensive `isinstance()` checks to safely extract error codes from plugin exceptions

### Tests
- **tests/unit/mcpgateway/test_main_error_handlers.py**: Added 5 new tests
  - Test both endpoints with `PluginError` and `PluginViolationError`
  - Verify JSON-RPC format compliance (presence of "jsonrpc", "error", "id" fields)
  - Test error code extraction and ID preservation
  
- **tests/unit/mcpgateway/test_main_extended.py**: Updated 2 existing tests
  - Changed from expecting re-raised exceptions to expecting JSON-RPC format responses
  - Tests now validate the correct behavior (returning structured errors)

## Testing

✅ **All 7 tests related to our changes pass:**
- 5 new tests for plugin exception handling
- 2 updated tests for close failure scenarios
- No regressions in existing functionality

## Impact

- **Severity**: High - Fixes broken plugin-based access control
- **Scope**: Only affects Rust MCP runtime execution path (`MCP_RUST_MODE=edge` or `full`)
- **Backwards Compatibility**: No breaking changes - internal Rust↔Python interface only

## Verification

Before this fix:
```
1. Rust calls resolve endpoint
2. Plugin blocks → PluginViolationError raised
3. Global handler returns incomplete error (missing "jsonrpc" field)
4. Rust validation fails → treats as fallback
5. Tool executes anyway ❌
```

After this fix:
```
1. Rust calls resolve endpoint  
2. Plugin blocks → PluginViolationError caught inline
3. Returns proper JSON-RPC: {"jsonrpc": "2.0", "error": {...}, "id": ...}
4. Rust validation succeeds → returns error to client
5. Tool properly blocked ✅
```

Closes #4103