### PR TITLE
fix: restore bundle_js template variable for Vite admin UI

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4073,6 +4073,7 @@ async def admin_ui(
             "require_token_expiration": getattr(settings, "require_token_expiration", True),
             "sri_hashes": load_sri_hashes(),
             "max_members_per_team": settings.max_members_per_team,
+            "bundle_js": get_bundle_js_filename(),
         },
     )
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4017,6 +4017,7 @@ async def admin_ui(
             "require_token_expiration": getattr(settings, "require_token_expiration", True),
             "sri_hashes": load_sri_hashes(),
             "max_members_per_team": settings.max_members_per_team,
+            "bundle_js": get_bundle_js_filename(),
         },
     )
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 🔗 Issue

Closes #4153

## 📌 Summary

The admin UI fails to load the Vite-bundled JavaScript because the `bundle_js` template variable is missing from the template context in `admin_ui()`. This causes a blank admin page or JavaScript errors.

## 🔁 Reproduction Steps

1. Start the gateway with the Vite-built admin UI
2. Navigate to the admin dashboard
3. The page loads without the main JS bundle — no interactive functionality

## 🐞 Root Cause

The `admin_ui()` handler in `admin.py` passes a template context dict to the Jinja2 template, but `bundle_js` (from `get_bundle_js_filename()`) was missing. The template references `{{ bundle_js }}` to load the correct hashed JS bundle filename, but it resolved to empty/undefined.

## 💡 Fix Description

Add `"bundle_js": get_bundle_js_filename()` to the template context dictionary in the `admin_ui()` handler. The `get_bundle_js_filename()` function already exists and resolves the Vite manifest to find the correct hashed bundle filename.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅     |
| Unit tests                            | `make test`          | ✅     |
| Coverage ≥ 80 %                       | `make coverage`      | ✅     |
| Manual regression no longer fails     | Admin UI loads correctly with JS bundle | ✅ |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed