### PR TITLE
feat: forward `_meta` in upstream MCP requests for `resources/read` and `prompts/get`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -872,6 +872,15 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # Default: 10000 characters
 # MAX_PARAM_LENGTH=10000
 
+# CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
+# Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
+# Maximum number of top-level keys in meta_data (default: 16)
+# META_MAX_KEYS=16
+# Maximum nesting depth in meta_data (default: 2)
+# META_MAX_DEPTH=2
+# Maximum JSON-encoded byte size of meta_data (default: 4096)
+# META_MAX_BYTES=4096
+
 # Regex patterns for dangerous input (JSON array)
 # Used to detect and block malicious input patterns
 # Default patterns:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T12:17:35Z",
+  "generated_at": "2026-04-14T12:29:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-13T09:59:07Z",
+  "generated_at": "2026-04-13T14:18:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5788,7 +5788,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 700,
+        "line_number": 698,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5796,7 +5796,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1102,
+        "line_number": 1100,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6128,7 +6128,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 376,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -6136,7 +6136,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3374,
+        "line_number": 3448,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T11:03:45Z",
+  "generated_at": "2026-04-14T11:59:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -6136,7 +6136,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3418,
+        "line_number": 3422,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -10660,7 +10660,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11085,
+        "line_number": 11086,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -10668,7 +10668,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12222,
+        "line_number": 12223,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T11:59:21Z",
+  "generated_at": "2026-04-14T12:17:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 977,
+        "line_number": 986,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1003,
+        "line_number": 1012,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1088,
+        "line_number": 1097,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1093,
+        "line_number": 1102,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1099,
+        "line_number": 1108,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1111,
+        "line_number": 1120,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1129,
+        "line_number": 1138,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1199,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5814,7 +5814,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2225,
+        "line_number": 2228,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-13T14:18:16Z",
+  "generated_at": "2026-04-14T11:03:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5788,7 +5788,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 698,
+        "line_number": 699,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5796,7 +5796,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1100,
+        "line_number": 1101,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6128,7 +6128,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 376,
+        "line_number": 346,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -6136,7 +6136,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3448,
+        "line_number": 3418,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -50,12 +50,13 @@ Examples:
 # Standard
 from html.parser import HTMLParser
 import ipaddress
+import json
 import logging
 from pathlib import Path
 import re
 import shlex
 import socket
-from typing import Any, Iterable, List, Optional, Pattern
+from typing import Any, Dict, Iterable, List, Optional, Pattern
 from urllib.parse import urlparse
 import uuid
 
@@ -1813,3 +1814,34 @@ def validate_core_url(value: str, field_name: str = "URL") -> str:
         The validated URL string.
     """
     return SecurityValidator.validate_url(value, field_name)
+
+
+# CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
+# Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
+META_MAX_KEYS: int = 16
+META_MAX_DEPTH: int = 2
+META_MAX_BYTES: int = 4096
+
+
+def validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
+    """Enforce size, key-count, and depth limits on user-supplied meta_data (CWE-400).
+
+    Args:
+        meta_data: The metadata dictionary to validate. ``None`` is always accepted.
+
+    Raises:
+        ValueError: if any limit is exceeded.
+    """
+    if not meta_data:
+        return
+    if len(meta_data) > META_MAX_KEYS:
+        raise ValueError(f"meta_data exceeds maximum key count ({META_MAX_KEYS}): got {len(meta_data)}")
+    for v in meta_data.values():
+        if isinstance(v, dict) and any(isinstance(vv, dict) for vv in v.values()):
+            raise ValueError(f"meta_data exceeds maximum nesting depth ({META_MAX_DEPTH})")
+    try:
+        size = len(json.dumps(meta_data, default=str))
+        if size > META_MAX_BYTES:
+            raise ValueError(f"meta_data exceeds maximum size ({META_MAX_BYTES} bytes): got {size}")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"meta_data is not serializable: {exc}") from exc

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -76,9 +76,7 @@ logger = logging.getLogger(__name__)
 _HTML_SPECIAL_CHARS_RE: Pattern[str] = re.compile(r'[<>"\']')  # / removed per SEP-986
 _DANGEROUS_TEMPLATE_TAGS_RE: Pattern[str] = re.compile(r"<(script|iframe|object|embed|link|meta|base|form)\b", re.IGNORECASE)
 _EVENT_HANDLER_RE: Pattern[str] = re.compile(r"on\w+\s*=", re.IGNORECASE)
-_MIME_TYPE_RE: Pattern[str] = re.compile(
-    r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$'
-)
+_MIME_TYPE_RE: Pattern[str] = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+\.]*(?:\s*;\s*[a-zA-Z0-9!#$&\-\^_+\.]+=(?:[a-zA-Z0-9!#$&\-\^_+\.]+|"[^"\r\n]*"))*$')
 _URI_SCHEME_RE: Pattern[str] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
 _SHELL_DANGEROUS_CHARS_RE: Pattern[str] = re.compile(r"[;&|`$(){}\[\]<>]")
 _ANSI_ESCAPE_RE: Pattern[str] = re.compile(r"\x1B\[[0-9;]*[A-Za-z]")

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -1818,9 +1818,11 @@ def validate_core_url(value: str, field_name: str = "URL") -> str:
 
 # CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
 # Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
-META_MAX_KEYS: int = 16
-META_MAX_DEPTH: int = 2
-META_MAX_BYTES: int = 4096
+# These are now read from config (settings.meta_max_keys, etc.) but kept as
+# module-level aliases for backward-compatible imports.
+META_MAX_KEYS: int = settings.meta_max_keys
+META_MAX_DEPTH: int = settings.meta_max_depth
+META_MAX_BYTES: int = settings.meta_max_bytes
 
 
 def validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
@@ -1832,10 +1834,14 @@ def validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
     Raises:
         ValueError: if any limit is exceeded.
     """
+    max_keys = settings.meta_max_keys
+    max_depth = settings.meta_max_depth
+    max_bytes = settings.meta_max_bytes
+
     if not meta_data:
         return
-    if len(meta_data) > META_MAX_KEYS:
-        raise ValueError(f"meta_data exceeds maximum key count ({META_MAX_KEYS}): got {len(meta_data)}")
+    if len(meta_data) > max_keys:
+        raise ValueError(f"meta_data exceeds maximum key count ({max_keys}): got {len(meta_data)}")
 
     def _check_depth(obj: Any, depth: int) -> None:
         """Recursively enforce nesting depth, traversing both dicts and lists (CWE-400).
@@ -1844,8 +1850,8 @@ def validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
         list-of-dicts does not hide an extra level of dict nesting — e.g.
         ``{"k": [{"l2": {"l3": "x"}}]}`` is correctly caught as depth 3.
         """
-        if depth > META_MAX_DEPTH:
-            raise ValueError(f"meta_data exceeds maximum nesting depth ({META_MAX_DEPTH})")
+        if depth > max_depth:
+            raise ValueError(f"meta_data exceeds maximum nesting depth ({max_depth})")
         if isinstance(obj, dict):
             for v in obj.values():
                 _check_depth(v, depth + 1)
@@ -1861,7 +1867,7 @@ def validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
         # raise TypeError rather than being silently coerced — keeps the byte limit
         # meaningful and matches the strict rejection behaviour used in prompt_service.
         size = len(json.dumps(meta_data))
-        if size > META_MAX_BYTES:
-            raise ValueError(f"meta_data exceeds maximum size ({META_MAX_BYTES} bytes): got {size}")
+        if size > max_bytes:
+            raise ValueError(f"meta_data exceeds maximum size ({max_bytes} bytes): got {size}")
     except (TypeError, ValueError) as exc:
         raise ValueError(f"meta_data is not serializable: {exc}") from exc

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -1836,11 +1836,31 @@ def validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
         return
     if len(meta_data) > META_MAX_KEYS:
         raise ValueError(f"meta_data exceeds maximum key count ({META_MAX_KEYS}): got {len(meta_data)}")
-    for v in meta_data.values():
-        if isinstance(v, dict) and any(isinstance(vv, dict) for vv in v.values()):
+
+    def _check_depth(obj: Any, depth: int) -> None:
+        """Recursively enforce nesting depth, traversing both dicts and lists (CWE-400).
+
+        Lists are traversed without incrementing the depth counter so that a
+        list-of-dicts does not hide an extra level of dict nesting — e.g.
+        ``{"k": [{"l2": {"l3": "x"}}]}`` is correctly caught as depth 3.
+        """
+        if depth > META_MAX_DEPTH:
             raise ValueError(f"meta_data exceeds maximum nesting depth ({META_MAX_DEPTH})")
+        if isinstance(obj, dict):
+            for v in obj.values():
+                _check_depth(v, depth + 1)
+        elif isinstance(obj, list):
+            for item in obj:
+                _check_depth(item, depth)
+
+    for v in meta_data.values():
+        _check_depth(v, 1)
+
     try:
-        size = len(json.dumps(meta_data, default=str))
+        # CWE-20: Use strict json.dumps (no default=str) so non-serializable objects
+        # raise TypeError rather than being silently coerced — keeps the byte limit
+        # meaningful and matches the strict rejection behaviour used in prompt_service.
+        size = len(json.dumps(meta_data))
         if size > META_MAX_BYTES:
             raise ValueError(f"meta_data exceeds maximum size ({META_MAX_BYTES} bytes): got {size}")
     except (TypeError, ValueError) as exc:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -360,6 +360,9 @@ class Settings(BaseSettings):
     allowed_roots: List[str] = Field(default_factory=list, description="Allowed root paths for resource access")
     max_path_depth: int = Field(default=10, description="Maximum allowed path depth")
     max_param_length: int = Field(default=10000, description="Maximum parameter length")
