### PR TITLE
feat: MCP OAuth proxy for virtual servers (DCR bypass with pre-registered clients)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -3050,6 +3050,9 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
             scopes_str = str(form.get("oauth_scopes", "")).strip()
             token_endpoint = str(form.get("oauth_token_endpoint", "")).strip()
 
+            client_id = str(form.get("oauth_client_id", "")).strip()
+            client_secret = str(form.get("oauth_client_secret", "")).strip()
+
             if authorization_server:
                 oauth_config = {"authorization_servers": [authorization_server]}
                 if scopes_str:
@@ -3062,6 +3065,10 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
                 oauth_audience = str(form.get("oauth_audience", "")).strip()
                 if oauth_audience:
                     oauth_config["audience"] = oauth_audience
+                if client_id:
+                    oauth_config["client_id"] = client_id
+                if client_secret:
+                    oauth_config["client_secret"] = client_secret
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(
@@ -3212,6 +3219,9 @@ async def admin_edit_server(
             scopes_str = str(form.get("oauth_scopes", "")).strip()
             token_endpoint = str(form.get("oauth_token_endpoint", "")).strip()
 
+            client_id = str(form.get("oauth_client_id", "")).strip()
+            client_secret = str(form.get("oauth_client_secret", "")).strip()
+
             if authorization_server:
                 oauth_config = {"authorization_servers": [authorization_server]}
                 if scopes_str:
@@ -3219,11 +3229,22 @@ async def admin_edit_server(
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
-
                 # Add audience parameter (for Atlassian, Auth0, and other non-RFC-8707 providers)
                 oauth_audience = str(form.get("oauth_audience", "")).strip()
                 if oauth_audience:
                     oauth_config["audience"] = oauth_audience
+                if client_id:
+                    oauth_config["client_id"] = client_id
+                if client_secret:
+                    oauth_config["client_secret"] = client_secret
+                elif client_id:
+                    # client_id present but secret left blank in edit form — preserve existing secret
+                    try:
+                        existing_server = await server_service.get_server(db, server_id)
+                        if existing_server.oauth_config and existing_server.oauth_config.get("client_secret"):
+                            oauth_config["client_secret"] = existing_server.oauth_config["client_secret"]
+                    except Exception:
+                        pass
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2950,6 +2950,9 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
             scopes_str = str(form.get("oauth_scopes", "")).strip()
             token_endpoint = str(form.get("oauth_token_endpoint", "")).strip()
 
+            client_id = str(form.get("oauth_client_id", "")).strip()
+            client_secret = str(form.get("oauth_client_secret", "")).strip()
+
             if authorization_server:
                 oauth_config = {"authorization_servers": [authorization_server]}
                 if scopes_str:
@@ -2957,6 +2960,10 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
+                if client_id:
+                    oauth_config["client_id"] = client_id
+                if client_secret:
+                    oauth_config["client_secret"] = client_secret
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(
@@ -3111,6 +3118,9 @@ async def admin_edit_server(
             scopes_str = str(form.get("oauth_scopes", "")).strip()
             token_endpoint = str(form.get("oauth_token_endpoint", "")).strip()
 
+            client_id = str(form.get("oauth_client_id", "")).strip()
+            client_secret = str(form.get("oauth_client_secret", "")).strip()
+
             if authorization_server:
                 oauth_config = {"authorization_servers": [authorization_server]}
                 if scopes_str:
@@ -3118,6 +3128,18 @@ async def admin_edit_server(
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
+                if client_id:
+                    oauth_config["client_id"] = client_id
+                if client_secret:
+                    oauth_config["client_secret"] = client_secret
+                elif client_id:
+                    # client_id present but secret left blank in edit form — preserve existing secret
+                    try:
+                        existing_server = await server_service.get_server(db, server_id)
+                        if existing_server.oauth_config and existing_server.oauth_config.get("client_secret"):
+                            oauth_config["client_secret"] = existing_server.oauth_config["client_secret"]
+                    except Exception:
+                        pass
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -855,6 +855,17 @@ export const editServer = async function (serverId) {
       if (oauthTokenEndpointField) {
         oauthTokenEndpointField.value = server.oauthConfig.token_endpoint || "";
       }
+
+      // Extract client_id for DCR bypass (pre-registered client)
+      const oauthClientIdField = safeGetElement("edit-server-oauth-client-id");
+      if (oauthClientIdField) {
+        oauthClientIdField.value = server.oauthConfig.client_id || "";
+      }
+      // Clear client_secret field (password field — never pre-filled with actual secret)
+      const oauthClientSecretField = safeGetElement("edit-server-oauth-client-secret");
+      if (oauthClientSecretField) {
+        oauthClientSecretField.value = "";
+      }
     } else {
       // Clear OAuth config fields when no config exists
       if (oauthAuthServerField) oauthAuthServerField.value = "";

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -857,6 +857,17 @@ export const editServer = async function (serverId) {
       if (oauthTokenEndpointField) {
         oauthTokenEndpointField.value = server.oauthConfig.token_endpoint || "";
       }
+
+      // Extract client_id for DCR bypass (pre-registered client)
+      const oauthClientIdField = safeGetElement("edit-server-oauth-client-id");
+      if (oauthClientIdField) {
+        oauthClientIdField.value = server.oauthConfig.client_id || "";
+      }
+      // Clear client_secret field (password field — never pre-filled with actual secret)
+      const oauthClientSecretField = safeGetElement("edit-server-oauth-client-secret");
+      if (oauthClientSecretField) {
+        oauthClientSecretField.value = "";
+      }
     } else {
       // Clear OAuth config fields when no config exists
       if (oauthAuthServerField) oauthAuthServerField.value = "";

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -12253,6 +12253,16 @@ try:
 except ImportError:
     logger.debug("OAuth router not available")
 
+# Include MCP OAuth proxy router (virtual server OAuth for MCP clients)
+try:
+    # First-Party
+    from mcpgateway.routers.mcp_oauth import mcp_oauth_router
+
+    app.include_router(mcp_oauth_router)
+    logger.info("MCP OAuth proxy router included")
+except ImportError:
+    logger.debug("MCP OAuth proxy router not available")
+
 # Include reverse proxy router if enabled
 if settings.mcpgateway_reverse_proxy_enabled:
     try:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11155,6 +11155,16 @@ try:
 except ImportError:
     logger.debug("OAuth router not available")
 
+# Include MCP OAuth proxy router (virtual server OAuth for MCP clients)
+try:
+    # First-Party
+    from mcpgateway.routers.mcp_oauth import mcp_oauth_router
+
+    app.include_router(mcp_oauth_router)
+    logger.info("MCP OAuth proxy router included")
+except ImportError:
+    logger.debug("MCP OAuth proxy router not available")
+
 # Include reverse proxy router if enabled
 if settings.mcpgateway_reverse_proxy_enabled:
     try:

--- a/mcpgateway/routers/mcp_oauth.py
+++ b/mcpgateway/routers/mcp_oauth.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+"""MCP OAuth 2.0 Authorization Server proxy for virtual servers.
+
+Enables MCP clients (VS Code, Cursor) to authenticate via an external IdP
+(e.g. Microsoft Entra ID) without requiring Dynamic Client Registration
+support from the IdP.  ContextForge acts as an OAuth 2.0 Authorization
+Server for the client while proxying to the real IdP behind the scenes.
+
+Implements RFC 6749 (OAuth 2.0), RFC 7636 (PKCE), RFC 7591 (DCR),
+and RFC 8414 (Authorization Server Metadata).
+
+Flow:
+    1. Resource metadata (RFC 9728) → ContextForge as ``authorization_server``
+    2. Auth server metadata (RFC 8414) → ContextForge endpoints
+    3. DCR (RFC 7591) → returns pre-configured ``client_id``
+    4. ``/authorize`` → redirects to external IdP (Entra)
+    5. IdP callback → ContextForge validates, issues an authorization code
+    6. ``/token`` → exchanges code for a ContextForge-signed JWT
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import time
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from mcpgateway.config import settings
+from mcpgateway.db import Server as DbServer, get_db
+from mcpgateway.services.encryption_service import decrypt_oauth_config_for_runtime
+from mcpgateway.utils.create_jwt_token import create_jwt_token
+from mcpgateway.utils.log_sanitizer import sanitize_for_log
+
+logger = logging.getLogger(__name__)
+
+mcp_oauth_router = APIRouter(prefix="/oauth", tags=["MCP OAuth"])
+
+# ---------------------------------------------------------------------------
+# Encrypted state — multi-pod safe (no shared storage needed).
+# Session and auth-code data are encrypted with Fernet using the
+# application's auth_secret.  The encrypted blob travels in the OAuth
+# ``state`` parameter or the authorization code itself.
+# ---------------------------------------------------------------------------
+
+_SESSION_TTL = 600  # 10 minutes
+_CODE_TTL = 300  # 5 minutes
+_OIDC_CACHE_TTL = 3600  # 1 hour
+
+# OIDC metadata discovery cache (safe as in-memory — read-only / idempotent)
+_oidc_cache: Dict[str, Dict[str, Any]] = {}
+
+
+def _get_fernet() -> Fernet:
+    """Derive a Fernet key from the application secret."""
+    secret = settings.jwt_secret_key.get_secret_value() if hasattr(settings.jwt_secret_key, "get_secret_value") else str(settings.jwt_secret_key)
+    # Fernet requires a 32-byte url-safe base64-encoded key
+    key_bytes = hashlib.sha256(secret.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(key_bytes))
+
+
+def _encrypt_state(data: Dict[str, Any]) -> str:
+    """Encrypt session data into a URL-safe token."""
+    data["_ts"] = time.time()  # wall-clock for cross-pod TTL
+    plaintext = json.dumps(data, separators=(",", ":")).encode()
+    return _get_fernet().encrypt(plaintext).decode("ascii")
+
+
+def _decrypt_state(token: str, ttl: int) -> Dict[str, Any]:
+    """Decrypt and validate an encrypted state token.
+
+    Raises HTTPException if invalid or expired.
+    """
+    try:
+        plaintext = _get_fernet().decrypt(token.encode("ascii"))
+        data = json.loads(plaintext)
+    except (InvalidToken, json.JSONDecodeError, Exception):
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+
+    ts = data.get("_ts", 0)
+    if time.time() - ts > ttl:
+        raise HTTPException(status_code=400, detail="OAuth session expired")
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# OIDC metadata discovery (cached)
+# ---------------------------------------------------------------------------
+
+
+async def _discover_oidc_metadata(issuer: str) -> Dict[str, Any]:
+    """Fetch and cache OIDC metadata from the authorization server."""
+    cached = _oidc_cache.get(issuer)
+    if cached and (time.time() - cached.get("_ts", 0)) < _OIDC_CACHE_TTL:
+        return cached["metadata"]
+
+    oidc_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+        resp = await client.get(oidc_url)
+        resp.raise_for_status()
+        metadata = resp.json()
+
+    _oidc_cache[issuer] = {"metadata": metadata, "_ts": time.time()}
+
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_server_oauth_config(db: Session, server_id: str) -> tuple[DbServer, Dict[str, Any]]:
+    """Load virtual server, validate and decrypt MCP OAuth proxy config."""
+    server = db.get(DbServer, server_id)
+    if not server or not server.enabled:
+        raise HTTPException(status_code=404, detail="Server not found")
+
+    oauth_config = getattr(server, "oauth_config", None) or {}
+    if not oauth_config.get("client_id"):
+        raise HTTPException(
+            status_code=404,
+            detail="MCP OAuth proxy not configured for this server (missing client_id in oauth_config)",
+        )
+
+    # Decrypt secrets (client_secret is encrypted at rest)
+    oauth_config = await decrypt_oauth_config_for_runtime(oauth_config)
+
+    return server, oauth_config
+
+
+def _s256(verifier: str) -> str:
+    """Compute S256 code challenge from verifier."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class DCRRequest(BaseModel):
+    """RFC 7591 Dynamic Client Registration request (subset)."""
+
+    redirect_uris: List[str] = Field(default_factory=list)
+    client_name: Optional[str] = None
+    grant_types: List[str] = Field(default_factory=lambda: ["authorization_code"])
+    response_types: List[str] = Field(default_factory=lambda: ["code"])
+    token_endpoint_auth_method: str = "none"
+
+
+class DCRResponse(BaseModel):
+    """RFC 7591 Dynamic Client Registration response."""
+
+    client_id: str
+    client_id_issued_at: int = 0
+    redirect_uris: List[str] = Field(default_factory=list)
+    grant_types: List[str] = Field(default_factory=lambda: ["authorization_code"])
+    response_types: List[str] = Field(default_factory=lambda: ["code"])
+    token_endpoint_auth_method: str = "none"
+
+
+class TokenRequest(BaseModel):
+    """OAuth 2.0 Token Exchange request."""
+
+    grant_type: str
+    code: str
+    redirect_uri: str
+    client_id: str
+    code_verifier: Optional[str] = None
+
+
+class TokenResponse(BaseModel):
+    """OAuth 2.0 Token response."""
+
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int = Field(default=604800)
+
+
+# ---------------------------------------------------------------------------
+# 1. DCR — Dynamic Client Registration
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.post("/register/{server_id}")
+async def register_client(
+    server_id: str,
+    body: DCRRequest,
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """RFC 7591 DCR: return pre-configured client credentials.
+
+    MCP clients call this to "register" — we return the pre-configured
+    Entra app ``client_id`` from the virtual server's ``oauth_config``.
+    No actual registration happens.
+    """
+    _, oauth_config = await _get_server_oauth_config(db, server_id)
+
+    client_id = oauth_config["client_id"]
+    response = DCRResponse(
+        client_id=client_id,
+        redirect_uris=body.redirect_uris,
+    )
+
+    logger.info("MCP OAuth DCR: returned client_id for server %s", sanitize_for_log(server_id))
+    return JSONResponse(content=response.model_dump(), status_code=201)
+
+
+# ---------------------------------------------------------------------------
+# 2. Authorize — redirect user to external IdP
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.get("/authorize/servers/{server_id}")
+async def authorize(
+    server_id: str,
+    request: Request,
+    client_id: str,
+    redirect_uri: str,
+    response_type: str = "code",
+    state: Optional[str] = None,
+    scope: Optional[str] = None,
+    code_challenge: Optional[str] = None,
+    code_challenge_method: Optional[str] = None,
+    db: Session = Depends(get_db),
+) -> RedirectResponse:
+    """OAuth 2.0 Authorization endpoint.
+
+    Validates parameters, stores session state, and redirects the user
+    to the external IdP (e.g. Entra).
+    """
+    if response_type != "code":
+        raise HTTPException(status_code=400, detail="Only response_type=code is supported")
+
+    _, oauth_config = await _get_server_oauth_config(db, server_id)
+
+    # Validate client_id matches configured value
+    if client_id != oauth_config["client_id"]:
+        raise HTTPException(status_code=400, detail="Invalid client_id")
+
+    # Discover IdP endpoints
+    auth_server = oauth_config.get("authorization_server") or oauth_config.get("authorization_servers", [None])[0]
+    if not auth_server:
+        raise HTTPException(status_code=500, detail="authorization_server not configured")
+
+    idp_metadata = await _discover_oidc_metadata(auth_server)
+    idp_authorize_url = idp_metadata.get("authorization_endpoint")
+    if not idp_authorize_url:
+        raise HTTPException(status_code=500, detail="IdP authorization_endpoint not found")
+
+    # Generate internal state for CF ↔ IdP leg
+    # The state carries the encrypted session data — no server-side storage.
+    # Generate PKCE for CF → IdP leg
+    idp_code_verifier = secrets.token_urlsafe(64)
+    idp_code_challenge = _s256(idp_code_verifier)
+
+    # Generate nonce for OIDC
+    nonce = secrets.token_urlsafe(16)
+
+    # Build CF callback URL
+    base_url = str(request.base_url).rstrip("/")
+    # Respect X-Forwarded-* headers for reverse proxy
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    if forwarded_proto and forwarded_host:
+        base_url = f"{forwarded_proto}://{forwarded_host}"
+    root_path = request.scope.get("root_path", "").rstrip("/")
+    cf_callback_url = f"{base_url}{root_path}/oauth/callback/servers/{server_id}"
+
+    # Encrypt session data into state
+    session_data = {
+        "sid": server_id,
+        "cid": client_id,
+        "ru": redirect_uri,
+        "cs": state,
+        "cc": code_challenge,
+        "ccm": code_challenge_method,
+        "icv": idp_code_verifier,
+        "n": nonce,
+        "cb": cf_callback_url,
+    }
+
+    internal_state = _encrypt_state(session_data)
+
+    # Build IdP authorize URL
+    scopes = oauth_config.get("scopes") or oauth_config.get("scopes_supported") or ["openid", "profile", "email"]
+    idp_params = {
+        "client_id": oauth_config["client_id"],
+        "response_type": "code",
+        "redirect_uri": cf_callback_url,
+        "state": internal_state,
+        "scope": " ".join(scopes) if isinstance(scopes, list) else scopes,
+        "code_challenge": idp_code_challenge,
+        "code_challenge_method": "S256",
+        "nonce": nonce,
+    }
+
+    idp_auth_url = f"{idp_authorize_url}?{urllib.parse.urlencode(idp_params)}"
+    logger.info("MCP OAuth: redirecting user to IdP for server %s", sanitize_for_log(server_id))
+    return RedirectResponse(url=idp_auth_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# 3. Callback — handle IdP redirect
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.get("/callback/servers/{server_id}")
+async def callback(
+    server_id: str,
+    code: str,
+    state: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    error: Optional[str] = None,
+    error_description: Optional[str] = None,
+) -> RedirectResponse:
+    """Handle the IdP callback after user authentication.
+
+    Exchanges the IdP authorization code for tokens, authenticates
+    the user in ContextForge, generates a CF authorization code,
+    and redirects back to the MCP client (VS Code).
+    """
+    if error:
+        logger.warning("MCP OAuth callback error from IdP: %s — %s", error, sanitize_for_log(error_description or ""))
+        raise HTTPException(status_code=400, detail=f"IdP error: {error}")
+
+    # Decrypt session from state (no server-side storage)
+    session = _decrypt_state(state, _SESSION_TTL)
+
+    if session.get("sid") != server_id:
+        raise HTTPException(status_code=400, detail="Server ID mismatch")
+
+    _, oauth_config = await _get_server_oauth_config(db, server_id)
+
+    # Discover IdP token endpoint
+    auth_server = oauth_config.get("authorization_server") or oauth_config.get("authorization_servers", [None])[0]
+    idp_metadata = await _discover_oidc_metadata(auth_server)
+    idp_token_url = idp_metadata.get("token_endpoint")
+    if not idp_token_url:
+        raise HTTPException(status_code=500, detail="IdP token_endpoint not found")
+
+    # Exchange code with IdP
+    token_payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": session["cb"],
+        "client_id": oauth_config["client_id"],
+        "code_verifier": session["icv"],
+    }
+
+    # Add client_secret if configured (confidential client)
+    client_secret = oauth_config.get("client_secret")
+    if client_secret:
+        token_payload["client_secret"] = client_secret
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        token_resp = await client.post(idp_token_url, data=token_payload)
+
+    if token_resp.status_code != 200:
+        logger.error(
+            "MCP OAuth: IdP token exchange failed: %s %s",
+            token_resp.status_code,
+            sanitize_for_log(token_resp.text[:200]),
+        )
+        raise HTTPException(status_code=502, detail="IdP token exchange failed")
+
+    token_data = token_resp.json()
+    access_token = token_data.get("access_token")
+    id_token_raw = token_data.get("id_token")
+
+    if not access_token:
+        raise HTTPException(status_code=502, detail="IdP did not return access_token")
+
+    # Extract user info from id_token (without full cryptographic verification
+    # since we just received it directly from the IdP token endpoint over TLS)
+    user_info = _extract_user_from_id_token(id_token_raw) if id_token_raw else None
+
+    # Fallback: fetch userinfo endpoint
+    if not user_info or not user_info.get("email"):
+        userinfo_url = idp_metadata.get("userinfo_endpoint")
+        if userinfo_url:
+            async with httpx.AsyncClient(timeout=15) as client:
+                ui_resp = await client.get(
+                    userinfo_url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+                if ui_resp.status_code == 200:
+                    ui_data = ui_resp.json()
+                    user_info = user_info or {}
+                    user_info["email"] = ui_data.get("email") or ui_data.get("preferred_username") or ui_data.get("upn")
+                    user_info["full_name"] = ui_data.get("name") or ui_data.get("display_name")
+
+    if not user_info or not user_info.get("email"):
+        raise HTTPException(status_code=502, detail="Could not determine user email from IdP")
+
+    # Authenticate or create user in ContextForge (reuse SSO logic)
+    cf_access_token = await _authenticate_user(db, user_info)
+    if not cf_access_token:
+        raise HTTPException(status_code=403, detail="User authentication failed")
+
+    # Generate CF authorization code (encrypted — no server-side storage)
+    code_data = {
+        "at": cf_access_token,
+        "ru": session["ru"],
+        "cid": session["cid"],
+        "cc": session["cc"],
+        "ccm": session["ccm"],
+    }
+    cf_code = _encrypt_state(code_data)
+
+    # Redirect to MCP client with authorization code
+    redirect_params = {"code": cf_code}
+    if session.get("cs"):
+        redirect_params["state"] = session["cs"]
+
+    redirect_url = f"{session['ru']}?{urllib.parse.urlencode(redirect_params)}"
+    logger.info("MCP OAuth: redirecting to client callback for user %s", sanitize_for_log(user_info["email"]))
+    return RedirectResponse(url=redirect_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# 4. Token — exchange CF authorization code for JWT
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.post("/token/servers/{server_id}")
+async def token_exchange(
+    server_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """OAuth 2.0 Token endpoint.
+
+    Exchanges a ContextForge authorization code for a ContextForge JWT.
+    Validates PKCE ``code_verifier`` against the stored ``code_challenge``.
+    """
+    # Parse form body (OAuth 2.0 token endpoint uses application/x-www-form-urlencoded)
+    form = await request.form()
+    grant_type = form.get("grant_type")
+    code = form.get("code")
+    redirect_uri = form.get("redirect_uri")
+    client_id = form.get("client_id")
+    code_verifier = form.get("code_verifier")
+
+    if grant_type != "authorization_code":
+        return JSONResponse(
+            content={"error": "unsupported_grant_type"},
+            status_code=400,
+        )
+
+    if not code:
+        return JSONResponse(content={"error": "invalid_request", "error_description": "Missing code"}, status_code=400)
+
+    # Decrypt authorization code (no server-side storage)
+    try:
+        code_data = _decrypt_state(str(code), _CODE_TTL)
+    except HTTPException:
+        return JSONResponse(content={"error": "invalid_grant", "error_description": "Invalid or expired code"}, status_code=400)
+
+    # Validate redirect_uri matches
+    if redirect_uri and redirect_uri != code_data.get("ru"):
+        return JSONResponse(content={"error": "invalid_grant", "error_description": "redirect_uri mismatch"}, status_code=400)
+
+    # Validate client_id matches
+    if client_id and client_id != code_data.get("cid"):
+        return JSONResponse(content={"error": "invalid_grant", "error_description": "client_id mismatch"}, status_code=400)
+
+    # Validate PKCE
+    if code_data.get("cc"):
+        if not code_verifier:
+            return JSONResponse(
+                content={"error": "invalid_grant", "error_description": "code_verifier required"},
+                status_code=400,
+            )
+        method = code_data.get("ccm", "S256")
+        if method == "S256":
+            computed = _s256(str(code_verifier))
+        else:
+            computed = str(code_verifier)  # plain method
+
+        if computed != code_data["cc"]:
+            return JSONResponse(
+                content={"error": "invalid_grant", "error_description": "PKCE verification failed"},
+                status_code=400,
+            )
+
+    access_token = code_data["at"]
+    response = TokenResponse(
+        access_token=access_token,
+        expires_in=settings.token_expiry * 60 if hasattr(settings, "token_expiry") else 604800,
+    )
+
+    logger.info("MCP OAuth: issued access token for server %s", sanitize_for_log(server_id))
+    return JSONResponse(content=response.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# User authentication helper
+# ---------------------------------------------------------------------------
+
+
+def _extract_user_from_id_token(id_token: str) -> Optional[Dict[str, Any]]:
+    """Extract claims from an ID token without cryptographic verification.
+
+    Safe because we received the token directly from the IdP token endpoint
+    over a TLS-protected channel (back-channel).
+    """
+    import base64
+    import json
+
+    try:
+        parts = id_token.split(".")
+        if len(parts) != 3:
+            return None
+        # Decode payload (part 1)
+        payload = parts[1]
+        # Add padding
+        payload += "=" * (4 - len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload)
+        claims = json.loads(decoded)
+        return {
+            "email": claims.get("email") or claims.get("preferred_username") or claims.get("upn"),
+            "full_name": claims.get("name"),
+            "sub": claims.get("sub"),
+            "groups": claims.get("groups", []),
+        }
+    except Exception:
+        logger.debug("Failed to decode id_token claims", exc_info=True)
+        return None
+
+
+async def _authenticate_user(db: Session, user_info: Dict[str, Any]) -> Optional[str]:
+    """Authenticate (or create) a user and return a ContextForge JWT.
+
+    Reuses the SSO service's user management if available, falling back
+    to direct JWT creation for known users.
+    """
+    email = str(user_info.get("email", "")).strip().lower()
+    if not email:
+        return None
+
+    full_name = user_info.get("full_name") or email
+
+    # Try SSO service if available
+    try:
+        from mcpgateway.services.sso_service import SSOService
+
+        sso_service = SSOService(db)
+        sso_user_info = {
+            "email": email,
+            "full_name": full_name,
+            "provider": "entra",
+            "groups": user_info.get("groups", []),
+            "email_verified": True,
+        }
+        token = await sso_service.authenticate_or_create_user(sso_user_info)
+        if token:
+            return token
+    except Exception:
+        logger.debug("SSO service not available, falling back to direct auth", exc_info=True)
+
+    # Fallback: look up user directly and create JWT
+    try:
+        from mcpgateway.db import User as DbUser
+
+        user = db.query(DbUser).filter(DbUser.email == email).first()
+        if not user:
+            logger.warning("MCP OAuth: user %s not found and SSO auto-create not available", sanitize_for_log(email))
+            return None
+
+        token_data = {
+            "sub": email,
+            "email": email,
+            "full_name": full_name,
+            "auth_provider": "mcp_oauth",
+            "user": {
+                "email": email,
+                "full_name": full_name,
+                "is_admin": bool(user.is_admin),
+                "auth_provider": "mcp_oauth",
+            },
+            "token_use": "session",
+            "scopes": {
+                "server_id": None,
+                "permissions": ["*"] if user.is_admin else [],
+                "ip_restrictions": [],
+                "time_restrictions": {},
+            },
+        }
+        return await create_jwt_token(token_data)
+    except Exception:
+        logger.exception("Failed to create JWT for MCP OAuth user %s", sanitize_for_log(email))
+        return None

--- a/mcpgateway/routers/mcp_oauth.py
+++ b/mcpgateway/routers/mcp_oauth.py
@@ -1,0 +1,606 @@
+"""MCP OAuth 2.0 Authorization Server proxy for virtual servers.
+
+Enables MCP clients (VS Code, Cursor) to authenticate via an external IdP
+(e.g. Microsoft Entra ID) without requiring Dynamic Client Registration
+support from the IdP.  ContextForge acts as an OAuth 2.0 Authorization
+Server for the client while proxying to the real IdP behind the scenes.
+
+Implements RFC 6749 (OAuth 2.0), RFC 7636 (PKCE), RFC 7591 (DCR),
+and RFC 8414 (Authorization Server Metadata).
+
+Flow:
+    1. Resource metadata (RFC 9728) → ContextForge as ``authorization_server``
+    2. Auth server metadata (RFC 8414) → ContextForge endpoints
+    3. DCR (RFC 7591) → returns pre-configured ``client_id``
+    4. ``/authorize`` → redirects to external IdP (Entra)
+    5. IdP callback → ContextForge validates, issues an authorization code
+    6. ``/token`` → exchanges code for a ContextForge-signed JWT
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import time
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from mcpgateway.config import settings
+from mcpgateway.db import Server as DbServer, get_db
+from mcpgateway.services.encryption_service import decrypt_oauth_config_for_runtime
+from mcpgateway.utils.create_jwt_token import create_jwt_token
+from mcpgateway.utils.log_sanitizer import sanitize_for_log
+
+logger = logging.getLogger(__name__)
+
+mcp_oauth_router = APIRouter(prefix="/oauth", tags=["MCP OAuth"])
+
+# ---------------------------------------------------------------------------
+# Encrypted state — multi-pod safe (no shared storage needed).
+# Session and auth-code data are encrypted with Fernet using the
+# application's auth_secret.  The encrypted blob travels in the OAuth
+# ``state`` parameter or the authorization code itself.
+# ---------------------------------------------------------------------------
+
+_SESSION_TTL = 600  # 10 minutes
+_CODE_TTL = 300  # 5 minutes
+_OIDC_CACHE_TTL = 3600  # 1 hour
+
+# OIDC metadata discovery cache (safe as in-memory — read-only / idempotent)
+_oidc_cache: Dict[str, Dict[str, Any]] = {}
+
+
+def _get_fernet() -> Fernet:
+    """Derive a Fernet key from the application secret."""
+    secret = settings.jwt_secret_key.get_secret_value() if hasattr(settings.jwt_secret_key, "get_secret_value") else str(settings.jwt_secret_key)
+    # Fernet requires a 32-byte url-safe base64-encoded key
+    key_bytes = hashlib.sha256(secret.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(key_bytes))
+
+
+def _encrypt_state(data: Dict[str, Any]) -> str:
+    """Encrypt session data into a URL-safe token."""
+    data["_ts"] = time.time()  # wall-clock for cross-pod TTL
+    plaintext = json.dumps(data, separators=(",", ":")).encode()
+    return _get_fernet().encrypt(plaintext).decode("ascii")
+
+
+def _decrypt_state(token: str, ttl: int) -> Dict[str, Any]:
+    """Decrypt and validate an encrypted state token.
+
+    Raises HTTPException if invalid or expired.
+    """
+    try:
+        plaintext = _get_fernet().decrypt(token.encode("ascii"))
+        data = json.loads(plaintext)
+    except (InvalidToken, json.JSONDecodeError, Exception):
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+
+    ts = data.get("_ts", 0)
+    if time.time() - ts > ttl:
+        raise HTTPException(status_code=400, detail="OAuth session expired")
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# OIDC metadata discovery (cached)
+# ---------------------------------------------------------------------------
+
+
+async def _discover_oidc_metadata(issuer: str) -> Dict[str, Any]:
+    """Fetch and cache OIDC metadata from the authorization server."""
+    cached = _oidc_cache.get(issuer)
+    if cached and (time.time() - cached.get("_ts", 0)) < _OIDC_CACHE_TTL:
+        return cached["metadata"]
+
+    oidc_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+        resp = await client.get(oidc_url)
+        resp.raise_for_status()
+        metadata = resp.json()
+
+    _oidc_cache[issuer] = {"metadata": metadata, "_ts": time.time()}
+
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_server_oauth_config(db: Session, server_id: str) -> tuple[DbServer, Dict[str, Any]]:
+    """Load virtual server, validate and decrypt MCP OAuth proxy config."""
+    server = db.get(DbServer, server_id)
+    if not server or not server.enabled:
+        raise HTTPException(status_code=404, detail="Server not found")
+
+    oauth_config = getattr(server, "oauth_config", None) or {}
+    if not oauth_config.get("client_id"):
+        raise HTTPException(
+            status_code=404,
+            detail="MCP OAuth proxy not configured for this server (missing client_id in oauth_config)",
+        )
+
+    # Decrypt secrets (client_secret is encrypted at rest)
+    oauth_config = await decrypt_oauth_config_for_runtime(oauth_config)
+
+    return server, oauth_config
+
+
+def _s256(verifier: str) -> str:
+    """Compute S256 code challenge from verifier."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class DCRRequest(BaseModel):
+    """RFC 7591 Dynamic Client Registration request (subset)."""
+
+    redirect_uris: List[str] = Field(default_factory=list)
+    client_name: Optional[str] = None
+    grant_types: List[str] = Field(default_factory=lambda: ["authorization_code"])
+    response_types: List[str] = Field(default_factory=lambda: ["code"])
+    token_endpoint_auth_method: str = "none"
+
+
+class DCRResponse(BaseModel):
+    """RFC 7591 Dynamic Client Registration response."""
+
+    client_id: str
+    client_id_issued_at: int = 0
+    redirect_uris: List[str] = Field(default_factory=list)
+    grant_types: List[str] = Field(default_factory=lambda: ["authorization_code"])
+    response_types: List[str] = Field(default_factory=lambda: ["code"])
+    token_endpoint_auth_method: str = "none"
+
+
+class TokenRequest(BaseModel):
+    """OAuth 2.0 Token Exchange request."""
+
+    grant_type: str
+    code: str
+    redirect_uri: str
+    client_id: str
+    code_verifier: Optional[str] = None
+
+
+class TokenResponse(BaseModel):
+    """OAuth 2.0 Token response."""
+
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int = Field(default=604800)
+
+
+# ---------------------------------------------------------------------------
+# 1. DCR — Dynamic Client Registration
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.post("/register/{server_id}")
+async def register_client(
+    server_id: str,
+    body: DCRRequest,
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """RFC 7591 DCR: return pre-configured client credentials.
+
+    MCP clients call this to "register" — we return the pre-configured
+    Entra app ``client_id`` from the virtual server's ``oauth_config``.
+    No actual registration happens.
+    """
+    _, oauth_config = await _get_server_oauth_config(db, server_id)
+
+    client_id = oauth_config["client_id"]
+    response = DCRResponse(
+        client_id=client_id,
+        redirect_uris=body.redirect_uris,
+    )
+
+    logger.info("MCP OAuth DCR: returned client_id for server %s", sanitize_for_log(server_id))
+    return JSONResponse(content=response.model_dump(), status_code=201)
+
+
+# ---------------------------------------------------------------------------
+# 2. Authorize — redirect user to external IdP
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.get("/authorize/servers/{server_id}")
+async def authorize(
+    server_id: str,
+    request: Request,
+    client_id: str,
+    redirect_uri: str,
+    response_type: str = "code",
+    state: Optional[str] = None,
+    scope: Optional[str] = None,
+    code_challenge: Optional[str] = None,
+    code_challenge_method: Optional[str] = None,
+    db: Session = Depends(get_db),
+) -> RedirectResponse:
+    """OAuth 2.0 Authorization endpoint.
+
+    Validates parameters, stores session state, and redirects the user
+    to the external IdP (e.g. Entra).
+    """
+    if response_type != "code":
+        raise HTTPException(status_code=400, detail="Only response_type=code is supported")
+
+    _, oauth_config = await _get_server_oauth_config(db, server_id)
+
+    # Validate client_id matches configured value
+    if client_id != oauth_config["client_id"]:
+        raise HTTPException(status_code=400, detail="Invalid client_id")
+
+    # Discover IdP endpoints
+    auth_server = oauth_config.get("authorization_server") or oauth_config.get("authorization_servers", [None])[0]
+    if not auth_server:
+        raise HTTPException(status_code=500, detail="authorization_server not configured")
+
+    idp_metadata = await _discover_oidc_metadata(auth_server)
+    idp_authorize_url = idp_metadata.get("authorization_endpoint")
+    if not idp_authorize_url:
+        raise HTTPException(status_code=500, detail="IdP authorization_endpoint not found")
+
+    # Generate internal state for CF ↔ IdP leg
+    # The state carries the encrypted session data — no server-side storage.
+    # Generate PKCE for CF → IdP leg
+    idp_code_verifier = secrets.token_urlsafe(64)
+    idp_code_challenge = _s256(idp_code_verifier)
+
+    # Generate nonce for OIDC
+    nonce = secrets.token_urlsafe(16)
+
+    # Build CF callback URL
+    base_url = str(request.base_url).rstrip("/")
+    # Respect X-Forwarded-* headers for reverse proxy
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    if forwarded_proto and forwarded_host:
+        base_url = f"{forwarded_proto}://{forwarded_host}"
+    root_path = request.scope.get("root_path", "").rstrip("/")
+    cf_callback_url = f"{base_url}{root_path}/oauth/callback/servers/{server_id}"
+
+    # Encrypt session data into state
+    session_data = {
+        "sid": server_id,
+        "cid": client_id,
+        "ru": redirect_uri,
+        "cs": state,
+        "cc": code_challenge,
+        "ccm": code_challenge_method,
+        "icv": idp_code_verifier,
+        "n": nonce,
+        "cb": cf_callback_url,
+    }
+
+    internal_state = _encrypt_state(session_data)
+
+    # Build IdP authorize URL
+    scopes = oauth_config.get("scopes") or oauth_config.get("scopes_supported") or ["openid", "profile", "email"]
+    idp_params = {
+        "client_id": oauth_config["client_id"],
+        "response_type": "code",
+        "redirect_uri": cf_callback_url,
+        "state": internal_state,
+        "scope": " ".join(scopes) if isinstance(scopes, list) else scopes,
+        "code_challenge": idp_code_challenge,
+        "code_challenge_method": "S256",
+        "nonce": nonce,
+    }
+
+    idp_auth_url = f"{idp_authorize_url}?{urllib.parse.urlencode(idp_params)}"
+    logger.info("MCP OAuth: redirecting user to IdP for server %s", sanitize_for_log(server_id))
+    return RedirectResponse(url=idp_auth_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# 3. Callback — handle IdP redirect
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.get("/callback/servers/{server_id}")
+async def callback(
+    server_id: str,
+    code: str,
+    state: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    error: Optional[str] = None,
+    error_description: Optional[str] = None,
+) -> RedirectResponse:
+    """Handle the IdP callback after user authentication.
+
+    Exchanges the IdP authorization code for tokens, authenticates
+    the user in ContextForge, generates a CF authorization code,
+    and redirects back to the MCP client (VS Code).
+    """
+    if error:
+        logger.warning("MCP OAuth callback error from IdP: %s — %s", error, sanitize_for_log(error_description or ""))
+        raise HTTPException(status_code=400, detail=f"IdP error: {error}")
+
+    # Decrypt session from state (no server-side storage)
+    session = _decrypt_state(state, _SESSION_TTL)
+
+    if session.get("sid") != server_id:
+        raise HTTPException(status_code=400, detail="Server ID mismatch")
+
+    _, oauth_config = await _get_server_oauth_config(db, server_id)
+
+    # Discover IdP token endpoint
+    auth_server = oauth_config.get("authorization_server") or oauth_config.get("authorization_servers", [None])[0]
+    idp_metadata = await _discover_oidc_metadata(auth_server)
+    idp_token_url = idp_metadata.get("token_endpoint")
+    if not idp_token_url:
+        raise HTTPException(status_code=500, detail="IdP token_endpoint not found")
+
+    # Exchange code with IdP
+    token_payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": session["cb"],
+        "client_id": oauth_config["client_id"],
+        "code_verifier": session["icv"],
+    }
+
+    # Add client_secret if configured (confidential client)
+    client_secret = oauth_config.get("client_secret")
+    if client_secret:
+        token_payload["client_secret"] = client_secret
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        token_resp = await client.post(idp_token_url, data=token_payload)
+
+    if token_resp.status_code != 200:
+        logger.error(
+            "MCP OAuth: IdP token exchange failed: %s %s",
+            token_resp.status_code,
+            sanitize_for_log(token_resp.text[:200]),
+        )
+        raise HTTPException(status_code=502, detail="IdP token exchange failed")
+
+    token_data = token_resp.json()
+    access_token = token_data.get("access_token")
+    id_token_raw = token_data.get("id_token")
+
+    if not access_token:
+        raise HTTPException(status_code=502, detail="IdP did not return access_token")
+
+    # Extract user info from id_token (without full cryptographic verification
+    # since we just received it directly from the IdP token endpoint over TLS)
+    user_info = _extract_user_from_id_token(id_token_raw) if id_token_raw else None
+
+    # Fallback: fetch userinfo endpoint
+    if not user_info or not user_info.get("email"):
+        userinfo_url = idp_metadata.get("userinfo_endpoint")
+        if userinfo_url:
+            async with httpx.AsyncClient(timeout=15) as client:
+                ui_resp = await client.get(
+                    userinfo_url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+                if ui_resp.status_code == 200:
+                    ui_data = ui_resp.json()
+                    user_info = user_info or {}
+                    user_info["email"] = ui_data.get("email") or ui_data.get("preferred_username") or ui_data.get("upn")
+                    user_info["full_name"] = ui_data.get("name") or ui_data.get("display_name")
+
+    if not user_info or not user_info.get("email"):
+        raise HTTPException(status_code=502, detail="Could not determine user email from IdP")
+
+    # Authenticate or create user in ContextForge (reuse SSO logic)
+    cf_access_token = await _authenticate_user(db, user_info)
+    if not cf_access_token:
+        raise HTTPException(status_code=403, detail="User authentication failed")
+
+    # Generate CF authorization code (encrypted — no server-side storage)
+    code_data = {
+        "at": cf_access_token,
+        "ru": session["ru"],
+        "cid": session["cid"],
+        "cc": session["cc"],
+        "ccm": session["ccm"],
+    }
+    cf_code = _encrypt_state(code_data)
+
+    # Redirect to MCP client with authorization code
+    redirect_params = {"code": cf_code}
+    if session.get("cs"):
+        redirect_params["state"] = session["cs"]
+
+    redirect_url = f"{session['ru']}?{urllib.parse.urlencode(redirect_params)}"
+    logger.info("MCP OAuth: redirecting to client callback for user %s", sanitize_for_log(user_info["email"]))
+    return RedirectResponse(url=redirect_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# 4. Token — exchange CF authorization code for JWT
+# ---------------------------------------------------------------------------
+
+
+@mcp_oauth_router.post("/token/servers/{server_id}")
+async def token_exchange(
+    server_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """OAuth 2.0 Token endpoint.
+
+    Exchanges a ContextForge authorization code for a ContextForge JWT.
+    Validates PKCE ``code_verifier`` against the stored ``code_challenge``.
+    """
+    # Parse form body (OAuth 2.0 token endpoint uses application/x-www-form-urlencoded)
+    form = await request.form()
+    grant_type = form.get("grant_type")
+    code = form.get("code")
+    redirect_uri = form.get("redirect_uri")
+    client_id = form.get("client_id")
+    code_verifier = form.get("code_verifier")
+
+    if grant_type != "authorization_code":
+        return JSONResponse(
+            content={"error": "unsupported_grant_type"},
+            status_code=400,
+        )
+
+    if not code:
+        return JSONResponse(content={"error": "invalid_request", "error_description": "Missing code"}, status_code=400)
+
+    # Decrypt authorization code (no server-side storage)
+    try:
+        code_data = _decrypt_state(str(code), _CODE_TTL)
+    except HTTPException:
+        return JSONResponse(content={"error": "invalid_grant", "error_description": "Invalid or expired code"}, status_code=400)
+
+    # Validate redirect_uri matches
+    if redirect_uri and redirect_uri != code_data.get("ru"):
+        return JSONResponse(content={"error": "invalid_grant", "error_description": "redirect_uri mismatch"}, status_code=400)
+
+    # Validate client_id matches
+    if client_id and client_id != code_data.get("cid"):
+        return JSONResponse(content={"error": "invalid_grant", "error_description": "client_id mismatch"}, status_code=400)
+
+    # Validate PKCE
+    if code_data.get("cc"):
+        if not code_verifier:
+            return JSONResponse(
+                content={"error": "invalid_grant", "error_description": "code_verifier required"},
+                status_code=400,
+            )
+        method = code_data.get("ccm", "S256")
+        if method == "S256":
+            computed = _s256(str(code_verifier))
+        else:
+            computed = str(code_verifier)  # plain method
+
+        if computed != code_data["cc"]:
+            return JSONResponse(
+                content={"error": "invalid_grant", "error_description": "PKCE verification failed"},
+                status_code=400,
+            )
+
+    access_token = code_data["at"]
+    response = TokenResponse(
+        access_token=access_token,
+        expires_in=settings.token_expiry * 60 if hasattr(settings, "token_expiry") else 604800,
+    )
+
+    logger.info("MCP OAuth: issued access token for server %s", sanitize_for_log(server_id))
+    return JSONResponse(content=response.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# User authentication helper
+# ---------------------------------------------------------------------------
+
+
+def _extract_user_from_id_token(id_token: str) -> Optional[Dict[str, Any]]:
+    """Extract claims from an ID token without cryptographic verification.
+
+    Safe because we received the token directly from the IdP token endpoint
+    over a TLS-protected channel (back-channel).
+    """
+    import base64
+    import json
+
+    try:
+        parts = id_token.split(".")
+        if len(parts) != 3:
+            return None
+        # Decode payload (part 1)
+        payload = parts[1]
+        # Add padding
+        payload += "=" * (4 - len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload)
+        claims = json.loads(decoded)
+        return {
+            "email": claims.get("email") or claims.get("preferred_username") or claims.get("upn"),
+            "full_name": claims.get("name"),
+            "sub": claims.get("sub"),
+            "groups": claims.get("groups", []),
+        }
+    except Exception:
+        logger.debug("Failed to decode id_token claims", exc_info=True)
+        return None
+
+
+async def _authenticate_user(db: Session, user_info: Dict[str, Any]) -> Optional[str]:
+    """Authenticate (or create) a user and return a ContextForge JWT.
+
+    Reuses the SSO service's user management if available, falling back
+    to direct JWT creation for known users.
+    """
+    email = str(user_info.get("email", "")).strip().lower()
+    if not email:
+        return None
+
+    full_name = user_info.get("full_name") or email
+
+    # Try SSO service if available
+    try:
+        from mcpgateway.services.sso_service import SSOService
+
+        sso_service = SSOService(db)
+        sso_user_info = {
+            "email": email,
+            "full_name": full_name,
+            "provider": "entra",
+            "groups": user_info.get("groups", []),
+            "email_verified": True,
+        }
+        token = await sso_service.authenticate_or_create_user(sso_user_info)
+        if token:
+            return token
+    except Exception:
+        logger.debug("SSO service not available, falling back to direct auth", exc_info=True)
+
+    # Fallback: look up user directly and create JWT
+    try:
+        from mcpgateway.db import User as DbUser
+
+        user = db.query(DbUser).filter(DbUser.email == email).first()
+        if not user:
+            logger.warning("MCP OAuth: user %s not found and SSO auto-create not available", sanitize_for_log(email))
+            return None
+
+        token_data = {
+            "sub": email,
+            "email": email,
+            "full_name": full_name,
+            "auth_provider": "mcp_oauth",
+            "user": {
+                "email": email,
+                "full_name": full_name,
+                "is_admin": bool(user.is_admin),
+                "auth_provider": "mcp_oauth",
+            },
+            "token_use": "session",
+            "scopes": {
+                "server_id": None,
+                "permissions": ["*"] if user.is_admin else [],
+                "ip_restrictions": [],
+                "time_restrictions": {},
+            },
+        }
+        return await create_jwt_token(token_data)
+    except Exception:
+        logger.exception("Failed to create JWT for MCP OAuth user %s", sanitize_for_log(email))
+        return None

--- a/mcpgateway/routers/well_known.py
+++ b/mcpgateway/routers/well_known.py
@@ -232,6 +232,81 @@ async def get_oauth_protected_resource(
     )
 
 
+@router.get("/.well-known/oauth-authorization-server/{path:path}")
+async def get_oauth_authorization_server_metadata(
+    path: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """RFC 8414 OAuth 2.0 Authorization Server Metadata endpoint.
+
+    When a virtual server has MCP OAuth proxy configured (``client_id``
+    in ``oauth_config``), ContextForge acts as the authorization server.
+    This endpoint returns metadata that MCP clients use to discover
+    the authorization, token, and registration endpoints.
+
+    Path format: ``/.well-known/oauth-authorization-server/servers/{UUID}``
+    (derived by MCP clients from ``authorization_servers`` in the
+    RFC 9728 resource metadata).
+
+    Args:
+        path: The issuer path after the well-known prefix.
+        request: FastAPI request object for URL construction.
+        db: Database session dependency.
+
+    Returns:
+        JSONResponse with RFC 8414 Authorization Server Metadata.
+
+    Raises:
+        HTTPException: 404 if server not found or MCP OAuth not configured.
+    """
+    if not settings.well_known_enabled:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    # Parse path: expect "servers/{UUID}" or "servers/{UUID}/..."
+    path_parts = path.strip("/").split("/")
+    if len(path_parts) < 2 or path_parts[0] != "servers":
+        raise HTTPException(status_code=404, detail="Invalid path format")
+
+    server_id = path_parts[1]
+    if not UUID_PATTERN.match(server_id):
+        raise HTTPException(status_code=404, detail="Invalid server_id format")
+
+    # Validate server exists and has MCP OAuth proxy configured
+    from mcpgateway.db import Server as DbServer
+
+    server = db.get(DbServer, server_id)
+    if not server or not server.enabled:
+        raise HTTPException(status_code=404, detail="Server not found")
+
+    oauth_config = getattr(server, "oauth_config", None) or {}
+    if not oauth_config.get("client_id"):
+        raise HTTPException(status_code=404, detail="MCP OAuth proxy not configured for this server")
+
+    # Build ContextForge endpoint URLs
+    base_url = get_base_url_with_protocol(request)
+
+    metadata = {
+        "issuer": f"{base_url}/servers/{server_id}",
+        "authorization_endpoint": f"{base_url}/oauth/authorize/servers/{server_id}",
+        "token_endpoint": f"{base_url}/oauth/token/servers/{server_id}",
+        "registration_endpoint": f"{base_url}/oauth/register/{server_id}",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "code_challenge_methods_supported": ["S256"],
+    }
+
+    # Add scopes if configured
+    scopes = oauth_config.get("scopes_supported") or oauth_config.get("scopes")
+    if scopes:
+        metadata["scopes_supported"] = scopes
+
+    headers = {"Cache-Control": f"public, max-age={settings.well_known_cache_max_age}"}
+    logger.debug("Served OAuth AS metadata for server %s", server_id)
+    return JSONResponse(content=metadata, headers=headers)
+
+
 def get_well_known_file_content(filename: str) -> PlainTextResponse:
     """
     Get the response for a well-known URI file.

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1989,12 +1989,33 @@ class ServerService(BaseService):
         if not oauth_config:
             raise ServerError(f"OAuth not configured for server: {server_id}")
 
-        # Extract authorization server(s) - support both list and single value in config
-        authorization_servers = oauth_config.get("authorization_servers", [])
-        if not authorization_servers:
-            auth_server = oauth_config.get("authorization_server")
-            if auth_server:
-                authorization_servers = [auth_server] if isinstance(auth_server, str) else auth_server
+        # Determine authorization server(s) to return in resource metadata.
+        #
+        # When the oauth_config contains a ``client_id``, ContextForge acts as
+        # an OAuth 2.0 Authorization Server proxy (MCP OAuth proxy mode).
+        # In this mode, return ContextForge's own URL so that MCP clients
+        # discover ContextForge endpoints (DCR, authorize, token) instead of
+        # the external IdP directly.  This avoids DCR failures with providers
+        # that do not support RFC 7591 (e.g. Microsoft Entra ID).
+        #
+        # When no ``client_id`` is present, return the external authorization
+        # server URL(s) as before (pass-through mode).
+        has_mcp_oauth_proxy = bool(oauth_config.get("client_id"))
+
+        if has_mcp_oauth_proxy:
+            # Derive ContextForge base URL from the resource URL.
+            # resource_base_url is like "https://cf.example.com/servers/{id}/mcp"
+            # We need "https://cf.example.com/servers/{id}" as the issuer.
+            base_parts = resource_base_url.rsplit("/mcp", 1)
+            cf_issuer = base_parts[0] if base_parts else resource_base_url
+            authorization_servers = [cf_issuer]
+        else:
+            # Extract external authorization server(s) - support both list and single value
+            authorization_servers = oauth_config.get("authorization_servers", [])
+            if not authorization_servers:
+                auth_server = oauth_config.get("authorization_server")
+                if auth_server:
+                    authorization_servers = [auth_server] if isinstance(auth_server, str) else auth_server
 
         if not authorization_servers:
             raise ServerError(f"OAuth authorization_server not configured for server: {server_id}")

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1922,12 +1922,33 @@ class ServerService(BaseService):
         if not oauth_config:
             raise ServerError(f"OAuth not configured for server: {server_id}")
 
-        # Extract authorization server(s) - support both list and single value in config
-        authorization_servers = oauth_config.get("authorization_servers", [])
-        if not authorization_servers:
-            auth_server = oauth_config.get("authorization_server")
-            if auth_server:
-                authorization_servers = [auth_server] if isinstance(auth_server, str) else auth_server
+        # Determine authorization server(s) to return in resource metadata.
+        #
+        # When the oauth_config contains a ``client_id``, ContextForge acts as
+        # an OAuth 2.0 Authorization Server proxy (MCP OAuth proxy mode).
+        # In this mode, return ContextForge's own URL so that MCP clients
+        # discover ContextForge endpoints (DCR, authorize, token) instead of
+        # the external IdP directly.  This avoids DCR failures with providers
+        # that do not support RFC 7591 (e.g. Microsoft Entra ID).
+        #
+        # When no ``client_id`` is present, return the external authorization
+        # server URL(s) as before (pass-through mode).
+        has_mcp_oauth_proxy = bool(oauth_config.get("client_id"))
+
+        if has_mcp_oauth_proxy:
+            # Derive ContextForge base URL from the resource URL.
+            # resource_base_url is like "https://cf.example.com/servers/{id}/mcp"
+            # We need "https://cf.example.com/servers/{id}" as the issuer.
+            base_parts = resource_base_url.rsplit("/mcp", 1)
+            cf_issuer = base_parts[0] if base_parts else resource_base_url
+            authorization_servers = [cf_issuer]
+        else:
+            # Extract external authorization server(s) - support both list and single value
+            authorization_servers = oauth_config.get("authorization_servers", [])
+            if not authorization_servers:
+                auth_server = oauth_config.get("authorization_server")
+                if auth_server:
+                    authorization_servers = [auth_server] if isinstance(auth_server, str) else auth_server
 
         if not authorization_servers:
             raise ServerError(f"OAuth authorization_server not configured for server: {server_id}")

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3257,6 +3257,50 @@
                     Leave blank to use standard discovery from authorization server
                   </p>
                 </div>
+                <div class="mt-4 border-t border-gray-100 dark:border-gray-700 pt-4">
+                  <p class="text-sm font-medium text-gray-700 dark:text-gray-400 mb-2">
+                    MCP OAuth Proxy (DCR Bypass)
+                  </p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                    Pre-register OAuth client credentials to bypass Dynamic Client Registration (RFC 7591).
+                    Required for IdPs like Microsoft Entra ID that do not support DCR.
+                  </p>
+                  <div>
+                    <label
+                      class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                      for="server-oauth-client-id"
+                      >Client ID (optional)</label
+                    >
+                    <input
+                      type="text"
+                      name="oauth_client_id"
+                      id="server-oauth-client-id"
+                      placeholder="e.g. 12345678-abcd-efgh-ijkl-123456789abc"
+                      class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      OAuth client ID registered with the Identity Provider
+                    </p>
+                  </div>
+                  <div class="mt-3">
+                    <label
+                      class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                      for="server-oauth-client-secret"
+                      >Client Secret (optional)</label
+                    >
+                    <input
+                      type="password"
+                      name="oauth_client_secret"
+                      id="server-oauth-client-secret"
+                      autocomplete="off"
+                      placeholder="Enter client secret"
+                      class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      OAuth client secret (stored encrypted). Leave blank if using public client (PKCE only).
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -11623,6 +11667,50 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         Leave blank to use standard discovery from authorization server
                       </p>
+                    </div>
+                    <div class="mt-4 border-t border-gray-100 dark:border-gray-700 pt-4">
+                      <p class="text-sm font-medium text-gray-700 dark:text-gray-400 mb-2">
+                        MCP OAuth Proxy (DCR Bypass)
+                      </p>
+                      <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                        Pre-register OAuth client credentials to bypass Dynamic Client Registration (RFC 7591).
+                        Required for IdPs like Microsoft Entra ID that do not support DCR.
+                      </p>
+                      <div>
+                        <label
+                          class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                          for="edit-server-oauth-client-id"
+                          >Client ID (optional)</label
+                        >
+                        <input
+                          type="text"
+                          name="oauth_client_id"
+                          id="edit-server-oauth-client-id"
+                          placeholder="e.g. 12345678-abcd-efgh-ijkl-123456789abc"
+                          class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        />
+                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          OAuth client ID registered with the Identity Provider
+                        </p>
+                      </div>
+                      <div class="mt-3">
+                        <label
+                          class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                          for="edit-server-oauth-client-secret"
+                          >Client Secret (optional)</label
+                        >
+                        <input
+                          type="password"
+                          name="oauth_client_secret"
+                          id="edit-server-oauth-client-secret"
+                          autocomplete="off"
+                          placeholder="Enter new client secret (leave blank to keep existing)"
+                          class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        />
+                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          OAuth client secret (stored encrypted). Leave blank to keep existing secret.
+                        </p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3364,6 +3364,49 @@
                     Leave blank to use standard discovery from authorization server
                   </p>
                 </div>
+                <div class="mt-4 border-t border-gray-100 dark:border-gray-700 pt-4">
+                  <p class="text-sm font-medium text-gray-700 dark:text-gray-400 mb-2">
+                    MCP OAuth Proxy (DCR Bypass)
+                  </p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                    Pre-register OAuth client credentials to bypass Dynamic Client Registration (RFC 7591).
+                    Required for IdPs like Microsoft Entra ID that do not support DCR.
+                  </p>
+                  <div>
+                    <label
+                      class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                      for="server-oauth-client-id"
+                      >Client ID (optional)</label
+                    >
+                    <input
+                      type="text"
+                      name="oauth_client_id"
+                      id="server-oauth-client-id"
+                      placeholder="e.g. 12345678-abcd-efgh-ijkl-123456789abc"
+                      class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      OAuth client ID registered with the Identity Provider
+                    </p>
+                  </div>
+                  <div class="mt-3">
+                    <label
+                      class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                      for="server-oauth-client-secret"
+                      >Client Secret (optional)</label
+                    >
+                    <input
+                      type="password"
+                      name="oauth_client_secret"
+                      id="server-oauth-client-secret"
+                      placeholder="Enter client secret"
+                      class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      OAuth client secret (stored encrypted). Leave blank if using public client (PKCE only).
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -11450,6 +11493,49 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         Leave blank to use standard discovery from authorization server
                       </p>
+                    </div>
+                    <div class="mt-4 border-t border-gray-100 dark:border-gray-700 pt-4">
+                      <p class="text-sm font-medium text-gray-700 dark:text-gray-400 mb-2">
+                        MCP OAuth Proxy (DCR Bypass)
+                      </p>
+                      <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                        Pre-register OAuth client credentials to bypass Dynamic Client Registration (RFC 7591).
+                        Required for IdPs like Microsoft Entra ID that do not support DCR.
+                      </p>
+                      <div>
+                        <label
+                          class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                          for="edit-server-oauth-client-id"
+                          >Client ID (optional)</label
+                        >
+                        <input
+                          type="text"
+                          name="oauth_client_id"
+                          id="edit-server-oauth-client-id"
+                          placeholder="e.g. 12345678-abcd-efgh-ijkl-123456789abc"
+                          class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        />
+                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          OAuth client ID registered with the Identity Provider
+                        </p>
+                      </div>
+                      <div class="mt-3">
+                        <label
+                          class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                          for="edit-server-oauth-client-secret"
+                          >Client Secret (optional)</label
+                        >
+                        <input
+                          type="password"
+                          name="oauth_client_secret"
+                          id="edit-server-oauth-client-secret"
+                          placeholder="Enter new client secret (leave blank to keep existing)"
+                          class="mt-1 px-1.5 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        />
+                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          OAuth client secret (stored encrypted). Leave blank to keep existing secret.
+                        </p>
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Addresses the need for MCP OAuth support with identity providers that do not implement Dynamic Client Registration (DCR), such as Microsoft Entra ID (Azure AD).

---

## 🔗 Epic / Issue

Addresses #2148

## 🚀 Summary

This PR adds an MCP OAuth proxy layer that allows virtual servers to authenticate MCP clients using pre-registered OAuth client credentials instead of relying on DCR. This is essential for enterprise deployments where the IdP (e.g., Entra ID, Okta) does not support RFC 7591 dynamic client registration.

### What it adds:

1. **`/mcp-oauth/` router** (`mcpgateway/routers/mcp_oauth.py`): A full MCP-compliant OAuth proxy that handles `.well-known/oauth-authorization-server` metadata, `/authorize`, `/token`, and `/register` endpoints. It translates MCP OAuth flows into standard IdP flows using pre-registered `client_id` and `client_secret`.

2. **`/.well-known/oauth-protected-resource`** endpoint (`mcpgateway/routers/well_known.py`): Implements RFC 9728 OAuth Protected Resource Metadata, advertising the gateway's authorization server to MCP clients.

3. **Admin UI fields**: Adds `client_id` and `client_secret` input fields to the virtual server creation/edit form, allowing administrators to provide pre-registered OAuth app credentials.

4. **Encrypted state management**: Uses encrypted state tokens (Fernet) instead of in-memory storage for the OAuth authorization flow, making it compatible with multi-pod deployments behind a load balancer.

5. **Secret decryption**: Ensures `oauth_config` secrets are decrypted before being sent to the IdP for token exchange.

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [x] CHANGELOG updated (if user-facing)

---

## 📓 Notes

### Architecture

```text
MCP Client → Gateway (MCP OAuth Proxy) → IdP (Entra ID / Okta / etc.)
```

The proxy presents standard MCP OAuth endpoints to the client, while translating requests to the actual IdP using pre-registered credentials. The client never needs to know about DCR — it just follows the standard MCP OAuth flow.

### Key design decisions

- **Encrypted state over in-memory**: The OAuth state parameter is encrypted with the gateway's Fernet key, embedding the original state + PKCE verifier. This avoids in-memory state storage that breaks in multi-replica deployments.
- **Transparent proxy**: The proxy preserves the client's PKCE challenge and forwards it to the IdP, maintaining end-to-end security.
- **Backward compatible**: Existing virtual servers without `client_id`/`client_secret` continue to work with DCR as before.