### PR TITLE
fix: inject stored OAuth token for authorization_code gateway manual refresh

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -6046,6 +6046,32 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             if request_headers:
                 pre_auth_headers = get_passthrough_headers(request_headers, {}, db, gateway)
 
+            # For Authorization Code OAuth gateways, retrieve the stored user token
+            # so that _initialize_gateway() can connect instead of early-returning.
+            if (
+                user_email
+                and gateway.auth_type == "oauth"
+                and isinstance(gateway.oauth_config, dict)
+                and gateway.oauth_config.get("grant_type") == "authorization_code"
+                and "Authorization" not in pre_auth_headers
+            ):
+                from mcpgateway.services.token_storage_service import TokenStorageService  # pylint: disable=import-outside-toplevel
+
+                token_service = TokenStorageService(db)
+                access_token = await token_service.get_user_token(gateway_id, user_email)
+                if access_token:
+                    pre_auth_headers["Authorization"] = f"Bearer {access_token}"
+                    logger.debug(
+                        "Injected stored OAuth token for auth_code gateway %s (user %s)",
+                        gateway_name, user_email,
+                    )
+                else:
+                    logger.info(
+                        "No stored OAuth token for auth_code gateway %s (user %s) — "
+                        "refresh will return empty; user must complete /oauth/authorize/%s first",
+                        gateway_name, user_email, gateway_id,
+                    )
+
         lock = self._get_refresh_lock(gateway_id)
 
         # Check if lock is already held (concurrent refresh in progress)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -5226,6 +5226,32 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             if request_headers:
                 pre_auth_headers = get_passthrough_headers(request_headers, {}, db, gateway)
 
+            # For Authorization Code OAuth gateways, retrieve the stored user token
+            # so that _initialize_gateway() can connect instead of early-returning.
+            if (
+                user_email
+                and gateway.auth_type == "oauth"
+                and isinstance(gateway.oauth_config, dict)
+                and gateway.oauth_config.get("grant_type") == "authorization_code"
+                and "Authorization" not in pre_auth_headers
+            ):
+                from mcpgateway.services.token_storage_service import TokenStorageService  # pylint: disable=import-outside-toplevel
+
+                token_service = TokenStorageService(db)
+                access_token = await token_service.get_user_token(gateway_id, user_email)
+                if access_token:
+                    pre_auth_headers["Authorization"] = f"Bearer {access_token}"
+                    logger.debug(
+                        "Injected stored OAuth token for auth_code gateway %s (user %s)",
+                        gateway_name, user_email,
+                    )
+                else:
+                    logger.info(
+                        "No stored OAuth token for auth_code gateway %s (user %s) — "
+                        "refresh will return empty; user must complete /oauth/authorize/%s first",
+                        gateway_name, user_email, gateway_id,
+                    )
+
         lock = self._get_refresh_lock(gateway_id)
 
         # Check if lock is already held (concurrent refresh in progress)


### PR DESCRIPTION
## 📌 Summary
Fix manual gateway refresh for OAuth `authorization_code` by injecting a stored token into refresh headers when payload token is absent.

Fixes #4193

## 🔁 Reproduction Steps
1. Configure a gateway with `auth_type=oauth` and `grantType=authorization_code`.
2. Keep `oauth_auto_fetch_tool_flag=false` (default).
3. Store a valid user token in token storage.
4. Call `POST /gateways/{id}/tools/refresh` without a token in request payload.
5. Before fix: refresh returns 0 tools due to early-return path in gateway initialization.

## 🐞 Root Cause
`refresh_gateway_manually()` did not retrieve and inject the stored user token for authorization-code gateways. As a result, `_initialize_gateway()` entered the authorization-code early-return path and skipped tool retrieval.

## 💡 Fix Description
In `mcpgateway/services/gateway_service.py`:
- Detect OAuth `authorization_code` flow in manual refresh.
- Read the stored user token from `TokenStorageService`.
- Inject `Authorization: Bearer <token>` into `pre_auth_headers` before initialization.

## 🧪 Verification
| Check | Result |
|---|---|
| Reproduction test | Before: 0 tools, After: tools imported successfully |
| Scope of change | Single file (`gateway_service.py`) |
| Backward compatibility | Preserved |

## 📐 MCP Compliance
- [x] No protocol/schema changes
- [x] No breaking API changes
- [x] Existing auth flows preserved

## ✅ Checklist
- [x] DCO sign-off present
- [x] No secrets or environment-specific values added
- [x] Minimal and targeted change