### PR TITLE
fix(oauth): honor advisory contract and accept array-shaped scope/scp

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1592,13 +1592,24 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             for warning in token_validation.warnings:
                 logger.warning("OAuth token validation for gateway %s: %s", gateway.name, warning)
 
-            # Fail fast if any claim is definitively mismatched (present but wrong).
-            # Claims that are simply absent from the token produce None (not False)
-            # and are NOT blocked — this preserves backward compat with legacy IdPs.
+            # Advisory: log mismatched claims but do not block forwarding.
+            # The upstream MCP server is the authoritative token validator
+            # (see mcpgateway.services.token_validation_service docstring).
+            # The operator-facing guidance from the previous hard-block path
+            # is preserved below as a warning so misconfiguration is still
+            # surfaced without breaking tool fetching for non-conforming
+            # IdPs (e.g. those that omit RFC 8707 resource echo or emit
+            # unusual claim shapes).
             blocking = token_validation.blocking_errors
             if blocking:
                 detail = "; ".join(blocking)
-                raise GatewayConnectionError(f"Refusing to forward OAuth token for gateway '{gateway.name}': " f"{detail}. " f"Fix oauth_config (resource/scopes/issuer) or the IdP token request.")
+                logger.warning(
+                    "OAuth token claim validation flagged issues for gateway '%s' "
+                    "(advisory, forwarding anyway): %s. "
+                    "Fix oauth_config (resource/scopes/issuer) or the IdP token request if this is unintended.",
+                    gateway.name,
+                    detail,
+                )
 
             # Now connect to MCP server with the access token
             authentication = {"Authorization": f"Bearer {access_token}"}

