### PR TITLE
fix: handling login in UI rewrite

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,11 +3,31 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss()],
 
-  // Assets are served from /static/app/ by FastAPI's StaticFiles mount
-  base: "/static/app/",
+  // Use "/" for dev server, "/static/app/" for production build
+  // Assets are served from /static/app/ by FastAPI's StaticFiles mount in production
+  base: mode === "production" ? "/static/app/" : "/",
+
+  // Proxy API requests to FastAPI backend during development
+  server: {
+    proxy: {
+      // Proxy all API endpoints to the FastAPI backend
+      "/auth": {
+        target: "http://localhost:4444",
+        changeOrigin: true,
+      },
+      "/api": {
+        target: "http://localhost:4444",
+        changeOrigin: true,
+      },
+      "/mcp": {
+        target: "http://localhost:4444",
+        changeOrigin: true,
+      },
+    },
+  },
 
   build: {
     // Output goes into mcpgateway/static/app/ — FastAPI serves /static/* from mcpgateway/static/
@@ -16,4 +36,4 @@ export default defineConfig({
     manifest: true,
     sourcemap: false,
   },
-});
+}));


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
When we run `make serve` and `cd client && npm install && npm run dev` the login page POST request returns 404.
We need to add configuration to vite.config.ts to fix this issue

## 🔁 Reproduction Steps
1. run `make serve` 
2. in other window run `cd client && npm install && npm run dev`
3. Open app in the http://localhost:5173/ and try to login to the app


