### PR TITLE
docs: restructure observability documentation for clarity and neutrality

### DIFF
--- a/docs/docs/architecture/observability-otel.md
+++ b/docs/docs/architecture/observability-otel.md
@@ -657,9 +657,22 @@ async def tool_pre_invoke(self, payload, context):
     return PluginResult(continue_processing=True)
 ```
 
-## References
+## Related Documentation
 
+### User Guides
+
+- [Observability Overview](../manage/observability.md) - Choosing the right observability approach
+- [OpenTelemetry Integration](../manage/observability/opentelemetry.md) - User-facing OTEL setup guide
+- [Internal Observability](../manage/observability/internal.md) - Built-in database-backed tracing
+- [Prometheus Metrics](../manage/observability/prometheus.md) - Time-series monitoring
+- [Langfuse Integration](../manage/observability/langfuse.md) - LLM observability platform
+- [Phoenix Integration](../manage/observability/phoenix.md) - AI/LLM-focused observability
+
+### Technical References
+
+- [OTEL Span Attributes Reference](otel-span-attributes.md) - Complete list of span attributes used in ContextForge
 - [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/)
 - [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [W3C Baggage](https://www.w3.org/TR/baggage/)
 - [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
 - [Langfuse OTEL Integration](https://langfuse.com/docs/integrations/opentelemetry)

--- a/docs/docs/architecture/otel-span-attributes.md
+++ b/docs/docs/architecture/otel-span-attributes.md
@@ -1,0 +1,415 @@
+# OpenTelemetry Span Attributes in ContextForge
+
+This document lists all span attributes created in the ContextForge codebase, organized by category with real-world code-level examples.
+
+---
+
+## **TOOL INVOCATION ATTRIBUTES**
+
+### Core Tool Attributes
+
+| Attribute               | Example Value                            | Description                        |
+| ----------------------- | ---------------------------------------- | ---------------------------------- |
+| `tool.name`             | `"get_weather"`                          | Tool name being invoked            |
+| `tool.id`               | `"550e8400-e29b-41d4-a716-446655440000"` | UUID of the tool                   |
+| `tool.integration_type` | `"MCP"`, `"REST"`, `"A2A"`               | Integration type                   |
+| `tool.gateway_id`       | `"7c9e6679-7425-40de-944b-e07fc1f90ae7"` | Gateway UUID if federated          |
+| `arguments_count`       | `3`                                      | Number of arguments passed         |
+| `has_headers`           | `true`                                   | Whether headers were provided      |
+| `success`               | `true`                                   | Whether invocation succeeded       |
+| `duration.ms`           | `245.67`                                 | Execution duration in milliseconds |
+
+### Tool Lookup Attributes
+
+| Attribute               | Example Value     | Description          |
+| ----------------------- | ----------------- | -------------------- |
+| `tool.name`             | `"calculate_sum"` | Tool being looked up |
+| `tool.id`               | `"abc-123-def"`   | Tool identifier      |
+| `tool.integration_type` | `"REST"`          | Integration type     |
+
+### Tool Gateway Call Attributes
+
+| Attribute               | Example Value              | Description      |
+| ----------------------- | -------------------------- | ---------------- |
+| `tool.name`             | `"fetch_data"`             | Tool name        |
+| `tool.id`               | `"tool-uuid-123"`          | Tool UUID        |
+| `tool.integration_type` | `"REST"`, `"MCP"`, `"A2A"` | Integration type |
+
+### Tool Post-Process Attributes
+
+| Attribute   | Example Value      | Description |
+| ----------- | ------------------ | ----------- |
+| `tool.name` | `"process_result"` | Tool name   |
+| `tool.id`   | `"uuid-456"`       | Tool UUID   |
+
+---
+
+## **MCP CLIENT ATTRIBUTES**
+
+### MCP Client Call Attributes
+
+| Attribute                 | Example Value                        | Description            |
+| ------------------------- | ------------------------------------ | ---------------------- |
+| `mcp.tool.name`           | `"echo_text"`                        | Original MCP tool name |
+| `contextforge.tool.id`    | `"tool-789"`                         | ContextForge tool ID   |
+| `contextforge.gateway_id` | `"gateway-abc"`                      | Gateway identifier     |
+| `contextforge.runtime`    | `"python"`                           | Runtime environment    |
+| `contextforge.transport`  | `"sse"`, `"streamablehttp"`          | MCP transport type     |
+| `network.protocol.name`   | `"mcp"`                              | Protocol name          |
+| `server.address`          | `"mcp.example.com"`                  | Server hostname        |
+| `server.port`             | `8080`                               | Server port            |
+| `url.path`                | `"/mcp"`                             | URL path               |
+| `url.full`                | `"https://mcp.example.com:8080/mcp"` | Full sanitized URL     |
+
+### MCP Client Initialize Attributes
+
+| Attribute                | Example Value               | Description         |
+| ------------------------ | --------------------------- | ------------------- |
+| `contextforge.transport` | `"sse"`, `"streamablehttp"` | Transport type      |
+| `contextforge.runtime`   | `"python"`                  | Runtime environment |
+
+### MCP Client Request Attributes
+
+| Attribute                 | Example Value    | Description     |
+| ------------------------- | ---------------- | --------------- |
+| `mcp.tool.name`           | `"get_time"`     | MCP tool name   |
+| `contextforge.tool.id`    | `"time-tool-id"` | Tool identifier |
+| `contextforge.gateway_id` | `"gw-123"`       | Gateway ID      |
+| `contextforge.runtime`    | `"python"`       | Runtime         |
+
+### MCP Client Response Attributes
+
+| Attribute                   | Example Value    | Description                |
+| --------------------------- | ---------------- | -------------------------- |
+| `mcp.tool.name`             | `"get_time"`     | Tool name                  |
+| `contextforge.tool.id`      | `"time-tool-id"` | Tool ID                    |
+| `contextforge.gateway_id`   | `"gw-123"`       | Gateway ID                 |
+| `contextforge.runtime`      | `"python"`       | Runtime                    |
+| `upstream.response.success` | `true`           | Whether upstream succeeded |
+
+---
+
+## **PLUGIN FRAMEWORK ATTRIBUTES**
+
+### Plugin Chain Attributes
+
+| Attribute                 | Example Value      | Description                |
+| ------------------------- | ------------------ | -------------------------- |
+| `plugin.chain.stopped`    | `true`             | Whether chain was stopped  |
+| `plugin.chain.stopped_by` | `"DenyListPlugin"` | Plugin that stopped chain  |
+| `plugin.executed_count`   | `5`                | Number of plugins executed |
+| `plugin.skipped_count`    | `2`                | Number of plugins skipped  |
+
+### Plugin Execution Attributes
+
+| Attribute                    | Example Value | Description                     |
+| ---------------------------- | ------------- | ------------------------------- |
+| `plugin.had_violation`       | `true`        | Whether plugin raised violation |
+| `plugin.modified_payload`    | `true`        | Whether payload was modified    |
+| `plugin.continue_processing` | `false`       | Whether to continue processing  |
+| `plugin.stopped_chain`       | `true`        | Whether plugin stopped chain    |
+
+### Plugin Hook Attributes
+
+| Attribute            | Example Value              | Description                        |
+| -------------------- | -------------------------- | ---------------------------------- |
+| `plugin.hook.invoke` | `"plugin.hook.invoke"`     | Plugin hook invocation marker      |
+| `plugin.hook.type`   | `"TOOL_PRE_INVOKE"`        | Type of hook being executed        |
+| `plugin.name`        | `"RetryWithBackoffPlugin"` | Name of the plugin                 |
+| `plugin.mode`        | `"enforce"`                | Plugin execution mode              |
+| `plugin.priority`    | `100`                      | Plugin priority (lower runs first) |
+
+---
+
+## **PROMPT ATTRIBUTES**
+
+### Prompt Render Attributes
+
+| Attribute                             | Example Value         | Description                        |
+| ------------------------------------- | --------------------- | ---------------------------------- |
+| `prompt.id`                           | `"prompt-123"`        | Prompt identifier                  |
+| `arguments_count`                     | `2`                   | Number of arguments provided       |
+| `user`                                | `"user@example.com"`  | User rendering the prompt          |
+| `server_id`                           | `"virtual-server-1"`  | Virtual server ID                  |
+| `tenant_id`                           | `"tenant-abc"`        | Tenant identifier                  |
+| `request_id`                          | `"req-xyz-789"`       | Request identifier                 |
+| `success`                             | `true`                | Whether rendering succeeded        |
+| `duration.ms`                         | `123.45`              | Rendering duration in milliseconds |
+| `langfuse.observation.prompt.name`    | `"greeting_template"` | Prompt name for Langfuse           |
+| `langfuse.observation.prompt.version` | `3`                   | Prompt version number              |
+| `messages.count`                      | `5`                   | Number of messages in result       |
+
+---
+
+## **RESOURCE ATTRIBUTES**
+
+### Resource Invocation Attributes
+
+| Attribute           | Example Value                   | Description            |
+| ------------------- | ------------------------------- | ---------------------- |
+| `resource.name`     | `"config_file"`                 | Resource name          |
+| `resource.id`       | `"res-456"`                     | Resource identifier    |
+| `resource.uri`      | `"file:///config.json"`         | Resource URI           |
+| `gateway.transport` | `"sse"`                         | Gateway transport type |
+| `gateway.url`       | `"https://gateway.example.com"` | Gateway URL            |
+
+### Resource Read Attributes
+
+| Attribute       | Example Value                    | Description               |
+| --------------- | -------------------------------- | ------------------------- |
+| `resource.uri`  | `"https://api.example.com/data"` | Resource URI being read   |
+| `user`          | `"user@example.com"`             | User reading the resource |
+| `server_id`     | `"virtual-server-1"`             | Virtual server ID         |
+| `request_id`    | `"req-abc-123"`                  | Request identifier        |
+| `http.url`      | `"https://api.example.com/data"` | HTTP URL (if applicable)  |
+| `resource.type` | `"template"`, `"static"`         | Resource type             |
+
+### Resource Get Attributes
+
+| Attribute          | Example Value | Description                           |
+| ------------------ | ------------- | ------------------------------------- |
+| `resource.id`      | `"res-789"`   | Resource identifier                   |
+| `include_inactive` | `false`       | Whether to include inactive resources |
+
+---
+
+## **GATEWAY ATTRIBUTES**
+
+### Gateway Health Check Attributes
+
+| Attribute           | Example Value | Description                              |
+| ------------------- | ------------- | ---------------------------------------- |
+| `gateway.count`     | `15`          | Number of gateways being checked         |
+| `check.type`        | `"health"`    | Type of check being performed            |
+| `check.duration_ms` | `2345`        | Duration of health check in milliseconds |
+| `check.completed`   | `true`        | Whether check completed successfully     |
+
+---
+
+## **A2A (AGENT-TO-AGENT) ATTRIBUTES**
+
+### A2A Invocation Attributes
+
+| Attribute              | Example Value                     | Description                    |
+| ---------------------- | --------------------------------- | ------------------------------ |
+| `a2a.agent.name`       | `"WeatherAgent"`                  | Agent name                     |
+| `a2a.agent.id`         | `"agent-123"`                     | Agent identifier               |
+| `a2a.agent.url`        | `"https://agent.example.com/api"` | Agent endpoint URL (sanitized) |
+| `a2a.agent.type`       | `"jsonrpc"`, `"generic"`          | Agent type                     |
+| `a2a.interaction_type` | `"query"`, `"command"`            | Type of interaction            |
+
+---
+
+## **LLM PROXY ATTRIBUTES**
+
+### LLM Request Attributes
+
+| Attribute                   | Example Value             | Description                   |
+| --------------------------- | ------------------------- | ----------------------------- |
+| `langfuse.observation.type` | `"generation"`            | Observation type for Langfuse |
+| `gen_ai.system`             | `"openai"`, `"anthropic"` | AI system/provider            |
+| `gen_ai.request.model`      | `"gpt-4"`                 | Model being requested         |
+| `gen_ai.response.model`     | `"gpt-4-0613"`            | Actual model that responded   |
+| `llm.provider.id`           | `"provider-456"`          | LLM provider identifier       |
+| `llm.provider.type`         | `"openai"`                | Provider type                 |
+| `llm.model.id`              | `"model-789"`             | Model identifier              |
+| `llm.stream`                | `true`                    | Whether streaming is enabled  |
+
+### LLM Usage Attributes
+
+| Attribute                    | Example Value | Description             |
+| ---------------------------- | ------------- | ----------------------- |
+| `gen_ai.usage.input_tokens`  | `150`         | Number of input tokens  |
+| `gen_ai.usage.output_tokens` | `75`          | Number of output tokens |
+| `gen_ai.usage.total_tokens`  | `225`         | Total tokens used       |
+
+---
+
+## **ROOT SERVICE ATTRIBUTES**
+
+### Root List Attributes
+
+| Attribute    | Example Value | Description            |
+| ------------ | ------------- | ---------------------- |
+| `root.count` | `3`           | Number of root entries |
+
+---
+
+## **USER & TEAM CONTEXT ATTRIBUTES**
+
+### Identity Attributes
+
+| Attribute       | Example Value                 | Description                  |
+| --------------- | ----------------------------- | ---------------------------- |
+| `user.email`    | `"user@example.com"`          | User email address           |
+| `user.is_admin` | `true`                        | Whether user is admin        |
+| `team.scope`    | `"team1,team2"` or `"public"` | Team scope (comma-separated) |
+| `team.name`     | `"Engineering"`               | Team name                    |
+
+### Authentication Attributes
+
+| Attribute     | Example Value                 | Description                |
+| ------------- | ----------------------------- | -------------------------- |
+| `auth.method` | `"jwt"`, `"oauth"`, `"basic"` | Authentication method used |
+
+---
+
+## **LANGFUSE-SPECIFIC ATTRIBUTES**
+
+### Langfuse Identity Attributes
+
+| Attribute              | Example Value               | Description              |
+| ---------------------- | --------------------------- | ------------------------ |
+| `langfuse.user.id`     | `"user@example.com"`        | Langfuse user identifier |
+| `langfuse.session.id`  | `"session-abc-123"`         | Session identifier       |
+| `langfuse.environment` | `"production"`, `"staging"` | Deployment environment   |
+
+### Langfuse Trace Attributes
+
+| Attribute                             | Example Value                            | Description               |
+| ------------------------------------- | ---------------------------------------- | ------------------------- |
+| `langfuse.trace.tags`                 | `["team:engineering", "env:production"]` | Trace tags array          |
+| `langfuse.trace.name`                 | `"Tool: get_weather"`                    | Human-readable trace name |
+| `langfuse.observation.level`          | `"DEFAULT"`, `"ERROR"`                   | Observation level         |
+| `langfuse.observation.status_message` | `"Request completed successfully"`       | Status message            |
+
+### Langfuse Input/Output Attributes
+
+| Attribute                     | Example Value                                 | Description               |
+| ----------------------------- | --------------------------------------------- | ------------------------- |
+| `langfuse.observation.input`  | `{"city": "London", "units": "metric"}`       | Serialized input payload  |
+| `langfuse.observation.output` | `{"temperature": 15, "conditions": "cloudy"}` | Serialized output payload |
+
+---
+
+## **REQUEST CONTEXT ATTRIBUTES**
+
+### Correlation & Request Attributes
+
+| Attribute        | Example Value           | Description                                 |
+| ---------------- | ----------------------- | ------------------------------------------- |
+| `correlation_id` | `"req-abc-123-def-456"` | Request correlation ID                      |
+| `request_id`     | `"req-abc-123-def-456"` | Request identifier (same as correlation_id) |
+| `server_id`      | `"virtual-server-1"`    | Virtual server ID                           |
+| `tenant_id`      | `"tenant-xyz"`          | Tenant identifier                           |
+
+### Baggage Attributes
+
+| Attribute       | Example Value               | Description                |
+| --------------- | --------------------------- | -------------------------- |
+| `baggage.{key}` | `baggage.trace_id="abc123"` | Baggage entries (prefixed) |
+
+---
+
+## **HTTP REQUEST ATTRIBUTES** (ObservabilityMiddleware)
+
+### HTTP Request Attributes
+
+| Attribute                  | Example Value                                 | Description                |
+| -------------------------- | --------------------------------------------- | -------------------------- |
+| `http.request.method`      | `"POST"`                                      | HTTP method                |
+| `http.route`               | `"/tools/invoke"`                             | Route path                 |
+| `url.path`                 | `"/tools/invoke"`                             | URL path                   |
+| `url.query`                | `"filter=active&limit=10"`                    | Sanitized query string     |
+| `network.protocol.version` | `"1.1"`                                       | HTTP version               |
+| `server.address`           | `"api.example.com"`                           | Server address             |
+| `server.port`              | `443`                                         | Server port                |
+| `client.address`           | `"192.168.1.100"`                             | Client IP address          |
+| `client.port`              | `54321`                                       | Client port                |
+| `user_agent.original`      | `"Mozilla/5.0 (Windows NT 10.0; Win64; x64)"` | User agent string          |
+| `correlation_id`           | `"req-xyz-789"`                               | Correlation ID from header |
+
+### HTTP Response Attributes
+
+| Attribute                   | Example Value | Description         |
+| --------------------------- | ------------- | ------------------- |
+| `http.response.status_code` | `200`         | HTTP status code    |
+| `http.status_code`          | `200`         | HTTP status (alias) |
+
+---
+
+## **ERROR ATTRIBUTES**
+
+### Error Attributes
+
+| Attribute       | Example Value               | Description               |
+| --------------- | --------------------------- | ------------------------- |
+| `error`         | `true`                      | Whether an error occurred |
+| `error.type`    | `"ValueError"`              | Exception class name      |
+| `error.message` | `"Invalid input parameter"` | Sanitized error message   |
+
+---
+
+## **SUMMARY BY CATEGORY**
+
+### Tool Invocation (12 attributes)
+
+- Core: `tool.name`, `tool.id`, `tool.integration_type`, `tool.gateway_id`, `arguments_count`, `has_headers`, `success`, `duration.ms`
+- Lookup: `tool.name`, `tool.id`, `tool.integration_type`
+- Gateway Call: `tool.name`, `tool.id`, `tool.integration_type`
+
+### MCP Protocol (15 attributes)
+
+- Call: `mcp.tool.name`, `contextforge.tool.id`, `contextforge.gateway_id`, `contextforge.runtime`, `contextforge.transport`, `network.protocol.name`, `server.address`, `server.port`, `url.path`, `url.full`
+- Initialize: `contextforge.transport`, `contextforge.runtime`
+- Request: `mcp.tool.name`, `contextforge.tool.id`, `contextforge.gateway_id`, `contextforge.runtime`
+- Response: `mcp.tool.name`, `contextforge.tool.id`, `contextforge.gateway_id`, `contextforge.runtime`, `upstream.response.success`
+
+### Plugin Framework (13 attributes)
+
+- Chain: `plugin.chain.stopped`, `plugin.chain.stopped_by`, `plugin.executed_count`, `plugin.skipped_count`
+- Execution: `plugin.had_violation`, `plugin.modified_payload`, `plugin.continue_processing`, `plugin.stopped_chain`
+- Hook: `plugin.hook.invoke`, `plugin.hook.type`, `plugin.name`, `plugin.mode`, `plugin.priority`
+
+### Prompt (11 attributes)
+
+- `prompt.id`, `arguments_count`, `user`, `server_id`, `tenant_id`, `request_id`, `success`, `duration.ms`, `langfuse.observation.prompt.name`, `langfuse.observation.prompt.version`, `messages.count`
+
+### Resource (11 attributes)
+
+- Invocation: `resource.name`, `resource.id`, `resource.uri`, `gateway.transport`, `gateway.url`
+- Read: `resource.uri`, `user`, `server_id`, `request_id`, `http.url`, `resource.type`
+- Get: `resource.id`, `include_inactive`
+
+### Gateway (4 attributes)
+
+- `gateway.count`, `check.type`, `check.duration_ms`, `check.completed`
+
+### A2A (5 attributes)
+
+- `a2a.agent.name`, `a2a.agent.id`, `a2a.agent.url`, `a2a.agent.type`, `a2a.interaction_type`
+
+### LLM Proxy (11 attributes)
+
+- Request: `langfuse.observation.type`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`, `llm.provider.id`, `llm.provider.type`, `llm.model.id`, `llm.stream`
+- Usage: `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens`
+
+### Root Service (1 attribute)
+
+- `root.count`
+
+### User & Team Context (5 attributes)
+
+- Identity: `user.email`, `user.is_admin`, `team.scope`, `team.name`
+- Auth: `auth.method` <!-- pragma: allowlist secret -->
+
+### Langfuse Integration (9 attributes)
+
+- Identity: `langfuse.user.id`, `langfuse.session.id`, `langfuse.environment`
+- Trace: `langfuse.trace.tags`, `langfuse.trace.name`, `langfuse.observation.level`, `langfuse.observation.status_message` <!-- pragma: allowlist secret -->
+- I/O: `langfuse.observation.input`, `langfuse.observation.output` <!-- pragma: allowlist secret -->
+
+### Request Context (5 attributes)
+
+- `correlation_id`, `request_id`, `server_id`, `tenant_id`, `baggage.{key}`
+
+### HTTP (11 attributes)
+
+- Request: `http.request.method`, `http.route`, `url.path`, `url.query`, `network.protocol.version`, `server.address`, `server.port`, `client.address`, `client.port`, `user_agent.original`, `correlation_id`
+- Response: `http.response.status_code`, `http.status_code`
+
+### Error Handling (3 attributes)
+
+- `error`, `error.type`, `error.message`
+
+**Total: 116 unique span attributes across all categories**

