### PR TITLE
Fixed bug in validation of tool error responses

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T21:47:51Z",
+  "generated_at": "2026-04-14T23:02:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8666,7 +8666,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2731,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8674,7 +8674,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2929,
+        "line_number": 3418,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8682,7 +8682,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2938,
+        "line_number": 3427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8690,7 +8690,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3329,
+        "line_number": 3818,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8698,7 +8698,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5711,
+        "line_number": 6746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8706,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5729,
+        "line_number": 6764,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8714,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5753,
+        "line_number": 6788,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8722,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5817,
+        "line_number": 6852,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8730,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5828,
+        "line_number": 6863,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8738,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5869,
+        "line_number": 6904,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8746,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5875,
+        "line_number": 6910,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8754,7 +8754,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6998,
+        "line_number": 8033,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9554,7 +9554,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11086,
+        "line_number": 11388,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9562,7 +9562,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12223,
+        "line_number": 12525,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T15:58:17Z",
+  "generated_at": "2026-04-14T21:47:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4876,7 +4876,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 175,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4884,7 +4884,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4892,7 +4892,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 268,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8698,7 +8698,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5738,
+        "line_number": 5711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8706,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5756,
+        "line_number": 5729,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8714,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5780,
+        "line_number": 5753,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8722,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5844,
+        "line_number": 5817,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8730,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5855,
+        "line_number": 5828,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8738,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5896,
+        "line_number": 5869,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8746,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5902,
+        "line_number": 5875,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8754,7 +8754,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7025,
+        "line_number": 6998,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T23:22:05Z",
+  "generated_at": "2026-04-14T23:25:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8666,7 +8666,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2887,
+        "line_number": 2936,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8674,7 +8674,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3574,
+        "line_number": 3623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8682,7 +8682,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3583,
+        "line_number": 3632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8690,7 +8690,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3974,
+        "line_number": 4023,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8698,7 +8698,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6902,
+        "line_number": 6951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8706,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6920,
+        "line_number": 6969,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8714,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6944,
+        "line_number": 6993,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8722,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7008,
+        "line_number": 7057,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8730,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7019,
+        "line_number": 7068,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8738,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7060,
+        "line_number": 7109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8746,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7066,
+        "line_number": 7115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8754,7 +8754,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8189,
+        "line_number": 8238,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T23:02:21Z",
+  "generated_at": "2026-04-14T23:22:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8666,7 +8666,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2731,
+        "line_number": 2887,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8674,7 +8674,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3418,
+        "line_number": 3574,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8682,7 +8682,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3427,
+        "line_number": 3583,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8690,7 +8690,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3818,
+        "line_number": 3974,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8698,7 +8698,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6746,
+        "line_number": 6902,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8706,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6764,
+        "line_number": 6920,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8714,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6788,
+        "line_number": 6944,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8722,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6852,
+        "line_number": 7008,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8730,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6863,
+        "line_number": 7019,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8738,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6904,
+        "line_number": 7060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8746,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6910,
+        "line_number": 7066,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8754,7 +8754,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8033,
+        "line_number": 8189,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T23:25:53Z",
+  "generated_at": "2026-04-14T23:29:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8666,7 +8666,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2936,
+        "line_number": 2980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8674,7 +8674,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3623,
+        "line_number": 3667,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8682,7 +8682,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3632,
+        "line_number": 3676,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8690,7 +8690,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4023,
+        "line_number": 4067,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8698,7 +8698,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6951,
+        "line_number": 6995,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8706,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6969,
+        "line_number": 7013,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8714,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6993,
+        "line_number": 7037,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8722,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7057,
+        "line_number": 7101,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8730,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7068,
+        "line_number": 7112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8738,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7109,
+        "line_number": 7153,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8746,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7115,
+        "line_number": 7159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8754,7 +8754,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8238,
+        "line_number": 8282,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-14T14:08:10Z",
+  "generated_at": "2026-04-14T15:58:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8698,7 +8698,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5613,
+        "line_number": 5738,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8706,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5631,
+        "line_number": 5756,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8714,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5655,
+        "line_number": 5780,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8722,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5719,
+        "line_number": 5844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8730,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5730,
+        "line_number": 5855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8738,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5771,
+        "line_number": 5896,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8746,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5777,
+        "line_number": 5902,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8754,7 +8754,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6900,
+        "line_number": 7025,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/tool-invocation-and-validation.md
+++ b/docs/docs/architecture/tool-invocation-and-validation.md
@@ -1,0 +1,183 @@
+# Tool Invocation & Output-Schema Validation
+
+ContextForge invokes tools across several very different backends — federated MCP peers, REST endpoints, OpenAPI-discovered services, A2A agents, and admin-registered tools — and in all cases exposes the result back to downstream MCP clients. Every one of those paths has at least one output-schema validation layer, and some have three. This document catalogues them end-to-end so contributors can reason about the full lifecycle of a tool call, the invariants at each hop, and where the MCP spec's "skip validation for error responses" rule takes effect.
+
+> **Why this matters:** ContextForge issue [#4202] surfaced a class of bug where error responses from a tool with a declared `outputSchema` were silently replaced with validation-error payloads at more than one layer in the pipeline. Fixing it required coordinated changes across the ingress validator, the transport handler's egress shape, and an upstream-fixture description filter. Keeping the flow documented prevents re-introductions.
+
+[#4202]: https://github.com/IBM/mcp-context-forge/issues/4202
+
+## High-level flow
+
+```
+ Downstream MCP client (e.g. mcp-cli via mcpgateway.wrapper)
+                   │  tools/call (JSON-RPC)
+                   ▼
+ ┌──────────────────────────────────────────────────────────┐
+ │ Gateway — MCP Python SERVER SDK                          │
+ │   streamablehttp_transport.py::call_tool                 │
+ │   (dispatches based on Tool.integration_type)            │
+ └──────────────────────────────────────────────────────────┘
+         │                                 │
+         │ integration_type == "MCP"       │ integration_type in {"REST","OPENAPI","A2A",...}
+         ▼                                 ▼
+ ┌───────────────────────┐         ┌────────────────────────────┐
+ │ mcp.ClientSession     │         │ HTTP client (httpx)        │
+ │ federation call to    │         │ REST-style invocation      │
+ │ upstream MCP server   │         │                            │
+ └───────────────────────┘         └────────────────────────────┘
+         │                                 │
+         │ upstream CallToolResult         │ upstream HTTP response
+         ▼                                 ▼
+ ┌────────────────────────────────┐ ┌────────────────────────────────┐
+ │ Validator A                    │ │ _coerce_to_tool_result │
+ │ ClientSession._validate_tool_  │ │ → ToolResult                   │
+ │ result (MCP CLIENT SDK)        │ └────────────────────────────────┘
+ │ Skips when isError=true.       │         │
+ │ Raises RuntimeError otherwise. │         ▼
+ └────────────────────────────────┘ ┌────────────────────────────────┐
+         │                          │ Validator B                    │
+         │ (federation path         │ ToolService._extract_and_      │
+         │  does NOT invoke         │ validate_structured_content    │
+         │  Validator B)            │ Skips when is_error=true       │
+         │                          │ (#4202 ingress fix).           │
+         │                          └────────────────────────────────┘
+         └──────────────┬────────────────────┘
+                        ▼
+        ToolResult (content[, structured_content][, is_error])
+                        │
+                        ▼
+ ┌──────────────────────────────────────────────────────────┐
+ │ streamablehttp_transport.py::call_tool — egress shape    │
+ │   if is_error: return types.CallToolResult(...)          │
+ │   else:        return (unstructured, structured) or list │
+ └──────────────────────────────────────────────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────────────────────┐
+ │ Validator C                                              │
+ │ MCP Python SERVER SDK (outbound)                         │
+ │ mcp.server.lowlevel.server (isinstance short-circuit)    │
+ │ • CallToolResult → short-circuits (no validation)        │
+ │ • list/tuple     → validates against gateway's own       │
+ │                    advertised outputSchema               │
+ └──────────────────────────────────────────────────────────┘
+                        │
+                        ▼
+ Downstream MCP client receives the response
+```
+
+## The three validation layers
+
+### Validator A — MCP client SDK (federation ingress)
+
+**Where:** `ClientSession._validate_tool_result` in the installed `mcp` client SDK.
+
+**When:** Gateway calls a federated MCP peer via `mcp.ClientSession`. Runs before the response returns from `ToolService.invoke_tool`.
+
+**Rule:**
+
+- If `result.isError` is truthy → **skip**. This is the spec rule codified by the MCP project itself ([Error Handling][spec-error]).
+- Else, if the tool advertised an `outputSchema` but `result.structuredContent` is `None` → raise `RuntimeError("Tool X has an output schema but did not return structured content")`.
+- Else, validate `structuredContent` against the *upstream-advertised* schema with `jsonschema.validate`.
+
+**Failure mode:** Raises `RuntimeError`; caught in `tool_service.py::invoke_tool` and re-wrapped as `Tool invocation failed: …` text. **The gateway never sees a malformed MCP-federated response** — the client SDK acts as the trust boundary for the upstream.
+
+### Validator B — `ToolService._extract_and_validate_structured_content`
+
+**Where:** `mcpgateway/services/tool_service.py`.
+
+**When:** Invoked explicitly and exclusively from the **REST** branch of `invoke_tool`. The MCP federation branch does **not** call it — Validator A is considered authoritative for federated peers. The **A2A branch does not call it either today** — that's a known gap; see "Known gaps and follow-ups" below.
+
+**Rule:**
+
+| Condition | Outcome |
+|---|---|
+| `is_error` or `isError` truthy | **Skip** (`return True`). The #4202 fix. |
+| `tool.output_schema` missing or empty | Skip (`return True`). |
+| `structured_content` set but not a JSON object | Fast-fail with a structured `invalid_structured_content_type` error. |
+| `structured_content` absent → best-effort promote first parseable `TextContent` item | Parses both raw dicts and Pydantic `TextContent` (needed since `_coerce_to_tool_result` produces the latter for REST responses). |
+| No structured payload obtainable + `is_error=False` + schema declared | Currently `return True` — known **spec deviation** tracked in [#4208]. |
+| `jsonschema.validate` raises | Replace `tool_result.content` with a validation-error TextContent, set `is_error=True`, `return False`. |
+
+**Failure mode:** In-place mutation of the passed `ToolResult`.
+
+### Validator C — MCP server SDK (downstream egress)
+
+**Where:** The `call_tool` dispatch in the installed `mcp` server-framework (`mcp.server.lowlevel.server` — look for the `isinstance(results, types.CallToolResult)` short-circuit).
+
+**When:** Runs for every `tools/call` the gateway serves. Receives whatever `streamablehttp_transport.py::call_tool` returns.
+
+**Rule:**
+
+| Handler return shape | SDK behaviour |
+|---|---|
+| `types.CallToolResult(...)` | **Short-circuit** — returned verbatim to the downstream client. Used for error responses to preserve the upstream error text intact (#4202 egress fix). |
+| `list[Content]` (no structured) | Treats as unstructured-only. If tool has `outputSchema` ⇒ replaces payload with `Output validation error: outputSchema defined but no structured output returned`. |
+| `tuple(list[Content], dict)` | Validates the dict against the gateway's `outputSchema`; on failure, synthesises `Output validation error: …`. |
+| `dict` | Treats as structured-only (unstructured is JSON-dumped). |
+
+**Failure mode:** Replaces the entire tool result with a synthesised error envelope. This is what #4202 was ultimately about on the outbound side — without the `CallToolResult` short-circuit, the server SDK re-clobbered error responses the ingress had just preserved.
+
+## Spec references
+
+- MCP 2025-11-25 **Error Handling**: <https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling>
+  - "Error responses do not require structured content."
+- MCP 2025-11-25 **Output Schema**: <https://modelcontextprotocol.io/specification/2025-11-25/server/tools#output-schema>
+  - "If an output schema is provided: Servers MUST provide structured results that conform to this schema."
+
+[spec-error]: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
+[spec-output]: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#output-schema
+
+## Per-path summary
+
+`DbTool.integration_type` is the primary discriminator at invocation time and is one of three literal values: `"MCP"`, `"REST"`, or `"A2A"` (see `mcpgateway/schemas.py::ToolCreate.integration_type`). The `invoke_tool` branches in `tool_service.py` fan out on this field — grep for `if tool_integration_type == "REST":` / `elif tool_integration_type == "MCP":` / `elif tool_integration_type == "A2A"` to land on each.
+
+> **OpenAPI is not a separate class.** There is no `"OPENAPI"` integration type. The OpenAPI importer in `mcpgateway/services/openapi_service.py` compiles each operation down into a `"REST"` tool at registration time — populating `base_url`, `path_template`, `query_mapping`, `header_mapping`, etc. on the resulting `DbTool`. At invocation time an OpenAPI-imported tool is indistinguishable from a hand-registered REST tool and takes the REST branch of `invoke_tool`. Treat the `"REST"` rows below as covering both hand-registered REST endpoints *and* OpenAPI-discovered ones.
+
+| Backend (`integration_type`) | Invocation branch | Validator A (MCP client SDK) | Validator B (`_extract_and_validate_structured_content`) | Validator C (MCP server SDK) |
+|---|---|---|---|---|
+| **MCP federation, success** | `elif tool_integration_type == "MCP":` (via `mcp.ClientSession`) | ✅ runs against upstream's advertised schema | — not invoked (Validator A is authoritative) | ✅ runs against gateway's advertised schema |
+| **MCP federation, `isError=true`** | same | skipped per MCP spec "Error Handling" | — not invoked | skipped via `CallToolResult` short-circuit (#4202 egress) |
+| **REST (incl. OpenAPI-imported), success** | `if tool_integration_type == "REST":` (via `httpx`) | — n/a (no federated client) | ✅ runs | ✅ runs |
+| **REST (incl. OpenAPI-imported), `isError=true`** | same | — n/a | skipped per MCP spec (#4202 ingress fix) | skipped via `CallToolResult` short-circuit |
+| **REST (incl. OpenAPI-imported), success but no structured payload** | same | — n/a | ⚠️ currently lenient (returns `True`) — tracked in [#4208] | ✅ runs (may reject) |
+| **A2A agent, success** | `elif tool_integration_type == "A2A"` (via A2A service) | — n/a (no MCP client SDK on this path) | ⚠️ **not invoked today** — Validator B gap | ✅ runs |
+| **A2A agent, `isError=true`** | same | — n/a | ⚠️ **not invoked today** (but moot — no schema enforcement to skip) | skipped via `CallToolResult` short-circuit |
+| **A2A agent, success but no structured payload** | same | — n/a | ⚠️ **not invoked today** | ✅ runs (may reject if Validator C sees outputSchema) |
+
+A2A tools do not currently route through Validator B. In practice this means gateway-side `output_schema` enforcement is absent for A2A — any validation on that path happens at Validator C only. Wiring A2A through a unified post-invoke pipeline (so REST and A2A really are symmetric) is scoped into the option-B refactor referenced in "Known gaps and follow-ups" below.
+
+[#4207]: https://github.com/IBM/mcp-context-forge/issues/4207
+[#4208]: https://github.com/IBM/mcp-context-forge/issues/4208
+
+## Known gaps and follow-ups
+
+- **[#4207] — e2e coverage for non-MCP paths.** REST (incl. OpenAPI-imported) tools have Validator B as their only gateway-side enforcement, and A2A has none (see the "option B" item below). Today those paths are covered by unit tests but not by `make test-mcp-cli` e2e tests.
+
+- **[#4208] — success path with declared schema but empty output.** Validator B currently returns `True` when it cannot obtain any structured payload, even if an `outputSchema` is declared. The MCP spec says servers MUST provide conforming structured output in that case. Tightening requires deciding how to handle upstream servers that legitimately return empty success bodies (HTTP 204, REST tools without data shapes) — scoped out of #4202 because the blast radius is wider.
+
+- **[#4210] — Option B: unify the tool-invocation pipeline around a canonical `ToolResult`.** Each `integration_type` currently builds `ToolResult` differently, and only REST currently routes through Validator B. The PR that closed #4202 landed a first structural step — a single `_coerce_to_tool_result` helper — but it is only wired into two of the four paths today: the REST branch and the MCP **direct-proxy** sub-branch. The MCP **non-direct-proxy** branch still builds its own `ToolResult` inline (via `tool_call_result.model_dump(by_alias=True)` + manual field extraction), and the A2A branch has its own bespoke construction as well. The remaining option-B work is the broader refactor that routes all four paths through the helper and a shared post-invoke pipeline: extract a `_post_invoke_pipeline` that owns plugins → Validator B → metrics, route A2A and the MCP non-direct-proxy branch through it, and promote the direct-proxy bypass from a mid-dispatch `if` into a first-class entry point with a documented contract. That refactor is the permanent fix for the #4202 class of divergent-shape bugs. See <https://github.com/IBM/mcp-context-forge/issues/4210>.
+
+## Testing map
+
+Unit tests:
+
+- `tests/unit/mcpgateway/services/test_tool_service_coverage.py::TestExtractAndValidateErrorResponses` — Validator B skip-on-error and its positive/negative schema branches.
+- `tests/unit/mcpgateway/services/test_tool_service_coverage.py::TestStructuredContentAdditional` — Validator B edge cases (non-dict structured content, malformed JSON in a text item, `orjson.dumps` fallback).
+- `tests/unit/mcpgateway/services/test_tool_service_coverage.py::TestCoerceToToolResult` — canonical-shape coercion fed to Validator B (MCP SDK `CallToolResult` round-trip, REST-payload field-dropping guards, `_meta` preservation).
+- `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py::test_call_tool_preserves_is_error_for_egress` — Validator C short-circuit, local (non-pooled) branch.
+- `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py::test_call_tool_session_affinity_forwarded_preserves_is_error` — Validator C short-circuit, worker-forwarded branch.
+
+End-to-end (via `make test-mcp-cli`):
+
+- `tests/e2e/test_mcp_cli_protocol.py::TestMcpStdioProtocol::test_tools_call_schema_error_preserves_payload` — drives the full pipeline against the upstream Rust fixture `fast-test-schema-error`, asserts the original error text arrives at the downstream client untouched (all three validator layers verified in concert).
+- `tests/e2e/test_mcp_cli_protocol.py::TestMcpStdioProtocol::test_tools_call_schema_success_validates_payload` — positive control against `fast-test-schema-success`, asserts `structuredContent` reaches the client when the payload satisfies the schema.
+
+## Adding a new backend
+
+When adding a new tool backend (e.g. gRPC, WebSocket stdio), keep the contract uniform:
+
+1. Produce a `ToolResult` pydantic model from the upstream response (use `_coerce_to_tool_result` for anything non-MCP-shaped).
+2. Decide whether the backend has its own authoritative validator (like Validator A for MCP). If so, you may skip Validator B; if not, call `_extract_and_validate_structured_content` before returning.
+3. Ensure the egress path in `streamablehttp_transport.py::call_tool` returns a `CallToolResult` for error responses so Validator C doesn't re-clobber them.
+4. Add regression tests at both layers — unit for the in-process validator(s), e2e for the full round-trip. A preflight `tools/list` guard like `_require_declared_output_schema` is worth replicating to give operators an actionable failure when the fixture stack is stale.

--- a/mcp-servers/rust/fast-test-server/src/main.rs
+++ b/mcp-servers/rust/fast-test-server/src/main.rs
@@ -12,7 +12,7 @@
 
 use axum::serve::ListenerExt;
 use axum::Router;
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use rand::Rng;
 use rand_distr::Normal;
 use rmcp::{
@@ -59,6 +59,28 @@ pub struct GetTimeRequest {
     /// IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Defaults to UTC.
     #[serde(default)]
     pub timezone: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ConvertTimeRequest {
+    /// Time to convert in RFC3339 format or common formats like '2006-01-02 15:04:05'
+    pub time: String,
+    /// Source IANA timezone name
+    pub source_timezone: String,
+    /// Target IANA timezone name
+    pub target_timezone: String,
+}
+
+/// Shape advertised by schema_* validation fixtures. `recognitionId` is the
+/// only required field; the handlers deliberately return payloads that match
+/// or violate this schema to exercise both branches of the gateway's output
+/// schema validator (including the error-response skip path from #4202).
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaFixtureResponse {
+    pub recognition_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 // ============================================================================
@@ -147,6 +169,87 @@ impl FastTestServer {
         Ok(CallToolResult::success(vec![Content::text(result)]))
     }
 
+    /// Convert a time value between two IANA timezones
+    #[tool(
+        description = "Convert a time value from a source IANA timezone to a target IANA timezone. Accepts RFC3339 or common formats like '2006-01-02 15:04:05'."
+    )]
+    async fn convert_time(
+        &self,
+        rmcp::handler::server::wrapper::Parameters(req): rmcp::handler::server::wrapper::Parameters<
+            ConvertTimeRequest,
+        >,
+    ) -> Result<CallToolResult, McpError> {
+        let mut count = self.request_count.lock().await;
+        *count += 1;
+
+        let source_offset = match parse_timezone(&req.source_timezone) {
+            Ok(o) => o,
+            Err(e) => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "invalid source timezone: {}",
+                    e
+                ))]));
+            }
+        };
+        let target_offset = match parse_timezone(&req.target_timezone) {
+            Ok(o) => o,
+            Err(e) => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "invalid target timezone: {}",
+                    e
+                ))]));
+            }
+        };
+
+        let parsed = parse_time_in_offset(&req.time, source_offset).map_err(|e| {
+            // Surface as isError=true so the gateway forwards the message as-is.
+            McpError::invalid_params(e, None)
+        });
+        let parsed = match parsed {
+            Ok(p) => p,
+            Err(_) => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "invalid time format: {}",
+                    req.time
+                ))]));
+            }
+        };
+
+        let converted = parsed.with_timezone(&target_offset).to_rfc3339();
+        Ok(CallToolResult::success(vec![Content::text(converted)]))
+    }
+
+    /// Always returns isError=true while declaring an outputSchema.
+    /// Exercises the gateway's schema-validation skip path for error
+    /// responses (MCP specification #4202).
+    #[tool(
+        description = "Always returns isError=true. Declares an outputSchema the error text intentionally does not satisfy.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<SchemaFixtureResponse>()
+    )]
+    async fn schema_error(&self) -> Result<CallToolResult, McpError> {
+        let mut count = self.request_count.lock().await;
+        *count += 1;
+        Ok(CallToolResult::error(vec![Content::text(
+            "You cannot send more than 200 points",
+        )]))
+    }
+
+    /// Returns a success payload that conforms to the declared outputSchema,
+    /// surfaced as both text and structured content. Exercises the positive
+    /// branch of output-schema validation (MCP SDK + gateway both pass).
+    #[tool(
+        description = "Returns a JSON payload that conforms to the declared outputSchema.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<SchemaFixtureResponse>()
+    )]
+    async fn schema_success(&self) -> Result<CallToolResult, McpError> {
+        let mut count = self.request_count.lock().await;
+        *count += 1;
+        Ok(CallToolResult::structured(json!({
+            "recognitionId": "rec-123",
+            "message": "ok",
+        })))
+    }
+
     /// Get server statistics
     #[tool(description = "Get server statistics including request count and uptime.")]
     async fn get_stats(&self) -> Result<CallToolResult, McpError> {
@@ -174,7 +277,7 @@ impl ServerHandler for FastTestServer {
                 .build(),
             server_info: Implementation::from_build_env(),
             instructions: Some(
-                "Ultra-fast MCP test server. Tools: echo (echoes message), get_system_time (returns time in timezone), get_stats (server stats).".to_string()
+                "Ultra-fast MCP test server. Tools: echo, get_system_time, convert_time, get_stats, plus schema_error and schema_success validation fixtures.".to_string()
             ),
         }
     }
