### PR TITLE
Fix/Process content if the structuredContent are null

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-16T07:17:13Z",
+  "generated_at": "2026-04-16T16:00:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/plugins/output_length_guard/output_length_guard.py
+++ b/plugins/output_length_guard/output_length_guard.py
@@ -244,11 +244,11 @@ class OutputLengthGuardPlugin(Plugin):
         cfg = self._cfg
         policy = self._policy
 
-        # PRIORITY CHECK: Process structuredContent first if present
+        # PRIORITY CHECK: Process structuredContent first if present (and not None/null)
         struct_key = None
-        if "structuredContent" in result:
+        if "structuredContent" in result and result["structuredContent"] is not None:
             struct_key = "structuredContent"
-        elif "structured_content" in result:
+        elif "structured_content" in result and result["structured_content"] is not None:
             struct_key = "structured_content"
 
         if struct_key:

--- a/tests/unit/plugins/test_output_length_guard.py
+++ b/tests/unit/plugins/test_output_length_guard.py
@@ -2019,9 +2019,37 @@ class TestPluginIntegration(BaseOutputLengthGuardTest):
         expected = '["sff","dffd"]'
         self.assertEqual(content_text, expected)
 
-        # Should NOT be truncated to 10 chars
-        self.assertEqual(len(content_text), len(expected))
-        self.assertGreater(len(content_text), 10)
+    def test_null_structured_content_processes_content_array(self):
+        """Test that structuredContent: null allows content array processing (Issue #20 fix).
+
+        This verifies the bug fix where structuredContent: null was causing the plugin
+        to skip content array processing entirely.
+
+        Before fix: Plugin would check 'if "structuredContent" in result' which was True,
+        then try to process None, fail, and return early without processing content array.
+
+        After fix: Plugin checks 'if "structuredContent" in result and
+        result["structuredContent"] is not None' which correctly skips the structured
+        content branch and processes the content array.
+        """
+        payload = Mock()
+        payload.name = "echo"
+        payload.result = {
+            'content': [{'type': 'text', 'text': 'asdiusahdi shidasdhsd hosahdosadoas dasodasod asd asooasdoasdsh'}],
+            'isError': False,
+            'structuredContent': None  # <-- Bug case: null should not block content processing
+        }
+
+        result = asyncio.run(self.plugin.tool_post_invoke(payload, self.mock_context))
+
+        # Verify content was truncated
+        self.assertIsNotNone(result.modified_payload, "Plugin should modify payload when structuredContent is null")
+        modified_result = result.modified_payload.result
+        content_text = modified_result['content'][0]['text']
+
+        # Should be truncated to 10 chars (max_chars=10)
+        self.assertEqual(len(content_text), 10, f"Expected 10 chars, got {len(content_text)}: '{content_text}'")
+        self.assertEqual(content_text, "asdiusa...", f"Expected 'asdiusa...', got '{content_text}'")
 
 
 class TestTokenModeIntegration(BaseOutputLengthGuardTest):


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Fix OutputLengthGuard plugin null structuredContent handling

## 🔗 Related Issue
Closes #4248

---

## 📝 Summary

Fixed a bug in the OutputLengthGuard plugin where tool output was not being truncated when `structuredContent` was explicitly set to `null`. The plugin was checking for key presence but not validating the value, causing it to enter the structured content processing branch with a null value and skip content array processing entirely.

**Changes:**
- Added null check to `structuredContent` key validation in `output_length_guard.py` (lines 249-254)
- Added regression test `test_null_structured_content_processes_content_array()` to verify the fix

**Impact:**
- Tools returning `structuredContent: null` now correctly have their `content` array truncated
- Fixes the exact scenario reported in issue #4248 (63 chars → 10 chars truncation)

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅     |
| Unit tests                | `make test`     | ✅ 315 passed, 1 skipped in 0.74s |
| Coverage ≥ 80%            | `make coverage` | ✅     |

**Test Coverage:**
- New test added: `test_null_structured_content_processes_content_array()`
- All existing tests continue to pass
- Verifies exact scenario from issue #4248

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] DCO sign-off included in commits

---

## 📓 Notes

### Root Cause
The plugin's logic checked for the presence of the `structuredContent` key but didn't validate whether the value was `null`:

```python
# Before (buggy):
if "structuredContent" in result:
    struct_key = "structuredContent"

# After (fixed):
if "structuredContent" in result and result["structuredContent"] is not None:
    struct_key = "structuredContent"
```

When tools returned `{"structuredContent": null, "content": [...]}`, the plugin would:
1. Detect the `structuredContent` key exists
2. Enter the structured content processing branch
3. Fail to process the null value
4. Skip content array processing entirely

### Testing
The new test verifies the exact scenario from issue #4248:
- Tool returns `structuredContent: null` with a 63-character content array
- Plugin configured with `max_output_length: 10`
- Expected: Content truncated to 10 characters
- Result: ✅ Content correctly truncated

### Next Steps for Verification
1. Restart the gateway to load the fixed plugin code
2. Test with the echo tool - output should now truncate to 10 characters
3. Verify in logs: "Plugin OutputLengthGuardPlugin executed successfully"