--- a/docs/docs/manage/observability.md
+++ b/docs/docs/manage/observability.md
@@ -1,19 +1,20 @@
-## Observability
+# Observability
 
-ContextForge provides comprehensive observability through two complementary systems:
+ContextForge provides comprehensive observability through multiple complementary systems, allowing you to monitor, trace, and analyze your gateway operations.
 
-1. **Internal Observability** - Built-in database-backed tracing with Admin UI dashboards
-2. **OpenTelemetry** - Standard distributed tracing to external backends (Phoenix, Jaeger, Tempo)
+## Overview
 
-## Documentation
+ContextForge offers three observability approaches:
 
-- **[OpenTelemetry Overview](observability/observability.md)** - External observability with OTLP backends
-- **[Internal Observability](observability/internal-observability.md)** - Built-in tracing, metrics, and Admin UI dashboards
-- **[Phoenix Integration](observability/phoenix.md)** - AI/LLM-focused observability with Arize Phoenix
+1. **[Internal Observability](observability/internal.md)** - Built-in database-backed tracing with Admin UI dashboards
+2. **[OpenTelemetry Integration](observability/opentelemetry.md)** - Standard distributed tracing to external backends (Phoenix, Jaeger, Tempo, Langfuse)
+3. **[Prometheus Metrics](observability/prometheus.md)** - Time-series metrics for monitoring and alerting
 
-## Quick Start
+## Quick Start Guides
 
 ### Internal Observability (Built-in)
+
+Database-backed tracing with Admin UI dashboards:
 
 ```bash
 # Enable internal observability
@@ -25,7 +26,13 @@ mcpgateway
 # View dashboards at http://localhost:4444/admin/observability
 ```
 
-### OpenTelemetry (External)
+**Features**: Tools/prompts/resources analytics, trace visualization, performance metrics, error tracking
+
+**[Full Guide →](observability/internal.md)**
+
+### OpenTelemetry (External Backends)
+
+Standard distributed tracing to external observability platforms:
 
 ```bash
 # Enable OpenTelemetry (disabled by default)
@@ -33,143 +40,210 @@ export OTEL_ENABLE_OBSERVABILITY=true
 export OTEL_TRACES_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
-# Start Phoenix for AI/LLM observability
-docker run -p 6006:6006 -p 4317:4317 arizephoenix/phoenix:latest
+# Run ContextForge
+mcpgateway
+```
+
+**Supported Backends**: Phoenix, Jaeger, Tempo, Langfuse, Zipkin, Datadog, New Relic, Honeycomb, and any OTLP-compatible backend
+
+**[Full Guide →](observability/opentelemetry.md)**
+
+### Prometheus Metrics
+
+Time-series metrics for monitoring and alerting:
+
+```bash
+# Enable Prometheus metrics endpoint
+export ENABLE_METRICS=true
+
+# Generate scrape token
+export METRICS_TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
+  --username prometheus@monitoring --exp 0 \
+  --secret $JWT_SECRET_KEY)
 
 # Run ContextForge
 mcpgateway
 
-# View traces at http://localhost:6006
+# Metrics available at http://localhost:4444/metrics/prometheus
 ```
 