@@ -275,6 +378,29 @@ fn parse_timezone(tz: &str) -> Result<FixedOffset, String> {
 
     FixedOffset::east_opt(offset_hours * 3600)
         .ok_or_else(|| format!("Invalid offset for timezone: {}", tz))
+}
+
+/// Parse an input time string in the given offset, accepting RFC3339 and a
+/// handful of common formats used by the Go fast-time-server port.
+fn parse_time_in_offset(time_str: &str, offset: FixedOffset) -> Result<DateTime<FixedOffset>, String> {
+    if let Ok(parsed) = DateTime::parse_from_rfc3339(time_str) {
+        return Ok(parsed.with_timezone(&offset));
+    }
+    for fmt in ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"] {
+        if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(time_str, fmt) {
+            if let Some(dt) = offset.from_local_datetime(&naive).single() {
+                return Ok(dt);
+            }
+        }
+        if let Ok(date) = chrono::NaiveDate::parse_from_str(time_str, fmt) {
+            if let Some(naive) = date.and_hms_opt(0, 0, 0) {
+                if let Some(dt) = offset.from_local_datetime(&naive).single() {
+                    return Ok(dt);
+                }
+            }
+        }
+    }
+    Err(format!("unrecognized time format: {}", time_str))
 }
 
 /// Parse an offset string like "+05:30" or "-08:00"

--- a/mcpgateway/middleware/request_logging_middleware.py
+++ b/mcpgateway/middleware/request_logging_middleware.py
@@ -63,6 +63,7 @@ from starlette.responses import Response
 # First-Party
 from mcpgateway.auth import get_current_user
 from mcpgateway.config import settings
+from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.middleware.path_filter import should_skip_request_logging
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.structured_logger import get_structured_logger
@@ -299,8 +300,8 @@ def _mask_json_payload_for_logging(payload: bytes, max_depth: int = 10) -> str:
                 if isinstance(masked_payload, bytes):
                     return masked_payload.decode("utf-8", errors="ignore")
                 return str(masked_payload)
-            except Exception:
-                logger.exception("Failed in processing the payload")
+            except Exception as exc:
+                logger.warning("Failed in processing the payload %s", SecurityValidator.sanitize_log_message(str(exc)))
 
     json_payload = orjson.loads(payload)
     payload_to_log = mask_sensitive_data(json_payload, max_depth)

--- a/mcpgateway/middleware/request_logging_middleware.py
+++ b/mcpgateway/middleware/request_logging_middleware.py
@@ -300,7 +300,7 @@ def _mask_json_payload_for_logging(payload: bytes, max_depth: int = 10) -> str:
                     return masked_payload.decode("utf-8", errors="ignore")
                 return str(masked_payload)
             except Exception:
-                pass
+                logger.exception("Failed in processing the payload")
 
     json_payload = orjson.loads(payload)
     payload_to_log = mask_sensitive_data(json_payload, max_depth)

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1236,6 +1236,8 @@ class ToolService(BaseService):
                       to parse the first TextContent item as JSON.
 
         Behavior:
+        - Per MCP specification, validation is skipped for error responses (isError: true).
+          Error responses with isError=true do not require structured content.
         - If ``candidate`` is provided it is used as the structured payload to validate.
         - Otherwise the method will try to parse the first ``TextContent`` item in
             ``tool_result.content`` as JSON and use that as the candidate.
@@ -1291,6 +1293,14 @@ class ToolService(BaseService):
                 True
         """
         try:
+            # CRITICAL: Skip validation for error responses per MCP spec
+            # Error responses with isError=true do not require structured content
+            # Reference: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
+            is_error = getattr(tool_result, "is_error", False) or getattr(tool_result, "isError", False)
+            if is_error:
+                logger.debug(f"Skipping output schema validation for error response from tool {getattr(tool, 'name', '<unknown>')}")
+                return True
+
             output_schema = getattr(tool, "output_schema", None)
             # Nothing to do if the tool doesn't declare a schema
             if not output_schema:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1678,7 +1678,23 @@ class ToolService(BaseService):
         # indicates an upstream whose shape the heuristic ought to learn
         # to recognise).
         logger.debug("Coercing %s payload to opaque text content", type(payload).__name__)
-        serialized = orjson.dumps(payload, option=orjson.OPT_INDENT_2)
+        # orjson cannot natively serialise arbitrary Pydantic ``BaseModel``
+        # instances. A BaseModel reaching this branch means it either
+        # failed the earlier ``ToolResult.model_validate`` step *or* did
+        # not expose a ``content`` attribute at all — dump it first so
+        # we don't raise ``TypeError`` and break the "always returns a
+        # valid ``ToolResult``" invariant.
+        serializable_payload = payload.model_dump(mode="json", by_alias=True) if isinstance(payload, BaseModel) else payload
+        try:
+            serialized = orjson.dumps(serializable_payload, option=orjson.OPT_INDENT_2)
+        except TypeError:
+            # Very last resort — something non-JSON-serialisable slipped
+            # through (e.g. ``set``, datetime without isoformat, a custom
+            # object without ``__json__``). Fall back to ``str(payload)``
+            # so the caller still sees *something* and the pipeline stays
+            # on contract.
+            logger.warning("Payload of type %s is not JSON-serialisable; using str() fallback", type(payload).__name__, exc_info=True)
+            return ToolResult(content=[TextContent(type="text", text=str(payload))])
         return ToolResult(content=[TextContent(type="text", text=serialized.decode())])
 
     async def register_tool(

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1678,23 +1678,31 @@ class ToolService(BaseService):
         # indicates an upstream whose shape the heuristic ought to learn
         # to recognise).
         logger.debug("Coercing %s payload to opaque text content", type(payload).__name__)
-        # orjson cannot natively serialise arbitrary Pydantic ``BaseModel``
-        # instances. A BaseModel reaching this branch means it either
-        # failed the earlier ``ToolResult.model_validate`` step *or* did
-        # not expose a ``content`` attribute at all — dump it first so
-        # we don't raise ``TypeError`` and break the "always returns a
-        # valid ``ToolResult``" invariant.
-        serializable_payload = payload.model_dump(mode="json", by_alias=True) if isinstance(payload, BaseModel) else payload
+        # Both ``BaseModel.model_dump`` and ``orjson.dumps`` can raise on
+        # pathological inputs: a BaseModel with a custom field serialiser
+        # that throws, a ``PydanticSerializationError`` (``ValueError``
+        # subclass, not ``TypeError``), or a plain Python object that
+        # isn't JSON-representable. Wrap the whole dump + serialise
+        # sequence so the helper's "always returns a valid ``ToolResult``"
+        # invariant holds even in the presence of upstream bugs.
         try:
+            serializable_payload = payload.model_dump(mode="json", by_alias=True) if isinstance(payload, BaseModel) else payload
             serialized = orjson.dumps(serializable_payload, option=orjson.OPT_INDENT_2)
-        except TypeError:
-            # Very last resort — something non-JSON-serialisable slipped
-            # through (e.g. ``set``, datetime without isoformat, a custom
-            # object without ``__json__``). Fall back to ``str(payload)``
-            # so the caller still sees *something* and the pipeline stays
-            # on contract.
-            logger.warning("Payload of type %s is not JSON-serialisable; using str() fallback", type(payload).__name__, exc_info=True)
-            return ToolResult(content=[TextContent(type="text", text=str(payload))])
+        except Exception:  # pylint: disable=broad-except
+            # Last-resort ``str(payload)`` so callers still see *something*.
+            # ``str()`` on a pathological object could itself raise, but
+            # ``repr()`` on an arbitrary Python object is effectively
+            # guaranteed by the runtime — keep the fallback defensive.
+            logger.warning(
+                "Payload of type %s could not be JSON-serialised; using str() fallback",
+                type(payload).__name__,
+                exc_info=True,
+            )
+            try:
+                text = str(payload)
+            except Exception:  # pylint: disable=broad-except
+                text = repr(payload)
+            return ToolResult(content=[TextContent(type="text", text=text)])
         return ToolResult(content=[TextContent(type="text", text=serialized.decode())])
 
     async def register_tool(

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1667,7 +1667,7 @@ class ToolService(BaseService):
                 # upstream gets flagged in ops logs rather than silently
                 # downgraded to text.
                 logger.warning(
-                    "Dict payload matched MCP-envelope heuristics but failed ToolResult validation; " "falling back to text serialisation",
+                    "Dict payload matched MCP-envelope heuristics but failed ToolResult validation; falling back to text serialisation",
                     exc_info=True,
                 )
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1298,7 +1298,7 @@ class ToolService(BaseService):
             # Reference: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
             is_error = getattr(tool_result, "is_error", False) or getattr(tool_result, "isError", False)
             if is_error:
-                logger.debug(f"Skipping output schema validation for error response from tool {getattr(tool, 'name', '<unknown>')}")
+                logger.debug(f"Skipping output schema validation for error response from tool {SecurityValidator.sanitize_log_message(getattr(tool, 'name', '<unknown>'))}")
                 return True
 
             output_schema = getattr(tool, "output_schema", None)

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -41,7 +41,7 @@ from mcp import ClientSession, types
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 import orjson
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import and_, delete, desc, or_, select
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import joinedload, selectinload, Session
@@ -293,6 +293,82 @@ def _decrypt_tool_headers_for_runtime(headers: Optional[Dict[str, Any]]) -> Dict
     if not isinstance(headers, dict):
         return {}
     return {key: _decrypt_tool_header_value(value) for key, value in headers.items()}
+
+
+#: Top-level keys that the MCP ``CallToolResult`` envelope admits (including
+#: the gateway's internal snake-case aliases). Any dict with keys outside
+#: this set is treated as a business payload rather than an MCP envelope.
+#: See :func:`_looks_like_mcp_envelope`.
+_MCP_ENVELOPE_KEYS: frozenset[str] = frozenset(
+    {
+        "content",
+        "isError",
+        "is_error",
+        "structuredContent",
+        "structured_content",
+        "_meta",
+        "meta",
+    }
+)
+
+
+def _looks_like_mcp_envelope(payload: dict) -> bool:
+    """Return ``True`` when a dict strongly resembles an MCP ``CallToolResult`` envelope.
+
+    Used by :meth:`ToolService._coerce_to_tool_result` to decide whether a
+    raw dict should be promoted to a ``ToolResult`` via
+    ``ToolResult.model_validate``. The check has two layers:
+
+    1. **No unknown top-level keys.** ``ToolResult`` inherits
+       ``BaseModelWithConfigDict``, which uses Pydantic's default
+       ``extra="ignore"`` — any sibling field not declared on the model
+       is **silently dropped** at validation time. Without this first
+       check, a REST payload like
+       ``{"content": [{"type": "text", "text": "ok"}], "isError": false,
+       "recognitionId": "rec-1"}`` would model-validate cleanly and lose
+       ``recognitionId`` without warning (Codex-flagged regression).
+       So we reject any dict whose keys aren't a subset of
+       :data:`_MCP_ENVELOPE_KEYS`.
+
+    2. **At least one positive MCP signal.** Even when the key set is a
+       valid subset, we require at least one MCP-specific marker —
+       either ``isError``/``is_error``, ``structuredContent``/
+       ``structured_content``, or ``content`` holding MCP ``ContentBlock``-
+       shaped items (dicts with a string ``type``). This stops a
+       minimal ``{"content": "plain text"}`` shape, which *could* be a
+       REST payload that coincidentally uses an allowed key name, from
+       being interpreted as MCP.
+
+    Both checks must pass. A REST business payload like
+    ``{"content": [{"widget": "x"}], "id": 1}`` fails check (1) (``id`` is
+    not an MCP envelope key); a minimal ``{"content": "hello"}`` fails
+    check (2) (no positive marker); both are therefore correctly treated
+    as opaque JSON by the caller.
+
+    Args:
+        payload: The dict candidate.
+
+    Returns:
+        ``True`` if the dict is confidently an MCP envelope and safe to
+        round-trip through ``ToolResult.model_validate`` without losing
+        sibling fields, else ``False``.
+    """
+    keys = payload.keys()
+    # Layer 1: reject if there are any keys outside the envelope schema.
+    # This is what guards against silent field-dropping for business payloads
+    # that happen to include ``content`` / ``isError`` among other fields.
+    if not keys <= _MCP_ENVELOPE_KEYS:
+        return False
+    # Layer 2: require a positive MCP signal so we don't misclassify
+    # anonymous REST bodies that merely happen to use a subset of allowed keys.
+    if "isError" in keys or "is_error" in keys:
+        return True
+    if "structuredContent" in keys or "structured_content" in keys:
+        return True
+    content = payload.get("content")
+    if isinstance(content, list) and content and all(isinstance(item, dict) and isinstance(item.get("type"), str) for item in content):
+        return True
+    return False
 
 
 def _handle_json_parse_error(response, error, is_error_response: bool = False) -> dict:
@@ -1225,20 +1301,121 @@ class ToolService(BaseService):
                 error_message=error_message,
             )
 
-    def _extract_and_validate_structured_content(self, tool: DbTool, tool_result: "ToolResult", candidate: Optional[Any] = None) -> bool:
+    def _extract_and_validate_structured_content(self, tool: DbTool, tool_result: "ToolResult") -> bool:
         """
         Extract structured content (if any) and validate it against ``tool.output_schema``.
+
+        This method is one of **three** output-schema validation layers the
+        gateway relies on. Understanding where each fires — and, crucially,
+        where each is *skipped* — is essential when reasoning about
+        ContextForge #4202 (https://github.com/IBM/mcp-context-forge/issues/4202)
+        and its successors. See
+        ``docs/docs/architecture/tool-invocation-and-validation.md`` for the
+        full flow diagram; a summary follows.
+
+        Tool invocation flow (downstream client → gateway → upstream tool → back):
+
+        1. **Downstream ingress (server SDK, inbound request)** — not a
+           validator; just decodes the ``tools/call`` JSON-RPC into
+           ``CallToolRequestParam`` and dispatches to the gateway's
+           handler at
+           ``mcpgateway/transports/streamablehttp_transport.py::call_tool``.
+
+        2. **Gateway dispatch** — ``call_tool`` routes based on the tool's
+           ``integration_type`` in the DB. Federation-backed MCP tools take
+           the MCP client SDK path (step 3). REST, OpenAPI, A2A and
+           admin-registered tools take the direct HTTP path (step 4).
+
+        3. **Validator A — MCP Python client SDK (federation only)**.
+           Upstream MCP calls go through ``mcp.ClientSession``, whose
+           ``ClientSession._validate_tool_result`` in the installed
+           ``mcp`` package
+           validates ``structuredContent`` against the *upstream-advertised*
+           output schema. Rules: (a) **skipped when ``isError=True``** —
+           this is what the MCP spec's "Error Handling" section mandates,
+           and why #4202 only surfaced on the gateway's own layer;
+           (b) raises ``RuntimeError`` on violation, which the gateway
+           catches at ``tool_service.py::invoke_tool`` and re-wraps as a
+           ``Tool invocation failed: ...`` error.
+
+        4. **Validator B — this method, ``_extract_and_validate_structured_content``**.
+           Currently invoked **only** from the REST branch of
+           ``invoke_tool`` (search for ``_extract_and_validate_structured_content(``).
+           The MCP federation branch relies on Validator A; the A2A
+           branch has **no gateway-side output-schema enforcement today**
+           — a known gap tracked alongside the option-B pipeline unification
+           refactor (see the issue below). Rules when Validator B does run:
+           - Skip when ``is_error=True`` or ``isError=True`` — the
+             ContextForge #4202 fix. Without this early return the gateway
+             would clobber the upstream's original error message with a
+             schema-mismatch dict.
+           - Require ``structured_content`` to be a JSON object when
+             explicitly set; reject lists, scalars and other shapes with a
+             structured ``invalid_structured_content_type`` error (per MCP
+             2025-11-25 "Output Schema").
+           - Otherwise best-effort promote the first parseable
+             ``TextContent`` item to ``structured_content`` (tolerates
+             both dict and Pydantic shapes, which matters because
+             ``_coerce_to_tool_result`` wraps REST JSON bodies into
+             Pydantic ``TextContent``).
+           - When no schema is declared, or no structured data can be
+             obtained and ``is_error=False``, return ``True`` — currently a
+             *lenient* deviation from the spec's "servers MUST provide
+             conforming structured output" rule, tracked in
+             https://github.com/IBM/mcp-context-forge/issues/4208.
+           - On schema violation, mutate ``tool_result`` in place:
+             replace ``content`` with a deterministic validation-error
+             TextContent and set ``is_error=True``.
+
+        5. **Validator C — MCP Python server SDK (downstream egress)**.
+           The gateway's ``call_tool`` handler in
+           ``mcpgateway/transports/streamablehttp_transport.py`` returns
+           either a raw ``list``/``tuple`` shape (success path) or a
+           fully-formed ``types.CallToolResult`` (``isError=True`` path).
+           The server SDK (``mcp.server.lowlevel.server``)
+           validates the list/tuple shape against the gateway's *own*
+           advertised output schema, but **short-circuits when the
+           handler returns a ``CallToolResult`` directly** (via the
+           ``isinstance(results, types.CallToolResult)`` check in its
+           ``_call_tool`` dispatch). We
+           exploit that short-circuit to preserve #4202 on the egress —
+           otherwise the server SDK's "Output validation error:
+           outputSchema defined but no structured output returned" message
+           would re-clobber the payload after Validator B had correctly
+           preserved it.
+
+        Net effect across paths:
+
+        - MCP-federated tool, success: Validators A + C both run; this
+          method does not.
+        - MCP-federated tool, error (``isError=True``): Validators A and C
+          both skip; this method does not run (no ingress invocation for
+          MCP branch).
+        - **REST** (incl. OpenAPI-imported) tool, success: this method
+          runs (B); Validator C runs on the way out.
+        - **REST** tool, error: this method skips (B early-return per
+          #4202); Validator C short-circuits because the egress handler
+          returns ``CallToolResult``.
+        - **A2A** tool, any outcome: this method is **not invoked**
+          today; Validator C runs (success) or short-circuits (error).
+          Wiring A2A through the unified post-invoke pipeline is part of
+          the option-B refactor and the A2A-specific validation gap.
+
+        End-to-end coverage for non-MCP paths (REST/OpenAPI/A2A) is
+        tracked in https://github.com/IBM/mcp-context-forge/issues/4207.
+        The A2A Validator B gap and the broader "single post-invoke
+        pipeline" refactor (option B) are tracked as a separate chore
+        issue — see ``docs/docs/architecture/tool-invocation-and-validation.md``
+        for the current per-path table.
 
         Args:
             tool: The tool with an optional output schema to validate against.
             tool_result: The tool result containing content to validate.
-            candidate: Optional structured payload to validate. If not provided, will attempt
-                      to parse the first TextContent item as JSON.
 
         Behavior:
         - Per MCP specification, validation is skipped for error responses (isError: true).
           Error responses with isError=true do not require structured content.
-        - If ``candidate`` is provided it is used as the structured payload to validate.
+        - When ``tool_result.structured_content`` is present it must be a JSON object and is used as the structured payload.
         - Otherwise the method will try to parse the first ``TextContent`` item in
             ``tool_result.content`` as JSON and use that as the candidate.
         - If no output schema is declared on the tool the method returns True (nothing to validate).
@@ -1271,7 +1448,8 @@ class ToolService(BaseService):
                 ...     {"output_schema": {"type": "object", "properties": {"foo": {"type": "string"}}, "required": ["foo"]}},
                 ... )()
                 >>> r = ToolResult(content=[])
-                >>> service._extract_and_validate_structured_content(tool, r, candidate={"foo": "bar"})
+                >>> r = ToolResult(content=[], structured_content={"foo": "bar"})
+                >>> service._extract_and_validate_structured_content(tool, r)
                 True
                 >>> r.structured_content == {"foo": "bar"}
                 True
@@ -1283,7 +1461,8 @@ class ToolService(BaseService):
                 ...     {"output_schema": {"type": "object", "properties": {"foo": {"type": "string"}}, "required": ["foo"]}},
                 ... )()
                 >>> r = ToolResult(content=[])