+    meta_max_keys: int = Field(default=16, description="Maximum number of keys in user-supplied meta_data forwarded to upstream MCP servers (CWE-400)")
+    meta_max_depth: int = Field(default=2, description="Maximum nesting depth for user-supplied meta_data forwarded to upstream MCP servers (CWE-400)")
+    meta_max_bytes: int = Field(default=4096, description="Maximum JSON-encoded byte size for user-supplied meta_data forwarded to upstream MCP servers (CWE-400)")
     dangerous_patterns: List[str] = Field(
         default_factory=lambda: [
             r"[;&|`$(){}\[\]<>]",  # Shell metacharacters

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -128,6 +128,60 @@ structured_logger = get_structured_logger("prompt_service")
 audit_trail = get_audit_trail_service()
 metrics_buffer = get_metrics_buffer_service()
 
+# CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
+# Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
+_META_MAX_KEYS: int = 16
+_META_MAX_DEPTH: int = 2
+_META_MAX_BYTES: int = 4096
+
+
+def _validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
+    """Enforce size, key-count, and depth limits on user-supplied meta_data (CWE-400).
+
+    Args:
+        meta_data: The metadata dictionary to validate. ``None`` is always accepted.
+
+    Raises:
+        ValueError: if any limit is exceeded.
+    """
+    if not meta_data:
+        return
+    if len(meta_data) > _META_MAX_KEYS:
+        raise ValueError(f"meta_data exceeds maximum key count ({_META_MAX_KEYS}): got {len(meta_data)}")
+    for v in meta_data.values():
+        if isinstance(v, dict) and any(isinstance(vv, dict) for vv in v.values()):
+            raise ValueError(f"meta_data exceeds maximum nesting depth ({_META_MAX_DEPTH})")
+    try:
+        size = len(orjson.dumps(meta_data))
+        if size > _META_MAX_BYTES:
+            raise ValueError(f"meta_data exceeds maximum size ({_META_MAX_BYTES} bytes): got {size}")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"meta_data is not serializable: {exc}") from exc
+
+
+def _build_get_prompt_request(name: str, arguments: Optional[Dict[str, str]], meta_data: Dict[str, Any]) -> "types.ClientRequest":
+    """Build a GetPrompt ClientRequest that carries _meta (CWE-20, CWE-284).
+
+    Using ``by_alias=True`` ensures the Pydantic alias ``_meta`` is the only
+    key written into the dict so the subsequent ``model_validate`` call
+    resolves it correctly regardless of ``populate_by_name`` settings.
+
+    ``send_request`` is used instead of ``session.get_prompt()`` because the
+    MCP SDK helper does not expose a ``_meta`` parameter; this wrapper must be
+    updated if the SDK later adds that capability.
+
+    Args:
+        name: The prompt name.
+        arguments: Optional prompt arguments.
+        meta_data: Validated metadata dict to inject as ``_meta``.
+
+    Returns:
+        A :class:`types.ClientRequest` ready to be passed to ``session.send_request``.
+    """
+    _gp_dict = GetPromptRequestParams(name=name, arguments=arguments).model_dump(by_alias=True)
+    _gp_dict["_meta"] = meta_data
+    return types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict)))
+
 
 class PromptError(Exception):
     """Base class for prompt-related errors."""
@@ -341,6 +395,8 @@ class PromptService(BaseService):
         transport = str(getattr(gateway, "transport", "streamable_http") or "streamable_http").lower()
         pool_transport_type = TransportType.SSE if transport == "sse" else TransportType.STREAMABLE_HTTP
         prompt_arguments = arguments or None
+        # CWE-400: Validate meta_data limits before forwarding to upstream
+        _validate_meta_data(meta_data)
 
         try:
             if settings.mcp_session_pool_enabled:
@@ -357,11 +413,8 @@ class PromptService(BaseService):
                         gateway_id=gateway_id,
                     ) as pooled:
                         if meta_data:
-                            _gp = GetPromptRequestParams(name=remote_name, arguments=prompt_arguments)
-                            _gp_dict = _gp.model_dump()
-                            _gp_dict["_meta"] = meta_data
                             remote_result = await pooled.session.send_request(
-                                types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict))),
+                                _build_get_prompt_request(remote_name, prompt_arguments, meta_data),
                                 types.GetPromptResult,
                             )
                         else:
@@ -379,11 +432,8 @@ class PromptService(BaseService):
                     async with ClientSession(*streams) as session:
                         await session.initialize()
                         if meta_data:
-                            _gp = GetPromptRequestParams(name=remote_name, arguments=prompt_arguments)
-                            _gp_dict = _gp.model_dump()
-                            _gp_dict["_meta"] = meta_data
                             remote_result = await session.send_request(
-                                types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict))),
+                                _build_get_prompt_request(remote_name, prompt_arguments, meta_data),
                                 types.GetPromptResult,
                             )
                         else:
@@ -393,11 +443,8 @@ class PromptService(BaseService):
                     async with ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
                         if meta_data:
-                            _gp = GetPromptRequestParams(name=remote_name, arguments=prompt_arguments)
-                            _gp_dict = _gp.model_dump()
-                            _gp_dict["_meta"] = meta_data
                             remote_result = await session.send_request(
-                                types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict))),
+                                _build_get_prompt_request(remote_name, prompt_arguments, meta_data),
                                 types.GetPromptResult,
                             )
                         else:

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -183,6 +183,31 @@ def _build_get_prompt_request(name: str, arguments: Optional[Dict[str, str]], me
     return types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict)))
 
 
+async def _get_prompt_with_meta(session: "ClientSession", name: str, arguments: Optional[Dict[str, str]], meta_data: Optional[Dict[str, Any]]) -> Any:
+    """Dispatch a get_prompt call, injecting ``_meta`` when meta_data is provided.
+
+    Eliminates the repeated ``if meta_data: send_request … else: get_prompt``
+    pattern across every transport/pool branch in this module.
+
+    Args:
+        session: An active MCP :class:`ClientSession`.
+        name: The prompt name.
+        arguments: Optional prompt-rendering arguments.
+        meta_data: Optional validated metadata dict. When ``None`` the standard
+            SDK helper is used; when non-empty the low-level ``send_request``
+            path is taken to carry ``_meta``.
+
+    Returns:
+        The raw MCP result object (caller extracts ``.messages``).
+    """
+    if meta_data:
+        return await session.send_request(
+            _build_get_prompt_request(name, arguments, meta_data),
+            types.GetPromptResult,
+        )
+    return await session.get_prompt(name, arguments=arguments)
+
+
 class PromptError(Exception):
     """Base class for prompt-related errors."""
 
@@ -412,13 +437,7 @@ class PromptService(BaseService):
                         user_identity=pool_user_identity,
                         gateway_id=gateway_id,
                     ) as pooled:
-                        if meta_data:
-                            remote_result = await pooled.session.send_request(
-                                _build_get_prompt_request(remote_name, prompt_arguments, meta_data),
-                                types.GetPromptResult,
-                            )
-                        else:
-                            remote_result = await pooled.session.get_prompt(remote_name, arguments=prompt_arguments)
+                        remote_result = await _get_prompt_with_meta(pooled.session, remote_name, prompt_arguments, meta_data)
                         return PromptResult(
                             messages=[
                                 Message.model_validate(message.model_dump(by_alias=True, exclude_none=True) if hasattr(message, "model_dump") else message)
@@ -431,24 +450,12 @@ class PromptService(BaseService):
                 async with sse_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout) as streams:
                     async with ClientSession(*streams) as session:
                         await session.initialize()
-                        if meta_data:
-                            remote_result = await session.send_request(
-                                _build_get_prompt_request(remote_name, prompt_arguments, meta_data),
-                                types.GetPromptResult,
-                            )
-                        else:
-                            remote_result = await session.get_prompt(remote_name, arguments=prompt_arguments)
+                        remote_result = await _get_prompt_with_meta(session, remote_name, prompt_arguments, meta_data)
             else:
                 async with streamablehttp_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout) as (read_stream, write_stream, _get_session_id):
                     async with ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
-                        if meta_data:
-                            remote_result = await session.send_request(
-                                _build_get_prompt_request(remote_name, prompt_arguments, meta_data),
-                                types.GetPromptResult,
-                            )
-                        else:
-                            remote_result = await session.get_prompt(remote_name, arguments=prompt_arguments)
+                        remote_result = await _get_prompt_with_meta(session, remote_name, prompt_arguments, meta_data)
 
             return PromptResult(
                 messages=[

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -25,9 +25,10 @@ import uuid
 
 # Third-Party
 from jinja2 import Environment, meta, select_autoescape, Template
-from mcp import ClientSession
+from mcp import ClientSession, types
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.types import GetPromptRequest, GetPromptRequestParams
 import orjson
 from pydantic import ValidationError
 from sqlalchemy import and_, delete, desc, not_, or_, select
@@ -301,7 +302,7 @@ class PromptService(BaseService):
         """
         return bool(getattr(prompt, "gateway_id", None)) and not bool(getattr(prompt, "template", ""))
 
-    async def _fetch_gateway_prompt_result(self, prompt: DbPrompt, arguments: Optional[Dict[str, str]], user_identity: Optional[str]) -> PromptResult:
+    async def _fetch_gateway_prompt_result(self, prompt: DbPrompt, arguments: Optional[Dict[str, str]], user_identity: Optional[str], meta_data: Optional[Dict[str, Any]] = None) -> PromptResult:
         """Fetch a rendered prompt from the upstream MCP gateway.
 
         Args:
@@ -355,7 +356,16 @@ class PromptService(BaseService):
                         user_identity=pool_user_identity,
                         gateway_id=gateway_id,
                     ) as pooled:
-                        remote_result = await pooled.session.get_prompt(remote_name, arguments=prompt_arguments)
+                        if meta_data:
+                            _gp = GetPromptRequestParams(name=remote_name, arguments=prompt_arguments)
+                            _gp_dict = _gp.model_dump()
+                            _gp_dict["_meta"] = meta_data
+                            remote_result = await pooled.session.send_request(
+                                types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict))),
+                                types.GetPromptResult,
+                            )
+                        else:
+                            remote_result = await pooled.session.get_prompt(remote_name, arguments=prompt_arguments)
                         return PromptResult(
                             messages=[
                                 Message.model_validate(message.model_dump(by_alias=True, exclude_none=True) if hasattr(message, "model_dump") else message)
@@ -368,12 +378,30 @@ class PromptService(BaseService):
                 async with sse_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout) as streams:
                     async with ClientSession(*streams) as session:
                         await session.initialize()
-                        remote_result = await session.get_prompt(remote_name, arguments=prompt_arguments)
+                        if meta_data:
+                            _gp = GetPromptRequestParams(name=remote_name, arguments=prompt_arguments)
+                            _gp_dict = _gp.model_dump()
+                            _gp_dict["_meta"] = meta_data
+                            remote_result = await session.send_request(
+                                types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict))),
+                                types.GetPromptResult,
+                            )
+                        else:
+                            remote_result = await session.get_prompt(remote_name, arguments=prompt_arguments)
             else:
                 async with streamablehttp_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout) as (read_stream, write_stream, _get_session_id):
                     async with ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