-## Prometheus metrics (important)
+**Features**: Request rates, error rates, latency percentiles, custom labels
 
-Note: the metrics exposure is wired from `mcpgateway/main.py` but the HTTP
-handler itself is registered by the metrics module. The main application
-imports and calls `setup_metrics(app)` from `mcpgateway.services.metrics`. The
-`setup_metrics` function instruments the FastAPI app and registers the
-Prometheus scrape endpoint using the Prometheus instrumentator; the endpoint
-available to Prometheus scrapers is:
+**[Full Guide →](observability/prometheus.md)**
 
-- GET /metrics/prometheus
+## Documentation
 
-The route is defined as a custom FastAPI endpoint in
-`mcpgateway/services/metrics.py` with `Depends(require_auth)` for JWT
-authentication. The endpoint is registered with `include_in_schema=True` (so it
-appears in OpenAPI / Swagger) and supports gzip compression via the
-`Accept-Encoding` header.
+### Core Guides
 
-### Env vars / settings that control metrics
+- **[Internal Observability](observability/internal.md)** - Built-in tracing, metrics, and Admin UI dashboards
+- **[OpenTelemetry Integration](observability/opentelemetry.md)** - External observability with OTLP backends
+- **[Prometheus Metrics](observability/prometheus.md)** - Time-series metrics and monitoring
 
-- `ENABLE_METRICS` (env) — set to `true` to enable instrumentation; defaults to `false`. The endpoint requires JWT authentication when enabled.
-- `METRICS_EXCLUDED_HANDLERS` (env / settings) — comma-separated regexes for endpoints to exclude from instrumentation (useful for SSE/WS or per-request high-cardinality paths). The implementation reads `settings.METRICS_EXCLUDED_HANDLERS` and compiles the patterns.
-- `METRICS_CUSTOM_LABELS` (env / settings) — comma-separated `key=value` pairs used as static labels on the `app_info` gauge (low-cardinality values only). When present, a Prometheus `app_info` gauge is created and set to 1 with those labels.
-- Additional settings in `mcpgateway/config.py`: `METRICS_NAMESPACE`, `METRICS_SUBSYSTEM`. Note: these config fields exist, but the current `metrics` module does not wire them into the instrumentator by default (they're available for future use/consumption by custom collectors).
+### Backend-Specific Guides
 
-### Enable / verify locally
+- **[Langfuse Integration](observability/langfuse.md)** - LLM observability, prompt management, and evaluations
+- **[Phoenix Integration](observability/phoenix.md)** - AI/LLM-focused observability with Arize Phoenix
 
-1. Set `ENABLE_METRICS=true` in your shell or `.env` and generate a scrape token.
+### Technical Documentation
 
-     ```bash
-     export ENABLE_METRICS=true
-     export METRICS_CUSTOM_LABELS="env=local,team=dev"
-     export METRICS_EXCLUDED_HANDLERS="/servers/.*/sse,/static/.*"
-     ```
+- **[OpenTelemetry Architecture](../architecture/observability-otel.md)** - Technical implementation details, W3C trace context, baggage
 
-2. Start the gateway (development). By default the app listens on port 4444. The Prometheus endpoint will be:
+## Choosing an Approach
 
-     http://localhost:4444/metrics/prometheus
+### Internal Observability
 
-3. Generate a scrape token (non-expiring service JWT):
+**Characteristics:**
+- Zero external dependencies
+- Database storage (SQLite or PostgreSQL)
+- Admin UI visualization
+- Self-contained deployment
 
-     ```bash
-     export METRICS_TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
-       --username prometheus@monitoring --exp 0 \
-       --secret $JWT_SECRET_KEY --algo HS256)
-     ```
+**Common Use Cases:**
+- Development and testing environments
+- Small to medium deployments
+- Scenarios where deployment simplicity is important
+- When external observability infrastructure is not available
 
-4. Quick check (get the first lines of exposition text):
+### OpenTelemetry
 
-     ```bash
-     curl -sS -H "Authorization: Bearer $METRICS_TOKEN" \
-       http://localhost:4444/metrics/prometheus | head -n 20
-     ```
+**Characteristics:**
+- Distributed tracing across multiple services
+- Vendor-agnostic standard (OTLP protocol)
+- Integration with existing observability platforms
+- Advanced APM capabilities
 
-5. If metrics are disabled, the endpoint returns a JSON 503 response (authentication is still required).
+**Common Use Cases:**
+- Production environments with multiple services
+- Organizations with existing observability infrastructure
+- Scenarios requiring vendor flexibility
+- High-scale deployments with specialized backends
 
-### Prometheus scrape job example
+### Prometheus
 
-Add the job below to your `prometheus.yml` for local testing:
+**Characteristics:**
+- Time-series metrics storage
+- Industry-standard exposition format
+- Integration with Grafana and alerting systems
+- Trend analysis and capacity planning
 
-```yaml
-scrape_configs:
-    - job_name: 'mcp-gateway'
-        metrics_path: /metrics/prometheus
-        authorization:
-            type: Bearer
-            credentials_file: /path/to/metrics-token.jwt
-        static_configs:
-            - targets: ['localhost:4444']
+**Common Use Cases:**
+- Production monitoring and alerting
+- Long-term trend analysis
+- Capacity planning
+- Integration with existing Prometheus/Grafana stacks
+
+### Combining Multiple Approaches
+
+ContextForge supports running multiple observability systems simultaneously:
+
+- Internal observability for local debugging alongside external production monitoring
+- Different retention policies for different data types
+- Redundancy in observability data collection
+- Supporting different team tooling preferences
+
+## Comparison Matrix
+
+| Feature | Internal | OpenTelemetry | Prometheus |
+|---------|----------|---------------|------------|
+| **Storage** | Database (SQLite/PostgreSQL) | External backends | Time-series DB |
+| **Setup** | Built-in, zero config | Requires external services | Requires Prometheus server |
+| **Cost** | Free, self-hosted | Depends on backend | Free (OSS) or paid (cloud) |
+| **Retention** | Configurable in-database | Backend-dependent | Configurable |
+| **UI** | Admin UI dashboards | Backend-specific UIs | Grafana dashboards |
+| **Use Cases** | Dev, testing, small deployments | Production, microservices | Monitoring, alerting |
+| **Standards** | Custom implementation | OpenTelemetry standard | Prometheus exposition format |
+| **Integration** | Self-contained | APM ecosystem | Monitoring ecosystem |
+
+## Configuration Reference
+
+### Internal Observability
+
+```bash
+OBSERVABILITY_ENABLED=true
+OBSERVABILITY_TRACE_HTTP_REQUESTS=true
+OBSERVABILITY_TRACE_RETENTION_DAYS=7
+OBSERVABILITY_MAX_TRACES=100000
+OBSERVABILITY_SAMPLE_RATE=1.0
 ```
 
-To create the token file: `echo -n "$METRICS_TOKEN" > /path/to/metrics-token.jwt`.
+**[Full Configuration →](observability/internal.md#configuration-reference)**
 
-If Prometheus runs in Docker, adjust the target host accordingly (host networking
-or container host IP). The Docker Compose monitoring profile generates the scrape
-token automatically via the `prometheus_token` service.
-See the repo `docs/manage/scale.md` for examples of deploying Prometheus in
-Kubernetes.
+### OpenTelemetry
 
-### Grafana and dashboards
+```bash
+OTEL_ENABLE_OBSERVABILITY=true
+OTEL_TRACES_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+OTEL_SERVICE_NAME=mcp-gateway
+OTEL_SERVICE_VERSION=1.0.0
+```
 
-- Use Grafana to import dashboards for Kubernetes, PostgreSQL and Redis (IDs
-    suggested elsewhere in the repo). For ContextForge app metrics, create panels
-    for:
+**[Full Configuration →](observability/opentelemetry.md#configuration-reference)**
 
-    - Request rate: `rate(http_requests_total[1m])`
-    - Error rate: `rate(http_requests_total{status=~"5.."}[5m])`
-    - P99 latency: `histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))`
+### Prometheus
 
-### Common pitfalls — short guidance
+```bash
+ENABLE_METRICS=true
+METRICS_CUSTOM_LABELS="env=production,region=us-east-1"
+METRICS_EXCLUDED_HANDLERS="/servers/.*/sse,/static/.*"
+```
 
-- High-cardinality labels
+**[Full Configuration →](observability/prometheus.md#configuration-reference)**
 
-    - Never add per-request identifiers (user IDs, full URIs, request IDs) as
-        Prometheus labels. They explode the number of time series and can crash
-        Prometheus memory.
-    - Use `METRICS_CUSTOM_LABELS` only for low-cardinality labels (env, region).
+## What Gets Traced
 
-- Compression (gzip) vs CPU
+All observability systems capture:
 
-    - The metrics exposer in `mcpgateway.services.metrics` enables gzip by
-        default for the `/metrics/prometheus` endpoint. Compressing the payload
-        reduces network usage but increases CPU on scrape time. On CPU-constrained
-        nodes consider increasing scrape interval (e.g. 15s→30s) or disabling gzip
-        at the instrumentor layer.
+- **Tool invocations** - Full lifecycle with arguments, results, and timing
+- **Prompt rendering** - Template processing and message generation
+- **Resource fetching** - URI resolution, caching, and content retrieval
+- **Gateway federation** - Cross-gateway requests and health checks
+- **Plugin execution** - Pre/post hooks if plugins are enabled
+- **Errors and exceptions** - Full context and error details
 
-- Duplicate collectors during reloads/tests
+## Production Deployment
 
-    - Instrumentation registers collectors on the global Prometheus registry.
-        When reloading the app in the same process (tests, interactive sessions)
-        you may see "collector already registered"; restart the process or clear
-        the registry in test fixtures.
+### High Availability
 
-### Quick checklist
+For production deployments:
 
-- [ ] `ENABLE_METRICS=true`
-- [ ] Generate scrape JWT: `python -m mcpgateway.utils.create_jwt_token --username prometheus@monitoring --exp 0 --secret $JWT_SECRET_KEY`
-- [ ] `/metrics/prometheus` reachable (with `Authorization: Bearer <token>`)
-- [ ] Add scrape job to Prometheus with `authorization: { type: Bearer, credentials_file: <path> }`
-- [ ] Exclude high-cardinality paths with `METRICS_EXCLUDED_HANDLERS`
-- [ ] Use tracing (OTel) for high-cardinality debugging information
+1. **Enable all three systems** for comprehensive observability
+2. **Use PostgreSQL** for internal observability storage
+3. **Deploy Prometheus** with remote write to long-term storage
+4. **Configure OpenTelemetry** to send to production APM
+5. **Set appropriate retention** policies for each system
 
-## Where to look in the code
+### Example Production Configuration
 
-- `mcpgateway/main.py` — wiring: imports and calls `setup_metrics(app)` from
-    `mcpgateway.services.metrics`. The function call instruments the app at
-    startup; the `/metrics/prometheus` endpoint is registered as a custom
-    auth-gated handler inside `mcpgateway/services/metrics.py`.
-- `mcpgateway/services/metrics.py` — instrumentation implementation and env-vars.
-- `mcpgateway/config.py` — settings defaults and names used by the app.
+```bash
+# Internal observability (short retention)
+OBSERVABILITY_ENABLED=true
+OBSERVABILITY_TRACE_RETENTION_DAYS=3
+OBSERVABILITY_SAMPLE_RATE=0.1
 
