### PR TITLE
fix(admin): preserve OAuth client_secret when editing gateways and A2A agents

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12871,10 +12871,13 @@ async def admin_edit_gateway(
                     oauth_config["redirect_uri"] = oauth_redirect_uri
                 if oauth_client_id:
                     oauth_config["client_id"] = oauth_client_id
-                if oauth_client_secret:
-                    # Encrypt the client secret
+                if oauth_client_secret and oauth_client_secret != settings.masked_auth_value:
+                    # Encrypt the new client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                elif oauth_client_id:
+                    # client_id present but secret left blank or masked — preserve existing secret
+                    oauth_config["client_secret"] = settings.masked_auth_value
 
                 # Add username and password for password grant type
                 if oauth_username:
@@ -16347,10 +16350,13 @@ async def admin_edit_a2a_agent(
                     oauth_config["redirect_uri"] = oauth_redirect_uri
                 if oauth_client_id:
                     oauth_config["client_id"] = oauth_client_id
-                if oauth_client_secret:
-                    # Encrypt the client secret
+                if oauth_client_secret and oauth_client_secret != settings.masked_auth_value:
+                    # Encrypt the new client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                elif oauth_client_id:
+                    # client_id present but secret left blank or masked — preserve existing secret
+                    oauth_config["client_secret"] = settings.masked_auth_value
 
                 # Add username and password for password grant type
                 if oauth_username:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12394,10 +12394,13 @@ async def admin_edit_gateway(
                     oauth_config["redirect_uri"] = oauth_redirect_uri
                 if oauth_client_id:
                     oauth_config["client_id"] = oauth_client_id
-                if oauth_client_secret:
-                    # Encrypt the client secret
+                if oauth_client_secret and oauth_client_secret != settings.masked_auth_value:
+                    # Encrypt the new client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                elif oauth_client_id:
+                    # client_id present but secret left blank or masked — preserve existing secret
+                    oauth_config["client_secret"] = settings.masked_auth_value
 
                 # Add username and password for password grant type
                 if oauth_username:
@@ -15719,10 +15722,13 @@ async def admin_edit_a2a_agent(
                     oauth_config["redirect_uri"] = oauth_redirect_uri
                 if oauth_client_id:
                     oauth_config["client_id"] = oauth_client_id
-                if oauth_client_secret:
-                    # Encrypt the client secret
+                if oauth_client_secret and oauth_client_secret != settings.masked_auth_value:
+                    # Encrypt the new client secret
                     encryption = get_encryption_service(settings.auth_encryption_secret)
                     oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
+                elif oauth_client_id:
+                    # client_id present but secret left blank or masked — preserve existing secret
+                    oauth_config["client_secret"] = settings.masked_auth_value
 
                 # Add username and password for password grant type
                 if oauth_username:

--- a/mcpgateway/admin_ui/a2aAgents.js
+++ b/mcpgateway/admin_ui/a2aAgents.js
@@ -569,7 +569,7 @@ export const editA2AAgent = async function (agentId) {
             oauthClientIdField.value = config.client_id || "";
           }
           if (oauthClientSecretField) {
-            oauthClientSecretField.value = ""; // Don't populate secret for security
+            oauthClientSecretField.value = config.client_secret ? MASKED_AUTH_VALUE : "";
           }
           if (oauthTokenUrlField) {
             oauthTokenUrlField.value = config.token_url || "";

--- a/mcpgateway/admin_ui/a2aAgents.js
+++ b/mcpgateway/admin_ui/a2aAgents.js
@@ -513,7 +513,7 @@ export const editA2AAgent = async function (agentId) {
             oauthClientIdField.value = config.client_id || "";
           }
           if (oauthClientSecretField) {
-            oauthClientSecretField.value = ""; // Don't populate secret for security
+            oauthClientSecretField.value = config.client_secret ? MASKED_AUTH_VALUE : "";
           }
           if (oauthTokenUrlField) {
             oauthTokenUrlField.value = config.token_url || "";

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -510,7 +510,7 @@ export const editGateway = async function (gatewayId) {
             oauthClientIdField.value = config.client_id || "";
           }
           if (oauthClientSecretField) {
-            oauthClientSecretField.value = ""; // Don't populate secret for security
+            oauthClientSecretField.value = config.client_secret ? MASKED_AUTH_VALUE : "";
           }
           if (oauthTokenUrlField) {
             oauthTokenUrlField.value = config.token_url || "";

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -1,5 +1,6 @@
 import { AppState } from "./appState.js";
 import { getCatalogUrl } from "./configExport.js";
+import { MASKED_AUTH_VALUE } from "./constants.js";
 import { toggleViewPublic } from "./filters.js";
 import { initGatewaySelect } from "./gateways.js";
 import { openModal } from "./modals.js";
@@ -854,6 +855,16 @@ export const editServer = async function (serverId) {
       // Extract token endpoint
       if (oauthTokenEndpointField) {
         oauthTokenEndpointField.value = server.oauthConfig.token_endpoint || "";
+      }
+
+      // Extract client_id for DCR bypass (pre-registered client)
+      const oauthClientIdField = safeGetElement("edit-server-oauth-client-id");
+      if (oauthClientIdField) {
+        oauthClientIdField.value = server.oauthConfig.client_id || "";
+      }
+      const oauthClientSecretField = safeGetElement("edit-server-oauth-client-secret");
+      if (oauthClientSecretField) {
+        oauthClientSecretField.value = server.oauthConfig.client_secret ? MASKED_AUTH_VALUE : "";
       }
     } else {
       // Clear OAuth config fields when no config exists

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -1,5 +1,6 @@
 import { AppState } from "./appState.js";
 import { getCatalogUrl } from "./configExport.js";
+import { MASKED_AUTH_VALUE } from "./constants.js";
 import { toggleViewPublic } from "./filters.js";
 import { initGatewaySelect } from "./gateways.js";
 import { openModal } from "./modals.js";
@@ -856,6 +857,16 @@ export const editServer = async function (serverId) {
       // Extract token endpoint
       if (oauthTokenEndpointField) {
         oauthTokenEndpointField.value = server.oauthConfig.token_endpoint || "";
+      }
+
+      // Extract client_id for DCR bypass (pre-registered client)
+      const oauthClientIdField = safeGetElement("edit-server-oauth-client-id");
+      if (oauthClientIdField) {
+        oauthClientIdField.value = server.oauthConfig.client_id || "";
+      }
+      const oauthClientSecretField = safeGetElement("edit-server-oauth-client-secret");
+      if (oauthClientSecretField) {
+        oauthClientSecretField.value = server.oauthConfig.client_secret ? MASKED_AUTH_VALUE : "";
       }
     } else {
       // Clear OAuth config fields when no config exists


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 🔗 Issue

Closes #4156

## 📌 Summary

Editing a gateway or A2A agent via the admin UI **silently erases** the OAuth `client_secret`, breaking all OAuth-authenticated gateways that are subsequently edited for any reason (e.g., changing tags, description, or team assignment).

## 🔁 Reproduction Steps

1. Create a gateway with OAuth authentication including a `client_secret`
2. Verify the gateway works (tools are discovered, OAuth token exchange succeeds)
3. Edit the gateway via the admin UI (change any field — description, tags, etc.)
4. Save the edit
5. The gateway is now broken — `client_secret` is gone from `oauth_config`
6. Any OAuth token exchange attempt fails with invalid_client

## 🐞 Root Cause

**Two bugs that combine to cause data loss:**

**Bug 1 — Frontend (`gateways.js`, `a2aAgents.js`):**

When the edit modal populates form fields, all secret fields (bearer token, password, custom headers, query params) are set to `MASKED_AUTH_VALUE` (`"*****"`) — **except** `oauth_client_secret` which is set to `""`:

```javascript
// All other secrets:
authTokenField.value = MASKED_AUTH_VALUE;       // ✅ Preserved
authPasswordField.value = MASKED_AUTH_VALUE;    // ✅ Preserved

// OAuth client_secret:
oauthClientSecretField.value = "";              // ❌ Sends empty string
```

**Bug 2 — Backend (`admin.py`, `admin_edit_gateway` and `admin_edit_a2a_agent`):**

When the form submits with `oauth_client_secret = ""`, the handler skips adding `client_secret` to the `oauth_config` dict entirely:

```python
if oauth_client_secret:               # False for "" → key never added
    oauth_config["client_secret"] = ...
# No fallback → client_secret simply missing → lost on save
```

The service layer's `protect_oauth_config_for_storage()` has preservation logic for `MASKED_AUTH_VALUE`, but it only works when the key **exists** in the dict. Since admin.py omits the key entirely, the preservation logic never fires.

**Note:** The `admin_edit_server` handler (virtual servers) already has the correct preservation pattern, making the inconsistency clear.

## 💡 Fix Description

**Frontend:** Set `oauthClientSecretField.value` to `MASKED_AUTH_VALUE` when a secret exists (consistent with all other secret fields), or `""` when no secret is configured.

**Backend:** When `oauth_client_secret` is empty or equals `MASKED_AUTH_VALUE` and a `client_id` is present, send the masked placeholder value so the service layer preserves the existing encrypted secret:

```python
if oauth_client_secret and oauth_client_secret != settings.masked_auth_value:
    # Encrypt new secret
    oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
elif oauth_client_id:
    # Preserve existing secret via masked placeholder
    oauth_config["client_secret"] = settings.masked_auth_value
```

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅     |
| Unit tests                            | `make test`          | ✅     |
| Coverage ≥ 80 %                       | `make coverage`      | ✅     |
| Manual regression no longer fails     | Edit gateway → secret preserved | ✅ |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed