### PR TITLE
fix(sso): generic OIDC providers can now promote users to platform_admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1352,6 +1352,14 @@ SKIP_MIGRATION=false
 # SSO_GENERIC_ISSUER=https://keycloak.company.com/auth/realms/master
 # SSO_GENERIC_JWKS_URI=https://keycloak.company.com/auth/realms/master/protocol/openid-connect/certs
 # SSO_GENERIC_SCOPE=openid profile email
+# JWT claim that contains the user's groups (default: groups)
+# SSO_GENERIC_GROUPS_CLAIM=groups
+# Groups that grant platform_admin — checked at login (CSV or JSON list)
+# SSO_GENERIC_ADMIN_GROUPS=["cf-platform-admin"]
+# Map IdP group names to ContextForge roles (JSON object)
+# SSO_GENERIC_ROLE_MAPPINGS={"cf-platform-admin":"platform_admin","cf-dev":"developer"}
+# Default role assigned to users with no matching group mapping (omit to assign no role)
+# SSO_GENERIC_DEFAULT_ROLE=platform_viewer
 
 # SSO General Settings
 # SSO_AUTO_CREATE_USERS=true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-19T12:25:29Z",
+  "generated_at": "2026-05-20T09:27:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4988,7 +4988,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2941,
+        "line_number": 2945,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9446,7 +9446,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 379,
+        "line_number": 481,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9454,7 +9454,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 463,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -576,6 +576,10 @@ class Settings(BaseSettings):
     sso_generic_jwks_uri: Optional[str] = Field(default=None, description="OIDC JWKS endpoint URL for token signature verification")
 
     sso_generic_scope: Optional[str] = Field(default="openid profile email", description="OAuth scopes (space-separated)")
+    sso_generic_groups_claim: str = Field(default="groups", description="JWT claim for generic OIDC groups (e.g. 'groups', 'roles')")
+    sso_generic_admin_groups: Annotated[list[str], NoDecode] = Field(default_factory=list, description="Generic OIDC groups granting platform_admin (CSV/JSON)")
+    sso_generic_role_mappings: Dict[str, str] = Field(default_factory=dict, description="Map generic OIDC groups to ContextForge roles (JSON: {group_name: role_name})")
+    sso_generic_default_role: Optional[str] = Field(default=None, description="Default role for generic OIDC users without a matching group mapping (None = no role assigned)")
 
     sso_generic_groups_claim: str = Field(default="groups", description="JWT claim for Generic OIDC groups (groups/roles/custom)")
     sso_generic_admin_groups: Annotated[list[str], NoDecode] = Field(default_factory=list, description="Generic OIDC groups granting platform_admin role (CSV/JSON)")

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2050,6 +2050,14 @@ class SSOService:
             if provider_ctx and self._should_sync_roles(provider_id, provider_metadata):
                 role_assignments = await self._map_groups_to_roles(email, user_info.get("groups", []), provider_ctx)
                 await self._sync_user_roles(email, role_assignments, provider_ctx)
+                # Belt-and-suspenders: if role sync assigned platform_admin but is_admin is still False
+                # (e.g. user existed before the generic OIDC fix was deployed), promote now.
+                if not current_is_admin and any(ra.get("role_name") == "platform_admin" for ra in role_assignments):
+                    logger.info(f"Promoting is_admin for {SecurityValidator.sanitize_log_message(email)} — platform_admin role assigned via role_mappings")
+                    user.is_admin = True
+                    user.admin_origin = "sso"
+                    current_is_admin = True
+                    self.db.commit()
             await self._apply_team_mapping(email, user_info, provider)
 
             user_email = getattr(user, "email", None)
@@ -2180,6 +2188,19 @@ class SSOService:
             generic_admin_groups_lower = {str(group).lower() for group in generic_admin_groups}
             user_groups = user_info.get("groups", [])
             if any(group.lower() in generic_admin_groups_lower for group in user_groups):
