### PR TITLE
fix: update scope['modified_path'] for server_id extraction with root_path

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3025,6 +3025,10 @@ class MCPPathRewriteMiddleware:
         root_path = (scope.get("root_path") or settings.app_root_path or "").rstrip("/")
         app_path = _normalize_scope_path(original_path, root_path)
 
+        # Update modified_path to the app-relative path (without root_path prefix).
+        # This ensures streamablehttp_transport can extract server_id via regex (#4266).
+        scope["modified_path"] = app_path
+
         # Skip rewriting for well-known URIs (RFC 9728 OAuth metadata, etc.)
         # These paths may end with /mcp but should not be rewritten to the MCP transport
         if not app_path.startswith("/.well-known/"):

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -2925,6 +2925,49 @@ class TestMCPPathRewriteMiddleware:
         app_mock.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_modified_path_set_to_app_relative_path(self):
+        """Regression test for #4266: modified_path should be app-relative for server_id extraction."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/gateway/servers/abc123/mcp",
+            "root_path": "/gateway",
+            "headers": []
+        }
+        receive, send = AsyncMock(), AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", return_value=True):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        # modified_path MUST be app-relative (without root_path prefix)
+        # so streamablehttp_transport can extract server_id via regex
+        assert scope["modified_path"] == "/servers/abc123/mcp"
+        # path is rewritten with root_path prefix preserved
+        assert scope["path"] == "/gateway/mcp/"
+        app_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_modified_path_without_root_path(self):
+        """When no root_path, modified_path equals original path."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/servers/xyz789/mcp",
+            "headers": []
+        }
+        receive, send = AsyncMock(), AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", return_value=True):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        # Without root_path, modified_path should equal the normalized path
+        assert scope["modified_path"] == "/servers/xyz789/mcp"
+        assert scope["path"] == "/mcp/"
+        app_mock.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_security_arbitrary_prefix_not_rewritten(self):
         """PR #3892 security: Arbitrary paths ending with /mcp are NOT rewritten."""
         app_mock = AsyncMock()


### PR DESCRIPTION
## Summary

Fixes #4266

The `/mcp` endpoint was returning ALL tools instead of server-scoped tools when accessed via `/servers/{id}/mcp` in reverse proxy deployments with `root_path` configured. The `/sse` endpoint worked correctly.

## Root Cause

PR #4217 introduced a bug in `MCPPathRewriteMiddleware` where:
1. `scope["modified_path"]` was set to the original path (line 3019)
2. `app_path` was computed by stripping `root_path` prefix (line 3026)
3. **`scope["modified_path"]` was never updated** to use `app_path`

When `streamablehttp_transport.py:2898` reads `scope["modified_path"]` to extract `server_id` via regex `r"^/servers/(?P<server_id>[^/]+)/mcp"`, the regex fails to match paths with prefixes (e.g., `/prefix/servers/123/mcp`), causing `server_id` to be `None` and `tools/list` to return all tools instead of server-scoped tools.

## Solution

Update `scope["modified_path"] = app_path` after computing the app-relative path (line 3030). This ensures `streamablehttp_transport` receives the path without `root_path` prefix for correct `server_id` extraction.

## Changes

### Code
- **mcpgateway/main.py** (line 3028-3030): Set `scope["modified_path"]` to `app_path` after stripping `root_path`

### Tests
- **tests/unit/mcpgateway/test_main_extended.py**:
  - `test_modified_path_set_to_app_relative_path`: Verifies `modified_path` is app-relative with `root_path`
  - `test_modified_path_without_root_path`: Verifies `modified_path` works without `root_path`

## Testing

```bash
# All MCPPathRewriteMiddleware tests pass (14/14)
pytest tests/unit/mcpgateway/test_main_extended.py::TestMCPPathRewriteMiddleware -v
```

## Impact

- **Severity**: High - Fixes multi-tenancy isolation breach in reverse proxy deployments
- **Scope**: Affects `/mcp` endpoint only; `/sse` endpoint already works correctly
- **Breaking Changes**: None - this is a bug fix that restores expected behavior

## Comparison with `/sse` Endpoint

The `/sse` endpoint works correctly because it extracts `server_id` directly from the FastAPI route parameter, not via regex on `modified_path`.