### PR TITLE
fix: remove hardcoded home paths

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -210,7 +210,7 @@ pytest -n auto tests/unit/
 
 ```bash
 # Test a specific file with coverage
-. /home/cmihai/.venv/mcpgateway/bin/activate
+. .venv/bin/activate
 pytest --cov-report=annotate tests/unit/mcpgateway/test_translate.py
 
 # Test with detailed output

--- a/crates/mcp_runtime/FOLLOWUPS.md
+++ b/crates/mcp_runtime/FOLLOWUPS.md
@@ -259,7 +259,7 @@ Status:
 
 Observed behavior:
 - The compose testing stack enables the plugin framework with `PLUGINS_ENABLED=true`.
-- However, the default [plugins/config.yaml](/home/cmihai/agents2/pr/mcp-context-forge/plugins/config.yaml) keeps built-in plugins such as `PIIFilterPlugin` in `mode: "disabled"`, so the current Rust MCP end-to-end battery does not exercise live plugin enforcement or transformation behavior.
+- However, the default [plugins/config.yaml](../../plugins/config.yaml) keeps built-in plugins such as `PIIFilterPlugin` in `mode: "disabled"`, so the current Rust MCP end-to-end battery does not exercise live plugin enforcement or transformation behavior.
 - Manual spot checks with temporary plugin enablement showed:
   - `resource_post_fetch` parity for `resources/read` using `LicenseHeaderInjector`
   - `prompt_pre_fetch` is reached on Rust full mode using `DenyListPlugin`
@@ -268,7 +268,7 @@ Observed behavior:
   - `tool_pre_invoke` / `tool_post_invoke`
   - `prompt_pre_fetch` / `prompt_post_fetch`
   - `resource_pre_fetch` / `resource_post_fetch`
-- In Rust full mode, the direct fast paths in [lib.rs](/home/cmihai/agents2/pr/mcp-context-forge/crates/mcp_runtime/src/lib.rs) serve several of those methods directly:
+- In Rust full mode, the direct fast paths in [lib.rs](src/lib.rs) serve several of those methods directly:
   - `direct_server_tools_list(...)`
   - `direct_server_resources_list(...)`
   - `direct_server_resource_templates_list(...)`
@@ -289,10 +289,10 @@ Why this matters:
   `prompts/get` happy path.
 
 Likely area:
-- [tool_service.py](/home/cmihai/agents2/pr/mcp-context-forge/mcpgateway/services/tool_service.py)
-- [prompt_service.py](/home/cmihai/agents2/pr/mcp-context-forge/mcpgateway/services/prompt_service.py)
-- [resource_service.py](/home/cmihai/agents2/pr/mcp-context-forge/mcpgateway/services/resource_service.py)
-- [lib.rs](/home/cmihai/agents2/pr/mcp-context-forge/crates/mcp_runtime/src/lib.rs)
+- [tool_service.py](../../mcpgateway/services/tool_service.py)
+- [prompt_service.py](../../mcpgateway/services/prompt_service.py)
+- [resource_service.py](../../mcpgateway/services/resource_service.py)
+- [lib.rs](src/lib.rs)
 
 Recommended next step:
 - Keep `make test-mcp-plugin-parity` green in both Python mode and Rust full mode using `tests/e2e/plugin_parity_config.yaml`.

--- a/crates/mcp_runtime/TESTING-DESIGN.md
+++ b/crates/mcp_runtime/TESTING-DESIGN.md
@@ -62,7 +62,7 @@ This design covers:
 - safe fallback behavior in `RUST_MCP_MODE=shadow`
 
 It assumes the compose-backed environment from
-[docker-compose.yml](/home/cmihai/agents2/pr/mcp-context-forge/docker-compose.yml),
+[docker-compose.yml](../../docker-compose.yml),
 which uses PostgreSQL and Redis.
 
 ## Why this matters
@@ -107,10 +107,10 @@ The following invariants should stay explicit and testable:
 
 Useful existing coverage already lives in:
 
-- [tests/e2e/test_mcp_rbac_transport.py](/home/cmihai/agents2/pr/mcp-context-forge/tests/e2e/test_mcp_rbac_transport.py)
-- [tests/integration/test_streamable_http_redis.py](/home/cmihai/agents2/pr/mcp-context-forge/tests/integration/test_streamable_http_redis.py)
-- [tests/e2e/test_session_pool_e2e.py](/home/cmihai/agents2/pr/mcp-context-forge/tests/e2e/test_session_pool_e2e.py)
-- [tests/loadtest/locustfile_mcp_protocol.py](/home/cmihai/agents2/pr/mcp-context-forge/tests/loadtest/locustfile_mcp_protocol.py)
+- [tests/e2e/test_mcp_rbac_transport.py](../../tests/e2e/test_mcp_rbac_transport.py)
+- [tests/integration/test_streamable_http_redis.py](../../tests/integration/test_streamable_http_redis.py)
+- [tests/e2e/test_session_pool_e2e.py](../../tests/e2e/test_session_pool_e2e.py)
+- [tests/loadtest/locustfile_mcp_protocol.py](../../tests/loadtest/locustfile_mcp_protocol.py)
 
 These are useful, but they are not enough on their own for Rust session-auth
 reuse.

--- a/docs/docs/manage/observability/observability.md
+++ b/docs/docs/manage/observability/observability.md
@@ -427,7 +427,7 @@ Use the trace generator helper to verify your observability backend is working:
 
 ```bash
 # Activate virtual environment if needed
-. /home/cmihai/.venv/mcpgateway/bin/activate
+. .venv/bin/activate
 
 # Run the trace generator
 python tests/integration/helpers/trace_generator.py