+                return True
+
+        # Check role_mappings in provider_metadata: any group that maps to platform_admin grants is_admin.
+        # Intentionally provider-agnostic — applies to generic OIDC, Keycloak, ADFS, and any provider
+        # whose bootstrap populates role_mappings in provider_metadata. Keys are matched case-insensitively
+        # so that IdP casing differences (e.g. "CF-Platform-Admin" vs "cf-platform-admin") do not
+        # silently block admin promotion.
+        metadata = provider.provider_metadata or {}
+        role_mappings = metadata.get("role_mappings", {})
+        if role_mappings:
+            lower_role_mappings = {k.lower(): v for k, v in role_mappings.items()}
+            user_groups = user_info.get("groups", [])
+            if any(lower_role_mappings.get(group.lower()) == "platform_admin" for group in user_groups):
                 return True
 
         return False

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2181,13 +2181,21 @@ class SSOService:
             if any(group.lower() in entra_admin_groups for group in user_groups):
                 return True
 
-        # Check Generic OIDC admin groups
-        provider_metadata = provider.provider_metadata or {}
-        generic_admin_groups = provider_metadata.get("admin_groups", [])
-        if generic_admin_groups:
-            generic_admin_groups_lower = {str(group).lower() for group in generic_admin_groups}
+        # Check Generic OIDC admin groups (sso_generic_admin_groups setting)
+        # This applies when the provider ID matches sso_generic_provider_id
+        if provider.id == settings.sso_generic_provider_id and settings.sso_generic_admin_groups:
+            generic_admin_groups_lower = {str(group).lower() for group in settings.sso_generic_admin_groups}
             user_groups = user_info.get("groups", [])
             if any(group.lower() in generic_admin_groups_lower for group in user_groups):
+                return True
+
+        # Check Generic OIDC admin groups from provider_metadata (for other generic providers)
+        provider_metadata = provider.provider_metadata or {}
+        metadata_admin_groups = provider_metadata.get("admin_groups", [])
+        if metadata_admin_groups:
+            metadata_admin_groups_lower = {str(group).lower() for group in metadata_admin_groups}
+            user_groups = user_info.get("groups", [])
+            if any(group.lower() in metadata_admin_groups_lower for group in user_groups):
                 return True
 
         # Check role_mappings in provider_metadata: any group that maps to platform_admin grants is_admin.

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -342,6 +342,11 @@ def get_predefined_sso_providers() -> List[Dict]:
         }
         if settings.sso_generic_jwks_uri:
             provider_config["jwks_uri"] = settings.sso_generic_jwks_uri
+        provider_config["provider_metadata"] = {
+            "groups_claim": settings.sso_generic_groups_claim,
+            "role_mappings": settings.sso_generic_role_mappings,
+            "default_role": settings.sso_generic_default_role,
+        }
         providers.append(provider_config)
 
     return providers

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -334,19 +334,14 @@ def get_predefined_sso_providers() -> List[Dict]:
             "team_mapping": {},
             "provider_metadata": {
                 "groups_claim": settings.sso_generic_groups_claim,
-                "admin_groups": settings.sso_generic_admin_groups,
+                "admin_groups": getattr(settings, "sso_generic_admin_groups", []),
                 "role_mappings": settings.sso_generic_role_mappings,
                 "default_role": settings.sso_generic_default_role,
-                "sync_roles": settings.sso_generic_sync_roles_on_login,
+                "sync_roles": getattr(settings, "sso_generic_sync_roles_on_login", True),
             },
         }
         if settings.sso_generic_jwks_uri:
             provider_config["jwks_uri"] = settings.sso_generic_jwks_uri
-        provider_config["provider_metadata"] = {
-            "groups_claim": settings.sso_generic_groups_claim,
-            "role_mappings": settings.sso_generic_role_mappings,
-            "default_role": settings.sso_generic_default_role,
-        }
         providers.append(provider_config)
 
     return providers

