### PR TITLE
[CHORE] Pin brotli transivite dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ maintainers = [
 dependencies = [
     "alembic>=1.18.4",
     "argon2-cffi>=25.1.0",
-    "brotli==1.2.0",  # Transitive pin (starlette-compress)
+    "brotli==1.2.0", # Transitive pin (starlette-compress)
     "cryptography>=46.0.7",
     "fastapi>=0.135.3",
     "filelock>=3.25.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ maintainers = [
 dependencies = [
     "alembic>=1.18.4",
     "argon2-cffi>=25.1.0",
+    "brotli==1.2.0",  # Transitive pin (starlette-compress)
     "cryptography>=46.0.7",
     "fastapi>=0.135.3",
     "filelock>=3.25.2",


### PR DESCRIPTION
## 📝 Summary
This PR pins Brotli (transitive dependency) to the latest version to ensure latest patches and fixes are available.
Previous version installed by starelette-compress

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |    pass    |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---