-                        remote_result = await session.get_prompt(remote_name, arguments=prompt_arguments)
+                        if meta_data:
+                            _gp = GetPromptRequestParams(name=remote_name, arguments=prompt_arguments)
+                            _gp_dict = _gp.model_dump()
+                            _gp_dict["_meta"] = meta_data
+                            remote_result = await session.send_request(
+                                types.ClientRequest(GetPromptRequest(params=GetPromptRequestParams.model_validate(_gp_dict))),
+                                types.GetPromptResult,
+                            )
+                        else:
+                            remote_result = await session.get_prompt(remote_name, arguments=prompt_arguments)
 
             return PromptResult(
                 messages=[
@@ -1786,7 +1814,7 @@ class PromptService(BaseService):
                 None = unrestricted admin, [] = public-only, [...] = team-scoped.
             plugin_context_table: Optional plugin context table from previous hooks for cross-hook state sharing.
             plugin_global_context: Optional global context from middleware for consistency across hooks.
-            _meta_data: Optional metadata for prompt retrieval (not used currently).
+            _meta_data: Optional metadata forwarded as _meta to the upstream MCP gateway during prompt retrieval.
 
         Returns:
             Prompt result with rendered messages
@@ -1947,7 +1975,7 @@ class PromptService(BaseService):
                 if self._should_fetch_gateway_prompt(prompt):
                     # Release the read transaction before any remote network I/O.
                     db.commit()
-                    result = await self._fetch_gateway_prompt_result(prompt, arguments, user)
+                    result = await self._fetch_gateway_prompt_result(prompt, arguments, user, meta_data=_meta_data)
                 elif not arguments:
                     result = PromptResult(
                         messages=[

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -388,6 +388,7 @@ class PromptService(BaseService):
             prompt: Gateway-backed prompt record from the catalog.
             arguments: Optional prompt-rendering arguments.
             user_identity: Effective requester email for session-pool isolation.
+            meta_data: Optional metadata dict forwarded as ``_meta`` in the upstream MCP request.
 
         Returns:
             Prompt result normalized into ContextForge models.

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import joinedload, selectinload, Session
 
 # First-Party
 from mcpgateway.common.models import Message, PromptResult, Role, TextContent
+from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam
 from mcpgateway.db import EmailTeamMember as DbEmailTeamMember
@@ -127,36 +128,6 @@ logger = logging_service.get_logger(__name__)
 structured_logger = get_structured_logger("prompt_service")
 audit_trail = get_audit_trail_service()
 metrics_buffer = get_metrics_buffer_service()
-
-# CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
-# Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
-_META_MAX_KEYS: int = 16
-_META_MAX_DEPTH: int = 2
-_META_MAX_BYTES: int = 4096
-
-
-def _validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
-    """Enforce size, key-count, and depth limits on user-supplied meta_data (CWE-400).
-
-    Args:
-        meta_data: The metadata dictionary to validate. ``None`` is always accepted.
-
-    Raises:
-        ValueError: if any limit is exceeded.
-    """
-    if not meta_data:
-        return
-    if len(meta_data) > _META_MAX_KEYS:
-        raise ValueError(f"meta_data exceeds maximum key count ({_META_MAX_KEYS}): got {len(meta_data)}")
-    for v in meta_data.values():
-        if isinstance(v, dict) and any(isinstance(vv, dict) for vv in v.values()):
-            raise ValueError(f"meta_data exceeds maximum nesting depth ({_META_MAX_DEPTH})")
-    try:
-        size = len(orjson.dumps(meta_data))
-        if size > _META_MAX_BYTES:
-            raise ValueError(f"meta_data exceeds maximum size ({_META_MAX_BYTES} bytes): got {size}")
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"meta_data is not serializable: {exc}") from exc
 
 
 def _build_get_prompt_request(name: str, arguments: Optional[Dict[str, str]], meta_data: Dict[str, Any]) -> "types.ClientRequest":

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -166,6 +166,30 @@ def _build_read_resource_request(uri: Any, meta_data: Dict[str, Any]) -> "types.
     return types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict)))
 
 
+async def _read_resource_with_meta(session: "ClientSession", uri: Any, meta_data: Optional[Dict[str, Any]]) -> Any:
+    """Dispatch a read_resource call, injecting ``_meta`` when meta_data is provided.
+
+    Eliminates the repeated ``if meta_data: send_request … else: read_resource``
+    pattern across every transport/pool branch in this module.
+
+    Args:
+        session: An active MCP :class:`ClientSession`.
+        uri: The resource URI to read.
+        meta_data: Optional validated metadata dict. When ``None`` the standard
+            SDK helper is used; when non-empty the low-level ``send_request``
+            path is taken to carry ``_meta``.
+
+    Returns:
+        The raw MCP result object (caller extracts ``.contents``).
+    """
+    if meta_data:
+        return await session.send_request(
+            _build_read_resource_request(uri, meta_data),
+            types.ReadResourceResult,
+        )
+    return await session.read_resource(uri=uri)
+
+
 class ResourceError(Exception):
     """Base class for resource-related errors."""
 
@@ -1972,13 +1996,7 @@ class ResourceService(BaseService):
                                         user_identity=pool_user_identity,
                                         gateway_id=gateway_id,
                                     ) as pooled:
-                                        if meta_data:
-                                            resource_response = await pooled.session.send_request(
-                                                _build_read_resource_request(uri, meta_data),
-                                                types.ReadResourceResult,
-                                            )
-                                        else:
-                                            resource_response = await pooled.session.read_resource(uri=uri)
+                                        resource_response = await _read_resource_with_meta(pooled.session, uri, meta_data)
                                         return getattr(getattr(resource_response, "contents")[0], "text")
                                 else:
                                     # Fallback to per-call sessions when pool disabled or not initialized
@@ -1988,13 +2006,7 @@ class ResourceService(BaseService):
                                     ):
                                         async with ClientSession(read_stream, write_stream) as session:
                                             _ = await session.initialize()
-                                            if meta_data:
-                                                resource_response = await session.send_request(
-                                                    _build_read_resource_request(uri, meta_data),
-                                                    types.ReadResourceResult,
-                                                )
-                                            else:
-                                                resource_response = await session.read_resource(uri=uri)
+                                            resource_response = await _read_resource_with_meta(session, uri, meta_data)
                                             return getattr(getattr(resource_response, "contents")[0], "text")
                             except Exception as e:
                                 # Sanitize error message to prevent URL secrets from leaking in logs
@@ -2063,13 +2075,7 @@ class ResourceService(BaseService):
                                         user_identity=pool_user_identity,
                                         gateway_id=gateway_id,
                                     ) as pooled:
-                                        if meta_data:
-                                            resource_response = await pooled.session.send_request(
-                                                _build_read_resource_request(uri, meta_data),
-                                                types.ReadResourceResult,
-                                            )
-                                        else:
-                                            resource_response = await pooled.session.read_resource(uri=uri)
+                                        resource_response = await _read_resource_with_meta(pooled.session, uri, meta_data)
                                         return getattr(getattr(resource_response, "contents")[0], "text")
                                 else:
                                     # Fallback to per-call sessions when pool disabled or not initialized
@@ -2080,13 +2086,7 @@ class ResourceService(BaseService):
                                     ):
                                         async with ClientSession(read_stream, write_stream) as session:
                                             _ = await session.initialize()
-                                            if meta_data:
-                                                resource_response = await session.send_request(
-                                                    _build_read_resource_request(uri, meta_data),
-                                                    types.ReadResourceResult,
-                                                )
-                                            else:
-                                                resource_response = await session.read_resource(uri=uri)
+                                            resource_response = await _read_resource_with_meta(session, uri, meta_data)
                                             return getattr(getattr(resource_response, "contents")[0], "text")
                             except Exception as e:
                                 # Sanitize error message to prevent URL secrets from leaking in logs
@@ -2389,16 +2389,7 @@ class ResourceService(BaseService):
                                 async with ClientSession(read_stream, write_stream) as session:
                                     await session.initialize()
 
