### PR TITLE
fix(api): support multipart/form-data and form-urlencoded for REST tool invocations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-17T07:49:43Z",
+  "generated_at": "2026-04-17T11:30:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-17T11:30:25Z",
+  "generated_at": "2026-04-17T13:24:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-27T09:51:05Z",
+  "generated_at": "2026-04-17T07:49:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8600,7 +8600,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3206,
+        "line_number": 3278,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8608,7 +8608,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3834,
+        "line_number": 3906,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8616,7 +8616,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7112,
+        "line_number": 7184,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8624,7 +8624,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7604,
+        "line_number": 7676,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8632,7 +8632,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8951,
+        "line_number": 9023,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8640,7 +8640,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9093,
+        "line_number": 9165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8648,7 +8648,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9469,
+        "line_number": 9541,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-17T13:24:41Z",
+  "generated_at": "2026-04-27T12:40:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4844,16 +4844,8 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 701,
+        "line_number": 753,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1103,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -8568,7 +8560,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 544,
+        "line_number": 549,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8576,7 +8568,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8584,7 +8576,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 561,
+        "line_number": 566,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8592,7 +8584,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1976,
+        "line_number": 1985,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8600,7 +8592,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3278,
+        "line_number": 3571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8608,7 +8600,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3906,
+        "line_number": 4204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8616,7 +8608,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7184,
+        "line_number": 7560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8624,7 +8616,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7676,
+        "line_number": 8052,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8632,7 +8624,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9023,
+        "line_number": 9399,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8640,7 +8632,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9165,
+        "line_number": 9541,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8648,7 +8640,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9541,
+        "line_number": 10023,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4844,8 +4844,16 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 701,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1103,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -8560,7 +8568,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 548,
+        "line_number": 544,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8568,7 +8576,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8576,7 +8584,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 561,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8584,7 +8592,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1984,
+        "line_number": 1976,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8592,7 +8600,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3321,
+        "line_number": 3206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8600,7 +8608,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3954,
+        "line_number": 3834,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8608,7 +8616,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7310,
+        "line_number": 7112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8616,7 +8624,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7802,
+        "line_number": 7604,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8624,7 +8632,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9149,
+        "line_number": 8951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8632,7 +8640,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9291,
+        "line_number": 9093,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8640,7 +8648,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9773,
+        "line_number": 9469,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-13T09:59:07Z",
+  "generated_at": "2026-04-13T13:00:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -9682,7 +9682,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 509,
+        "line_number": 510,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9690,7 +9690,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 510,
+        "line_number": 511,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9698,7 +9698,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 526,
+        "line_number": 527,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9706,7 +9706,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1941,
+        "line_number": 1942,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9714,7 +9714,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2994,
+        "line_number": 3172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9722,7 +9722,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3622,
+        "line_number": 3800,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9730,7 +9730,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6376,
+        "line_number": 6554,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9738,7 +9738,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6868,
+        "line_number": 7046,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9746,7 +9746,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8215,
+        "line_number": 8393,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9754,7 +9754,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8357,
+        "line_number": 8535,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9762,7 +9762,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8733,
+        "line_number": 8911,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -78,7 +78,9 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
+_MIME_TYPE_RE: Pattern[str] = re.compile(
+    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
+)
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,9 +76,7 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(
-    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
-)
+_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,7 +76,9 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
+_MIME_TYPE_RE: Pattern[str] = re.compile(
+    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
+)
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4916,6 +4916,7 @@ class ToolService(BaseService):
 
                     # Use the tool's request_type rather than defaulting to POST (using local variable)
                     method = tool_request_type.upper() if tool_request_type else "POST"
+                    _qp = query_params if not tool_query_mapping else None
 
                     # Detect body encoding from the final Content-Type header (after auth/plugin/mapping modifications).
                     # Supports application/x-www-form-urlencoded and multipart/form-data in addition to the default JSON.
@@ -4952,12 +4953,12 @@ class ToolService(BaseService):
                                 response = await asyncio.wait_for(self._http_client.get(final_url, params=payload, headers=headers), timeout=effective_timeout)
                             elif _ct_base == "application/x-www-form-urlencoded":
                                 form_payload = {k: _to_str(v) for k, v in payload.items()}
