### PR TITLE
fix(oauth): parse form-encoded responses in `refresh_token()`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-16T20:31:39Z",
+  "generated_at": "2026-04-16T23:14:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8404,7 +8404,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 458,
+        "line_number": 500,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8412,7 +8412,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 535,
+        "line_number": 576,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8420,7 +8420,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 538,
+        "line_number": 579,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-16T23:14:39Z",
+  "generated_at": "2026-04-17T07:05:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5192,7 +5192,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5200,7 +5200,7 @@
         "hashed_secret": "819ef87051ee2837fefbb462d846b8d282d3b756",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 108,
+        "line_number": 109,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8388,7 +8388,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 399,
+        "line_number": 372,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8396,7 +8396,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 419,
+        "line_number": 391,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8404,7 +8404,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 500,
+        "line_number": 640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8412,7 +8412,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 716,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8420,7 +8420,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 579,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -1326,7 +1326,25 @@ class OAuthManager:
                 client = await self._get_client()
                 response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 if response.status_code == 200:
-                    token_response = response.json()
+                    # Handle both JSON and form-encoded responses
+                    content_type = response.headers.get("content-type", "")
+                    if "application/x-www-form-urlencoded" in content_type:
+                        # Parse form-encoded response
+                        text_response = response.text
+                        token_response = {}
+                        for pair in text_response.split("&"):
+                            if "=" in pair:
+                                key, value = pair.split("=", 1)
+                                token_response[key] = value
+                    else:
+                        # Try JSON response
+                        try:
+                            token_response = response.json()
+                        except Exception as e:
+                            logger.warning(f"Failed to parse JSON response: {e}")
+                            # Fallback to text parsing
+                            text_response = response.text
+                            token_response = {"raw_response": text_response}
 
                     # Validate required fields
                     if "access_token" not in token_response:

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -17,9 +17,10 @@ import base64
 from datetime import datetime, timedelta, timezone
 import hashlib
 import logging
+import re
 import secrets
 from typing import Any, Dict, Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse
 
 # Third-Party
 import httpx
@@ -236,6 +237,142 @@ class OAuthManager:
             logger.warning("Failed to prepare runtime OAuth credentials for %s flow: %s", flow_name, exc)
         return credentials
 