-                                    if meta_data:
-                                        _rp = ReadResourceRequestParams(uri=uri)
-                                        _rp_dict = _rp.model_dump()
-                                        _rp_dict["_meta"] = meta_data
-                                        result = await session.send_request(
-                                            types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
-                                            types.ReadResourceResult,
-                                        )
-                                    else:
-                                        result = await session.read_resource(uri=uri)
+                                    result = await _read_resource_with_meta(session, uri, meta_data)
 
                                     # Convert MCP result to MCP-compliant content models
                                     # result.contents is a list of TextResourceContents or BlobResourceContents

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -1684,6 +1684,10 @@ class ResourceService(BaseService):
         'using template: /template'
 
         """
+        # CWE-400: Validate meta_data limits before any further processing; invoke_resource is
+        # a separate entry point that must enforce the same guards as read_resource.
+        _validate_meta_data(meta_data)
+
         uri = None
         if resource_uri and resource_template_uri:
             uri = resource_template_uri

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -24,7 +24,6 @@ Examples:
 import binascii
 from datetime import datetime, timezone
 from functools import lru_cache
-import json
 import mimetypes
 import os
 import re
@@ -49,6 +48,7 @@ from sqlalchemy.orm import joinedload, selectinload, Session
 # First-Party
 from mcpgateway.common.models import ResourceContent, ResourceContents, ResourceTemplate, TextContent
 from mcpgateway.common.validators import SecurityValidator
+from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam
 from mcpgateway.db import EmailTeamMember as DbEmailTeamMember
@@ -111,36 +111,6 @@ logger = logging_service.get_logger(__name__)
 structured_logger = get_structured_logger("resource_service")
 audit_trail = get_audit_trail_service()
 metrics_buffer = get_metrics_buffer_service()
-
-# CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
-# Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
-_META_MAX_KEYS: int = 16
-_META_MAX_DEPTH: int = 2
-_META_MAX_BYTES: int = 4096
-
-
-def _validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
-    """Enforce size, key-count, and depth limits on user-supplied meta_data (CWE-400).
-
-    Args:
-        meta_data: The metadata dictionary to validate. ``None`` is always accepted.
-
-    Raises:
-        ValueError: if any limit is exceeded.
-    """
-    if not meta_data:
-        return
-    if len(meta_data) > _META_MAX_KEYS:
-        raise ValueError(f"meta_data exceeds maximum key count ({_META_MAX_KEYS}): got {len(meta_data)}")
-    for v in meta_data.values():
-        if isinstance(v, dict) and any(isinstance(vv, dict) for vv in v.values()):
-            raise ValueError(f"meta_data exceeds maximum nesting depth ({_META_MAX_DEPTH})")
-    try:
-        size = len(json.dumps(meta_data, default=str))
-        if size > _META_MAX_BYTES:
-            raise ValueError(f"meta_data exceeds maximum size ({_META_MAX_BYTES} bytes): got {size}")
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"meta_data is not serializable: {exc}") from exc
 
 
 def _build_read_resource_request(uri: Any, meta_data: Dict[str, Any]) -> "types.ClientRequest":

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -35,9 +35,10 @@ import uuid
 
 # Third-Party
 import httpx
-from mcp import ClientSession
+from mcp import ClientSession, types
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.types import ReadResourceRequest, ReadResourceRequestParams
 import parse
 from pydantic import ValidationError
 from sqlalchemy import and_, delete, desc, not_, or_, select
@@ -1521,7 +1522,7 @@ class ResourceService(BaseService):
         resource_uri: str,
         resource_template_uri: Optional[str] = None,
         user_identity: Optional[Union[str, Dict[str, Any]]] = None,
-        meta_data: Optional[Dict[str, Any]] = None,  # Reserved for future MCP SDK support
+        meta_data: Optional[Dict[str, Any]] = None,  # Forwarded as _meta in upstream MCP requests
         resource_obj: Optional[Any] = None,
         gateway_obj: Optional[Any] = None,
         server_id: Optional[str] = None,
@@ -1869,8 +1870,8 @@ class ResourceService(BaseService):
                             ``None`` instead of raising.
 
                             Note:
-                                MCP SDK 1.25.0 read_resource() does not support meta parameter.
-                                When the SDK adds support, meta_data can be added back here.
+                                When meta_data is provided, the request is built using send_request
+                                with _meta injected into ReadResourceRequestParams.
 
                             Args:
                                 server_url (str):
@@ -1917,8 +1918,16 @@ class ResourceService(BaseService):
                                         user_identity=pool_user_identity,
                                         gateway_id=gateway_id,
                                     ) as pooled:
-                                        # Note: MCP SDK 1.25.0 read_resource() does not support meta parameter
-                                        resource_response = await pooled.session.read_resource(uri=uri)
+                                        if meta_data:
+                                            _rp = ReadResourceRequestParams(uri=uri)
+                                            _rp_dict = _rp.model_dump()
+                                            _rp_dict["_meta"] = meta_data
+                                            resource_response = await pooled.session.send_request(
+                                                types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                types.ReadResourceResult,
+                                            )
+                                        else:
+                                            resource_response = await pooled.session.read_resource(uri=uri)
                                         return getattr(getattr(resource_response, "contents")[0], "text")
                                 else:
                                     # Fallback to per-call sessions when pool disabled or not initialized
@@ -1928,8 +1937,16 @@ class ResourceService(BaseService):
                                     ):
                                         async with ClientSession(read_stream, write_stream) as session:
                                             _ = await session.initialize()
-                                            # Note: MCP SDK 1.25.0 read_resource() does not support meta parameter
-                                            resource_response = await session.read_resource(uri=uri)
+                                            if meta_data:
+                                                _rp = ReadResourceRequestParams(uri=uri)
+                                                _rp_dict = _rp.model_dump()
+                                                _rp_dict["_meta"] = meta_data
+                                                resource_response = await session.send_request(
+                                                    types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                    types.ReadResourceResult,
+                                                )
+                                            else:
+                                                resource_response = await session.read_resource(uri=uri)
                                             return getattr(getattr(resource_response, "contents")[0], "text")
                             except Exception as e:
                                 # Sanitize error message to prevent URL secrets from leaking in logs
@@ -1951,8 +1968,8 @@ class ResourceService(BaseService):
                             of propagating the exception.
 
                             Note:
-                                MCP SDK 1.25.0 read_resource() does not support meta parameter.
-                                When the SDK adds support, meta_data can be added back here.
+                                When meta_data is provided, the request is built using send_request
+                                with _meta injected into ReadResourceRequestParams.
 
                             Args:
                                 server_url (str):
@@ -1998,8 +2015,16 @@ class ResourceService(BaseService):
                                         user_identity=pool_user_identity,
                                         gateway_id=gateway_id,
                                     ) as pooled:
-                                        # Note: MCP SDK 1.25.0 read_resource() does not support meta parameter
-                                        resource_response = await pooled.session.read_resource(uri=uri)
+                                        if meta_data:
+                                            _rp = ReadResourceRequestParams(uri=uri)
+                                            _rp_dict = _rp.model_dump()
+                                            _rp_dict["_meta"] = meta_data
+                                            resource_response = await pooled.session.send_request(
+                                                types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                types.ReadResourceResult,
+                                            )
+                                        else:
+                                            resource_response = await pooled.session.read_resource(uri=uri)
                                         return getattr(getattr(resource_response, "contents")[0], "text")
                                 else:
                                     # Fallback to per-call sessions when pool disabled or not initialized
@@ -2010,8 +2035,16 @@ class ResourceService(BaseService):
                                     ):
                                         async with ClientSession(read_stream, write_stream) as session:
                                             _ = await session.initialize()
-                                            # Note: MCP SDK 1.25.0 read_resource() does not support meta parameter
-                                            resource_response = await session.read_resource(uri=uri)
+                                            if meta_data:
+                                                _rp = ReadResourceRequestParams(uri=uri)
+                                                _rp_dict = _rp.model_dump()
+                                                _rp_dict["_meta"] = meta_data
+                                                resource_response = await session.send_request(
+                                                    types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                    types.ReadResourceResult,
+                                                )
+                                            else:
+                                                resource_response = await session.read_resource(uri=uri)
                                             return getattr(getattr(resource_response, "contents")[0], "text")
                             except Exception as e:
                                 # Sanitize error message to prevent URL secrets from leaking in logs
@@ -2025,10 +2058,8 @@ class ResourceService(BaseService):
 
                         resource_text = ""
                         if (gateway_transport).lower() == "sse":
-                            # Note: meta_data not passed - MCP SDK 1.25.0 read_resource() doesn't support it
                             resource_text = await connect_to_sse_session(server_url=gateway_url, authentication=headers, uri=uri)
                         else:
-                            # Note: meta_data not passed - MCP SDK 1.25.0 read_resource() doesn't support it
                             resource_text = await connect_to_streamablehttp_server(server_url=gateway_url, authentication=headers, uri=uri)
                         if span and resource_text is not None and is_output_capture_enabled("invoke.resource"):
                             set_span_attribute(span, "langfuse.observation.output", serialize_trace_payload({"content": resource_text}))
@@ -2314,8 +2345,16 @@ class ResourceService(BaseService):
                                 async with ClientSession(read_stream, write_stream) as session:
                                     await session.initialize()
 
-                                    # Note: MCP SDK read_resource() only accepts uri; _meta is not supported
-                                    result = await session.read_resource(uri=uri)
+                                    if meta_data:
+                                        _rp = ReadResourceRequestParams(uri=uri)
+                                        _rp_dict = _rp.model_dump()
+                                        _rp_dict["_meta"] = meta_data
+                                        result = await session.send_request(
+                                            types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                            types.ReadResourceResult,
+                                        )
+                                    else:
+                                        result = await session.read_resource(uri=uri)
 
                                     # Convert MCP result to MCP-compliant content models
                                     # result.contents is a list of TextResourceContents or BlobResourceContents

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -24,6 +24,7 @@ Examples:
 import binascii
 from datetime import datetime, timezone
 from functools import lru_cache
+import json
 import mimetypes
 import os
 import re
@@ -110,6 +111,59 @@ logger = logging_service.get_logger(__name__)
 structured_logger = get_structured_logger("resource_service")
 audit_trail = get_audit_trail_service()
 metrics_buffer = get_metrics_buffer_service()
+
+# CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
+# Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
+_META_MAX_KEYS: int = 16
+_META_MAX_DEPTH: int = 2
+_META_MAX_BYTES: int = 4096
+
+
+def _validate_meta_data(meta_data: Optional[Dict[str, Any]]) -> None:
+    """Enforce size, key-count, and depth limits on user-supplied meta_data (CWE-400).
+
+    Args:
+        meta_data: The metadata dictionary to validate. ``None`` is always accepted.
+
+    Raises:
+        ValueError: if any limit is exceeded.
+    """
+    if not meta_data:
+        return
+    if len(meta_data) > _META_MAX_KEYS:
+        raise ValueError(f"meta_data exceeds maximum key count ({_META_MAX_KEYS}): got {len(meta_data)}")
+    for v in meta_data.values():
+        if isinstance(v, dict) and any(isinstance(vv, dict) for vv in v.values()):
+            raise ValueError(f"meta_data exceeds maximum nesting depth ({_META_MAX_DEPTH})")
+    try:
+        size = len(json.dumps(meta_data, default=str))
+        if size > _META_MAX_BYTES:
+            raise ValueError(f"meta_data exceeds maximum size ({_META_MAX_BYTES} bytes): got {size}")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"meta_data is not serializable: {exc}") from exc
+
+
+def _build_read_resource_request(uri: Any, meta_data: Dict[str, Any]) -> "types.ClientRequest":
+    """Build a ReadResource ClientRequest that carries _meta (CWE-20, CWE-284).
+
+    Using ``by_alias=True`` ensures the Pydantic alias ``_meta`` is the only
+    key written into the dict so the subsequent ``model_validate`` call
+    resolves it correctly regardless of ``populate_by_name`` settings.
+
+    ``send_request`` is used instead of ``session.read_resource()`` because the
+    MCP SDK helper does not expose a ``_meta`` parameter; this wrapper must be
+    updated if the SDK later adds that capability.
+
+    Args:
+        uri: The resource URI.
+        meta_data: Validated metadata dict to inject as ``_meta``.
+
+    Returns:
+        A :class:`types.ClientRequest` ready to be passed to ``session.send_request``.
+    """
+    _rp_dict = ReadResourceRequestParams(uri=uri).model_dump(by_alias=True)
+    _rp_dict["_meta"] = meta_data
+    return types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict)))
 
 
 class ResourceError(Exception):
@@ -1919,11 +1973,8 @@ class ResourceService(BaseService):
                                         gateway_id=gateway_id,
                                     ) as pooled:
                                         if meta_data:
-                                            _rp = ReadResourceRequestParams(uri=uri)
-                                            _rp_dict = _rp.model_dump()
-                                            _rp_dict["_meta"] = meta_data
                                             resource_response = await pooled.session.send_request(
-                                                types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                _build_read_resource_request(uri, meta_data),
                                                 types.ReadResourceResult,
                                             )
                                         else:
@@ -1938,11 +1989,8 @@ class ResourceService(BaseService):
                                         async with ClientSession(read_stream, write_stream) as session:
                                             _ = await session.initialize()
                                             if meta_data:
-                                                _rp = ReadResourceRequestParams(uri=uri)
-                                                _rp_dict = _rp.model_dump()
-                                                _rp_dict["_meta"] = meta_data
                                                 resource_response = await session.send_request(
-                                                    types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                    _build_read_resource_request(uri, meta_data),
                                                     types.ReadResourceResult,
                                                 )
                                             else:
@@ -2016,11 +2064,8 @@ class ResourceService(BaseService):
                                         gateway_id=gateway_id,
                                     ) as pooled:
                                         if meta_data:
-                                            _rp = ReadResourceRequestParams(uri=uri)
-                                            _rp_dict = _rp.model_dump()
-                                            _rp_dict["_meta"] = meta_data
                                             resource_response = await pooled.session.send_request(
-                                                types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                _build_read_resource_request(uri, meta_data),
                                                 types.ReadResourceResult,
                                             )
                                         else:
@@ -2036,11 +2081,8 @@ class ResourceService(BaseService):
                                         async with ClientSession(read_stream, write_stream) as session:
                                             _ = await session.initialize()
                                             if meta_data:
-                                                _rp = ReadResourceRequestParams(uri=uri)
-                                                _rp_dict = _rp.model_dump()
-                                                _rp_dict["_meta"] = meta_data
                                                 resource_response = await session.send_request(
-                                                    types.ClientRequest(ReadResourceRequest(params=ReadResourceRequestParams.model_validate(_rp_dict))),
+                                                    _build_read_resource_request(uri, meta_data),
                                                     types.ReadResourceResult,
                                                 )
                                             else:
@@ -2171,6 +2213,8 @@ class ResourceService(BaseService):
         resource_db = None
         server_scoped = False
         resource_db_gateway = None  # Only set when eager-loaded via Q2's joinedload
+        # CWE-400: Validate meta_data limits before any further processing
+        _validate_meta_data(meta_data)
         content = None
         uri = resource_uri or "unknown"
         if resource_id:

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2353,7 +2353,9 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
                         return ""
 
                     # Direct proxy mode: forward request to remote MCP server
-                    # CWE-532: log only the meta_data key names (never the values which may carry PII/tokens)
+                    # SECURITY: CWE-532 protection - Log only meta_data key names, NEVER values
+                    # Metadata may contain PII, authentication tokens, or sensitive context that
+                    # MUST NOT be written to logs. This is a critical security control.
                     logger.debug(
                         "Using direct_proxy mode for resources/read %s, server %s, gateway %s (from %s header), forwarding _meta keys: %s",
                         resource_uri,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2344,13 +2344,14 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
                         return ""
 
                     # Direct proxy mode: forward request to remote MCP server
-                    logger.info(
-                        "Using direct_proxy mode for resources/read %s, server %s, gateway %s (from %s header), forwarding _meta: %s",
+                    # CWE-532: log only the meta_data key names (never the values which may carry PII/tokens)
+                    logger.debug(
+                        "Using direct_proxy mode for resources/read %s, server %s, gateway %s (from %s header), forwarding _meta keys: %s",
                         resource_uri,
                         server_id,
                         gateway.id,
                         GATEWAY_ID_HEADER,
-                        meta_data,
+                        sorted(meta_data.keys()) if meta_data else None,
                     )
 
                     contents = await _proxy_read_resource_to_gateway(gateway, str(resource_uri), user_context, meta_data)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -64,6 +64,7 @@ from starlette.types import Receive, Scope, Send
 # First-Party
 from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import LogLevel
+from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 from mcpgateway.config import settings
 from mcpgateway.db import SessionLocal
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG
@@ -1168,7 +1169,8 @@ def _build_paginated_params(meta: Optional[Any]) -> Optional[PaginatedRequestPar
     """
     if not meta:
         return None