-                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, headers=headers), timeout=effective_timeout)
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, params=_qp, headers=headers), timeout=effective_timeout)
                             elif _ct_base == "multipart/form-data":
                                 # Strip Content-Type so httpx can set it with the correct boundary parameter
                                 headers_mp = {k: v for k, v in headers.items() if k.lower() != "content-type"}
                                 files_payload = {k: (None, _to_str(v)) for k, v in payload.items()}
-                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, headers=headers_mp), timeout=effective_timeout)
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, params=_qp, headers=headers_mp), timeout=effective_timeout)
                             else:
                                 # For POST/PUT/PATCH/DELETE: Different behavior based on mapping presence
                                 if has_query_mapping or has_header_mapping:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4916,29 +4916,22 @@ class ToolService(BaseService):
 
                     # Use the tool's request_type rather than defaulting to POST (using local variable)
                     method = tool_request_type.upper() if tool_request_type else "POST"
-                    _qp = query_params if not tool_query_mapping else None
+                    _url_query_params = query_params if not tool_query_mapping else None
 
                     # Detect body encoding from the final Content-Type header (after auth/plugin/mapping modifications).
                     # Supports application/x-www-form-urlencoded and multipart/form-data in addition to the default JSON.
                     _ct_base = next((v for k, v in headers.items() if k.lower() == "content-type"), "").lower().split(";")[0].strip()
 
-                    # For form-urlencoded and multipart POST without mappings, extract URL query
-                    # params so they are forwarded via params= (query string) rather than being
-                    # silently embedded in the URL or lost.  GET already handles this below; JSON
-                    # POST intentionally preserves query params in the URL for signed-URL support.
-                    if not has_query_mapping and not has_header_mapping and _ct_base in ("application/x-www-form-urlencoded", "multipart/form-data"):
+                    # For non-GET form-urlencoded and multipart requests without mappings,
+                    # extract URL query params so they are forwarded via params= (query string)
+                    # rather than being silently embedded in the URL or lost.  GET has its own
+                    # extraction below; JSON POST intentionally preserves query params in the URL
+                    # for signed-URL support.
+                    if method != "GET" and not has_query_mapping and not has_header_mapping and _ct_base in ("application/x-www-form-urlencoded", "multipart/form-data"):
                         parsed = urlparse(final_url)
                         if parsed.query:
                             final_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-                            _qp = {k: v[0] for k, v in parse_qs(parsed.query).items()}
-
-                    def _to_str(v: Any) -> str:
-                        """Coerce a payload value to string for form/multipart encoding."""
-                        if v is None:
-                            return ""
-                        if isinstance(v, (dict, list)):
-                            return orjson.dumps(v).decode()
-                        return str(v)
+                            _url_query_params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
 
                     with create_child_span("tool.gateway_call", {"tool.name": name, "tool.id": tool_id, "tool.integration_type": "REST"}):
                         rest_start_time = time.time()
@@ -4962,13 +4955,21 @@ class ToolService(BaseService):
                                 payload.update(query_params)
                                 response = await asyncio.wait_for(self._http_client.get(final_url, params=payload, headers=headers), timeout=effective_timeout)
                             elif _ct_base == "application/x-www-form-urlencoded":
-                                form_payload = {k: _to_str(v) for k, v in payload.items()}
-                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, params=_qp, headers=headers), timeout=effective_timeout)
+                                # NOTE: Intentional asymmetry with the JSON/default path below.
+                                # Form-encoded bodies use params= to keep URL query params on the
+                                # query string (semantically correct for form encoding), whereas
+                                # the JSON path merges them into the body via payload.update() for
+                                # backward compatibility and signed-URL support.
+                                form_payload = {k: self._form_value_to_str(v) for k, v in payload.items()}
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, params=_url_query_params, headers=headers), timeout=effective_timeout)
                             elif _ct_base == "multipart/form-data":
-                                # Strip Content-Type so httpx can set it with the correct boundary parameter
+                                # Strip Content-Type so httpx can set it with the correct boundary parameter.
+                                # URL query params forwarded via params= (same asymmetry as form-urlencoded above).
                                 headers_mp = {k: v for k, v in headers.items() if k.lower() != "content-type"}