+    # Keys whose values must never be echoed in error messages or logs.
+    _SENSITIVE_TOKEN_KEYS = frozenset({"access_token", "refresh_token", "id_token", "client_secret", "password"})
+
+    # Cap on raw_response excerpts and any other string values surfaced via
+    # OAuthError / logs (defense-in-depth against unbounded provider bodies).
+    _MAX_RAW_RESPONSE_LEN = 256
+
+    # OAuth parameter names per RFC 6749 are token-shaped (alphanumerics plus
+    # a few separators). A parsed key outside this shape means parse_qsl picked
+    # garbage out of an HTML body (e.g. <meta charset="utf-8">).
+    _OAUTH_KEY_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+
+    # Scrub URL/form-style ``key=value`` leaks inside arbitrary strings so that
+    # secrets embedded in HTML error pages or stack traces don't survive the
+    # length cap (the value can fit entirely inside the truncation window).
+    _LEAKY_PARAM_RE = re.compile(
+        r"(?i)\b(access_token|refresh_token|id_token|token|code|secret|key|password|api[_-]?key)=[^&\s\"'<>]+",
+    )
+
+    @staticmethod
+    def _safe_response_text(response: httpx.Response) -> str:
+        """Return ``response.text`` or a placeholder if the body is undecodable.
+
+        ``httpx.Response.text`` raises ``UnicodeDecodeError`` (or ``LookupError``
+        for an unknown charset) when the body bytes don't match the declared
+        encoding. The caller wants a string for diagnostics, not a crash.
+
+        Args:
+            response: HTTP response whose body we want as text.
+
+        Returns:
+            Decoded body, or a ``"<undecodable body, N bytes>"`` placeholder.
+        """
+        try:
+            return response.text
+        except (ValueError, LookupError):
+            return f"<undecodable body, {len(response.content)} bytes>"
+
+    @staticmethod
+    def _parse_token_response(response: httpx.Response) -> Dict[str, Any]:
+        """Parse an OAuth token response that may be JSON or form-encoded.
+
+        Per RFC 7231 §3.1.1.1, media type tokens are case-insensitive.
+        Form-encoded values are URL-decoded via ``urllib.parse.parse_qsl``.
+        Failures fall back to ``{"raw_response": <text>}`` so operators see
+        what the provider actually sent, in three cases: a JSON parse error
+        (``ValueError`` covering ``json.JSONDecodeError`` and
+        ``UnicodeDecodeError``), ``parse_qsl`` returning ``{}`` from a
+        non-empty body (e.g. an HTML error page served with a form-encoded
+        content-type), and ``response.text`` failing to decode the body
+        bytes.
+
+        Args:
+            response: HTTP response from the token endpoint.
+
+        Returns:
+            Parsed token payload, or ``{"raw_response": <text>}`` when the
+            body is neither valid JSON nor parseable as form-encoded.
+        """
+        raw_content_type = response.headers.get("content-type", "")
+        content_type = raw_content_type.lower()
+
+        if "application/x-www-form-urlencoded" in content_type:
+            text = OAuthManager._safe_response_text(response)
+            # parse_qsl drops malformed pairs (no "="); we deliberately do not
+            # set keep_blank_values=True so that garbage like an HTML error page
+            # parses to {} and falls through to the raw_response capture below.
+            parsed = dict(parse_qsl(text))
+            # An HTML body that happens to contain "=" (e.g. <meta charset="utf-8">)
+            # parses to a non-empty dict with garbage keys. Reject anything whose
+            # keys aren't OAuth parameter shaped so the leak is bounded by the
+            # raw_response truncation in _redact_token_response.
+            if parsed and not all(OAuthManager._OAUTH_KEY_RE.match(k) for k in parsed):
+                return {"raw_response": text}
+            if not parsed and text:
+                return {"raw_response": text}
+            return parsed
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            # ValueError covers json.JSONDecodeError (malformed JSON) and
+            # UnicodeDecodeError (bad charset). Narrower than bare Exception,
+            # which would swallow httpx.ResponseNotRead, MemoryError, etc.
+            text = OAuthManager._safe_response_text(response)
+            logger.warning(
+                "Failed to parse OAuth token response as JSON: %s (status=%s, content-type=%r, body_bytes=%d)",
+                exc,
+                response.status_code,
+                raw_content_type,
+                len(response.content),
+                exc_info=True,
+            )
+            return {"raw_response": text}
+
+    @staticmethod
+    def _redact_token_response(token_response: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a log/error-safe copy of a token response.
+
+        Three layers of protection so that misbehaving providers, HTML error
+        pages, and verbose stack traces don't leak secrets via OAuthError or
+        log lines:
+
+        1. Replace values for known credential-bearing keys with
+           ``"[REDACTED]"``.
+        2. Scrub URL/form-style ``<key>=<secret>`` patterns inside any string
+           value (HTML hrefs, form actions, stack traces).
+        3. Cap any string value at ``_MAX_RAW_RESPONSE_LEN`` chars with a
+           ``... [truncated, N chars total]`` marker.
+
+        Args:
+            token_response: Parsed token payload (possibly containing tokens
+                or a captured raw body).
+
+        Returns:
+            New dict safe to interpolate into log lines and exception messages.
+        """
+        cap = OAuthManager._MAX_RAW_RESPONSE_LEN
+        redacted: Dict[str, Any] = {}
+        for key, value in token_response.items():
+            if key in OAuthManager._SENSITIVE_TOKEN_KEYS:
+                redacted[key] = "[REDACTED]"
+                continue
+            if isinstance(value, str):
+                # Scrub URL/form-style "<key>=<secret>" patterns first (HTML
+                # bodies often carry tokens in href / form action attributes
+                # that fit entirely inside the truncation window), then cap.
+                scrubbed = OAuthManager._LEAKY_PARAM_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", value)
+                if len(scrubbed) > cap:
+                    redacted[key] = f"{scrubbed[:cap]}... [truncated, {len(value)} chars total]"
+                else:
+                    redacted[key] = scrubbed
+            else:
+                redacted[key] = value
+        return redacted
+
     async def _client_credentials_flow(self, credentials: Dict[str, Any]) -> str:
         """Machine-to-machine authentication using client credentials.
 
@@ -271,28 +408,10 @@ class OAuthManager:
                 response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
-                # GitHub returns form-encoded responses, not JSON
-                content_type = response.headers.get("content-type", "")
-                if "application/x-www-form-urlencoded" in content_type:
-                    # Parse form-encoded response
-                    text_response = response.text
-                    token_response = {}
-                    for pair in text_response.split("&"):
-                        if "=" in pair:
-                            key, value = pair.split("=", 1)
-                            token_response[key] = value
-                else:
-                    # Try JSON response
-                    try:
-                        token_response = response.json()
-                    except Exception as e:
-                        logger.warning(f"Failed to parse JSON response: {e}")
-                        # Fallback to text parsing
-                        text_response = response.text
-                        token_response = {"raw_response": text_response}
+                token_response = self._parse_token_response(response)
 
                 if "access_token" not in token_response:
-                    raise OAuthError(f"No access_token in response: {token_response}")
+                    raise OAuthError(f"No access_token in response: {self._redact_token_response(token_response)}")
 
                 logger.info("""Successfully obtained access token via client credentials""")
                 return token_response["access_token"]
@@ -357,28 +476,10 @@ class OAuthManager:
                 response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
-                # Handle both JSON and form-encoded responses
-                content_type = response.headers.get("content-type", "")
-                if "application/x-www-form-urlencoded" in content_type:
-                    # Parse form-encoded response
-                    text_response = response.text
-                    token_response = {}
-                    for pair in text_response.split("&"):
-                        if "=" in pair:
-                            key, value = pair.split("=", 1)
-                            token_response[key] = value
-                else:
-                    # Try JSON response
-                    try:
-                        token_response = response.json()
-                    except Exception as e:
-                        logger.warning(f"Failed to parse JSON response: {e}")
-                        # Fallback to text parsing
-                        text_response = response.text
-                        token_response = {"raw_response": text_response}
+                token_response = self._parse_token_response(response)
 
                 if "access_token" not in token_response:
-                    raise OAuthError(f"No access_token in response: {token_response}")
+                    raise OAuthError(f"No access_token in response: {self._redact_token_response(token_response)}")
 
                 logger.info("Successfully obtained access token via password grant")
                 return token_response["access_token"]
@@ -455,28 +556,10 @@ class OAuthManager:
                 response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
-                # GitHub returns form-encoded responses, not JSON
-                content_type = response.headers.get("content-type", "")
-                if "application/x-www-form-urlencoded" in content_type:
-                    # Parse form-encoded response
-                    text_response = response.text
-                    token_response = {}
-                    for pair in text_response.split("&"):
-                        if "=" in pair:
-                            key, value = pair.split("=", 1)
-                            token_response[key] = value
-                else:
-                    # Try JSON response
-                    try:
-                        token_response = response.json()
-                    except Exception as e:
-                        logger.warning(f"Failed to parse JSON response: {e}")
-                        # Fallback to text parsing
-                        text_response = response.text
-                        token_response = {"raw_response": text_response}
+                token_response = self._parse_token_response(response)
 
                 if "access_token" not in token_response:
-                    raise OAuthError(f"No access_token in response: {token_response}")
+                    raise OAuthError(f"No access_token in response: {self._redact_token_response(token_response)}")
 
                 logger.info("""Successfully exchanged authorization code for access token""")
                 return token_response["access_token"]
@@ -1232,28 +1315,10 @@ class OAuthManager:
                 response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 response.raise_for_status()
 
-                # GitHub returns form-encoded responses, not JSON
-                content_type = response.headers.get("content-type", "")
-                if "application/x-www-form-urlencoded" in content_type:
-                    # Parse form-encoded response
-                    text_response = response.text
-                    token_response = {}
-                    for pair in text_response.split("&"):
-                        if "=" in pair:
-                            key, value = pair.split("=", 1)
-                            token_response[key] = value
-                else:
-                    # Try JSON response
-                    try:
-                        token_response = response.json()
-                    except Exception as e:
-                        logger.warning(f"Failed to parse JSON response: {e}")
-                        # Fallback to text parsing
-                        text_response = response.text
-                        token_response = {"raw_response": text_response}
+                token_response = self._parse_token_response(response)
 
                 if "access_token" not in token_response:
-                    raise OAuthError(f"No access_token in response: {token_response}")
+                    raise OAuthError(f"No access_token in response: {self._redact_token_response(token_response)}")
 
                 logger.info("""Successfully exchanged authorization code for tokens""")
                 return token_response
@@ -1326,38 +1391,23 @@ class OAuthManager:
                 client = await self._get_client()
                 response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
                 if response.status_code == 200:
-                    # Handle both JSON and form-encoded responses
-                    content_type = response.headers.get("content-type", "")
-                    if "application/x-www-form-urlencoded" in content_type:
-                        # Parse form-encoded response
-                        text_response = response.text
-                        token_response = {}
-                        for pair in text_response.split("&"):
-                            if "=" in pair:
-                                key, value = pair.split("=", 1)
-                                token_response[key] = value
-                    else:
-                        # Try JSON response
-                        try:
-                            token_response = response.json()
-                        except Exception as e:
-                            logger.warning(f"Failed to parse JSON response: {e}")
-                            # Fallback to text parsing
-                            text_response = response.text
-                            token_response = {"raw_response": text_response}
+                    token_response = self._parse_token_response(response)
 
                     # Validate required fields
                     if "access_token" not in token_response:
-                        raise OAuthError("No access_token in refresh response")
+                        raise OAuthError(f"No access_token in refresh response: {self._redact_token_response(token_response)}")
 
                     logger.info("Successfully refreshed OAuth token")
                     return token_response
 
-                error_text = response.text
-                # If we get a 400/401, the refresh token is likely invalid
+                # Bound and redact the body before surfacing it. Some providers echo
+                # request parameters (including refresh_token / client_secret) in error
+                # responses, and HTML error pages can be unbounded — both leak via logs
+                # and OAuthError messages without this scrub.
+                error_payload = self._redact_token_response(self._parse_token_response(response))
                 if response.status_code in [400, 401]:
-                    raise OAuthError(f"Refresh token invalid or expired: {error_text}")
-                logger.warning(f"Token refresh failed with status {response.status_code}: {error_text}")
+                    raise OAuthError(f"Refresh token invalid or expired: {error_payload}")
+                logger.warning("Token refresh failed with status %s: %s", response.status_code, error_payload)
 
             except httpx.HTTPError as e:
                 logger.warning(f"Token refresh attempt {attempt + 1} failed: {str(e)}")

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -449,6 +449,7 @@ async def test_exchange_code_for_token_no_secret(oauth_manager):
 async def test_refresh_token_success(oauth_manager):
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
     mock_response.json.return_value = {"access_token": "new-tok", "refresh_token": "new-rt"}
 
     mock_client = AsyncMock()
@@ -458,6 +459,46 @@ async def test_refresh_token_success(oauth_manager):
             "old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"}
         )
     assert result["access_token"] == "new-tok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_form_encoded_response(oauth_manager):
