### PR TITLE
fix(ui): Normalize team_id whitespace checks across all edit functions and server-side visibility guard

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-06T02:43:07Z",
+  "generated_at": "2026-05-06T13:31:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4178,7 +4178,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4190,
+        "line_number": 4205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4186,7 +4186,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4825,
+        "line_number": 4840,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4194,7 +4194,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4827,
+        "line_number": 4842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4202,7 +4202,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15206,
+        "line_number": 15211,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1694,7 +1694,7 @@ def _check_public_visibility_allowed(visibility: str, team_id: Optional[str] = N
     Raises:
         HTTPException: 422 when flag is false, team_id is set, and visibility is 'public'.
     """
-    if not settings.allow_public_visibility and visibility == "public" and team_id:
+    if not settings.allow_public_visibility and visibility == "public" and team_id and team_id.strip():
         raise HTTPException(
             status_code=422,
             detail="Public visibility is disabled by platform configuration (ALLOW_PUBLIC_VISIBILITY=false).",

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -806,6 +806,25 @@ def _validated_team_id_param(team_id: Optional[str] = Query(None, description="F
         raise HTTPException(status_code=400, detail="Invalid team ID") from exc
 
 
+def _form_team_id(form: Any) -> Optional[str]:
+    """Extract and normalize team_id from form data, converting whitespace-only values to None.
+
+    Normalizes at the point of extraction so that both the public-visibility guard
+    and ``TeamManagementService.verify_team_for_user`` receive the same value, making
+    ``?team_id=%20`` behave identically to an absent ``team_id`` end-to-end.
+
+    Args:
+        form: The multipart form data object from the request.
+
+    Returns:
+        The stripped team_id string, or None if absent or whitespace-only.
+    """
+    raw = form.get("team_id")
+    if not raw:
+        return None
+    return str(raw).strip() or None
+
+
 def _build_admin_redirect(root_path: str, fragment: str, *, error: Optional[str] = None, include_inactive: bool = False, team_id: Optional[str] = None) -> str:
     """Build an admin redirect URL preserving query parameters.
 
@@ -2873,13 +2892,14 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
     """
     form = await request.form()
     # is_inactive_checked = form.get("is_inactive_checked", "false")
+    team_id = _form_team_id(form)
 
     # Parse tags from comma-separated string
     tags_str = str(form.get("tags", ""))
     tags: list[str] = [tag.strip() for tag in tags_str.split(",") if tag.strip()] if tags_str else []
 
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
 
     try:
         LOGGER.debug(f"User {get_user_email(user)} is adding a new server with name: {form['name']}")
@@ -2934,10 +2954,6 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
         return ORJSONResponse(content={"message": f"Missing required field: {e}", "success": False}, status_code=422)
     try:
         user_email = get_user_email(user)
-        # Determine personal team for default assignment
-        team_id_raw = form.get("team_id", None)
-        team_id = str(team_id_raw) if team_id_raw is not None else None
-
         team_service = TeamManagementService(db)
         team_id = await team_service.verify_team_for_user(user_email, team_id)
 
@@ -3019,6 +3035,7 @@ async def admin_edit_server(
         'admin_edit_server'
     """
     form = await request.form()
+    team_id = _form_team_id(form)
 
     # Parse tags from comma-separated string
     tags_str = str(form.get("tags", ""))
@@ -3026,10 +3043,8 @@ async def admin_edit_server(
     try:
         LOGGER.debug(f"User {get_user_email(user)} is editing server ID {server_id} with name: {form.get('name')}")
         visibility = str(form.get("visibility", "private"))
-        _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+        _check_public_visibility_allowed(visibility, team_id=team_id)
         user_email = get_user_email(user)
-        team_id_raw = form.get("team_id", None)
-        team_id = str(team_id_raw) if team_id_raw is not None else None
 
         # Preserve existing server's team_id when no explicit team_id is provided.
         # Without this guard, verify_team_for_user() falls back to the user's
@@ -11496,10 +11511,11 @@ async def admin_add_tool(
     LOGGER.debug(f"User {get_user_email(user)} is adding a new tool")
     form = await request.form()
     LOGGER.debug(f"Received form data: {dict(form)}")
+    team_id = _form_team_id(form)
     integration_type = form.get("integrationType", "REST")
     request_type = form.get("requestType")
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
 
     if request_type is None:
         if integration_type == "REST":
@@ -11510,8 +11526,6 @@ async def admin_add_tool(
             request_type = "GET"
 
     user_email = get_user_email(user)
-    # Determine personal team for default assignment
-    team_id = form.get("team_id", None)
     team_service = TeamManagementService(db)
     team_id = await team_service.verify_team_for_user(user_email, team_id)
     # Parse tags from comma-separated string
@@ -11664,6 +11678,7 @@ async def admin_edit_tool(
     """
     LOGGER.debug(f"User {get_user_email(user)} is editing tool ID {tool_id}")
     form = await request.form()
+    team_id = _form_team_id(form)
     # Parse tags from comma-separated string
     tags_str = str(form.get("tags", ""))
     tags: list[str] = [tag.strip() for tag in tags_str.split(",") if tag.strip()] if tags_str else []
@@ -11672,11 +11687,9 @@ async def admin_edit_tool(
     auth_obj = _build_auth_obj_from_form(form)
 
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
 
     user_email = get_user_email(user)
-    # Determine personal team for default assignment
-    team_id = form.get("team_id", None)
     LOGGER.info(f"before Verifying team for user {user_email} with team_id {team_id}")
     team_service = TeamManagementService(db)
     team_id = await team_service.verify_team_for_user(user_email, team_id)
@@ -12055,8 +12068,9 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
     """
     LOGGER.debug(f"User {get_user_email(user)} is adding a new gateway")
     form = await request.form()
+    team_id = _form_team_id(form)
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
     try:
         # Parse tags from comma-separated string
         tags_str = str(form.get("tags", ""))
@@ -12220,7 +12234,6 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
         return ORJSONResponse(content={"success": False, "message": "; ".join(error_ctx)}, status_code=422)
 
     user_email = get_user_email(user)
-    team_id = form.get("team_id", None)
 
     team_service = TeamManagementService(db)
     team_id = await team_service.verify_team_for_user(user_email, team_id)
@@ -12318,13 +12331,14 @@ async def admin_edit_gateway(
     """
     LOGGER.debug(f"User {get_user_email(user)} is editing gateway ID {gateway_id}")
     form = await request.form()
+    team_id = _form_team_id(form)
     try:
         # Parse tags from comma-separated string
         tags_str = str(form.get("tags", ""))
         tags: List[str] = [tag.strip() for tag in tags_str.split(",") if tag.strip()] if tags_str else []
 
         visibility = str(form.get("visibility", "private"))
-        _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+        _check_public_visibility_allowed(visibility, team_id=team_id)
 
         # Parse auth_headers JSON if present
         auth_headers_json = form.get("auth_headers") or ""
@@ -12411,10 +12425,6 @@ async def admin_edit_gateway(
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_grant_type}, issuer={oauth_issuer}")
 
         user_email = get_user_email(user)
-        # Determine personal team for default assignment
-        team_id_raw = form.get("team_id", None)
-        team_id = str(team_id_raw) if team_id_raw is not None else None
-
         # Preserve existing gateway's team_id when no explicit team_id is provided.
         # Without this guard, verify_team_for_user() falls back to the user's
         # personal team, silently reassigning the gateway on every edit.
@@ -12664,15 +12674,14 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
     """
     LOGGER.debug(f"User {get_user_email(user)} is adding a new resource")
     form = await request.form()
+    team_id = _form_team_id(form)
 
     # Parse tags from comma-separated string
     tags_str = str(form.get("tags", ""))
     tags: List[str] = [tag.strip() for tag in tags_str.split(",") if tag.strip()] if tags_str else []
     visibility = str(form.get("visibility", "public"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
     user_email = get_user_email(user)
-    # Determine personal team for default assignment
-    team_id = form.get("team_id", None)
     team_service = TeamManagementService(db)
     team_id = await team_service.verify_team_for_user(user_email, team_id)
 
@@ -12798,12 +12807,11 @@ async def admin_edit_resource(
     LOGGER.debug(f"User {get_user_email(user)} is editing resource ID {resource_id}")
     form = await request.form()
     LOGGER.info(f"Form data received for resource edit: {form}")
+    team_id = _form_team_id(form)
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
 
     user_email = get_user_email(user)
-    team_id_raw = form.get("team_id", None)
-    team_id = str(team_id_raw) if team_id_raw is not None else None
 
     # Preserve existing resource's team_id when no explicit team_id is provided.
     # Without this guard, verify_team_for_user() falls back to the user's
@@ -13067,11 +13075,10 @@ async def admin_add_prompt(request: Request, db: Session = Depends(get_db), user
     """
     LOGGER.debug(f"User {get_user_email(user)} is adding a new prompt")
     form = await request.form()
+    team_id = _form_team_id(form)
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
     user_email = get_user_email(user)
-    # Determine personal team for default assignment
-    team_id = form.get("team_id", None)
     team_service = TeamManagementService(db)
     team_id = await team_service.verify_team_for_user(user_email, team_id)
 
@@ -13190,13 +13197,11 @@ async def admin_edit_prompt(
     """
     LOGGER.debug(f"User {get_user_email(user)} is editing prompt {prompt_id}")
     form = await request.form()
+    team_id = _form_team_id(form)
 
     visibility = str(form.get("visibility", "private"))
-    _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+    _check_public_visibility_allowed(visibility, team_id=team_id)
     user_email = get_user_email(user)
-    # Determine personal team for default assignment
-    team_id_raw = form.get("team_id", None)
-    team_id = str(team_id_raw) if team_id_raw is not None else None
 
     # Preserve existing prompt's team_id when no explicit team_id is provided.
     # Without this guard, verify_team_for_user() falls back to the user's
@@ -15431,14 +15436,13 @@ async def admin_add_a2a_agent(
         )
 
     form = await request.form()
+    team_id = _form_team_id(form)
     try:
         LOGGER.info(f"A2A agent creation form data: {dict(form)}")
 
-        _check_public_visibility_allowed(str(form.get("visibility", "private")), team_id=str(form.get("team_id", "")) or None)
+        _check_public_visibility_allowed(str(form.get("visibility", "private")), team_id=team_id)
 
         user_email = get_user_email(user)
-        # Determine personal team for default assignment
-        team_id = form.get("team_id", None)
         team_service = TeamManagementService(db)
         team_id = await team_service.verify_team_for_user(user_email, team_id)
 
@@ -15670,6 +15674,7 @@ async def admin_edit_a2a_agent(
 
     try:
         form = await request.form()
+        team_id = _form_team_id(form)
 
         # Normalize tags
         tags_raw = str(form.get("tags", ""))
@@ -15677,7 +15682,7 @@ async def admin_edit_a2a_agent(
 
         # Visibility
         visibility = str(form.get("visibility", "private"))
-        _check_public_visibility_allowed(visibility, team_id=form.get("team_id"))
+        _check_public_visibility_allowed(visibility, team_id=team_id)
 
         # Agent Type
         agent_type = str(form.get("agent_type", "generic"))
@@ -15785,8 +15790,6 @@ async def admin_edit_a2a_agent(
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_grant_type}, issuer={oauth_issuer}")
 
         user_email = get_user_email(user)
-        team_id_raw = form.get("team_id", None)
-        team_id = str(team_id_raw) if team_id_raw is not None else None
 
         # Preserve existing agent's team_id when no explicit team_id is provided.
         # Without this guard, verify_team_for_user() falls back to the user's

--- a/mcpgateway/admin_ui/a2aAgents.js
+++ b/mcpgateway/admin_ui/a2aAgents.js
@@ -1,7 +1,7 @@
 import { getAuthHeaders, loadAuthHeaders } from "./auth.js";
 import { closeModal, openModal } from "./modals.js";
 import { escapeHtml, validateInputName, validateUrl } from "./security.js";
-import { applyVisibilityRestrictions } from "./teams.js";
+import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   decodeHtml,
   fetchWithTimeout,
@@ -413,7 +413,7 @@ export const editA2AAgent = async function (agentId) {
       const effectiveVisibility =
         window.ALLOW_PUBLIC_VISIBILITY === false &&
         visibility === "public" &&
-        teamId
+        isTeamScopedView()
           ? "team"
           : visibility;
       if (effectiveVisibility === "public" && publicRadio) {

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -14,7 +14,7 @@ import {
   serverSideToolSearch,
 } from "./search.js";
 import { getEditSelections } from "./servers.js";
-import { applyVisibilityRestrictions } from "./teams.js";
+import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import { initToolSelect } from "./tools.js";
 import {
   buildTableUrl,
@@ -339,7 +339,7 @@ export const editGateway = async function (gatewayId) {
       const effectiveVisibility =
         window.ALLOW_PUBLIC_VISIBILITY === false &&
         visibility === "public" &&
-        teamId
+        isTeamScopedView()
           ? "team"
           : visibility;
       if (effectiveVisibility === "public" && publicRadio) {

--- a/mcpgateway/admin_ui/prompts.js
+++ b/mcpgateway/admin_ui/prompts.js
@@ -3,7 +3,7 @@ import { getSelectedGatewayIds } from "./gateways.js";
 import { openModal } from "./modals.js";
 import { escapeAttrValue, escapeHtml, validateInputName, validateJson } from "./security.js";
 import { getEditSelections } from "./servers.js";
-import { applyVisibilityRestrictions } from "./teams.js";
+import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   decodeHtml,
   fetchWithTimeout,
@@ -382,11 +382,10 @@ export const editPrompt = async function (promptId) {
     if (visibility) {
       // When public visibility is disabled and we're in a team-scoped view,
       // coerce legacy-public records to team.
-      const _teamId = new URL(window.location.href).searchParams.get("team_id");
       const effectiveVisibility =
         window.ALLOW_PUBLIC_VISIBILITY === false &&
         visibility === "public" &&
-        _teamId
+        isTeamScopedView()
           ? "team"
           : visibility;
       if (effectiveVisibility === "public" && publicRadio) {

--- a/mcpgateway/admin_ui/resources.js
+++ b/mcpgateway/admin_ui/resources.js
@@ -2,7 +2,7 @@ import { getSelectedGatewayIds } from "./gateways.js";
 import { openModal } from "./modals.js";
 import { validateInputName } from "./security.js";
 import { getEditSelections } from "./servers.js";
-import { applyVisibilityRestrictions } from "./teams.js";
+import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   decodeHtml,
   fetchWithTimeout,
@@ -645,11 +645,10 @@ export const editResource = async function (resourceId) {
     if (visibility) {
       // When public visibility is disabled and we're in a team-scoped view,
       // coerce legacy-public records to team.
-      const _teamId = new URL(window.location.href).searchParams.get("team_id");
       const effectiveVisibility =
         window.ALLOW_PUBLIC_VISIBILITY === false &&
         visibility === "public" &&
-        _teamId
+        isTeamScopedView()
           ? "team"
           : visibility;
       if (effectiveVisibility === "public" && publicRadio) {

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -6,7 +6,7 @@ import { openModal } from "./modals.js";
 import { initPromptSelect } from "./prompts.js";
 import { initResourceSelect } from "./resources.js";
 import { validateInputName, validateUrl } from "./security.js";
-import { applyVisibilityRestrictions } from "./teams.js";
+import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   safeGetElement,
   fetchWithTimeout,
@@ -712,11 +712,10 @@ export const editServer = async function (serverId) {
     if (visibility) {
       // When public visibility is disabled and we're in a team-scoped view,
       // coerce legacy-public records to team.
-      const _teamId = new URL(window.location.href).searchParams.get("team_id");
       const effectiveVisibility =
         window.ALLOW_PUBLIC_VISIBILITY === false &&
         visibility === "public" &&
-        _teamId
+        isTeamScopedView()
           ? "team"
           : visibility;
       if (effectiveVisibility === "public" && publicRadio) {

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -66,7 +66,6 @@ export const viewServer = async function (serverId) {
         const serverDesc = document.createElement("p");
         serverDesc.className = "text-sm text-gray-600 dark:text-gray-400 mt-1";
         serverDesc.textContent = decodeHtml(server.description);
-        serverDesc.textContent = server.description;
         headerTextDiv.appendChild(serverDesc);
       }
 

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -14,7 +14,7 @@ import {
 } from "./security.js";
 import { getEditSelections } from "./servers.js";
 import { getUiHiddenSections } from "./tabs.js";
-import { applyVisibilityRestrictions } from "./teams.js";
+import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   decodeHtml,
   fetchWithTimeout,
@@ -619,7 +619,7 @@ export const editTool = async function (toolId) {
       const effectiveVisibility =
         window.ALLOW_PUBLIC_VISIBILITY === false &&
         visibility === "public" &&
-        teamId
+        isTeamScopedView()
           ? "team"
           : visibility;
       if (effectiveVisibility === "public" && publicRadio) {

--- a/tests/integration/test_rate_limiter_redis_url_from_yaml.py
+++ b/tests/integration/test_rate_limiter_redis_url_from_yaml.py
@@ -27,8 +27,8 @@ import socket
 import pytest
 import redis
 
-# First-Party
-from mcpgateway.plugins.framework.loader.config import ConfigLoader
+# Third-Party
+from cpex.framework import ConfigLoader
 
 # Anchor the plugins/config.yaml path to this file's location so the test
 # works regardless of where pytest is invoked from (repo root, tests/, etc.).
@@ -60,12 +60,8 @@ def test_rate_limiter_redis_url_resolves_and_connects(monkeypatch):
     rl = next(p for p in cfg.plugins if p.name == "RateLimiterPlugin")
     resolved = rl.config.get("redis_url")
 
-    assert resolved, (
-        "redis_url must resolve to a non-empty string after Jinja substitution"
-    )
-    assert "{{" not in resolved, (
-        f"Jinja placeholder leaked through unrendered: {resolved!r}"
-    )
+    assert resolved, "redis_url must resolve to a non-empty string after Jinja substitution"
+    assert "{{" not in resolved, f"Jinja placeholder leaked through unrendered: {resolved!r}"
 
     client = redis.from_url(resolved, socket_connect_timeout=2, socket_timeout=2)
     try:

--- a/tests/unit/js/prompts.test.js
+++ b/tests/unit/js/prompts.test.js
@@ -671,7 +671,7 @@ describe("editPrompt - Extended", () => {
 
     // Mock URL with team_id
     Object.defineProperty(window, "location", {
-      value: { href: "http://localhost?team_id=team1" },
+      value: { href: "http://localhost?team_id=team1", search: "?team_id=team1" },
       writable: true,
     });
 
@@ -679,6 +679,61 @@ describe("editPrompt - Extended", () => {
 
     // Should coerce public to team when ALLOW_PUBLIC_VISIBILITY=false
     expect(teamRadio.checked).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  test("does not coerce visibility when team_id is whitespace-only", async () => {
+    window.ROOT_PATH = "";
+    window.ALLOW_PUBLIC_VISIBILITY = false;
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const nameInput = document.createElement("input");
+    nameInput.id = "edit-prompt-name";
+    document.body.appendChild(nameInput);
+
+    const descInput = document.createElement("textarea");
+    descInput.id = "edit-prompt-description";
+    document.body.appendChild(descInput);
+
+    const publicRadio = document.createElement("input");
+    publicRadio.type = "radio";
+    publicRadio.id = "edit-prompt-visibility-public";
+    document.body.appendChild(publicRadio);
+
+    const teamRadio = document.createElement("input");
+    teamRadio.type = "radio";
+    teamRadio.id = "edit-prompt-visibility-team";
+    document.body.appendChild(teamRadio);
+
+    const privateRadio = document.createElement("input");
+    privateRadio.type = "radio";
+    privateRadio.id = "edit-prompt-visibility-private";
+    document.body.appendChild(privateRadio);
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: "p1",
+          name: "test-prompt",
+          description: "desc",
+          arguments: [],
+          template: "Hello",
+          visibility: "public",
+        }),
+    });
+
+    // Whitespace-only team_id should not trigger coercion
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost?team_id=%20", search: "?team_id=%20" },
+      writable: true,
+    });
+
+    await editPrompt("p1");
+
+    // public visibility should be preserved — no coercion for whitespace-only team_id
+    expect(publicRadio.checked).toBe(true);
+    expect(teamRadio.checked).toBe(false);
     consoleSpy.mockRestore();
   });
 

--- a/tests/unit/js/resources.test.js
+++ b/tests/unit/js/resources.test.js
@@ -35,6 +35,7 @@ vi.mock("../../../mcpgateway/admin_ui/servers.js", () => ({
 }));
 vi.mock("../../../mcpgateway/admin_ui/teams.js", () => ({
   applyVisibilityRestrictions: vi.fn(),
+  isTeamScopedView: vi.fn(() => false),
 }));
 vi.mock("../../../mcpgateway/admin_ui/utils", () => ({
   decodeHtml: vi.fn((s) => s || ""),

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -22269,6 +22269,62 @@ class TestPublicVisibilityGuard:
 
 
 # ---------------------------------------------------------------------------
+# _form_team_id — end-to-end whitespace normalization (#4235)
+# ---------------------------------------------------------------------------
+
+
+class TestFormTeamId:
+    """Unit tests for the _form_team_id normalisation helper."""
+
+    def _make_form(self, team_id_value):
+        """Return a dict-like object whose .get() mirrors multipart form behaviour."""
+        if team_id_value is None:
+            return {}
+        return {"team_id": team_id_value}
+
+    def test_absent_returns_none(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({}) is None
+
+    def test_none_value_returns_none(self):
+        from mcpgateway.admin import _form_team_id
+
+        # Some form parsers may return None explicitly
+        assert _form_team_id({"team_id": None}) is None
+
+    def test_empty_string_returns_none(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({"team_id": ""}) is None
+
+    def test_spaces_only_returns_none(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({"team_id": "   "}) is None
+
+    def test_tab_only_returns_none(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({"team_id": "\t"}) is None
+
+    def test_newline_only_returns_none(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({"team_id": "\n"}) is None
+
+    def test_real_team_id_returned_stripped(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({"team_id": "  team-abc  "}) == "team-abc"
+
+    def test_real_team_id_no_surrounding_spaces(self):
+        from mcpgateway.admin import _form_team_id
+
+        assert _form_team_id({"team_id": "team-abc"}) == "team-abc"
+
+
+# ---------------------------------------------------------------------------
 # include_public parameter — team isolation with public overlay (#3411)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -22241,6 +22241,32 @@ class TestPublicVisibilityGuard:
         result = await admin_create_grpc_service(service, mock_request, mock_db, user={"email": "u@e.com", "db": mock_db})
         assert result.status_code == 201
 
+    # --- Whitespace-only team_id: treated as absent, public must NOT be blocked ---
+    # Test _check_public_visibility_allowed directly to avoid unrelated form-processing
+    # side effects (e.g. TeamManagementService.verify_team_for_user returning [] for
+    # whitespace-only input, which would cause Pydantic to reject ToolCreate).
+
+    def test_check_public_visibility_spaces_not_blocked(self, monkeypatch):
+        from mcpgateway.admin import _check_public_visibility_allowed
+
+        monkeypatch.setattr("mcpgateway.admin.settings.allow_public_visibility", False)
+        # Should not raise — whitespace-only team_id treated as absent
+        _check_public_visibility_allowed("public", team_id="   ")
+
+    def test_check_public_visibility_tab_not_blocked(self, monkeypatch):
+        from mcpgateway.admin import _check_public_visibility_allowed
+
+        monkeypatch.setattr("mcpgateway.admin.settings.allow_public_visibility", False)
+        _check_public_visibility_allowed("public", team_id="\t")
+
+    def test_check_public_visibility_real_team_id_blocked(self, monkeypatch):
+        from mcpgateway.admin import _check_public_visibility_allowed
+
+        monkeypatch.setattr("mcpgateway.admin.settings.allow_public_visibility", False)
+        with pytest.raises(HTTPException) as exc_info:
+            _check_public_visibility_allowed("public", team_id="team-abc")
+        assert exc_info.value.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # include_public parameter — team isolation with public overlay (#3411)


### PR DESCRIPTION
## :pushpin: Summary

This PR contains two fixes:

### 1. Whitespace `team_id` visibility coercion

All 6 edit functions in the Admin UI (`editTool`, `editGateway`, `editA2AAgent`, `editResource`, `editPrompt`, `editServer`) were checking raw `teamId` truthiness to decide whether to coerce a `public` visibility record to `team`. A whitespace-only URL parameter (`?team_id=%20`) is truthy in JS, causing silent coercion while `isTeamScopedView()` — already trim-aware — correctly returned `false`. The Python server-side guard had the same gap. This fix makes all checks consistent.

### 2. Dead code removal in `servers.js`

`serverDesc.textContent` was assigned via `decodeHtml()` and then immediately overwritten with the raw value on the next line, making the `decodeHtml` call unreachable and causing HTML entities in server descriptions to render incorrectly.

## :link: Related Issue
Closes: #3338

## :repeat: Reproduction Steps

1. Set `ALLOW_PUBLIC_VISIBILITY=false`.
2. Navigate to the admin UI with `?team_id=%20` in the URL.
3. Open the edit modal for any tool, gateway, A2A agent, resource, prompt, or server that has `public` visibility.
4. Observe: the public radio button appears enabled (because `isTeamScopedView()` returns `false`), but the visibility is silently coerced to `team` on submit.

## 🐞  Root Cause

The `effectiveVisibility` ternary in each of the 6 edit functions used the raw URL-derived `teamId`/`_teamId` variable directly:

```js
// Before — raw truthiness, no trim
teamId ? "team" : visibility
```

`" "` (whitespace) is truthy, so it triggered coercion. Meanwhile `isTeamScopedView()` in `teams.js` correctly trims before checking, returning `false` for whitespace-only values. The two code paths were inconsistent.

On the Python side, `_check_public_visibility_allowed` in `admin.py` had the same raw-truthiness check (`and team_id`).

## :bulb: Fix Description

### Fix 1 — Whitespace `team_id` coercion

- **JS (6 files):** Added `isTeamScopedView` to the import from `./teams.js` in each affected module and replaced the raw `teamId` / `_teamId` condition in the `effectiveVisibility` ternary with `isTeamScopedView()`. For `editResource`, `editPrompt`, and `editServer`, the now-redundant local `_teamId` variable was also removed.
- **Python (`admin.py`):** Changed `and team_id` → `and team_id and team_id.strip()` in `_check_public_visibility_allowed` so both layers treat whitespace-only values as absent.

### Fix 2 — Dead code removal (`servers.js`)

- Removed the redundant `serverDesc.textContent = server.description` line that immediately overwrote the `decodeHtml()` result, so HTML entities in server descriptions are now decoded correctly.
- **Tests:** Fixed the existing visibility-coercion test in `prompts.test.js` to include `search` in the mocked `window.location` (required since `isTeamScopedView` reads `location.search`, not `href`). Added a whitespace-only `team_id` test asserting no coercion occurs. Updated the `teams.js` mock in `resources.test.js` to export `isTeamScopedView` (previously missing, would throw at runtime in tests). Added 3 direct tests of `_check_public_visibility_allowed` in `test_admin.py` covering spaces-only, tab, and a real `team_id` to verify the `team_id.strip()` branch.

## :test_tube: Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 90 % | `make coverage` | |
| Manual regression no longer fails | Visit `?team_id=%20`, open any edit modal with a public entity — coercion no longer occurs | |

## :triangular_ruler: MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## :white_check_mark: Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