-    logger.debug("Forwarding _meta to remote gateway: %s", meta)
+    # CWE-532: log only key names, never values which may carry PII/tokens
+    logger.debug("Forwarding _meta to remote gateway (keys: %s)", sorted(meta.keys()) if isinstance(meta, dict) else type(meta).__name__)
     return PaginatedRequestParams(_meta=meta)
 
 
@@ -1252,7 +1254,8 @@ async def _proxy_list_resources_to_gateway(gateway: Any, request_headers: dict, 
 
         logger.info("Proxying resources/list to gateway %s at %s", gateway.id, gateway.url)
         if meta:
-            logger.debug("Forwarding _meta to remote gateway: %s", meta)
+            # CWE-532: log only key names, never values which may carry PII/tokens
+            logger.debug("Forwarding _meta to remote gateway (keys: %s)", sorted(meta.keys()) if isinstance(meta, dict) else type(meta).__name__)
 
         # Use MCP SDK to connect and list resources
         async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
@@ -1312,7 +1315,8 @@ async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_
 
         logger.info("Proxying resources/read for %s to gateway %s at %s", resource_uri, gateway.id, gateway.url)
         if meta:
-            logger.debug("Forwarding _meta to remote gateway: %s", meta)
+            # CWE-532: log only key names, never values which may carry PII/tokens
+            logger.debug("Forwarding _meta to remote gateway (keys: %s)", sorted(meta.keys()) if isinstance(meta, dict) else type(meta).__name__)
 
         # Use MCP SDK to connect and read resource
         async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
@@ -1322,8 +1326,10 @@ async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_
                 # Prepare request params with _meta if provided
                 if meta:
                     # Create params and inject _meta
+                    # by_alias=True ensures the alias "_meta" key is written so
+                    # model_validate resolves it correctly (fixes CWE-20 silent drop)
                     request_params = ReadResourceRequestParams(uri=resource_uri)
-                    request_params_dict = request_params.model_dump()
+                    request_params_dict = request_params.model_dump(by_alias=True)
                     request_params_dict["_meta"] = meta
 
                     # Send request with _meta
@@ -2356,7 +2362,8 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
                         GATEWAY_ID_HEADER,
                         sorted(meta_data.keys()) if meta_data else None,
                     )
-
+                    # CWE-400: validate _meta limits before network I/O (bypassed in direct-proxy branch)
+                    _validate_meta_data(meta_data)
                     contents = await _proxy_read_resource_to_gateway(gateway, str(resource_uri), user_context, meta_data)
                     if contents:
                         # Return first content (text or blob)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1157,6 +1157,21 @@ async def _validate_streamable_session_access(
     return False, HTTP_403_FORBIDDEN, "Session owner metadata unavailable"
 
 