--- a/mcpgateway/services/token_validation_service.py
+++ b/mcpgateway/services/token_validation_service.py
@@ -185,8 +185,16 @@ def _validate_scopes(claims: Dict[str, Any], oauth_config: Dict[str, Any], gatew
     if not configured_scopes:
         return
 
-    # Entra ID uses 'scp' claim; standard OAuth uses 'scope'
-    token_scope_str = claims.get("scope") or claims.get("scp") or ""
+    # Entra ID uses 'scp' claim; standard OAuth uses 'scope'.
+    # Some IdPs (Ory Hydra, Keycloak, certain Auth0 configurations) emit
+    # these claims as JSON arrays rather than space-separated strings —
+    # normalize the array shape to a single space-separated string before
+    # tokenization so ``_normalize_scope`` continues to receive a ``str``.
+    token_scope = claims.get("scope") or claims.get("scp") or ""
+    if isinstance(token_scope, list):
+        token_scope_str = " ".join(str(s) for s in token_scope if s)
+    else:
+        token_scope_str = str(token_scope) if token_scope else ""
     if not token_scope_str:
         logger.debug("OAuth token for gateway %s has no 'scope'/'scp' claim", gateway_name)
         return
@@ -287,8 +295,27 @@ def validate_oauth_token_claims(
 
     result.is_jwt = True
 
-    _validate_audience(claims, oauth_config, gateway_url, gateway_name, result)
-    _validate_scopes(claims, oauth_config, gateway_name, result)
-    _validate_issuer(claims, oauth_config, gateway_name, result)
+    # Advisory: each claim validator is best-effort.  Unexpected claim shapes
+    # from non-conforming IdPs must not abort the forwarding path — the
+    # upstream MCP server remains the authoritative validator (see module
+    # docstring).  Wrap each validator so one crashing check does not skip
+    # the others and does not propagate to the caller.
+    try:
+        _validate_audience(claims, oauth_config, gateway_url, gateway_name, result)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("OAuth audience validation crashed for gateway %s: %s", gateway_name, exc)
+        result.warnings.append(f"audience validation error (non-blocking): {type(exc).__name__}: {exc}")
+
+    try:
+        _validate_scopes(claims, oauth_config, gateway_name, result)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("OAuth scope validation crashed for gateway %s: %s", gateway_name, exc)
+        result.warnings.append(f"scope validation error (non-blocking): {type(exc).__name__}: {exc}")
+
+    try:
+        _validate_issuer(claims, oauth_config, gateway_name, result)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("OAuth issuer validation crashed for gateway %s: %s", gateway_name, exc)
+        result.warnings.append(f"issuer validation error (non-blocking): {type(exc).__name__}: {exc}")
 
     return result

--- a/tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py
@@ -16,6 +16,7 @@ These tests specifically target OAuth functionality in gateway_service.py includ
 from __future__ import annotations
 
 # Standard
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -699,8 +700,11 @@ class TestFetchToolsAfterOauthTokenValidation:
     """Tests that token claim validation is called and warnings flow through."""
 
     @pytest.mark.asyncio
-    async def test_audience_mismatch_blocks_before_connection(self, gateway_service, mock_oauth_auth_code_gateway, test_db):
-        """Token with audience mismatch is blocked BEFORE the network call is made."""
+    async def test_audience_mismatch_logs_advisory_warning_and_forwards(self, gateway_service, mock_oauth_auth_code_gateway, test_db, caplog):
+        """Advisory contract: audience mismatch is surfaced as a warning log but
+        forwarding proceeds — the upstream MCP server is the authoritative
+        validator (see token_validation_service module docstring).
+        """
         # Third-Party
         import jwt as pyjwt
 
@@ -717,11 +721,20 @@ class TestFetchToolsAfterOauthTokenValidation:
             mock_tss_inst.get_user_token = AsyncMock(return_value=token)
             mock_connect.return_value = ({}, [], [], [])
 
-            with pytest.raises(GatewayConnectionError, match="audience"):
+            with caplog.at_level(logging.WARNING, logger="mcpgateway.services.gateway_service"):
                 await gateway_service.fetch_tools_after_oauth(test_db, "gw-id", "user@example.com")
 
-            # Connection must NOT have been attempted — error raised before network call
-            mock_connect.assert_not_called()
+            # Forwarding proceeded — the upstream MCP server is authoritative.
+            mock_connect.assert_called_once()
+            _, connect_kwargs = mock_connect.call_args
+            # Warnings are surfaced for downstream diagnostic use.
+            assert any("audience mismatch" in w.lower() for w in connect_kwargs.get("validation_warnings", []))
+            # Operator-facing log captures the mismatch detail + remediation hint,
+            # tagged as advisory so readers know it did not block forwarding.
+            lower_log = caplog.text.lower()
+            assert "advisory" in lower_log
+            assert "audience mismatch" in lower_log
+            assert "fix oauth_config" in lower_log
 
     @pytest.mark.asyncio
     async def test_opaque_token_no_warnings(self, gateway_service, mock_oauth_auth_code_gateway, test_db):
@@ -743,29 +756,6 @@ class TestFetchToolsAfterOauthTokenValidation:
             # No JWT-related warnings for opaque tokens
             jwt_warnings = [w for w in kwargs.get("validation_warnings", []) if "audience" in w.lower() or "scope" in w.lower() or "issuer" in w.lower()]
             assert jwt_warnings == []
-
-    @pytest.mark.asyncio
-    async def test_audience_mismatch_raises_before_connection_with_diagnostic(self, gateway_service, mock_oauth_auth_code_gateway, test_db):
-        """Token audience mismatch is blocked before the network call, with diagnostic detail."""
-        # Third-Party
-        import jwt as pyjwt
-
-        mock_oauth_auth_code_gateway.oauth_config["resource"] = "api://correct"
-        token = pyjwt.encode({"aud": "api://wrong"}, "k", algorithm="HS256")
-        test_db.execute.return_value = _make_execute_result(scalar=mock_oauth_auth_code_gateway)
-
-        with (
-            patch("mcpgateway.services.token_storage_service.TokenStorageService") as MockTSS,
-            patch.object(gateway_service, "_connect_to_sse_server_without_validation", new_callable=AsyncMock) as mock_connect,
-        ):
-            mock_tss_inst = MockTSS.return_value
-            mock_tss_inst.get_user_token = AsyncMock(return_value=token)
-
-            with pytest.raises(GatewayConnectionError, match="audience"):
-                await gateway_service.fetch_tools_after_oauth(test_db, "gw-id", "user@example.com")
-
-            # Connection must NOT have been attempted — blocked before network call
-            mock_connect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_sse_connection_401_diagnostic_error(self, gateway_service):

--- a/tests/unit/mcpgateway/services/test_token_validation_service.py
+++ b/tests/unit/mcpgateway/services/test_token_validation_service.py
@@ -388,3 +388,144 @@ class TestValidateOauthTokenClaims:
 
         # Should not crash
         assert result.is_jwt is True
+
+
+# ---------- scope / scp as array (Ory Hydra, Keycloak, some Auth0 configs) ----------
+
+
+class TestScopeClaimArrayShape:
+    """RFC 6749 defines ``scope`` as a space-delimited string at the
+    authorization response layer but does not prescribe a shape for the
+    JWT access-token claim.  Ory Hydra (used by Amplitude's MCP among
+    others), Keycloak, and certain Auth0 configurations emit the claim as
+    a JSON array.  The validator must normalize both shapes."""
+
+    def test_scp_as_list_matches_configured_scope(self):
+        token = _make_jwt({"scp": ["mcp:read", "offline_access"]})
+        oauth_config = {"scopes": ["mcp:read"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.is_jwt is True
+        assert result.scopes_sufficient is True
+        assert not any("missing required scopes" in w.lower() for w in result.warnings)
+
+    def test_scope_as_list_with_uri_prefix(self):
+        """A list-shaped claim must still trigger URI-prefix normalization."""
+        token = _make_jwt({"scope": ["api://app-a/Tools.Read", "api://app-a/Tools.Write"]})
+        oauth_config = {"scopes": ["api://app-a/Tools.Read"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.scopes_sufficient is True
+
+    def test_scp_as_list_with_missing_scope(self):
+        token = _make_jwt({"scp": ["mcp:read"]})
+        oauth_config = {"scopes": ["mcp:write"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.scopes_sufficient is False
+        assert any("missing required scopes" in w.lower() for w in result.warnings)
+
+    def test_scope_empty_list_treated_as_absent(self):
+        """Empty list is treated as an absent claim (scopes_sufficient stays None)."""
+        token = _make_jwt({"scp": []})
+        oauth_config = {"scopes": ["mcp:read"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.scopes_sufficient is None
+        assert not any("scope" in w.lower() for w in result.warnings)
+
+
+# ---------- Advisory contract: individual validators must not propagate ----------
+
+
+class TestValidatorAdvisoryContract:
+    """The module docstring declares the validator is best-effort advisory:
+    ``Validation is advisory — the upstream MCP server remains the
+    authoritative validator.``  Unexpected exceptions inside any single
+    ``_validate_*`` helper must therefore be caught locally, appended as a
+    non-blocking warning, and must not skip sibling validators or propagate
+    to the caller."""
+
+    def _baseline_token_and_config(self):
+        token = _make_jwt(
+            {
+                "aud": "api://x",
+                "scope": "read",
+                "iss": "https://auth.example.com",
+            }
+        )
+        oauth_config = {
+            "resource": "api://x",
+            "scopes": ["read"],
+            "issuer": "https://auth.example.com",
+        }
+        return token, oauth_config
+
+    def test_audience_validator_crash_does_not_propagate(self):
+        token, oauth_config = self._baseline_token_and_config()
+
+        with patch(
+            "mcpgateway.services.token_validation_service._validate_audience",
+            side_effect=RuntimeError("boom-aud"),
+        ):
+            result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.is_jwt is True
+        # Non-blocking warning was recorded with the error type for diagnosability
+        assert any("audience validation error" in w.lower() for w in result.warnings)
+        assert any("RuntimeError" in w for w in result.warnings)
+        # audience_match stays at its initial None (real validator was replaced)
+        assert result.audience_match is None
+        # Sibling validators still ran
+        assert result.scopes_sufficient is True
+        assert result.issuer_match is True
+
+    def test_scope_validator_crash_does_not_skip_sibling_validators(self):
+        """Regression guard: a crash in ``_validate_scopes`` must not prevent
+        the audience or issuer checks from running, and must not escape the
+        public API."""
+        token, oauth_config = self._baseline_token_and_config()
+
+        with patch(
+            "mcpgateway.services.token_validation_service._validate_scopes",
+            side_effect=AttributeError("'list' object has no attribute 'split'"),
+        ):
+            result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.is_jwt is True
+        assert result.audience_match is True  # ran before the crash
+        assert result.issuer_match is True  # ran after the crash
+        assert any("scope validation error" in w.lower() for w in result.warnings)
+        assert any("AttributeError" in w for w in result.warnings)
+
+    def test_issuer_validator_crash_does_not_propagate(self):
+        token, oauth_config = self._baseline_token_and_config()
+
+        with patch(
+            "mcpgateway.services.token_validation_service._validate_issuer",
+            side_effect=RuntimeError("boom-iss"),
+        ):
+            result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.is_jwt is True
+        assert any("issuer validation error" in w.lower() for w in result.warnings)
+        assert result.audience_match is True
+        assert result.scopes_sufficient is True
+
+    def test_crash_warnings_are_not_classified_as_blocking(self):
+        """``TokenValidationResult.blocking_errors`` keys off ``*_match is
+        False``.  A validator crash leaves those flags at ``None``, so the
+        non-blocking warning must not end up in ``blocking_errors``."""
+        token, oauth_config = self._baseline_token_and_config()
+
+        with patch(
+            "mcpgateway.services.token_validation_service._validate_scopes",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        # Crash warning is recorded but the corresponding flag is None,
+        # so blocking_errors must stay empty for that path.
+        assert any("scope validation error" in w.lower() for w in result.warnings)
+        assert result.scopes_sufficient is None
+        assert all("validation error" not in b.lower() for b in result.blocking_errors)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4213

---

## 📝 Summary

Two small regressions in the OAuth token claim validator introduced in #3941 break tool fetching for non-conforming IdPs:

1. `_validate_scopes` calls `.split()` on the `scope` / `scp` claim, which crashes when the IdP emits an array (Ory Hydra, Keycloak, some Auth0 configurations).
2. `gateway_service.py::fetch_tools_after_oauth` raises `GatewayConnectionError` on any mismatched claim, contradicting the module's own "advisory — the upstream MCP server remains the authoritative validator" contract stated in `token_validation_service.py`.

This PR:
- Normalizes array-shaped `scope`/`scp` to a space-separated string before tokenization.
- Wraps each `_validate_*` call in its own `try / except` so one crashing validator cannot abort siblings or propagate to the caller; crashes become non-blocking warnings.
- Downgrades the hard-block in `fetch_tools_after_oauth` to a `logger.warning` that preserves the existing operator guidance (`Fix oauth_config(resource/scopes/issuer) …`). The upstream MCP server remains the authoritative validator, per the module docstring.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |   pass     |
| Coverage ≥ 80%            | `make coverage` |        |


---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
- Reproduced end-to-end against **Amplitude's public MCP server** (`https://mcp.amplitude.com/mcp`, Ory Hydra-backed, issuer `https://auth.amplitude.com`) which emits `scp` as an array and `aud` as an empty list even when the client sends RFC 8707 `resource=` on both `/authorize` and `/token`. Full decoded JWT claims (from a direct DCR + PKCE flow, bypassing ContextForge) are included in #4213.
- The previous "Refusing to forward OAuth token … Fix oauth_config …" diagnostic is preserved as a warning log, so operators still get the remediation hint when a mismatch is genuinely their misconfiguration.
- If reviewers prefer to keep the strict blocking behavior available to deployments that want it, happy to follow up with an opt-in `oauth_config.strict_claim_validation` flag — did not include it here to keep the change focused on the regression.
