### PR TITLE
fix(ci): install node directly in playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,11 +61,22 @@ jobs:
           version: "0.9.2"
           python-version: "3.12"
 
-      - name: 🟢 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
+      - name: 🟢 Install Node.js 22
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+            | sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y nodejs
+          node --version
+          npm --version
+
+      - name: 🔧 Upgrade npm to minimum required version
+        run: sudo npm install -g npm@^11.10.0
 
       - name: 📦 Install gateway dependencies
         run: |


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
This fixes the Playwright smoke workflow so it installs Node.js without `actions/setup-node`, matching the repo's current CI pattern for Node bootstrap.

## 🔁 Reproduction Steps
1. Open `.github/workflows/playwright.yml`.
2. See the workflow use `actions/setup-node@v4`.
3. Run in an environment where that action is not allowed.
4. The Playwright CI job cannot complete its Node setup phase.

## 🐞 Root Cause
`playwright.yml` still depended on `actions/setup-node`, while other repo workflows already install Node directly through the Nodesource apt repository. That left Playwright CI out of line with the allowed CI setup pattern.

## 💡 Fix Description
- Replaced `actions/setup-node` with a direct apt-based Node 22 install.
- Added the same npm minimum-version upgrade used in other Node-based workflows.
- Left the rest of the Playwright smoke job unchanged.

## 🧪 Verification

| Check                                 | Command                                                                 | Status |
|---------------------------------------|-------------------------------------------------------------------------|--------|
| Workflow lint                         | `actionlint .github/workflows/playwright.yml`                           | ✅ |
| Admin UI build path                   | `npm ci && npm run vite:build`                                          | ✅ |
| Playwright CI smoke locally           | `TEST_BASE_URL=http://127.0.0.1:4444 make test-ui-ci-smoke` against `make serve` | ✅ |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