-                                files_payload = {k: (None, _to_str(v)) for k, v in payload.items()}
-                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, params=_qp, headers=headers_mp), timeout=effective_timeout)
+                                files_payload = {k: (None, self._form_value_to_str(v)) for k, v in payload.items()}
+                                response = await asyncio.wait_for(
+                                    self._http_client.request(method, final_url, files=files_payload, params=_url_query_params, headers=headers_mp), timeout=effective_timeout
+                                )
                             else:
                                 # For POST/PUT/PATCH/DELETE: Different behavior based on mapping presence
                                 if has_query_mapping or has_header_mapping:
@@ -6028,6 +6029,15 @@ class ToolService(BaseService):
                 # Track performance with threshold checking
                 with perf_tracker.track_operation("tool_invocation", name):
                     pass  # Duration already captured above
+
+    @staticmethod
+    def _form_value_to_str(v: Any) -> str:
+        """Coerce a payload value to string for form/multipart encoding."""
+        if v is None:
+            return ""
+        if isinstance(v, (dict, list)):
+            return orjson.dumps(v).decode()
+        return str(v)
 
     @staticmethod
     def _check_tool_name_conflict(db: Session, custom_name: str, visibility: str, tool_id: str, team_id: Optional[str] = None, owner_email: Optional[str] = None) -> None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4922,6 +4922,16 @@ class ToolService(BaseService):
                     # Supports application/x-www-form-urlencoded and multipart/form-data in addition to the default JSON.
                     _ct_base = next((v for k, v in headers.items() if k.lower() == "content-type"), "").lower().split(";")[0].strip()
 
+                    # For form-urlencoded and multipart POST without mappings, extract URL query
+                    # params so they are forwarded via params= (query string) rather than being
+                    # silently embedded in the URL or lost.  GET already handles this below; JSON
+                    # POST intentionally preserves query params in the URL for signed-URL support.
+                    if not has_query_mapping and not has_header_mapping and _ct_base in ("application/x-www-form-urlencoded", "multipart/form-data"):
+                        parsed = urlparse(final_url)
+                        if parsed.query:
+                            final_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+                            _qp = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+
                     def _to_str(v: Any) -> str:
                         """Coerce a payload value to string for form/multipart encoding."""
                         if v is None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -204,6 +204,8 @@ _SENSITIVE_TOOL_HEADER_PATTERNS = (
     re.compile(r"^content-length$", re.IGNORECASE),
     re.compile(r"^connection$", re.IGNORECASE),
     re.compile(r"^upgrade$", re.IGNORECASE),
+    # Prevent caller-controllable encoding dispatch via header_mapping (see #4139).
+    re.compile(r"^content-type$", re.IGNORECASE),
 )
 
 
@@ -6035,7 +6037,7 @@ class ToolService(BaseService):
         """Coerce a payload value to string for form/multipart encoding."""
         if v is None:
             return ""
-        if isinstance(v, (dict, list)):
+        if isinstance(v, (dict, list, bool)):
             return orjson.dumps(v).decode()
         return str(v)
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4916,6 +4916,19 @@ class ToolService(BaseService):
 
                     # Use the tool's request_type rather than defaulting to POST (using local variable)
                     method = tool_request_type.upper() if tool_request_type else "POST"
+
+                    # Detect body encoding from the final Content-Type header (after auth/plugin/mapping modifications).
+                    # Supports application/x-www-form-urlencoded and multipart/form-data in addition to the default JSON.
+                    _ct_base = next((v for k, v in headers.items() if k.lower() == "content-type"), "").lower().split(";")[0].strip()
+
+                    def _to_str(v: Any) -> str:
+                        """Coerce a payload value to string for form/multipart encoding."""
+                        if v is None:
+                            return ""
+                        if isinstance(v, (dict, list)):
+                            return orjson.dumps(v).decode()
+                        return str(v)
+
                     with create_child_span("tool.gateway_call", {"tool.name": name, "tool.id": tool_id, "tool.integration_type": "REST"}):
                         rest_start_time = time.time()
                         try:
@@ -4937,6 +4950,14 @@ class ToolService(BaseService):
 
                                 payload.update(query_params)
                                 response = await asyncio.wait_for(self._http_client.get(final_url, params=payload, headers=headers), timeout=effective_timeout)