-                >>> ok = service._extract_and_validate_structured_content(tool, r, candidate={"foo": 123})
+                >>> r = ToolResult(content=[], structured_content={"foo": 123})
+                >>> ok = service._extract_and_validate_structured_content(tool, r)
                 >>> ok
                 False
                 >>> r.is_error
@@ -1293,12 +1472,21 @@ class ToolService(BaseService):
                 True
         """
         try:
-            # CRITICAL: Skip validation for error responses per MCP spec
-            # Error responses with isError=true do not require structured content
-            # Reference: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
+            # Error responses do not require structured content per MCP spec:
+            # https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
             is_error = getattr(tool_result, "is_error", False) or getattr(tool_result, "isError", False)
             if is_error:
-                logger.debug(f"Skipping output schema validation for error response from tool {SecurityValidator.sanitize_log_message(getattr(tool, 'name', '<unknown>'))}")
+                # Lazy %-formatting + SecurityValidator.sanitize_log_message to
+                # prevent log injection via tool names containing control
+                # characters. ``or "<unknown>"`` guards against explicit
+                # ``tool.name = None`` on partially-hydrated ORM rows — plain
+                # ``getattr(..., "<unknown>")`` would return ``None`` and the
+                # sanitizer would collapse it to an empty string, losing the
+                # diagnostic signal.
+                logger.debug(
+                    "Skipping output schema validation for error response from tool %s",
+                    SecurityValidator.sanitize_log_message(getattr(tool, "name", None) or "<unknown>"),
+                )
                 return True
 
             output_schema = getattr(tool, "output_schema", None)
@@ -1307,15 +1495,37 @@ class ToolService(BaseService):
                 return True
 
             structured: Optional[Any] = None
-            # Prefer explicit candidate
-            if candidate is not None:
-                structured = candidate
-            else:
-                # Try to parse first TextContent text payload as JSON
+            # Prefer normalized structured content already attached to the result
+            structured = getattr(tool_result, "structured_content", None)
+            if structured is None:
+                structured = getattr(tool_result, "structuredContent", None)
+
+            if structured is not None and not isinstance(structured, dict):
+                details = {
+                    "code": "invalid_structured_content_type",
+                    "expected": "object",
+                    "received": type(structured).__name__.lower(),
+                    "path": [],
+                    "message": "structured_content must be a JSON object",
+                }
+                try:
+                    tool_result.content = [TextContent(type="text", text=orjson.dumps(details).decode())]
+                except Exception:
+                    tool_result.content = [TextContent(type="text", text=str(details))]
+                tool_result.is_error = True
+                return False
+
+            if structured is None:
+                # Try to parse first TextContent text payload as JSON. Content
+                # items may be raw dicts (MCP wire shape) or pydantic objects
+                # (e.g. TextContent synthesized by _coerce_to_tool_result
+                # for REST responses); support both.
                 for c in getattr(tool_result, "content", []) or []:
                     try:
-                        if isinstance(c, dict) and "type" in c and c.get("type") == "text" and "text" in c:
-                            structured = orjson.loads(c.get("text") or "null")
+                        c_type = c.get("type") if isinstance(c, dict) else getattr(c, "type", None)
+                        c_text = c.get("text") if isinstance(c, dict) else getattr(c, "text", None)
+                        if c_type == "text" and c_text is not None:
+                            structured = orjson.loads(c_text)
                             break
                     except (orjson.JSONDecodeError, TypeError, ValueError):
                         # ignore JSON parse errors and continue
@@ -1325,32 +1535,19 @@ class ToolService(BaseService):
             if structured is None:
                 return True
 
-            # Try to normalize common wrapper shapes to match schema expectations
-            schema_type = None
-            try:
-                if isinstance(output_schema, dict):
-                    schema_type = output_schema.get("type")
-            except Exception:
-                schema_type = None
-
-            # Unwrap single-element list wrappers when schema expects object
-            if isinstance(structured, list) and len(structured) == 1 and schema_type == "object":
-                inner = structured[0]
-                # If inner is a TextContent-like dict with 'text' JSON string, parse it
-                if isinstance(inner, dict) and "text" in inner and "type" in inner and inner.get("type") == "text":
-                    try:
-                        structured = orjson.loads(inner.get("text") or "null")
-                    except Exception:
-                        # leave as-is if parsing fails
-                        structured = inner
-                else:
-                    structured = inner
-
-            # Attach structured content
+            # Attach structured content. A frozen or slotted ``tool_result``
+            # that refuses the assignment is a genuine contract violation —
+            # downstream code relies on ``structured_content`` being
+            # populated — so surface at WARNING with a stack trace rather
+            # than swallowing silently at DEBUG.
             try:
                 setattr(tool_result, "structured_content", structured)
             except Exception:
-                logger.debug("Failed to set structured_content on ToolResult")
+                logger.warning(
+                    "Failed to set structured_content on ToolResult for tool %s",
+                    SecurityValidator.sanitize_log_message(getattr(tool, "name", None) or "<unknown>"),
+                    exc_info=True,
+                )
 
             # Validate using cached schema validator
             try:
@@ -1369,11 +1566,120 @@ class ToolService(BaseService):
                 except Exception:
                     tool_result.content = [TextContent(type="text", text=str(details))]
                 tool_result.is_error = True
-                logger.debug(f"structured_content validation failed for tool {getattr(tool, 'name', '<unknown>')}: {details}")
+                logger.debug(
+                    "structured_content validation failed for tool %s: %s",
+                    SecurityValidator.sanitize_log_message(getattr(tool, "name", None) or "<unknown>"),
+                    details,
+                )
                 return False
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error(f"Error extracting/validating structured_content: {exc}")
+            # Defensive catch for unexpected validator failures (schema
+            # compilation crash, attribute errors on malformed ``tool_result``,
+            # orjson edge cases). Log with exc_info=True so the stack trace
+            # reaches ops — without it, the method just returns False with no
+            # diagnostic trail, which is a six-months-from-now debugging
+            # nightmare.
+            logger.error(
+                "Error extracting/validating structured_content for tool %s: %s",
+                SecurityValidator.sanitize_log_message(getattr(tool, "name", None) or "<unknown>"),
+                exc,
+                exc_info=True,
+            )
             return False
+
+    def _coerce_to_tool_result(self, payload: Any) -> ToolResult:
+        """Coerce any tool-result-shaped payload into the gateway's canonical ``ToolResult``.
+
+        Single source of truth for turning heterogeneous upstream
+        responses into one canonical internal type. Funnelling every
+        integration branch through here gives us uniform ``is_error`` and
+        ``structured_content`` semantics regardless of source, which is
+        the foundation of #4202's fix across multiple integration types
+        (see https://github.com/IBM/mcp-context-forge/issues/4202) and
+        the first structural step toward the option-B "single
+        canonical-ToolResult pipeline" refactor tracked separately.
+
+        Accepted inputs:
+
+        - ``ToolResult`` → returned as-is (fast path).
+        - MCP SDK ``CallToolResult`` (or any other Pydantic model whose
+          ``model_dump(by_alias=True)`` emits an MCP-shaped envelope) →
+          round-tripped through ``ToolResult.model_validate`` so
+          camelCase ``isError`` / ``structuredContent`` map cleanly onto
+          the gateway's snake-cased aliases. This path is what closes the
+          direct-proxy egress regression Codex flagged: previously the
+          egress ``is_error`` check only recognised snake-case and
+          silently re-clobbered error responses coming back from
+          ``session.call_tool(...)``.
+        - A raw dict that looks *strongly* like an MCP envelope —
+          presence of ``isError`` / ``is_error`` / ``structuredContent`` /
+          ``structured_content`` keys, or a ``content`` list whose items
+          carry a string ``type`` field (i.e. MCP ``ContentBlock`` shape).
+          A dict with merely a top-level ``content`` key is **not**
+          enough: a REST business payload like
+          ``{"content": [{"widget": "x"}], "recognitionId": "rec-1"}``
+          must not be reinterpreted as an MCP envelope with its sibling
+          fields silently discarded (Codex P2).
+        - Anything else → JSON-serialised into a single ``TextContent``.
+
+        Args:
+            payload: The upstream response in whatever shape the
+                integration branch happens to produce.
+
+        Returns:
+            A canonical ``ToolResult`` instance.
+        """
+        # Fast path — already canonical.
+        if isinstance(payload, ToolResult):
+            return payload
+
+        # MCP SDK CallToolResult (or any Pydantic model exposing
+        # MCP-shaped fields via by-alias dump). The MCP SDK emits
+        # ``isError`` / ``structuredContent`` in camelCase; our
+        # ``ToolResult`` declares those as aliases, so the dump feeds
+        # straight into ``model_validate`` without a bespoke mapper.
+        if isinstance(payload, BaseModel) and hasattr(payload, "content"):
+            try:
+                return ToolResult.model_validate(payload.model_dump(by_alias=True, mode="json"))
+            except ValidationError:
+                # User-visible reshape: an MCP-looking Pydantic upstream
+                # result is about to be downgraded to an opaque text blob.
+                # Log at WARNING so operators notice protocol or schema
+                # drift between the gateway and the upstream SDK.
+                logger.warning(
+                    "%s did not validate as ToolResult; falling back to text serialisation",
+                    type(payload).__name__,
+                    exc_info=True,
+                )
+
+        # Raw dict — only treat as MCP-shaped when strong markers are
+        # present. Without this guard a REST payload that coincidentally
+        # contains a top-level ``content`` field would be misread as an
+        # MCP envelope and its sibling business fields silently dropped
+        # (Codex P2 regression).
+        if isinstance(payload, dict) and _looks_like_mcp_envelope(payload):
+            try:
+                return ToolResult.model_validate(payload)
+            except ValidationError:
+                # User-visible reshape: the heuristic admitted a dict as
+                # an MCP envelope but the strict ToolResult model then
+                # rejected it. Surface at WARNING so the non-conforming
+                # upstream gets flagged in ops logs rather than silently
+                # downgraded to text.
+                logger.warning(
+                    "Dict payload matched MCP-envelope heuristics but failed ToolResult validation; " "falling back to text serialisation",
+                    exc_info=True,
+                )
+
+        # Last resort — opaque JSON body. Preserves the payload for the
+        # caller to inspect while keeping the rest of the pipeline on a
+        # uniform ``ToolResult`` contract. Log at DEBUG so operators can
+        # spot integrations regularly hitting this branch (which usually
+        # indicates an upstream whose shape the heuristic ought to learn
+        # to recognise).
+        logger.debug("Coercing %s payload to opaque text content", type(payload).__name__)
+        serialized = orjson.dumps(payload, option=orjson.OPT_INDENT_2)
+        return ToolResult(content=[TextContent(type="text", text=serialized.decode())])
 
     async def register_tool(
         self,
@@ -4440,14 +4746,19 @@ class ToolService(BaseService):
                                 tool_result = ToolResult(content=filtered_response, is_error=True)
                                 success = False
                             else:
-                                # Success case - serialize the filtered response
-                                serialized = orjson.dumps(filtered_response, option=orjson.OPT_INDENT_2)
-                                tool_result = ToolResult(content=[TextContent(type="text", text=serialized.decode())])
-                                success = True
-                            # If output schema is present, validate and attach structured content
+                                tool_result = self._coerce_to_tool_result(filtered_response)
+                            # If output schema is present, validate and attach structured content.
+                            # The validator skips for isError=true (per #4202) and, on validation
+                            # failure, mutates tool_result in place with is_error=True, so the
+                            # single post-validation read below covers all cases uniformly.
                             if tool_output_schema:
-                                valid = self._extract_and_validate_structured_content(tool_for_validation, tool_result, candidate=filtered_response)
-                                success = bool(valid)
+                                self._extract_and_validate_structured_content(tool_for_validation, tool_result)
+                            # ``success`` must reflect both upstream ``isError`` *and* any
+                            # validator-imposed error state. Previously this path set
+                            # ``success = bool(valid)``, which clobbered an upstream
+                            # ``is_error=True`` back to ``success=True`` because the
+                            # validator skips (returns True) for error responses.
+                            success = not getattr(tool_result, "is_error", False)
                 elif tool_integration_type == "MCP":
                     transport = tool_request_type.lower() if tool_request_type else "sse"
 
@@ -5021,10 +5332,15 @@ class ToolService(BaseService):
                         elif transport == "streamablehttp":
                             tool_call_result = await connect_to_streamablehttp_server(gateway_url, headers=headers)
 
-                        # In direct proxy mode, use the tool result as-is without splitting content
+                        # In direct proxy mode, preserve the upstream response verbatim
+                        # (no jsonpath filtering, no structured/unstructured split) but
+                        # still route through the canonical coercion so the egress sees
+                        # a ``ToolResult`` with snake-case ``is_error`` rather than a
+                        # raw MCP SDK ``CallToolResult`` with camelCase ``isError``
+                        # (#4202 egress regression on the direct-proxy path).
                         if is_direct_proxy:
-                            tool_result = tool_call_result
-                            success = not getattr(tool_call_result, "is_error", False) and not getattr(tool_call_result, "isError", False)
+                            tool_result = self._coerce_to_tool_result(tool_call_result)
+                            success = not tool_result.is_error
                             logger.debug(f"Direct proxy mode: using tool result as-is: {tool_result}")
                         else:
                             dump = tool_call_result.model_dump(by_alias=True, mode="json")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -371,6 +371,61 @@ def _looks_like_mcp_envelope(payload: dict) -> bool:
     return False
 
 
+def _safe_type_name(obj: Any) -> str:
+    """Return ``type(obj).__name__``, or a sentinel if that itself raises.
+
+    Used inside :meth:`ToolService._coerce_to_tool_result`'s last-resort
+    fallback so logging and diagnostic text on a pathological object
+    (broken proxy, ``__class__`` descriptor that raises, etc.) cannot
+    themselves raise and escape the "always returns a valid
+    ``ToolResult``" invariant.
+    """
+    try:
+        return type(obj).__name__
+    except Exception:  # pylint: disable=broad-except
+        return "<untypeable>"
+
+
+def _safe_text_repr(obj: Any, fallback_type: str) -> str:
+    """Coerce an arbitrary object to a non-raising text representation.
+
+    Tries ``str(obj)``, then ``repr(obj)``, then ``f"<{fallback_type}
+    object>"``, and finally a fixed sentinel. Used by the opaque-JSON
+    last-resort branch of
+    :meth:`ToolService._coerce_to_tool_result` — neither ``str`` nor
+    ``repr`` is guaranteed to succeed on arbitrary Python objects (a
+    class can override either to raise), and without this staged
+    fallback a malicious or simply buggy payload could escape the
+    helper and break the "never raises" contract downstream code relies
+    on.
+
+    Args:
+        obj: The payload to stringify.
+        fallback_type: Pre-computed type name used in the third-tier
+            sentinel; keeps ``type().__name__`` out of this function's
+            hot path since it has its own :func:`_safe_type_name`
+            guard upstream.
+
+    Returns:
+        A ``str``. Never raises.
+    """
+    try:
+        text = str(obj)
+        if isinstance(text, str):
+            return text
+    except Exception:  # pylint: disable=broad-except
+        pass
+    try:
+        text = repr(obj)
+        if isinstance(text, str):
+            return text
+    except Exception:  # pylint: disable=broad-except
+        pass
+    # ``fallback_type`` came from ``_safe_type_name`` so it's
+    # guaranteed to be a ``str`` already.
+    return f"<{fallback_type} object (unrepresentable)>"
+
+
 def _handle_json_parse_error(response, error, is_error_response: bool = False) -> dict:
     """Handle JSON parsing failures with graceful fallback to raw text.
 
@@ -1673,36 +1728,27 @@ class ToolService(BaseService):
 
         # Last resort — opaque JSON body. Preserves the payload for the
         # caller to inspect while keeping the rest of the pipeline on a
-        # uniform ``ToolResult`` contract. Log at DEBUG so operators can
-        # spot integrations regularly hitting this branch (which usually
-        # indicates an upstream whose shape the heuristic ought to learn
-        # to recognise).
-        logger.debug("Coercing %s payload to opaque text content", type(payload).__name__)
-        # Both ``BaseModel.model_dump`` and ``orjson.dumps`` can raise on
-        # pathological inputs: a BaseModel with a custom field serialiser
-        # that throws, a ``PydanticSerializationError`` (``ValueError``
-        # subclass, not ``TypeError``), or a plain Python object that
-        # isn't JSON-representable. Wrap the whole dump + serialise
-        # sequence so the helper's "always returns a valid ``ToolResult``"
-        # invariant holds even in the presence of upstream bugs.
+        # uniform ``ToolResult`` contract. The helper's invariant is
+        # "always returns a valid ``ToolResult``, never raises", so every
+        # step below must be guarded — both ``BaseModel.model_dump`` and
+        # ``orjson.dumps`` can raise on pathological inputs (custom
+        # serialisers that throw, ``PydanticSerializationError`` —
+        # ``ValueError`` subclass, not ``TypeError`` — fields holding
+        # non-representable objects), and even ``str()`` / ``repr()`` /
+        # ``type().__name__`` can fail on sufficiently broken proxy
+        # objects.
+        payload_type = _safe_type_name(payload)
+        logger.debug("Coercing %s payload to opaque text content", payload_type)
         try:
             serializable_payload = payload.model_dump(mode="json", by_alias=True) if isinstance(payload, BaseModel) else payload
             serialized = orjson.dumps(serializable_payload, option=orjson.OPT_INDENT_2)
         except Exception:  # pylint: disable=broad-except
-            # Last-resort ``str(payload)`` so callers still see *something*.
-            # ``str()`` on a pathological object could itself raise, but
-            # ``repr()`` on an arbitrary Python object is effectively
-            # guaranteed by the runtime — keep the fallback defensive.
             logger.warning(
-                "Payload of type %s could not be JSON-serialised; using str() fallback",
-                type(payload).__name__,
+                "Payload of type %s could not be JSON-serialised; using textual fallback",
+                payload_type,
                 exc_info=True,
             )
-            try:
-                text = str(payload)
-            except Exception:  # pylint: disable=broad-except
-                text = repr(payload)
-            return ToolResult(content=[TextContent(type="text", text=text)])
+            return ToolResult(content=[TextContent(type="text", text=_safe_text_repr(payload, payload_type))])
         return ToolResult(content=[TextContent(type="text", text=serialized.decode())])
 
     async def register_tool(

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1349,6 +1349,40 @@ async def _proxy_read_resource_to_gateway(gateway: Any, resource_uri: str, user_
         return []
 
 
+def _truthy_is_error(result: Any) -> bool:
+    """Return ``True`` when ``result`` represents an MCP error response.
+
+    Centralises the #4202 egress check so both the local and pooled
+    branches of :func:`call_tool` read ``is_error`` identically, and so
+    the mitigation for MagicMock-attribute pollution in the test suite
+    lives in one place. Semantics:
+
+    - A real ``mcpgateway.common.models.ToolResult`` has ``is_error`` as a
+      typed ``bool`` with default ``False`` — ``result.is_error is True``
+      and ``bool(result.is_error)`` agree, so either form is correct in
+      production.
+    - A ``unittest.mock.MagicMock`` auto-materialises attributes as truthy
+      ``MagicMock`` objects. ``bool(mock.is_error)`` reports ``True``
+      even when the test author didn't explicitly set the attribute,
+      which used to silently route success-path transport tests into the
+      ``CallToolResult`` short-circuit branch. The ``is True`` identity
+      check rejects that shape.
+    - The identity check does silently coerce truthy non-``True`` values
+      (e.g. ``1``, ``"true"``) to ``False``. That's acceptable because
+      production ``ToolResult.is_error`` is typed ``bool`` and the
+      failure mode of a misbehaving upstream producing a truthy non-bool
+      is already caught at the ``_coerce_to_tool_result`` boundary.
+
+    Args:
+        result: Upstream tool result (ToolResult, MCP SDK CallToolResult,
+            MagicMock, or any duck-typed carrier).
+
+    Returns:
+        ``True`` only when ``result.is_error`` is literally ``True``.
+    """
+    return getattr(result, "is_error", False) is True
+
+
 @mcp_app.call_tool(validate_input=False)
 async def call_tool(name: str, arguments: dict) -> Union[
     types.CallToolResult,
@@ -1559,6 +1593,25 @@ async def call_tool(name: str, arguments: dict) -> Union[
 
                 unstructured = _rehydrate_content_items(result_data.get("content", []))
                 structured = result_data.get("structuredContent") or result_data.get("structured_content")
+                if not isinstance(structured, dict):
+                    structured = None
+                is_error = bool(result_data.get("isError") or result_data.get("is_error"))
+                if is_error:
+                    # Preserve the upstream error payload verbatim (#4202). Wrap
+                    # in CallToolResult so the MCP SDK's server-side
+                    # ``isinstance(results, types.CallToolResult)`` short-circuit
+                    # (in ``mcp.server.lowlevel.server``) skips re-validation
+                    # and doesn't clobber the message with "Output validation
+                    # error: outputSchema defined but no structured output
+                    # returned".
+                    return types.CallToolResult(
+                        content=unstructured,
+                        structuredContent=structured,
+                        isError=True,
+                    )
+                # Success path: return the list/tuple shape so the MCP SDK's
+                # server-side validator runs and enforces the tool's
+                # outputSchema against the structured payload.
                 if structured:
                     return (unstructured, structured)
                 return unstructured
@@ -1683,15 +1736,39 @@ async def call_tool(name: str, arguments: dict) -> Union[
                 structured = None
 
             # Fallback to by-alias dump (in case the result is a pydantic model with alias fields)
-            if structured is None:
+            if not isinstance(structured, dict):
                 try:
-                    structured = result.model_dump(by_alias=True).get("structuredContent") if hasattr(result, "model_dump") else None
+                    dump = result.model_dump(by_alias=True) if hasattr(result, "model_dump") else {}
+                    structured = dump.get("structuredContent") if isinstance(dump, dict) else None
                 except Exception:
                     structured = None
 
+            # MCP CallToolResult.structuredContent accepts dict or None only;
+            # reject anything else (e.g. stray MagicMocks in tests, bad shapes).
+            if not isinstance(structured, dict):
+                structured = None
+
+            is_error = _truthy_is_error(result)
+
+            if is_error:
+                # Preserve the upstream error payload verbatim (#4202). Wrap
+                # in CallToolResult so the MCP SDK's server-side
+                # ``isinstance(results, types.CallToolResult)`` short-circuit
+                # (in ``mcp.server.lowlevel.server``) skips re-validation
+                # and doesn't clobber the message with "Output validation
+                # error: outputSchema defined but no structured output
+                # returned".
+                return types.CallToolResult(
+                    content=unstructured,
+                    structuredContent=structured,
+                    isError=True,
+                )
+
+            # Success path: return the list/tuple shape so the MCP SDK's
+            # server-side validator runs and enforces the tool's
+            # outputSchema against the structured payload.
             if structured:
                 return (unstructured, structured)
-
             return unstructured
     except Exception as e:
         logger.exception("Error calling tool '%s': %s", name, e)

--- a/tests/e2e/test_mcp_cli_protocol.py
+++ b/tests/e2e/test_mcp_cli_protocol.py
@@ -337,6 +337,154 @@ class TestMcpStdioProtocol:
         text = result["content"][0]["text"]
         print(f"    -> get-stats = {text[:120]}")
 
+    def _require_declared_output_schema(self, tool_name: str) -> dict:
+        """Preflight guard: assert the gateway advertises ``tool_name`` with a non-empty outputSchema.
+
+        Without this guard, a stale fast_test_server image, an uncompleted
+        federation sync, or a gateway-side tool validation rejection (such
+        as the unsafe-character filter that caused a ``schema_error``
+        description with ``;`` to be silently dropped during PR development)
+        would cause the actual ``tools/call`` tests below to fail with a
+        misleading assertion. This helper hits ``tools/list`` through the
+        same stdio wrapper the tests use, confirms both the tool name and
+        the declared schema are present, and fails fast with an actionable
+        message pointing the operator at the image rebuild.
+
+        MCP spec reference: 2025-11-25 "Output Schema" — tools with a
+        declared output schema must expose it via ``tools/list``.
+        """
+        messages = [
+            _build_initialize(1),
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        ]
+        responses = _send_jsonrpc_via_wrapper(self.env, messages)
+        list_resp = next((r for r in responses if r.get("id") == 2), None)
+        assert list_resp is not None, f"No tools/list response: {responses}"
+        tools = list_resp.get("result", {}).get("tools", [])
+        match = next((t for t in tools if t.get("name") == tool_name), None)
+        assert match is not None, (
+            f"Tool {tool_name!r} is not registered in the gateway. " f"Rebuild the fast_test_server image and restart docker-compose so " f"register_fast_test picks up the new schema fixtures."
+        )
+        schema = match.get("outputSchema") or match.get("output_schema")
+        assert schema, (
+            f"Tool {tool_name!r} has no outputSchema declared in the gateway: {match}. " f"Check that the upstream tool declares an output_schema and that " f"the gateway sync completed successfully."
+        )
+        return schema
+
+    def test_tools_call_schema_error_preserves_payload(self) -> None:
+        """End-to-end regression guard for ContextForge #4202.
+
+        Issue: https://github.com/IBM/mcp-context-forge/issues/4202
+
+        Drives the full MCP-federation path through the stdio wrapper →
+        gateway (server-side SDK) → federated Rust ``fast_test_server`` →
+        gateway ingress validator → gateway egress handler → back to the
+        stdio client. The upstream ``fast-test-schema-error`` tool declares
+        an ``outputSchema`` of ``{"required": ["recognitionId"], ...}`` and
+        always returns ``isError=true`` with the verbatim user text
+        "You cannot send more than 200 points". Every validator in the
+        chain — MCP Python client SDK, gateway's own
+        ``_extract_and_validate_structured_content`` (ingress fix), and
+        the MCP Python server SDK at the gateway's egress (via the
+        ``types.CallToolResult`` short-circuit) — must honour the spec's
+        "error responses do not require structured content" rule and leave
+        the payload untouched.
+
+        The assertion additionally guards against the specific pre-fix
+        symptom: a payload substituted with a JSON validation-error dict
+        containing ``"validator"`` or ``"required"`` keys. Seeing those
+        strings in the returned text indicates a regression of the ingress
+        fix, the egress fix, or both.
+
+        MCP spec references:
+        - 2025-11-25 "Error Handling":
+          https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
+        - 2025-11-25 "Output Schema":
+          https://modelcontextprotocol.io/specification/2025-11-25/server/tools#output-schema
+
+        Related:
+        - Ingress unit guards:
+          ``tests/unit/mcpgateway/services/test_tool_service_coverage.py::TestExtractAndValidateErrorResponses``
+        - Egress unit guards (local + pooled branches):
+          ``tests/unit/mcpgateway/transports/test_streamablehttp_transport.py::test_call_tool_preserves_is_error_for_egress``
+          and ``::test_call_tool_session_affinity_forwarded_preserves_is_error``
+        - Non-MCP path coverage gap (REST/OpenAPI/A2A):
+          https://github.com/IBM/mcp-context-forge/issues/4207
+        """
+        self._require_declared_output_schema("fast-test-schema-error")
+        messages = [
+            _build_initialize(1),
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "fast-test-schema-error", "arguments": {}}},
+        ]
+        responses = _send_jsonrpc_via_wrapper(self.env, messages)
+        call_resp = next((r for r in responses if r.get("id") == 2), None)
+        assert call_resp is not None, f"No response for id=2: {responses}"
+        assert "result" in call_resp, f"Expected result envelope: {call_resp}"
+        result = call_resp["result"]
+        assert result.get("isError") is True, f"Expected isError=true, got: {result}"
+        text = result.get("content", [{}])[0].get("text", "")
+        # The original error text must be preserved — not replaced by a schema
+        # validation error payload (which would contain keys like 'validator'
+        # or 'required').
+        assert "200 points" in text, f"Expected original error text to be preserved, got: {text!r}"
+        assert '"validator"' not in text and '"required"' not in text, f"Error payload appears to have been replaced by a validation error (regression of #4202): {text!r}"
+        print(f"    -> schema_error isError=true preserved: {text}")
+
+    def test_tools_call_schema_success_validates_payload(self) -> None:
+        """End-to-end positive control for the #4202 fix.
+
+        While ``test_tools_call_schema_error_preserves_payload`` proves the
+        gateway *skips* validation for error responses, this test proves
+        that validation *still runs and succeeds* for legitimate responses —
+        catching any over-broad fix that accidentally disables the success
+        path. The upstream ``fast-test-schema-success`` Rust fixture
+        declares the same ``outputSchema`` as ``schema_error`` but returns
+        ``isError=false`` with ``{"recognitionId": "rec-123", "message":
+        "ok"}``, which satisfies the schema. Assertions:
+
+        1. ``isError`` is absent/false.
+        2. The text content round-trips through JSON.
+        3. The MCP SDK's server-side validator at the gateway's egress
+           propagates ``structuredContent`` to the downstream client —
+           proving the egress handler's success branch still returns the
+           ``(unstructured, structured)`` tuple so the SDK validates.
+
+        Without this positive control, a future refactor that simply drops
+        the validator everywhere would pass
+        ``test_tools_call_schema_error_preserves_payload`` (no validation
+        runs, error text is preserved) while silently breaking
+        ``outputSchema`` enforcement.
+
+        MCP spec reference: 2025-11-25 "Output Schema":
+        https://modelcontextprotocol.io/specification/2025-11-25/server/tools#output-schema
+
+        Related:
+        - Negative counterpart (#4202 skip):
+          ``test_tools_call_schema_error_preserves_payload``
+        - Structured-content attachment by the ingress validator:
+          ``tests/unit/mcpgateway/services/test_tool_service_coverage.py::TestExtractAndValidateErrorResponses::test_validate_success_response_normally``
+        """
+        self._require_declared_output_schema("fast-test-schema-success")
+        messages = [
+            _build_initialize(1),
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "fast-test-schema-success", "arguments": {}}},
+        ]
+        responses = _send_jsonrpc_via_wrapper(self.env, messages)
+        call_resp = next((r for r in responses if r.get("id") == 2), None)
+        assert call_resp is not None, f"No response for id=2: {responses}"
+        assert "result" in call_resp, f"Expected result envelope: {call_resp}"
+        result = call_resp["result"]
+        assert not result.get("isError", False), f"Expected success, got: {result}"
+        text = result.get("content", [{}])[0].get("text", "")
+        payload = json.loads(text)
+        assert payload.get("recognitionId") == "rec-123", f"Unexpected payload: {payload}"
+        # When validation succeeds the gateway attaches structured_content
+        # alongside the original text content.
+        structured = result.get("structuredContent") or result.get("structured_content")
+        assert structured is not None, f"Expected structured content on successful validation: {result}"
+        assert structured.get("recognitionId") == "rec-123", f"Unexpected structured content: {structured}"
+        print(f"    -> schema_success validated: {payload}")
+
     def test_tools_call_nonexistent_tool(self) -> None:
         """JSON-RPC tools/call nonexistent-tool-xyz: returns error response."""
         messages = [

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -3546,6 +3546,39 @@ class TestRegisterToolBranches:
         tool.tags = []
         tool.team_id = "team-1"
 
+        existing = MagicMock()
+        existing.name = "my_tool"
+        existing.enabled = True
+        existing.id = "existing-id"
+        existing.visibility = "team"
+
+        db = MagicMock()
+        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=existing)))
+
+        with pytest.raises(ToolNameConflictError):
+            await tool_service.register_tool(db, tool, visibility="team", team_id="team-1", owner_email="user@test.com")
+
+    @pytest.mark.asyncio
+    async def test_defaults_visibility_from_tool_object(self, tool_service):
+        """When visibility is None, defaults from tool.visibility then checks name conflict."""
+        tool = MagicMock()
+        tool.name = "dup_tool_defaults"
+        tool.team_id = "team-99"
+        tool.owner_email = "default@test.com"
+        tool.visibility = "team"  # will be used as default since visibility=None
+
+        existing = MagicMock()
+        existing.name = "dup_tool_defaults"
+        existing.enabled = True
+        existing.id = "existing-id"
+        existing.visibility = "team"
+
+        db = MagicMock()
+        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=existing)))
+
+        # visibility=None => uses tool.visibility="team", team_id defaults from tool.team_id
+        with pytest.raises(ToolNameConflictError):
+            await tool_service.register_tool(db, tool, visibility=None, owner_email=None)
 
     def test_skip_validation_for_error_response_is_error(self, tool_service):
         """Skip output schema validation when is_error=True per MCP spec."""