----
+# OpenTelemetry (production APM)
+OTEL_ENABLE_OBSERVABILITY=true
+OTEL_TRACES_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector.prod.example.com
+OTEL_TRACES_SAMPLER_ARG=0.01
+
+# Prometheus (monitoring)
+ENABLE_METRICS=true
+METRICS_CUSTOM_LABELS="env=production,region=us-east-1"
+METRICS_EXCLUDED_HANDLERS="/health.*,/metrics.*,/static/.*"
+```
+
+## Getting Started
+
+1. **Choose an approach**: Review the comparison matrix and use cases above
+2. **Follow the quick start**: Use the configuration examples for your chosen system(s)
+3. **Configure backends**: See the backend-specific guides for detailed setup instructions
+4. **Set up dashboards**: Configure visualization tools (Admin UI, Grafana, or backend-specific UIs)
+5. **Configure retention**: Adjust sampling rates and retention policies based on your requirements
+
+## Related Documentation
+
+- [Configuration Reference](configuration.md) - All observability settings
+- [Scaling Guide](scale.md) - Production deployment patterns
+- [Security Features](../architecture/security-features.md) - Authentication and authorization
+- [Admin UI Documentation](ui-customization.md) - Customizing observability dashboards

--- a/docs/docs/manage/observability/.pages
+++ b/docs/docs/manage/observability/.pages
@@ -1,5 +1,8 @@
+title: Observability
 nav:
-  - Overview: observability.md
-  - Internal Observability: internal-observability.md
-  - Langfuse Integration: langfuse.md
-  - Phoenix Integration: phoenix.md
+  - index.md
+  - opentelemetry.md
+  - internal.md
+  - prometheus.md
+  - langfuse.md
+  - phoenix.md

--- a/docs/docs/manage/observability/internal.md
+++ b/docs/docs/manage/observability/internal.md
@@ -1,0 +1,837 @@
+# Internal Observability System
+
+ContextForge includes a built-in observability system that provides comprehensive performance monitoring, error tracking, and analytics without requiring external observability platforms. All trace data is stored in your database (SQLite/PostgreSQL) and visualized through the Admin UI.
+
+## Overview
+
+The internal observability system captures detailed performance metrics and traces for:
+
+- **Tools** - Invocation frequency, performance metrics, error rates
+- **Prompts** - Rendering frequency, latency percentiles, error tracking
+- **Resources** - Fetch frequency, performance metrics, error tracking
+- **HTTP Requests** - Complete request/response tracing with timing
+
+Unlike OpenTelemetry (which sends traces to external systems like Phoenix or Jaeger), the internal observability system is self-contained, making it ideal for:
+
+- Development and testing environments
+- Organizations that prefer self-hosted solutions
+- Scenarios where external observability platforms are not available
+- Quick performance analysis without additional infrastructure
+
+## Key Features
+
+### Performance Analytics
+
+- **Latency Percentiles**: p50, p90, p95, p99 metrics for detailed performance analysis
+- **Duration Tracking**: Millisecond-precision timing for all operations
+- **Throughput Metrics**: Request counts and rates over time
+- **Comparative Analysis**: Side-by-side comparison of multiple resources
+
+### Error Tracking
+
+- **Error Rate Monitoring**: Percentage of failed operations with health indicators
+- **Error-Prone Analysis**: Identify resources with highest failure rates
+- **Status Code Tracking**: HTTP response codes and error messages
+- **Root Cause Analysis**: Detailed traces with full context
+
+### Interactive Dashboards
+
+- **Summary Cards**: At-a-glance health status, most used, slowest, and most error-prone resources
+- **Performance Charts**: Interactive visualizations using Chart.js
+- **Time-Based Filtering**: Analyze performance over custom time ranges
+- **Auto-Refresh**: Dashboards update every 60 seconds automatically
+
+### Trace Visualization
+
+- **Gantt Chart Timeline**: Visual representation of span execution order and timing
+- **Flame Graphs**: Hierarchical view of nested operations
+- **Trace Details**: Complete trace metadata, attributes, and context
+- **Span Explorer**: Drill down into individual operations
+
+## Quick Start
+
+### 1. Enable Observability
+
+Add to your `.env` file:
+
+```bash
+# Enable internal observability
+OBSERVABILITY_ENABLED=true
+
+# Automatically trace HTTP requests
+OBSERVABILITY_TRACE_HTTP_REQUESTS=true
+
+# Retention and limits
+OBSERVABILITY_TRACE_RETENTION_DAYS=7
+OBSERVABILITY_MAX_TRACES=100000
+
+# Trace sampling (1.0 = 100%, 0.1 = 10%)
+OBSERVABILITY_SAMPLE_RATE=1.0
+
+# Include paths (JSON array of regex patterns)
+OBSERVABILITY_INCLUDE_PATHS=["^/rpc/?$","^/sse$","^/message$","^/mcp(?:/|$)","^/servers/[^/]+/mcp/?$","^/servers/[^/]+/sse$","^/servers/[^/]+/message$","^/a2a(?:/|$)"]
+
+# Exclude paths (JSON array of regex patterns, applied after include patterns)
+OBSERVABILITY_EXCLUDE_PATHS=["/health","/healthz","/ready","/metrics","/static/.*"]
+
+# Enable metrics and events
+OBSERVABILITY_METRICS_ENABLED=true
+OBSERVABILITY_EVENTS_ENABLED=true
+```
+
+### 2. Start ContextForge
+
+```bash
+# With environment variables
+export OBSERVABILITY_ENABLED=true
+mcpgateway
+
+# Or start development server
+make dev
+```
+
+### 3. Access Admin UI
+
+Navigate to the Observability section in the Admin UI:
+
+```
+http://localhost:4444/admin/observability
+```
+
+## Configuration Reference
+
+### Core Settings
+
+| Variable | Description | Default | Options |
+|----------|-------------|---------|---------|
+| `OBSERVABILITY_ENABLED` | Master switch for internal observability | `false` | `true`, `false` |
+| `OBSERVABILITY_TRACE_HTTP_REQUESTS` | Auto-trace HTTP requests | `true` | `true`, `false` |
+
+### Retention & Limits
+
+| Variable | Description | Default | Range |
+|----------|-------------|---------|-------|
+| `OBSERVABILITY_TRACE_RETENTION_DAYS` | Days to retain trace data | `7` | 1-365 |
+| `OBSERVABILITY_MAX_TRACES` | Maximum traces to store | `100000` | 1000+ |
+
+### Sampling & Filtering
+
+| Variable | Description | Default | Range |
+|----------|-------------|---------|-------|
+| `OBSERVABILITY_SAMPLE_RATE` | Trace sampling rate | `1.0` | 0.0-1.0 |
+| `OBSERVABILITY_INCLUDE_PATHS` | Regex patterns to include for tracing | `["^/rpc/?$","^/sse$","^/message$","^/mcp(?:/|$)","^/servers/[^/]+/mcp/?$","^/servers/[^/]+/sse$","^/servers/[^/]+/message$","^/a2a(?:/|$)"]` | JSON array |
+| `OBSERVABILITY_EXCLUDE_PATHS` | Regex patterns to exclude (after include patterns) | `["/health","/healthz","/ready","/metrics","/static/.*"]` | JSON array |
+
+### Feature Flags
+
+| Variable | Description | Default | Options |
+|----------|-------------|---------|---------|
+| `DB_METRICS_RECORDING_ENABLED` | Enable execution metrics (tool/resource/prompt/server/A2A) | `true` | `true`, `false` |
+| `OBSERVABILITY_METRICS_ENABLED` | Enable metrics collection | `true` | `true`, `false` |
+| `OBSERVABILITY_EVENTS_ENABLED` | Enable event logging | `true` | `true`, `false` |
+
+## Admin UI Dashboards
+
+### Tools Dashboard
+
+**Path**: `/admin/observability/tools`
+
+Provides comprehensive analytics for MCP tool invocations:
+
+#### Summary Cards
+
+- **Overall Health**: Success rate with color-coded status
+
+  - Green: <5% errors (healthy)
+  - Yellow: 5-20% errors (degraded)
+  - Red: >20% errors (unhealthy)
+
+- **Most Used**: Top tool by invocation count
+- **Slowest**: Tool with highest p99 latency
+- **Most Error-Prone**: Tool with highest error rate
+
+#### Performance Charts
+
+1. **Tool Usage Chart**: Bar chart showing invocation counts
+2. **Average Latency Chart**: Bar chart with millisecond precision
+3. **Error Rate Chart**: Percentage visualization with color coding
+4. **Top N Error-Prone Tools**: Focused view of problematic tools
+
+#### Detailed Metrics Table
+
+For each tool:
+
+- **Invocation Count**: Total number of calls
+- **Latency Percentiles**: p50, p90, p95, p99 in milliseconds
+- **Error Rate**: Percentage with color-coded status
+- **Last Used**: Timestamp of most recent invocation
+
+#### Filtering Options
+
+- **Time Range**: Last 1 hour, 24 hours, 7 days, 30 days
+- **Result Limit**: Top 10, 20, 50, or 100 tools
+- **Auto-Refresh**: 60-second automatic updates
+
+### Prompts Dashboard
+
+**Path**: `/admin/observability/prompts`
+
+Analyzes MCP prompt rendering performance:
+
+#### Summary Cards
+
+- **Overall Health**: Rendering success rate
+- **Most Used**: Most frequently rendered prompt
+- **Slowest**: Prompt with highest p99 latency
+- **Most Error-Prone**: Prompt with highest failure rate
+
+#### Performance Charts
+
+1. **Prompt Render Frequency**: Usage distribution
+2. **Average Latency**: Rendering performance
+3. **Error Rate**: Failure rate analysis
+4. **Top N Error-Prone Prompts**: Problem identification
+
+#### Detailed Metrics
+
+- **Render Count**: Total rendering operations
+- **Latency Percentiles**: p50, p90, p95, p99 metrics
+- **Error Rate**: Failure percentage with status
+- **Last Rendered**: Most recent usage timestamp
+
+### Resources Dashboard
+
+**Path**: `/admin/observability/resources`
+
+Monitors MCP resource fetch operations:
+
+#### Summary Cards
+
+- **Overall Health**: Fetch success rate
+- **Most Used**: Most accessed resource
+- **Slowest**: Resource with highest p99 latency
+- **Most Error-Prone**: Resource with highest error rate
+
+#### Performance Charts
+
+1. **Resource Fetch Frequency**: Access patterns
+2. **Average Latency**: Fetch performance
+3. **Error Rate**: Failure analysis
+4. **Top N Error-Prone Resources**: Issue detection
+
+#### Detailed Metrics
+
+- **Fetch Count**: Total access operations
+- **Latency Percentiles**: p50, p90, p95, p99 metrics
+- **Error Rate**: Failure rate with health status
+- **Last Fetched**: Recent access timestamp
+
+## Trace Visualization
+
+### Trace List
+
+**Path**: `/admin/observability/traces`
+
+Browse all captured traces with:
+
+- **Trace ID**: Unique identifier
+- **Operation Name**: Human-readable description
+- **Start Time**: When the trace began
+- **Duration**: Total execution time
+- **Status**: Success/error indicator
+- **HTTP Details**: Method, URL, status code
+
+### Trace Detail View
+
+**Path**: `/admin/observability/traces/{trace_id}`
+
+Comprehensive trace analysis:
+
+#### Trace Metadata
+
+- **Trace ID**: Unique identifier (W3C format)
+- **Name**: Operation description
+- **Status**: Overall outcome
+- **Duration**: Total execution time
+- **HTTP Context**: Method, URL, status code, user agent
+- **User Context**: Email, IP address
+- **Timestamps**: Start, end, created times
+
+#### Gantt Chart Timeline
+
+Visual representation showing:
+
+- **Span Execution Order**: Chronological flow
+- **Nested Operations**: Parent-child relationships
+- **Duration Bars**: Relative timing visualization
+- **Overlap Detection**: Concurrent operations
+
+#### Flame Graph
+
+Hierarchical view displaying:
+
+- **Call Stack**: Nested span relationships
+- **Time Distribution**: Width represents duration
+- **Critical Path**: Longest execution chains
+- **Bottleneck Identification**: Performance hotspots
+
+#### Spans Table
+
+Detailed span information:
+
+- **Span ID**: Unique identifier
+- **Name**: Operation description
+- **Kind**: Span type (internal, server, client)
+- **Start/End Time**: Execution window
+- **Duration**: Millisecond precision
+- **Status**: Success/error indicator
+- **Resource Info**: Type, name, ID
+- **Attributes**: Custom metadata
+
+## Performance Metrics
+
+### Latency Percentiles
+
+The system calculates accurate percentiles using database aggregation:
+
+- **p50 (Median)**: 50% of requests complete faster
+- **p90**: 90% of requests complete faster
+- **p95**: 95% of requests complete faster
+- **p99**: 99% of requests complete faster
+
+These metrics help identify performance outliers and establish SLAs.
+
+### Health Status Indicators
+
+Color-coded status based on error rates:
+
+```
+Green  (<5% errors)   - Healthy
+Yellow (5-20% errors) - Degraded
+Red    (>20% errors)  - Unhealthy
+```
+
+### Metrics Calculation
+
+All metrics are calculated dynamically based on your selected time range:
+
+- Real-time aggregation from trace database
+- No pre-computation or caching delays
+- Accurate percentile calculations using SQLite/PostgreSQL functions
+- Efficient indexing for fast queries
+
+## Data Retention
+
+### Automatic Cleanup
+
+Traces older than `OBSERVABILITY_TRACE_RETENTION_DAYS` are automatically deleted:
+
+```bash
+# Retain traces for 7 days (default)
+OBSERVABILITY_TRACE_RETENTION_DAYS=7
+
+# Extend retention to 30 days
+OBSERVABILITY_TRACE_RETENTION_DAYS=30
+```
+
+### Size Limits
+
+Prevent unbounded growth with `OBSERVABILITY_MAX_TRACES`:
+
+```bash
+# Store up to 100,000 traces (default)
+OBSERVABILITY_MAX_TRACES=100000
+
+# Increase for high-volume environments
+OBSERVABILITY_MAX_TRACES=1000000
+```
+
+When the limit is reached, oldest traces are deleted first.
+
+### Manual Cleanup
+
+Use the CLI for manual trace management:
+
+```bash
+# Delete traces older than 7 days
+mcpgateway observability cleanup --days 7
+
+# Delete specific trace by ID
+mcpgateway observability delete-trace <trace_id>
+
+# Clear all traces (use with caution!)
+mcpgateway observability clear-all
+```
+
+## Sampling Strategies
+
+### Full Sampling (Development)
+
+Capture all requests for complete visibility:
+
+```bash
+OBSERVABILITY_SAMPLE_RATE=1.0  # 100% sampling
+```
+
+### Partial Sampling (Production)
+
+Reduce overhead while maintaining visibility:
+
+```bash
+# Sample 10% of requests
+OBSERVABILITY_SAMPLE_RATE=0.1
+
+# Sample 1% of requests (high volume)
+OBSERVABILITY_SAMPLE_RATE=0.01
+```
+
+### Path Exclusion
+
+Tune which paths are traced:
+
+```bash
+# Limit tracing to MCP/A2A endpoints (default include list)
+OBSERVABILITY_INCLUDE_PATHS=["^/rpc/?$","^/sse$","^/message$","^/mcp(?:/|$)","^/servers/[^/]+/mcp/?$","^/servers/[^/]+/sse$","^/servers/[^/]+/message$","^/a2a(?:/|$)"]
+
+# Trace all endpoints (leave include list empty)
+OBSERVABILITY_INCLUDE_PATHS=[]
+
+# Default exclusions
+OBSERVABILITY_EXCLUDE_PATHS=["/health","/healthz","/ready","/metrics","/static/.*"]
+
+# Custom exclusions (regex patterns applied after includes)
+OBSERVABILITY_EXCLUDE_PATHS=["/health.*","/metrics.*","/static/.*","/admin/assets/.*"]
+```
+
+## Database Schema
+
+### ObservabilityTrace Table
+
+Stores complete request traces:
+
+```sql
+CREATE TABLE observability_traces (
+    trace_id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP,
+    duration_ms FLOAT,
+    status VARCHAR(20) DEFAULT 'unset',
+    status_message TEXT,
+    http_method VARCHAR(10),
+    http_url VARCHAR(767),
+    http_status_code INTEGER,
+    user_email VARCHAR(255),
+    user_agent TEXT,
+    ip_address VARCHAR(45),
+    attributes JSON,
+    resource_attributes JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### ObservabilitySpan Table
+
+Stores individual operations within traces:
+
+```sql
+CREATE TABLE observability_spans (
+    span_id VARCHAR(36) PRIMARY KEY,
+    trace_id VARCHAR(36) NOT NULL,
+    parent_span_id VARCHAR(36),
+    name VARCHAR(255) NOT NULL,
+    kind VARCHAR(20) DEFAULT 'internal',
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP,
+    duration_ms FLOAT,
+    status VARCHAR(20) DEFAULT 'unset',
+    status_message TEXT,
+    attributes JSON,
+    resource_name VARCHAR(255),
+    resource_type VARCHAR(50),
+    resource_id VARCHAR(36),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (trace_id) REFERENCES observability_traces(trace_id),
+    FOREIGN KEY (parent_span_id) REFERENCES observability_spans(span_id)
+);
+```
+
+### Performance Indexes
+
+Optimized for fast queries:
+
+```sql
+-- Trace indexes
+CREATE INDEX idx_observability_traces_start_time ON observability_traces(start_time);
+CREATE INDEX idx_observability_traces_user_email ON observability_traces(user_email);
+CREATE INDEX idx_observability_traces_status ON observability_traces(status);
+CREATE INDEX idx_observability_traces_http_status_code ON observability_traces(http_status_code);
+
+-- Span indexes
+CREATE INDEX idx_observability_spans_trace_id ON observability_spans(trace_id);
+CREATE INDEX idx_observability_spans_parent_span_id ON observability_spans(parent_span_id);
+CREATE INDEX idx_observability_spans_start_time ON observability_spans(start_time);
+CREATE INDEX idx_observability_spans_resource_type ON observability_spans(resource_type);
+CREATE INDEX idx_observability_spans_resource_name ON observability_spans(resource_name);
+```
+
+## REST API
+
+### List Traces
+
+```bash
+GET /observability/traces
+```
+
+Query parameters:
+
+- `start_time`: Filter traces after this timestamp (ISO 8601)
+- `end_time`: Filter traces before this timestamp
+- `min_duration_ms`: Minimum duration in milliseconds
+- `max_duration_ms`: Maximum duration in milliseconds
+- `status`: Filter by status (`ok`, `error`)
+- `http_status_code`: Filter by HTTP status code
+- `http_method`: Filter by HTTP method
+- `user_email`: Filter by user email
+- `limit`: Maximum results (default: 100)
+- `offset`: Result offset (default: 0)
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4444/observability/traces?limit=10&status=error"
+```
+
+### Get Trace Details
+
+```bash
+GET /observability/traces/{trace_id}
+```
+
+Returns complete trace with all spans, events, and metrics.
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4444/observability/traces/550e8400-e29b-41d4-a716-446655440000"
+```
+
+### Query Tool Metrics
+
+```bash
+GET /observability/tools/metrics
+```
+
+Query parameters:
+
+- `time_range`: Time window (`1h`, `24h`, `7d`, `30d`)
+- `limit`: Number of tools to return
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4444/observability/tools/metrics?time_range=24h&limit=20"
+```
+
+### Query Prompt Metrics
+
+```bash
+GET /observability/prompts/metrics
+```
+
+Same parameters as tool metrics.
+
+### Query Resource Metrics
+
+```bash
+GET /observability/resources/metrics
+```
+
+Same parameters as tool metrics.
+
+## Comparison: Internal vs OpenTelemetry
+
+| Feature | Internal Observability | OpenTelemetry |
+|---------|----------------------|---------------|
+| **Storage** | Database (SQLite/PostgreSQL) | External backends (Phoenix, Jaeger, Tempo) |
+| **Setup** | Built-in, zero configuration | Requires external services |
+| **Cost** | Free, self-hosted | Depends on backend (free OSS or paid SaaS) |
+| **Retention** | Configurable in-database | Backend-dependent |
+| **UI** | Admin UI dashboards | Backend-specific UIs |
+| **Performance Impact** | Minimal (database writes) | Minimal (async exports) |
+| **Use Cases** | Development, testing, small deployments | Production, microservices, distributed systems |
+| **Standards** | Custom implementation | OpenTelemetry standard |
+| **Integration** | Self-contained | Integrates with APM ecosystem |
+
+### When to Use Each
+
+**Use Internal Observability when:**
+
+- You want zero external dependencies
+- Database storage is acceptable
+- Admin UI visualization is sufficient
+- Deployment simplicity is a priority
+- You're in development/testing mode
+
+**Use OpenTelemetry when:**
+
+- You need distributed tracing across multiple services
+- You want vendor-agnostic standard
+- You have existing observability infrastructure
+- You need advanced APM features
+- You're in production with high scale
+
+**Use Both when:**
+
+- You want local debugging with external production monitoring
+- You need different retention policies
+- You want redundancy in observability data
+
+## Production Considerations
+
+### Performance Impact
+
+The internal observability system is designed for minimal overhead:
+
+- **Database Writes**: Async, batched when possible
+- **Indexing**: Optimized indexes for fast queries
+- **Sampling**: Reduce load with configurable sample rates
+- **Cleanup**: Automatic retention management
+
+### Scaling Recommendations
+
+For high-volume deployments:
+
+```bash
+# Reduce sampling rate
+OBSERVABILITY_SAMPLE_RATE=0.1  # 10% sampling
+
+# Aggressive retention
+OBSERVABILITY_TRACE_RETENTION_DAYS=3
+
+# Exclude high-frequency paths
+OBSERVABILITY_EXCLUDE_PATHS=["/health.*","/metrics.*","/static/.*"]
+
+# Disable HTTP request tracing (manual traces only)
+OBSERVABILITY_TRACE_HTTP_REQUESTS=false
+```
+
+### Database Considerations
+
+#### SQLite
+
+Suitable for:
+
+- Development and testing
+- Single-instance deployments
+- Low to medium traffic
+
+Limitations:
+
+- Write concurrency limits
+- File-based storage
+
+#### PostgreSQL
+
+Recommended for:
+
+- Production deployments
+- High-volume environments
+- Multi-instance setups
+
+Benefits:
+
+- Superior write concurrency
+- Advanced indexing
+- Better query performance
+
+### Monitoring the Monitor
+
+Track observability system health:
+
+```bash
+# Check trace count
+SELECT COUNT(*) FROM observability_traces;
+
+# Check database size
+SELECT pg_size_pretty(pg_total_relation_size('observability_traces'));
+SELECT pg_size_pretty(pg_total_relation_size('observability_spans'));
+
+# Check oldest trace
+SELECT MIN(start_time) FROM observability_traces;
+
+# Check cleanup effectiveness
+SELECT COUNT(*) FROM observability_traces
+WHERE start_time < NOW() - INTERVAL '7 days';
+```
+
+## Troubleshooting
+
+### No Traces Appearing
+
+1. **Verify observability is enabled**:
+
+   ```bash
+   echo $OBSERVABILITY_ENABLED  # Should be "true"
+   ```
+
+2. **Check sampling rate**:
+
+   ```bash
+   echo $OBSERVABILITY_SAMPLE_RATE  # Should be > 0.0
+   ```
+
+3. **Review included paths**:
+
+   ```bash
+   echo $OBSERVABILITY_INCLUDE_PATHS
+   # Ensure your test path is included
+   ```
+
+4. **Review excluded paths**:
+
+   ```bash
+   echo $OBSERVABILITY_EXCLUDE_PATHS
+   # Ensure your test path is not excluded
+   ```
+
+5. **Check database connection**:
+
+   ```bash
+   # Verify database is accessible
+   mcpgateway db-check
+   ```
+
+6. **Enable debug logging**:
+
+   ```bash
+   export LOG_LEVEL=DEBUG
+   mcpgateway
+   # Look for observability-related log messages
+   ```
+
+### High Database Size
+
+1. **Reduce retention period**:
+
+   ```bash
+   OBSERVABILITY_TRACE_RETENTION_DAYS=3
+   ```
+
+2. **Lower maximum traces**:
+
+   ```bash
+   OBSERVABILITY_MAX_TRACES=10000
+   ```
+
+3. **Increase sampling threshold**:
+
+   ```bash
+   OBSERVABILITY_SAMPLE_RATE=0.1
+   ```
+
+4. **Manually cleanup**:
+
+   ```bash
+   mcpgateway observability cleanup --days 1
+   ```
+
+### Slow Dashboard Loading
+
+1. **Reduce query time range**:
+
+   - Use shorter time windows (1 hour instead of 30 days)
+
+2. **Limit result count**:
+
+   - Query top 10 instead of top 100
+
+3. **Add database indexes** (if custom deployment):
+
+   ```sql
+   CREATE INDEX idx_custom ON observability_spans(resource_type, start_time);
+   ```
+
+4. **Optimize database**:
+
+   ```bash
+   # PostgreSQL
+   VACUUM ANALYZE observability_traces;
+   VACUUM ANALYZE observability_spans;
+
+   # SQLite
+   VACUUM;
+   ```
+
+### Missing Spans or Metrics
+
+1. **Check span creation**:
+
+   - Verify tool/prompt/resource operations are completing
+   - Look for errors in application logs
+
+2. **Verify metrics enabled**:
+
+   ```bash
+   echo $OBSERVABILITY_METRICS_ENABLED  # Should be "true"
+   ```
+
+3. **Check events enabled**:
+
+   ```bash
+   echo $OBSERVABILITY_EVENTS_ENABLED  # Should be "true"
+   ```
+
+## Best Practices
+
+### Development
+
+```bash
+# Full tracing, short retention
+OBSERVABILITY_ENABLED=true
+OBSERVABILITY_SAMPLE_RATE=1.0
+OBSERVABILITY_TRACE_RETENTION_DAYS=1
+OBSERVABILITY_MAX_TRACES=10000
+```
+
+### Staging
+
+```bash
+# Partial tracing, moderate retention
+OBSERVABILITY_ENABLED=true
+OBSERVABILITY_SAMPLE_RATE=0.5
+OBSERVABILITY_TRACE_RETENTION_DAYS=7
+OBSERVABILITY_MAX_TRACES=100000
+```
+
+### Production
+
+```bash
+# Sampled tracing, longer retention
+OBSERVABILITY_ENABLED=true
+OBSERVABILITY_SAMPLE_RATE=0.1
+OBSERVABILITY_TRACE_RETENTION_DAYS=14
+OBSERVABILITY_MAX_TRACES=1000000
+OBSERVABILITY_EXCLUDE_PATHS=["/health.*","/metrics.*"]
+```
+
+## Next Steps
+
+- Review [Configuration Reference](../configuration.md) for all observability settings
+- Explore [OpenTelemetry Integration](opentelemetry.md) for external monitoring
+- Set up [Phoenix Integration](phoenix.md) for AI-specific observability
+- Configure [Prometheus Metrics](prometheus.md) for time-series monitoring
+- Implement [Custom Dashboards](#admin-ui-dashboards) based on your metrics
+
+## Related Documentation
+
+- [Configuration Reference](../configuration.md) - Environment variable configuration
+- [OpenTelemetry Observability](opentelemetry.md) - External tracing backends
+- [Phoenix Integration](phoenix.md) - AI/LLM observability
+- [Langfuse Integration](langfuse.md) - LLM observability and prompt management
+- [Prometheus Metrics](prometheus.md) - Time-series monitoring
+- [Admin UI Documentation](../ui-customization.md) - Customizing the Admin UI
+- [Database Configuration](../configuration.md#database-configuration) - Database setup and tuning

--- a/docs/docs/manage/observability/langfuse.md
+++ b/docs/docs/manage/observability/langfuse.md
@@ -396,7 +396,8 @@ If the gateway exits during startup with a Langfuse credential error:
 
 ## Next Steps
 
-- [OpenTelemetry Overview](observability.md) - All supported backends
+- [OpenTelemetry Overview](opentelemetry.md) - All supported backends
 - [Phoenix Integration](phoenix.md) - Alternative AI observability backend
-- [Internal Observability](internal-observability.md) - Built-in database-backed observability
+- [Internal Observability](internal.md) - Built-in database-backed observability
+- [Prometheus Metrics](prometheus.md) - Time-series monitoring
 - [Langfuse Documentation](https://langfuse.com/docs) - Full Langfuse documentation

--- a/docs/docs/manage/observability/opentelemetry.md
+++ b/docs/docs/manage/observability/opentelemetry.md
@@ -1,0 +1,503 @@
+# Observability
+
+ContextForge includes production-grade OpenTelemetry instrumentation for distributed tracing, enabling you to monitor performance, debug issues, and understand request flows across your gateway instances.
+
+## Overview
+
+The observability implementation is **vendor-agnostic** at the transport/export layer and works with any OTLP-compatible backend. ContextForge also supports optional Langfuse-oriented span enrichment when you point OTLP at a Langfuse ingestion endpoint, or when you explicitly enable that schema with `OTEL_EMIT_LANGFUSE_ATTRIBUTES=true`.
+
+## Recommended Backend Options
+
+### Langfuse - LLM Observability and Analytics
+
+**Best for**: LLM trace visualization, prompt management, evaluations, and cost tracking
+
+[Langfuse](https://langfuse.com) is an open-source LLM observability platform that receives traces via standard OTLP/HTTP. It provides a comprehensive suite of tools for monitoring, evaluating, and improving LLM applications.
+
+**Key Features**:
+
+- **Trace Visualization**: End-to-end request traces with latency breakdown and error analysis
+- **Prompt Management**: Version, test, and deploy prompts with A/B testing
+- **Evaluations**: Score traces with custom or built-in evaluators
+- **Cost Tracking**: Token usage and cost analytics per model and user
+- **Datasets**: Create test datasets from production traces for regression testing
+- **OpenTelemetry Native**: Standard OTLP/HTTP ingestion (v3.22.0+)
+
+**Ideal Use Cases**:
+
+- Monitoring LLM-powered tool invocations and prompt rendering
+- Tracking costs and token usage across gateway operations
+- Building evaluation pipelines for response quality
+- Managing and versioning prompt templates
+
+**Transport**: Uses OTLP over HTTP (gRPC not supported)
+
+See the [Langfuse Integration Guide](langfuse.md) for setup instructions.
+
+### Arize Phoenix - AI/LLM-Focused Observability
+
+**Best for**: AI applications, LLM debugging, and prompt optimization
+
+[Arize Phoenix](https://github.com/Arize-ai/phoenix) is an open-source AI observability platform specifically designed for LLM applications and AI systems. Built on OpenTelemetry, it provides specialized features for understanding AI application behavior.
+
+**Key Features**:
+
+- **LLM Tracing**: Purpose-built for tracking LLM calls, token usage, and model performance
+- **Evaluation Tools**: Built-in evaluators for response quality, retrieval accuracy, and hallucination detection
+- **Prompt Playground**: Interactive environment for optimizing prompts with version control and experimentation
+- **Framework Support**: Native integrations with LlamaIndex, LangChain, Haystack, DSPy, and major LLM providers
+- **Cost Tracking**: Monitor token usage and API costs across different providers
+- **Zero Lock-in**: Fully open source and self-hostable with no feature gates
+
+**Ideal Use Cases**:
+
+- Debugging RAG (Retrieval-Augmented Generation) pipelines
+- Optimizing prompt templates and model parameters
+- Tracking LLM performance metrics and costs
+- Evaluating response quality and accuracy
+
+**Transport**: Uses OTLP (OpenTelemetry Protocol) via gRPC
+
+### Jaeger - Production-Grade Distributed Tracing
+
+**Best for**: Microservices architectures, production deployments, and general-purpose tracing
+
+[Jaeger](https://www.jaegertracing.io/) is a mature, battle-tested distributed tracing platform originally created by Uber and now a CNCF graduated project. It excels at monitoring complex distributed systems.
+
+**Key Features**:
+
+- **Proven Scale**: Handles high-volume production environments with battle-tested reliability
+- **Full Observability**: Comprehensive request flow visualization across microservices
+- **Multiple Storage Backends**: Supports Elasticsearch, Cassandra, and other scalable storage solutions
+- **Kubernetes Native**: Deep integration with cloud-native environments
+- **Advanced Sampling**: Configurable sampling strategies (constant, probabilistic, rate-limiting)
+- **OpenTelemetry Integration**: Full OTLP support in v2 with native OpenTelemetry data model
+
+**Ideal Use Cases**:
+
+- Large-scale microservices deployments
+- Performance bottleneck identification
+- Service dependency mapping
+- Root cause analysis of distributed failures
+
+**Transport**: Supports both native Jaeger protocol and OTLP
+
+### Grafana Tempo - Cost-Efficient High-Scale Tracing
+
+**Best for**: High-volume environments, cost-conscious deployments, and Grafana ecosystem users
+
+[Grafana Tempo](https://grafana.com/oss/tempo/) is a high-scale, low-cost distributed tracing backend that eliminates expensive indexing by leveraging object storage (S3, GCS, Azure Blob).
+
+**Key Features**:
+
+- **Extreme Cost Efficiency**: Uses cheap object storage instead of expensive databases (Elasticsearch/Cassandra)
+- **Massive Scale**: Designed to handle 100% trace capture without prohibitive costs
+- **No Heavy Indexing**: Lightweight bloom filters instead of full-text indexes reduce storage costs dramatically
+- **TraceQL Query Language**: Powerful query language inspired by PromQL and LogQL
+- **Grafana Ecosystem Integration**: Deep integration with Grafana, Prometheus, Loki, and Mimir
+- **Multi-Protocol Support**: Compatible with Jaeger, Zipkin, OpenCensus, and OpenTelemetry
+
+**Ideal Use Cases**:
+
+- High-volume microservices (170k+ spans/second proven in production)
+- Cost-sensitive environments requiring long trace retention
+- Organizations already using Grafana stack
+- Teams wanting 100% trace capture without sampling
+
+**Transport**: Uses OTLP (OpenTelemetry Protocol) via gRPC
+
+### Other Compatible Backends
+
+The OTLP exporter also works with commercial APM solutions:
+
+- **Datadog APM** - Full-featured commercial observability platform
+- **New Relic** - Cloud-based application performance monitoring
+- **Honeycomb** - Observability for production systems
+- **Zipkin** - Lightweight distributed tracing (legacy but widely supported)
+
+## What Gets Traced
+
+- **Tool invocations** - Full lifecycle with arguments, results, and timing
+- **Prompt rendering** - Template processing and message generation
+- **Resource fetching** - URI resolution, caching, and content retrieval
+- **Gateway federation** - Cross-gateway requests and health checks
+- **Plugin execution** - Pre/post hooks if plugins are enabled
+- **Errors and exceptions** - Full stack traces and error context
+
+## Quick Start
+
+### 1. Install Dependencies
+
+The observability packages are included in the Docker containers by default. For local development:
+
+```bash
+# Install base gateway with core observability support
+pip install mcp-contextforge-gateway[observability]
+```
+
+**Important**: Only one exporter backend should be installed at a time - they are mutually exclusive. Install the specific backend package based on your chosen observability platform (see backend-specific instructions in the "Start Your Backend" section below).
+
+### 2. Configure Environment
+
+Set these environment variables (or add to `.env`):
+
+```bash
+# Enable observability (default: false)
+export OTEL_ENABLE_OBSERVABILITY=true
+
+# Service identification
+export OTEL_SERVICE_NAME=mcp-gateway
+export OTEL_SERVICE_VERSION=1.0.0-RC-3
+export OTEL_DEPLOYMENT_ENVIRONMENT=development
+
+# Choose your backend (otlp, jaeger, zipkin, console, none)
+export OTEL_TRACES_EXPORTER=otlp
+
+# OTLP Configuration (for Phoenix, Tempo, etc.)
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_INSECURE=true
+```
+
+### 3. Start Your Backend
+
+Choose your preferred observability backend:
+
+#### Phoenix (AI/LLM Focus)
+
+```bash
+# Install Phoenix exporter backend
+pip install opentelemetry-exporter-otlp-proto-grpc
+
+# Start Phoenix
+docker run -d \
+  --name phoenix \
+  -p 6006:6006 \
+  -p 4317:4317 \
+  arizephoenix/phoenix:latest
+
+# Configure environment
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_SERVICE_NAME=mcp-gateway
+
+# View UI at http://localhost:6006
+```
+
+#### Jaeger
+
+```bash
+# Install Jaeger exporter backend
+pip install opentelemetry-exporter-jaeger
+
+# Start Jaeger
+docker run -d \
+  --name jaeger \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  jaegertracing/all-in-one
+
+# Configure environment
+export OTEL_TRACES_EXPORTER=jaeger
+export OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14268/api/traces
+export OTEL_SERVICE_NAME=mcp-gateway
+
+# View UI at http://localhost:16686
+```
+
+#### Zipkin
+
+```bash
+# Install Zipkin exporter backend
+pip install opentelemetry-exporter-zipkin
+
+# Start Zipkin
+docker run -d \
+  --name zipkin \
+  -p 9411:9411 \
+  openzipkin/zipkin
+
+# Configure environment
+export OTEL_TRACES_EXPORTER=zipkin
+export OTEL_EXPORTER_ZIPKIN_ENDPOINT=http://localhost:9411/api/v2/spans
+export OTEL_SERVICE_NAME=mcp-gateway
+
+# View UI at http://localhost:9411
+```
+
+#### Grafana Tempo
+
+```bash
+# Install OTLP exporter backend (Tempo uses OTLP)
+pip install opentelemetry-exporter-otlp-proto-grpc
+
+# Start Tempo
+docker run -d \
+  --name tempo \
+  -p 4317:4317 \
+  -p 3200:3200 \
+  grafana/tempo:latest
+
+# Configure environment (uses OTLP)
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_SERVICE_NAME=mcp-gateway
+```
+
+#### Console (Development)
+
+```bash
+# For debugging - prints traces to stdout
+export OTEL_TRACES_EXPORTER=console
+export OTEL_SERVICE_NAME=mcp-gateway
+```
+
+### 4. Run ContextForge
+
+```bash
+# Start the gateway (observability is disabled by default)
+mcpgateway
+
+# Or with Docker
+docker run -e OTEL_ENABLE_OBSERVABILITY=true \
+           -e OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317 \
+           ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+```
+
+## Configuration Reference
+
+### Core Settings
+
+| Variable | Description | Default | Options |
+|----------|-------------|---------|---------|
+| `OTEL_ENABLE_OBSERVABILITY` | Master switch | `false` | `true`, `false` |
+| `OTEL_SERVICE_NAME` | Service identifier | `mcp-gateway` | Any string |
+| `OTEL_SERVICE_VERSION` | Service version | `1.0.0-RC-3` | Any string |
+| `DEPLOYMENT_ENV` / `ENVIRONMENT` | Environment tag | `development` | `development`, `staging`, `production` |
+| `OTEL_TRACES_EXPORTER` | Export backend | `otlp` | `otlp`, `jaeger`, `zipkin`, `console`, `none` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Custom attributes | - | `key=value,key2=value2` |
+| `OTEL_COPY_RESOURCE_ATTRS_TO_SPANS` | Copy selected resource attrs onto spans | `false` | `true`, `false` |
+
+### OTLP Configuration
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | - | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Protocol | `grpc` | `grpc`, `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Auth headers | - | `api-key=secret,x-auth=token` | <!-- pragma: allowlist secret -->
+| `LANGFUSE_OTEL_ENDPOINT` | Optional Langfuse OTLP/HTTP endpoint override | - | `https://cloud.langfuse.com/api/public/otel/v1/traces` |
+| `LANGFUSE_PUBLIC_KEY` | Langfuse project public key for derived OTLP auth | - | `pk-lf-...` |
+| `LANGFUSE_SECRET_KEY` | Langfuse project secret key for derived OTLP auth | - | `sk-lf-...` | <!-- pragma: allowlist secret -->
+| `LANGFUSE_OTEL_AUTH` | Optional base64-encoded `pk:sk` auth override | - | base64 string |
+| `OTEL_EXPORTER_OTLP_INSECURE` | Skip TLS verify | `true` | `true`, `false` |
+| `OTEL_EMIT_LANGFUSE_ATTRIBUTES` | Force-enable or disable Langfuse-specific span attributes | auto | `true`, `false` |
+| `OTEL_CAPTURE_IDENTITY_ATTRIBUTES` | Force-enable or disable user/team identity enrichment | auto | `true`, `false` |
+
+### Alternative Backends
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_JAEGER_ENDPOINT` | Jaeger collector | `http://localhost:14268/api/traces` |
+| `OTEL_EXPORTER_JAEGER_USER` | Jaeger collector username | - |
+| `OTEL_EXPORTER_JAEGER_PASSWORD` | Jaeger collector password | - |
+| `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin collector | `http://localhost:9411/api/v2/spans` |
+
+### Payload Capture and Redaction
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_REDACT_FIELDS` | Comma-separated field names redacted from structured trace payloads and free-text error messages | `password,secret,token,...` |
+| `OTEL_MAX_TRACE_PAYLOAD_SIZE` | Maximum serialized trace payload size in characters | `32768` |
+| `OTEL_CAPTURE_INPUT_SPANS` | Comma-separated allowlist of span names that may capture observation input payloads | empty |
+| `OTEL_CAPTURE_OUTPUT_SPANS` | Comma-separated allowlist of span names that may capture observation output payloads | empty |
+
+Input/output capture is allowlist-based. ContextForge does not capture those payloads by default unless the relevant span names are listed. Structured payloads are redacted by field name, and exported string values are also scrubbed for sensitive URLs, `key=value` secret patterns, and embedded `Bearer` / `Basic` credentials. The local Langfuse compose overlay sets a dev-friendly input allowlist for `tool.invoke,prompt.render,llm.proxy,a2a.invoke`; production deployments should decide that list intentionally.
+
+### Performance Tuning
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_TRACES_SAMPLER` | Sampling strategy | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sample rate (0.0-1.0) | `0.1` (10%) |
+| `OTEL_BSP_MAX_QUEUE_SIZE` | Max queued spans | `2048` |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Batch size | `512` |
+| `OTEL_BSP_SCHEDULE_DELAY` | Export interval (ms) | `5000` |
+
+## Understanding Traces
+
+### Span Attributes
+
+Each span includes standard attributes:
+
+- **Operation name** - e.g., `tool.invoke`, `prompt.render`, `resource.read`
+- **Service info** - Service name, version, environment
+- **User context** - User ID, tenant ID, request ID
+- **Timing** - Start time, duration, end time
+- **Status** - Success/error status with error details
+
+### Tool Invocation Spans
+
+```json
+{
+  "name": "tool.invoke",
+  "attributes": {
+    "tool.name": "github_search",
+    "tool.id": "550e8400-e29b-41d4-a716",
+    "tool.integration_type": "REST",
+    "arguments_count": 3,
+    "success": true,
+    "duration.ms": 234.5,
+    "http.status_code": 200
+  }
+}
+```
+
+### Error Tracking
+
+Failed operations include:
+
+- `error`: `true`
+- `error.type`: Exception class name
+- `error.message`: Error description
+- Sanitized exception event metadata (`exception.type`, `exception.message`)
+
+## Production Deployment
+
+### Docker Compose
+
+Use the provided compose files:
+
+```bash
+# Start ContextForge with Phoenix observability
+docker-compose -f docker-compose.yml \
+               -f docker-compose.with-phoenix.yml up -d
+```
+
+### Kubernetes
+
+Add environment variables to your deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-gateway
+spec:
+  template:
+    spec:
+      containers:
+
+      - name: gateway
+        image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+        env:
+
+        - name: OTEL_ENABLE_OBSERVABILITY
+          value: "true"
+
+        - name: OTEL_TRACES_EXPORTER
+          value: "otlp"
+
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otel-collector:4317"
+
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/name']
+```
+
+### Sampling Strategies
+
+For production, adjust sampling to balance visibility and performance:
+
+```bash
+# Sample 1% of traces
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.01
+
+# Always sample errors (coming in future update)
+# export OTEL_TRACES_SAMPLER=parentbased_always_on_errors
+```
+
+## Testing Your Setup
+
+### Generate Test Traces
+
+Use the trace generator helper to verify your observability backend is working:
+
+```bash
+# Activate virtual environment if needed
+. .venv/bin/activate
+
+# Run the trace generator
+python tests/integration/helpers/trace_generator.py
+```
+
+This will send sample traces for:
+
+- Tool invocations
+- Prompt rendering
+- Resource fetching
+- Gateway federation
+- Complex workflows with nested spans
+
+## Troubleshooting
+
+### No Traces Appearing
+
+1. Check observability is enabled:
+
+   ```bash
+   echo $OTEL_ENABLE_OBSERVABILITY  # Should be "true"
+   ```
+
+2. Verify endpoint is reachable:
+
+   ```bash
+   curl -v http://localhost:4317  # Should connect
+   ```
+
+3. Use console exporter for debugging:
+
+   ```bash
+   export OTEL_TRACES_EXPORTER=console
+   mcpgateway  # Traces will print to stdout
+   ```
+
+### High Memory Usage
+
+Reduce batch size and queue limits:
+
+```bash
+export OTEL_BSP_MAX_QUEUE_SIZE=512
+export OTEL_BSP_MAX_EXPORT_BATCH_SIZE=128
+```
+
+### Missing Spans
+
+Check sampling rate:
+
+```bash
+# Temporarily disable sampling
+export OTEL_TRACES_SAMPLER=always_on
+```
+
+## Performance Impact
+
+- **When disabled**: Zero overhead (no-op context managers)
+- **When enabled**: ~0.1-0.5ms per span
+- **Memory**: ~50MB for typical workload
+- **Network**: Batched exports every 5 seconds
+
+## Next Steps
+
+- [Phoenix Integration](phoenix.md) - AI/LLM-focused observability
+- [Langfuse Integration](langfuse.md) - LLM observability and prompt management
+- [Internal Observability](internal.md) - Built-in database-backed tracing
+- [Prometheus Metrics](prometheus.md) - Time-series monitoring
+
+## Related Documentation
+
+- [OTEL Span Attributes](../../architecture/otel-span-attributes.md) - Complete span attributes reference
+- [OpenTelemetry Architecture](../../architecture/observability-otel.md) - Technical implementation details
+- [OpenTelemetry Best Practices](https://opentelemetry.io/docs/best-practices/) - Official OTEL documentation

--- a/docs/docs/manage/observability/phoenix.md
+++ b/docs/docs/manage/observability/phoenix.md
@@ -366,6 +366,10 @@ Phoenix stores traces in memory by default. For production:
 
 ## Next Steps
 
+- [OpenTelemetry Overview](opentelemetry.md) - All supported backends
+- [Langfuse Integration](langfuse.md) - Alternative LLM observability platform
+- [Internal Observability](internal.md) - Built-in database-backed observability
+- [Prometheus Metrics](prometheus.md) - Time-series monitoring
 - [Configure Phoenix Evaluations](https://docs.arize.com/phoenix/evaluation)
 - [Set up Phoenix Datasets](https://docs.arize.com/phoenix/datasets)
 - [Integrate with Arize Platform](https://docs.arize.com/arize)

--- a/docs/docs/manage/observability/prometheus.md
+++ b/docs/docs/manage/observability/prometheus.md
@@ -1,0 +1,491 @@
+# Prometheus Metrics
+
+ContextForge exposes Prometheus metrics for monitoring gateway performance, request rates, error rates, and latency distributions.
+
+## Overview
+
+The Prometheus metrics endpoint provides:
+
+- **Request metrics** - HTTP request counts, rates, and status codes
+- **Latency metrics** - Request duration histograms with percentiles
+- **Error tracking** - Error rates and types
+- **Custom labels** - Static labels for environment identification
+- **Gzip compression** - Reduced network usage for large metric sets
+
+## Quick Start
+
+### 1. Enable Metrics
+
+```bash
+# Enable Prometheus metrics endpoint
+export ENABLE_METRICS=true
+
+# Optional: Add custom labels (low-cardinality only)
+export METRICS_CUSTOM_LABELS="env=production,region=us-east-1"
+
+# Optional: Exclude high-frequency paths
+export METRICS_EXCLUDED_HANDLERS="/servers/.*/sse,/static/.*"
+```
+
+### 2. Generate Scrape Token
+
+Create a non-expiring JWT token for Prometheus to authenticate:
+
+```bash
+export METRICS_TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
+  --username prometheus@monitoring \
+  --exp 0 \
+  --secret $JWT_SECRET_KEY \
+  --algo HS256)
+
+# Save to file for Prometheus
+echo -n "$METRICS_TOKEN" > /path/to/metrics-token.jwt
+```
+
+### 3. Start ContextForge
+
+```bash
+mcpgateway
+```
+
+The metrics endpoint will be available at:
+
+```
+http://localhost:4444/metrics/prometheus
+```
+
+### 4. Verify Metrics
+
+```bash
+# Test the endpoint
+curl -sS -H "Authorization: Bearer $METRICS_TOKEN" \
+  http://localhost:4444/metrics/prometheus | head -n 20
+```
+
+## Prometheus Configuration
+
+### Scrape Job
+
+Add this job to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'mcp-gateway'
+    metrics_path: /metrics/prometheus
+    authorization:
+      type: Bearer
+      credentials_file: /path/to/metrics-token.jwt
+    static_configs:
+      - targets: ['localhost:4444']
+```
+
+### Docker Compose
+
+If Prometheus runs in Docker, adjust the target:
+
+```yaml
+scrape_configs:
+  - job_name: 'mcp-gateway'
+    metrics_path: /metrics/prometheus
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/metrics-token.jwt
+    static_configs:
+      - targets: ['gateway:4444']  # Use service name
+```
+
+Mount the token file:
+
+```yaml
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./metrics-token.jwt:/etc/prometheus/metrics-token.jwt:ro
+```
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Description | Default | Options |
+|----------|-------------|---------|---------|
+| `ENABLE_METRICS` | Enable Prometheus endpoint | `false` | `true`, `false` |
+| `METRICS_EXCLUDED_HANDLERS` | Regex patterns to exclude | (empty) | comma-separated |
+| `METRICS_NAMESPACE` | Metrics namespace prefix | `default` | string |
+| `METRICS_SUBSYSTEM` | Metrics subsystem prefix | (empty) | string |
+| `METRICS_CUSTOM_LABELS` | Static labels for app_info | (empty) | `key=value,...` |
+
+### Excluded Handlers
+
+Exclude high-frequency or high-cardinality paths:
+
+```bash
+# Exclude SSE streams and static assets
+METRICS_EXCLUDED_HANDLERS="/servers/.*/sse,/static/.*,/health.*"
+```
+
+Patterns are compiled as regular expressions and matched against request paths.
+
+### Custom Labels
+
+Add static labels to the `app_info` gauge:
+
+```bash
+# Low-cardinality labels only
+METRICS_CUSTOM_LABELS="env=production,region=us-east-1,team=platform"
+```
+
+**Warning**: Never use high-cardinality values (user IDs, request IDs, timestamps) as labels.
+
+## Available Metrics
+
+### Request Metrics
+
+```
+# Total HTTP requests
+http_requests_total{method="POST",handler="/tools/invoke",status="200"}
+
+# Request rate (requests per second)
+rate(http_requests_total[1m])
+```
+
+### Latency Metrics
+
+```
+# Request duration histogram
+http_request_duration_seconds_bucket{le="0.1"}
+http_request_duration_seconds_bucket{le="0.5"}
+http_request_duration_seconds_bucket{le="1.0"}
+
+# P50 latency
+histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))
+
+# P95 latency
+histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))
+
+# P99 latency
+histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))
+```
+
+### Error Metrics
+
+```
+# Error rate (5xx responses)
+rate(http_requests_total{status=~"5.."}[5m])
+
+# Error percentage
+sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) * 100
+```
+
+### Application Info
+
+```
+# Application metadata
+app_info{env="production",region="us-east-1",version="1.0.0"}
+```
+
+## Grafana Dashboards
+
+### Example Queries
+
+**Request Rate**:
+```promql
+rate(http_requests_total[1m])
+```
+
+**Error Rate**:
+```promql
+rate(http_requests_total{status=~"5.."}[5m])
+```
+
+**P99 Latency**:
+```promql
+histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))
+```
+
+**Success Rate**:
+```promql
+sum(rate(http_requests_total{status=~"2.."}[5m])) / sum(rate(http_requests_total[5m])) * 100
+```
+
+### Dashboard Panels
+
+Create panels for:
+
+1. **Request Rate** - Line graph of requests per second
+2. **Error Rate** - Line graph of 5xx errors per second
+3. **Latency Percentiles** - Multi-line graph (P50, P95, P99)
+4. **Status Code Distribution** - Pie chart or bar graph
+5. **Top Endpoints** - Table sorted by request count
+
+### Import Dashboards
+
+Use community dashboards for common components:
+
+- **Kubernetes**: Dashboard ID 315
+- **PostgreSQL**: Dashboard ID 9628
+- **Redis**: Dashboard ID 11835
+
+## Production Deployment
+
+### Kubernetes
+
+Deploy Prometheus with the gateway:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-token
+type: Opaque
+stringData:
+  token: <base64-encoded-jwt>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    scrape_configs:
+      - job_name: 'mcp-gateway'
+        metrics_path: /metrics/prometheus
+        authorization:
+          type: Bearer
+          credentials: <token-from-secret>  # pragma: allowlist secret
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - mcp-gateway
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: mcp-gateway
+```
+
+### High Availability
+
+For HA deployments:
+
+1. **Multiple Prometheus instances** - Scrape all gateway replicas
+2. **Federation** - Aggregate metrics from multiple Prometheus servers
+3. **Remote Write** - Send metrics to long-term storage (Thanos, Cortex)
+
+### Retention
+
+Configure Prometheus retention:
+
+```yaml
+# prometheus.yml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+# Command line flags
+--storage.tsdb.retention.time=30d
+--storage.tsdb.retention.size=50GB
+```
+
+## Security Best Practices
+
+### Token Management
+
+1. **Non-expiring tokens** - Use `--exp 0` for service accounts
+2. **Rotate regularly** - Update tokens quarterly
+3. **Restrict permissions** - Token only needs read access
+4. **Secure storage** - Store tokens in secrets management
+
+### Network Security
+
+1. **Internal network** - Keep Prometheus on private network
+2. **Firewall rules** - Restrict access to metrics endpoint
+3. **TLS** - Use HTTPS for production deployments
+4. **Authentication** - Always require JWT authentication
+
+## Performance Considerations
+
+### High-Cardinality Labels
+
+**Never use** high-cardinality values as labels:
+
+```bash
+# BAD - Explodes time series
+http_requests_total{user_id="12345",request_id="abc-123"}
+
+# GOOD - Low cardinality
+http_requests_total{method="POST",status="200"}
+```
+
+High-cardinality labels can:
+- Crash Prometheus with OOM errors
+- Slow down queries significantly
+- Increase storage requirements exponentially
+
+### Compression
+
+The metrics endpoint supports gzip compression:
+
+```bash
+# Prometheus automatically uses compression
+curl -H "Accept-Encoding: gzip" \
+     -H "Authorization: Bearer $TOKEN" \
+     http://localhost:4444/metrics/prometheus
+```
+
+**Trade-off**: Compression reduces network usage but increases CPU on scrape.
+
+### Scrape Interval
+
+Balance freshness vs. load:
+
+```yaml
+# High frequency (more load)
+scrape_interval: 5s
+
+# Standard (recommended)
+scrape_interval: 15s
+
+# Low frequency (less load)
+scrape_interval: 30s
+```
+
+### Excluded Handlers
+
+Reduce metric cardinality by excluding paths:
+
+```bash
+# Exclude high-frequency endpoints
+METRICS_EXCLUDED_HANDLERS="/health,/healthz,/ready,/metrics,/static/.*"
+```
+
+## Troubleshooting
+
+### No Metrics Appearing
+
+1. **Check metrics are enabled**:
+   ```bash
+   echo $ENABLE_METRICS  # Should be "true"
+   ```
+
+2. **Verify endpoint is accessible**:
+   ```bash
+   curl -v http://localhost:4444/metrics/prometheus
+   # Should return 401 without token
+   ```
+
+3. **Test with token**:
+   ```bash
+   curl -H "Authorization: Bearer $METRICS_TOKEN" \
+     http://localhost:4444/metrics/prometheus
+   ```
+
+4. **Check gateway logs**:
+   ```bash
+   docker logs mcpgateway | grep -i metrics
+   ```
+
+### Metrics Disabled Response
+
+If metrics are disabled, the endpoint returns:
+
+```json
+{
+  "detail": "Metrics endpoint is disabled. Set ENABLE_METRICS=true to enable."
+}
+```
+
+Status code: 503 Service Unavailable
+
+### Authentication Errors
+
+```json
+{
+  "detail": "Not authenticated"
+}
+```
+
+**Solutions**:
+1. Verify token is valid: `python -m mcpgateway.utils.verify_jwt_token --token $METRICS_TOKEN`
+2. Check token hasn't expired
+3. Ensure `JWT_SECRET_KEY` matches between token generation and gateway
+
+### High Memory Usage
+
+If Prometheus uses excessive memory:
+
+1. **Reduce retention**: `--storage.tsdb.retention.time=7d`
+2. **Increase scrape interval**: `scrape_interval: 30s`
+3. **Exclude high-cardinality paths**: `METRICS_EXCLUDED_HANDLERS`
+4. **Review custom labels**: Remove high-cardinality labels
+
+### Duplicate Collectors
+
+Error: "Collector already registered"
+
+**Cause**: Instrumentation registered multiple times (tests, reloads)
+
+**Solution**: Restart the gateway process or clear the registry in test fixtures
+
+## Integration with Other Systems
+
+### Datadog
+
+Forward Prometheus metrics to Datadog:
+
+```yaml
+# datadog-agent.yaml
+prometheus_scrape:
+  enabled: true
+  configs:
+    - configurations:
+        - url: http://gateway:4444/metrics/prometheus
+          headers:
+            Authorization: Bearer <token>
+```
+
+### New Relic
+
+Use the Prometheus OpenMetrics integration:
+
+```yaml
+# newrelic-infrastructure.yml
+integrations:
+  - name: nri-prometheus
+    config:
+      urls:
+        - http://gateway:4444/metrics/prometheus
+      bearer_token: <token>
+```
+
+### Splunk
+
+Use the Splunk OpenTelemetry Collector:
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'mcp-gateway'
+          authorization:
+            type: Bearer
+            credentials: <token>  # pragma: allowlist secret
+          static_configs:
+            - targets: ['gateway:4444']
+```
+
+## Next Steps
+
+- [Internal Observability](internal.md) - Built-in database-backed tracing
+- [OpenTelemetry](opentelemetry.md) - Distributed tracing with OTLP
+- [Grafana Setup](../scale.md#grafana-dashboards) - Dashboard configuration
+
+## Related Documentation
+
+- [Configuration Reference](../configuration.md#prometheus-metrics) - All metrics settings
+- [Scaling Guide](../scale.md) - Production deployment patterns
+- [Security Features](../../architecture/security-features.md) - Authentication and authorization


### PR DESCRIPTION
## Summary

Restructures the observability documentation to improve clarity, eliminate duplication, and use neutral language that describes capabilities rather than prescribing choices.

## Changes

### New Files
- **** - Comprehensive Prometheus metrics guide (extracted from landing page)
- **** - Span attributes reference (moved from repository root)

### Renamed Files
-  →  (clearer naming)
-  →  (shorter, clearer)

### Updated Files
- **** - Rewritten landing page with neutral language and comparison matrix
- **** - Updated navigation structure
- **Cross-references** - Fixed all broken links in langfuse.md, phoenix.md, and architecture docs

## Key Improvements

1. **Eliminated Duplication** - Prometheus content extracted to dedicated file
2. **Neutral Language** - Removed prescriptive terms like "Perfect for", "Ideal for", "Essential for"
3. **Factual Descriptions** - Changed from "Use When" to "Characteristics" and "Common Use Cases"
4. **Better Organization** - Clear separation between user guides (manage/) and technical docs (architecture/)
5. **Complete Cross-References** - All documentation properly linked

## Documentation Structure

```
docs/docs/
├── manage/
│   ├── observability.md (landing page)
│   └── observability/
│       ├── opentelemetry.md (external backends)
│       ├── internal.md (built-in tracing)
│       ├── prometheus.md (NEW - metrics)
│       ├── langfuse.md (LLM observability)
│       └── phoenix.md (AI/LLM observability)
└── architecture/
    ├── observability-otel.md (OTEL architecture)
    └── otel-span-attributes.md (NEW - span reference)
```

## Testing

- [x] Documentation builds successfully with make: Nothing to be done for `build'.
- [x] All cross-references verified
- [x] Navigation structure updated
- [x] No broken links

Closes #4245