+                            elif _ct_base == "application/x-www-form-urlencoded":
+                                form_payload = {k: _to_str(v) for k, v in payload.items()}
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, headers=headers), timeout=effective_timeout)
+                            elif _ct_base == "multipart/form-data":
+                                # Strip Content-Type so httpx can set it with the correct boundary parameter
+                                headers_mp = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+                                files_payload = {k: (None, _to_str(v)) for k, v in payload.items()}
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, headers=headers_mp), timeout=effective_timeout)
                             else:
                                 # For POST/PUT/PATCH/DELETE: Different behavior based on mapping presence
                                 if has_query_mapping or has_header_mapping:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4273,6 +4273,7 @@ class ToolService(BaseService):
 
                     # Use the tool's request_type rather than defaulting to POST (using local variable)
                     method = tool_request_type.upper() if tool_request_type else "POST"
+                    _qp = query_params if not tool_query_mapping else None
 
                     # Detect body encoding from the final Content-Type header (after auth/plugin/mapping modifications).
                     # Supports application/x-www-form-urlencoded and multipart/form-data in addition to the default JSON.
@@ -4296,12 +4297,12 @@ class ToolService(BaseService):
                                 response = await asyncio.wait_for(self._http_client.get(final_url, params=payload, headers=headers), timeout=effective_timeout)
                             elif _ct_base == "application/x-www-form-urlencoded":
                                 form_payload = {k: _to_str(v) for k, v in payload.items()}
-                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, headers=headers), timeout=effective_timeout)
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, params=_qp, headers=headers), timeout=effective_timeout)
                             elif _ct_base == "multipart/form-data":
                                 # Strip Content-Type so httpx can set it with the correct boundary parameter
                                 headers_mp = {k: v for k, v in headers.items() if k.lower() != "content-type"}
                                 files_payload = {k: (None, _to_str(v)) for k, v in payload.items()}
-                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, headers=headers_mp), timeout=effective_timeout)
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, params=_qp, headers=headers_mp), timeout=effective_timeout)
                             else:
                                 # For POST/PUT/PATCH/DELETE: merge query params into the JSON body
                                 # (preserves backward compatibility with existing tool configurations)

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4273,6 +4273,19 @@ class ToolService(BaseService):
 
                     # Use the tool's request_type rather than defaulting to POST (using local variable)
                     method = tool_request_type.upper() if tool_request_type else "POST"
+
+                    # Detect body encoding from the final Content-Type header (after auth/plugin/mapping modifications).
+                    # Supports application/x-www-form-urlencoded and multipart/form-data in addition to the default JSON.
+                    _ct_base = next((v for k, v in headers.items() if k.lower() == "content-type"), "").lower().split(";")[0].strip()
+
+                    def _to_str(v: Any) -> str:
+                        """Coerce a payload value to string for form/multipart encoding."""
+                        if v is None:
+                            return ""
+                        if isinstance(v, (dict, list)):
+                            return orjson.dumps(v).decode()
+                        return str(v)
+
                     with create_child_span("tool.gateway_call", {"tool.name": name, "tool.id": tool_id, "tool.integration_type": "REST"}):
                         rest_start_time = time.time()
                         try:
@@ -4281,6 +4294,14 @@ class ToolService(BaseService):
                                 if not tool_query_mapping:
                                     payload.update(query_params)
                                 response = await asyncio.wait_for(self._http_client.get(final_url, params=payload, headers=headers), timeout=effective_timeout)
