### PR TITLE
Fix OTEL environment override variable in example doc

### DIFF
--- a/docs/docs/manage/observability/observability.md
+++ b/docs/docs/manage/observability/observability.md
@@ -148,7 +148,7 @@ export OTEL_ENABLE_OBSERVABILITY=true
 # Service identification
 export OTEL_SERVICE_NAME=mcp-gateway
 export OTEL_SERVICE_VERSION=1.0.0-RC-3
-export OTEL_DEPLOYMENT_ENVIRONMENT=development
+export DEPLOYMENT_ENV=development
 
 # Choose your backend (otlp, jaeger, zipkin, console, none)
 export OTEL_TRACES_EXPORTER=otlp


### PR DESCRIPTION
# 📚 Documentation PR

> Run `make markdownlint spellcheck` and fix any issues.
> Preview locally with `cd docs && make serve`.
> Do **not** commit secrets or internal URLs.

---

## 🔗 Related Issue / Epic
_Link to the doc bug or epic this PR addresses:_
Closes #

---

## 📝 Summary (1-2 sentences)
_What section of the docs is changing and why?_

The docs specify `OTEL_DEPLOYMENT_ENVIRONMENT` and `DEPLOYMENT_ENV` in separate places as controlling the OTEL environment. Per the code and my testing, this is the correct one to use when wanting a different value than `ENVIRONMENT` must be set to.

---

## ✏️ Type of Change
- [ ] Typo / formatting
- [X] Outdated or incorrect info
- [ ] Missing explanation / example
- [X] Unclear instructions
- [ ] New page or major rewrite
- [ ] Other (describe)

---