--- a/mcp-servers/python/mcp-rss-search/Makefile
+++ b/mcp-servers/python/mcp-rss-search/Makefile
@@ -3,7 +3,8 @@
 .PHONY: help install dev-install format lint test dev serve-http serve-sse test-http mcp-info clean
 
 PYTHON ?= python3
-VENV ?= /home/cmihai/.venv/mcpgateway
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+VENV ?= $(abspath $(MAKEFILE_DIR)/../../../.venv)
 HTTP_PORT ?= 9100
 HTTP_HOST ?= 0.0.0.0
 

--- a/mcp-servers/python/mcp-rss-search/README.md
+++ b/mcp-servers/python/mcp-rss-search/README.md
@@ -974,7 +974,7 @@ make test lint format
 **Solution**: Make sure the virtual environment is activated and the package is installed:
 
 ```bash
-. /home/cmihai/.venv/mcpgateway/bin/activate
+. .venv/bin/activate
 cd mcp-servers/python/mcp-rss-search
 pip install -e .
 ```

--- a/mcp-servers/python/mcp-rss-search/test_live.sh
+++ b/mcp-servers/python/mcp-rss-search/test_live.sh
@@ -7,7 +7,13 @@ echo "🚀 Starting MCP RSS Search Server..."
 echo ""
 
 # Activate virtual environment and start server in background
-. /home/cmihai/.venv/mcpgateway/bin/activate
+if [ -n "${VIRTUAL_ENV:-}" ] && [ -f "$VIRTUAL_ENV/bin/activate" ]; then
+    # shellcheck disable=SC1090
+    . "$VIRTUAL_ENV/bin/activate"
+elif [ -f "../../../.venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    . "../../../.venv/bin/activate"
+fi
 python3 -m mcp_rss_search.server_fastmcp --transport http --host 127.0.0.1 --port 9100 > /tmp/rss_server.log 2>&1 &
 SERVER_PID=$!
 

--- a/mcp-servers/python/output_schema_test_server/TESTING.md
+++ b/mcp-servers/python/output_schema_test_server/TESTING.md
@@ -12,7 +12,7 @@ This document provides step-by-step instructions for testing the `outputSchema` 
 
 2. **Start ContextForge** (in separate terminal):
    ```bash
-   cd /home/cmihai/github/mcp-context-forge
+   cd /path/to/mcp-context-forge
    make dev
    ```
 

--- a/tests/performance/utils/setup-auth.sh
+++ b/tests/performance/utils/setup-auth.sh
@@ -51,9 +51,15 @@ fi
 cd "$PROJECT_ROOT" || exit 1
 
 # Activate virtual environment if available
-if [ -f "/home/cmihai/.venv/mcpgateway/bin/activate" ]; then
+if [ -n "${VIRTUAL_ENV:-}" ] && [ -f "$VIRTUAL_ENV/bin/activate" ]; then
+    # shellcheck disable=SC1090
+    source "$VIRTUAL_ENV/bin/activate"
+elif [ -f "$PROJECT_ROOT/.venv/bin/activate" ]; then
     # shellcheck disable=SC1091
-    source /home/cmihai/.venv/mcpgateway/bin/activate
+    source "$PROJECT_ROOT/.venv/bin/activate"
+elif [ -f "$HOME/.venv/mcpgateway/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source "$HOME/.venv/mcpgateway/bin/activate"
 fi
 
 # Generate token

--- a/tests/unit/test_no_machine_specific_paths.py
+++ b/tests/unit/test_no_machine_specific_paths.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_repository_does_not_include_machine_specific_home_paths() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    machine_specific_home = "/home/" + "cmihai"
+    offenders: list[str] = []
+
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if ".git" in path.parts:
+            continue
+        if path.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".ico", ".pdf", ".pyc"}:
+            continue
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        if machine_specific_home in content:
+            offenders.append(str(path.relative_to(repo_root)))
+
+    assert offenders == []


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 80 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Removes machine-specific `/home/cmihai` paths from checked-in scripts, Makefiles, and docs so the repo works across developer environments. Adds a regression test to prevent reintroducing user-specific home paths.

## 🔁 Reproduction Steps
No linked issue.

1. Inspect the repo for `/home/cmihai`.
2. Observe hardcoded virtualenv and absolute repo paths in helper scripts and documentation.
3. Try to reuse those commands on another machine and see them fail or point at the wrong checkout.

## 🐞 Root Cause
Several checked-in files captured one developer's local home directory and checkout path instead of using portable path discovery, `$HOME`, `VIRTUAL_ENV`, or repo-relative links.

## 💡 Fix Description
- Replaced hardcoded virtualenv activation in shell scripts with portable lookup order: active `VIRTUAL_ENV`, repo `.venv`, then `$HOME/.venv/mcpgateway`.
- Changed the RSS search Makefile default venv path to the repo's `.venv`.
- Replaced machine-local absolute filesystem links in docs with repo-relative links or neutral placeholders.
- Added a unit test that fails if the machine-specific home path appears in tracked text files.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Not run |
| Unit tests                            | `make test`          | Not run |
| Coverage ≥ 80 %                       | `make coverage`      | Not run |
| Manual regression no longer fails     | `uv run pytest -q tests/unit/test_no_machine_specific_paths.py`; `rg -n '/home/cmihai' .`; `bash -n tests/performance/utils/setup-auth.sh`; `bash -n mcp-servers/python/mcp-rss-search/test_live.sh` | Passed |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

## 📓 Notes
This is intentionally small and surgical. The remaining generic `/home/user` strings are test fixtures or neutral examples, not machine-specific runtime paths.

The standard `detailed-code-review` workflow has not been run yet and should happen before marking this draft ready.