+                            elif _ct_base == "application/x-www-form-urlencoded":
+                                form_payload = {k: _to_str(v) for k, v in payload.items()}
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, data=form_payload, headers=headers), timeout=effective_timeout)
+                            elif _ct_base == "multipart/form-data":
+                                # Strip Content-Type so httpx can set it with the correct boundary parameter
+                                headers_mp = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+                                files_payload = {k: (None, _to_str(v)) for k, v in payload.items()}
+                                response = await asyncio.wait_for(self._http_client.request(method, final_url, files=files_payload, headers=headers_mp), timeout=effective_timeout)
                             else:
                                 # For POST/PUT/PATCH/DELETE: merge query params into the JSON body
                                 # (preserves backward compatibility with existing tool configurations)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2368,6 +2368,78 @@ class TestToolService:
             assert sent_headers.get("X-Custom") == "keep-me"
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_rest_get_with_form_urlencoded_content_type(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """GET request with Content-Type: application/x-www-form-urlencoded should still use the GET branch, not the form branch."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "GET"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/data?version=v1"
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"ok": True})
+
+        tool_service._http_client.get = AsyncMock(return_value=mock_response)
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"ok": True}),
+        ):
+            await tool_service.invoke_tool(test_db, "test_tool", {"q": "hello"}, request_headers=None)
+
+            # GET branch should win — uses .get() not .request()
+            tool_service._http_client.get.assert_called_once()
+            call_kwargs = tool_service._http_client.get.call_args
+            # URL query params merged into payload
+            assert call_kwargs.kwargs.get("params") == {"q": "hello", "version": "v1"}
+            # URL should have query string stripped
+            assert call_kwargs.args[0] == "http://example.com/api/data"
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_urlencoded_with_query_mapping(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Form-urlencoded POST with query_mapping should send mapped params in the form body, not as query string."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/submit?static_key=preserved"
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        mock_tool.query_mapping = {"search": "q"}
+        mock_tool.header_mapping = None
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"ok": True})
+        tool_service._http_client.request = AsyncMock(return_value=mock_response)
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"ok": True}),
+        ):
+            await tool_service.invoke_tool(test_db, "test_tool", {"search": "hello"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # query_mapping renames "search" -> "q"; mapped payload is form-encoded in the body
+            # along with the URL's static query params (merged via apply_mapping_into_target)
+            assert call_kwargs.kwargs.get("data") == {"q": "hello", "static_key": "preserved"}
+            # When query_mapping is set, _url_query_params is None (params not forwarded separately)
+            assert call_kwargs.kwargs.get("params") is None
+
+    @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """REST invocation should send decrypted values for encrypted custom headers."""
         mock_tool.integration_type = "REST"

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -10,6 +10,7 @@ Tests for tool service implementation.
 # Standard
 import asyncio
 import base64
+import json
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timezone
 import logging
@@ -2290,8 +2291,7 @@ class TestToolService:
             data = call_kwargs.kwargs.get("data")
             assert data["scalar"] == "42"
             assert data["nothing"] == ""
-            import json as _json
-            assert _json.loads(data["nested"]) == {"key": "val"}
+            assert json.loads(data["nested"]) == {"key": "val"}
 
     @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2294,6 +2294,80 @@ class TestToolService:
             assert json.loads(data["nested"]) == {"key": "val"}
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_urlencoded_with_url_query_params(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Form-urlencoded POST with URL query params should forward them via params= (query string), not in the form body."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/submit?token=abc123&version=v2"
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"ok": True})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"ok": True}),
+        ):
+            await tool_service.invoke_tool(test_db, "test_tool", {"name": "test"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # Body should only contain the user-supplied payload (form-encoded)
+            assert call_kwargs.kwargs.get("data") == {"name": "test"}
+            # URL query params should be forwarded via params= (on the query string)
+            assert call_kwargs.kwargs.get("params") == {"token": "abc123", "version": "v2"}
+            # URL should have query string stripped
+            assert call_kwargs.args[1] == "http://example.com/api/submit"
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_multipart_with_url_query_params(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Multipart POST with URL query params should forward them via params= (query string), not in the multipart body."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/upload?token=secret"
+        mock_tool.headers = {"Content-Type": "multipart/form-data", "X-Custom": "keep-me"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"uploaded": True})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"uploaded": True}),
+        ):
+            await tool_service.invoke_tool(test_db, "test_tool", {"file_name": "doc.pdf"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # Body should only contain user-supplied payload (multipart files=)
+            assert call_kwargs.kwargs.get("files") == {"file_name": (None, "doc.pdf")}
+            # URL query params should be forwarded via params=
+            assert call_kwargs.kwargs.get("params") == {"token": "secret"}
+            # URL should have query string stripped
+            assert call_kwargs.args[1] == "http://example.com/api/upload"
+            # Content-Type stripped, but other headers preserved
+            sent_headers = call_kwargs.kwargs.get("headers", {})
+            assert "Content-Type" not in sent_headers
+            assert sent_headers.get("X-Custom") == "keep-me"
+
+    @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """REST invocation should send decrypted values for encrypted custom headers."""
         mock_tool.integration_type = "REST"

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2190,6 +2190,110 @@ class TestToolService:
             assert call_kwargs["error_message"] is None
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_urlencoded(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """REST tool with Content-Type: application/x-www-form-urlencoded should use data= encoding."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "form response"})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "form response"}),
+        ):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            # Should use data= (form-urlencoded), not json=
+            call_kwargs = tool_service._http_client.request.call_args
+            assert call_kwargs.kwargs.get("data") == {"param": "value"}
+            assert "json" not in call_kwargs.kwargs
+            assert result.content[0].text == '{\n  "result": "form response"\n}'
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_multipart(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """REST tool with Content-Type: multipart/form-data should use files= encoding and strip Content-Type header."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.headers = {"Content-Type": "multipart/form-data", "X-Custom": "custom-value"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "multipart response"})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "multipart response"}),
+        ):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # Should use files= (multipart), not json=
+            assert call_kwargs.kwargs.get("files") == {"param": (None, "value")}
+            assert "json" not in call_kwargs.kwargs
+            # Content-Type must be stripped so httpx can set it with the correct boundary
+            sent_headers = call_kwargs.kwargs.get("headers", {})
+            assert "Content-Type" not in sent_headers
+            assert "content-type" not in {k.lower() for k in sent_headers}
+            # Other headers should still be present
+            assert sent_headers.get("X-Custom") == "custom-value"
+            assert result.content[0].text == '{\n  "result": "multipart response"\n}'
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_nested_values(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Form-encoded payload should stringify scalars and JSON-encode nested dicts/lists; None becomes empty string."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"ok": True})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"ok": True}),
+        ):
+            args = {"nested": {"key": "val"}, "scalar": 42, "nothing": None}
+            await tool_service.invoke_tool(test_db, "test_tool", args, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            data = call_kwargs.kwargs.get("data")
+            assert data["scalar"] == "42"
+            assert data["nothing"] == ""
+            import json as _json
+            assert _json.loads(data["nested"]) == {"key": "val"}
+
+    @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """REST invocation should send decrypted values for encrypted custom headers."""
         mock_tool.integration_type = "REST"

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -10,6 +10,7 @@ Tests for tool service implementation.
 # Standard
 import asyncio
 import base64
+import json
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timezone
 import logging
@@ -2247,8 +2248,7 @@ class TestToolService:
             data = call_kwargs.kwargs.get("data")
             assert data["scalar"] == "42"
             assert data["nothing"] == ""
-            import json as _json
-            assert _json.loads(data["nested"]) == {"key": "val"}
+            assert json.loads(data["nested"]) == {"key": "val"}
 
     @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2147,6 +2147,110 @@ class TestToolService:
             assert call_kwargs["error_message"] is None
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_urlencoded(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """REST tool with Content-Type: application/x-www-form-urlencoded should use data= encoding."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "form response"})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "form response"}),
+        ):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            # Should use data= (form-urlencoded), not json=
+            call_kwargs = tool_service._http_client.request.call_args
+            assert call_kwargs.kwargs.get("data") == {"param": "value"}
+            assert "json" not in call_kwargs.kwargs
+            assert result.content[0].text == '{\n  "result": "form response"\n}'
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_multipart(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """REST tool with Content-Type: multipart/form-data should use files= encoding and strip Content-Type header."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.headers = {"Content-Type": "multipart/form-data", "X-Custom": "custom-value"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "multipart response"})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "multipart response"}),
+        ):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # Should use files= (multipart), not json=
+            assert call_kwargs.kwargs.get("files") == {"param": (None, "value")}
+            assert "json" not in call_kwargs.kwargs
+            # Content-Type must be stripped so httpx can set it with the correct boundary
+            sent_headers = call_kwargs.kwargs.get("headers", {})
+            assert "Content-Type" not in sent_headers
+            assert "content-type" not in {k.lower() for k in sent_headers}
+            # Other headers should still be present
+            assert sent_headers.get("X-Custom") == "custom-value"
+            assert result.content[0].text == '{\n  "result": "multipart response"\n}'
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_nested_values(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Form-encoded payload should stringify scalars and JSON-encode nested dicts/lists; None becomes empty string."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"ok": True})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"ok": True}),
+        ):
+            args = {"nested": {"key": "val"}, "scalar": 42, "nothing": None}
+            await tool_service.invoke_tool(test_db, "test_tool", args, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            data = call_kwargs.kwargs.get("data")
+            assert data["scalar"] == "42"
+            assert data["nothing"] == ""
+            import json as _json
+            assert _json.loads(data["nested"]) == {"key": "val"}
+
+    @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """REST invocation should send decrypted values for encrypted custom headers."""
         mock_tool.integration_type = "REST"

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2251,6 +2251,80 @@ class TestToolService:
             assert json.loads(data["nested"]) == {"key": "val"}
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_form_urlencoded_with_url_query_params(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Form-urlencoded POST with URL query params should forward them via params= (query string), not in the form body."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/submit?token=abc123&version=v2"
+        mock_tool.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"ok": True})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"ok": True}),
+        ):
+            await tool_service.invoke_tool(test_db, "test_tool", {"name": "test"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # Body should only contain the user-supplied payload (form-encoded)
+            assert call_kwargs.kwargs.get("data") == {"name": "test"}
+            # URL query params should be forwarded via params= (on the query string)
+            assert call_kwargs.kwargs.get("params") == {"token": "abc123", "version": "v2"}
+            # URL should have query string stripped
+            assert call_kwargs.args[1] == "http://example.com/api/submit"
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_rest_post_multipart_with_url_query_params(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Multipart POST with URL query params should forward them via params= (query string), not in the multipart body."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        mock_tool.url = "http://example.com/api/upload?token=secret"
+        mock_tool.headers = {"Content-Type": "multipart/form-data", "X-Custom": "keep-me"}
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"uploaded": True})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"uploaded": True}),
+        ):
+            await tool_service.invoke_tool(test_db, "test_tool", {"file_name": "doc.pdf"}, request_headers=None)
+
+            call_kwargs = tool_service._http_client.request.call_args
+            # Body should only contain user-supplied payload (multipart files=)
+            assert call_kwargs.kwargs.get("files") == {"file_name": (None, "doc.pdf")}
+            # URL query params should be forwarded via params=
+            assert call_kwargs.kwargs.get("params") == {"token": "secret"}
+            # URL should have query string stripped
+            assert call_kwargs.args[1] == "http://example.com/api/upload"
+            # Content-Type stripped, but other headers preserved
+            sent_headers = call_kwargs.kwargs.get("headers", {})
+            assert "Content-Type" not in sent_headers
+            assert sent_headers.get("X-Custom") == "keep-me"
+
+    @pytest.mark.asyncio
     async def test_invoke_tool_rest_decrypts_encrypted_custom_headers(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """REST invocation should send decrypted values for encrypted custom headers."""
         mock_tool.integration_type = "REST"


### PR DESCRIPTION
## 📌 Summary
REST tools always sent request bodies as `application/json` regardless of what the upstream API required. Any API expecting `multipart/form-data` or `application/x-www-form-urlencoded` would return 400 Bad Request with no way to configure the encoding.

## 🔁 Reproduction Steps
Closes #4058

1. Register a REST tool pointing to an API that requires `multipart/form-data` (e.g. uses `-F` form fields)
2. Set `Content-Type: multipart/form-data` in the tool's headers
3. Invoke the tool — previously returned 400 Bad Request

## 🐞 Root Cause
`tool_service.py` hardcoded `json=payload` for all non-GET REST requests, causing httpx to always serialize the body as JSON and override any user-configured `Content-Type` header with `application/json`.

## 💡 Fix Description
After all header modifications (auth merge, passthrough, plugin hooks, header mapping), inspect the final `Content-Type` header and dispatch to the appropriate httpx body encoding:

- `application/x-www-form-urlencoded` → `data=` (scalars stringified, nested values JSON-encoded)
- `multipart/form-data` → `files=` with `Content-Type` stripped so httpx sets the correct `boundary=` parameter
- Anything else (including unset or `application/json`) → `json=` — unchanged default, no behaviour change for existing tools

No DB/schema/migration changes — behaviour is driven entirely by the `Content-Type` header already stored on the tool.

## 🧪 Verification

| Check                             | Command                                                                                  | Status |
|-----------------------------------|------------------------------------------------------------------------------------------|--------|
| Lint suite                        | `make lint`                                                                              | ✅     |
| Unit tests                        | `uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -v`                  | ✅ 337/337 |
| New encoding tests                | `uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -k "rest_post" -v`   | ✅ 4/4  |
| Manual regression no longer fails | Register a REST tool with `Content-Type: application/x-www-form-urlencoded`, invoke it — response `form` field contains parameters instead of 400 | ✅ |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed