### PR TITLE
feat: add binding_reference_id to tool plugin bindings and expand plugin config schemas

### DIFF
--- a/docs/docs/api/plugin-bindings-api.md
+++ b/docs/docs/api/plugin-bindings-api.md
@@ -54,6 +54,8 @@ Non-admin callers may only create bindings for teams they belong to. Attempting 
 - **Updated in place** if a row already exists (the `id`, `created_at`, and `created_by` are preserved).
 - **Inserted** if no matching row exists.
 
+**Stale tool pruning**: when a policy includes a `binding_reference_id`, any existing binding that shares the same `binding_reference_id` and `plugin_id` but whose `tool_name` is **not** in the incoming `tool_names` list is automatically deleted. This keeps the stored state in sync when an external system (e.g. WXO) sends a full replacement tool list on an UPDATE event.
+
 On success, returns **all created/updated** bindings and immediately invalidates the in-process plugin cache so the new config takes effect on the very next tool call.
 
 #### Request body
@@ -68,6 +70,7 @@ On success, returns **all created/updated** bindings and immediately invalidates
           "plugin_id": "<PLUGIN_ID>",
           "mode": "enforce | permissive | disabled",
           "priority": 10,
+          "binding_reference_id": "<EXTERNAL_BINDING_ID>",
           "config": { /* plugin-specific — see below */ }
         }
       ]
@@ -84,6 +87,7 @@ On success, returns **all created/updated** bindings and immediately invalidates
 | `policies[].plugin_id`      | enum string     | ✅        | —          | `OUTPUT_LENGTH_GUARD`, `RATE_LIMITER`, or `SECRETS_DETECTION`      |
 | `policies[].mode`           | enum string     | ❌        | `enforce`  | `enforce` = fail on violation; `permissive` = log only; `disabled` = skip |
 | `policies[].priority`       | int (1–1000)    | ❌        | `50`       | Lower runs first                                                    |
+| `policies[].binding_reference_id` | string   | ❌        | `null`     | External reference ID (e.g. WXO binding ID). Used for stale-tool pruning on UPDATE and bulk delete on DELETE. |
 | `policies[].config`         | object          | ✅        | —          | All config fields for the plugin must be present (full replace, no partial patch) |
 
 #### `mode` semantics
@@ -102,9 +106,18 @@ On success, returns **all created/updated** bindings and immediately invalidates
 
 List all bindings across all teams (admin use).
 
+| Query param            | Type   | Required | Description                                          |
+|------------------------|--------|----------|------------------------------------------------------|
+| `binding_reference_id` | string | ❌        | Filter — return only bindings with this reference ID |
+
 ```bash
+# All bindings
 curl -s -H "Authorization: Bearer $TOKEN" \
   http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings | jq
+
+# Filtered by external reference ID
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings?binding_reference_id=<WXO_BINDING_ID>" | jq
 ```
 
 ---
@@ -113,9 +126,32 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 List all bindings for a specific team.
 
+| Query param            | Type   | Required | Description                                          |
+|------------------------|--------|----------|------------------------------------------------------|
+| `binding_reference_id` | string | ❌        | Filter — return only bindings with this reference ID |
+
 ```bash
+# All bindings for a team
 curl -s -H "Authorization: Bearer $TOKEN" \
   http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings/<YOUR_TEAM_ID> | jq
+
+# Filtered by external reference ID within a team
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings/<YOUR_TEAM_ID>?binding_reference_id=<WXO_BINDING_ID>" | jq
+```
+
+---
+
+### `DELETE /v1/tools/plugin_bindings?binding_reference_id={ref}`
+
+Delete **all** bindings tagged with the given external reference ID. Intended for external systems (e.g. WXO sidecar) that need to remove all ContextForge bindings for one of their own binding objects on a `BINDING_DELETED` event, without knowing the internal ContextForge UUIDs.
+
+Returns the deleted records. Returns an empty list (not an error) if no bindings matched.
+
+```bash
+curl -s -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings?binding_reference_id=<WXO_BINDING_ID>" | jq
 ```
 
 ---
@@ -152,6 +188,7 @@ All write operations (`POST`, `DELETE`) and read operations (`GET`) return the s
     "strategy": "truncate",
     "ellipsis": "..."
   },
+  "binding_reference_id": "<WXO_BINDING_ID>",
   "created_at": "2026-04-07T17:00:00Z",
   "created_by": "admin@example.com",
   "updated_at": "2026-04-07T17:05:00Z",
@@ -456,7 +493,7 @@ curl -s -X POST \
 | `400`       | Invalid request payload (missing fields, bad config values)              |
 | `401`       | Missing or invalid Bearer token                                          |
 | `403`       | Caller lacks `tools.manage_plugins` or configuring bindings for a team they don't belong to |
-| `404`       | Binding ID not found (DELETE only)                                       |
+| `404`       | Binding ID not found (DELETE `/{binding_id}` only)                       |
 
 ### Example 400 — bad `OUTPUT_LENGTH_GUARD` config
 

--- a/docs/docs/api/plugin-bindings-api.md
+++ b/docs/docs/api/plugin-bindings-api.md
@@ -54,7 +54,7 @@ Non-admin callers may only create bindings for teams they belong to. Attempting 
 - **Updated in place** if a row already exists (the `id`, `created_at`, and `created_by` are preserved).
 - **Inserted** if no matching row exists.
 
-**Stale tool pruning**: when a policy includes a `binding_reference_id`, any existing binding that shares the same `binding_reference_id` and `plugin_id` but whose `tool_name` is **not** in the incoming `tool_names` list is automatically deleted. This keeps the stored state in sync when an external system (e.g. WXO) sends a full replacement tool list on an UPDATE event.
+**Stale tool pruning**: when a policy includes a `binding_reference_id`, any existing binding that shares the same `binding_reference_id` and `plugin_id` but whose `tool_name` is **not** in the incoming `tool_names` list is automatically deleted. This keeps the stored state in sync when an external system sends a full replacement tool list on an update event.
 
 On success, returns **all created/updated** bindings and immediately invalidates the in-process plugin cache so the new config takes effect on the very next tool call.
 
@@ -87,7 +87,7 @@ On success, returns **all created/updated** bindings and immediately invalidates
 | `policies[].plugin_id`      | enum string     | ✅        | —          | `OUTPUT_LENGTH_GUARD`, `RATE_LIMITER`, or `SECRETS_DETECTION`      |
 | `policies[].mode`           | enum string     | ❌        | `enforce`  | `enforce` = fail on violation; `permissive` = log only; `disabled` = skip |
 | `policies[].priority`       | int (1–1000)    | ❌        | `50`       | Lower runs first                                                    |
-| `policies[].binding_reference_id` | string   | ❌        | `null`     | External reference ID (e.g. WXO binding ID). Used for stale-tool pruning on UPDATE and bulk delete on DELETE. |
+| `policies[].binding_reference_id` | string   | ❌        | `null`     | External reference ID for correlating this binding with an upstream system. Used for stale-tool pruning on update and bulk delete. |
 | `policies[].config`         | object          | ✅        | —          | All config fields for the plugin must be present (full replace, no partial patch) |
 
 #### `mode` semantics
@@ -117,7 +117,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 # Filtered by external reference ID
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings?binding_reference_id=<WXO_BINDING_ID>" | jq
+  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings?binding_reference_id=<EXTERNAL_REFERENCE_ID>" | jq
 ```
 
 ---
@@ -126,37 +126,32 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 List all bindings for a specific team.
 
-| Query param            | Type   | Required | Description                                          |
-|------------------------|--------|----------|------------------------------------------------------|
-| `binding_reference_id` | string | ❌        | Filter — return only bindings with this reference ID |
+| Query param            | Type   | Required | Description                                                                                          |
+|------------------------|--------|----------|------------------------------------------------------------------------------------------------------|
+| `binding_reference_id` | string | ❌        | If provided, **takes precedence over `team_id`** — returns all bindings with this reference ID across all teams |
 
 ```bash
 # All bindings for a team
 curl -s -H "Authorization: Bearer $TOKEN" \
   http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings/<YOUR_TEAM_ID> | jq
 
-# Filtered by external reference ID within a team
+# Filtered by external reference ID (team_id is ignored when binding_reference_id is present)
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings/<YOUR_TEAM_ID>?binding_reference_id=<WXO_BINDING_ID>" | jq
+  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings/<YOUR_TEAM_ID>?binding_reference_id=<EXTERNAL_REFERENCE_ID>" | jq
 ```
 
 ---
 
 ### `DELETE /v1/tools/plugin_bindings?binding_reference_id={ref}`
 
-Delete **all** bindings tagged with the given external reference ID. Intended for external systems (e.g. WXO sidecar) that need to remove all ContextForge bindings for one of their own binding objects on a `BINDING_DELETED` event, without knowing the internal ContextForge UUIDs.
+Delete **all** bindings tagged with the given external reference ID. Intended for external systems that need to remove all bindings associated with one of their own reference objects without knowing the internal ContextForge UUIDs.
 
 Returns the deleted records. Returns an empty list (not an error) if no bindings matched.
 
 ```bash
 curl -s -X DELETE \
   -H "Authorization: Bearer $TOKEN" \
