### PR TITLE
fix: rewrite bare /mcp to /mcp/ in MCPPathRewriteMiddleware so stream…

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3013,6 +3013,18 @@ class MCPPathRewriteMiddleware:
         # Skip rewriting for well-known URIs (RFC 9728 OAuth metadata, etc.)
         # These paths may end with /mcp but should not be rewritten to the MCP transport
         if not app_path.startswith("/.well-known/"):
+            # Normalise bare /mcp to /mcp/ so the Starlette Mount at /mcp matches
+            # directly. Without this rewrite Starlette would emit a 307 redirect
+            # to /mcp/, which httpx cannot follow for streaming POST bodies
+            # (chunked Streamable HTTP) and surfaces as httpx.ReadError during
+            # initialize. See #4275.
+            if app_path == "/mcp":
+                new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
+                scope["path"] = new_path
+                if "raw_path" in scope:
+                    scope["raw_path"] = new_path.encode("latin-1")
+                await self.application(scope, receive, send)
+                return
             if (app_path.endswith("/mcp") and app_path != "/mcp") or (app_path.endswith("/mcp/") and app_path != "/mcp/"):
                 # SECURITY: Only rewrite recognised MCP paths — /servers/{id}/mcp.
                 # Arbitrary prefixes (e.g. /foo/mcp) must NOT be rewritten to
@@ -3033,8 +3045,13 @@ class MCPPathRewriteMiddleware:
                     await self.application(scope, receive, send)
                     return
                 # Rewrite to /mcp/ and continue through middleware (lets CORSMiddleware handle preflight)
-                # Preserve root_path prefix when rewriting
-                scope["path"] = f"{root_path}/mcp/" if root_path else "/mcp/"
+                # Preserve root_path prefix when rewriting. Keep raw_path aligned so
+                # downstream URL reconstruction (e.g. Starlette RedirectResponse) stays
+                # consistent with the rewritten path (#4275).
+                new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
+                scope["path"] = new_path
+                if "raw_path" in scope:
+                    scope["raw_path"] = new_path.encode("latin-1")
                 await self.application(scope, receive, send)
                 return
         await self.application(scope, receive, send)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -2989,6 +2989,79 @@ class TestMCPPathRewriteMiddleware:
         # ORJSONResponse sends http.response.start + http.response.body
         assert any(m.get("status") == 404 for m in sent if m.get("type") == "http.response.start")
 
+    @pytest.mark.asyncio
+    async def test_rewrite_bare_mcp_to_trailing_slash(self):
+        """Bare /mcp rewrites to /mcp/ so Starlette's Mount matches without a 307 redirect (#4275)."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/mcp", "headers": []}
+        receive, send = AsyncMock(), AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_rewrite_bare_mcp_with_root_path(self):
+        """Bare /mcp with reverse-proxy prefix rewrites to /<prefix>/mcp/ (#4275)."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/gateway/mcp",
+            "root_path": "/gateway",
+            "headers": [],
+        }
+        receive, send = AsyncMock(), AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/gateway/mcp/"
+        app_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rewrite_updates_raw_path(self):
+        """Rewriting keeps scope['raw_path'] aligned with scope['path'] (#4275)."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/servers/123/mcp",
+            "raw_path": b"/servers/123/mcp",
+            "headers": [],
+        }
+        receive, send = AsyncMock(), AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/mcp/"
+        assert scope["raw_path"] == b"/mcp/"
+        app_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bare_mcp_updates_raw_path(self):
+        """Bare /mcp rewrite also syncs raw_path so URL reconstruction stays correct (#4275)."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "headers": [],
+        }
+        receive, send = AsyncMock(), AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/mcp/"
+        assert scope["raw_path"] == b"/mcp/"
+        app_mock.assert_called_once()
+
 
 class TestServerEndpointCoverage:
     """Exercise server endpoints and SSE coverage."""


### PR DESCRIPTION

  ## 🔗 Related Issue
  Closes #4275                                                                                                                                  
   
  ---                                                                                                                                           
                  
  ## 📝 Summary
  `MCPPathRewriteMiddleware` only rewrote `/servers/<id>/mcp` to `/mcp/`, leaving bare `/mcp` untouched. Because the Starlette mount is at
  `/mcp` (compiled as `/mcp/{path:path}`), `/mcp` without the trailing slash did not match and FastAPI's router emitted a 307 redirect to
  `/mcp/`. For chunked Streamable HTTP POSTs the client cannot replay the body across a redirect, so the handshake failed with `httpx.ReadError`
   during `initialize`.

  This PR normalises bare `/mcp` to `/mcp/` inside the middleware so the mount matches directly without a redirect. It also mirrors every
  rewrite into `scope["raw_path"]` alongside `scope["path"]` (both the new bare-`/mcp` branch and the existing `/servers/<id>/mcp` branch),
  keeping downstream URL reconstruction consistent with the rewritten path.

  Security posture is unchanged: arbitrary prefixes ending in `/mcp` (e.g. `/foo/mcp`) still pass through unrewritten, and empty server IDs
  (`/servers//mcp`) still return 404.

  ---

  ## 🏷️  Type of Change
  - [x] Bug fix
  - [ ] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)
  - [ ] Other (describe below)

  ---

  ## 🧪 Verification

  | Check                     | Command         | Status |
  |---------------------------|-----------------|--------|
  | Lint suite                | `make lint`     | ✅ ruff/isort/black clean on changed lines (pre-existing drift untouched) |
  | Unit tests                | `make test`     | ✅ 1864+ related tests pass (main, middleware, auth, streamable HTTP transport) |
  | Coverage ≥ 80%            | `make coverage` | ⏳ to be verified in CI |

  ---

  ## ✅ Checklist
  - [x] Code formatted (`make black isort pre-commit`)
  - [x] Tests added/updated for changes
  - [ ] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

  ---

  ## 📓 Notes (optional)
  Four new unit tests in `TestMCPPathRewriteMiddleware` cover:
  - `test_rewrite_bare_mcp_to_trailing_slash` — `/mcp` → `/mcp/`
  - `test_rewrite_bare_mcp_with_root_path` — `/gateway/mcp` → `/gateway/mcp/` (reverse-proxy prefix)
  - `test_rewrite_updates_raw_path` — `/servers/<id>/mcp` rewrite keeps `raw_path` aligned
  - `test_bare_mcp_updates_raw_path` — bare-`/mcp` rewrite syncs `raw_path`