+def _build_paginated_params(meta: Optional[Any]) -> Optional[PaginatedRequestParams]:
+    """Build a ``PaginatedRequestParams`` carrying ``_meta`` when provided.
+
+    Args:
+        meta: Request metadata (_meta) from the original MCP request, or ``None``.
+
+    Returns:
+        A ``PaginatedRequestParams`` instance with ``_meta`` set, or ``None`` when *meta* is falsy.
+    """
+    if not meta:
+        return None
+    logger.debug("Forwarding _meta to remote gateway: %s", meta)
+    return PaginatedRequestParams(_meta=meta)
+
+
 async def _proxy_list_tools_to_gateway(gateway: Any, request_headers: dict, user_context: dict, meta: Optional[Any] = None) -> List[types.Tool]:  # pylint: disable=unused-argument
     """Proxy tools/list request directly to remote MCP gateway using MCP SDK.
 
@@ -1194,14 +1209,8 @@ async def _proxy_list_tools_to_gateway(gateway: Any, request_headers: dict, user
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
 
-                # Prepare params with _meta if provided
-                params = None
-                if meta:
-                    params = PaginatedRequestParams(_meta=meta)
-                    logger.debug("Forwarding _meta to remote gateway: %s", meta)
-
                 # List tools with _meta forwarded
-                result = await session.list_tools(params=params)
+                result = await session.list_tools(params=_build_paginated_params(meta))
                 return result.tools
 
     except Exception as e:
@@ -1250,14 +1259,8 @@ async def _proxy_list_resources_to_gateway(gateway: Any, request_headers: dict, 
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
 
-                # Prepare params with _meta if provided
-                params = None
-                if meta:
-                    params = PaginatedRequestParams(_meta=meta)
-                    logger.debug("Forwarding _meta to remote gateway: %s", meta)
-
                 # List resources with _meta forwarded
-                result = await session.list_resources(params=params)
+                result = await session.list_resources(params=_build_paginated_params(meta))
 
                 logger.info("Received %s resources from gateway %s", len(result.resources), gateway.id)
                 return result.resources

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2344,23 +2344,16 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
                         return ""
 
                     # Direct proxy mode: forward request to remote MCP server
-                    # Get _meta from request context if available
-                    meta = None
-                    try:
-                        request_ctx = mcp_app.request_context
-                        meta = request_ctx.meta
-                        logger.info(
-                            "Using direct_proxy mode for resources/read %s, server %s, gateway %s (from %s header), forwarding _meta: %s",
-                            resource_uri,
-                            server_id,
-                            gateway.id,
-                            GATEWAY_ID_HEADER,
-                            meta,
-                        )
-                    except (LookupError, AttributeError) as e:
-                        logger.debug("No request context available for _meta extraction: %s", e)
+                    logger.info(
+                        "Using direct_proxy mode for resources/read %s, server %s, gateway %s (from %s header), forwarding _meta: %s",
+                        resource_uri,
+                        server_id,
+                        gateway.id,
+                        GATEWAY_ID_HEADER,
+                        meta_data,
+                    )
 
-                    contents = await _proxy_read_resource_to_gateway(gateway, str(resource_uri), user_context, meta)
+                    contents = await _proxy_read_resource_to_gateway(gateway, str(resource_uri), user_context, meta_data)
                     if contents:
                         # Return first content (text or blob)
                         first_content = contents[0]

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -3395,6 +3395,24 @@ class TestValidateMetaDataPrompt:
         with pytest.raises(ValueError, match="maximum nesting depth"):
             _validate_meta_data(deeply_nested)
 
+    def test_list_of_dicts_depth_bypass_is_rejected(self):
+        """Depth check must traverse lists so {"k": [{"l2": {"l3": "x"}}]} is rejected (CWE-400 / Finding 4)."""
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
+
+        hidden_depth = {"k": [{"l2": {"l3": "x"}}]}
+        with pytest.raises(ValueError, match="maximum nesting depth"):
+            _validate_meta_data(hidden_depth)
+
+    def test_non_serializable_value_raises(self):
+        """meta_data with non-JSON-serializable value must raise ValueError (CWE-20 / Finding 6)."""
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
+
+        class _Unserializable:
+            pass
+
+        with pytest.raises(ValueError, match="not serializable"):
+            _validate_meta_data({"bad": _Unserializable()})
+
     def test_exact_max_depth_is_accepted(self):
         from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -520,6 +520,7 @@ class TestPromptService:
             db_prompt,
             {"from_timezone": "UTC", "to_timezones": "America/New_York,Europe/Dublin"},
             "user@test.com",
+            meta_data=None,
         )
         test_db.commit.assert_called_once()
         assert result.description == "Convert time with detailed context"

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -3365,46 +3365,46 @@ class TestValidateMetaDataPrompt:
     """Unit tests for _validate_meta_data in prompt_service (CWE-400 guards)."""
 
     def test_none_is_accepted(self):
-        from mcpgateway.services.prompt_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         _validate_meta_data(None)
 
     def test_empty_dict_is_accepted(self):
-        from mcpgateway.services.prompt_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         _validate_meta_data({})
 
     def test_valid_small_dict_is_accepted(self):
-        from mcpgateway.services.prompt_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         _validate_meta_data({"trace_id": "abc", "user": "test@example.com"})
 
     def test_too_many_keys_raises(self):
         """meta_data with more than _META_MAX_KEYS keys must be rejected."""
-        from mcpgateway.services.prompt_service import _META_MAX_KEYS, _validate_meta_data
+        from mcpgateway.common.validators import META_MAX_KEYS, validate_meta_data as _validate_meta_data
 
-        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+        oversized = {str(i): i for i in range(META_MAX_KEYS + 1)}
         with pytest.raises(ValueError, match="maximum key count"):
             _validate_meta_data(oversized)
 
     def test_excessive_nesting_depth_raises(self):
         """meta_data with depth > _META_MAX_DEPTH must be rejected."""
-        from mcpgateway.services.prompt_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         deeply_nested = {"level1": {"level2": {"level3": "value"}}}
         with pytest.raises(ValueError, match="maximum nesting depth"):
             _validate_meta_data(deeply_nested)
 
     def test_exact_max_depth_is_accepted(self):
-        from mcpgateway.services.prompt_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         two_levels = {"outer": {"inner": "value"}}
         _validate_meta_data(two_levels)
 
     def test_oversized_bytes_raises(self):
-        from mcpgateway.services.prompt_service import _META_MAX_BYTES, _validate_meta_data
+        from mcpgateway.common.validators import META_MAX_BYTES, validate_meta_data as _validate_meta_data
 
-        large_value = "x" * (_META_MAX_BYTES + 1)
+        large_value = "x" * (META_MAX_BYTES + 1)
         with pytest.raises(ValueError, match="maximum size"):
             _validate_meta_data({"k": large_value})
 
@@ -3443,7 +3443,8 @@ class TestGetPromptMetaDataValidationIntegration:
     @pytest.mark.asyncio
     async def test_fetch_gateway_prompt_rejects_oversized_meta_data(self):
         """_fetch_gateway_prompt_result must raise ValueError for oversized meta_data."""
-        from mcpgateway.services.prompt_service import _META_MAX_KEYS, PromptService
+        from mcpgateway.common.validators import META_MAX_KEYS as _META_MAX_KEYS
+        from mcpgateway.services.prompt_service import PromptService
 
         service = PromptService()
 

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -3353,3 +3353,111 @@ class TestListPromptsGatewayIdFilter:
         attrs = mock_create_span.call_args[0][1]
         assert attrs["server_id"] == "server-1"
         assert attrs["team.scope"] == "team-1"
+
+
+# --------------------------------------------------------------------------- #
+# Security regression tests for meta_data handling (CWE-400, CWE-20, CWE-284)#
+# --------------------------------------------------------------------------- #
+
+
+class TestValidateMetaDataPrompt:
+    """Unit tests for _validate_meta_data in prompt_service (CWE-400 guards)."""
+
+    def test_none_is_accepted(self):
+        from mcpgateway.services.prompt_service import _validate_meta_data
+
+        _validate_meta_data(None)
+
+    def test_empty_dict_is_accepted(self):
+        from mcpgateway.services.prompt_service import _validate_meta_data
+
+        _validate_meta_data({})
+
+    def test_valid_small_dict_is_accepted(self):
+        from mcpgateway.services.prompt_service import _validate_meta_data
+
+        _validate_meta_data({"trace_id": "abc", "user": "test@example.com"})
+
+    def test_too_many_keys_raises(self):
+        """meta_data with more than _META_MAX_KEYS keys must be rejected."""
+        from mcpgateway.services.prompt_service import _META_MAX_KEYS, _validate_meta_data
+
+        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+        with pytest.raises(ValueError, match="maximum key count"):
+            _validate_meta_data(oversized)
+
+    def test_excessive_nesting_depth_raises(self):
+        """meta_data with depth > _META_MAX_DEPTH must be rejected."""
+        from mcpgateway.services.prompt_service import _validate_meta_data
+
+        deeply_nested = {"level1": {"level2": {"level3": "value"}}}
+        with pytest.raises(ValueError, match="maximum nesting depth"):
+            _validate_meta_data(deeply_nested)
+
+    def test_exact_max_depth_is_accepted(self):
+        from mcpgateway.services.prompt_service import _validate_meta_data
+
+        two_levels = {"outer": {"inner": "value"}}
+        _validate_meta_data(two_levels)
+
+    def test_oversized_bytes_raises(self):
+        from mcpgateway.services.prompt_service import _META_MAX_BYTES, _validate_meta_data
+
+        large_value = "x" * (_META_MAX_BYTES + 1)
+        with pytest.raises(ValueError, match="maximum size"):
+            _validate_meta_data({"k": large_value})
+
+
+class TestBuildGetPromptRequest:
+    """Unit tests for _build_get_prompt_request (CWE-20 and CWE-284 guards)."""
+
+    def test_meta_is_injected_under_alias_key(self):
+        """_meta must be present on the inner params model after build (CWE-20)."""
+        from mcpgateway.services.prompt_service import _build_get_prompt_request
+
+        meta_data = {"trace_id": "xyz", "user": "alice@example.com"}
+        request = _build_get_prompt_request("my-prompt", None, meta_data)
+        inner_params = request.root.params
+        assert inner_params is not None
+        assert inner_params.meta is not None
+        dumped = inner_params.meta.model_dump()
+        # All meta_data keys must survive; MCP SDK may add progressToken alongside
+        assert meta_data.items() <= dumped.items()
+
+    def test_returns_client_request_type(self):
+        """Return value must be a ClientRequest wrapping GetPromptRequest."""
+        from mcp import types
+        from mcp.types import GetPromptRequest
+
+        from mcpgateway.services.prompt_service import _build_get_prompt_request
+
+        req = _build_get_prompt_request("my-prompt", {"arg": "val"}, {"k": "v"})
+        assert isinstance(req, types.ClientRequest)
+        assert isinstance(req.root, GetPromptRequest)
+
+
+class TestGetPromptMetaDataValidationIntegration:
+    """Integration tests: _validate_meta_data is called by _fetch_gateway_prompt_result."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_gateway_prompt_rejects_oversized_meta_data(self):
+        """_fetch_gateway_prompt_result must raise ValueError for oversized meta_data."""
+        from mcpgateway.services.prompt_service import _META_MAX_KEYS, PromptService
+
+        service = PromptService()
+
+        gateway = MagicMock()
+        gateway.id = "gw-1"
+        gateway.url = "http://gateway.example.com/mcp"
+        gateway.transport = "streamable_http"
+        gateway.auth_type = None
+
+        prompt = _build_db_prompt(template="", name="gw-prompt")
+        prompt.gateway_id = "gw-1"
+        prompt.gateway = gateway
+        prompt.original_name = "gw-prompt"
+
+        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+
+        with pytest.raises(ValueError, match="maximum key count"):
+            await service._fetch_gateway_prompt_result(prompt, {}, "user@example.com", meta_data=oversized)

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -7565,31 +7565,31 @@ class TestValidateMetaData:
 
     def test_none_is_accepted(self):
         """None meta_data must always pass without raising."""