-  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings?binding_reference_id=<WXO_BINDING_ID>" | jq
-```
-
----
-
-### `DELETE /v1/tools/plugin_bindings/{binding_id}`
+  "http://<GATEWAY_HOST>:<GATEWAY_PORT>/v1/tools/plugin_bindings?binding_reference_id=<EXTERNAL_REFERENCE_ID>" | jq
 
 Delete a single binding by its UUID. Returns the deleted record.
 
@@ -188,7 +183,7 @@ All write operations (`POST`, `DELETE`) and read operations (`GET`) return the s
     "strategy": "truncate",
     "ellipsis": "..."
   },
-  "binding_reference_id": "<WXO_BINDING_ID>",
+  "binding_reference_id": "<EXTERNAL_REFERENCE_ID>",
   "created_at": "2026-04-07T17:00:00Z",
   "created_by": "admin@example.com",
   "updated_at": "2026-04-07T17:05:00Z",

--- a/mcpgateway/alembic/versions/d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py
+++ b/mcpgateway/alembic/versions/d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "d3e4f5a6b7c8"
-down_revision: Union[str, Sequence[str], None] = "c2d3e4f5a6b7"
+revision: str = "d3e4f5a6b7c8"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "c2d3e4f5a6b7"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py
+++ b/mcpgateway/alembic/versions/d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py
@@ -22,21 +22,49 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Add nullable binding_reference_id column and index to tool_plugin_bindings."""
-    op.add_column(
-        "tool_plugin_bindings",
-        sa.Column("binding_reference_id", sa.String(255), nullable=True),
-    )
-    op.create_index(
-        "ix_tool_plugin_bindings_binding_reference_id",
-        "tool_plugin_bindings",
-        ["binding_reference_id"],
-    )
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Skip if table doesn't exist (fresh DB uses db.py models directly)
+    if "tool_plugin_bindings" not in inspector.get_table_names():
+        return
+
+    # Skip if column already exists (idempotent re-run guard)
+    columns = [col["name"] for col in inspector.get_columns("tool_plugin_bindings")]
+    if "binding_reference_id" not in columns:
+        op.add_column(
+            "tool_plugin_bindings",
+            sa.Column("binding_reference_id", sa.String(255), nullable=True),
+        )
+
+    # Add index only if it doesn't already exist
+    indexes = [idx["name"] for idx in inspector.get_indexes("tool_plugin_bindings")]
+    if "ix_tool_plugin_bindings_binding_reference_id" not in indexes:
+        op.create_index(
+            "ix_tool_plugin_bindings_binding_reference_id",
+            "tool_plugin_bindings",
+            ["binding_reference_id"],
+        )
 
 
 def downgrade() -> None:
     """Remove binding_reference_id column and index from tool_plugin_bindings."""
-    op.drop_index(
-        "ix_tool_plugin_bindings_binding_reference_id",
-        table_name="tool_plugin_bindings",
-    )
-    op.drop_column("tool_plugin_bindings", "binding_reference_id")
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Skip if table doesn't exist
+    if "tool_plugin_bindings" not in inspector.get_table_names():
+        return
+
+    # Drop index if it exists
+    indexes = [idx["name"] for idx in inspector.get_indexes("tool_plugin_bindings")]
+    if "ix_tool_plugin_bindings_binding_reference_id" in indexes:
+        op.drop_index(
+            "ix_tool_plugin_bindings_binding_reference_id",
+            table_name="tool_plugin_bindings",
+        )
+
+    # Drop column if it exists
+    columns = [col["name"] for col in inspector.get_columns("tool_plugin_bindings")]
+    if "binding_reference_id" in columns:
+        op.drop_column("tool_plugin_bindings", "binding_reference_id")

--- a/mcpgateway/alembic/versions/d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py
+++ b/mcpgateway/alembic/versions/d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Add binding_reference_id to tool_plugin_bindings.
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-04-10
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3e4f5a6b7c8"
+down_revision: Union[str, Sequence[str], None] = "c2d3e4f5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable binding_reference_id column and index to tool_plugin_bindings."""
+    op.add_column(
+        "tool_plugin_bindings",
+        sa.Column("binding_reference_id", sa.String(255), nullable=True),
+    )
+    op.create_index(
+        "ix_tool_plugin_bindings_binding_reference_id",
+        "tool_plugin_bindings",
+        ["binding_reference_id"],
+    )
+
+
+def downgrade() -> None:
+    """Remove binding_reference_id column and index from tool_plugin_bindings."""
+    op.drop_index(
+        "ix_tool_plugin_bindings_binding_reference_id",
+        table_name="tool_plugin_bindings",
+    )
+    op.drop_column("tool_plugin_bindings", "binding_reference_id")

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6608,6 +6608,7 @@ class ToolPluginBinding(Base):
     mode: Mapped[str] = mapped_column(String(20), nullable=False, default="enforce")
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=50)
     config: Mapped[Dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    binding_reference_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
     created_by: Mapped[str] = mapped_column(String(255), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
@@ -6620,6 +6621,7 @@ class ToolPluginBinding(Base):
         UniqueConstraint("team_id", "tool_name", "plugin_id", name="uq_tool_plugin_binding"),
         Index("ix_tool_plugin_bindings_team_id", "team_id"),
         Index("ix_tool_plugin_bindings_tool_name", "tool_name"),
+        Index("ix_tool_plugin_bindings_binding_reference_id", "binding_reference_id"),
     )
 
     def __repr__(self) -> str:

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6578,7 +6578,7 @@ class ToolPluginBinding(Base):
         mode (str): ``"enforce"`` | ``"permissive"`` | ``"disabled"``.
         priority (int): Execution priority — lower numbers run first.
         config (dict): Plugin-specific JSON configuration blob.
-        binding_reference_id (str): Optional external reference ID (e.g. WXO binding ID) for bulk delete and stale-tool pruning.
+        binding_reference_id (str): Optional external reference ID for bulk delete and stale-tool pruning.
         created_at (datetime): Row creation timestamp (UTC).
         created_by (str): Email of the user who created the binding.
         updated_at (datetime): Last update timestamp (UTC).

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6578,6 +6578,7 @@ class ToolPluginBinding(Base):
         mode (str): ``"enforce"`` | ``"permissive"`` | ``"disabled"``.
         priority (int): Execution priority — lower numbers run first.
         config (dict): Plugin-specific JSON configuration blob.
+        binding_reference_id (str): Optional external reference ID (e.g. WXO binding ID) for bulk delete and stale-tool pruning.
         created_at (datetime): Row creation timestamp (UTC).
         created_by (str): Email of the user who created the binding.
         updated_at (datetime): Last update timestamp (UTC).

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -19,7 +19,7 @@ Endpoints:
 from typing import Any, Dict, List, Optional
 
 # Third-Party
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -172,15 +172,15 @@ async def list_tool_plugin_bindings_for_team(
 @router.delete("/", response_model=ToolPluginBindingListResponse, status_code=status.HTTP_200_OK)
 @require_permission("tools.manage_plugins")
 async def delete_tool_plugin_bindings_by_reference(
-    binding_reference_id: str,
+    binding_reference_id: str = Query(..., min_length=1, description="External reference ID whose bindings to delete"),
     current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> ToolPluginBindingListResponse:
     """Delete all bindings associated with an external reference ID.
 
-    Intended for use by external systems (e.g. a WXO sidecar) that need to
-    remove all ContextForge bindings tied to one of their own binding objects
-    on a BINDING_DELETED event, without knowing the internal ContextForge UUIDs.
+    Intended for use by external systems that need to remove all ContextForge
+    bindings tied to one of their own reference objects without knowing the
+    internal ContextForge UUIDs.
 
     Returns the deleted records (empty list if none matched — not an error).
 

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -8,14 +8,15 @@ Tool Plugin Bindings Router.
 Provides endpoints for configuring per-tool per-tenant plugin policies.
 
 Endpoints:
-    POST   /v1/tools/plugin_bindings          — Create or update bindings (upsert)
-    GET    /v1/tools/plugin_bindings           — List all bindings
-    GET    /v1/tools/plugin_bindings/{team_id} — List bindings for a specific team
-    DELETE /v1/tools/plugin_bindings/{id}      — Delete a binding by ID
+    POST   /v1/tools/plugin_bindings                              — Create or update bindings (upsert)
+    GET    /v1/tools/plugin_bindings                              — List all bindings
+    GET    /v1/tools/plugin_bindings/{team_id}                    — List bindings for a specific team
+    DELETE /v1/tools/plugin_bindings?binding_reference_id={ref}   — Delete all bindings by external reference ID
+    DELETE /v1/tools/plugin_bindings/{id}                         — Delete a binding by UUID
 """
 
 # Standard
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -107,12 +108,14 @@ async def upsert_tool_plugin_bindings(
 @router.get("/", response_model=ToolPluginBindingListResponse)
 @require_permission("tools.read")
 async def list_tool_plugin_bindings(
+    binding_reference_id: Optional[str] = None,
     current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> ToolPluginBindingListResponse:
     """List all tool plugin bindings across all teams.
 
     Args:
+        binding_reference_id: Optional filter — return only bindings with this reference ID.
         current_user_ctx: Authenticated user context.
         db: Database session.
 
@@ -124,7 +127,7 @@ async def list_tool_plugin_bindings(
         >>> asyncio.iscoroutinefunction(list_tool_plugin_bindings)
         True
     """
-    bindings = _service.list_bindings(db, team_id=None)
+    bindings = _service.list_bindings(db, team_id=None, binding_reference_id=binding_reference_id)
     return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
 
 
@@ -137,6 +140,7 @@ async def list_tool_plugin_bindings(
 @require_permission("tools.read")
 async def list_tool_plugin_bindings_for_team(
     team_id: str,
+    binding_reference_id: Optional[str] = None,
     current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> ToolPluginBindingListResponse:
@@ -144,6 +148,7 @@ async def list_tool_plugin_bindings_for_team(
 
     Args:
         team_id: Team identifier to filter by.
+        binding_reference_id: Optional filter — return only bindings with this reference ID.
         current_user_ctx: Authenticated user context.
         db: Database session.
 
@@ -155,8 +160,49 @@ async def list_tool_plugin_bindings_for_team(
         >>> asyncio.iscoroutinefunction(list_tool_plugin_bindings_for_team)
         True
     """
-    bindings = _service.list_bindings(db, team_id=team_id)
+    bindings = _service.list_bindings(db, team_id=team_id, binding_reference_id=binding_reference_id)
     return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
+
+
+# ---------------------------------------------------------------------------
+# DELETE / — remove all bindings by external reference ID
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/", response_model=ToolPluginBindingListResponse, status_code=status.HTTP_200_OK)
+@require_permission("tools.manage_plugins")
+async def delete_tool_plugin_bindings_by_reference(
+    binding_reference_id: str,
+    current_user_ctx: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ToolPluginBindingListResponse:
+    """Delete all bindings associated with an external reference ID.
+
+    Intended for use by external systems (e.g. a WXO sidecar) that need to
+    remove all ContextForge bindings tied to one of their own binding objects
+    on a BINDING_DELETED event, without knowing the internal ContextForge UUIDs.
+
+    Returns the deleted records (empty list if none matched — not an error).
+
+    Args:
+        binding_reference_id: The external reference ID whose bindings to delete.
+        current_user_ctx: Authenticated user context.
+        db: Database session.
+
+    Returns:
+        ToolPluginBindingListResponse: All deleted binding records.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(delete_tool_plugin_bindings_by_reference)
+        True
+    """
+    deleted: List[ToolPluginBindingResponse] = _service.delete_bindings_by_reference(db, binding_reference_id)
+    db.commit()
+    # Invalidate cache for every affected (team_id, tool_name) pair.
+    for ctx_id in {make_context_id(b.team_id, b.tool_name) for b in deleted}:
+        await reload_plugin_context(ctx_id)
+    return ToolPluginBindingListResponse(bindings=deleted, total=len(deleted))
 
 
 # ---------------------------------------------------------------------------

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7999,30 +7999,48 @@ class OutputLengthGuardConfig(BaseModel):
 
     Attributes:
         min_chars: Minimum character count (>= 0).
-        max_chars: Maximum character count (> 1).
+        max_chars: Maximum character count. None disables the check.
+        min_tokens: Minimum token count (0 disables).
+        max_tokens: Maximum token count. None disables the check.
+        chars_per_token: Characters per token ratio for estimation (1-10).
+        limit_mode: Enforcement mode — 'character' or 'token'.
         strategy: What to do when limit is exceeded.
         ellipsis: Suffix appended when truncating.
+        word_boundary: Truncate at word boundaries to avoid mid-word cuts.
+        max_text_length: Maximum text size to process (bytes). Prevents memory exhaustion.
+        max_structure_size: Maximum items in list/dict. Prevents DoS attacks.
+        max_recursion_depth: Maximum nesting depth. Prevents stack overflow.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     min_chars: int = Field(0, ge=0, description="Minimum character count, must be >= 0")
-    max_chars: int = Field(2000, gt=1, description="Maximum character count, must be > 1")
+    max_chars: Optional[int] = Field(None, description="Maximum character count; None or 0 disables the check")
+    min_tokens: int = Field(0, ge=0, description="Minimum token count; 0 disables")
+    max_tokens: Optional[int] = Field(None, description="Maximum token count; None or 0 disables")
+    chars_per_token: int = Field(4, ge=1, le=10, description="Characters per token ratio for estimation")
+    limit_mode: Literal["character", "token"] = Field("character", description="Enforcement mode: 'character' or 'token'")
     strategy: Literal["truncate", "block"] = Field("truncate", description="Action when limit exceeded")
-    ellipsis: str = Field("...", max_length=20, description="Suffix appended on truncation")
+    ellipsis: str = Field("\u2026", max_length=20, description="Suffix appended on truncation")
+    word_boundary: bool = Field(False, description="Truncate at word boundaries to avoid mid-word cuts")
+    max_text_length: int = Field(1_000_000, ge=1, description="Maximum text size to process; prevents memory exhaustion")
+    max_structure_size: int = Field(10_000, ge=1, description="Maximum items in list/dict; prevents DoS")
+    max_recursion_depth: int = Field(100, ge=1, description="Maximum nesting depth; prevents stack overflow")
 
     @model_validator(mode="after")
     def min_less_than_max(self) -> "OutputLengthGuardConfig":
-        """Validate min_chars < max_chars.
+        """Validate min < max for both chars and tokens when the max is set.
 
         Returns:
             self after validation.
 
         Raises:
-            ValueError: If min_chars >= max_chars.
+            ValueError: If min_chars >= max_chars or min_tokens >= max_tokens.
         """
-        if self.min_chars >= self.max_chars:
+        if self.max_chars is not None and self.max_chars > 0 and self.min_chars >= self.max_chars:
             raise ValueError("min_chars must be less than max_chars")
+        if self.max_tokens is not None and self.max_tokens > 0 and self.min_tokens >= self.max_tokens:
+            raise ValueError("min_tokens must be less than max_tokens")
         return self
 
 
@@ -8035,16 +8053,26 @@ class RateLimiterConfig(BaseModel):
     Attributes:
         by_user: Rate limit per user.
         by_tenant: Rate limit per tenant.
-        by_tool: Rate limit per tool.
+        by_tool: Per-tool rate limits as a dict of tool_name to rate string.
+        algorithm: Counting algorithm.
+        backend: Storage backend.
+        redis_url: Redis connection URL (required when backend='redis').
+        redis_key_prefix: Prefix for all Redis keys.
+        redis_fallback: Fall back to memory if Redis is unavailable.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     by_user: Optional[str] = Field(None, description="Rate limit per user, e.g. '60/m' or '10/s'")
     by_tenant: Optional[str] = Field(None, description="Rate limit per tenant, e.g. '600/m'")
-    by_tool: Optional[str] = Field(None, description="Rate limit per tool, e.g. '10/m'")
+    by_tool: Optional[Dict[str, str]] = Field(None, description="Per-tool rate limits, e.g. {'search': '10/m'}")
+    algorithm: Literal["fixed_window", "sliding_window", "token_bucket"] = Field("fixed_window", description="Counting algorithm")
+    backend: Literal["memory", "redis"] = Field("memory", description="Storage backend")
+    redis_url: Optional[str] = Field(None, description="Redis URL, e.g. 'redis://localhost:6379/0'; required when backend='redis'")
+    redis_key_prefix: str = Field("rl", description="Prefix for all Redis keys")
+    redis_fallback: bool = Field(True, description="Fall back to memory if Redis is unavailable")
 
-    @field_validator("by_user", "by_tenant", "by_tool", mode="before")
+    @field_validator("by_user", "by_tenant", mode="before")
     @classmethod
     def validate_rate_string(cls, v: Optional[str]) -> Optional[str]:
         """Validate rate string format <count>/<s|m>.
@@ -8062,6 +8090,27 @@ class RateLimiterConfig(BaseModel):
             return v
         if not re.match(r"^\d+/[sm]$", v):
             raise ValueError(f"Rate string '{v}' is invalid. Use format '<count>/s' or '<count>/m'")
+        return v
+
+    @field_validator("by_tool", mode="before")
+    @classmethod
+    def validate_by_tool_rate_strings(cls, v: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
+        """Validate each per-tool rate string.
+
+        Args:
+            v: Dict of tool_name to rate string.
+
+        Returns:
+            Validated dict or None.
+
+        Raises:
+            ValueError: If any rate string is invalid.
+        """
+        if v is None:
+            return v
+        for tool_name, rate in v.items():
+            if not re.match(r"^\d+/[sm]$", rate):
+                raise ValueError(f"Rate string '{rate}' for tool '{tool_name}' is invalid. Use format '<count>/s' or '<count>/m'")
         return v
 
 
@@ -8114,7 +8163,7 @@ class PluginPolicyItem(BaseModel):
     mode: PluginBindingMode = Field(PluginBindingMode.ENFORCE, description="Execution mode: enforce, permissive, or disabled")
     priority: int = Field(50, ge=1, le=1000, description="Execution priority; lower numbers run first")
     config: Dict[str, Any] = Field(
-        ..., description="Plugin-specific configuration; always provide all fields you care about — on upsert the config is fully replaced, so any key you omit reverts to the plugin's default value"
+        ..., description="Plugin-specific configuration. All schema fields for the selected plugin must be provided — partial configs are rejected at validation time. On upsert the entire config is fully replaced; there is no merge with the previously stored config."
     )
     binding_reference_id: Optional[str] = Field(None, description="Optional external reference ID (e.g. WXO binding ID) for correlating this binding with an upstream system")
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8165,7 +8165,12 @@ class PluginPolicyItem(BaseModel):
     config: Dict[str, Any] = Field(
         ..., description="Plugin-specific configuration. All schema fields for the selected plugin must be provided — partial configs are rejected at validation time. On upsert the entire config is fully replaced; there is no merge with the previously stored config."
     )
-    binding_reference_id: Optional[str] = Field(None, max_length=255, description="Optional external reference ID for correlating this binding with an upstream system")
+    binding_reference_id: Optional[str] = Field(
+        None,
+        max_length=255,
+        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$",
+        description="Optional external reference ID for correlating this binding with an upstream system",
+    )
 
     @model_validator(mode="after")
     def validate_config_for_plugin(self) -> "PluginPolicyItem":

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8014,18 +8014,18 @@ class OutputLengthGuardConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    min_chars: int = Field(0, ge=0, description="Minimum character count, must be >= 0")
-    max_chars: Optional[int] = Field(None, description="Maximum character count; None or 0 disables the check")
-    min_tokens: int = Field(0, ge=0, description="Minimum token count; 0 disables")
-    max_tokens: Optional[int] = Field(None, description="Maximum token count; None or 0 disables")
-    chars_per_token: int = Field(4, ge=1, le=10, description="Characters per token ratio for estimation")
-    limit_mode: Literal["character", "token"] = Field("character", description="Enforcement mode: 'character' or 'token'")
-    strategy: Literal["truncate", "block"] = Field("truncate", description="Action when limit exceeded")
-    ellipsis: str = Field("\u2026", max_length=20, description="Suffix appended on truncation")
-    word_boundary: bool = Field(False, description="Truncate at word boundaries to avoid mid-word cuts")
-    max_text_length: int = Field(1_000_000, ge=1, description="Maximum text size to process; prevents memory exhaustion")
-    max_structure_size: int = Field(10_000, ge=1, description="Maximum items in list/dict; prevents DoS")
-    max_recursion_depth: int = Field(100, ge=1, description="Maximum nesting depth; prevents stack overflow")
+    min_chars: int = Field(..., ge=0, description="Minimum character count, must be >= 0")
+    max_chars: Optional[int] = Field(..., description="Maximum character count; None or 0 disables the check")
+    min_tokens: int = Field(..., ge=0, description="Minimum token count; 0 disables")
+    max_tokens: Optional[int] = Field(..., description="Maximum token count; None or 0 disables")
+    chars_per_token: int = Field(..., ge=1, le=10, description="Characters per token ratio for estimation")
+    limit_mode: Literal["character", "token"] = Field(..., description="Enforcement mode: 'character' or 'token'")
+    strategy: Literal["truncate", "block"] = Field(..., description="Action when limit exceeded")
+    ellipsis: str = Field(..., max_length=20, description="Suffix appended on truncation")
+    word_boundary: bool = Field(..., description="Truncate at word boundaries to avoid mid-word cuts")
+    max_text_length: int = Field(..., ge=1, description="Maximum text size to process; prevents memory exhaustion")
+    max_structure_size: int = Field(..., ge=1, description="Maximum items in list/dict; prevents DoS")
+    max_recursion_depth: int = Field(..., ge=1, description="Maximum nesting depth; prevents stack overflow")
 
     @model_validator(mode="after")
     def min_less_than_max(self) -> "OutputLengthGuardConfig":
@@ -8063,14 +8063,14 @@ class RateLimiterConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    by_user: Optional[str] = Field(None, description="Rate limit per user, e.g. '60/m' or '10/s'")
-    by_tenant: Optional[str] = Field(None, description="Rate limit per tenant, e.g. '600/m'")
-    by_tool: Optional[Dict[str, str]] = Field(None, description="Per-tool rate limits, e.g. {'search': '10/m'}")
-    algorithm: Literal["fixed_window", "sliding_window", "token_bucket"] = Field("fixed_window", description="Counting algorithm")
-    backend: Literal["memory", "redis"] = Field("memory", description="Storage backend")
-    redis_url: Optional[str] = Field(None, description="Redis URL, e.g. 'redis://localhost:6379/0'; required when backend='redis'")
-    redis_key_prefix: str = Field("rl", description="Prefix for all Redis keys")
-    redis_fallback: bool = Field(True, description="Fall back to memory if Redis is unavailable")
+    by_user: Optional[str] = Field(..., description="Rate limit per user, e.g. '60/m' or '10/s'; null disables")
+    by_tenant: Optional[str] = Field(..., description="Rate limit per tenant, e.g. '600/m'; null disables")
+    by_tool: Optional[Dict[str, str]] = Field(..., description="Per-tool rate limits, e.g. {'search': '10/m'}; null disables")
+    algorithm: Literal["fixed_window", "sliding_window", "token_bucket"] = Field(..., description="Counting algorithm")
+    backend: Literal["memory", "redis"] = Field(..., description="Storage backend")
+    redis_url: Optional[str] = Field(..., description="Redis URL, e.g. 'redis://localhost:6379/0'; required when backend='redis', null otherwise")
+    redis_key_prefix: str = Field(..., description="Prefix for all Redis keys")
+    redis_fallback: bool = Field(..., description="Fall back to memory if Redis is unavailable")
 
     @field_validator("by_user", "by_tenant", mode="before")
     @classmethod
@@ -8127,11 +8127,11 @@ class SecretsDetectionConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: Dict[str, bool] = Field(default_factory=dict, description="Map of pattern names to enabled flag, e.g. {'aws_key': true}")
-    redact: bool = Field(True, description="Whether to redact detected secrets")
-    redaction_text: str = Field("[REDACTED]", max_length=50, description="Text to replace secrets with when redacting")
-    block_on_detection: bool = Field(False, description="Whether to block the response when secrets are detected")
-    min_findings_to_block: int = Field(1, ge=1, description="Minimum number of findings required to block")
+    enabled: Dict[str, bool] = Field(..., description="Map of pattern names to enabled flag, e.g. {'aws_key': true}")
+    redact: bool = Field(..., description="Whether to redact detected secrets")
+    redaction_text: str = Field(..., max_length=50, description="Text to replace secrets with when redacting")
+    block_on_detection: bool = Field(..., description="Whether to block the response when secrets are detected")
+    min_findings_to_block: int = Field(..., ge=1, description="Minimum number of findings required to block")
 
 
 # Map of plugin_id → config schema class for validation

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8116,6 +8116,7 @@ class PluginPolicyItem(BaseModel):
     config: Dict[str, Any] = Field(
         ..., description="Plugin-specific configuration; always provide all fields you care about — on upsert the config is fully replaced, so any key you omit reverts to the plugin's default value"
     )
+    binding_reference_id: Optional[str] = Field(None, description="Optional external reference ID (e.g. WXO binding ID) for correlating this binding with an upstream system")
 
     @model_validator(mode="after")
     def validate_config_for_plugin(self) -> "PluginPolicyItem":
@@ -8214,6 +8215,7 @@ class ToolPluginBindingResponse(BaseModelWithConfigDict):
     mode: str = Field(..., description="Execution mode")
     priority: int = Field(..., description="Execution priority")
     config: Dict[str, Any] = Field(..., description="Plugin-specific configuration")
+    binding_reference_id: Optional[str] = Field(None, description="Optional external reference ID for correlating with an upstream system")
     created_at: datetime = Field(..., description="Creation timestamp")
     created_by: str = Field(..., description="Email of creator")
     updated_at: datetime = Field(..., description="Last update timestamp")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8014,18 +8014,18 @@ class OutputLengthGuardConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    min_chars: int = Field(..., ge=0, description="Minimum character count, must be >= 0")
-    max_chars: Optional[int] = Field(..., description="Maximum character count; None or 0 disables the check")
-    min_tokens: int = Field(..., ge=0, description="Minimum token count; 0 disables")
-    max_tokens: Optional[int] = Field(..., description="Maximum token count; None or 0 disables")
-    chars_per_token: int = Field(..., ge=1, le=10, description="Characters per token ratio for estimation")
-    limit_mode: Literal["character", "token"] = Field(..., description="Enforcement mode: 'character' or 'token'")
-    strategy: Literal["truncate", "block"] = Field(..., description="Action when limit exceeded")
-    ellipsis: str = Field(..., max_length=20, description="Suffix appended on truncation")
-    word_boundary: bool = Field(..., description="Truncate at word boundaries to avoid mid-word cuts")
-    max_text_length: int = Field(..., ge=1, description="Maximum text size to process; prevents memory exhaustion")
-    max_structure_size: int = Field(..., ge=1, description="Maximum items in list/dict; prevents DoS")
-    max_recursion_depth: int = Field(..., ge=1, description="Maximum nesting depth; prevents stack overflow")
+    min_chars: int = Field(default=0, ge=0, description="Minimum character count, must be >= 0")
+    max_chars: Optional[int] = Field(default=None, description="Maximum character count; None or 0 disables the check")
+    min_tokens: int = Field(default=0, ge=0, description="Minimum token count; 0 disables")
+    max_tokens: Optional[int] = Field(default=None, description="Maximum token count; None or 0 disables")
+    chars_per_token: int = Field(default=4, ge=1, le=10, description="Characters per token ratio for estimation")
+    limit_mode: Literal["character", "token"] = Field(default="character", description="Enforcement mode: 'character' or 'token'")
+    strategy: Literal["truncate", "block"] = Field(default="truncate", description="Action when limit exceeded")
+    ellipsis: str = Field(default="\u2026", max_length=20, description="Suffix appended on truncation")
+    word_boundary: bool = Field(default=False, description="Truncate at word boundaries to avoid mid-word cuts")
+    max_text_length: int = Field(default=1_000_000, ge=1, description="Maximum text size to process; prevents memory exhaustion")
+    max_structure_size: int = Field(default=10_000, ge=1, description="Maximum items in list/dict; prevents DoS")
+    max_recursion_depth: int = Field(default=100, ge=1, description="Maximum nesting depth; prevents stack overflow")
 
     @model_validator(mode="after")
     def min_less_than_max(self) -> "OutputLengthGuardConfig":
@@ -8063,14 +8063,14 @@ class RateLimiterConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    by_user: Optional[str] = Field(..., description="Rate limit per user, e.g. '60/m' or '10/s'; null disables")
-    by_tenant: Optional[str] = Field(..., description="Rate limit per tenant, e.g. '600/m'; null disables")
-    by_tool: Optional[Dict[str, str]] = Field(..., description="Per-tool rate limits, e.g. {'search': '10/m'}; null disables")
-    algorithm: Literal["fixed_window", "sliding_window", "token_bucket"] = Field(..., description="Counting algorithm")
-    backend: Literal["memory", "redis"] = Field(..., description="Storage backend")
-    redis_url: Optional[str] = Field(..., description="Redis URL, e.g. 'redis://localhost:6379/0'; required when backend='redis', null otherwise")
-    redis_key_prefix: str = Field(..., description="Prefix for all Redis keys")
-    redis_fallback: bool = Field(..., description="Fall back to memory if Redis is unavailable")
+    by_user: Optional[str] = Field(default=None, description="Rate limit per user, e.g. '60/m' or '10/s'; null disables")
+    by_tenant: Optional[str] = Field(default=None, description="Rate limit per tenant, e.g. '600/m'; null disables")
+    by_tool: Optional[Dict[str, str]] = Field(default=None, description="Per-tool rate limits, e.g. {'search': '10/m'}; null disables")
+    algorithm: Literal["fixed_window", "sliding_window", "token_bucket"] = Field(default="fixed_window", description="Counting algorithm")
+    backend: Literal["memory", "redis"] = Field(default="memory", description="Storage backend")
+    redis_url: Optional[str] = Field(default=None, description="Redis URL, e.g. 'redis://localhost:6379/0'; required when backend='redis', null otherwise")
+    redis_key_prefix: str = Field(default="rl", description="Prefix for all Redis keys")
+    redis_fallback: bool = Field(default=True, description="Fall back to memory if Redis is unavailable")
 
     @field_validator("by_user", "by_tenant", mode="before")
     @classmethod
@@ -8127,11 +8127,11 @@ class SecretsDetectionConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: Dict[str, bool] = Field(..., description="Map of pattern names to enabled flag, e.g. {'aws_key': true}")
-    redact: bool = Field(..., description="Whether to redact detected secrets")
-    redaction_text: str = Field(..., max_length=50, description="Text to replace secrets with when redacting")
-    block_on_detection: bool = Field(..., description="Whether to block the response when secrets are detected")
-    min_findings_to_block: int = Field(..., ge=1, description="Minimum number of findings required to block")
+    enabled: Dict[str, bool] = Field(default_factory=dict, description="Map of pattern names to enabled flag, e.g. {'aws_key': true}")
+    redact: bool = Field(default=True, description="Whether to redact detected secrets")
+    redaction_text: str = Field(default="[REDACTED]", max_length=50, description="Text to replace secrets with when redacting")
+    block_on_detection: bool = Field(default=False, description="Whether to block the response when secrets are detected")
+    min_findings_to_block: int = Field(default=1, ge=1, description="Minimum number of findings required to block")
 
 
 # Map of plugin_id → config schema class for validation

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8165,7 +8165,7 @@ class PluginPolicyItem(BaseModel):
     config: Dict[str, Any] = Field(
         ..., description="Plugin-specific configuration. All schema fields for the selected plugin must be provided — partial configs are rejected at validation time. On upsert the entire config is fully replaced; there is no merge with the previously stored config."
     )
-    binding_reference_id: Optional[str] = Field(None, description="Optional external reference ID (e.g. WXO binding ID) for correlating this binding with an upstream system")
+    binding_reference_id: Optional[str] = Field(None, max_length=255, description="Optional external reference ID for correlating this binding with an upstream system")
 
     @model_validator(mode="after")
     def validate_config_for_plugin(self) -> "PluginPolicyItem":

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -94,6 +94,7 @@ class ToolPluginBindingService:
             mode=binding.mode,
             priority=binding.priority,
             config=binding.config,
+            binding_reference_id=binding.binding_reference_id,
             created_at=binding.created_at,
             created_by=binding.created_by,
             updated_at=binding.updated_at,
@@ -117,6 +118,13 @@ class ToolPluginBindingService:
         - If a row already exists → update mode/priority/config/updated_by/updated_at.
         - If no row exists → insert a new row.
 
+        **Stale tool pruning**: when a policy carries a ``binding_reference_id``,
+        any existing binding that shares the same ``binding_reference_id`` and
+        ``plugin_id`` but whose ``tool_name`` is *not* in the incoming
+        ``tool_names`` list is deleted.  This keeps the stored state in sync
+        when an external system (e.g. WXO) sends a full replacement list of
+        tools on an UPDATE event.
+
         **Config replacement policy**: ``config`` is always fully replaced on
         update — it is NOT merged with the stored value.  To preserve existing
         keys the caller must include them in the new request payload.
@@ -139,8 +147,19 @@ class ToolPluginBindingService:
         existing_rows = db.query(ToolPluginBinding).filter(ToolPluginBinding.team_id.in_(team_ids)).all()
         existing_map: dict = {(b.team_id, b.tool_name, b.plugin_id): b for b in existing_rows}
 
+        # Track which (binding_reference_id, plugin_id) pairs appear in this
+        # request and which tool_names are authoritative for each pair so we
+        # can prune stale rows after the upsert loop.
+        # Structure: {(binding_reference_id, plugin_id_value): set_of_incoming_tool_names}
+        ref_plugin_tool_names: dict = {}
+
         for team_id, team_policies in request.teams.items():
             for policy in team_policies.policies:
+                # Build the authoritative tool-name set for stale pruning.
+                if policy.binding_reference_id:
+                    key = (policy.binding_reference_id, policy.plugin_id.value)
+                    ref_plugin_tool_names.setdefault(key, set()).update(policy.tool_names)
+
                 for tool_name in policy.tool_names:
                     existing = existing_map.get((team_id, tool_name, policy.plugin_id.value))
 
@@ -149,6 +168,7 @@ class ToolPluginBindingService:
                         existing.mode = policy.mode.value
                         existing.priority = policy.priority
                         existing.config = policy.config
+                        existing.binding_reference_id = policy.binding_reference_id
                         existing.updated_at = now
                         existing.updated_by = caller_email
                         results.append(self._to_response(existing))
@@ -168,6 +188,7 @@ class ToolPluginBindingService:
                             mode=policy.mode.value,
                             priority=policy.priority,
                             config=policy.config,
+                            binding_reference_id=policy.binding_reference_id,
                             created_at=now,
                             created_by=caller_email,
                             updated_at=now,
@@ -183,7 +204,30 @@ class ToolPluginBindingService:
                             policy.plugin_id.value,
                         )
 
-        db.flush()  # single flush for all inserts/updates
+        # Prune stale tool bindings for any (binding_reference_id, plugin_id)
+        # pair present in this request — rows whose tool_name is no longer in
+        # the authoritative incoming list are deleted.
+        for (ref_id, plugin_id_val), incoming_tools in ref_plugin_tool_names.items():
+            stale_rows = (
+                db.query(ToolPluginBinding)
+                .filter(
+                    ToolPluginBinding.binding_reference_id == ref_id,
+                    ToolPluginBinding.plugin_id == plugin_id_val,
+                    ToolPluginBinding.tool_name.notin_(incoming_tools),
+                )
+                .all()
+            )
+            for stale in stale_rows:
+                logger.debug(
+                    "Pruning stale tool binding id=%s ref=%s tool=%s plugin=%s",
+                    stale.id,
+                    ref_id,
+                    stale.tool_name,
+                    plugin_id_val,
+                )
+                db.delete(stale)
+
+        db.flush()  # single flush for all inserts/updates/deletes
         return results
 
     # ------------------------------------------------------------------
@@ -194,12 +238,14 @@ class ToolPluginBindingService:
         self,
         db: Session,
         team_id: Optional[str] = None,
+        binding_reference_id: Optional[str] = None,
     ) -> List[ToolPluginBindingResponse]:
-        """Return all bindings, optionally filtered by team.
+        """Return all bindings, optionally filtered by team and/or binding_reference_id.
 
         Args:
             db: SQLAlchemy session.
             team_id: If provided, return only bindings for this team.
+            binding_reference_id: If provided, return only bindings with this reference ID.
 
         Returns:
             List[ToolPluginBindingResponse]: Matching bindings.
@@ -207,6 +253,8 @@ class ToolPluginBindingService:
         query = db.query(ToolPluginBinding)
         if team_id:
             query = query.filter(ToolPluginBinding.team_id == team_id)
+        if binding_reference_id:
+            query = query.filter(ToolPluginBinding.binding_reference_id == binding_reference_id)
         bindings = query.order_by(ToolPluginBinding.team_id, ToolPluginBinding.priority).all()
         return [self._to_response(b) for b in bindings]
 
@@ -238,3 +286,31 @@ class ToolPluginBindingService:
         db.flush()  # flush so the DELETE is sent before the caller's commit
         logger.debug("Deleted tool plugin binding id=%s", binding_id)
         return response
+
+    def delete_bindings_by_reference(
+        self,
+        db: Session,
+        binding_reference_id: str,
+    ) -> List[ToolPluginBindingResponse]:
+        """Delete all bindings tagged with a given external reference ID.
+
+        Intended for use by external systems (e.g. WXO sidecar) that need to
+        remove all ContextForge bindings associated with one of their own
+        binding objects on a BINDING_DELETED event, without knowing the
+        internal ContextForge UUIDs.
+
+        Args:
+            db: SQLAlchemy session.
+            binding_reference_id: The external reference ID to match.
+
+        Returns:
+            List[ToolPluginBindingResponse]: All deleted binding records.
+                Returns an empty list (not an error) if no bindings matched.
+        """
+        rows = db.query(ToolPluginBinding).filter(ToolPluginBinding.binding_reference_id == binding_reference_id).all()
+        responses = [self._to_response(r) for r in rows]
+        for row in rows:
+            logger.debug("Deleted tool plugin binding id=%s ref=%s", row.id, binding_reference_id)
+            db.delete(row)
+        db.flush()
+        return responses

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -127,8 +127,8 @@ class ToolPluginBindingService:
         any existing binding that shares the same ``binding_reference_id`` and
         ``plugin_id`` but whose ``tool_name`` is *not* in the incoming
         ``tool_names`` list is deleted.  This keeps the stored state in sync
-        when an external system (e.g. WXO) sends a full replacement list of
-        tools on an UPDATE event.
+        when an external system sends a full replacement list of
+        tools on an update event.
 
         **Config replacement policy**: ``config`` is always fully replaced on
         update — it is NOT merged with the stored value.  To preserve existing
@@ -264,21 +264,27 @@ class ToolPluginBindingService:
         team_id: Optional[str] = None,
         binding_reference_id: Optional[str] = None,
     ) -> List[ToolPluginBindingResponse]:
-        """Return all bindings, optionally filtered by team and/or binding_reference_id.
+        """Return all bindings, optionally filtered by team or binding_reference_id.
+
+        When ``binding_reference_id`` is provided it takes precedence and
+        ``team_id`` is ignored — a reference ID is globally unique so scoping
+        by team is redundant and would produce confusing results.
 
         Args:
             db: SQLAlchemy session.
-            team_id: If provided, return only bindings for this team.
-            binding_reference_id: If provided, return only bindings with this reference ID.
+            team_id: If provided (and ``binding_reference_id`` is not), return
+                only bindings for this team.
+            binding_reference_id: If provided, return only bindings with this
+                reference ID (``team_id`` is ignored).
 
         Returns:
             List[ToolPluginBindingResponse]: Matching bindings.
         """
         query = db.query(ToolPluginBinding)
-        if team_id:
-            query = query.filter(ToolPluginBinding.team_id == team_id)
         if binding_reference_id:
             query = query.filter(ToolPluginBinding.binding_reference_id == binding_reference_id)
+        elif team_id:
+            query = query.filter(ToolPluginBinding.team_id == team_id)
         bindings = query.order_by(ToolPluginBinding.team_id, ToolPluginBinding.priority).all()
         return [self._to_response(b) for b in bindings]
 
@@ -318,10 +324,9 @@ class ToolPluginBindingService:
     ) -> List[ToolPluginBindingResponse]:
         """Delete all bindings tagged with a given external reference ID.
 
-        Intended for use by external systems (e.g. WXO sidecar) that need to
-        remove all ContextForge bindings associated with one of their own
-        binding objects on a BINDING_DELETED event, without knowing the
-        internal ContextForge UUIDs.
+        Intended for use by external systems that need to
+        remove all bindings associated with one of their own reference objects
+        without knowing the internal ContextForge UUIDs.
 
         Args:
             db: SQLAlchemy session.

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -282,6 +282,13 @@ class ToolPluginBindingService:
         """
         query = db.query(ToolPluginBinding)
         if binding_reference_id:
+            if team_id:
+                logger.warning(
+                    "Both team_id=%r and binding_reference_id=%r supplied to list_bindings; "
+                    "team_id will be ignored. Omit team_id when filtering by binding_reference_id.",
+                    team_id,
+                    binding_reference_id,
+                )
             query = query.filter(ToolPluginBinding.binding_reference_id == binding_reference_id)
         elif team_id:
             query = query.filter(ToolPluginBinding.team_id == team_id)

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -35,9 +35,9 @@ def get_bindings_for_tool(
     """Return deduplicated plugin bindings for a (team_id, tool_name) pair.
 
     Includes wildcard ``"*"`` bindings alongside exact-match bindings.
-    For duplicate plugin_ids, the most recently updated binding wins
-    (last-write-wins) so a specific tool_name entry overrides a ``"*"`` entry
-    when both exist for the same plugin.
+    For duplicate plugin_ids, an exact ``tool_name`` binding always takes
+    precedence over a ``"*"`` wildcard binding, regardless of insertion or
+    update order (specificity-wins semantics).
 
     Args:
         db: SQLAlchemy session.
@@ -53,15 +53,20 @@ def get_bindings_for_tool(
             ToolPluginBinding.team_id == team_id,
             ToolPluginBinding.tool_name.in_([tool_name, "*"]),
         )
-        .order_by(ToolPluginBinding.updated_at.asc())
         .all()
     )
-    # Last-write-wins: iterate ascending updated_at so exact matches (later)
-    # overwrite wildcard matches (earlier) for the same plugin_id.
-    seen: dict[str, ToolPluginBinding] = {}
+    # Specificity-wins: wildcard ("*") is the fallback; an exact tool_name
+    # binding always overrides the wildcard for the same plugin_id, regardless
+    # of insertion/update order.
+    wildcard: dict[str, ToolPluginBinding] = {}
+    specific: dict[str, ToolPluginBinding] = {}
     for binding in rows:
-        seen[binding.plugin_id] = binding
-    return list(seen.values())
+        if binding.tool_name == "*":
+            wildcard[binding.plugin_id] = binding
+        else:
+            specific[binding.plugin_id] = binding
+    # Merge: start with wildcards, let specific bindings overwrite
+    return list({**wildcard, **specific}.values())
 
 
 class ToolPluginBindingService:
@@ -164,6 +169,25 @@ class ToolPluginBindingService:
                     existing = existing_map.get((team_id, tool_name, policy.plugin_id.value))
 
                     if existing:
+                        # Warn if binding_reference_id ownership is changing — this means two
+                        # different external references are claiming the same (team, tool, plugin)
+                        # triple.  The new reference_id wins (last-caller-wins), but the old
+                        # caller's DELETE by reference will now be a no-op.
+                        if (
+                            existing.binding_reference_id
+                            and policy.binding_reference_id
+                            and existing.binding_reference_id != policy.binding_reference_id
+                        ):
+                            logger.warning(
+                                "binding_reference_id ownership transfer: "
+                                "team=%s tool=%s plugin=%s old_ref=%s new_ref=%s — "
+                                "DELETE by old_ref will now be a no-op",
+                                team_id,
+                                tool_name,
+                                policy.plugin_id.value,
+                                existing.binding_reference_id,
+                                policy.binding_reference_id,
+                            )
                         # Upsert — update mutable fields only
                         existing.mode = policy.mode.value
                         existing.priority = policy.priority

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -47,6 +47,23 @@ from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingSer
 
 
 # ---------------------------------------------------------------------------
+# Canonical full-field configs (must include all schema fields)
+# ---------------------------------------------------------------------------
+
+_OLG: dict = {
+    "min_chars": 0, "max_chars": 2000, "min_tokens": 0, "max_tokens": None,
+    "chars_per_token": 4, "limit_mode": "character", "strategy": "truncate",
+    "ellipsis": "\u2026", "word_boundary": False, "max_text_length": 1_000_000,
+    "max_structure_size": 10_000, "max_recursion_depth": 100,
+}
+_RL: dict = {
+    "by_user": None, "by_tenant": None, "by_tool": None,
+    "algorithm": "fixed_window", "backend": "memory",
+    "redis_url": None, "redis_key_prefix": "rl", "redis_fallback": True,
+}
+
+
+# ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
 
@@ -134,7 +151,7 @@ class TestGetConfigFromDb:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.ENFORCE,
                             priority=42,
-                            config={"min_chars": 0, "max_chars": 500, "strategy": "truncate", "ellipsis": "..."},
+                            config={**_OLG, "max_chars": 500},
                         )
                     ]
                 )
@@ -151,7 +168,7 @@ class TestGetConfigFromDb:
         assert o.name == "OutputLengthGuardPlugin"
         assert o.mode == PluginMode.ENFORCE
         assert o.priority == 42
-        assert o.config == {"min_chars": 0, "max_chars": 500, "strategy": "truncate", "ellipsis": "..."}
+        assert o.config == {**_OLG, "max_chars": 500}
 
     @pytest.mark.asyncio
     async def test_unknown_plugin_id_is_skipped(self, db_session):
@@ -194,7 +211,7 @@ class TestGetConfigFromDb:
                             plugin_id=PluginId.RATE_LIMITER,
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=5,
-                            config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+                            config={**_RL, "by_user": "60/m", "by_tenant": "600/m"},
                         )
                     ]
                 )

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -32,6 +32,7 @@ from sqlalchemy.pool import StaticPool
 from mcpgateway.db import Base
 from mcpgateway.routers.tool_plugin_bindings import (
     delete_tool_plugin_binding,
+    delete_tool_plugin_bindings_by_reference,
     list_tool_plugin_bindings,
     list_tool_plugin_bindings_for_team,
     upsert_tool_plugin_bindings,
@@ -533,3 +534,222 @@ class TestToolPluginBindingsRouter:
             )
 
         mock_reload.assert_awaited_once_with("team-a::tool_x")
+
+    # ------------------------------------------------------------------
+    # DELETE / — delete_tool_plugin_bindings_by_reference
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_delete_by_reference_success_multiple_bindings(self, user_ctx, db_session):
+        """DELETE ?binding_reference_id= removes all bindings with that reference and returns them."""
+        ref_request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x", "tool_y"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ext-ref-001",
+                        )
+                    ]
+                )
+            }
+        )
+        await upsert_tool_plugin_bindings(
+            request=ref_request,
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        result = await delete_tool_plugin_bindings_by_reference(
+            binding_reference_id="ext-ref-001",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        assert isinstance(result, ToolPluginBindingListResponse)
+        assert result.total == 2
+        assert all(b.binding_reference_id == "ext-ref-001" for b in result.bindings)
+        assert {b.tool_name for b in result.bindings} == {"tool_x", "tool_y"}
+
+        # Confirm both rows are gone
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_by_reference_no_match_returns_empty(self, user_ctx, db_session):
+        """DELETE ?binding_reference_id= with no matching bindings is not an error — returns empty list."""
+        result = await delete_tool_plugin_bindings_by_reference(
+            binding_reference_id="nonexistent-ref",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        assert isinstance(result, ToolPluginBindingListResponse)
+        assert result.total == 0
+        assert result.bindings == []
+
+    @pytest.mark.asyncio
+    async def test_delete_by_reference_only_deletes_matching_ref(self, user_ctx, db_session):
+        """DELETE ?binding_reference_id= only removes bindings with that specific reference ID."""
+        r1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-alpha",
+                        )
+                    ]
+                )
+            }
+        )
+        r2 = ToolPluginBindingRequest(
+            teams={
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_y"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-beta",
+                        )
+                    ]
+                )
+            }
+        )
+        await upsert_tool_plugin_bindings(request=r1, current_user_ctx=user_ctx, db=db_session)
+        await upsert_tool_plugin_bindings(request=r2, current_user_ctx=user_ctx, db=db_session)
+
+        deleted = await delete_tool_plugin_bindings_by_reference(
+            binding_reference_id="ref-alpha",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        assert deleted.total == 1
+        assert deleted.bindings[0].binding_reference_id == "ref-alpha"
+
+        # ref-beta binding must still be present
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 1
+        assert after.bindings[0].binding_reference_id == "ref-beta"
+
+    @pytest.mark.asyncio
+    async def test_delete_by_reference_calls_reload_plugin_context(self, user_ctx, db_session):
+        """DELETE ?binding_reference_id= calls reload_plugin_context for each deleted binding."""
+        from unittest.mock import AsyncMock
+
+        ref_request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x", "tool_y"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-cache-test",
+                        )
+                    ]
+                )
+            }
+        )
+        await upsert_tool_plugin_bindings(
+            request=ref_request, current_user_ctx=user_ctx, db=db_session
+        )
+
+        with patch(
+            "mcpgateway.routers.tool_plugin_bindings.reload_plugin_context",
+            new_callable=AsyncMock,
+        ) as mock_reload:
+            await delete_tool_plugin_bindings_by_reference(
+                binding_reference_id="ref-cache-test",
+                current_user_ctx=user_ctx,
+                db=db_session,
+            )
+
+        called_ids = {call.args[0] for call in mock_reload.await_args_list}
+        assert called_ids == {"team-a::tool_x", "team-a::tool_y"}
+
+    # ------------------------------------------------------------------
+    # GET / and GET /{team_id} — binding_reference_id query filter
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_list_all_filtered_by_binding_reference_id(self, user_ctx, db_session):
+        """GET /?binding_reference_id= returns only bindings with that reference ID."""
+        r1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-001",
+                        )
+                    ]
+                )
+            }
+        )
+        r2 = ToolPluginBindingRequest(
+            teams={
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_y"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-002",
+                        )
+                    ]
+                )
+            }
+        )
+        await upsert_tool_plugin_bindings(request=r1, current_user_ctx=user_ctx, db=db_session)
+        await upsert_tool_plugin_bindings(request=r2, current_user_ctx=user_ctx, db=db_session)
+
+        result = await list_tool_plugin_bindings(
+            binding_reference_id="ref-001",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        assert result.total == 1
+        assert result.bindings[0].binding_reference_id == "ref-001"
+        assert result.bindings[0].team_id == "team-a"
+
+    @pytest.mark.asyncio
+    async def test_list_by_team_binding_reference_id_takes_precedence(self, user_ctx, db_session):
+        """GET /{team_id}?binding_reference_id= uses reference ID and ignores team_id filter."""
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="cross-team-ref",
+                        )
+                    ]
+                )
+            }
+        )
+        await upsert_tool_plugin_bindings(request=r, current_user_ctx=user_ctx, db=db_session)
+
+        # Query with team_id="team-b" but binding_reference_id for team-a's binding —
+        # reference ID takes precedence so the team-a binding is still returned.
+        result = await list_tool_plugin_bindings_for_team(
+            team_id="team-b",
+            binding_reference_id="cross-team-ref",
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+
+        assert result.total == 1
+        assert result.bindings[0].team_id == "team-a"
+        assert result.bindings[0].binding_reference_id == "cross-team-ref"

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -85,6 +85,23 @@ def user_ctx(db_session):
     }
 
 
+# ---------------------------------------------------------------------------
+# Canonical full-field configs (must include all schema fields)
+# ---------------------------------------------------------------------------
+
+_OLG: dict = {
+    "min_chars": 0, "max_chars": 2000, "min_tokens": 0, "max_tokens": None,
+    "chars_per_token": 4, "limit_mode": "character", "strategy": "truncate",
+    "ellipsis": "\u2026", "word_boundary": False, "max_text_length": 1_000_000,
+    "max_structure_size": 10_000, "max_recursion_depth": 100,
+}
+_RL: dict = {
+    "by_user": None, "by_tenant": None, "by_tool": None,
+    "algorithm": "fixed_window", "backend": "memory",
+    "redis_url": None, "redis_key_prefix": "rl", "redis_fallback": True,
+}
+
+
 def _simple_request() -> ToolPluginBindingRequest:
     """Minimal single-team single-tool POST payload."""
     return ToolPluginBindingRequest(
@@ -96,7 +113,7 @@ def _simple_request() -> ToolPluginBindingRequest:
                         plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                         mode=PluginBindingMode.ENFORCE,
                         priority=50,
-                        config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                        config=dict(_OLG),
                     )
                 ]
             )
@@ -115,7 +132,7 @@ def _two_team_request() -> ToolPluginBindingRequest:
                         plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                         mode=PluginBindingMode.ENFORCE,
                         priority=50,
-                        config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                        config=dict(_OLG),
                     )
                 ]
             ),
@@ -126,7 +143,7 @@ def _two_team_request() -> ToolPluginBindingRequest:
                         plugin_id=PluginId.RATE_LIMITER,
                         mode=PluginBindingMode.PERMISSIVE,
                         priority=30,
-                        config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+                        config={**_RL, "by_user": "60/m", "by_tenant": "600/m"},
                     )
                 ]
             ),
@@ -189,7 +206,7 @@ class TestToolPluginBindingsRouter:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=99,
-                            config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."},
+                            config={**_OLG, "max_chars": 500, "strategy": "block"},
                         )
                     ]
                 )
@@ -335,7 +352,7 @@ class TestToolPluginBindingsRouter:
         assert team_a.plugin_id == "OUTPUT_LENGTH_GUARD"
         assert team_a.mode == "enforce"
         assert team_a.priority == 50
-        assert team_a.config == {"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."}
+        assert team_a.config == _OLG
         assert team_a.created_by == "admin@example.com"
 
         team_b = by_team["team-b"]
@@ -343,7 +360,7 @@ class TestToolPluginBindingsRouter:
         assert team_b.plugin_id == "RATE_LIMITER"
         assert team_b.mode == "permissive"
         assert team_b.priority == 30
-        assert team_b.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
+        assert team_b.config == {**_RL, "by_user": "60/m", "by_tenant": "600/m"}
         assert team_b.created_by == "admin@example.com"
 
     # ------------------------------------------------------------------
@@ -372,7 +389,7 @@ class TestToolPluginBindingsRouter:
         assert binding.plugin_id == "OUTPUT_LENGTH_GUARD"
         assert binding.mode == "enforce"
         assert binding.priority == 50
-        assert binding.config == {"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."}
+        assert binding.config == _OLG
         assert binding.created_by == "admin@example.com"
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -1433,6 +1433,3 @@ class TestListBindingsByReference:
         """list_bindings with a non-existent binding_reference_id returns an empty list."""
         results = service.list_bindings(db_session, binding_reference_id="does-not-exist")
         assert results == []
-
-
-

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -45,6 +45,49 @@ from mcpgateway.services.tool_plugin_binding_service import (
 
 
 # ---------------------------------------------------------------------------
+# Canonical "full" config dicts
+#
+# The PluginPolicyItem validator requires every schema field to be explicitly
+# present in the config dict (so callers are aware of all available knobs).
+# Use these module-level constants instead of inline partial dicts.
+# ---------------------------------------------------------------------------
+
+_OLG: dict = {
+    "min_chars": 0,
+    "max_chars": 2000,
+    "min_tokens": 0,
+    "max_tokens": None,
+    "chars_per_token": 4,
+    "limit_mode": "character",
+    "strategy": "truncate",
+    "ellipsis": "\u2026",
+    "word_boundary": False,
+    "max_text_length": 1_000_000,
+    "max_structure_size": 10_000,
+    "max_recursion_depth": 100,
+}
+
+_RL: dict = {
+    "by_user": None,
+    "by_tenant": None,
+    "by_tool": None,
+    "algorithm": "fixed_window",
+    "backend": "memory",
+    "redis_url": None,
+    "redis_key_prefix": "rl",
+    "redis_fallback": True,
+}
+
+_SD: dict = {
+    "enabled": {},
+    "redact": True,
+    "redaction_text": "[REDACTED]",
+    "block_on_detection": False,
+    "min_findings_to_block": 1,
+}
+
+
+# ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
@@ -57,6 +100,7 @@ def _make_binding(
     mode="enforce",
     priority=50,
     config=None,
+    binding_reference_id=None,
     created_by="admin@example.com",
     updated_by="admin@example.com",
 ):
@@ -68,7 +112,8 @@ def _make_binding(
     b.plugin_id = plugin_id
     b.mode = mode
     b.priority = priority
-    b.config = config if config is not None else {"max_chars": 2000, "strategy": "truncate"}
+    b.config = config if config is not None else dict(_OLG)
+    b.binding_reference_id = binding_reference_id
     b.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     b.created_by = created_by
     b.updated_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
@@ -117,7 +162,7 @@ def simple_request():
                         plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                         mode=PluginBindingMode.ENFORCE,
                         priority=50,
-                        config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                        config=dict(_OLG),
                     )
                 ]
             )
@@ -146,6 +191,7 @@ class TestToResponse:
         assert result.mode == binding.mode
         assert result.priority == binding.priority
         assert result.config == binding.config
+        assert result.binding_reference_id == binding.binding_reference_id
         assert result.created_at == binding.created_at
         assert result.created_by == binding.created_by
         assert result.updated_at == binding.updated_at
@@ -171,7 +217,7 @@ class TestUpsertBindings:
         assert r.plugin_id == "OUTPUT_LENGTH_GUARD"
         assert r.mode == "enforce"
         assert r.priority == 50
-        assert r.config == {"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."}
+        assert r.config == dict(_OLG)
         assert r.created_by == "admin@example.com"
         assert r.updated_by == "admin@example.com"
 
@@ -182,6 +228,9 @@ class TestUpsertBindings:
 
     def test_update_existing_binding(self, service, db_session):
         """Re-upserting the same triple updates mutable fields; id and created_by are preserved."""
+        cfg_v1 = {**_OLG, "max_chars": 500, "strategy": "truncate"}
+        cfg_v2 = {**_OLG, "max_chars": 2000, "strategy": "block"}
+
         request_v1 = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
@@ -191,7 +240,7 @@ class TestUpsertBindings:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=10,
-                            config={"min_chars": 0, "max_chars": 500, "strategy": "truncate", "ellipsis": "..."},
+                            config=cfg_v1,
                         )
                     ]
                 )
@@ -209,7 +258,7 @@ class TestUpsertBindings:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.ENFORCE,
                             priority=50,
-                            config={"min_chars": 0, "max_chars": 2000, "strategy": "block", "ellipsis": "..."},
+                            config=cfg_v2,
                         )
                     ]
                 )
@@ -223,36 +272,39 @@ class TestUpsertBindings:
         assert r.id == original_id                       # primary key preserved
         assert r.mode == "enforce"
         assert r.priority == 50
-        assert r.config == {"min_chars": 0, "max_chars": 2000, "strategy": "block", "ellipsis": "..."}
+        assert r.config == cfg_v2
         assert r.updated_by == "updater@example.com"
         assert r.created_by == "creator@example.com"     # creation author unchanged
 
     def test_config_is_fully_replaced_not_merged(self, service, db_session):
         """On update, config is entirely replaced — values absent from the new payload do not survive."""
+        cfg_v1 = {**_RL, "by_user": "10/s", "by_tenant": None}
+        cfg_v2 = {**_RL, "by_user": None, "by_tenant": "600/m"}
+
         r1 = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": "10/s", "by_tenant": None, "by_tool": None})]
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=cfg_v1)]
                 )
             }
         )
         service.upsert_bindings(db_session, r1, caller_email="admin@example.com")
 
-        # Upsert with by_tenant set and by_user explicitly None — original by_user value must NOT survive
         r2 = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": None, "by_tenant": "600/m", "by_tool": None})]
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=cfg_v2)]
                 )
             }
         )
         results = service.upsert_bindings(db_session, r2, caller_email="admin@example.com")
 
-        assert results[0].config == {"by_user": None, "by_tenant": "600/m", "by_tool": None}
+        assert results[0].config == cfg_v2
         assert results[0].config["by_user"] is None  # original "10/s" is gone
 
     def test_multiple_tool_names_in_one_policy(self, service, db_session):
         """A policy with multiple tool_names produces one binding per tool, each with the full config."""
+        cfg = {**_RL, "by_user": "60/m", "by_tenant": "600/m"}
         request = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
@@ -262,7 +314,7 @@ class TestUpsertBindings:
                             plugin_id=PluginId.RATE_LIMITER,
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=20,
-                            config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+                            config=cfg,
                         )
                     ]
                 )
@@ -281,24 +333,25 @@ class TestUpsertBindings:
         assert tool_a.plugin_id == "RATE_LIMITER"
         assert tool_a.mode == "permissive"
         assert tool_a.priority == 20
-        assert tool_a.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
+        assert tool_a.config == cfg
 
         tool_b = by_tool["tool_b"]
         assert tool_b.team_id == "team-a"
         assert tool_b.plugin_id == "RATE_LIMITER"
         assert tool_b.mode == "permissive"
         assert tool_b.priority == 20
-        assert tool_b.config == {"by_user": "60/m", "by_tenant": "600/m", "by_tool": None}
+        assert tool_b.config == cfg
 
     def test_multiple_teams(self, service, db_session):
         """A request spanning two teams produces one binding per team."""
+        cfg_olg = {**_OLG, "max_chars": 500, "strategy": "block"}
         request = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."})]
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, config=cfg_olg)]
                 ),
                 "team-b": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config={"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 1})]
+                    policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config=dict(_SD))]
                 ),
             }
         )
@@ -313,12 +366,12 @@ class TestUpsertBindings:
         team_a = by_team["team-a"]
         assert team_a.tool_name == "tool_x"
         assert team_a.plugin_id == "OUTPUT_LENGTH_GUARD"
-        assert team_a.config == {"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."}
+        assert team_a.config == cfg_olg
 
         team_b = by_team["team-b"]
         assert team_b.tool_name == "tool_y"
         assert team_b.plugin_id == "SECRETS_DETECTION"
-        assert team_b.config == {"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 1}
+        assert team_b.config == dict(_SD)
 
     def test_caller_email_stored_in_audit_fields(self, service, db_session, simple_request):
         """caller_email is written to both created_by and updated_by on insert."""
@@ -326,6 +379,72 @@ class TestUpsertBindings:
 
         assert results[0].created_by == "admin@example.com"
         assert results[0].updated_by == "admin@example.com"
+
+    def test_binding_reference_id_persisted(self, service, db_session):
+        """binding_reference_id is stored in the DB and returned in the response."""
+        request = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="wxo-bind-001",
+                        )
+                    ]
+                )
+            }
+        )
+        results = service.upsert_bindings(db_session, request, caller_email="admin@example.com")
+
+        assert results[0].binding_reference_id == "wxo-bind-001"
+
+        row = db_session.query(ToolPluginBinding).one()
+        assert row.binding_reference_id == "wxo-bind-001"
+
+    def test_ownership_transfer_logs_warning(self, service, db_session, caplog):
+        """Upserting the same (team, tool, plugin) triple with a different binding_reference_id
+        logs a WARNING and the new reference_id wins."""
+        import logging
+
+        r1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="wxo-bind-old",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r1, caller_email="admin@example.com")
+
+        r2 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="wxo-bind-new",
+                        )
+                    ]
+                )
+            }
+        )
+        with caplog.at_level(logging.WARNING):
+            results = service.upsert_bindings(db_session, r2, caller_email="admin@example.com")
+
+        # New reference wins
+        assert results[0].binding_reference_id == "wxo-bind-new"
+        # Warning was emitted
+        assert any("ownership transfer" in record.message for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -341,8 +460,8 @@ class TestListBindings:
         """Insert two bindings for different teams before each test."""
         request = ToolPluginBindingRequest(
             teams={
-                "team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": None, "by_tenant": None, "by_tool": None})]),
-                "team-b": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config={"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 1})]),
+                "team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=dict(_RL))]),
+                "team-b": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config=dict(_SD))]),
             }
         )
         service.upsert_bindings(db_session, request, caller_email="seeder@example.com")
@@ -365,7 +484,7 @@ class TestListBindings:
         r = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_z"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, priority=10, config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."})]
+                    policies=[PluginPolicyItem(tool_names=["tool_z"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, priority=10, config={**_OLG, "max_chars": 500, "strategy": "block"})]
                 )
             }
         )
@@ -393,7 +512,7 @@ class TestDeleteBinding:
     def test_delete_success(self, service, db_session):
         """delete_binding returns the deleted record's details and removes it from the DB."""
         r = ToolPluginBindingRequest(
-            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config={"by_user": None, "by_tenant": None, "by_tool": None})])}
+            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=dict(_RL))])}
         )
         inserted = service.upsert_bindings(db_session, r, caller_email="admin@example.com")
         binding_id = inserted[0].id
@@ -404,7 +523,7 @@ class TestDeleteBinding:
         assert deleted.team_id == "team-a"
         assert deleted.tool_name == "tool_x"
         assert deleted.plugin_id == "RATE_LIMITER"
-        assert deleted.config == {"by_user": None, "by_tenant": None, "by_tool": None}
+        assert deleted.config == dict(_RL)
         # Confirm the row is gone from the DB
         assert db_session.query(ToolPluginBinding).filter_by(id=binding_id).first() is None
 
@@ -423,12 +542,20 @@ class TestOutputLengthGuardConfig:
     """Pydantic validation for OutputLengthGuardConfig."""
 
     def test_valid_defaults(self):
-        """Default construction succeeds — schema defaults remain available for internal/plugin-manager use."""
+        """Default construction succeeds with all new field defaults."""
         cfg = OutputLengthGuardConfig()
         assert cfg.min_chars == 0
-        assert cfg.max_chars == 2000
+        assert cfg.max_chars is None        # disabled by default
+        assert cfg.min_tokens == 0
+        assert cfg.max_tokens is None       # disabled by default
+        assert cfg.chars_per_token == 4
+        assert cfg.limit_mode == "character"
         assert cfg.strategy == "truncate"
-        assert cfg.ellipsis == "..."
+        assert cfg.ellipsis == "…"          # Unicode ellipsis
+        assert cfg.word_boundary is False
+        assert cfg.max_text_length == 1_000_000
+        assert cfg.max_structure_size == 10_000
+        assert cfg.max_recursion_depth == 100
 
     def test_valid_explicit(self):
         """Explicit valid values are accepted."""
@@ -448,10 +575,47 @@ class TestOutputLengthGuardConfig:
         with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
             OutputLengthGuardConfig(min_chars=1000, max_chars=100, strategy="truncate", ellipsis="...")
 
-    def test_max_chars_must_be_greater_than_one(self):
-        """max_chars=1 is rejected (must be > 1)."""
-        with pytest.raises(ValidationError, match=r"(?s)max_chars.*greater than 1"):
-            OutputLengthGuardConfig(min_chars=0, max_chars=1, strategy="truncate", ellipsis="...")
+    def test_max_chars_none_disables_check(self):
+        """max_chars=None is valid — explicitly disables the character limit."""
+        cfg = OutputLengthGuardConfig(max_chars=None)
+        assert cfg.max_chars is None
+
+    def test_max_tokens_none_disables_check(self):
+        """max_tokens=None is valid — explicitly disables the token limit."""
+        cfg = OutputLengthGuardConfig(max_tokens=None)
+        assert cfg.max_tokens is None
+
+    def test_limit_mode_token_accepted(self):
+        """limit_mode='token' is a valid choice."""
+        cfg = OutputLengthGuardConfig(limit_mode="token", max_tokens=500)
+        assert cfg.limit_mode == "token"
+
+    def test_word_boundary_true_accepted(self):
+        """word_boundary=True is accepted."""
+        cfg = OutputLengthGuardConfig(word_boundary=True)
+        assert cfg.word_boundary is True
+
+    def test_min_tokens_equal_to_max_tokens_rejected(self):
+        """min_tokens == max_tokens is rejected by the cross-validator."""
+        with pytest.raises(ValidationError, match="min_tokens must be less than max_tokens"):
+            OutputLengthGuardConfig(min_tokens=100, max_tokens=100)
+
+    def test_min_tokens_greater_than_max_tokens_rejected(self):
+        """min_tokens > max_tokens is rejected by the cross-validator."""
+        with pytest.raises(ValidationError, match="min_tokens must be less than max_tokens"):
+            OutputLengthGuardConfig(min_tokens=500, max_tokens=100)
+
+    def test_max_tokens_zero_skips_token_validator(self):
+        """max_tokens=0 disables the check — min_tokens can be higher without error."""
+        cfg = OutputLengthGuardConfig(min_tokens=100, max_tokens=0)
+        assert cfg.min_tokens == 100
+
+    def test_chars_per_token_out_of_range_rejected(self):
+        """chars_per_token must be between 1 and 10."""
+        with pytest.raises(ValidationError):
+            OutputLengthGuardConfig(chars_per_token=0)
+        with pytest.raises(ValidationError):
+            OutputLengthGuardConfig(chars_per_token=11)
 
     def test_min_chars_must_be_non_negative(self):
         """min_chars=-1 is rejected (must be >= 0)."""
@@ -490,10 +654,11 @@ class TestRateLimiterConfig:
         assert cfg.by_tool is None
 
     def test_valid_per_minute(self):
-        """Rate strings ending in /m are accepted."""
-        cfg = RateLimiterConfig(by_user="60/m", by_tenant="600/m", by_tool="10/m")
+        """Rate strings ending in /m are accepted for all rate fields."""
+        cfg = RateLimiterConfig(by_user="60/m", by_tenant="600/m", by_tool={"search": "10/m"})
         assert cfg.by_user == "60/m"
         assert cfg.by_tenant == "600/m"
+        assert cfg.by_tool == {"search": "10/m"}
 
     def test_valid_per_second(self):
         """Rate strings ending in /s are accepted."""
@@ -506,9 +671,9 @@ class TestRateLimiterConfig:
             RateLimiterConfig(by_user="60/h")
 
     def test_invalid_no_slash(self):
-        """Rate strings without a slash are rejected."""
-        with pytest.raises(ValidationError, match=r"Rate string '100' is invalid"):
-            RateLimiterConfig(by_tool="100")
+        """Rate strings without a slash inside by_tool dict values are rejected."""
+        with pytest.raises(ValidationError, match=r"Rate string '100' for tool 'search' is invalid"):
+            RateLimiterConfig(by_tool={"search": "100"})
 
     def test_invalid_missing_count(self):
         """Rate strings missing the numeric count are rejected."""
@@ -520,10 +685,37 @@ class TestRateLimiterConfig:
         with pytest.raises(ValidationError, match=r"Rate string 'fast/m' is invalid"):
             RateLimiterConfig(by_user="fast/m")
 
-    def test_extra_fields_forbidden(self):
-        """Unknown fields are rejected (extra='forbid')."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-            RateLimiterConfig(by_ip="10/m")
+    def test_by_tool_dict_individual_value_invalid(self):
+        """A dict value with invalid period in by_tool is rejected."""
+        with pytest.raises(ValidationError, match=r"Rate string '60/h' for tool 'search' is invalid"):
+            RateLimiterConfig(by_tool={"search": "60/h"})
+
+    def test_algorithm_values_accepted(self):
+        """All three algorithm values are accepted."""
+        for algo in ("fixed_window", "sliding_window", "token_bucket"):
+            cfg = RateLimiterConfig(algorithm=algo)
+            assert cfg.algorithm == algo
+
+    def test_invalid_algorithm_rejected(self):
+        """An unknown algorithm is rejected."""
+        with pytest.raises(ValidationError):
+            RateLimiterConfig(algorithm="round_robin")
+
+    def test_backend_redis_with_redis_url(self):
+        """backend='redis' with a redis_url is accepted."""
+        cfg = RateLimiterConfig(backend="redis", redis_url="redis://localhost:6379/0")
+        assert cfg.backend == "redis"
+        assert cfg.redis_url == "redis://localhost:6379/0"
+
+    def test_invalid_backend_rejected(self):
+        """An unknown backend is rejected."""
+        with pytest.raises(ValidationError):
+            RateLimiterConfig(backend="postgres")
+
+    def test_redis_fallback_false(self):
+        """redis_fallback=False is accepted."""
+        cfg = RateLimiterConfig(redis_fallback=False)
+        assert cfg.redis_fallback is False
 
 
 # ---------------------------------------------------------------------------
@@ -580,21 +772,21 @@ class TestPluginPolicyItemValidation:
     """Tests for PluginPolicyItem including config cross-validation per plugin."""
 
     def test_defaults_mode_and_priority(self):
-        """PluginPolicyItem defaults for mode and priority; RATE_LIMITER accepts all-null config (explicit no-limit)."""
+        """PluginPolicyItem defaults for mode and priority; RATE_LIMITER full config is accepted."""
         item = PluginPolicyItem(
             tool_names=["tool_x"],
             plugin_id=PluginId.RATE_LIMITER,
-            config={"by_user": None, "by_tenant": None, "by_tool": None},
+            config=dict(_RL),
         )
         assert item.mode == PluginBindingMode.ENFORCE
         assert item.priority == 50
 
     def test_output_length_guard_valid_config(self):
-        """OUTPUT_LENGTH_GUARD with all required fields passes cross-validation."""
+        """OUTPUT_LENGTH_GUARD with all fields passes cross-validation."""
         item = PluginPolicyItem(
             tool_names=["tool_x"],
             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
-            config={"min_chars": 0, "max_chars": 500, "strategy": "block", "ellipsis": "..."},
+            config={**_OLG, "max_chars": 500, "strategy": "block"},
         )
         assert item.plugin_id == PluginId.OUTPUT_LENGTH_GUARD
 
@@ -604,7 +796,7 @@ class TestPluginPolicyItemValidation:
             PluginPolicyItem(
                 tool_names=["tool_x"],
                 plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
-                config={"min_chars": 5000, "max_chars": 3000, "strategy": "truncate", "ellipsis": "..."},
+                config={**_OLG, "min_chars": 5000, "max_chars": 3000},
             )
 
     def test_output_length_guard_rejects_empty_config(self):
@@ -617,11 +809,11 @@ class TestPluginPolicyItemValidation:
             )
 
     def test_rate_limiter_valid_config(self):
-        """RATE_LIMITER with all three fields (some None) passes cross-validation."""
+        """RATE_LIMITER with full config passes cross-validation."""
         item = PluginPolicyItem(
             tool_names=["tool_y"],
             plugin_id=PluginId.RATE_LIMITER,
-            config={"by_user": "60/m", "by_tenant": "600/m", "by_tool": None},
+            config={**_RL, "by_user": "60/m", "by_tenant": "600/m"},
         )
         assert item.plugin_id == PluginId.RATE_LIMITER
 
@@ -631,7 +823,7 @@ class TestPluginPolicyItemValidation:
             PluginPolicyItem(
                 tool_names=["tool_y"],
                 plugin_id=PluginId.RATE_LIMITER,
-                config={"by_user": "60/h", "by_tenant": None, "by_tool": None},  # /h not allowed
+                config={**_RL, "by_user": "60/h"},  # /h not allowed
             )
 
     def test_secrets_detection_valid_config(self):
@@ -677,7 +869,7 @@ class TestPluginPolicyItemValidation:
                 tool_names=["tool_x"],
                 plugin_id=PluginId.RATE_LIMITER,
                 priority=0,
-                config={"by_user": None, "by_tenant": None, "by_tool": None},
+                config=dict(_RL),
             )
 
     def test_priority_above_maximum_rejected(self):
@@ -687,8 +879,27 @@ class TestPluginPolicyItemValidation:
                 tool_names=["tool_x"],
                 plugin_id=PluginId.RATE_LIMITER,
                 priority=1001,
-                config={"by_user": None, "by_tenant": None, "by_tool": None},
+                config=dict(_RL),
             )
+
+    def test_binding_reference_id_accepted(self):
+        """binding_reference_id is optional and stored when provided."""
+        item = PluginPolicyItem(
+            tool_names=["tool_x"],
+            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+            config=dict(_OLG),
+            binding_reference_id="wxo-bind-001",
+        )
+        assert item.binding_reference_id == "wxo-bind-001"
+
+    def test_binding_reference_id_defaults_to_none(self):
+        """binding_reference_id is None when not specified."""
+        item = PluginPolicyItem(
+            tool_names=["tool_x"],
+            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+            config=dict(_OLG),
+        )
+        assert item.binding_reference_id is None
 
     def test_invalid_plugin_id_rejected(self):
         """An unrecognised plugin_id string is rejected by the PluginId enum."""
@@ -766,9 +977,13 @@ class TestTopLevelSchemas:
                     "teams": {
                         "team-a": {
                             "policies": [
-                                # item 0: OLG with an invalid value — triggers the new ValueError format
-                                {"tool_names": ["tool_x"], "plugin_id": "OUTPUT_LENGTH_GUARD", "config": {"min_chars": 0, "max_chars": 2000, "strategy": "drop", "ellipsis": "..."}},
-                                # item 1: RATE_LIMITER with missing fields — triggers the existing ValueError
+                                # item 0: OLG with full config but invalid strategy value
+                                {
+                                    "tool_names": ["tool_x"],
+                                    "plugin_id": "OUTPUT_LENGTH_GUARD",
+                                    "config": {**_OLG, "strategy": "drop"},
+                                },
+                                # item 1: RATE_LIMITER with empty config — triggers "Missing config fields"
                                 {"tool_names": ["tool_y"], "plugin_id": "RATE_LIMITER", "config": {}},
                             ]
                         }
@@ -785,9 +1000,9 @@ class TestTopLevelSchemas:
         assert errors_by_index[0]["loc"] == ("teams", "team-a", "policies", 0)
         assert errors_by_index[0]["msg"] == "Value error, Invalid OUTPUT_LENGTH_GUARD config: [strategy: Input should be 'truncate' or 'block']"
 
-        # item 1: RATE_LIMITER — missing all three fields (sorted alphabetically in the error)
+        # item 1: RATE_LIMITER — all 8 fields are missing (sorted alphabetically in the error)
         assert errors_by_index[1]["loc"] == ("teams", "team-a", "policies", 1)
-        assert errors_by_index[1]["msg"] == "Value error, Missing config fields for RATE_LIMITER: ['by_tenant', 'by_tool', 'by_user']"
+        assert errors_by_index[1]["msg"] == "Value error, Missing config fields for RATE_LIMITER: ['algorithm', 'backend', 'by_tenant', 'by_tool', 'by_user', 'redis_fallback', 'redis_key_prefix', 'redis_url']"
 
 
 # ---------------------------------------------------------------------------
@@ -814,7 +1029,7 @@ class TestGetBindingsForTool:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.ENFORCE,
                             priority=50,
-                            config={"min_chars": 0, "max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
+                            config=dict(_OLG),
                         )
                     ]
                 )
@@ -832,7 +1047,7 @@ class TestGetBindingsForTool:
                             plugin_id=PluginId.RATE_LIMITER,
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=10,
-                            config={"by_user": "100/m", "by_tenant": "1000/m", "by_tool": None},
+                            config={**_RL, "by_user": "100/m", "by_tenant": "1000/m"},
                         )
                     ]
                 )
@@ -859,7 +1074,7 @@ class TestGetBindingsForTool:
 
     def test_exact_overrides_wildcard_for_same_plugin(self, service, db_session):
         """When both an exact and a wildcard binding exist for the same plugin_id,
-        the more recently updated one wins (exact was inserted after wildcard here)."""
+        the exact (more specific) binding wins regardless of insertion order."""
         # Insert a wildcard OUTPUT_LENGTH_GUARD first
         wc_req = ToolPluginBindingRequest(
             teams={
@@ -870,7 +1085,7 @@ class TestGetBindingsForTool:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=1,
-                            config={"min_chars": 0, "max_chars": 100, "strategy": "truncate", "ellipsis": "..."},
+                            config={**_OLG, "max_chars": 100},
                         )
                     ]
                 )
@@ -888,7 +1103,7 @@ class TestGetBindingsForTool:
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             mode=PluginBindingMode.ENFORCE,
                             priority=99,
-                            config={"min_chars": 0, "max_chars": 9999, "strategy": "truncate", "ellipsis": "..."},
+                            config={**_OLG, "max_chars": 9999},
                         )
                     ]
                 )
@@ -897,10 +1112,10 @@ class TestGetBindingsForTool:
         service.upsert_bindings(db_session, exact_req, caller_email="admin@example.com")
 
         results = get_bindings_for_tool(db_session, "team-b", "tool_z")
-        # Only one entry per plugin_id — the one with the higher updated_at wins
+        # Specificity wins: exact tool_name binding always beats the '*' wildcard
         olg_results = [b for b in results if b.plugin_id == "OUTPUT_LENGTH_GUARD"]
         assert len(olg_results) == 1
-        # The exact binding has priority=99 (inserted last → higher updated_at)
+        # The exact binding (priority=99, max_chars=9999) wins — not the wildcard (priority=1, max_chars=100)
         assert olg_results[0].priority == 99
 
     def test_does_not_cross_team_boundaries(self):

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -901,6 +901,16 @@ class TestPluginPolicyItemValidation:
         )
         assert item.binding_reference_id is None
 
+    def test_binding_reference_id_max_length(self):
+        """binding_reference_id longer than 255 characters is rejected (matches DB column limit)."""
+        with pytest.raises(ValidationError):
+            PluginPolicyItem(
+                tool_names=["tool_x"],
+                plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                config=dict(_OLG),
+                binding_reference_id="a" * 256,
+            )
+
     def test_invalid_plugin_id_rejected(self):
         """An unrecognised plugin_id string is rejected by the PluginId enum."""
         with pytest.raises(ValidationError, match=r"(?s)plugin_id.*Input should be"):
@@ -1122,3 +1132,307 @@ class TestGetBindingsForTool:
         """Bindings for a different team are not returned."""
         results = get_bindings_for_tool(self._db, "team-b", "tool_x")
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Stale-tool pruning tests
+# ---------------------------------------------------------------------------
+
+
+class TestStalePruning:
+    """Tests for the stale-tool pruning logic in upsert_bindings.
+
+    When an upsert includes a binding_reference_id, any existing binding
+    that shares the same (binding_reference_id, plugin_id) pair but whose
+    tool_name is absent from the incoming list is automatically deleted.
+    """
+
+    def test_stale_tools_pruned_when_binding_reference_id_present(self, service, db_session):
+        """Tools removed from the incoming list are deleted when binding_reference_id is set."""
+        # Initial upsert: bind ref-001 to tool_a, tool_b, tool_c
+        r1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a", "tool_b", "tool_c"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-001",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r1, caller_email="admin@example.com")
+        assert db_session.query(ToolPluginBinding).count() == 3
+
+        # Second upsert: ref-001 now only covers tool_a and tool_b — tool_c is stale
+        r2 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a", "tool_b"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-001",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r2, caller_email="admin@example.com")
+
+        remaining = db_session.query(ToolPluginBinding).all()
+        assert len(remaining) == 2
+        tool_names = {b.tool_name for b in remaining}
+        assert tool_names == {"tool_a", "tool_b"}
+
+    def test_tools_in_incoming_list_are_preserved(self, service, db_session):
+        """Tools that are still in the incoming list are NOT pruned."""
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a", "tool_b"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-002",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+
+        # Upsert again with the same list — nothing should be pruned
+        service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+
+        assert db_session.query(ToolPluginBinding).count() == 2
+
+    def test_no_pruning_when_binding_reference_id_is_none(self, service, db_session):
+        """Bindings without a binding_reference_id are never pruned by subsequent upserts."""
+        r1 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a", "tool_b"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            # intentionally no binding_reference_id
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r1, caller_email="admin@example.com")
+
+        # Second upsert — same plugin, no reference ID, reduced tool list
+        r2 = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r2, caller_email="admin@example.com")
+
+        # tool_b must NOT be pruned because no binding_reference_id was supplied
+        assert db_session.query(ToolPluginBinding).count() == 2
+
+    def test_pruning_only_affects_matching_ref_and_plugin(self, service, db_session):
+        """Pruning is scoped to (binding_reference_id, plugin_id) — other refs/plugins are untouched."""
+        # ref-A binds OLG to tool_a and tool_b
+        r_a = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a", "tool_b"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-A",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r_a, caller_email="admin@example.com")
+
+        # ref-B binds RL to tool_c
+        r_b = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_c"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            config=dict(_RL),
+                            binding_reference_id="ref-B",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r_b, caller_email="admin@example.com")
+
+        assert db_session.query(ToolPluginBinding).count() == 3
+
+        # Update ref-A/OLG to only cover tool_a — tool_b should be pruned
+        r_a_updated = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_a"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-A",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r_a_updated, caller_email="admin@example.com")
+
+        remaining = db_session.query(ToolPluginBinding).all()
+        assert len(remaining) == 2
+        tool_names = {b.tool_name for b in remaining}
+        # tool_b pruned; tool_a (ref-A/OLG) and tool_c (ref-B/RL) survive
+        assert tool_names == {"tool_a", "tool_c"}
+
+    def test_multiple_reference_ids_pruned_independently(self, service, db_session):
+        """A single upsert containing multiple reference IDs prunes each independently."""
+        # Seed: ref-X owns tool_1, tool_2; ref-Y owns tool_3, tool_4
+        seed = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_1", "tool_2"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-X",
+                        ),
+                        PluginPolicyItem(
+                            tool_names=["tool_3", "tool_4"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            config=dict(_RL),
+                            binding_reference_id="ref-Y",
+                        ),
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, seed, caller_email="admin@example.com")
+        assert db_session.query(ToolPluginBinding).count() == 4
+
+        # Update: ref-X shrinks to tool_1 only; ref-Y shrinks to tool_3 only
+        update = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_1"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-X",
+                        ),
+                        PluginPolicyItem(
+                            tool_names=["tool_3"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            config=dict(_RL),
+                            binding_reference_id="ref-Y",
+                        ),
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, update, caller_email="admin@example.com")
+
+        remaining = db_session.query(ToolPluginBinding).all()
+        assert len(remaining) == 2
+        assert {b.tool_name for b in remaining} == {"tool_1", "tool_3"}
+
+
+# ---------------------------------------------------------------------------
+# list_bindings — binding_reference_id filter tests
+# ---------------------------------------------------------------------------
+
+
+class TestListBindingsByReference:
+    """Tests for list_bindings filtering by binding_reference_id."""
+
+    def test_filter_by_binding_reference_id(self, service, db_session):
+        """list_bindings with binding_reference_id returns only matching bindings."""
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="ref-filter-001",
+                        )
+                    ]
+                ),
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_y"],
+                            plugin_id=PluginId.RATE_LIMITER,
+                            config=dict(_RL),
+                            binding_reference_id="ref-filter-002",
+                        )
+                    ]
+                ),
+            }
+        )
+        service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+
+        results = service.list_bindings(db_session, binding_reference_id="ref-filter-001")
+        assert len(results) == 1
+        assert results[0].binding_reference_id == "ref-filter-001"
+        assert results[0].team_id == "team-a"
+
+    def test_binding_reference_id_takes_precedence_over_team_id(self, service, db_session):
+        """When both team_id and binding_reference_id are provided, reference ID wins."""
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            config=dict(_OLG),
+                            binding_reference_id="unique-ref",
+                        )
+                    ]
+                )
+            }
+        )
+        service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+
+        # Supply team_id="team-b" (which has no bindings) but binding_reference_id
+        # for team-a's binding — reference ID takes precedence.
+        results = service.list_bindings(db_session, team_id="team-b", binding_reference_id="unique-ref")
+        assert len(results) == 1
+        assert results[0].team_id == "team-a"
+
+    def test_filter_by_reference_id_no_match_returns_empty(self, service, db_session):
+        """list_bindings with a non-existent binding_reference_id returns an empty list."""
+        results = service.list_bindings(db_session, binding_reference_id="does-not-exist")
+        assert results == []
+
+
+

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -391,7 +391,7 @@ class TestUpsertBindings:
                             tool_names=["tool_x"],
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             config=dict(_OLG),
-                            binding_reference_id="wxo-bind-001",
+                            binding_reference_id="test-bind-001",
                         )
                     ]
                 )
@@ -399,10 +399,10 @@ class TestUpsertBindings:
         )
         results = service.upsert_bindings(db_session, request, caller_email="admin@example.com")
 
-        assert results[0].binding_reference_id == "wxo-bind-001"
+        assert results[0].binding_reference_id == "test-bind-001"
 
         row = db_session.query(ToolPluginBinding).one()
-        assert row.binding_reference_id == "wxo-bind-001"
+        assert row.binding_reference_id == "test-bind-001"
 
     def test_ownership_transfer_logs_warning(self, service, db_session, caplog):
         """Upserting the same (team, tool, plugin) triple with a different binding_reference_id
@@ -415,7 +415,7 @@ class TestUpsertBindings:
                             tool_names=["tool_x"],
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             config=dict(_OLG),
-                            binding_reference_id="wxo-bind-old",
+                            binding_reference_id="test-bind-old",
                         )
                     ]
                 )
@@ -431,7 +431,7 @@ class TestUpsertBindings:
                             tool_names=["tool_x"],
                             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
                             config=dict(_OLG),
-                            binding_reference_id="wxo-bind-new",
+                            binding_reference_id="test-bind-new",
                         )
                     ]
                 )
@@ -441,7 +441,7 @@ class TestUpsertBindings:
             results = service.upsert_bindings(db_session, r2, caller_email="admin@example.com")
 
         # New reference wins
-        assert results[0].binding_reference_id == "wxo-bind-new"
+        assert results[0].binding_reference_id == "test-bind-new"
         # Warning was emitted
         assert any("ownership transfer" in record.message for record in caplog.records)
 
@@ -887,9 +887,9 @@ class TestPluginPolicyItemValidation:
             tool_names=["tool_x"],
             plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
             config=dict(_OLG),
-            binding_reference_id="wxo-bind-001",
+            binding_reference_id="test-bind-001",
         )
-        assert item.binding_reference_id == "wxo-bind-001"
+        assert item.binding_reference_id == "test-bind-001"
 
     def test_binding_reference_id_defaults_to_none(self):
         """binding_reference_id is None when not specified."""

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -14,6 +14,7 @@ Tests cover:
 """
 
 # Standard
+import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -406,8 +407,6 @@ class TestUpsertBindings:
     def test_ownership_transfer_logs_warning(self, service, db_session, caplog):
         """Upserting the same (team, tool, plugin) triple with a different binding_reference_id
         logs a WARNING and the new reference_id wins."""
-        import logging
-
         r1 = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
@@ -1405,8 +1404,8 @@ class TestListBindingsByReference:
         assert results[0].binding_reference_id == "ref-filter-001"
         assert results[0].team_id == "team-a"
 
-    def test_binding_reference_id_takes_precedence_over_team_id(self, service, db_session):
-        """When both team_id and binding_reference_id are provided, reference ID wins."""
+    def test_binding_reference_id_takes_precedence_over_team_id(self, service, db_session, caplog):
+        """When both team_id and binding_reference_id are provided, reference ID wins and a warning is logged."""
         r = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
@@ -1424,10 +1423,18 @@ class TestListBindingsByReference:
         service.upsert_bindings(db_session, r, caller_email="admin@example.com")
 
         # Supply team_id="team-b" (which has no bindings) but binding_reference_id
-        # for team-a's binding — reference ID takes precedence.
-        results = service.list_bindings(db_session, team_id="team-b", binding_reference_id="unique-ref")
+        # for team-a's binding — reference ID takes precedence and a warning is emitted.
+        with caplog.at_level(logging.WARNING):
+            results = service.list_bindings(db_session, team_id="team-b", binding_reference_id="unique-ref")
         assert len(results) == 1
         assert results[0].team_id == "team-a"
+        expected_warning = (
+            "Both team_id='team-b' and binding_reference_id='unique-ref' supplied to list_bindings; "
+            "team_id will be ignored. Omit team_id when filtering by binding_reference_id."
+        )
+        assert expected_warning in caplog.messages, (
+            f"Expected warning not found. Got: {caplog.messages}"
+        )
 
     def test_filter_by_reference_id_no_match_returns_empty(self, service, db_session):
         """list_bindings with a non-existent binding_reference_id returns an empty list."""


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4122 partially

---

## 📝 Summary
Adds `binding_reference_id` to `tool_plugin_bindings` to allow upstream systems (e.g. WXO) to correlate CF plugin bindings with their own identifiers. Also expands `OutputLengthGuardConfig` (4 → 12 fields) and `RateLimiterConfig` (3 → 8 fields, `by_tool` changed from `str` to `Dict[str, str]`) to fully reflect the capabilities of the underlying plugins. All unit tests were updated and extended to cover the new fields and behaviours (76/76 passing).

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     | ✅ 76/76 passing |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**DB / Migration**
- New nullable `binding_reference_id` column (`VARCHAR(255)`) on `tool_plugin_bindings`, with an index for fast lookups.
- Alembic migration: `d3e4f5a6b7c8_add_binding_reference_id_to_tool_plugin_bindings.py` (reversible).

**Schema changes**
- `OutputLengthGuardConfig` — added `max_chars` (Optional), `min_tokens`, `max_tokens`, `chars_per_token`, `limit_mode`, `word_boundary`, `max_text_length`, `max_structure_size`, `max_recursion_depth`; `min < max` validator covers both chars and tokens.
- `RateLimiterConfig` — added `algorithm`, `backend`, `redis_url`, `redis_key_prefix`, `redis_fallback`; `by_tool` is now `Dict[str, str]` (per-tool rate strings).
- `PluginPolicyItem` / `ToolPluginBindingResponse` — `binding_reference_id: Optional[str]` added; `config` docstring clarified to reflect full-replacement semantics (no partial configs, no merge).

**Service**
- `upsert_bindings` stores `binding_reference_id`, logs a `WARNING` on ownership transfer, and prunes stale tool bindings keyed by `(binding_reference_id, plugin_id)`.
- `get_bindings_for_tool` uses specificity-wins wildcard resolution (`"*"` is overridden by an exact `tool_name` match).

**Router**
- `GET /v1/tools/plugin_bindings` and `GET /v1/tools/plugin_bindings/{team_id}` accept an optional `?binding_reference_id=` filter.
- `DELETE /v1/tools/plugin_bindings` supports bulk delete by `binding_reference_id`.