### PR TITLE
fix: outputSchema declared but no structured output now fails validation (#4208)

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1311,9 +1311,27 @@ class ToolService(BaseService):
                         # ignore JSON parse errors and continue
                         continue
 
-            # If no structured data found, treat as valid (nothing to validate)
+            # If no structured data found, treat as validation failure per MCP spec
+            # "If an output schema is provided: Servers MUST provide structured results that conform to this schema."
             if structured is None:
-                return True
+                # Skip for error responses — errors don't need structured content
+                is_error = getattr(tool_result, "is_error", False) or getattr(tool_result, "isError", False)
+                if is_error:
+                    return True
+                schema_type_str = output_schema.get("type", "object") if isinstance(output_schema, dict) else "object"
+                details = {
+                    "code": "missing_structured_output",
+                    "expected": schema_type_str,
+                    "received": "null",
+                    "message": "outputSchema declared but no structuredContent was returned",
+                }
+                try:
+                    tool_result.content = [TextContent(type="text", text=orjson.dumps(details).decode())]
+                except Exception:
+                    tool_result.content = [TextContent(type="text", text=str(details))]
+                tool_result.is_error = True
+                logger.debug(f"structured_content validation failed for tool {getattr(tool, 'name', '<unknown>')}: {details}")
+                return False
 
             # Try to normalize common wrapper shapes to match schema expectations
             schema_type = None

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -659,12 +659,49 @@ class TestExtractAndValidateStructuredContent:
         ok = tool_service._extract_and_validate_structured_content(tool, result)
         assert ok is True
 
-    def test_no_structured_data_found_returns_true(self, tool_service):
-        """No structured data found should return True."""
-        tool = SimpleNamespace(output_schema={"type": "object"})
+    def test_no_structured_data_with_schema_fails_validation(self, tool_service):
+        """When outputSchema is declared but no structured content is returned, should fail validation."""
+        tool = SimpleNamespace(output_schema={"type": "object"}, name="test_tool")
         result = ToolResult(content=[])
         ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is False
+        assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["code"] == "missing_structured_output"
+        assert details["message"] == "outputSchema declared but no structuredContent was returned"
+
+    def test_no_structured_data_error_response_skips_validation(self, tool_service):
+        """Error responses (is_error=True) should skip structured content validation."""
+        tool = SimpleNamespace(output_schema={"type": "object"}, name="test_tool")
+        result = ToolResult(content=[], is_error=True)
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
         assert ok is True
+
+    def test_no_structured_data_error_response_alias_skips_validation(self, tool_service):
+        """Error responses (isError=True) should skip structured content validation."""
+        tool = SimpleNamespace(output_schema={"type": "object"}, name="test_tool")
+        result = ToolResult(content=[])
+        result.isError = True
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is True
+
+    def test_no_structured_data_non_text_content_fails(self, tool_service):
+        """Non-text content with no structured data should fail validation when schema is declared."""
+        tool = SimpleNamespace(output_schema={"type": "object"}, name="test_tool")
+        result = ToolResult(content=[{"type": "image", "data": "base64data"}])
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is False
+        assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["code"] == "missing_structured_output"
+
+    def test_no_structured_data_null_text_fails(self, tool_service):
+        """TextContent with 'null' text and schema declared should fail validation."""
+        tool = SimpleNamespace(output_schema={"type": "object"}, name="test_tool")
+        result = ToolResult(content=[{"type": "text", "text": "null"}])
+        ok = tool_service._extract_and_validate_structured_content(tool, result)
+        assert ok is False
+        assert result.is_error is True
 
     def test_unwrap_single_element_list(self, tool_service):
         """Single-element list wrapping a TextContent-like dict should be unwrapped."""
@@ -1893,14 +1930,17 @@ class TestStructuredContentAdditional:
         assert isinstance(ok, bool)
 
     def test_content_with_null_text_parses_to_none(self, tool_service):
-        """Content with text=None should parse to null and be treated as no structured data."""
-        tool = SimpleNamespace(output_schema={"type": "object"})
-        # text=None -> orjson.loads("null") -> None -> treated as no structured data
+        """Content with text='null' should parse to None and fail validation when schema is declared."""
+        tool = SimpleNamespace(output_schema={"type": "object"}, name="test_tool")
+        # text="null" -> orjson.loads("null") -> None -> treated as no structured data
         content = [{"type": "text", "text": "null"}]
         result = ToolResult(content=content)
         ok = tool_service._extract_and_validate_structured_content(tool, result)
-        # null parse -> structured=None -> treat as valid (nothing to validate)
-        assert ok is True
+        # null parse -> structured=None -> should fail per MCP spec
+        assert ok is False
+        assert result.is_error is True
+        details = orjson.loads(result.content[0].text)
+        assert details["code"] == "missing_structured_output"
 
     def test_validation_error_orjson_fallback(self, tool_service):
         """When orjson.dumps fails for error details, fall back to str()."""


### PR DESCRIPTION
## Fix for #4208: outputSchema declared but no structured output silently passes gateway validation

### Problem

When a tool declares `output_schema` but returns no structured content (empty `content`, no parseable JSON, or `structured_content=None`), the gateway silently returns `True` (valid). This violates the MCP 2025-11-25 spec:

> "If an output schema is provided: Servers **MUST** provide structured results that conform to this schema."

### Root Cause

`ToolService._extract_and_validate_structured_content` at lines 1314-1316:
```python
# If no structured data found, treat as valid (nothing to validate)
if structured is None:
    return True
```

### Fix

Replaced the lenient early return with strict validation:

1. **Error responses are still exempted** — checks `is_error`/`isError` first (consistent with #4202)
2. **Success responses with no structured content now fail** with `is_error=True` and error details:
```json
{
  "code": "missing_structured_output",
  "expected": "object",
  "received": "null",
  "message": "outputSchema declared but no structuredContent was returned"
}
```

### Changes

| File | Change |
|------|--------|
| `mcpgateway/services/tool_service.py` | Lines 1314-1316: replaced lenient pass with strict validation + error response exemption |
| `tests/.../test_tool_service_coverage.py` | Updated 2 tests, added 5 new tests |

### Tests

- test_no_structured_data_with_schema_fails_validation — main behavior change
- test_no_structured_data_error_response_skips_validation — is_error=True exempted
- test_no_structured_data_error_response_alias_skips_validation — isError=True exempted
- test_no_structured_data_non_text_content_fails — non-text content fails
- test_no_structured_data_null_text_fails — text="null" parses to None, fails
- test_content_with_null_text_parses_to_none — updated from assert ok is True to assert ok is False
- Existing validation tests (valid candidate, invalid candidate, TextContent parsing) still pass

### Related

- Complements PR #4202 (error-path fix) — this is the success-path fix
- Aligned with MCP Python SDK server-side validator behavior