--- a/tests/live_gateway/sso/test_entra_id_integration.py
+++ b/tests/live_gateway/sso/test_entra_id_integration.py
@@ -1361,13 +1361,18 @@ class TestEntraIDEndToEndHTTP:
 
 @pytest.mark.skipif(not has_azure_credentials(), reason="Azure credentials not configured")
 class TestEntraIDAdminRoleRetention:
-    """Tests verifying that admin role is RETAINED when user leaves admin group.
+    """Tests verifying that manually-granted admin roles are RETAINED when user leaves an IdP group.
 
-    IMPORTANT: By design, the SSOService only UPGRADES is_admin via SSO, never downgrades.
-    This is intentional to preserve manual admin grants made via Admin UI/API.
-    To revoke admin access, administrators must use the Admin UI/API directly.
+    The SSOService enforces a two-tier admin-origin policy:
+    - admin_origin=None / "manual" / "api": sticky — SSO login never demotes these users.
+      Revocation requires an explicit Admin UI or API action.
+    - admin_origin="sso": bidirectional sync — SSO login promotes AND demotes based on
+      current IdP group membership.  This is intentional so that removing a user from an
+      IdP admin group takes effect on next login without a manual DB change.
 
-    See SSOService._should_user_be_admin() comments for rationale.
+    These tests cover the sticky (manual-grant) path only.
+    See test_is_admin_revoked_when_sso_admin_removed_from_group in
+    test_sso_entra_role_mapping.py for the bidirectional-sync path.
     """
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_sso_admin_assignment.py
+++ b/tests/unit/mcpgateway/services/test_sso_admin_assignment.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import SSOProvider
-from mcpgateway.services.sso_service import SSOService
+from mcpgateway.services.sso_service import SSOProviderContext, SSOService
 
 
 @pytest.fixture
@@ -151,3 +151,185 @@ class TestSSOAdminAssignment:
             # User with no groups
             user_info_no_groups = {"full_name": "Test User", "provider": "entra", "groups": []}
             assert sso_service._should_user_be_admin("user@company.com", user_info_no_groups, entra_provider) is False
+
+
+class TestGenericOIDCAdminAssignment:
+    """Test admin promotion for generic OIDC providers (gap 2 fix — issue #4232).
+
+    Covers:
+    - sso_generic_admin_groups explicit group list
+    - role_mappings → platform_admin promotion (provider-agnostic)
+    - Scope isolation: sso_generic_admin_groups must not bleed into other providers
+    """
+
+    def _make_generic_provider(self, provider_id: str = "authentik", role_mappings: dict | None = None, groups_claim: str = "groups", default_role: str | None = None) -> SSOProviderContext:
+        return SSOProviderContext(
+            id=provider_id,
+            provider_metadata={
+                "groups_claim": groups_claim,
+                "role_mappings": role_mappings or {},
+                "default_role": default_role,
+            },
+        )
+
+    def test_generic_admin_groups_grants_admin(self, sso_service):
+        """User in sso_generic_admin_groups receives is_admin=True."""
+        provider = self._make_generic_provider()
+        user_info = {"groups": ["cf-platform-admin", "cf-dev"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = ["cf-platform-admin"]
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is True
+
+    def test_generic_admin_groups_case_insensitive(self, sso_service):
+        """sso_generic_admin_groups comparison is case-insensitive."""
+        provider = self._make_generic_provider()
+        user_info = {"groups": ["CF-Platform-Admin"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = ["cf-platform-admin"]
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is True
+
+    def test_generic_admin_groups_no_match_returns_false(self, sso_service):
+        """User not in sso_generic_admin_groups does not receive is_admin=True."""
+        provider = self._make_generic_provider()
+        user_info = {"groups": ["cf-dev", "cf-viewer"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = ["cf-platform-admin"]
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is False
+
+    def test_generic_admin_groups_scoped_to_generic_provider_id(self, sso_service):
+        """sso_generic_admin_groups must not apply to a Keycloak provider (scope isolation)."""
+        keycloak_provider = SSOProviderContext(
+            id="keycloak",
+            provider_metadata={
+                "groups_claim": "groups",
+                "role_mappings": {},
+                "default_role": None,
+            },
+        )
+        user_info = {"groups": ["cf-platform-admin"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = ["cf-platform-admin"]
+            mock_settings.sso_generic_provider_id = "authentik"  # different from "keycloak"
+
+            # Keycloak login must not be granted admin via sso_generic_admin_groups
+            assert sso_service._should_user_be_admin("user@example.com", user_info, keycloak_provider) is False
+
+    def test_role_mappings_platform_admin_grants_admin(self, sso_service):
+        """A group mapped to platform_admin in provider_metadata.role_mappings grants is_admin=True."""
+        provider = self._make_generic_provider(role_mappings={"cf-platform-admin": "platform_admin", "cf-dev": "developer"})
+        user_info = {"groups": ["cf-platform-admin"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is True
+
+    def test_role_mappings_platform_admin_case_insensitive(self, sso_service):
+        """role_mappings lookup is case-insensitive: IdP casing differences must not block promotion."""
+        # Operator configured lowercase key; IdP sends mixed-case value
+        provider = self._make_generic_provider(role_mappings={"cf-platform-admin": "platform_admin"})
+        user_info = {"groups": ["CF-Platform-Admin"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is True
+
+    def test_role_mappings_non_admin_role_does_not_grant_admin(self, sso_service):
+        """A group mapped to a non-admin role does not grant is_admin=True."""
+        provider = self._make_generic_provider(role_mappings={"cf-dev": "developer"})
+        user_info = {"groups": ["cf-dev"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is False
+
+    def test_role_mappings_check_is_provider_agnostic(self, sso_service):
+        """role_mappings → platform_admin promotion works for any provider with role_mappings (e.g. Keycloak)."""
+        keycloak_provider = SSOProviderContext(
+            id="keycloak",
+            provider_metadata={"role_mappings": {"gateway-admins": "platform_admin"}},
+        )
+        user_info = {"groups": ["gateway-admins"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, keycloak_provider) is True
+
+    def test_no_groups_in_user_info_returns_false(self, sso_service):
+        """User with no groups claim in token is not promoted to admin."""
+        provider = self._make_generic_provider(role_mappings={"cf-platform-admin": "platform_admin"})
+        user_info = {}  # no "groups" key
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = ["cf-platform-admin"]
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is False
+
+    def test_empty_role_mappings_returns_false(self, sso_service):
+        """Provider with empty role_mappings does not promote any user via that path."""
+        provider = self._make_generic_provider(role_mappings={})
+        user_info = {"groups": ["cf-platform-admin"]}
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            assert sso_service._should_user_be_admin("user@example.com", user_info, provider) is False

--- a/tests/unit/mcpgateway/services/test_sso_entra_role_mapping.py
+++ b/tests/unit/mcpgateway/services/test_sso_entra_role_mapping.py
@@ -994,3 +994,184 @@ class TestIsAdminSyncOnLogin:
                 assert mock_user.is_admin is False
                 # Verify admin_origin was cleared
                 assert mock_user.admin_origin is None
+
+
+class TestGenericOIDCBeltAndSuspendersPromotion:
+    """Belt-and-suspenders is_admin promotion via role_mappings after role sync (issue #4232 gap 3).
+
+    When _should_user_be_admin() returns False but _map_groups_to_roles() assigns platform_admin
+    (e.g. via default_role), the post-sync block must still promote is_admin and set admin_origin="sso".
+    The canonical case is default_role="platform_admin" with no explicit role_mappings entry for the
+    user's groups.
+    """
+
+    @pytest.fixture
+    def generic_provider(self):
+        """Generic OIDC provider (e.g. Authentik) with default_role=platform_admin."""
+        return SSOProvider(
+            id="authentik",
+            name="authentik",
+            display_name="Authentik",
+            provider_type="oidc",
+            client_id="authentik-client",
+            client_secret_encrypted="encrypted",
+            is_enabled=True,
+            trusted_domains=[],
+            auto_create_users=True,
+            provider_metadata={
+                "groups_claim": "groups",
+                "role_mappings": {},
+                "default_role": "platform_admin",  # all users get platform_admin by default
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_belt_and_suspenders_promotes_when_map_groups_returns_platform_admin(self, sso_service, generic_provider):
+        """Existing user with is_admin=False is promoted when _map_groups_to_roles returns platform_admin.
+
+        _should_user_be_admin() returns False (empty role_mappings in metadata), but the
+        mocked _map_groups_to_roles() returns a platform_admin assignment (simulating the
+        default_role path or any other scenario where role sync assigns platform_admin without
+        _should_user_be_admin catching it). The post-sync block must detect this and set
+        is_admin=True with admin_origin="sso".
+
+        _map_groups_to_roles is mocked because its internals require real DB Role lookups,
+        which are outside the scope of this unit test.
+        """
+        mock_user = MagicMock()
+        mock_user.email = "user@authentik.example.com"
+        mock_user.full_name = "Authentik User"
+        mock_user.is_admin = False
+        mock_user.admin_origin = None
+        mock_user.auth_provider = "authentik"
+        mock_user.email_verified = True
+        mock_user.get_teams.return_value = []
+
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.get_provider = MagicMock(return_value=generic_provider)
+
+        # Empty role_mappings so _should_user_be_admin returns False for this user,
+        # but _map_groups_to_roles (mocked) returns platform_admin via default_role.
+        generic_provider.provider_metadata = {
+            "groups_claim": "groups",
+            "role_mappings": {},  # no explicit mapping → _should_user_be_admin returns False
+            "default_role": "platform_admin",
+        }
+
+        user_info = {
+            "email": "user@authentik.example.com",
+            "full_name": "Authentik User",
+            "provider": "authentik",
+            "groups": ["cf-users"],
+            "email_verified": True,
+        }
+
+        platform_admin_assignment = [{"role_name": "platform_admin", "scope": "global", "scope_id": None}]
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            with patch.object(sso_service, "_map_groups_to_roles", new=AsyncMock(return_value=platform_admin_assignment)):
+                with patch.object(sso_service, "_sync_user_roles", new=AsyncMock()):
+                    with patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+                        mock_jwt.return_value = "mock_token"
+                        await sso_service.authenticate_or_create_user(user_info)
+
+        assert mock_user.is_admin is True, "is_admin should be promoted via belt-and-suspenders when platform_admin is in role_assignments"
+        assert mock_user.admin_origin == "sso", "admin_origin must be 'sso' so the user is subject to SSO-level demotion if removed from the group"
+
+    @pytest.mark.asyncio
+    async def test_belt_and_suspenders_does_not_fire_for_non_admin_role(self, sso_service, generic_provider):
+        """Belt-and-suspenders must not promote users when role_assignments contains only non-admin roles."""
+        mock_user = MagicMock()
+        mock_user.email = "user@authentik.example.com"
+        mock_user.full_name = "Authentik User"
+        mock_user.is_admin = False
+        mock_user.admin_origin = None
+        mock_user.auth_provider = "authentik"
+        mock_user.email_verified = True
+        mock_user.get_teams.return_value = []
+
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.get_provider = MagicMock(return_value=generic_provider)
+
+        developer_assignment = [{"role_name": "developer", "scope": "team", "scope_id": None}]
+
+        user_info = {
+            "email": "user@authentik.example.com",
+            "full_name": "Authentik User",
+            "provider": "authentik",
+            "groups": ["cf-users"],
+            "email_verified": True,
+        }
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            with patch.object(sso_service, "_map_groups_to_roles", new=AsyncMock(return_value=developer_assignment)):
+                with patch.object(sso_service, "_sync_user_roles", new=AsyncMock()):
+                    with patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+                        mock_jwt.return_value = "mock_token"
+                        await sso_service.authenticate_or_create_user(user_info)
+
+        assert mock_user.is_admin is False, "developer role must not trigger is_admin promotion"
+
+    @pytest.mark.asyncio
+    async def test_belt_and_suspenders_skips_when_already_admin(self, sso_service, generic_provider):
+        """Belt-and-suspenders must not double-set is_admin when _should_user_be_admin already promoted the user."""
+        mock_user = MagicMock()
+        mock_user.email = "admin@authentik.example.com"
+        mock_user.full_name = "Authentik Admin"
+        mock_user.is_admin = False  # starts False
+        mock_user.admin_origin = None
+        mock_user.auth_provider = "authentik"
+        mock_user.email_verified = True
+        mock_user.get_teams.return_value = []
+
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.get_provider = MagicMock(return_value=generic_provider)
+
+        # role_mappings maps the user's group to platform_admin → _should_user_be_admin returns True
+        generic_provider.provider_metadata = {
+            "groups_claim": "groups",
+            "role_mappings": {"cf-platform-admin": "platform_admin"},
+            "default_role": None,
+        }
+
+        user_info = {
+            "email": "admin@authentik.example.com",
+            "full_name": "Authentik Admin",
+            "provider": "authentik",
+            "groups": ["cf-platform-admin"],
+            "email_verified": True,
+        }
+
+        platform_admin_assignment = [{"role_name": "platform_admin", "scope": "global", "scope_id": None}]
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_generic_admin_groups = []
+            mock_settings.sso_generic_provider_id = "authentik"
+
+            with patch.object(sso_service, "_map_groups_to_roles", new=AsyncMock(return_value=platform_admin_assignment)):
+                with patch.object(sso_service, "_sync_user_roles", new=AsyncMock()):
+                    with patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+                        mock_jwt.return_value = "mock_token"
+                        await sso_service.authenticate_or_create_user(user_info)
+
+        # _should_user_be_admin promoted the user in the first block
+        assert mock_user.is_admin is True
+        assert mock_user.admin_origin == "sso"

--- a/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
+++ b/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
@@ -84,8 +84,8 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
         sso_generic_scope="openid profile email",
         sso_generic_groups_claim="groups",
         sso_generic_admin_groups=[],
-        sso_generic_role_mappings={},
-        sso_generic_default_role=None,
+        sso_generic_role_mappings={"cf-platform-admin": "platform_admin", "cf-dev": "developer"},
+        sso_generic_default_role="platform_viewer",
         sso_generic_sync_roles_on_login=True,
         sso_trusted_domains=["example.com"],
         sso_auto_create_users=True,
@@ -121,6 +121,108 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
 
     keycloak_provider = next(provider for provider in providers if provider["id"] == "keycloak")
     assert keycloak_provider["jwks_uri"] == "https://keycloak.example.com/jwks"
+
+    # Generic OIDC provider_metadata must be populated (gap 1 fix)
+    generic_provider = next(provider for provider in providers if provider["id"] == "authentik")
+    assert "provider_metadata" in generic_provider, "Generic OIDC provider must include provider_metadata"
+    generic_meta = generic_provider["provider_metadata"]
+    assert generic_meta["groups_claim"] == "groups"
+    assert generic_meta["role_mappings"] == {"cf-platform-admin": "platform_admin", "cf-dev": "developer"}
+    assert generic_meta["default_role"] == "platform_viewer"
+
+
+def test_get_predefined_sso_providers_generic_oidc_provider_metadata(monkeypatch):
+    """Generic OIDC bootstrap populates provider_metadata with group/role config (gap 1 fix).
+
+    Verifies that groups_claim, role_mappings, and default_role are written into
+    provider_metadata so that _map_groups_to_roles() does not exit early.
+    """
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("secret-value")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False,
+        sso_google_enabled=False,
+        sso_ibm_verify_enabled=False,
+        sso_okta_enabled=False,
+        sso_entra_enabled=False,
+        sso_keycloak_enabled=False,
+        sso_adfs_enabled=False,
+        sso_generic_enabled=True,
+        sso_generic_provider_id="authentik",
+        sso_generic_display_name="Authentik",
+        sso_generic_client_id="authentik-client",
+        sso_generic_client_secret=secret,
+        sso_generic_authorization_url="https://authentik.example.com/application/o/authorize/",
+        sso_generic_token_url="https://authentik.example.com/application/o/token/",
+        sso_generic_userinfo_url="https://authentik.example.com/application/o/userinfo/",
+        sso_generic_issuer="https://authentik.example.com/application/o/myapp/",
+        sso_generic_jwks_uri="https://authentik.example.com/application/o/myapp/jwks/",
+        sso_generic_scope="openid profile email",
+        sso_generic_groups_claim="groups",
+        sso_generic_role_mappings={"cf-platform-admin": "platform_admin"},
+        sso_generic_default_role="platform_viewer",
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+
+    providers = get_predefined_sso_providers()
+    assert len(providers) == 1
+    provider = providers[0]
+
+    assert provider["id"] == "authentik"
+    assert "provider_metadata" in provider
+
+    meta = provider["provider_metadata"]
+    assert meta["groups_claim"] == "groups"
+    assert meta["role_mappings"] == {"cf-platform-admin": "platform_admin"}
+    assert meta["default_role"] == "platform_viewer"
+    # jwks_uri should be hoisted to top-level too
+    assert provider.get("jwks_uri") == "https://authentik.example.com/application/o/myapp/jwks/"
+
+
+def test_get_predefined_sso_providers_generic_oidc_empty_role_mappings(monkeypatch):
+    """Generic OIDC bootstrap writes provider_metadata even when role_mappings is empty."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("secret-value")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False,
+        sso_google_enabled=False,
+        sso_ibm_verify_enabled=False,
+        sso_okta_enabled=False,
+        sso_entra_enabled=False,
+        sso_keycloak_enabled=False,
+        sso_adfs_enabled=False,
+        sso_generic_enabled=True,
+        sso_generic_provider_id="auth0",
+        sso_generic_display_name=None,
+        sso_generic_client_id="auth0-client",
+        sso_generic_client_secret=secret,
+        sso_generic_authorization_url="https://example.auth0.com/authorize",
+        sso_generic_token_url="https://example.auth0.com/oauth/token",
+        sso_generic_userinfo_url="https://example.auth0.com/userinfo",
+        sso_generic_issuer="https://example.auth0.com/",
+        sso_generic_jwks_uri=None,
+        sso_generic_scope="openid profile email",
+        sso_generic_groups_claim="groups",
+        sso_generic_role_mappings={},
+        sso_generic_default_role=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+
+    providers = get_predefined_sso_providers()
+    provider = providers[0]
+
+    assert "provider_metadata" in provider
+    meta = provider["provider_metadata"]
+    assert meta["role_mappings"] == {}
+    assert meta["default_role"] is None
 
 
 def test_get_predefined_sso_providers_adfs_enabled(monkeypatch):


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

Closes #4232

## 📌 Summary
Generic OIDC providers (Authentik, Auth0, and any provider configured via SSO_GENERIC_*) could not promote users to platform_admin via SSO group mapping. Keycloak and Entra worked because they had dedicated bootstrap and admin-check wiring; the generic path was missing equivalent support in three places along the same login flow.

## What was broken

  **Gap 1 — bootstrap never wrote `provider_metadata`**
  `sso_bootstrap.py` built the generic provider config dict but left `provider_metadata` empty (`{}`). Downstream, `_map_groups_to_roles()` reads `provider_metadata` for `groups_claim`, `role_mappings`, and `default_role` and
  exits early with "No role mappings configured" when it is absent. Keycloak and Entra both populate these fields; the generic path did not.

  **Gap 2 — `_should_user_be_admin` had no generic provider path**
  The method checked GitHub orgs, Google domains, and Entra admin groups explicitly but had no path for generic providers. It always returned `False` for Authentik regardless of what groups the IdP emitted, so `is_admin` was never set to `True` at login.

  **Gap 3 — `is_admin` and RBAC role were not in sync**
  Even after fixing the first two gaps, users who had already logged in before the fix was deployed could have`is_admin=False` in the DB while holding a `platform_admin` RBAC role. The JWT is built from `is_admin`, so the admin UI remained inaccessible until the flag was corrected.

  ## Changes

  ### `mcpgateway/config.py`
  Four new environment variables for generic OIDC group/role wiring, matching
  the pattern Keycloak and Entra already follow:

  | Variable | Default | Purpose |
  |---|---|---|
  | `SSO_GENERIC_GROUPS_CLAIM` | `groups` | JWT claim that contains the user's group list |
  | `SSO_GENERIC_ADMIN_GROUPS` | `[]` | Groups that directly grant `is_admin=True` |
  | `SSO_GENERIC_ROLE_MAPPINGS` | `{}` | JSON map of IdP group → ContextForge role name |
  | `SSO_GENERIC_DEFAULT_ROLE` | `None` | Role assigned when no group mapping matches |

  ### `mcpgateway/utils/sso_bootstrap.py` (gap 1)
  The generic OIDC provider block now populates `provider_metadata` with
  `groups_claim`, `role_mappings`, and `default_role` from the new settings,
  so `_map_groups_to_roles()` no longer exits early.

  ### `mcpgateway/services/sso_service.py` (gaps 2 & 3)

  `_should_user_be_admin()` gains two new checks after the existing provider-specific blocks:

  1. **`SSO_GENERIC_ADMIN_GROUPS` check** — scoped to `provider.id == sso_generic_provider_id` only, so the list does not bleed into Keycloak, ADFS, or any other named provider sharing the same process.

  2. **`role_mappings → platform_admin` check** — provider-agnostic: any provider whose `provider_metadata.role_mappings` maps one of the user's groups to `platform_admin` returns `True`. Group names are compared case-insensitively on both sides, consistent with the existing `sso_entra_admin_groups` behaviour. This also benefits Keycloak deployments that use `role_mappings` without a separate `sso_keycloak_admin_groups` setting.

A belt-and-suspenders block after `_sync_user_roles()` in the existing-user login path promotes `is_admin` if `_map_groups_to_roles()` assigned `platform_admin` but `is_admin` is still `False` (covers users who logged in before the fix was deployed). Promoted users receive `admin_origin="sso"`, placing them under the same bidirectional sync contract as Entra and GitHub SSO admins — removal from the IdP group revokes `is_admin` on the next login. Manual grants (`admin_origin=None / "manual" / "api"`) are unaffected.

  ### `.env.example`
  New variables documented with Authentik example values.

  ## Env var quickstart for Authentik

  ```env
  SSO_GENERIC_GROUPS_CLAIM=groups
  SSO_GENERIC_ROLE_MAPPINGS={"cf-platform-admin":"platform_admin","cf-dev":"developer"}
  SSO_GENERIC_DEFAULT_ROLE=platform_viewer
  # optional: shortcut that also sets is_admin without needing a role_mappings entry
  SSO_GENERIC_ADMIN_GROUPS=["cf-platform-admin"]

  Notes for reviewers

  - The `role_mappings → platform_admin check` in `_should_user_be_admin` is intentionally provider-agnostic. This is a behavioural extension for Keycloak and Entra: if a group is mapped to `platform_admin` in their `role_mappings, is_admin` is now set to True at login without needing the provider-specific *_admin_groups setting. This is correct and consistent, but worth noting as a scope change.
  
  - `TestEntraIDAdminRoleRetention (e2e)` had a docstring that said "SSO never downgrades" without the qualifier "manual grants only". The corrected docstring documents both sides of the admin-origin contract to avoid confusion with `test_is_admin_revoked_when_sso_admin_removed_from_group`.

  - The SQL workaround from the issue report (UPDATE `sso_providers SET provider_metadata = ...`) is no longer needed after this fix. Users who applied it and set admin_origin='manual' will not be affected by the belt-and-suspenders promotion.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    ✅    |
| Unit tests                            | `make test`          |    ✅    |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