@@ -3644,66 +3677,6 @@ class TestRegisterToolBranches:
         assert tool_result.is_error is True
         # Content should be replaced with validation error details
         assert "recognitionId" in tool_result.content[0].text or "required" in tool_result.content[0].text.lower()
-
-
-# ---------------------------------------------------------------------------
-# register_tool — team name conflict (lines 1075-1078) + defaults (1059-1062)
-# ---------------------------------------------------------------------------
-
-
-class TestRegisterToolBranches:
-    @pytest.mark.asyncio
-    async def test_team_name_conflict(self, tool_service):
-        """Raises ToolNameConflictError when team tool with same name exists."""
-        tool = MagicMock()
-        tool.name = "my_tool"
-        tool.displayName = "My Tool"
-        tool.url = "http://example.com"
-        tool.description = "desc"
-        tool.integration_type = "REST"
-        tool.request_type = "GET"
-        tool.headers = {}
-        tool.input_schema = {}
-        tool.output_schema = None
-        tool.annotations = {}
-        tool.jsonpath_filter = None
-        tool.auth = None
-        tool.tags = []
-        tool.team_id = "team-1"
-
-        existing = MagicMock()
-        existing.name = "my_tool"
-        existing.enabled = True
-        existing.id = "existing-id"
-        existing.visibility = "team"
-
-        db = MagicMock()
-        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=existing)))
-
-        with pytest.raises(ToolNameConflictError):
-            await tool_service.register_tool(db, tool, visibility="team", team_id="team-1", owner_email="user@test.com")
-
-    @pytest.mark.asyncio
-    async def test_defaults_visibility_from_tool_object(self, tool_service):
-        """When visibility is None, defaults from tool.visibility then checks name conflict."""
-        tool = MagicMock()
-        tool.name = "dup_tool_defaults"
-        tool.team_id = "team-99"
-        tool.owner_email = "default@test.com"
-        tool.visibility = "team"  # will be used as default since visibility=None
-
-        existing = MagicMock()
-        existing.name = "dup_tool_defaults"
-        existing.enabled = True
-        existing.id = "existing-id"
-        existing.visibility = "team"
-
-        db = MagicMock()
-        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=existing)))
-
-        # visibility=None => uses tool.visibility="team", team_id defaults from tool.team_id
-        with pytest.raises(ToolNameConflictError):
-            await tool_service.register_tool(db, tool, visibility=None, owner_email=None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -635,16 +635,16 @@ class TestExtractAndValidateStructuredContent:
     def test_valid_candidate_passes(self, tool_service):
         """Valid candidate should pass validation and be attached."""
         tool = SimpleNamespace(output_schema={"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]})
-        result = ToolResult(content=[])
-        ok = tool_service._extract_and_validate_structured_content(tool, result, candidate={"x": "hello"})
+        result = ToolResult(content=[], structured_content={"x": "hello"})
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
         assert ok is True
         assert result.structured_content == {"x": "hello"}
 
     def test_invalid_candidate_marks_error(self, tool_service):
         """Invalid candidate should mark result as error."""
         tool = SimpleNamespace(output_schema={"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]})
-        result = ToolResult(content=[])
-        ok = tool_service._extract_and_validate_structured_content(tool, result, candidate={"x": 123})
+        result = ToolResult(content=[], structured_content={"x": 123})
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
         assert ok is False
         assert result.is_error is True
         # Error details should be in content
@@ -664,14 +664,6 @@ class TestExtractAndValidateStructuredContent:
         tool = SimpleNamespace(output_schema={"type": "object"})
         result = ToolResult(content=[])
         ok = tool_service._extract_and_validate_structured_content(tool, result)
-        assert ok is True
-
-    def test_unwrap_single_element_list(self, tool_service):
-        """Single-element list wrapping a TextContent-like dict should be unwrapped."""
-        tool = SimpleNamespace(output_schema={"type": "object", "properties": {"a": {"type": "integer"}}})
-        result = ToolResult(content=[])
-        candidate = [{"type": "text", "text": '{"a": 5}'}]
-        ok = tool_service._extract_and_validate_structured_content(tool, result, candidate=candidate)
         assert ok is True
 
 
@@ -1871,26 +1863,37 @@ class TestSubscribeEvents:
 
 
 class TestStructuredContentAdditional:
-    """Additional branch coverage for _extract_and_validate_structured_content."""
+    """Branch coverage for ``_extract_and_validate_structured_content``.
 
-    def test_unwrap_single_element_list_non_textcontent_inner(self, tool_service):
-        """Single-element list with non-TextContent dict should be unwrapped directly."""
-        tool = SimpleNamespace(output_schema={"type": "object", "properties": {"a": {"type": "integer"}}})
-        result = ToolResult(content=[])
-        # This is a single-element list with a non-text dict
-        candidate = [{"a": 5}]
-        ok = tool_service._extract_and_validate_structured_content(tool, result, candidate=candidate)
-        assert ok is True
+    These tests cover the edges of the validator that are not themselves
+    part of the #4202 error-handling fix but exercise the surrounding
+    contract introduced by PR #4204: that ``structured_content``, when
+    present, MUST be a JSON object per the MCP 2025-11-25 specification's
+    "Output Schema" section, and that the content-item JSON-parse fallback
+    loop tolerates malformed items gracefully.
+    """
 
-    def test_unwrap_inner_text_with_unparseable_json(self, tool_service):
-        """When inner text fails to parse as JSON, should use inner dict directly."""
+    def test_invalid_structured_content_type_marks_error(self, tool_service):
+        """Non-dict ``structured_content`` fast-fails with a structured error.
+
+        The MCP 2025-11-25 "Output Schema" section requires that
+        ``structuredContent`` be a JSON object. When the gateway receives a
+        list or scalar there it must refuse to validate (since there is no
+        way the payload can conform to the standard
+        ``{"type": "object", ...}`` shape of an outputSchema) and surface a
+        deterministic error describing the type mismatch, so callers can
+        distinguish this from genuine schema-validation failures.
+
+        MCP spec reference: 2025-11-25 "Output Schema".
+        """
         tool = SimpleNamespace(output_schema={"type": "object"})
-        result = ToolResult(content=[])
-        candidate = [{"type": "text", "text": "not-json-at-all"}]
-        # This will try to parse the inner text, fail, and use the inner dict
-        ok = tool_service._extract_and_validate_structured_content(tool, result, candidate=candidate)
-        # Validation may pass or fail depending on schema, but shouldn't crash
-        assert isinstance(ok, bool)
+        result = SimpleNamespace(content=[], structured_content=[{"a": 5}], is_error=False)
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is False
+        assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["code"] == "invalid_structured_content_type"
+        assert details["expected"] == "object"
 
     def test_content_with_null_text_parses_to_none(self, tool_service):
         """Content with text=None should parse to null and be treated as no structured data."""
@@ -1902,14 +1905,500 @@ class TestStructuredContentAdditional:
         # null parse -> structured=None -> treat as valid (nothing to validate)
         assert ok is True
 
-    def test_validation_error_orjson_fallback(self, tool_service):
-        """When orjson.dumps fails for error details, fall back to str()."""
+    def test_invalid_scalar_structured_content_marks_error(self, tool_service):
+        """Scalar ``structured_content`` (int, string, bool) also fast-fails.
+
+        Complements ``test_invalid_structured_content_type_marks_error`` by
+        exercising the other half of the "not a JSON object" taxonomy — the
+        MCP 2025-11-25 "Output Schema" section forbids any non-object shape
+        in ``structuredContent``, and the validator's fast-fail branch must
+        fire identically for scalars and for arrays. The error dict's
+        ``received`` field must report the actual offending type name so the
+        error is diagnosable.
+
+        MCP spec reference: 2025-11-25 "Output Schema".
+        """
         tool = SimpleNamespace(output_schema={"type": "string"})
-        result = ToolResult(content=[])
-        # Provide an invalid candidate (number when string expected)
-        ok = tool_service._extract_and_validate_structured_content(tool, result, candidate=42)
+        result = SimpleNamespace(content=[], structured_content=42, is_error=False)
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
         assert ok is False
         assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["received"] == "int"
+
+    def test_content_text_parse_failure_skips_and_continues(self, tool_service):
+        """Content-fallback loop tolerates malformed items and continues.
+
+        The MCP specification does not require all ``content`` items to be
+        valid JSON — free-form text, logs and human-readable diagnostics are
+        legal ``TextContent`` payloads. When no ``structured_content`` has
+        been set explicitly, the gateway tries to promote the first parseable
+        text item into the structured channel so ``output_schema``
+        enforcement can run. That promotion must be best-effort: an item
+        whose text is not valid JSON must be silently skipped
+        (``orjson.JSONDecodeError`` caught in the ``except`` branch of the
+        content-fallback loop in ``_extract_and_validate_structured_content``)
+        rather than aborting the loop, so a valid JSON item later in the
+        list is still used.
+
+        MCP spec reference: 2025-11-25 "Content Types" (TextContent admits
+        arbitrary text) and "Output Schema" (structured promotion is
+        best-effort).
+        """
+        tool = SimpleNamespace(output_schema={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]})
+        result = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "definitely not json"},  # raises JSONDecodeError -> except -> continue
+                {"type": "text", "text": '{"x": 42}'},  # parses successfully
+            ],
+            structured_content=None,
+            is_error=False,
+        )
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is True
+        # Verifies the loop skipped the bad item and picked up the good one.
+        assert result.structured_content == {"x": 42}
+
+    def test_single_element_list_structured_content_fast_fails(self, tool_service):
+        """Pin the deliberate removal of the old single-element-list unwrap heuristic.
+
+        Before the #4202 refactor, ``_extract_and_validate_structured_content``
+        accepted ``structured_content=[{...}]`` (a one-element list) and
+        silently unwrapped it to ``{...}`` when the declared schema was
+        ``{"type": "object"}``. That heuristic was removed in favour of
+        the stricter MCP 2025-11-25 "Output Schema" rule that
+        ``structuredContent`` must be a JSON *object* — not a list
+        containing one. The new canonical behaviour is the
+        ``invalid_structured_content_type`` fast-fail at
+        ``tool_service.py`` (the same branch ``test_invalid_structured_content_type_marks_error``
+        covers for generic lists).
+
+        This test pins the specific single-element-list shape because
+        that was the one the removed heuristic quietly rescued. Without
+        this guard, a future "help the user" change that reintroduces
+        unwrapping would silently reopen the quirk the refactor closed.
+        """
+        tool = SimpleNamespace(output_schema={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]})
+        # Exactly one element — the shape the old heuristic used to unwrap.
+        result = SimpleNamespace(content=[], structured_content=[{"x": 42}], is_error=False)
+
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+
+        # Current canonical behaviour: reject with structured error, not unwrap.
+        assert ok is False
+        assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["code"] == "invalid_structured_content_type"
+        assert details["expected"] == "object"
+        assert details["received"] == "list"
+        # The inner dict is NOT silently promoted — that was the old heuristic.
+        assert getattr(result, "structured_content", [{"x": 42}]) == [{"x": 42}]
+
+    def test_single_element_list_in_textcontent_text_does_not_unwrap(self, tool_service):
+        """Complementary guard — unwrap is also removed from the text-parse fallback.
+
+        The old heuristic unwrapped both ``structured_content=[{...}]`` and
+        cases where the first ``TextContent.text`` parsed as a JSON array
+        containing a single dict. The new pipeline treats a parsed list
+        as a list and hands it to ``jsonschema.validate``; because the
+        declared schema is ``{"type": "object"}``, validation rejects a
+        list-shaped instance with a ``type`` validator error.
+
+        Note the error ``code`` here (``"type"``) differs from the
+        explicit ``invalid_structured_content_type`` fast-fail code that
+        fires when ``structured_content`` is pre-set with a non-dict
+        value (see ``test_single_element_list_structured_content_fast_fails``).
+        Both paths end in the same user-visible outcome: the list is not
+        unwrapped into an object, and the response is marked as an
+        error. Asserting the distinct error codes pins both paths so
+        that a future refactor can't accidentally route one through the
+        other and silently change the diagnostic surface.
+        """
+        tool = SimpleNamespace(output_schema={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]})
+        result = SimpleNamespace(
+            content=[{"type": "text", "text": '[{"x": 42}]'}],  # single-element JSON array
+            structured_content=None,
+            is_error=False,
+        )
+
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+
+        # Under the new strict contract the array body is not unwrapped; it
+        # flows into jsonschema.validate which reports a type mismatch.
+        assert ok is False
+        assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["code"] == "type"
+        assert details["expected"] == "object"
+        assert details["received"] == "list"
+
+    def test_invalid_structured_content_orjson_dumps_failure_falls_back_to_str(self, tool_service, monkeypatch):
+        """Defensive fallback when JSON serialisation of the error envelope fails.
+
+        When the validator rejects a non-object ``structured_content`` it
+        synthesises a validation-error dict and writes it onto
+        ``tool_result.content`` as a ``TextContent(text=json)``. In the rare
+        case where ``orjson.dumps`` itself raises (e.g., a sentinel object
+        was smuggled into the details dict), the validator must still
+        produce *some* content so the caller sees a populated error shape
+        rather than an empty response. The fallback at
+        the bare-except ``str(details)`` branch inside
+        ``_extract_and_validate_structured_content``'s non-dict-structured-content
+        fast-fail block uses ``str(details)`` — not valid JSON,
+        but human-readable — which is what this test asserts (by checking
+        that the content text contains the error ``code`` verbatim but
+        cannot round-trip through ``orjson.loads``).
+
+        This mirrors the analogous ``str(details)`` fallback inside the
+        ``except jsonschema.ValidationError`` branch of
+        ``_extract_and_validate_structured_content`` (search the method
+        for ``"str(details)"``).
+
+        MCP spec reference: 2025-11-25 "Error Handling" — error responses
+        must always carry ``content``; the shape must not be empty.
+        """
+        tool = SimpleNamespace(output_schema={"type": "object"})
+        result = SimpleNamespace(content=[], structured_content=[1, 2, 3], is_error=False)
+
+        real_dumps = orjson.dumps
+
+        def flaky_dumps(obj, *args, **kwargs):
+            # Force the non-dict-structured-content details dict to fail so the
+            # except branch runs; leave other callers untouched.
+            if isinstance(obj, dict) and obj.get("code") == "invalid_structured_content_type":
+                raise TypeError("simulated orjson failure")
+            return real_dumps(obj, *args, **kwargs)
+
+        monkeypatch.setattr("mcpgateway.services.tool_service.orjson.dumps", flaky_dumps)
+
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is False
+        assert result.is_error is True
+        # Content was stringified via str(details) rather than serialized as JSON
+        assert "invalid_structured_content_type" in result.content[0].text
+        with pytest.raises(orjson.JSONDecodeError):
+            orjson.loads(result.content[0].text)
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 24b. _coerce_to_tool_result — canonical payload coercion
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+class TestCoerceToToolResult:
+    """Coverage for ``ToolService._coerce_to_tool_result``.
+
+    The helper is the gateway's single source of truth for turning
+    heterogeneous upstream responses into the canonical ``ToolResult``
+    shape. Correct behaviour here is the foundation of #4202's egress
+    fix across multiple integration types — Codex review identified two
+    regressions when this coercion was too loose (``_coerce_to_tool_result``
+    predecessor):
+
+    - **P1** — direct-proxy MCP calls returned a raw MCP SDK
+      ``CallToolResult`` (camelCase ``isError``) to the egress, which
+      only recognised snake-case, so error responses fell through to
+      the SDK's server-side validator and were re-clobbered
+      (https://github.com/IBM/mcp-context-forge/issues/4202). The new
+      helper coerces MCP SDK ``CallToolResult`` into ``ToolResult`` via
+      ``model_dump(by_alias=True)``, mapping camelCase to snake-case.
+    - **P2** — any dict with a top-level ``content`` key was being
+      reinterpreted as an MCP envelope, silently discarding sibling
+      business fields. The new helper requires strong MCP markers
+      (``isError`` / ``structuredContent`` / ``content`` items with a
+      string ``type`` field) before attempting ``ToolResult.model_validate``.
+
+    MCP spec reference: 2025-11-25 "Tool Result" — the canonical
+    ``CallToolResult`` shape is the target type.
+    """
+
+    def test_passthrough_when_already_toolresult(self, tool_service):
+        """Existing ``ToolResult`` instances are returned by identity.
+
+        Fast path: when an upstream layer has already constructed a proper
+        ``ToolResult`` (e.g. the MCP federation branch that produces one
+        explicitly at ``tool_service.py`` when ``is_direct_proxy=False``),
+        the helper must be a no-op. Returning the same object reference
+        is important because downstream code may have attached
+        ``structured_content`` already; re-wrapping would risk dropping
+        that metadata.
+        """
+        original = ToolResult(content=[TextContent(type="text", text="hello")], is_error=False)
+        result = tool_service._coerce_to_tool_result(original)
+        assert result is original
+
+    def test_coerces_mcp_sdk_calltoolresult_to_toolresult(self, tool_service):
+        """MCP SDK ``CallToolResult`` (camelCase) is coerced to ``ToolResult``.
+
+        Regression guard for Codex P1. Before this helper existed, the
+        ``is_direct_proxy`` branch at ``tool_service.py`` assigned the
+        MCP SDK ``CallToolResult`` directly to ``tool_result``, and the
+        egress handler's ``getattr(result, "is_error", False) is True``
+        check returned ``False`` for the camelCase-only ``isError``
+        attribute. Error responses for direct-proxy tools with a declared
+        ``outputSchema`` then fell through to the success branch and the
+        SDK's server-side validator replaced the original error text with
+        ``"Output validation error: outputSchema defined but no
+        structured output returned"``.
+
+        This test uses the upstream MCP SDK's ``CallToolResult`` type
+        directly to prove the coercion works on real production types,
+        not just on dicts that happen to look MCP-shaped.
+        """
+        # Third-party — use the real MCP SDK type so the test fails if a
+        # future SDK bump renames / restructures fields.
+        # First-Party
+        from mcp import types as mcp_types  # pylint: disable=import-outside-toplevel
+
+        sdk_result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text="You cannot send more than 200 points")],
+            isError=True,
+        )
+
+        result = tool_service._coerce_to_tool_result(sdk_result)
+
+        assert isinstance(result, ToolResult)
+        assert result.is_error is True
+        # Text content preserved verbatim across the coercion.
+        assert result.content[0].text == "You cannot send more than 200 points"
+
+    def test_coerces_mcp_sdk_calltoolresult_preserves_meta(self, tool_service):
+        """Protocol-level ``_meta`` survives the coercion unchanged.
+
+        ``_meta`` carries cross-cutting MCP protocol extensions (progress
+        tokens, trace correlation IDs, etc.). A reviewer raised concern
+        that ``_coerce_to_tool_result`` might silently drop ``_meta``
+        because an earlier variant of ``ToolResult`` elsewhere in the
+        codebase (``mcpgateway/schemas.py`` — not the one this service
+        imports) omits the field. This test pins that the helper, which
+        imports ``ToolResult`` from ``mcpgateway.common.models`` (aliased
+        to ``CallToolResult`` with ``meta: Optional[Dict[str, Any]] =
+        Field(None, alias="_meta")``), round-trips ``_meta`` from an
+        upstream MCP SDK ``CallToolResult`` through
+        ``model_dump(by_alias=True)`` into a canonical ``ToolResult``
+        and emits it again on ``model_dump(by_alias=True)``.
+
+        Without this guard, a future refactor that swaps the imported
+        ``ToolResult`` source or drops the ``meta`` field would silently
+        strip every direct-proxy response of its trace correlation,
+        which matters for observability and debugging across the
+        gateway ↔ upstream boundary.
+        """
+        # First-Party
+        from mcp import types as mcp_types  # pylint: disable=import-outside-toplevel
+
+        meta_payload = {"trace_id": "abc-123", "request_id": "r-42"}
+        sdk_result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text="ok")],
+            isError=False,
+            _meta=meta_payload,
+        )
+
+        coerced = tool_service._coerce_to_tool_result(sdk_result)
+
+        # Field survives into the canonical ToolResult under its Python
+        # attribute name…
+        assert coerced.meta == meta_payload
+        # …and is re-serialised with the wire alias on the way back out.
+        egress = coerced.model_dump(by_alias=True, mode="json")
+        assert egress.get("_meta") == meta_payload
+
+    def test_rejects_rest_payload_with_content_key_but_no_mcp_markers(self, tool_service):
+        """REST business payloads that coincidentally use ``content`` are not misread as MCP envelopes.
+
+        Regression guard for Codex P2. A REST tool's native response shape
+        ``{"content": [{"widget": "alpha"}], "recognitionId": "rec-1"}``
+        must be treated as an opaque JSON body (wrapped into a single
+        ``TextContent``) rather than have its ``content`` list reinterpreted
+        as MCP ``ContentBlock`` items and its ``recognitionId`` sibling
+        silently discarded. The gating heuristic
+        (``_looks_like_mcp_envelope``) requires strong MCP markers
+        (``isError`` / ``structuredContent`` / typed content items) before
+        attempting ``ToolResult.model_validate``.
+        """
+        rest_payload = {"content": [{"widget": "alpha"}], "recognitionId": "rec-1"}
+
+        result = tool_service._coerce_to_tool_result(rest_payload)
+
+        assert isinstance(result, ToolResult)
+        # Payload preserved in full — no fields lost — in the serialized text.
+        assert result.content[0].type == "text"
+        roundtripped = orjson.loads(result.content[0].text)
+        assert roundtripped == rest_payload
+
+    def test_accepts_dict_with_mcp_markers(self, tool_service):
+        """Positive counterpart to the P2 heuristic check.
+
+        A dict carrying a strong MCP marker (``isError`` key, or
+        ``structuredContent``, or ``content`` items with a string ``type``
+        field) is a legitimate MCP envelope and should round-trip through
+        ``ToolResult.model_validate``.
+        """
+        mcp_shaped = {
+            "content": [{"type": "text", "text": "ok"}],
+            "isError": False,
+            "structuredContent": {"recognitionId": "rec-1"},
+        }
+
+        result = tool_service._coerce_to_tool_result(mcp_shaped)
+
+        assert isinstance(result, ToolResult)
+        assert result.is_error is False
+        assert result.structured_content == {"recognitionId": "rec-1"}
+        assert result.content[0].text == "ok"
+
+    def test_validation_error_falls_back_to_text_serialization(self, tool_service, caplog):
+        """Dicts admitted by the heuristic but rejected by Pydantic fall back to text.
+
+        The heuristic may admit a payload whose keys are all within the
+        MCP envelope set (so it is not a business payload with extras)
+        but whose *shape* still violates ``ToolResult`` (e.g. ``content``
+        is a scalar rather than a list). The helper must not raise in
+        that case — it falls back to serialising the payload into a
+        single ``TextContent`` and logs at DEBUG for diagnosis.
+        """
+        # Only MCP envelope keys present (so the heuristic admits it),
+        # ``isError`` gives a strong positive signal, but ``content`` as a
+        # scalar breaks ``ToolResult.model_validate``.
+        malformed = {"isError": True, "content": 123}
+
+        # User-visible reshape: must surface at WARNING so operators see protocol drift.
+        with caplog.at_level("WARNING", logger="mcpgateway.services.tool_service"):
+            result = tool_service._coerce_to_tool_result(malformed)
+
+        assert isinstance(result, ToolResult)
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        payload = orjson.loads(result.content[0].text)
+        assert payload == malformed
+        assert "failed ToolResult validation" in caplog.text or "falling back" in caplog.text
+        # Severity check — must be WARNING, not DEBUG (would hide the reshape from ops logs).
+        relevant_records = [r for r in caplog.records if "falling back" in r.message or "failed ToolResult validation" in r.message]
+        assert relevant_records, "Expected a reshape log record"
+        assert relevant_records[-1].levelname == "WARNING", f"Expected WARNING, got {relevant_records[-1].levelname}"
+
+    def test_rest_payload_with_mcp_marker_and_extra_key_is_not_coerced(self, tool_service):
+        """Regression guard for the Codex field-dropping follow-up.
+
+        Before the heuristic required *no* keys outside the MCP envelope
+        schema, a payload like
+        ``{"isError": False, "content": [{"type": "text", "text": "ok"}], "recognitionId": "rec-1"}``
+        would pass the old "has isError, therefore MCP" check, round-trip
+        through ``ToolResult.model_validate`` (which inherits
+        ``extra="ignore"`` from ``BaseModelWithConfigDict``), and silently
+        drop ``recognitionId`` on the floor. Any REST tool whose native
+        response happens to use a field name in the MCP envelope set
+        (``isError``, ``structuredContent``, ``content``, ``_meta`` / ``meta``)
+        was vulnerable to this field-dropping bug.
+
+        The fix in ``_looks_like_mcp_envelope`` is to require the dict's
+        full key set to be a subset of the MCP envelope schema — a single
+        unknown sibling key fails the check and the payload is preserved
+        verbatim via the text-serialisation fallback.
+        """
+        rest_payload = {
+            "isError": False,
+            "content": [{"type": "text", "text": "ok"}],
+            "recognitionId": "rec-1",
+        }
+
+        result = tool_service._coerce_to_tool_result(rest_payload)
+
+        # Must be wrapped as opaque text so ``recognitionId`` survives; a
+        # successful MCP-envelope coercion would strip it silently.
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        roundtripped = orjson.loads(result.content[0].text)
+        assert roundtripped == rest_payload
+        # Specifically pin that the caller-visible payload still carries the
+        # business field — this is the exact regression guard Codex asked for.
+        assert "recognitionId" in roundtripped
+
+    def test_rest_payload_with_structured_content_and_extra_key_is_not_coerced(self, tool_service):
+        """Variant of the preceding guard — triggers via ``structuredContent``.
+
+        Any of the MCP strong markers (``isError``, ``structuredContent``,
+        typed ``content`` items) *must* be paired with the no-extra-keys
+        check. This test exercises the ``structuredContent`` path because
+        it is the marker that historically had the least exercise in
+        unit tests and is the one a future "help the user" change (e.g.
+        auto-populating ``structuredContent`` from a REST tool's schema)
+        would most likely collide with.
+        """
+        rest_payload = {
+            "structuredContent": {"result": "ok"},
+            "content": [{"type": "text", "text": "ok"}],
+            "details": {"trace_id": "abc123"},
+        }
+
+        result = tool_service._coerce_to_tool_result(rest_payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        roundtripped = orjson.loads(result.content[0].text)
+        assert roundtripped == rest_payload
+        assert "details" in roundtripped
+        assert roundtripped["details"]["trace_id"] == "abc123"
+
+    def test_rest_payload_with_typed_content_list_and_extra_key_is_not_coerced(self, tool_service):
+        """Variant of the preceding guard — triggers via typed ``content`` items.
+
+        The weakest positive MCP signal is "``content`` is a list of
+        dicts each carrying a string ``type`` field". A REST tool that
+        happens to return MCP-like typed items alongside a business
+        field (e.g. a pagination cursor) must not have that sibling
+        silently dropped.
+        """
+        rest_payload = {
+            "content": [{"type": "text", "text": "page 1"}],
+            "nextCursor": "page-2-token",
+        }
+
+        result = tool_service._coerce_to_tool_result(rest_payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        roundtripped = orjson.loads(result.content[0].text)
+        assert roundtripped == rest_payload
+        assert roundtripped["nextCursor"] == "page-2-token"
+
+    def test_mcp_envelope_with_meta_is_still_accepted(self, tool_service):
+        """Positive counterpart — ``_meta`` / ``meta`` are legitimate envelope keys.
+
+        Ensures the tightened heuristic did not over-constrain:
+        well-formed MCP envelopes that include protocol-level metadata
+        (``_meta`` on the wire, ``meta`` in Python) must still be coerced
+        cleanly. Without this test a future simplification that forgot
+        ``_meta`` would silently start text-wrapping valid MCP responses.
+        """
+        envelope = {
+            "content": [{"type": "text", "text": "ok"}],
+            "isError": False,
+            "_meta": {"request_id": "abc-123"},
+        }
+
+        result = tool_service._coerce_to_tool_result(envelope)
+
+        assert isinstance(result, ToolResult)
+        assert result.is_error is False
+        assert result.content[0].text == "ok"
+        assert result.meta == {"request_id": "abc-123"}
+
+    def test_opaque_non_mcp_payload_wraps_into_text_content(self, tool_service):
+        """Arbitrary JSON values (arrays, scalars, no-``content`` dicts) wrap cleanly.
+
+        The fallback serialises with ``orjson.OPT_INDENT_2`` so the
+        resulting ``TextContent`` is human-inspectable. The goal is the
+        invariant "every path yields a well-formed ``ToolResult``" rather
+        than any particular formatting choice.
+        """
+        payload = [{"id": 1, "name": "alpha"}, {"id": 2, "name": "beta"}]
+
+        result = tool_service._coerce_to_tool_result(payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.is_error is False
+        assert orjson.loads(result.content[0].text) == payload
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -3474,17 +3963,6 @@ class TestValidateToolOutputSchemaBranches:
         # Should not crash; schema_type falls to None
         assert result is True or result is False
 
-    def test_single_element_list_unwrap_for_object_schema(self, tool_service):
-        """Unwrap [item] when schema expects object type."""
-        tool_result = SimpleNamespace(content=None, is_error=False)
-        tool = SimpleNamespace(
-            name="t",
-            output_schema={"type": "object", "properties": {"key": {"type": "string"}}},
-        )
-        # Pass a list with single element as candidate
-        result = tool_service._extract_and_validate_structured_content(tool, tool_result, candidate=[{"key": "val"}])
-        assert result is True
-
     def test_validation_error_json_encoding_failure(self, tool_service):
         """When orjson can't encode validation details, falls back to str()."""
         tool_result = SimpleNamespace(
@@ -3522,7 +4000,7 @@ class TestValidateToolOutputSchemaBranches:
 
 
 # ---------------------------------------------------------------------------
-# register_tool — team name conflict (lines 1075-1078) + defaults (1059-1062)
+# register_tool — team name conflict + default visibility
 # ---------------------------------------------------------------------------
 
 
@@ -3580,8 +4058,50 @@ class TestRegisterToolBranches:
         with pytest.raises(ToolNameConflictError):
             await tool_service.register_tool(db, tool, visibility=None, owner_email=None)
 
+
+# ---------------------------------------------------------------------------
+# _extract_and_validate_structured_content — error response handling (#4202)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAndValidateErrorResponses:
+    """Regression guards for ContextForge #4202 on the gateway's ingress validator.
+
+    Issue: https://github.com/IBM/mcp-context-forge/issues/4202
+
+    The MCP 2025-11-25 specification's "Error Handling" section
+    (https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling)
+    states that tool execution errors are reported via ``isError: true`` and
+    explicitly that "error responses do not require structured content". Before
+    #4202 was fixed, ``ToolService._extract_and_validate_structured_content``
+    cross-validated error responses against the tool's declared
+    ``outputSchema`` and, on the expected mismatch, clobbered the original
+    error payload with a validation-error dict — discarding the upstream
+    server's actual error message. The tests in this class pin the
+    spec-compliant behaviour: when ``isError=true`` the validator is a
+    no-op, regardless of whether ``structured_content`` / ``isError`` / both
+    flags are present, and regardless of whether the payload matches the
+    declared schema.
+
+    Related:
+    - Egress-side counterpart guard:
+      ``tests/unit/mcpgateway/transports/test_streamablehttp_transport.py::test_call_tool_preserves_is_error_for_egress``
+    - End-to-end regression:
+      ``tests/e2e/test_mcp_cli_protocol.py::test_tools_call_schema_error_preserves_payload``
+    """
+
     def test_skip_validation_for_error_response_is_error(self, tool_service):
-        """Skip output schema validation when is_error=True per MCP spec."""
+        """Baseline #4202 guard — snake-case ``is_error`` flag.
+
+        Exercises the primary MCP Python shape where ``ToolResult.is_error``
+        is the Pydantic attribute. The method must return ``True`` (skip) and
+        leave the original error text verbatim on ``content[0]["text"]``,
+        proving that the validator did not run the schema check and did not
+        replace the payload with a validation-error dict.
+
+        MCP spec reference: 2025-11-25 "Error Handling" — error responses
+        do not require structured content.
+        """
         tool_result = SimpleNamespace(
             content=[{"type": "text", "text": "You cannot send more than 200 points"}],
             is_error=True,
@@ -3599,7 +4119,18 @@ class TestRegisterToolBranches:
         assert tool_result.is_error is True
 
     def test_skip_validation_for_error_response_isError(self, tool_service):
-        """Skip output schema validation when isError=True (alias) per MCP spec."""
+        """#4202 guard — wire-format camelCase ``isError`` flag.
+
+        MCP JSON-RPC responses serialise the flag as ``isError`` (camelCase).
+        Some code paths (notably federated peers forwarding raw dicts through
+        the streamable-http transport) deliver the result with the camelCase
+        attribute intact instead of the snake-cased pydantic alias. The
+        validator must respect both spellings so the skip behaviour is
+        transport-agnostic. Fixed at ``tool_service.py`` by OR-ing
+        ``getattr(result, "is_error", False) or getattr(result, "isError", False)``.
+
+        MCP spec reference: 2025-11-25 "Error Handling".
+        """
         tool_result = SimpleNamespace(
             content=[{"type": "text", "text": "Tool execution failed"}],
             isError=True,
@@ -3617,7 +4148,17 @@ class TestRegisterToolBranches:
         assert tool_result.isError is True
 
     def test_skip_validation_both_error_flags(self, tool_service):
-        """Skip validation when both is_error and isError are present."""
+        """#4202 guard — both ``is_error`` and ``isError`` present simultaneously.
+
+        When a pydantic ``ToolResult`` crosses a serialisation boundary its
+        snake-case attribute may end up alongside the camelCase alias from a
+        ``model_dump(by_alias=True)``. The validator must still skip — it
+        must not, for instance, treat one as authoritative and compare them.
+        Any truthy signal from either spelling is sufficient to invoke the
+        MCP error-response exemption.
+
+        MCP spec reference: 2025-11-25 "Error Handling".
+        """
         tool_result = SimpleNamespace(
             content=[{"type": "text", "text": "Error message"}],
             is_error=True,
@@ -3632,22 +4173,133 @@ class TestRegisterToolBranches:
         assert result is True
         assert tool_result.content[0]["text"] == "Error message"
 
+    def test_skip_validation_for_error_with_populated_structured_content(self, tool_service):
+        """Scenario A from MCP spec review.
+
+        The spec (2025-11-25 "Error Handling") permits ``isError=true`` responses
+        to carry both ``content`` and ``structuredContent`` and explicitly
+        states that error responses "do not require structured content".
+        It prescribes no validation of ``structuredContent`` against
+        ``outputSchema`` on error responses, and no precedence rule between the
+        two fields.
+
+        Pin the gateway's spec-compliant behaviour: validation is skipped
+        regardless of whether ``structuredContent`` is present, and both the
+        unstructured and structured payloads are preserved verbatim for the
+        caller to inspect.
+        """
+        # Structured payload does NOT satisfy the declared schema — that's the
+        # point: validation must not run, so the mismatch must not clobber the
+        # payload.
+        populated_structured = {"debug": "diagnostic info", "code": 429}
+        tool_result = ToolResult(
+            content=[TextContent(type="text", text="Rate limit exceeded")],
+            structured_content=populated_structured,
+            is_error=True,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={
+                "type": "object",
+                "required": ["recognitionId"],
+                "properties": {"recognitionId": {"type": "string"}},
+            },
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+
+        assert result is True
+        # is_error remains True; neither payload mutated.
+        assert tool_result.is_error is True
+        assert tool_result.content[0].text == "Rate limit exceeded"
+        assert tool_result.structured_content == populated_structured
+
+    def test_success_with_schema_but_no_content_currently_passes(self, tool_service):
+        """Scenario B from MCP spec review — known spec deviation pinned as
+        a regression guard.
+
+        Per the 2025-11-25 spec ("Output Schema" section) a server MUST
+        provide structured results conforming to a declared ``outputSchema``.
+        The gateway currently treats the absence of structured data as
+        "nothing to validate" and returns True — lenient behaviour that masks
+        upstream servers violating the spec. This test pins that behaviour so
+        any future change is explicit. Tightening tracked in
+        https://github.com/IBM/mcp-context-forge/issues/4208.
+        """
+        tool_result = ToolResult(content=[], is_error=False)
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={
+                "type": "object",
+                "required": ["recognitionId"],
+                "properties": {"recognitionId": {"type": "string"}},
+            },
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+
+        # Current lenient behaviour: passes silently.
+        assert result is True
+        assert tool_result.is_error is False
+        assert tool_result.content == []
+        assert tool_result.structured_content is None
+
+    def test_skip_validation_when_candidate_payload_is_error_shape(self, tool_service):
+        """#4202 guard — REST/normalised payloads whose body encodes a ToolResult-shaped error.
+
+        When a REST tool's upstream response happens to return a JSON dict
+        that *looks like* a serialised MCP ``CallToolResult``
+        (``{"isError": true, "content": [...]}``), ``_coerce_to_tool_result``
+        passes it through ``ToolResult.model_validate`` and produces a
+        ToolResult whose ``is_error`` attribute is already ``True`` while
+        ``content`` retains the verbatim JSON string representation of the
+        error envelope. The validator must still recognise the error state
+        and skip schema checking so the original envelope reaches the
+        downstream client untouched.
+
+        MCP spec reference: 2025-11-25 "Error Handling" — isError takes
+        precedence over outputSchema enforcement.
+        """
+        tool_result = ToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text='{"isError":true,"content":[{"type":"text","text":"Value exceeds maximum allowed (Requested: 150)"}]}',
+                )
+            ],
+            is_error=True,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={"type": "object", "required": ["recognitionId"], "properties": {"recognitionId": {"type": "string"}}},
+        )
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+
+        assert result is True
+        assert tool_result.is_error is True
+        assert tool_result.content[0].text == '{"isError":true,"content":[{"type":"text","text":"Value exceeds maximum allowed (Requested: 150)"}]}'
+
     def test_validate_success_response_normally(self, tool_service):
-        """Successful responses (is_error=False) still validate against output schema."""
+        """Positive control for #4202 — success path continues to validate.
+
+        The #4202 fix narrows the skip to error responses only; successful
+        responses with a declared ``outputSchema`` must still be validated
+        against that schema, and the validator must populate
+        ``tool_result.structured_content`` from the parsed JSON text so
+        downstream code (and the MCP SDK's server-side validator on the
+        egress side) sees a conforming payload.
+
+        MCP spec reference: 2025-11-25 "Output Schema" — servers MUST
+        provide structured results conforming to the declared schema on
+        successful responses.
+        """
         tool_result = SimpleNamespace(
             content=[{"type": "text", "text": '{"recognitionId": "123", "message": "Success"}'}],
             is_error=False,
         )
         tool = SimpleNamespace(
             name="test_tool",
-            output_schema={
-                "type": "object",
-                "required": ["recognitionId", "message"],
-                "properties": {
-                    "recognitionId": {"type": "string"},
-                    "message": {"type": "string"}
-                }
-            },
+            output_schema={"type": "object", "required": ["recognitionId", "message"], "properties": {"recognitionId": {"type": "string"}, "message": {"type": "string"}}},
         )
 
         result = tool_service._extract_and_validate_structured_content(tool, tool_result)
@@ -3657,18 +4309,28 @@ class TestRegisterToolBranches:
         assert tool_result.structured_content["recognitionId"] == "123"
 
     def test_validate_success_response_fails_validation(self, tool_service):
-        """Successful responses that fail validation are marked as errors."""
+        """Complement to #4202 — schema-violating success payload still fails.
+
+        Confirms that the fix does not overreach: a non-error response whose
+        parsed structured payload violates the declared ``outputSchema``
+        must still be flagged by the validator, and the original content
+        must be replaced with a deterministic validation-error dict (code,
+        expected, received, path, message) so callers can diagnose the
+        mismatch. This is the inverse of the #4202 bug — without this
+        branch, relaxing the error-case check would also relax the
+        success-case check.
+
+        MCP spec reference: 2025-11-25 "Output Schema" — conforming
+        structured output is required on success; non-conforming responses
+        should be surfaced as errors.
+        """
         tool_result = SimpleNamespace(
             content=[{"type": "text", "text": '{"wrong": "field"}'}],
             is_error=False,
         )
         tool = SimpleNamespace(
             name="test_tool",
-            output_schema={
-                "type": "object",
-                "required": ["recognitionId"],
-                "properties": {"recognitionId": {"type": "string"}}
-            },
+            output_schema={"type": "object", "required": ["recognitionId"], "properties": {"recognitionId": {"type": "string"}}},
         )
 
         result = tool_service._extract_and_validate_structured_content(tool, tool_result)
@@ -3677,6 +4339,109 @@ class TestRegisterToolBranches:
         assert tool_result.is_error is True
         # Content should be replaced with validation error details
         assert "recognitionId" in tool_result.content[0].text or "required" in tool_result.content[0].text.lower()
+
+    def test_validate_rest_normalized_payload_with_pydantic_text_content(self, tool_service):
+        """Regression guard — REST integration path must still be validated.
+
+        Raised during PR #4204 review as a P1 against the initial fix:
+        ``_coerce_to_tool_result`` wraps a REST tool's JSON body into
+        ``ToolResult(content=[TextContent(...)])``, where ``content`` holds
+        Pydantic objects rather than raw dicts. The first iteration of the
+        #4202 refactor made the content-item fallback loop dict-only, so
+        REST responses parsed to Pydantic ``TextContent`` items were silently
+        skipped and ``output_schema`` was never enforced — an invalid REST
+        payload would be forwarded as success. This test asserts the
+        fallback loop now accepts both dicts and Pydantic content, so a REST
+        payload that is missing the required ``recognitionId`` field is
+        correctly detected and surfaced as an error.
+
+        MCP spec reference: 2025-11-25 "Output Schema".
+        Related issues:
+        - Gateway-side validator is the only enforcement for non-MCP tool
+          invocation paths; e2e coverage for those paths tracked in
+          https://github.com/IBM/mcp-context-forge/issues/4207.
+        """
+        payload = {"wrong": "field"}
+        tool_result = tool_service._coerce_to_tool_result(payload)
+        assert isinstance(tool_result.content[0], TextContent)
+        tool = SimpleNamespace(
+            name="rest_tool",
+            output_schema={
+                "type": "object",
+                "required": ["recognitionId"],
+                "properties": {"recognitionId": {"type": "string"}},
+            },
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        # Must not silently pass: schema requires recognitionId, payload lacks it.
+        assert result is False
+        assert tool_result.is_error is True
+        assert "recognitionId" in tool_result.content[0].text or "required" in tool_result.content[0].text.lower()
+
+    def test_validate_rest_normalized_payload_passes_when_schema_matches(self, tool_service):
+        """Positive counterpart to the REST fallback-loop regression guard.
+
+        A REST payload that matches its declared ``output_schema`` must
+        round-trip cleanly through
+        ``_coerce_to_tool_result`` → Pydantic ``TextContent`` → the
+        fallback loop → schema validation, and the parsed dict must end up
+        attached to ``tool_result.structured_content`` so the egress path
+        can populate the downstream-facing ``structuredContent`` field. Pairs
+        with ``test_validate_rest_normalized_payload_with_pydantic_text_content``
+        to prove the fix is symmetric (rejects bad, accepts good).
+
+        MCP spec reference: 2025-11-25 "Output Schema" — success payloads
+        matching the schema must be surfaced as structured content.
+        Related: https://github.com/IBM/mcp-context-forge/issues/4207 (e2e
+        coverage gap for non-MCP paths).
+        """
+        payload = {"recognitionId": "rec-42", "message": "ok"}
+        tool_result = tool_service._coerce_to_tool_result(payload)
+        tool = SimpleNamespace(
+            name="rest_tool",
+            output_schema={
+                "type": "object",
+                "required": ["recognitionId"],
+                "properties": {
+                    "recognitionId": {"type": "string"},
+                    "message": {"type": "string"},
+                },
+            },
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        assert result is True
+        assert tool_result.structured_content == payload
+
+    @pytest.mark.skip(
+        reason=(
+            "Intentional coverage marker, not an implementation assertion. "
+            "The A2A branch of ToolService.invoke_tool does not currently "
+            "invoke _extract_and_validate_structured_content at all — any A2A "
+            "tool returning isError=true with a declared output_schema "
+            "therefore bypasses the gateway-side validator entirely. This is "
+            "neither a #4202 fix regression nor a correctness hazard today "
+            "(Validator C still runs on the egress and the SDK short-circuit "
+            "still preserves the payload for isError=true), but it means "
+            "there is currently no gateway-side output-schema enforcement for "
+            "A2A tools. Tracked under "
+            "https://github.com/IBM/mcp-context-forge/issues/4210 (Option B: "
+            "unify tool-invocation pipeline around canonical ToolResult). "
+            "Un-skip this test and implement it once #4210 step 3 lands "
+            "(routing A2A through the unified _post_invoke_pipeline)."
+        )
+    )
+    def test_a2a_invoke_with_iserror_outputschema_does_not_clobber(self):
+        """Future regression guard for A2A + #4202 — currently unreachable.
+
+        When #4210 routes the A2A branch through Validator B, this test
+        should drive ``invoke_tool`` against an A2A tool whose upstream
+        agent returns ``isError=True`` with a declared ``output_schema``
+        and assert the original error text is preserved end-to-end —
+        mirroring ``test_rest_payload_shaped_error_skips_output_schema_validation``
+        but for the A2A transport.
+        """
 
 
 # ---------------------------------------------------------------------------
@@ -5408,6 +6173,276 @@ class TestInvokeToolRestSuccess:
 
             result = await tool_service.invoke_tool(db, "test_tool", {})
         assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_rest_payload_shaped_error_skips_output_schema_validation(self, tool_service):
+        """End-to-end #4202 guard through the REST integration branch of ``invoke_tool``.
+
+        Drives the full REST invocation pipeline (not the unit-scoped
+        ``_extract_and_validate_structured_content`` helper) with an upstream
+        HTTP response whose JSON body is a pre-serialised MCP error envelope:
+        ``{"isError": true, "content": [{"type":"text","text": "<user message>"}]}``.
+        ``_coerce_to_tool_result`` recognises the MCP shape and
+        pydantic-validates it into a ToolResult with ``is_error=True``, after
+        which the validator must skip schema enforcement so the verbatim user
+        message (``"Value exceeds maximum allowed (Requested: 150)"``) reaches
+        the caller unchanged. This is the most realistic #4202 scenario in
+        the non-MCP-federated path — which, per
+        https://github.com/IBM/mcp-context-forge/issues/4207, has no e2e
+        coverage today.
+
+        MCP spec references:
+        - 2025-11-25 "Error Handling" — isError responses do not require
+          structured content and must not be cross-validated against
+          outputSchema.
+        - 2025-11-25 "Output Schema" — governs only the success path.
+        """
+        tp = _make_tool_payload(
+            integration_type="REST",
+            request_type="GET",
+            output_schema={"type": "object", "required": ["recognitionId"], "properties": {"recognitionId": {"type": "string"}}},
+        )
+        db = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(
+            return_value={
+                "isError": True,
+                "content": [{"type": "text", "text": "Value exceeds maximum allowed (Requested: 150)"}],
+            }
+        )
+        mock_response.raise_for_status = MagicMock()
+
+        async def fake_get(*a, **kw):
+            return mock_response
+
+        with (
+            _setup_cache_for_invoke(tp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            mock_mbuf.return_value = MagicMock()
+
+            tool_service._http_client = AsyncMock()
+            tool_service._http_client.get = fake_get
+
+            result = await tool_service.invoke_tool(db, "test_tool", {})
+
+        assert result is not None
+        assert result.is_error is True
+        assert result.content[0].text == "Value exceeds maximum allowed (Requested: 150)"
+
+    @pytest.mark.asyncio
+    async def test_rest_payload_shaped_error_records_success_false_in_metrics(self, tool_service):
+        """Regression guard — metrics must record ``success=False`` for REST ``isError=True`` with outputSchema.
+
+        Before this fix, the REST branch at
+        ``tool_service.py::invoke_tool`` ran
+        ``_extract_and_validate_structured_content`` after
+        ``_coerce_to_tool_result`` and then did ``success = bool(valid)``
+        — clobbering ``success`` back to ``True`` because the validator
+        correctly skips (returns ``True``) on ``isError=true`` per the
+        #4202 fix. That meant every REST tool whose upstream returned a
+        pre-serialised MCP error envelope was recorded in
+        ``metrics_buffer.record_tool_metric`` with ``success=True``,
+        corrupting tool-level success rates and masking real failures in
+        observability.
+
+        The fix replaces the ``success = bool(valid)`` override with
+        ``success = not tool_result.is_error`` after the optional
+        validator call, so the metric reflects both upstream error state
+        *and* any validator-imposed error state uniformly.
+
+        This test drives the full REST pipeline, captures the arguments
+        passed to ``record_tool_metric``, and asserts ``success=False``.
+        The companion assertion on ``result.is_error`` (already covered
+        by ``test_rest_payload_shaped_error_skips_output_schema_validation``)
+        proves the user-visible payload is correct; this test
+        additionally proves the internal bookkeeping is correct.
+        """
+        tp = _make_tool_payload(
+            integration_type="REST",
+            request_type="GET",
+            output_schema={"type": "object", "required": ["recognitionId"], "properties": {"recognitionId": {"type": "string"}}},
+        )
+        db = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(
+            return_value={
+                "isError": True,
+                "content": [{"type": "text", "text": "Value exceeds maximum allowed (Requested: 150)"}],
+            }
+        )
+        mock_response.raise_for_status = MagicMock()
+
+        async def fake_get(*a, **kw):
+            return mock_response
+
+        # Capture arguments to record_tool_metric so we can assert success=False.
+        # Patch the module-level singleton directly — ``metrics_buffer`` is
+        # bound at import time in tool_service.py.
+        metrics_record = MagicMock()
+        mock_metrics_buffer = MagicMock()
+        mock_metrics_buffer.record_tool_metric = metrics_record
+        mock_metrics_buffer.record_server_metric = MagicMock()
+
+        with (
+            _setup_cache_for_invoke(tp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            tool_service._http_client = AsyncMock()
+            tool_service._http_client.get = fake_get
+
+            result = await tool_service.invoke_tool(db, "test_tool", {})
+
+        # User-visible payload is still the verbatim upstream error.
+        assert result.is_error is True
+        assert result.content[0].text == "Value exceeds maximum allowed (Requested: 150)"
+        # Metrics were recorded with success=False — the specific bookkeeping
+        # invariant this test exists to pin.
+        assert metrics_record.called, "record_tool_metric was not invoked"
+        # The recorder is called via keyword arguments; accept either form.
+        recorded_success = metrics_record.call_args.kwargs.get("success")
+        if recorded_success is None and metrics_record.call_args.args:
+            # Positional fallback: the `success` argument is the 3rd positional
+            # after (tool_id, start_time, success) in the recorder signature.
+            recorded_success = metrics_record.call_args.args[2]
+        assert recorded_success is False, f"Expected metrics success=False for REST isError=true response, got {recorded_success}. " "This regression would silently inflate tool success rates."
+
+    @pytest.mark.asyncio
+    async def test_mcp_non_direct_proxy_iserror_records_success_false_in_metrics(self, tool_service):
+        """Sibling-path regression guard for the REST metrics fix.
+
+        The REST branch's success-metric bug (``success = bool(valid)``
+        clobber) lived inside ``tool_service.py::invoke_tool``'s
+        ``if tool_integration_type == "REST":`` branch, right after the
+        optional ``_extract_and_validate_structured_content`` call, and
+        was fixed by this PR. The **MCP non-direct-proxy** branch — the
+        ``else`` arm of ``if is_direct_proxy:`` inside
+        ``elif tool_integration_type == "MCP":`` — correctly uses
+        ``success = not is_err`` today (search for the assignment
+        immediately after ``is_err = getattr(tool_call_result, ...)``),
+        but there was no regression test pinning that invariant for
+        federated MCP tools. A future refactor wiring Validator B into
+        the MCP branch for symmetry with REST — or simply re-using the
+        ``bool(valid)`` idiom — would silently re-introduce the #4202
+        clobber here with no unit test to catch it.
+
+        This test drives ``invoke_tool`` through the MCP SSE path with
+        a mocked ``ClientSession.call_tool`` returning an
+        ``isError=True`` ``CallToolResult`` and asserts that
+        ``metrics_buffer.record_tool_metric`` is invoked with
+        ``success=False``. The user-visible assertion on ``is_error``
+        is the secondary check; the primary value is pinning the
+        metric bookkeeping against a future refactor.
+
+        Related tests:
+        - ``test_rest_payload_shaped_error_records_success_false_in_metrics``
+          — REST-branch twin of this guard.
+        - ``test_call_tool_preserves_is_error_for_direct_proxy_egress``
+          — direct-proxy branch; already uses ``_coerce_to_tool_result``
+          + ``success = not tool_result.is_error``.
+        """
+        # Third-party — ``session.call_tool(...)`` returns ``mcp.types.CallToolResult``
+        # (camelCase ``isError``), not the gateway's internal ``ToolResult``.
+        # Using the real SDK type here exercises the
+        # ``getattr(tool_call_result, "isError", False)`` fallback that fires
+        # for federated MCP calls in production. A gateway-type stand-in would
+        # only trip the first ``getattr(..., "is_error")`` branch and hide the
+        # camelCase path from regression coverage.
+        # First-Party
+        from mcp import types as mcp_types  # pylint: disable=import-outside-toplevel
+
+        tp = _make_tool_payload(integration_type="MCP", request_type="SSE", gateway_id="gw-uuid-1", jsonpath_filter="")
+        gp = _make_gateway_payload()
+        db = MagicMock()
+
+        # Real upstream shape — MCP SDK CallToolResult with camelCase isError.
+        sdk_error_result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text="You cannot send more than 200 points")],
+            isError=True,
+        )
+
+        def fake_sse_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
+            class _CM:
+                async def __aenter__(self):
+                    return (MagicMock(), MagicMock(), AsyncMock())
+
+                async def __aexit__(self, *exc):
+                    return False
+
+            return _CM()
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=sdk_error_result)
+
+        class _SessionCM:
+            async def __aenter__(self):
+                return mock_session
+
+            async def __aexit__(self, *exc):
+                return False
+
+        # Capture what gets passed to the module-level metrics_buffer.
+        metrics_record = MagicMock()
+        mock_metrics_buffer = MagicMock()
+        mock_metrics_buffer.record_tool_metric = metrics_record
+        mock_metrics_buffer.record_server_metric = MagicMock()
+
+        with (
+            _setup_cache_for_invoke(tp, gp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+            patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
+            patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
+            patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
+            patch.object(settings, "mcp_session_pool_enabled", False),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await tool_service.invoke_tool(db, "test_tool", {})
+
+        # User-visible payload preserved verbatim (the #4202 contract).
+        assert result.is_error is True
+        assert result.content[0].text == "You cannot send more than 200 points"
+
+        # Primary assertion: metric bookkeeping is correct. The MCP
+        # non-direct-proxy branch must record success=False for
+        # isError=true upstream responses, symmetric with the REST fix.
+        assert metrics_record.called, "record_tool_metric was not invoked"
+        recorded_success = metrics_record.call_args.kwargs.get("success")
+        assert recorded_success is False, (
+            f"Expected metrics success=False for MCP non-direct-proxy isError=true response, got {recorded_success}. " "This would silently inflate federated-tool success rates."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -3546,6 +3546,131 @@ class TestRegisterToolBranches:
         tool.tags = []
         tool.team_id = "team-1"
 
+
+    def test_skip_validation_for_error_response_is_error(self, tool_service):
+        """Skip output schema validation when is_error=True per MCP spec."""
+        tool_result = SimpleNamespace(
+            content=[{"type": "text", "text": "You cannot send more than 200 points"}],
+            is_error=True,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={"type": "object", "required": ["recognitionId"], "properties": {"recognitionId": {"type": "string"}}},
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        # Should return True (skip validation) for error responses
+        assert result is True
+        # Error content should be preserved, not overwritten with validation error
+        assert tool_result.content[0]["text"] == "You cannot send more than 200 points"
+        assert tool_result.is_error is True
+
+    def test_skip_validation_for_error_response_isError(self, tool_service):
+        """Skip output schema validation when isError=True (alias) per MCP spec."""
+        tool_result = SimpleNamespace(
+            content=[{"type": "text", "text": "Tool execution failed"}],
+            isError=True,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={"type": "object", "required": ["data"], "properties": {"data": {"type": "string"}}},
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        # Should return True (skip validation) for error responses
+        assert result is True
+        # Error content should be preserved
+        assert tool_result.content[0]["text"] == "Tool execution failed"
+        assert tool_result.isError is True
+
+    def test_skip_validation_both_error_flags(self, tool_service):
+        """Skip validation when both is_error and isError are present."""
+        tool_result = SimpleNamespace(
+            content=[{"type": "text", "text": "Error message"}],
+            is_error=True,
+            isError=True,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={"type": "object", "required": ["field"], "properties": {"field": {"type": "string"}}},
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        assert result is True
+        assert tool_result.content[0]["text"] == "Error message"
+
+    def test_validate_success_response_normally(self, tool_service):
+        """Successful responses (is_error=False) still validate against output schema."""
+        tool_result = SimpleNamespace(
+            content=[{"type": "text", "text": '{"recognitionId": "123", "message": "Success"}'}],
+            is_error=False,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={
+                "type": "object",
+                "required": ["recognitionId", "message"],
+                "properties": {
+                    "recognitionId": {"type": "string"},
+                    "message": {"type": "string"}
+                }
+            },
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        # Should validate and succeed
+        assert result is True
+        assert hasattr(tool_result, "structured_content")
+        assert tool_result.structured_content["recognitionId"] == "123"
+
+    def test_validate_success_response_fails_validation(self, tool_service):
+        """Successful responses that fail validation are marked as errors."""
+        tool_result = SimpleNamespace(
+            content=[{"type": "text", "text": '{"wrong": "field"}'}],
+            is_error=False,
+        )
+        tool = SimpleNamespace(
+            name="test_tool",
+            output_schema={
+                "type": "object",
+                "required": ["recognitionId"],
+                "properties": {"recognitionId": {"type": "string"}}
+            },
+        )
+
+        result = tool_service._extract_and_validate_structured_content(tool, tool_result)
+        # Should fail validation
+        assert result is False
+        assert tool_result.is_error is True
+        # Content should be replaced with validation error details
+        assert "recognitionId" in tool_result.content[0].text or "required" in tool_result.content[0].text.lower()
+
+
+# ---------------------------------------------------------------------------
+# register_tool — team name conflict (lines 1075-1078) + defaults (1059-1062)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterToolBranches:
+    @pytest.mark.asyncio
+    async def test_team_name_conflict(self, tool_service):
+        """Raises ToolNameConflictError when team tool with same name exists."""
+        tool = MagicMock()
+        tool.name = "my_tool"
+        tool.displayName = "My Tool"
+        tool.url = "http://example.com"
+        tool.description = "desc"
+        tool.integration_type = "REST"
+        tool.request_type = "GET"
+        tool.headers = {}
+        tool.input_schema = {}
+        tool.output_schema = None
+        tool.annotations = {}
+        tool.jsonpath_filter = None
+        tool.auth = None
+        tool.tags = []
+        tool.team_id = "team-1"
+
         existing = MagicMock()
         existing.name = "my_tool"
         existing.enabled = True

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -2332,6 +2332,55 @@ class TestCoerceToToolResult:
         roundtripped = orjson.loads(result.content[0].text)
         assert roundtripped == payload
 
+    def test_basemodel_whose_model_dump_raises_falls_back_to_str(self, tool_service, caplog):
+        """``BaseModel.model_dump`` raising is caught by the last-resort handler.
+
+        Regression guard for a real failure mode: a Pydantic ``BaseModel``
+        whose ``model_dump(mode="json")`` raises (custom field serialiser
+        that throws, ``PydanticSerializationError`` — a ``ValueError``
+        subclass, not ``TypeError`` — fields holding non-representable
+        objects). Before this fix the ``model_dump`` call lived *outside*
+        the ``try/except`` block, so any such failure escaped the helper
+        and broke the "always returns a valid ``ToolResult``" invariant.
+
+        The current implementation wraps the entire dump-plus-serialise
+        sequence, catches any ``Exception``, logs at WARNING with
+        ``exc_info=True``, and falls back to ``str(payload)``.
+        """
+        # Third-Party
+        from pydantic import BaseModel  # pylint: disable=import-outside-toplevel
+
+        class RaisingDumpModel(BaseModel):
+            """BaseModel whose ``model_dump`` always raises.
+
+            Simulates a third-party model with a broken custom serialiser.
+            Must NOT expose a ``content`` attribute so the earlier
+            BaseModel-with-content branch doesn't handle it — this test
+            targets the opaque-JSON-fallback branch specifically.
+            """
+
+            # A benign field; the model_dump override is where the failure lives.
+            placeholder: str = "ignored"
+
+            def model_dump(self, *_args, **_kwargs):  # type: ignore[override]
+                raise ValueError("simulated custom-serialiser failure")
+
+            def __str__(self) -> str:
+                return "RaisingDumpModel<str-fallback>"
+
+        payload = RaisingDumpModel()
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.tool_service"):
+            result = tool_service._coerce_to_tool_result(payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        assert result.content[0].text == "RaisingDumpModel<str-fallback>"
+        relevant = [r for r in caplog.records if "could not be JSON-serialised" in r.message]
+        assert relevant, "Expected a WARNING-level log from the str() fallback"
+        assert relevant[-1].levelname == "WARNING"
+        assert relevant[-1].exc_info is not None
+
     def test_non_json_serialisable_payload_falls_back_to_str(self, tool_service, caplog):
         """``orjson.dumps`` TypeError is caught and we fall back to ``str(payload)``.
 
@@ -2361,7 +2410,7 @@ class TestCoerceToToolResult:
         assert result.content[0].type == "text"
         # ``str(payload)`` should be visible in the fallback text.
         assert "NotJSONSerialisable" in result.content[0].text
-        relevant = [r for r in caplog.records if "not JSON-serialisable" in r.message]
+        relevant = [r for r in caplog.records if "could not be JSON-serialised" in r.message]
         assert relevant, "Expected a WARNING-level log from the str() fallback"
         assert relevant[-1].levelname == "WARNING"
         assert relevant[-1].exc_info is not None

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -2247,6 +2247,162 @@ class TestCoerceToToolResult:
         assert result.structured_content == {"recognitionId": "rec-1"}
         assert result.content[0].text == "ok"
 
+    def test_accepts_dict_with_structured_content_marker_only(self, tool_service):
+        """Dict with ``structuredContent`` (camelCase) but no ``isError`` is an envelope.
+
+        Covers the ``structuredContent`` branch of ``_looks_like_mcp_envelope``'s
+        layer-2 positive-marker check (search the helper for ``"structuredContent" in keys"``).
+        This exercises the camelCase wire form; the snake-case sibling is
+        covered by the next test.
+        """
+        # No ``isError`` — so the heuristic must admit via structuredContent.
+        payload = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": {"recognitionId": "rec-42"},
+        }
+
+        result = tool_service._coerce_to_tool_result(payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.structured_content == {"recognitionId": "rec-42"}
+        assert result.content[0].text == "ok"
+        # ToolResult.is_error defaults to False when unset in the payload.
+        assert result.is_error is False
+
+    def test_accepts_dict_with_snake_case_structured_content_marker(self, tool_service):
+        """Dict with ``structured_content`` (snake_case, gateway-internal) is an envelope.
+
+        Covers the ``structured_content`` half of the layer-2 check. Both
+        spellings live in ``_MCP_ENVELOPE_KEYS`` because forwarded-worker
+        responses and internal serialisations may emit either form.
+        """
+        payload = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structured_content": {"recognitionId": "rec-99"},
+        }
+
+        result = tool_service._coerce_to_tool_result(payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.structured_content == {"recognitionId": "rec-99"}
+
+    def test_accepts_dict_with_only_typed_content_items(self, tool_service):
+        """Dict whose only MCP signal is typed ``content`` items is still admitted.
+
+        Covers the weakest positive marker in ``_looks_like_mcp_envelope`` —
+        ``content`` as a non-empty list of dicts each carrying a string
+        ``type`` field (MCP ``ContentBlock`` shape). No ``isError``,
+        no ``structuredContent``, no ``_meta`` — this test exists so a
+        future tightening that accidentally drops the typed-content branch
+        is caught.
+        """
+        payload = {
+            "content": [
+                {"type": "text", "text": "line 1"},
+                {"type": "text", "text": "line 2"},
+            ],
+        }
+
+        result = tool_service._coerce_to_tool_result(payload)
+
+        assert isinstance(result, ToolResult)
+        assert len(result.content) == 2
+        assert result.content[0].text == "line 1"
+        assert result.content[1].text == "line 2"
+
+    def test_rejects_dict_with_only_meta_marker(self, tool_service):
+        """Dict with only ``_meta`` and no positive signal is not an MCP envelope.
+
+        Covers the final ``return False`` branch of
+        ``_looks_like_mcp_envelope`` — all keys are in the envelope set
+        (layer 1 passes) but no positive marker fires (``isError`` /
+        ``structuredContent`` / typed content items). ``_meta`` alone
+        doesn't make a payload MCP-shaped. The payload is therefore
+        coerced via the opaque-JSON fallback so the caller can inspect
+        the ``_meta`` contents without them being reinterpreted as
+        protocol metadata.
+        """
+        payload = {"_meta": {"trace_id": "abc"}, "content": []}
+
+        result = tool_service._coerce_to_tool_result(payload)
+
+        # Falls through to text-serialisation; ``_meta`` preserved as data.
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        roundtripped = orjson.loads(result.content[0].text)
+        assert roundtripped == payload
+
+    def test_non_json_serialisable_payload_falls_back_to_str(self, tool_service, caplog):
+        """``orjson.dumps`` TypeError is caught and we fall back to ``str(payload)``.
+
+        ``_coerce_to_tool_result``'s contract is to always return a valid
+        ``ToolResult``, even for payloads that aren't natively JSON-
+        serialisable (e.g. sets, circular references, custom objects
+        without a ``__json__`` method). The last-resort ``TypeError``
+        fallback at the end of the helper catches the ``orjson.dumps``
+        failure, logs at WARNING with ``exc_info=True``, and wraps
+        ``str(payload)`` into a single ``TextContent``. Without this
+        guard the helper would raise and break the pipeline's
+        "always-produces-a-ToolResult" invariant.
+        """
+
+        class NotJSONSerialisable:
+            """Plain Python class with no JSON representation."""
+
+            def __repr__(self) -> str:
+                return "NotJSONSerialisable(opaque)"
+
+        payload = NotJSONSerialisable()
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.tool_service"):
+            result = tool_service._coerce_to_tool_result(payload)
+
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        # ``str(payload)`` should be visible in the fallback text.
+        assert "NotJSONSerialisable" in result.content[0].text
+        relevant = [r for r in caplog.records if "not JSON-serialisable" in r.message]
+        assert relevant, "Expected a WARNING-level log from the str() fallback"
+        assert relevant[-1].levelname == "WARNING"
+        assert relevant[-1].exc_info is not None
+
+    def test_basemodel_with_content_that_fails_validation_falls_back(self, tool_service, caplog):
+        """Pydantic ``BaseModel`` path that fails ``ToolResult`` validation falls back to text.
+
+        Covers the ``except ValidationError`` branch inside
+        ``_coerce_to_tool_result``'s BaseModel dispatch. A caller could
+        conceivably pass a non-MCP Pydantic model that happens to expose
+        a ``content`` attribute but whose ``model_dump(by_alias=True)``
+        produces a shape that ``ToolResult.model_validate`` refuses
+        (e.g. ``content`` is a scalar rather than a list).
+
+        The helper must not raise — it must log at WARNING (so operators
+        see the protocol/schema drift) and fall through to the opaque
+        JSON-serialisation path so the rest of the pipeline still gets
+        a valid ``ToolResult``.
+        """
+        # Third-Party
+        from pydantic import BaseModel  # pylint: disable=import-outside-toplevel
+
+        class BadUpstreamModel(BaseModel):
+            """Stand-in for a third-party model that has ``content`` but wrong shape."""
+
+            content: int = 42  # ``ToolResult.content`` requires ``list[ContentBlock]``
+
+        bad_model = BadUpstreamModel()
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.tool_service"):
+            result = tool_service._coerce_to_tool_result(bad_model)
+
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        # The WARNING-severity reshape log must have fired (see #4202 egress
+        # review round — user-visible reshapes promoted from DEBUG).
+        relevant = [r for r in caplog.records if "did not validate as ToolResult" in r.message]
+        assert relevant, "Expected a WARNING-level reshape log from the BaseModel ValidationError branch"
+        assert relevant[-1].levelname == "WARNING"
+        assert relevant[-1].exc_info is not None, "Expected exc_info=True for post-mortem diagnosis"
+
     def test_validation_error_falls_back_to_text_serialization(self, tool_service, caplog):
         """Dicts admitted by the heuristic but rejected by Pydantic fall back to text.
 

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -2332,6 +2332,50 @@ class TestCoerceToToolResult:
         roundtripped = orjson.loads(result.content[0].text)
         assert roundtripped == payload
 
+    def test_payload_with_broken_str_and_repr_still_produces_toolresult(self, tool_service, caplog):
+        """Even objects whose ``__str__`` *and* ``__repr__`` raise yield a ToolResult.
+
+        The helper's hardest invariant is "never raises, always returns
+        a valid ``ToolResult``". This test exercises the extreme tail of
+        the opaque-JSON last-resort branch: a payload that (1) is not a
+        BaseModel with MCP-shaped fields, (2) isn't JSON-serialisable
+        (so ``orjson.dumps`` raises), (3) whose ``__str__`` raises when
+        the helper tries ``str(payload)``, and (4) whose ``__repr__``
+        also raises. Without ``_safe_text_repr``'s third-tier
+        ``f"<{type_name} object>"`` sentinel, either of those would
+        escape the helper.
+
+        Pairs with ``test_non_json_serialisable_payload_falls_back_to_str``
+        (normal ``str()`` path) and
+        ``test_basemodel_whose_model_dump_raises_falls_back_to_str``
+        (BaseModel.model_dump raising).
+        """
+
+        class AdversarialPayload:
+            """Payload whose textual representations both raise."""
+
+            def __str__(self) -> str:  # pragma: no cover - intentionally explodes
+                raise RuntimeError("__str__ is broken")
+
+            def __repr__(self) -> str:  # pragma: no cover - intentionally explodes
+                raise RuntimeError("__repr__ is also broken")
+
+        payload = AdversarialPayload()
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.tool_service"):
+            result = tool_service._coerce_to_tool_result(payload)
+
+        # Contract held — we got a ``ToolResult`` rather than an exception.
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        # Third-tier sentinel used; must be a non-empty string.
+        assert "AdversarialPayload" in result.content[0].text
+        assert "unrepresentable" in result.content[0].text
+        # WARNING-severity reshape log should still have fired.
+        relevant = [r for r in caplog.records if "could not be JSON-serialised" in r.message]
+        assert relevant, "Expected a WARNING-level log from the last-resort fallback"
+        assert relevant[-1].levelname == "WARNING"
+
     def test_basemodel_whose_model_dump_raises_falls_back_to_str(self, tool_service, caplog):
         """``BaseModel.model_dump`` raising is caught by the last-resort handler.
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -532,6 +532,236 @@ async def test_call_tool_with_structured_content(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_call_tool_preserves_is_error_for_egress(monkeypatch):
+    """Egress regression guard for ContextForge #4202 — local (non-pooled) branch.
+
+    Issue: https://github.com/IBM/mcp-context-forge/issues/4202
+
+    The #4202 fix on the ingress side (see
+    ``mcpgateway/services/tool_service.py::_extract_and_validate_structured_content``)
+    stops the gateway's own validator from clobbering upstream error
+    responses. However, the gateway is itself an MCP *server* to its
+    downstream clients, and the MCP Python SDK ships a server-side
+    validator in ``mcp.server.lowlevel.server`` that re-runs the
+    same check on the way out. When the tool handler returns a bare list
+    or tuple and the tool declares an ``outputSchema``, that SDK validator
+    fabricates the error message ``"Output validation error: outputSchema
+    defined but no structured output returned"`` — re-clobbering the very
+    payload the ingress fix just preserved.
+
+    The fix for the egress side is to hand the SDK a fully-formed
+    ``types.CallToolResult`` on error responses so the SDK's
+    ``isinstance(results, types.CallToolResult)`` short-circuit in
+    ``mcp.server.lowlevel.server`` fires and skips validation, preventing
+    any re-clobbering. This test pins that contract for the local (non-pooled) branch
+    of ``call_tool`` in ``streamablehttp_transport.py``. Successful
+    responses intentionally continue to flow through as list/tuple so the
+    SDK still enforces ``outputSchema`` for them (tested by the other
+    ``test_call_tool_*`` tests in this file that use ``is_error=False``).
+
+    MCP spec references:
+    - 2025-11-25 "Error Handling" — error responses do not require
+      structured content and must not be cross-validated against
+      ``outputSchema``.
+    - 2025-11-25 "Output Schema" — governs only successful responses.
+
+    Complements:
+    - Ingress-side guard:
+      ``tests/unit/mcpgateway/services/test_tool_service_coverage.py::TestExtractAndValidateErrorResponses``
+    - Pooled/worker-forwarded branch:
+      ``test_call_tool_session_affinity_forwarded_preserves_is_error`` in
+      this file.
+    - End-to-end verification:
+      ``tests/e2e/test_mcp_cli_protocol.py::TestMcpStdioProtocol::test_tools_call_schema_error_preserves_payload``.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = "You cannot send more than 200 points"
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.is_error = True
+    # Error responses typically carry no structured content, even when the
+    # tool declares an outputSchema (per MCP spec, see #4202).
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("mytool", {"foo": "bar"})
+
+    assert isinstance(result, types.CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent is None
+    # The original error text must be preserved verbatim.
+    assert result.content[0].text == "You cannot send more than 200 points"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_preserves_is_error_for_direct_proxy_egress(monkeypatch):
+    """Regression guard for Codex P1 — direct-proxy egress.
+
+    Before the ``_coerce_to_tool_result`` helper landed, the
+    ``is_direct_proxy`` branch at ``tool_service.py`` assigned the
+    upstream MCP SDK ``CallToolResult`` (camelCase ``isError``) directly
+    to the invocation result. The egress handler's snake-case-only
+    ``is_error is True`` check returned ``False`` for those objects and
+    error responses fell through to the success branch, where the MCP
+    server SDK's validator clobbered the original error text.
+
+    After the helper, ``invoke_tool`` always returns a canonical
+    ``ToolResult`` with snake-case ``is_error``, so the egress check
+    fires correctly even for direct-proxy error responses. This test
+    simulates the post-coercion contract end-to-end: mock
+    ``invoke_tool`` to return a ``ToolResult(is_error=True)``, and
+    assert the egress wraps in ``CallToolResult(isError=True)`` to
+    short-circuit server-side SDK validation (#4202 egress).
+
+    Complements ``test_call_tool_preserves_is_error_for_egress`` which
+    covers the same contract via a mock ``MagicMock`` rather than a
+    real ``ToolResult``; this variant pins the direct-proxy path
+    specifically.
+    """
+    # First-Party
+    from mcpgateway.common.models import TextContent, ToolResult
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service, types
+
+    mock_db = MagicMock()
+    # Real ToolResult — after coercion this is what invoke_tool returns on
+    # the direct-proxy path; the egress must pick up its snake-case
+    # is_error attribute.
+    coerced_result = ToolResult(
+        content=[TextContent(type="text", text="You cannot send more than 200 points")],
+        is_error=True,
+    )
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=coerced_result))
+
+    result = await call_tool("mytool", {"foo": "bar"})
+
+    assert isinstance(result, types.CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent is None
+    assert result.content[0].text == "You cannot send more than 200 points"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_header_direct_proxy_preserves_is_error(monkeypatch):
+    """Regression guard for #4202 on the header-path direct-proxy egress branch.
+
+    ``streamablehttp_transport.call_tool`` has **two** direct-proxy code
+    paths that differ in where the decision is made:
+
+    1. **Header path** — this test. When the inbound request carries an
+       ``X-Context-Forge-Gateway-Id`` header and the target gateway has
+       ``gateway_mode="direct_proxy"``, ``call_tool`` returns the result
+       from ``tool_service.invoke_tool_direct`` verbatim to the SDK. Early
+       return, no coercion, no egress `is_error` check. The SDK's
+       ``isinstance(result, CallToolResult)`` short-circuit at the server
+       framework is what preserves ``isError`` downstream.
+
+    2. **Internal flag path** — the existing
+       ``test_call_tool_preserves_is_error_for_direct_proxy_egress`` in
+       this file. When ``invoke_tool`` chooses direct-proxy *internally*
+       (``is_direct_proxy=True`` branch inside the MCP dispatch) it now
+       routes its raw ``CallToolResult`` through ``_coerce_to_tool_result``
+       so the egress sees a canonical ``ToolResult`` with snake-case
+       ``is_error``. That's the Codex P1 fix.
+
+    This test closes the coverage gap for path (1). Without it, a future
+    change to the SDK's server-framework short-circuit, or a transport
+    refactor that accidentally re-wraps the direct-proxy result before
+    returning it, would silently re-introduce the #4202 symptom (error
+    payload replaced with ``"Output validation error: outputSchema
+    defined but no structured output returned"``) for direct-proxy tools
+    with a declared ``outputSchema``. Asserts:
+
+    - ``call_tool`` returns the exact ``CallToolResult`` object produced
+      by ``invoke_tool_direct`` (so the SDK short-circuits correctly).
+    - ``isError=True`` survives unchanged.
+    - The verbatim upstream error text is preserved (no validation-error
+      substitution).
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (  # pylint: disable=import-outside-toplevel
+        call_tool,
+        request_headers_var,
+        tool_service,
+        types,
+        user_context_var,
+    )
+
+    # Enable the feature flag that the direct-proxy code path gates on.
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_direct_proxy_enabled", True)
+
+    # Gateway lookup — return a gateway in direct_proxy mode.
+    mock_gateway = MagicMock()
+    mock_gateway.id = "gw-direct"
+    mock_gateway.gateway_mode = "direct_proxy"
+    mock_gateway.url = "http://remote.example.com/mcp"
+
+    mock_db = MagicMock()
+    mock_db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=mock_gateway)))
+
+    @asynccontextmanager
+    async def mock_get_db():
+        yield mock_db
+
+    # Upstream response: raw MCP SDK CallToolResult with isError=True and a
+    # verbatim error message that must not be clobbered on the way out.
+    upstream_error = types.CallToolResult(
+        content=[types.TextContent(type="text", text="You cannot send more than 200 points")],
+        isError=True,
+    )
+    mock_invoke_direct = AsyncMock(return_value=upstream_error)
+
+    # Request headers + user context — the header triggers the direct-proxy branch.
+    h_token = request_headers_var.set({"x-context-forge-gateway-id": "gw-direct"})
+    u_token = user_context_var.set({"email": "user@example.com", "teams": ["team1"], "is_authenticated": True, "is_admin": False})
+
+    try:
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", mock_get_db),
+            patch("mcpgateway.transports.streamablehttp_transport.check_gateway_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "invoke_tool_direct", mock_invoke_direct),
+        ):
+            result = await call_tool("mytool", {"foo": "bar"})
+    finally:
+        request_headers_var.reset(h_token)
+        user_context_var.reset(u_token)
+
+    # invoke_tool_direct must have been called — proves we took the header path.
+    mock_invoke_direct.assert_called_once()
+    call_kwargs = mock_invoke_direct.call_args.kwargs
+    assert call_kwargs["gateway_id"] == "gw-direct"
+    assert call_kwargs["name"] == "mytool"
+    assert call_kwargs["arguments"] == {"foo": "bar"}
+
+    # Early return: the CallToolResult from invoke_tool_direct is returned by
+    # identity — the SDK's isinstance(result, CallToolResult) short-circuit is
+    # what preserves isError for the downstream client.
+    assert result is upstream_error
+    assert isinstance(result, types.CallToolResult)
+    assert result.isError is True
+    assert result.content[0].text == "You cannot send more than 200 points"
+
+
+@pytest.mark.asyncio
 async def test_call_tool_no_content(monkeypatch, caplog):
     """Test call_tool returns [] and logs warning if no content."""
     # First-Party
@@ -5422,6 +5652,78 @@ async def test_call_tool_session_affinity_forwarded_with_structured(monkeypatch)
             result = await call_tool("my_tool", {})
         assert isinstance(result, tuple)
         assert result[1] == {"key": "val"}
+    finally:
+        request_headers_var.reset(h_token)
+        user_context_var.reset(u_token)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_session_affinity_forwarded_preserves_is_error(monkeypatch):
+    """Egress regression guard for #4202 — pooled/worker-forwarded branch.
+
+    Issue: https://github.com/IBM/mcp-context-forge/issues/4202
+
+    ``streamablehttp_transport.call_tool`` has two return sites that need
+    identical #4202 treatment:
+
+    1. The local branch (covered by
+       ``test_call_tool_preserves_is_error_for_egress``), used in
+       single-worker setups and when session affinity is not triggered.
+    2. The session-affinity branch below, used when
+       ``mcpgateway_session_affinity_enabled`` is true and the request
+       carries a valid ``mcp-session-id`` header that resolves to another
+       worker. In this branch the result comes from
+       ``pool.forward_request_to_owner`` as a raw JSON-RPC ``result``
+       dict (camelCase ``isError``, not Pydantic), so the code has to
+       detect ``isError`` directly from that dict before wrapping.
+
+    Without this guard a multi-worker deployment that happens to route an
+    MCP error response through a forwarded worker would silently regress
+    #4202 even while the local branch test passes. The review raised this
+    as a P1 coverage gap
+    (https://github.com/IBM/mcp-context-forge/pull/4204 review comments).
+
+    MCP spec references:
+    - 2025-11-25 "Error Handling" — isError responses must bypass
+      outputSchema validation.
+    - 2025-11-25 "Output Schema" — only governs success responses.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, request_headers_var, types, user_context_var
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+
+    h_token = request_headers_var.set({"mcp-session-id": "abc-123-valid-session"})
+    u_token = user_context_var.set({"email": "user@test.com", "teams": ["t1"], "is_admin": False})
+
+    mock_pool = MagicMock()
+    mock_pool.forward_request_to_owner = AsyncMock(
+        return_value={
+            "result": {
+                "content": [{"type": "text", "text": "You cannot send more than 200 points"}],
+                "isError": True,
+            }
+        }
+    )
+    mock_pool.register_session_mapping = AsyncMock()
+
+    mock_cache = AsyncMock()
+    mock_cache.get = AsyncMock(return_value=None)
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    try:
+        with (
+            patch("mcpgateway.services.mcp_session_pool.get_mcp_session_pool", return_value=mock_pool),
+            patch("mcpgateway.services.mcp_session_pool.MCPSessionPool", mock_session_class),
+            patch("mcpgateway.cache.tool_lookup_cache.tool_lookup_cache", mock_cache),
+        ):
+            result = await call_tool("my_tool", {})
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        assert result.structuredContent is None
+        assert result.content[0].text == "You cannot send more than 200 points"
     finally:
         request_headers_var.reset(h_token)
         user_context_var.reset(u_token)


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

This PR fixes a regression where ContextForge Gateway incorrectly enforces `outputSchema` validation on MCP tool error responses (`isError: true`), breaking MCP specification compliance and preventing standard error handling.

**What was broken:** The gateway validated structured output against `outputSchema` even when tools returned error responses with `isError: true`, causing validation failures and obscuring the actual error messages from tools.

**Why it matters:** This regression broke previously functional MCP integrations and forced developers to implement non-standard workarounds that violate the MCP specification.

## 🔁 Reproduction Steps


**Minimal reproduction:**

1. Create an MCP tool that raises `ToolError` (or use test endpoint: https://mcptest.1yhjfkkdsl9j.us-south.codeengine.appdomain.cloud/mcp)

```python
from fastmcp import FastMCP
from fastmcp.exceptions import ToolError
from pydantic import BaseModel, Field
from uuid import UUID, uuid4

mcp = FastMCP("Test MCP")
    
class RecognitionResult(BaseModel):
    recognitionId: UUID
    message: str

@mcp.tool(description="Submits a recognition for a recipient.")
def submit_recognition(points: int = Field(description="The number of points to award")) -> RecognitionResult:
    if points > 200:
        raise ToolError(f"You cannot send more than 200 points (Requested: {points})")
    
    return RecognitionResult(
        recognitionId=uuid4(),
        message="Recognition submitted successfully with " + str(points) + " points"
    )

if __name__ == "__main__":
    mcp.run(transport="streamable-http", host="0.0.0.0", port=8000)
```

2. Invoke the tool via ContextForge Gateway with `points > 200`
3. **Before fix:** Observe "Output validation error: outputSchema defined but no structured output returned"
4. **After fix:** Error message properly surfaces: "You cannot send more than 200 points (Requested: 2023)"

## 🐞 Root Cause

**Location:** `mcpgateway/services/tool_service.py`, method `_extract_and_validate_structured_content` (lines 1228-1375)

**Problem:** The validation method did not check if `tool_result.is_error` or `tool_result.isError` was `True` before enforcing output schema validation.

**MCP Specification:** According to the [MCP Error Handling Specification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling), error responses with `isError: true` should contain:
- `content` array with text messages
- **NO requirement for `structuredContent`**

The gateway was unconditionally validating all responses, including errors, causing:
1. Validation failures for standards-compliant error responses
2. Original error messages being overwritten with validation errors
3. Breaking compatibility with MCP-compliant tools

## 💡 Fix Description

**Solution:** Skip output schema validation for error responses per MCP specification.

**Implementation:**

1. **Added early return check** in `_extract_and_validate_structured_content`:
   ```python
   # CRITICAL: Skip validation for error responses per MCP spec
   # Error responses with isError=true do not require structured content
   # Reference: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
   is_error = getattr(tool_result, "is_error", False) or getattr(tool_result, "isError", False)
   if is_error:
       logger.debug(f"Skipping output schema validation for error response from tool {getattr(tool, 'name', '<unknown>')}")
       return True
   ```

2. **Updated docstring** to document MCP error handling behavior

3. **Added comprehensive unit tests** covering:
   - Error responses with `is_error=True` skip validation
   - Error responses with `isError=True` (alias) skip validation
   - Error content is preserved (not overwritten)
   - Successful responses still validate normally
   - Validation failures for successful responses still work correctly

**Key design points:**
- Early return pattern for performance (no unnecessary validation)
- Checks both `is_error` and `isError` for compatibility
- Preserves original error messages
- No impact on successful response validation
- Aligns with MCP specification

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅ Pass |
| Unit tests                            | `make test`          | ✅ Pass (678 tests) |
| Coverage ≥ 80 %                       | `make coverage`      | ✅ Pass |
| Manual regression no longer fails     | Tested with reproduction case | ✅ Pass |

**Test results:**
- All 678 existing tests pass
- 5 new tests added for error response handling
- No regressions in tool invocation or validation logic

**Manual verification:**
- Error responses with `isError: true` now pass through without validation
- Original error messages are preserved and surfaced to users
- Successful responses continue to validate against `outputSchema`
- Validation errors for successful responses still work correctly

## 📐 MCP Compliance

- [x] Matches current MCP spec (error handling section)
- [x] No breaking change to MCP clients
- [x] Restores compatibility with MCP-compliant tools
- [x] Removes need for non-standard workarounds

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
- [x] Comprehensive unit tests added
- [x] All existing tests pass
- [x] Documentation updated (docstring)
- [x] MCP specification compliance verified
- [x] Backward compatibility maintained (bug fix only)

## 📊 Impact

**Severity:** High - Regression breaking previously functional integrations

**Benefits:**
- ✅ Restores MCP specification compliance
- ✅ Enables standard `ToolError` exception handling
- ✅ Eliminates need for non-standard workarounds
- ✅ Improves error message visibility for users
- ✅ Maintains backward compatibility (bug fix only)

**Related Issues:** Closes #4202