+    """Token endpoints that return application/x-www-form-urlencoded are parsed correctly."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/x-www-form-urlencoded; charset=utf-8"}
+    mock_response.text = "access_token=new-tok&token_type=bearer&refresh_token=new-rt&scope=repo"
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        result = await oauth_manager.refresh_token(
+            "old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"}
+        )
+
+    assert result["access_token"] == "new-tok"
+    assert result["refresh_token"] == "new-rt"
+    assert result["token_type"] == "bearer"
+    # JSON parser must not be invoked for form-encoded responses
+    mock_response.json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_non_json_non_form_raises(oauth_manager):
+    """An unexpected response body falls back to raw capture and raises when access_token is absent."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "text/plain"}
+    mock_response.text = "something unexpected"
+    mock_response.json.side_effect = ValueError("not JSON")
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError, match="No access_token"):
+            await oauth_manager.refresh_token(
+                "old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"}
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -2,6 +2,8 @@
 """Unit tests for OAuthManager service."""
 
 # Standard
+import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -100,9 +102,7 @@ async def test_client_credentials_flow_success_json(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager._client_credentials_flow(
-            {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"})
     assert result == "json-tok"
 
 
@@ -116,9 +116,7 @@ async def test_client_credentials_flow_success_form_encoded(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager._client_credentials_flow(
-            {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"})
     assert result == "form-tok"
 
 
@@ -132,9 +130,7 @@ async def test_client_credentials_flow_with_scopes(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager._client_credentials_flow(
-            {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token", "scopes": ["read", "write"]}
-        )
+        result = await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token", "scopes": ["read", "write"]})
     assert result == "scoped-tok"
 
 
@@ -158,9 +154,7 @@ async def test_client_credentials_flow_decrypt_secret(oauth_manager):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
         # Secret longer than 50 chars triggers decryption
         long_secret = "x" * 60
-        result = await oauth_manager._client_credentials_flow(
-            {"client_id": "cid", "client_secret": long_secret, "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": long_secret, "token_url": "https://auth/token"})
     assert result == "dec-tok"
 
 
@@ -182,9 +176,7 @@ async def test_client_credentials_flow_decrypt_returns_none(oauth_manager):
         patch("mcpgateway.services.oauth_manager.get_encryption_service", return_value=mock_enc),
     ):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
-        result = await oauth_manager._client_credentials_flow(
-            {"client_id": "cid", "client_secret": "x" * 60, "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "x" * 60, "token_url": "https://auth/token"})
     assert result == "tok"
 
 
@@ -204,9 +196,7 @@ async def test_client_credentials_flow_decrypt_exception(oauth_manager):
         patch("mcpgateway.services.oauth_manager.get_encryption_service", side_effect=RuntimeError("enc fail")),
     ):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
-        result = await oauth_manager._client_credentials_flow(
-            {"client_id": "cid", "client_secret": "x" * 60, "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "x" * 60, "token_url": "https://auth/token"})
     assert result == "tok"
 
 
@@ -221,9 +211,7 @@ async def test_client_credentials_flow_no_access_token(oauth_manager):
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
         with pytest.raises(OAuthError, match="No access_token"):
-            await oauth_manager._client_credentials_flow(
-                {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"}
-            )
+            await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"})
 
 
 @pytest.mark.asyncio
@@ -232,9 +220,7 @@ async def test_client_credentials_flow_http_error(oauth_manager):
     mock_client.post.side_effect = httpx.HTTPError("connection failed")
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
         with pytest.raises(OAuthError, match="Failed to obtain access token"):
-            await oauth_manager._client_credentials_flow(
-                {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"}
-            )
+            await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"})
 
 
 @pytest.mark.asyncio
@@ -242,16 +228,14 @@ async def test_client_credentials_flow_json_parse_failure(oauth_manager):
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.headers = {"content-type": "text/html"}
-    mock_response.json.side_effect = ValueError("bad json")
+    mock_response.json.side_effect = json.JSONDecodeError("bad json", "raw_response_text", 0)
     mock_response.text = "raw_response_text"
 
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
         with pytest.raises(OAuthError, match="No access_token"):
-            await oauth_manager._client_credentials_flow(
-                {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"}
-            )
+            await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"})
 
 
 # ---------- _password_flow ----------
@@ -267,9 +251,7 @@ async def test_password_flow_success(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager._password_flow(
-            {"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token", "username": "user", "password": "pass"}
-        )
+        result = await oauth_manager._password_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token", "username": "user", "password": "pass"})
     assert result == "pwd-tok"
 
 
@@ -291,9 +273,7 @@ async def test_password_flow_form_encoded(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager._password_flow(
-            {"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "pass", "scopes": ["openid"]}
-        )
+        result = await oauth_manager._password_flow({"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "pass", "scopes": ["openid"]})
     assert result == "form-pwd-tok"
 
 
@@ -315,9 +295,7 @@ async def test_password_flow_decrypt_secret(oauth_manager):
         patch("mcpgateway.services.oauth_manager.get_encryption_service", return_value=mock_enc),
     ):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
-        result = await oauth_manager._password_flow(
-            {"client_id": "cid", "client_secret": "x" * 60, "token_url": "https://auth/token", "username": "user", "password": "pass"}
-        )
+        result = await oauth_manager._password_flow({"client_id": "cid", "client_secret": "x" * 60, "token_url": "https://auth/token", "username": "user", "password": "pass"})
     assert result == "tok"
 
 
@@ -341,9 +319,7 @@ async def test_password_flow_decrypts_encrypted_password(oauth_manager):
         patch("mcpgateway.services.oauth_manager.get_encryption_service", return_value=mock_enc),
     ):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
-        result = await oauth_manager._password_flow(
-            {"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "enc-password"}
-        )
+        result = await oauth_manager._password_flow({"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "enc-password"})
 
     assert result == "tok"
     posted_data = mock_client.post.await_args.kwargs["data"]
@@ -370,9 +346,7 @@ async def test_password_flow_encrypted_password_decrypt_returns_none(oauth_manag
         patch("mcpgateway.services.oauth_manager.get_encryption_service", return_value=mock_enc),
     ):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
-        result = await oauth_manager._password_flow(
-            {"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "enc-password"}
-        )
+        result = await oauth_manager._password_flow({"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "enc-password"})
 
     assert result == "tok"
     posted_data = mock_client.post.await_args.kwargs["data"]
@@ -395,9 +369,7 @@ async def test_password_flow_encrypted_password_decrypt_exception(oauth_manager)
         patch("mcpgateway.services.oauth_manager.get_encryption_service", side_effect=RuntimeError("enc fail")),
     ):
         mock_gs.return_value = MagicMock(auth_encryption_secret="key")
-        result = await oauth_manager._password_flow(
-            {"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "enc-password"}
-        )
+        result = await oauth_manager._password_flow({"client_id": "cid", "token_url": "https://auth/token", "username": "user", "password": "enc-password"})
 
     assert result == "tok"
 
@@ -455,9 +427,7 @@ async def test_refresh_token_success(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager.refresh_token(
-            "old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
     assert result["access_token"] == "new-tok"
 
 
@@ -472,9 +442,7 @@ async def test_refresh_token_form_encoded_response(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager.refresh_token(
-            "old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"}
-        )
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
 
     assert result["access_token"] == "new-tok"
     assert result["refresh_token"] == "new-rt"
@@ -484,21 +452,193 @@ async def test_refresh_token_form_encoded_response(oauth_manager):
 
 
 @pytest.mark.asyncio
-async def test_refresh_token_non_json_non_form_raises(oauth_manager):
-    """An unexpected response body falls back to raw capture and raises when access_token is absent."""
+async def test_refresh_token_form_encoded_mixed_case_content_type(oauth_manager):
+    """Per RFC 7231, media types are case-insensitive — mixed-case Content-Type must still parse."""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.headers = {"content-type": "text/plain"}
-    mock_response.text = "something unexpected"
-    mock_response.json.side_effect = ValueError("not JSON")
+    mock_response.headers = {"content-type": "Application/X-WWW-Form-Urlencoded; Charset=UTF-8"}
+    mock_response.text = "access_token=new-tok&token_type=bearer"
 
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        with pytest.raises(OAuthError, match="No access_token"):
-            await oauth_manager.refresh_token(
-                "old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"}
-            )
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    assert result["access_token"] == "new-tok"
+    mock_response.json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_form_encoded_url_decodes_values(oauth_manager):
+    """Form-encoded values must be URL-decoded so callers see the spec-compliant value."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/x-www-form-urlencoded"}
+    mock_response.text = "access_token=new-tok&scope=repo%3Astatus+repo%3Adeployment"
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    assert result["scope"] == "repo:status repo:deployment"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_non_json_non_form_raises(oauth_manager, caplog):
+    """An unexpected response body falls back to raw capture, logs, and raises when access_token is absent."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "text/plain"}
+    mock_response.text = "something unexpected"
+    mock_response.json.side_effect = json.JSONDecodeError("not JSON", "something unexpected", 0)
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.services.oauth_manager"):
+            with pytest.raises(OAuthError, match=r"No access_token.*raw_response.*something unexpected"):
+                await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    # JSON path was attempted before the fallback ran
+    assert mock_response.json.called
+    # Parse failure was logged with diagnostic context
+    assert any("Failed to parse OAuth token response as JSON" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_json_branch_parse_failure_logs_and_falls_back(oauth_manager, caplog):
+    """A malformed body served as application/json must hit the JSON-branch fallback and log."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = "<html>not json</html>"
+    mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "<html>not json</html>", 0)
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.services.oauth_manager"):
+            with pytest.raises(OAuthError, match=r"raw_response.*not json"):
+                await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    assert mock_response.json.called
+    assert any("Failed to parse OAuth token response as JSON" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_json_branch_unicode_decode_error_falls_back(oauth_manager, caplog):
+    """A UnicodeDecodeError from response.json() (bad charset) must hit the same fallback as JSONDecodeError."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = "<binary garbage>"
+    mock_response.json.side_effect = UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte")
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.services.oauth_manager"):
+            with pytest.raises(OAuthError, match=r"raw_response.*binary garbage"):
+                await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    assert mock_response.json.called
+    assert any("Failed to parse OAuth token response as JSON" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_missing_content_type_header_uses_json_branch(oauth_manager):
+    """When the content-type header is absent, the JSON branch must still parse a valid JSON body."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.json.return_value = {"access_token": "json-tok", "refresh_token": "json-rt"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    assert result["access_token"] == "json-tok"
+    assert mock_response.json.called
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_empty_form_body_raises_with_payload(oauth_manager):
+    """An empty form-encoded body parses to an empty dict, surfaces via OAuthError with the payload."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/x-www-form-urlencoded"}
+    mock_response.text = ""
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError, match=r"No access_token in refresh response: \{\}"):
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+    mock_response.json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_error_redacts_secrets_in_token_response(oauth_manager):
+    """A response missing access_token but carrying other tokens must not leak them via OAuthError."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"id_token": "secret-id-jwt", "refresh_token": "secret-rt", "token_type": "bearer"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError) as exc_info:
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    msg = str(exc_info.value)
+    assert "[REDACTED]" in msg
+    assert "secret-id-jwt" not in msg
+    assert "secret-rt" not in msg
+    # Non-sensitive fields are preserved for diagnostics.
+    assert "bearer" in msg
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_error_truncates_long_raw_response(oauth_manager):
+    """A long unparseable body must be truncated in the OAuthError to bound log size."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "text/plain"}
+    long_body = "X" * 1024
+    mock_response.text = long_body
+    mock_response.content = long_body.encode()
+    mock_response.json.side_effect = json.JSONDecodeError("not JSON", long_body, 0)
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError) as exc_info:
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+
+    msg = str(exc_info.value)
+    assert "[truncated, 1024 chars total]" in msg
+    # The full body must NOT appear; only the leading slice does.
+    assert long_body not in msg
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_form_garbage_body_falls_back_to_raw_response(oauth_manager):
+    """A form-encoded content-type with an HTML body (parses to {}) must surface the body via raw_response."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/x-www-form-urlencoded"}
+    mock_response.text = "<html><body>upstream error</body></html>"
+    mock_response.content = mock_response.text.encode()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError, match=r"raw_response.*upstream error"):
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
+    mock_response.json.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -604,30 +744,102 @@ async def test_refresh_token_no_client_id(oauth_manager):
 async def test_refresh_token_400_error(oauth_manager):
     mock_response = MagicMock()
     mock_response.status_code = 400
-    mock_response.text = "invalid_grant"
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = '{"error": "invalid_grant"}'
+    mock_response.content = mock_response.text.encode()
+    mock_response.json.return_value = {"error": "invalid_grant"}
 
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        with pytest.raises(OAuthError, match="Refresh token invalid"):
-            await oauth_manager.refresh_token(
-                "old-rt", {"client_id": "cid", "token_url": "https://auth/token"}
-            )
+        with pytest.raises(OAuthError, match=r"Refresh token invalid.*invalid_grant"):
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
 
 
 @pytest.mark.asyncio
 async def test_refresh_token_401_error(oauth_manager):
     mock_response = MagicMock()
     mock_response.status_code = 401
-    mock_response.text = "unauthorized"
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = '{"error": "unauthorized_client"}'
+    mock_response.content = mock_response.text.encode()
+    mock_response.json.return_value = {"error": "unauthorized_client"}
 
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        with pytest.raises(OAuthError, match="Refresh token invalid"):
-            await oauth_manager.refresh_token(
-                "old-rt", {"client_id": "cid", "token_url": "https://auth/token"}
-            )
+        with pytest.raises(OAuthError, match=r"Refresh token invalid.*unauthorized_client"):
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_4xx_redacts_echoed_refresh_token(oauth_manager):
+    """If a provider echoes the refresh_token in the error body, OAuthError must not leak it."""
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.headers = {"content-type": "application/x-www-form-urlencoded"}
+    mock_response.text = "error=invalid_grant&refresh_token=leaked-rt-value&client_secret=leaked-secret"
+    mock_response.content = mock_response.text.encode()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError) as exc_info:
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
+
+    msg = str(exc_info.value)
+    assert "[REDACTED]" in msg
+    assert "leaked-rt-value" not in msg
+    assert "leaked-secret" not in msg
+    # Non-sensitive fields preserved for diagnostics.
+    assert "invalid_grant" in msg
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_4xx_form_encoded_html_with_equals_redacts_embedded_token(oauth_manager):
+    """Form-encoded content-type with HTML containing '=' must not leak embedded tokens via OAuthError."""
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.headers = {"content-type": "application/x-www-form-urlencoded"}
+    # parse_qsl would otherwise split this into garbage key/value pairs and surface
+    # the embedded token verbatim. The key-shape check should reject the parse and
+    # fall back to raw_response, which then truncates.
+    long_body = '<html><meta charset="utf-8"><a href="https://evil.example/?token=secret-token-value-do-not-leak">' + ("X" * 1024) + "</a></html>"
+    mock_response.text = long_body
+    mock_response.content = long_body.encode()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError) as exc_info:
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
+
+    msg = str(exc_info.value)
+    assert "secret-token-value-do-not-leak" not in msg
+    assert "[truncated," in msg
+    mock_response.json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_4xx_truncates_long_html_error_body(oauth_manager):
+    """A 1KB HTML error page must be truncated in the OAuthError to bound log size."""
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.headers = {"content-type": "text/html"}
+    long_body = "<html>" + ("E" * 1024) + "</html>"
+    mock_response.text = long_body
+    mock_response.content = long_body.encode()
+    mock_response.json.side_effect = json.JSONDecodeError("not JSON", long_body, 0)
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        with pytest.raises(OAuthError) as exc_info:
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
+
+    msg = str(exc_info.value)
+    assert "[truncated," in msg
+    assert long_body not in msg
 
 
 @pytest.mark.asyncio
@@ -640,9 +852,7 @@ async def test_refresh_token_no_access_token_in_response(oauth_manager):
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
         with pytest.raises(OAuthError, match="No access_token"):
-            await oauth_manager.refresh_token(
-                "old-rt", {"client_id": "cid", "token_url": "https://auth/token"}
-            )
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
 
 
 @pytest.mark.asyncio
@@ -651,9 +861,7 @@ async def test_refresh_token_http_error(oauth_manager):
     mock_client.post.side_effect = httpx.HTTPError("timeout")
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
         with pytest.raises(OAuthError, match="Failed to refresh token"):
-            await oauth_manager.refresh_token(
-                "old-rt", {"client_id": "cid", "token_url": "https://auth/token"}
-            )
+            await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token"})
 
 
 @pytest.mark.asyncio
@@ -682,9 +890,7 @@ async def test_refresh_token_with_resource_string(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager.refresh_token(
-            "old-rt", {"client_id": "cid", "token_url": "https://auth/token", "resource": "https://mcp.example.com"}
-        )
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token", "resource": "https://mcp.example.com"})
     assert result["access_token"] == "new-tok"
 
 
@@ -697,9 +903,7 @@ async def test_refresh_token_with_resource_list(oauth_manager):
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
-        result = await oauth_manager.refresh_token(
-            "old-rt", {"client_id": "cid", "token_url": "https://auth/token", "resource": ["https://a.com", "https://b.com"]}
-        )
+        result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "token_url": "https://auth/token", "resource": ["https://a.com", "https://b.com"]})
     assert result["access_token"] == "new-tok"
 
 
@@ -1047,3 +1251,116 @@ async def test_get_redis_client_no_redis():
     finally:
         om._REDIS_INITIALIZED = original_init
         om._redis_client = original_client
+
+
+# ---------- _safe_response_text / _redact_token_response ----------
+
+
+class _FakeResponseTextRaises:
+    """Minimal stand-in for httpx.Response whose .text raises on access."""
+
+    def __init__(self, exc: BaseException, content: bytes):
+        self._exc = exc
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        raise self._exc
+
+
+def test_safe_response_text_returns_placeholder_on_unicode_error():
+    fake = _FakeResponseTextRaises(
+        UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte"),
+        b"\xff\xfe\x00\x01",
+    )
+    assert OAuthManager._safe_response_text(fake) == "<undecodable body, 4 bytes>"
+
+
+def test_safe_response_text_returns_placeholder_on_lookup_error():
+    fake = _FakeResponseTextRaises(LookupError("unknown encoding"), b"abc")
+    assert OAuthManager._safe_response_text(fake) == "<undecodable body, 3 bytes>"
+
+
+def test_parse_token_response_form_branch_handles_undecodable_body():
+    """Form branch must not crash when response.text raises UnicodeDecodeError."""
+    fake = _FakeResponseTextRaises(
+        UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte"),
+        b"\xff\xfe",
+    )
+    fake.headers = {"content-type": "application/x-www-form-urlencoded"}
+    fake.status_code = 200
+    result = OAuthManager._parse_token_response(fake)
+    assert result == {"raw_response": "<undecodable body, 2 bytes>"}
+
+
+def test_redact_token_response_redacts_known_secret_keys():
+    payload = {
+        "access_token": "AT",
+        "refresh_token": "RT",
+        "id_token": "ID",
+        "client_secret": "CS",  # pragma: allowlist secret
+        "password": "PW",  # pragma: allowlist secret
+        "token_type": "bearer",
+        "scope": "repo",
+    }
+    out = OAuthManager._redact_token_response(payload)
+    for key in ("access_token", "refresh_token", "id_token", "client_secret", "password"):
+        assert out[key] == "[REDACTED]"
+    assert out["token_type"] == "bearer"
+    assert out["scope"] == "repo"
+
+
+def test_redact_token_response_truncates_long_raw_response():
+    payload = {"raw_response": "X" * 1000}
+    out = OAuthManager._redact_token_response(payload)
+    assert out["raw_response"].startswith("X" * 256)
+    assert "[truncated, 1000 chars total]" in out["raw_response"]
+    assert "X" * 1000 not in out["raw_response"]
+
+
+def test_redact_token_response_scrubs_embedded_url_param_secrets():
+    """key=value leaks inside arbitrary string values (e.g. URLs in HTML) are redacted in place."""
+    payload = {
+        "raw_response": '<a href="https://evil.example/?access_token=AT123&code=C456&api_key=K789">click</a>',
+        "error_description": "Try again with token=alsoLeaked",
+    }
+    out = OAuthManager._redact_token_response(payload)
+    for leaked in ("AT123", "C456", "K789", "alsoLeaked"):
+        assert leaked not in out["raw_response"] + out["error_description"]
+    assert "access_token=[REDACTED]" in out["raw_response"]
+    assert "code=[REDACTED]" in out["raw_response"]
+    assert "api_key=[REDACTED]" in out["raw_response"]
+    assert "token=[REDACTED]" in out["error_description"]
+
+
+def test_redact_token_response_truncates_long_arbitrary_string_value():
+    """Defense-in-depth: any long string value (not just raw_response) is capped."""
+    payload = {"error_description": "stack trace: " + ("Y" * 1024), "error": "server_error"}
+    out = OAuthManager._redact_token_response(payload)
+    assert "[truncated," in out["error_description"]
+    assert len(out["error_description"]) < 400  # cap (256) + truncation suffix
+    assert out["error"] == "server_error"
+
+
+def test_parse_token_response_form_with_garbage_keys_falls_back_to_raw_response():
+    """An HTML body containing '=' must not leak through parse_qsl as garbage keys."""
+    fake = MagicMock()
+    fake.headers = {"content-type": "application/x-www-form-urlencoded"}
+    fake.status_code = 400
+    fake.text = '<html><meta charset="utf-8"><body>error</body></html>'
+    fake.content = fake.text.encode()
+    result = OAuthManager._parse_token_response(fake)
+    assert result == {"raw_response": fake.text}
+
+
+def test_redact_token_response_leaves_short_raw_response_intact():
+    payload = {"raw_response": "short body"}
+    out = OAuthManager._redact_token_response(payload)
+    assert out == {"raw_response": "short body"}
+
+
+def test_redact_token_response_returns_new_dict():
+    """Caller-side guarantee: redaction must not mutate the input."""
+    payload = {"access_token": "AT", "scope": "repo"}
+    OAuthManager._redact_token_response(payload)
+    assert payload["access_token"] == "AT"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4258

---

## 📝 Summary

`OAuthManager.refresh_token()` in `mcpgateway/services/oauth_manager.py` assumed the token endpoint always returns JSON, but GitHub's OAuth token endpoint returns `application/x-www-form-urlencoded` by default. Without an `Accept: application/json` header, `response.json()` raised `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`, silently failing the refresh, letting the access token expire, and driving gateways offline on the next health check.

This PR applies the **same content-type branch already used in the three other token-fetching paths** in the same file (`_client_credentials_flow` at L274, `_password_flow` at L360, and the two authorization code exchanges at L458 and L1235) so `refresh_token()` handles both JSON and form-encoded responses uniformly.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

### Root cause (file reference)

`mcpgateway/services/oauth_manager.py`, `OAuthManager.refresh_token()`, around L1327:

```python3
  # Before
  response = await client.post(token_url, data=token_data, timeout=self.request_timeout)
  if response.status_code == 200:
      token_response = response.json()  # ← raises on GitHub (form-encoded body)

  # After — aligns with _client_credentials_flow / authorization_code paths
  if response.status_code == 200:
      content_type = response.headers.get("content-type", "")
      if "application/x-www-form-urlencoded" in content_type:
          text_response = response.text
          token_response = {}
          for pair in text_response.split("&"):
              if "=" in pair:
                  key, value = pair.split("=", 1)
                  token_response[key] = value
      else:
          try:
              token_response = response.json()
          except Exception as e:
              logger.warning(f"Failed to parse JSON response: {e}")
              token_response = {"raw_response": response.text}
      ...
```