### PR TITLE
fix(ui): fix login in Vite dev mode

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -52,10 +52,18 @@ interface RequestOptions {
   headers?: Record<string, string>;
   /** Pass `true` to skip adding the Authorization header (e.g. login). */
   unauthenticated?: boolean;
+  /**
+   * Pass `true` to throw ApiError on 401 instead of redirecting to login.
+   * Use only for auth-flow endpoints (login, token refresh, SSO callback,
+   * password reset) where a 401 is an expected error, not an expired session.
+   * Misuse on regular authenticated calls will leave the app in an
+   * inconsistent state if the session expires.
+   */
+  skipRedirectOn401?: boolean;
 }
 
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const { method = "GET", body, headers: extraHeaders = {}, unauthenticated = false } = options;
+  const { method = "GET", body, headers: extraHeaders = {}, unauthenticated = false, skipRedirectOn401 = false } = options;
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -81,11 +89,13 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   });
 
   if (response.status === 401) {
-    clearToken();
-    // replace() rather than href= so the failed page is not added to history
-    // (the user can't hit Back into an unauthenticated state).
-    window.location.replace(LOGIN_PATH);
-    throw new ApiError(401, null, "Session expired — redirecting to login");
+    if (!skipRedirectOn401) {
+      clearToken();
+      // replace() rather than href= so the failed page is not added to history
+      // (the user can't hit Back into an unauthenticated state).
+      window.location.replace(LOGIN_PATH);
+    }
+    throw new ApiError(401, null, skipRedirectOn401 ? "HTTP 401" : "Session expired — redirecting to login");
   }
 
   if (!response.ok) {

--- a/client/src/auth/AuthContext.tsx
+++ b/client/src/auth/AuthContext.tsx
@@ -69,7 +69,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const data = await api.post<LoginResponse>(
       "/auth/login",
       { email, password },
-      { unauthenticated: true }
+      { unauthenticated: true, skipRedirectOn401: true }
     );
 
     setToken(data.access_token);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,11 +3,20 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss()],
 
-  // Assets are served from /static/app/ by FastAPI's StaticFiles mount
-  base: "/static/app/",
+  // In dev the router uses /app/* paths directly; in production FastAPI
+  // serves static assets from /static/app/ via StaticFiles.
+  base: command === "build" ? "/static/app/" : "/",
+
+  server: {
+    proxy: {
+      // Forward API/auth calls to the FastAPI backend
+      "/auth": "http://localhost:4444",
+      "/api": "http://localhost:4444",
+    },
+  },
 
   build: {
     // Output goes into mcpgateway/static/app/ — FastAPI serves /static/* from mcpgateway/static/
@@ -16,4 +25,4 @@ export default defineConfig({
     manifest: true,
     sourcemap: false,
   },
-});
+}));


### PR DESCRIPTION
Three bugs prevented login from working when running the React app via `npm run dev`:

1. No dev proxy: relative `/auth/*` and `/api/*` fetch calls resolved to the Vite port (5173) instead of the FastAPI backend on 4444. Added `server.proxy` to forward these paths.

2. Wrong base in dev: Vite base was `/static/app/` in all modes. The custom router pushes paths like `/app/login`, which Vite rejected as outside the base. Changed base to `/` for dev, keeping `/static/app/` only for production builds.

3. Unconditional 401 redirect: any 401 — including from the login endpoint itself — triggered `window.location.replace("/app/login")`, so wrong-password attempts reloaded the page instead of showing "Invalid credentials."

   Fix: add `skipRedirectOn401` to `RequestOptions`. When true, a 401 throws ApiError without redirecting, leaving the caller in control. This is intentionally separate from `unauthenticated` so the two concerns stay independently composable as the app grows (token refresh, SSO callback, password reset all need skipRedirectOn401 without necessarily being unauthenticated, or vice versa).

   The login call now passes both flags explicitly.

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

---

## 📝 Use cases and behavior

Normal authenticated request (unauthenticated: false, skipRedirectOn401: false)

Token is added to the header. On 401, the token is cleared and the user is redirected to login. This is the session-expiry path, the right behavior for the majority of calls.

  ---
Login (unauthenticated: true, skipRedirectOn401: true)

No token in header (none exists yet). On 401, no redirect: the Login component catches the ApiError and shows `Invalid credentials`. note: this is the case I ran across.

Edge case: the backend returns 401 for reasons other than wrong password: account locked, account inactive, IP blocked, brute-force throttle. All of these currently surface to the user as `Invalid credentials` which is intentionally vague for security reasons. The Login component would need separate handling (checking err.body) to show more specific messages if the backend sends them.

  ---
  Token refresh (unauthenticated: false, skipRedirectOn401: true)

The expired access token is still sent in the header (the refresh endpoint may need it to identify the session). On 401, no redirect: the caller handles it, likely by clearing the session and navigating to login programmatically with a `session expired` message rather than a silent redirect. This gives the app control over the UX (e.g. showing a modal rather than losing in-progress form state).

Edge case: if the refresh token is also expired or revoked, the 401 should be treated as a hard logout. The caller must handle this explicitly: skipRedirectOn401 means it won't happen automatically.

  ---
SSO/OIDC callback (unauthenticated: true, skipRedirectOn401: true)

The browser returns from the IdP with an auth code. The app exchanges it without a Bearer token. On 401, the exchange failed: bad code, clock skew, nonce mismatch. No redirect is correct here; redirecting to login mid-SSO flow would create a loop. The caller handles the error and shows a meaningful message or restarts the flow.

  ---
Password reset submission (unauthenticated: true, skipRedirectOn401: true)

The reset token in the request body is the credential. On 401, the token is expired or invalid. No redirect: the user should see an error on the reset page, not be sent to login (they're already trying to recover access).

Edge case: the reset endpoint might return 401 vs 400 vs 410 (Gone) for different failure modes: expired token vs malformed token vs already-used token. skipRedirectOn401 handles the redirect suppression; distinguishing these requires checking err.status and err.body in the caller.

  ---
Public endpoint that returns 401 (unauthenticated: true, skipRedirectOn401: false)

Example: public tool listing on a ContextForge instance that has been reconfigured to require auth. The app has no token, makes an unauthenticated request, gets 401. With skipRedirectOn401: false, the user is redirected to login (correct behavior). This is why the two flags need to be independent: unauthenticated doesn't imply skipRedirectOn401.

Edge case: if the user is mid-flow (e.g. filling out a form on a page that also fetches a public resource), the redirect interrupts them. This is a general SPA problem, not specific to this design.

  ---
Misuse: skipRedirectOn401 (true on a normal authenticated call)
  
If a developer sets this on a regular API call and the session expires, the user gets an error message instead of being redirected to login. The app may end up in an inconsistent authenticated-looking state. The JSDoc on the option is the primary guard against this.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
logic changes in `client.ts` and `AuthContext.tsx` are worth covering when a test framework gets set up:               
                                                                                      
  client.ts — skipRedirectOn401                                                       
  - 401 with skipRedirectOn401: false (default): clears token, calls                  
  window.location.replace, throws ApiError(401)
  - 401 with skipRedirectOn401: true: does NOT redirect, does NOT clear token, throws
  ApiError(401)
  - 401 with unauthenticated: true, skipRedirectOn401: true (login case): same as
  above — no redirect, no token clear

  AuthContext.tsx
  - Failed login (backend 401): ApiError(401) propagates to the caller, no redirect
  occurs
  - Successful login: token stored, user state set

  These are the highest-value cases to test when Vitest or Jest gets added. 

---
🤖 AI assisted 
🧑🏻‍💻 human edited / reviewed