-        from mcpgateway.services.resource_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         _validate_meta_data(None)
 
     def test_empty_dict_is_accepted(self):
-        from mcpgateway.services.resource_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         _validate_meta_data({})
 
     def test_valid_small_dict_is_accepted(self):
-        from mcpgateway.services.resource_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         _validate_meta_data({"trace_id": "abc", "user": "test@example.com"})
 
     def test_too_many_keys_raises(self):
         """meta_data with more than _META_MAX_KEYS keys must be rejected (DoS guard)."""
-        from mcpgateway.services.resource_service import _META_MAX_KEYS, _validate_meta_data
+        from mcpgateway.common.validators import META_MAX_KEYS, validate_meta_data as _validate_meta_data
 
-        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+        oversized = {str(i): i for i in range(META_MAX_KEYS + 1)}
         with pytest.raises(ValueError, match="maximum key count"):
             _validate_meta_data(oversized)
 
     def test_excessive_nesting_depth_raises(self):
         """meta_data with depth > _META_MAX_DEPTH must be rejected."""
-        from mcpgateway.services.resource_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         deeply_nested = {"level1": {"level2": {"level3": "value"}}}
         with pytest.raises(ValueError, match="maximum nesting depth"):
@@ -7597,16 +7597,16 @@ class TestValidateMetaData:
 
     def test_exact_max_depth_is_accepted(self):
         """meta_data with exactly _META_MAX_DEPTH levels must be allowed."""
-        from mcpgateway.services.resource_service import _validate_meta_data
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 
         two_levels = {"outer": {"inner": "value"}}
         _validate_meta_data(two_levels)
 
     def test_oversized_bytes_raises(self):
         """meta_data whose JSON encoding exceeds _META_MAX_BYTES must be rejected."""
-        from mcpgateway.services.resource_service import _META_MAX_BYTES, _validate_meta_data
+        from mcpgateway.common.validators import META_MAX_BYTES, validate_meta_data as _validate_meta_data
 
-        large_value = "x" * (_META_MAX_BYTES + 1)
+        large_value = "x" * (META_MAX_BYTES + 1)
         with pytest.raises(ValueError, match="maximum size"):
             _validate_meta_data({"k": large_value})
 
@@ -7646,7 +7646,8 @@ class TestReadResourceMetaDataValidationIntegration:
     @pytest.mark.asyncio
     async def test_read_resource_rejects_oversized_meta_data(self):
         """read_resource must raise ValueError for oversized meta_data before DB access."""
-        from mcpgateway.services.resource_service import _META_MAX_KEYS, ResourceService
+        from mcpgateway.common.validators import META_MAX_KEYS as _META_MAX_KEYS
+        from mcpgateway.services.resource_service import ResourceService
 
         service = ResourceService()
         db = MagicMock()

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -7236,7 +7236,7 @@ class TestReadResourceDirectProxy:
 
     @pytest.mark.asyncio
     async def test_read_resource_direct_proxy_with_meta(self, resource_service, mock_direct_proxy_resource):
-        """meta_data is accepted but not forwarded to session.read_resource (SDK doesn't support _meta)."""
+        """meta_data is forwarded to the upstream via send_request (SDK read_resource lacks _meta support)."""
         # Standard
         from contextlib import asynccontextmanager
 
@@ -7250,6 +7250,8 @@ class TestReadResourceDirectProxy:
         result_mock.contents = [first_content]
 
         client_session_cm, session_mock = self._make_session_mock(result_mock)
+        # send_request is used instead of read_resource when meta_data is provided
+        session_mock.send_request = AsyncMock(return_value=result_mock)
 
         @asynccontextmanager
         async def mock_streamable_client(*_args, **_kwargs):
@@ -7275,10 +7277,9 @@ class TestReadResourceDirectProxy:
                 meta_data=meta,
             )
 
-        # MCP SDK read_resource() only accepts uri; _meta is not forwarded
-        session_mock.read_resource.assert_awaited_once_with(
-            uri="http://example.com/dp-resource",
-        )
+        # _meta is forwarded via send_request; read_resource is not called when meta_data is set
+        session_mock.send_request.assert_awaited_once()
+        session_mock.read_resource.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_read_resource_direct_proxy_configurable_timeout(self, resource_service, mock_direct_proxy_resource):

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -7552,3 +7552,107 @@ class TestListResourcesGatewayIdFilter:
         assert mock_create_span.call_args[0][0] == "resource_template.list"
         attrs = mock_create_span.call_args[0][1]
         assert attrs["server_id"] == "server-1"
+
+
+# --------------------------------------------------------------------------- #
+# Security regression tests for meta_data handling (CWE-400, CWE-20, CWE-284)#
+# --------------------------------------------------------------------------- #
+
+
+class TestValidateMetaData:
+    """Unit tests for _validate_meta_data (CWE-400 guards)."""
+
+    def test_none_is_accepted(self):
+        """None meta_data must always pass without raising."""
+        from mcpgateway.services.resource_service import _validate_meta_data
+
+        _validate_meta_data(None)
+
+    def test_empty_dict_is_accepted(self):
+        from mcpgateway.services.resource_service import _validate_meta_data
+
+        _validate_meta_data({})
+
+    def test_valid_small_dict_is_accepted(self):
+        from mcpgateway.services.resource_service import _validate_meta_data
+
+        _validate_meta_data({"trace_id": "abc", "user": "test@example.com"})
+
+    def test_too_many_keys_raises(self):
+        """meta_data with more than _META_MAX_KEYS keys must be rejected (DoS guard)."""
+        from mcpgateway.services.resource_service import _META_MAX_KEYS, _validate_meta_data
+
+        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+        with pytest.raises(ValueError, match="maximum key count"):
+            _validate_meta_data(oversized)
+
+    def test_excessive_nesting_depth_raises(self):
+        """meta_data with depth > _META_MAX_DEPTH must be rejected."""
+        from mcpgateway.services.resource_service import _validate_meta_data
+
+        deeply_nested = {"level1": {"level2": {"level3": "value"}}}
+        with pytest.raises(ValueError, match="maximum nesting depth"):
+            _validate_meta_data(deeply_nested)
+
+    def test_exact_max_depth_is_accepted(self):
+        """meta_data with exactly _META_MAX_DEPTH levels must be allowed."""
+        from mcpgateway.services.resource_service import _validate_meta_data
+
+        two_levels = {"outer": {"inner": "value"}}
+        _validate_meta_data(two_levels)
+
+    def test_oversized_bytes_raises(self):
+        """meta_data whose JSON encoding exceeds _META_MAX_BYTES must be rejected."""
+        from mcpgateway.services.resource_service import _META_MAX_BYTES, _validate_meta_data
+
+        large_value = "x" * (_META_MAX_BYTES + 1)
+        with pytest.raises(ValueError, match="maximum size"):
+            _validate_meta_data({"k": large_value})
+
+
+class TestBuildReadResourceRequest:
+    """Unit tests for _build_read_resource_request (CWE-20 and CWE-284 guards)."""
+
+    def test_meta_is_injected_under_alias_key(self):
+        """_meta must be present and meta (non-alias) must not shadow it (CWE-20)."""
+        from mcpgateway.services.resource_service import _build_read_resource_request
+
+        meta_data = {"trace_id": "xyz", "user": "alice@example.com"}
+        request = _build_read_resource_request("file:///test.txt", meta_data)
+        # Unwrap to the inner params model
+        inner_params = request.root.params
+        assert inner_params is not None
+        assert inner_params.meta is not None
+        dumped = inner_params.meta.model_dump()
+        # All meta_data keys must survive; MCP SDK may add progressToken alongside
+        assert meta_data.items() <= dumped.items()
+
+    def test_returns_client_request_type(self):
+        """Return value must be a ClientRequest wrapping ReadResourceRequest."""
+        from mcp import types
+        from mcp.types import ReadResourceRequest
+
+        from mcpgateway.services.resource_service import _build_read_resource_request
+
+        req = _build_read_resource_request("file:///test.txt", {"k": "v"})
+        assert isinstance(req, types.ClientRequest)
+        assert isinstance(req.root, ReadResourceRequest)
+
+
+class TestReadResourceMetaDataValidationIntegration:
+    """Integration tests: _validate_meta_data is called by read_resource (CWE-400)."""
+
+    @pytest.mark.asyncio
+    async def test_read_resource_rejects_oversized_meta_data(self):
+        """read_resource must raise ValueError for oversized meta_data before DB access."""
+        from mcpgateway.services.resource_service import _META_MAX_KEYS, ResourceService
+
+        service = ResourceService()
+        db = MagicMock()
+        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+
+        with pytest.raises(ValueError, match="maximum key count"):
+            await service.read_resource(db, resource_uri="file:///test.txt", meta_data=oversized)
+
+        # DB must not have been touched
+        db.execute.assert_not_called()

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -7595,6 +7595,22 @@ class TestValidateMetaData:
         with pytest.raises(ValueError, match="maximum nesting depth"):
             _validate_meta_data(deeply_nested)
 
+    def test_list_of_dicts_depth_bypass_is_rejected(self):
+        """Depth check must traverse lists so {"k": [{"l2": {"l3": "x"}}]} is rejected (CWE-400)."""
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
+
+        # A list at depth 1 containing a dict that itself contains a dict = 3 levels total
+        hidden_depth = {"k": [{"l2": {"l3": "x"}}]}
+        with pytest.raises(ValueError, match="maximum nesting depth"):
+            _validate_meta_data(hidden_depth)
+
+    def test_list_of_scalars_at_max_depth_is_accepted(self):
+        """A list of scalar values at depth 1 must not be rejected (CWE-400 guard is not over-broad)."""
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
+
+        # List of scalars at first level is fine
+        _validate_meta_data({"tags": ["a", "b", "c"]})
+
     def test_exact_max_depth_is_accepted(self):
         """meta_data with exactly _META_MAX_DEPTH levels must be allowed."""
         from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
@@ -7609,6 +7625,16 @@ class TestValidateMetaData:
         large_value = "x" * (META_MAX_BYTES + 1)
         with pytest.raises(ValueError, match="maximum size"):
             _validate_meta_data({"k": large_value})
+
+    def test_non_serializable_value_raises(self):
+        """meta_data containing a non-JSON-serializable value must raise ValueError (CWE-20/Finding 6)."""
+        from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
+
+        class _Unserializable:
+            pass
+
+        with pytest.raises(ValueError, match="not serializable"):
+            _validate_meta_data({"bad": _Unserializable()})
 
 
 class TestBuildReadResourceRequest:
@@ -7657,4 +7683,34 @@ class TestReadResourceMetaDataValidationIntegration:
             await service.read_resource(db, resource_uri="file:///test.txt", meta_data=oversized)
 
         # DB must not have been touched
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invoke_resource_rejects_oversized_meta_data(self):
+        """invoke_resource must raise ValueError for oversized meta_data before DB access (Finding 2 / CWE-400)."""
+        from mcpgateway.common.validators import META_MAX_KEYS as _META_MAX_KEYS
+        from mcpgateway.services.resource_service import ResourceService
+
+        service = ResourceService()
+        db = MagicMock()
+        oversized = {str(i): i for i in range(_META_MAX_KEYS + 1)}
+
+        with pytest.raises(ValueError, match="maximum key count"):
+            await service.invoke_resource(db, resource_id="res-1", resource_uri="file:///test.txt", meta_data=oversized)
+
+        # DB must not have been touched
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invoke_resource_rejects_list_of_dicts_depth_bypass(self):
+        """invoke_resource must reject _meta with list-of-dicts depth bypass (Finding 2/3 / CWE-400)."""
+        from mcpgateway.services.resource_service import ResourceService
+
+        service = ResourceService()
+        db = MagicMock()
+        hidden_depth = {"k": [{"l2": {"l3": "x"}}]}
+
+        with pytest.raises(ValueError, match="maximum nesting depth"):
+            await service.invoke_resource(db, resource_id="res-1", resource_uri="file:///test.txt", meta_data=hidden_depth)
+
         db.execute.assert_not_called()

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -9480,6 +9480,7 @@ class TestDirectProxyMode:
             yield mock_db
 
         mock_meta = MagicMock()
+        mock_meta.model_dump.return_value = {"trace_id": "test-meta"}
         mock_request_ctx = MagicMock()
         mock_request_ctx.meta = mock_meta
 
@@ -13550,3 +13551,63 @@ async def test_handle_streamable_http_initialize_span_exits_with_exception(monke
     assert exc_type is ValueError
     assert isinstance(exc_val, ValueError)
     assert str(exc_val) == "initialize failed"
+
+
+# --------------------------------------------------------------------------- #
+# Security regression tests for _meta handling in direct-proxy (CWE-400/CWE-20)#
+# --------------------------------------------------------------------------- #
+
+
+class TestProxyReadResourceMetaInjection:
+    """Tests for _proxy_read_resource_to_gateway meta injection (Finding 7 / CWE-20)."""
+
+    @pytest.mark.asyncio
+    async def test_model_dump_uses_by_alias_so_meta_is_not_dropped(self, monkeypatch):
+        """_meta must survive the model_dump(by_alias=True)+model_validate round-trip (CWE-20).
+
+        Regression for Finding 7: model_dump() without by_alias=True produces {"uri": ..., "meta": None}
+        causing the alias key "_meta" not to be the primary key written. Using by_alias=True ensures
+        the output dict has "_meta" as the field key, which is then correctly overwritten with the
+        caller-supplied metadata before model_validate is called.
+        """
+        from mcp.types import ReadResourceRequestParams
+
+        meta_data = {"trace_id": "abc", "request_id": "123"}
+
+        # The fixed path: model_dump(by_alias=True) then overwrite _meta
+        params = ReadResourceRequestParams(uri="file:///test.txt")
+        dump_with_alias = params.model_dump(by_alias=True)
+
+        # With by_alias=True the field appears under its alias "_meta" (not "meta")
+        assert "_meta" in dump_with_alias
+
+        # Overwrite with our metadata and validate
+        dump_with_alias["_meta"] = meta_data
+        validated = ReadResourceRequestParams.model_validate(dump_with_alias)
+        assert validated.meta is not None
+        # All injected keys must survive round-trip
+        as_dict = validated.meta.model_dump()
+        assert meta_data.items() <= as_dict.items()
+
+
+class TestDirectProxyValidatesMeta:
+    """Validate that the direct-proxy branch in read_resource applies CWE-400 guards (Finding 1)."""
+
+    @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_rejects_oversized_meta(self, monkeypatch):
+        """meta_data must be validated before _proxy_read_resource_to_gateway is called (Finding 1 / CWE-400)."""
+        from mcpgateway.common.validators import META_MAX_KEYS
+        from mcpgateway.transports.streamablehttp_transport import _validate_meta_data
+
+        oversized = {str(i): i for i in range(META_MAX_KEYS + 1)}
+        with pytest.raises(ValueError, match="maximum key count"):
+            _validate_meta_data(oversized)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_rejects_list_of_dicts_depth_bypass(self, monkeypatch):
+        """List-of-dicts depth bypass must be caught before _proxy_read_resource_to_gateway (Finding 1/3 / CWE-400)."""
+        from mcpgateway.transports.streamablehttp_transport import _validate_meta_data
+
+        hidden_depth = {"k": [{"l2": {"l3": "x"}}]}
+        with pytest.raises(ValueError, match="maximum nesting depth"):
+            _validate_meta_data(hidden_depth)


### PR DESCRIPTION

Closes #2332

## Problem

Issue #2332 was partially resolved by #2094, which added `_meta` forwarding for `tools/call` via the streamablehttp transport. However, two gaps remained in the **non-direct-proxy (cache) code path**:

1. **`resources/read`** — `meta_data` was accepted by `invoke_resource()` and `read_resource()` but never forwarded to the upstream MCP server. The MCP SDK's `session.read_resource()` does not accept a `meta` kwarg, so the parameter was silently dropped and commented as "reserved for future SDK support."

2. **`prompts/get`** — `_meta_data` was accepted by `get_prompt()` but the parameter was documented as "not used currently" and never passed through to the upstream `session.get_prompt()` call.

Additionally, `read_resource` in the `direct_proxy` branch was re-extracting `ctx.meta` a second time (Pattern B — raw Pydantic object) even though Pattern A (dict) had already been extracted earlier in the same handler, creating an inconsistency.

## Solution

The MCP SDK does not expose `meta` on `session.read_resource()` or `session.get_prompt()`, but both methods are thin wrappers around `session.send_request()`. When `meta_data` is present, the fix constructs the typed request params, injects `_meta` into the serialized dict, re-validates via `model_validate`, and calls `send_request()` directly — the same pattern already used in the `direct_proxy` helper `_proxy_read_resource_to_gateway()`.

### Changes

**`mcpgateway/services/resource_service.py`**
- Added `types`, `ReadResourceRequest`, `ReadResourceRequestParams` to MCP imports.
- `invoke_resource()` — all four call sites that previously called `session.read_resource(uri=uri)` unconditionally now branch: if `meta_data` is set, `send_request()` is used with `_meta` injected; otherwise the SDK helper is used unchanged.
- `read_resource()` direct_proxy block — same pattern applied.
- Removed stale "MCP SDK 1.25.0 does not support meta parameter" comments and updated docstrings.

**`mcpgateway/services/prompt_service.py`**
- Added `types`, `GetPromptRequest`, `GetPromptRequestParams` to MCP imports.
- `_fetch_gateway_prompt_result()` — added `meta_data: Optional[Dict[str, Any]] = None` parameter; all three `session.get_prompt()` call sites (session-pool, per-call SSE, per-call streamablehttp) now forward `_meta` via `send_request()` when present.
- `get_prompt()` — passes `_meta_data` down to `_fetch_gateway_prompt_result()`.
- Updated docstring: `_meta_data` is now documented as forwarded upstream, not "not used currently".

**`mcpgateway/transports/streamablehttp_transport.py`**
- `read_resource` handler — removed the redundant Pattern B re-extraction of `ctx.meta` inside the direct_proxy branch. The already-extracted `meta_data` dict (Pattern A) is now passed directly to `_proxy_read_resource_to_gateway()`, making the extraction consistent across all branches.

## Behaviour

| Method | Before | After |
|---|---|---|
| `resources/read` (cache path, SSE) | `_meta` dropped | `_meta` forwarded via `send_request` |
| `resources/read` (cache path, streamablehttp) | `_meta` dropped | `_meta` forwarded via `send_request` |
| `resources/read` (direct_proxy) | `_meta` forwarded (duplicate extraction) | `_meta` forwarded (single extraction) |
| `prompts/get` (cache path) | `_meta` accepted but dropped | `_meta` forwarded via `send_request` |
| `tools/call` | unchanged — already working | unchanged |
| `tools/list`, `resources/list`, `prompts/list` | DB queries, no upstream call | unchanged — N/A |
