### PR TITLE
fix(transport): return 405 on session-less GET /mcp (#4205)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-17T15:20:26Z",
+  "generated_at": "2026-04-17T16:42:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -309,32 +309,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 486,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "MIGRATION-0.7.0.md": [
-      {
-        "hashed_secret": "a6778f1880744bd1a342a8e3789135412d8f9da2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 117,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2ea7922634de2875ff5c42d0fa29b4164099d035",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 255,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "14991a6831690bfa16045ce03c951b254e477476",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 451,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6740,7 +6714,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 288,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -6748,7 +6722,7 @@
         "hashed_secret": "120340c3d011e9621b9bb88b5884221b25251b88",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2063,
+        "line_number": 2065,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9630,7 +9604,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11527,
+        "line_number": 11609,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9638,7 +9612,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12664,
+        "line_number": 12784,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-17T07:05:17Z",
+  "generated_at": "2026-04-17T15:20:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -9630,7 +9630,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11388,
+        "line_number": 11527,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9638,7 +9638,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12525,
+        "line_number": 12664,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/b
 # Use Debian slim so basic tooling exists without Alpine.
 FROM debian:bookworm-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates tzdata && \
+    apt-get install -y --no-install-recommends ca-certificates tzdata wget && \
     rm -rf /var/lib/apt/lists/* && \
     useradd --uid 1001 --create-home --shell /usr/sbin/nologin app
 COPY --from=builder /usr/local/bin/a2a-echo-agent /usr/local/bin/a2a-echo-agent

--- a/crates/a2a_runtime/src/event_store.rs
+++ b/crates/a2a_runtime/src/event_store.rs
@@ -320,7 +320,7 @@ impl EventStore {
             };
 
         let mut result = Vec::with_capacity(entries.len());
-        for ((event_id, score), payload) in entries.into_iter().zip(payloads.into_iter()) {
+        for ((event_id, score), payload) in entries.into_iter().zip(payloads) {
             result.push(StoredEvent {
                 event_id,
                 sequence: score as i64,

--- a/crates/a2a_runtime/src/server.rs
+++ b/crates/a2a_runtime/src/server.rs
@@ -267,18 +267,14 @@ fn normalize_task_proxy_params(action: &str, body: &Value, resolved_agent_id: &s
 
     if let Value::Object(ref mut map) = params {
         match action {
-            "get" | "cancel" => {
-                if !map.contains_key("task_id") {
-                    if let Some(task_id) = map.get("id").cloned() {
-                        map.insert("task_id".to_string(), task_id);
-                    }
+            "get" | "cancel" if !map.contains_key("task_id") => {
+                if let Some(task_id) = map.get("id").cloned() {
+                    map.insert("task_id".to_string(), task_id);
                 }
             }
-            "list" => {
-                if !map.contains_key("state") {
-                    if let Some(state) = map.get("status").cloned() {
-                        map.insert("state".to_string(), state);
-                    }
+            "list" if !map.contains_key("state") => {
+                if let Some(state) = map.get("status").cloned() {
+                    map.insert("state".to_string(), state);
                 }
             }
             _ => {}

--- a/crates/mcp_runtime/src/lib.rs
+++ b/crates/mcp_runtime/src/lib.rs
@@ -4622,26 +4622,37 @@ async fn forward_transport_request(
         }
     }
 
-    // #4205: Passive GET SSE stream fallback. The MCP spec allows servers to
-    // return 405 when they cannot anchor such a stream to a session. Two
-    // branches land here:
-    //   (a) session_core is disabled globally — Rust has no way to validate
-    //       a session it could anchor a stream to, and the live-stream relay
-    //       would commit to a `text/event-stream` response before discovering
-    //       the backend can't service the GET (empty-stream cascade).
-    //   (b) no session id was presented in either the `Mcp-Session-Id` header
-    //       or the `session_id` query parameter.
-    // Why 405 rather than 404/400: the `/mcp` path exists and the request is
-    // syntactically valid; 405 + `Allow: POST, DELETE` tells the client the
-    // resource is real and which verbs it supports, which is exactly what the
-    // MCP Streamable HTTP spec (2025-03-26 rev.) sanctions here.
-    // Counter (total + session-core-disabled subcount) and level-split logs
-    // let ops distinguish "no traffic" from "every client rejected"; capability
-    // headers keep parity with the other terminal responses in this function.
-    if method == reqwest::Method::GET {
-        let session_id_present = runtime_session_id_from_request(&incoming_headers, &uri).is_some();
-        let session_core_enabled = state.session_core_enabled();
-        if !session_core_enabled || !session_id_present {
+    if method == reqwest::Method::GET
+        && state.live_stream_core_enabled()
+        && accepts_sse(&incoming_headers)
+        && !incoming_headers.contains_key("last-event-id")
+    {
+        // #4205: Guard the live-stream relay with a 405 when we have no
+        // session to anchor a passive SSE stream to. Two branches land here:
+        //   (a) session_core is disabled globally — Rust has no session
+        //       infrastructure to validate against.
+        //   (b) session_core is enabled but no valid session id was presented
+        //       (neither `Mcp-Session-Id`/`x-mcp-session-id` header nor
+        //       `session_id` query parameter).
+        // Without this gate, `handle_live_stream_transport_request` commits
+        // to a `text/event-stream` response before discovering the backend
+        // can't anchor the stream, producing the empty-stream cascade that
+        // times out strict MCP clients (the #4205 symptom). For GETs that
+        // don't enter this branch (live_stream_core disabled, or no SSE
+        // Accept), we let the request fall through to the Python transport
+        // bridge, which has its own 405 logic — Rust must not pre-empt that
+        // proxy path.
+        //
+        // Why 405 rather than 404/400: the `/mcp` path exists and the
+        // request is syntactically valid; 405 + `Allow: POST, DELETE` tells
+        // the client the resource is real and which verbs it supports,
+        // which is what the MCP Streamable HTTP spec (2025-03-26 rev.)
+        // sanctions here. Counter (total + session-core-disabled subcount)
+        // and level-split logs let ops distinguish "no traffic" from "every
+        // client rejected"; capability headers keep parity with the other
+        // terminal responses in this function.
+        if session_id.is_none() {
+            let session_core_enabled = state.session_core_enabled();
             let reject_reason = if !session_core_enabled {
                 TransportGetRejectReason::SessionCoreDisabled
             } else {
@@ -4664,16 +4675,14 @@ async fn forward_transport_request(
                     warn!(
                         path = %public_path,
                         session_core_enabled = session_core_enabled,
-                        session_id_present = session_id_present,
-                        "rejecting GET with 405 — session_core disabled"
+                        "rejecting passive-stream GET with 405 — session_core disabled"
                     );
                 }
                 TransportGetRejectReason::NoSessionId => {
                     debug!(
                         path = %public_path,
                         session_core_enabled = session_core_enabled,
-                        session_id_present = session_id_present,
-                        "rejecting GET with 405 — no session id presented"
+                        "rejecting passive-stream GET with 405 — no session id presented"
                     );
                 }
             }
@@ -4695,13 +4704,7 @@ async fn forward_transport_request(
             );
             return response;
         }
-    }
 
-    if method == reqwest::Method::GET
-        && state.live_stream_core_enabled()
-        && accepts_sse(&incoming_headers)
-        && !incoming_headers.contains_key("last-event-id")
-    {
         return handle_live_stream_transport_request(
             state,
             &incoming_headers,
@@ -13556,12 +13559,20 @@ mod unit_tests {
         // id to anchor it to. 405 + Allow + capability headers + counter tick.
         // Also asserts the session-core-disabled subcounter does NOT tick on
         // this branch, so the split counter stays trustworthy for ops.
+        // The 405 gate sits INSIDE the live-stream branch — the request must
+        // present `accept: text/event-stream` to reach it; otherwise the GET
+        // falls through to the Python transport bridge proxy.
         let state = AppState::new(&test_config()).expect("state");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("accept"),
+            HeaderValue::from_static("text/event-stream"),
+        );
         let before = state.runtime_stats().snapshot().transport;
         let response = forward_transport_request(
             &state,
             reqwest::Method::GET,
-            HeaderMap::new(),
+            headers,
             "/mcp".to_string(),
             "/mcp".parse::<Uri>().expect("uri"),
         )

--- a/crates/mcp_runtime/src/lib.rs
+++ b/crates/mcp_runtime/src/lib.rs
@@ -236,8 +236,14 @@ pub struct RuntimeStatsSnapshot {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TransportStatsSnapshot {
-    // #4205: GETs rejected with 405 because no session id was presented.
+    // #4205: Total GETs rejected with 405 because a passive SSE stream could
+    // not be anchored to a session — sum of both branches below.
     pub get_rejected_no_session: u64,
+    // #4205: Subset of `get_rejected_no_session` where `session_core` is
+    // disabled on this runtime (deployment-config condition, distinct from
+    // normal client behaviour). Non-zero here means clients are being turned
+    // away even if they *did* present a session id.
+    pub get_rejected_session_core_disabled: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -289,6 +295,7 @@ struct RuntimeStats {
     affinity_forward_attempts: AtomicU64,
     affinity_forwarded_requests: AtomicU64,
     transport_get_rejected_no_session: AtomicU64,
+    transport_get_rejected_session_core_disabled: AtomicU64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -308,6 +315,14 @@ enum SessionAccessDenyReason {
     OwnerEmailMismatch,
     MissingAuthBindingFingerprint,
     AuthBindingMismatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TransportGetRejectReason {
+    // GET arrived without a session id in either header or query param.
+    NoSessionId,
+    // `session_core` is disabled globally, so no GET can be anchored.
+    SessionCoreDisabled,
 }
 
 const CLIENT_ERROR_DETAIL: &str = "See server logs";
@@ -1187,6 +1202,9 @@ impl RuntimeStats {
                 get_rejected_no_session: self
                     .transport_get_rejected_no_session
                     .load(Ordering::Relaxed),
+                get_rejected_session_core_disabled: self
+                    .transport_get_rejected_session_core_disabled
+                    .load(Ordering::Relaxed),
             },
         }
     }
@@ -1271,9 +1289,13 @@ impl RuntimeStats {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn record_transport_get_rejected_no_session(&self) {
+    fn record_transport_get_rejected_no_session(&self, reason: TransportGetRejectReason) {
         self.transport_get_rejected_no_session
             .fetch_add(1, Ordering::Relaxed);
+        if matches!(reason, TransportGetRejectReason::SessionCoreDisabled) {
+            self.transport_get_rejected_session_core_disabled
+                .fetch_add(1, Ordering::Relaxed);
+        }
     }
 }
 
@@ -3899,8 +3921,13 @@ fn runtime_session_id_from_request(
     incoming_headers: &HeaderMap,
     uri: &axum::http::Uri,
 ) -> Option<String> {
+    // Accept both `mcp-session-id` (canonical per MCP Streamable HTTP) and
+    // `x-mcp-session-id` (legacy alias the Python gateway already honours).
+    // Keeping the two runtimes aligned avoids clients being accepted by one
+    // and 405'd by the other when they migrate between them.
     incoming_headers
         .get("mcp-session-id")
+        .or_else(|| incoming_headers.get("x-mcp-session-id"))
         .and_then(|value| value.to_str().ok())
         .map(str::to_string)
         .or_else(|| query_param(uri, "session_id"))
@@ -4604,44 +4631,70 @@ async fn forward_transport_request(
     //       the backend can't service the GET (empty-stream cascade).
     //   (b) no session id was presented in either the `Mcp-Session-Id` header
     //       or the `session_id` query parameter.
-    // Counter + info log let ops distinguish "no traffic" from "every client
-    // rejected"; capability headers keep parity with the other terminal
-    // responses in this function.
-    if method == reqwest::Method::GET
-        && (!state.session_core_enabled()
-            || runtime_session_id_from_request(&incoming_headers, &uri).is_none())
-    {
-        state
-            .runtime_stats()
-            .record_transport_get_rejected_no_session();
-        let detail = if state.session_core_enabled() {
-            "Passive SSE stream requires an Mcp-Session-Id from a prior initialize."
-        } else {
-            "Passive SSE stream not available: session management is disabled on this runtime."
-        };
-        info!(
-            path = %public_path,
-            session_core_enabled = state.session_core_enabled(),
-            session_id_present = runtime_session_id_from_request(&incoming_headers, &uri).is_some(),
-            "rejecting GET with 405"
-        );
-        let mut response =
-            json_response(StatusCode::METHOD_NOT_ALLOWED, json!({ "detail": detail }));
-        response.headers_mut().insert(
-            HeaderName::from_static("allow"),
-            HeaderValue::from_static("POST, DELETE"),
-        );
-        inject_runtime_capability_headers(
-            &mut response,
-            &[
-                (SESSION_CORE_HEADER, state.session_core_enabled()),
-                (EVENT_STORE_HEADER, state.event_store_enabled()),
-                (RESUME_CORE_HEADER, state.resume_core_enabled()),
-                (LIVE_STREAM_CORE_HEADER, state.live_stream_core_enabled()),
-                (AFFINITY_CORE_HEADER, state.affinity_core_enabled()),
-            ],
-        );
-        return response;
+    // Why 405 rather than 404/400: the `/mcp` path exists and the request is
+    // syntactically valid; 405 + `Allow: POST, DELETE` tells the client the
+    // resource is real and which verbs it supports, which is exactly what the
+    // MCP Streamable HTTP spec (2025-03-26 rev.) sanctions here.
+    // Counter (total + session-core-disabled subcount) and level-split logs
+    // let ops distinguish "no traffic" from "every client rejected"; capability
+    // headers keep parity with the other terminal responses in this function.
+    if method == reqwest::Method::GET {
+        let session_id_present = runtime_session_id_from_request(&incoming_headers, &uri).is_some();
+        let session_core_enabled = state.session_core_enabled();
+        if !session_core_enabled || !session_id_present {
+            let reject_reason = if !session_core_enabled {
+                TransportGetRejectReason::SessionCoreDisabled
+            } else {
+                TransportGetRejectReason::NoSessionId
+            };
+            state
+                .runtime_stats()
+                .record_transport_get_rejected_no_session(reject_reason);
+            let detail = if session_core_enabled {
+                "Passive SSE stream requires an Mcp-Session-Id from a prior initialize."
+            } else {
+                "Passive SSE stream not available: session management is disabled on this runtime."
+            };
+            // Log level split by reason: disabled session_core is an
+            // operator-facing config condition (warn); missing session id is
+            // routine behaviour from strict MCP clients probing before
+            // `initialize` and would flood info-level logs (debug).
+            match reject_reason {
+                TransportGetRejectReason::SessionCoreDisabled => {
+                    warn!(
+                        path = %public_path,
+                        session_core_enabled = session_core_enabled,
+                        session_id_present = session_id_present,
+                        "rejecting GET with 405 — session_core disabled"
+                    );
+                }
+                TransportGetRejectReason::NoSessionId => {
+                    debug!(
+                        path = %public_path,
+                        session_core_enabled = session_core_enabled,
+                        session_id_present = session_id_present,
+                        "rejecting GET with 405 — no session id presented"
+                    );
+                }
+            }
+            let mut response =
+                json_response(StatusCode::METHOD_NOT_ALLOWED, json!({ "detail": detail }));
+            response.headers_mut().insert(
+                HeaderName::from_static("allow"),
+                HeaderValue::from_static("POST, DELETE"),
+            );
+            inject_runtime_capability_headers(
+                &mut response,
+                &[
+                    (SESSION_CORE_HEADER, session_core_enabled),
+                    (EVENT_STORE_HEADER, state.event_store_enabled()),
+                    (RESUME_CORE_HEADER, state.resume_core_enabled()),
+                    (LIVE_STREAM_CORE_HEADER, state.live_stream_core_enabled()),
+                    (AFFINITY_CORE_HEADER, state.affinity_core_enabled()),
+                ],
+            );
+            return response;
+        }
     }
 
     if method == reqwest::Method::GET
@@ -13501,12 +13554,10 @@ mod unit_tests {
     async fn forward_transport_request_get_without_session_id_returns_method_not_allowed() {
         // #4205: A passive GET SSE stream cannot be served without a session
         // id to anchor it to. 405 + Allow + capability headers + counter tick.
+        // Also asserts the session-core-disabled subcounter does NOT tick on
+        // this branch, so the split counter stays trustworthy for ops.
         let state = AppState::new(&test_config()).expect("state");
-        let before = state
-            .runtime_stats()
-            .snapshot()
-            .transport
-            .get_rejected_no_session;
+        let before = state.runtime_stats().snapshot().transport;
         let response = forward_transport_request(
             &state,
             reqwest::Method::GET,
@@ -13539,12 +13590,16 @@ mod unit_tests {
             body_detail.starts_with("Passive SSE stream requires an Mcp-Session-Id"),
             "unexpected 405 detail: {body_detail}"
         );
-        let after = state
-            .runtime_stats()
-            .snapshot()
-            .transport
-            .get_rejected_no_session;
-        assert_eq!(after, before + 1, "counter should tick on 405");
+        let after = state.runtime_stats().snapshot().transport;
+        assert_eq!(
+            after.get_rejected_no_session,
+            before.get_rejected_no_session + 1,
+            "total 405 counter should tick"
+        );
+        assert_eq!(
+            after.get_rejected_session_core_disabled, before.get_rejected_session_core_disabled,
+            "session-core-disabled subcounter must NOT tick on the no-session-id branch"
+        );
     }
 
     #[tokio::test]
@@ -13554,6 +13609,9 @@ mod unit_tests {
         // SSE stream to a validated session. Even a GET that presents a
         // session header must be 405'd — otherwise live_stream_core would
         // commit to a `text/event-stream` response and relay an empty stream.
+        // Also asserts this branch ticks BOTH the total counter AND the
+        // session-core-disabled subcounter (the deployment-config signal
+        // ops filter on).
         let mut config = test_config();
         config.session_core_enabled = false;
         config.live_stream_core_enabled = true;
@@ -13569,6 +13627,7 @@ mod unit_tests {
             HeaderValue::from_static("text/event-stream"),
         );
 
+        let before = state.runtime_stats().snapshot().transport;
         let response = forward_transport_request(
             &state,
             reqwest::Method::GET,
@@ -13585,6 +13644,17 @@ mod unit_tests {
         assert!(
             body_detail.contains("session management is disabled"),
             "unexpected 405 detail: {body_detail}"
+        );
+        let after = state.runtime_stats().snapshot().transport;
+        assert_eq!(
+            after.get_rejected_no_session,
+            before.get_rejected_no_session + 1,
+            "total 405 counter should tick for session-core-disabled branch"
+        );
+        assert_eq!(
+            after.get_rejected_session_core_disabled,
+            before.get_rejected_session_core_disabled + 1,
+            "session-core-disabled subcounter should tick for this branch"
         );
     }
 
@@ -13641,6 +13711,7 @@ mod unit_tests {
             HeaderValue::from_static("text/event-stream"),
         );
 
+        let before = state.runtime_stats().snapshot().transport;
         let response = forward_transport_request(
             &state,
             reqwest::Method::GET,
@@ -13663,6 +13734,15 @@ mod unit_tests {
                 .get("x-contextforge-mcp-live-stream-core")
                 .and_then(|value| value.to_str().ok()),
             Some("rust")
+        );
+        let after = state.runtime_stats().snapshot().transport;
+        assert_eq!(
+            after.get_rejected_no_session, before.get_rejected_no_session,
+            "happy-path GET must not tick the 405 counter"
+        );
+        assert_eq!(
+            after.get_rejected_session_core_disabled, before.get_rejected_session_core_disabled,
+            "happy-path GET must not tick the session-core-disabled subcounter"
         );
     }
 
@@ -13700,6 +13780,7 @@ mod unit_tests {
         )
         .await;
 
+        let before = state.runtime_stats().snapshot().transport;
         let response = forward_transport_request(
             &state,
             reqwest::Method::GET,
@@ -13709,6 +13790,72 @@ mod unit_tests {
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
+        let after = state.runtime_stats().snapshot().transport;
+        assert_eq!(
+            after.get_rejected_no_session, before.get_rejected_no_session,
+            "query-param session id must not tick the 405 counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_transport_request_get_accepts_x_mcp_session_id_alias() {
+        // #4205 parity: the Python gateway accepts both `mcp-session-id` and
+        // `x-mcp-session-id`. Rust must do the same so clients aren't
+        // accepted by one runtime and 405'd by the other.
+        let backend = Router::new().route(
+            "/_internal/mcp/transport",
+            axum::routing::get(|| async { Json(json!({"ok": true})) }),
+        );
+        let backend_url = spawn_router(backend).await;
+
+        let mut config = test_config();
+        config.backend_rpc_url = format!("{backend_url}/rpc");
+        config.live_stream_core_enabled = false;
+        config.affinity_core_enabled = false;
+        let state = AppState::new(&config).expect("state");
+
+        upsert_runtime_session(
+            &state,
+            "alias-session".to_string(),
+            RuntimeSessionRecord {
+                owner_email: None,
+                server_id: None,
+                protocol_version: None,
+                client_capabilities: None,
+                encoded_auth_context: None,
+                auth_binding_fingerprint: None,
+                auth_context_expires_at_epoch_ms: None,
+                created_at: std::time::Instant::now(),
+                last_used: std::time::Instant::now(),
+            },
+        )
+        .await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-mcp-session-id"),
+            HeaderValue::from_static("alias-session"),
+        );
+
+        let before = state.runtime_stats().snapshot().transport;
+        let response = forward_transport_request(
+            &state,
+            reqwest::Method::GET,
+            headers,
+            "/mcp".to_string(),
+            "/mcp".parse::<Uri>().expect("uri"),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "x-mcp-session-id alias should be accepted"
+        );
+        let after = state.runtime_stats().snapshot().transport;
+        assert_eq!(
+            after.get_rejected_no_session, before.get_rejected_no_session,
+            "alias-header GET must not tick the 405 counter"
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp_runtime/src/lib.rs
+++ b/crates/mcp_runtime/src/lib.rs
@@ -231,6 +231,13 @@ pub struct RuntimeStatsSnapshot {
     pub session_auth_reuse: SessionAuthReuseStatsSnapshot,
     pub session_access_denials: SessionAccessDenialStatsSnapshot,
     pub affinity: AffinityStatsSnapshot,
+    pub transport: TransportStatsSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TransportStatsSnapshot {
+    // #4205: GETs rejected with 405 because no session id was presented.
+    pub get_rejected_no_session: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -281,6 +288,7 @@ struct RuntimeStats {
     session_access_auth_binding_mismatches: AtomicU64,
     affinity_forward_attempts: AtomicU64,
     affinity_forwarded_requests: AtomicU64,
+    transport_get_rejected_no_session: AtomicU64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1175,6 +1183,11 @@ impl RuntimeStats {
                 forward_attempts: self.affinity_forward_attempts.load(Ordering::Relaxed),
                 forwarded_requests: self.affinity_forwarded_requests.load(Ordering::Relaxed),
             },
+            transport: TransportStatsSnapshot {
+                get_rejected_no_session: self
+                    .transport_get_rejected_no_session
+                    .load(Ordering::Relaxed),
+            },
         }
     }
 
@@ -1255,6 +1268,11 @@ impl RuntimeStats {
 
     fn record_affinity_forwarded_request(&self) {
         self.affinity_forwarded_requests
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_transport_get_rejected_no_session(&self) {
+        self.transport_get_rejected_no_session
             .fetch_add(1, Ordering::Relaxed);
     }
 }
@@ -4575,6 +4593,55 @@ async fn forward_transport_request(
             );
             return response;
         }
+    }
+
+    // #4205: Passive GET SSE stream fallback. The MCP spec allows servers to
+    // return 405 when they cannot anchor such a stream to a session. Two
+    // branches land here:
+    //   (a) session_core is disabled globally — Rust has no way to validate
+    //       a session it could anchor a stream to, and the live-stream relay
+    //       would commit to a `text/event-stream` response before discovering
+    //       the backend can't service the GET (empty-stream cascade).
+    //   (b) no session id was presented in either the `Mcp-Session-Id` header
+    //       or the `session_id` query parameter.
+    // Counter + info log let ops distinguish "no traffic" from "every client
+    // rejected"; capability headers keep parity with the other terminal
+    // responses in this function.
+    if method == reqwest::Method::GET
+        && (!state.session_core_enabled()
+            || runtime_session_id_from_request(&incoming_headers, &uri).is_none())
+    {
+        state
+            .runtime_stats()
+            .record_transport_get_rejected_no_session();
+        let detail = if state.session_core_enabled() {
+            "Passive SSE stream requires an Mcp-Session-Id from a prior initialize."
+        } else {
+            "Passive SSE stream not available: session management is disabled on this runtime."
+        };
+        info!(
+            path = %public_path,
+            session_core_enabled = state.session_core_enabled(),
+            session_id_present = runtime_session_id_from_request(&incoming_headers, &uri).is_some(),
+            "rejecting GET with 405"
+        );
+        let mut response =
+            json_response(StatusCode::METHOD_NOT_ALLOWED, json!({ "detail": detail }));
+        response.headers_mut().insert(
+            HeaderName::from_static("allow"),
+            HeaderValue::from_static("POST, DELETE"),
+        );
+        inject_runtime_capability_headers(
+            &mut response,
+            &[
+                (SESSION_CORE_HEADER, state.session_core_enabled()),
+                (EVENT_STORE_HEADER, state.event_store_enabled()),
+                (RESUME_CORE_HEADER, state.resume_core_enabled()),
+                (LIVE_STREAM_CORE_HEADER, state.live_stream_core_enabled()),
+                (AFFINITY_CORE_HEADER, state.affinity_core_enabled()),
+            ],
+        );
+        return response;
     }
 
     if method == reqwest::Method::GET
@@ -11116,15 +11183,41 @@ mod unit_tests {
 
         let mut config = test_config();
         config.backend_rpc_url = format!("{backend_url}/_internal/mcp/rpc");
-        config.session_core_enabled = false;
+        // Keep session_core_enabled=true: the 405 gate (#4205) now blocks
+        // GETs when session_core is disabled, so this test keeps session_core
+        // on and disables live_stream to still exercise the backend fallthrough.
         config.live_stream_core_enabled = false;
         let state = AppState::new(&config).expect("state");
 
+        upsert_runtime_session(
+            &state,
+            "scoped-session".to_string(),
+            RuntimeSessionRecord {
+                owner_email: None,
+                server_id: Some("server-xyz".to_string()),
+                protocol_version: None,
+                client_capabilities: None,
+                encoded_auth_context: None,
+                auth_binding_fingerprint: None,
+                auth_context_expires_at_epoch_ms: None,
+                created_at: std::time::Instant::now(),
+                last_used: std::time::Instant::now(),
+            },
+        )
+        .await;
+
+        // GET requires a session id (see #4205); provide one so this test
+        // continues to exercise the server-id-header injection path.
+        let mut get_headers = HeaderMap::new();
+        get_headers.insert(
+            HeaderName::from_static("mcp-session-id"),
+            HeaderValue::from_static("scoped-session"),
+        );
         let get_response = transport_get_server_scoped(
             State(state.clone()),
             AxumPath("server-xyz".to_string()),
             TrustedPeerAddr::default(),
-            HeaderMap::new(),
+            get_headers,
             "/servers/server-xyz/mcp".parse::<Uri>().expect("uri"),
         )
         .await;
@@ -13402,6 +13495,220 @@ mod unit_tests {
             response_json(response).await["detail"],
             "mcp-session-id header or session_id query parameter is required for resumable GET /mcp"
         );
+    }
+
+    #[tokio::test]
+    async fn forward_transport_request_get_without_session_id_returns_method_not_allowed() {
+        // #4205: A passive GET SSE stream cannot be served without a session
+        // id to anchor it to. 405 + Allow + capability headers + counter tick.
+        let state = AppState::new(&test_config()).expect("state");
+        let before = state
+            .runtime_stats()
+            .snapshot()
+            .transport
+            .get_rejected_no_session;
+        let response = forward_transport_request(
+            &state,
+            reqwest::Method::GET,
+            HeaderMap::new(),
+            "/mcp".to_string(),
+            "/mcp".parse::<Uri>().expect("uri"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response
+                .headers()
+                .get("allow")
+                .and_then(|value| value.to_str().ok()),
+            Some("POST, DELETE")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("x-contextforge-mcp-session-core")
+                .and_then(|value| value.to_str().ok()),
+            Some("rust"),
+            "405 response should carry the same capability headers as other terminal responses"
+        );
+        let body_detail = response_json(response).await["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            body_detail.starts_with("Passive SSE stream requires an Mcp-Session-Id"),
+            "unexpected 405 detail: {body_detail}"
+        );
+        let after = state
+            .runtime_stats()
+            .snapshot()
+            .transport
+            .get_rejected_no_session;
+        assert_eq!(after, before + 1, "counter should tick on 405");
+    }
+
+    #[tokio::test]
+    async fn forward_transport_request_get_returns_405_when_session_core_disabled_even_with_header()
+    {
+        // #4205 regression guard: without session_core, Rust can't anchor an
+        // SSE stream to a validated session. Even a GET that presents a
+        // session header must be 405'd — otherwise live_stream_core would
+        // commit to a `text/event-stream` response and relay an empty stream.
+        let mut config = test_config();
+        config.session_core_enabled = false;
+        config.live_stream_core_enabled = true;
+        let state = AppState::new(&config).expect("state");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("mcp-session-id"),
+            HeaderValue::from_static("client-supplied-id"),
+        );
+        headers.insert(
+            HeaderName::from_static("accept"),
+            HeaderValue::from_static("text/event-stream"),
+        );
+
+        let response = forward_transport_request(
+            &state,
+            reqwest::Method::GET,
+            headers,
+            "/mcp".to_string(),
+            "/mcp".parse::<Uri>().expect("uri"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        let body_detail = response_json(response).await["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            body_detail.contains("session management is disabled"),
+            "unexpected 405 detail: {body_detail}"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_transport_request_get_with_session_id_reaches_live_stream_branch() {
+        // #4205 regression guard: the 405 short-circuit must not pre-empt the
+        // live-stream branch when a session id IS presented. We set up a
+        // backend that returns a valid SSE response so handle_live_stream
+        // streams it back.
+        let backend = Router::new().route(
+            "/_internal/mcp/transport",
+            axum::routing::get(|| async {
+                (
+                    StatusCode::OK,
+                    [(
+                        "content-type",
+                        HeaderValue::from_static("text/event-stream"),
+                    )],
+                    "data: ok\n\n",
+                )
+            }),
+        );
+        let backend_url = spawn_router(backend).await;
+
+        let mut config = test_config();
+        config.backend_rpc_url = format!("{backend_url}/rpc");
+        config.affinity_core_enabled = false;
+        let state = AppState::new(&config).expect("state");
+
+        upsert_runtime_session(
+            &state,
+            "live-session".to_string(),
+            RuntimeSessionRecord {
+                owner_email: None,
+                server_id: None,
+                protocol_version: None,
+                client_capabilities: None,
+                encoded_auth_context: None,
+                auth_binding_fingerprint: None,
+                auth_context_expires_at_epoch_ms: None,
+                created_at: std::time::Instant::now(),
+                last_used: std::time::Instant::now(),
+            },
+        )
+        .await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("mcp-session-id"),
+            HeaderValue::from_static("live-session"),
+        );
+        headers.insert(
+            HeaderName::from_static("accept"),
+            HeaderValue::from_static("text/event-stream"),
+        );
+
+        let response = forward_transport_request(
+            &state,
+            reqwest::Method::GET,
+            headers,
+            "/mcp".to_string(),
+            "/mcp".parse::<Uri>().expect("uri"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("x-contextforge-mcp-live-stream-core")
+                .and_then(|value| value.to_str().ok()),
+            Some("rust")
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_transport_request_get_with_session_id_query_param_is_accepted() {
+        // #4205: A session id provided via query parameter should be accepted
+        // (mirrors runtime_session_id_from_request which checks both header
+        // and `session_id` query param).
+        let backend = Router::new().route(
+            "/_internal/mcp/transport",
+            axum::routing::get(|| async { Json(json!({"ok": true})) }),
+        );
+        let backend_url = spawn_router(backend).await;
+
+        let mut config = test_config();
+        config.backend_rpc_url = format!("{backend_url}/rpc");
+        config.live_stream_core_enabled = false;
+        config.affinity_core_enabled = false;
+        let state = AppState::new(&config).expect("state");
+
+        upsert_runtime_session(
+            &state,
+            "qp-session".to_string(),
+            RuntimeSessionRecord {
+                owner_email: None,
+                server_id: None,
+                protocol_version: None,
+                client_capabilities: None,
+                encoded_auth_context: None,
+                auth_binding_fingerprint: None,
+                auth_context_expires_at_epoch_ms: None,
+                created_at: std::time::Instant::now(),
+                last_used: std::time::Instant::now(),
+            },
+        )
+        .await;
+
+        let response = forward_transport_request(
+            &state,
+            reqwest::Method::GET,
+            HeaderMap::new(),
+            "/mcp".to_string(),
+            "/mcp?session_id=qp-session".parse::<Uri>().expect("uri"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/wrapper/src/json_rpc_id_fast.rs
+++ b/crates/wrapper/src/json_rpc_id_fast.rs
@@ -29,15 +29,15 @@ pub fn parse_field_fast(json: &[u8], field_name: &str) -> Id {
                     break;
                 }
             }
-            JsonEvent::FieldName => {
-                if depth == 1 && parser.current_str().is_ok_and(|name| name == field_name) {
-                    // Get the very next event (the value)
-                    if let Ok(Some(val_event)) = parser.next_event() {
-                        match parser.current_str() {
-                            Ok(s) => return to_id(&val_event, s),
-                            Err(e) => {
-                                error!("Invalid string: {e}");
-                            }
+            JsonEvent::FieldName
+                if depth == 1 && parser.current_str().is_ok_and(|name| name == field_name) =>
+            {
+                // Get the very next event (the value)
+                if let Ok(Some(val_event)) = parser.next_event() {
+                    match parser.current_str() {
+                        Ok(s) => return to_id(&val_event, s),
+                        Err(e) => {
+                            error!("Invalid string: {e}");
                         }
                     }
                 }

--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -131,6 +131,18 @@ oauth_verify_events_counter = Counter(
     ["outcome"],
 )
 
+# Streamable HTTP GET rejections (#4205). Clients that probe a passive SSE
+# stream before `initialize` (or against a stateless gateway) are 405'd with
+# `Allow: POST, DELETE`. Outcome labels mirror the Rust runtime's counter
+# split so ops can distinguish client-side from deployment-config causes:
+#   no_session_id           — client didn't present `Mcp-Session-Id`
+#   stateful_disabled       — this gateway runs with `use_stateful_sessions=False`
+transport_get_rejected_counter = Counter(
+    "transport_get_rejected_total",
+    "GET /mcp 405 rejections by reason (no session anchor available)",
+    ["outcome"],
+)
+
 
 def setup_metrics(app):
     """

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2971,6 +2971,34 @@ class SessionManagerWrapper:
         if validated is _REJECT:
             return
 
+        # #4205: Passive GET SSE stream fallback. The MCP spec allows servers
+        # to return 405 on GET when they cannot anchor a passive stream to a
+        # session. Two branches land here:
+        #   (a) stateful sessions disabled globally (no session infrastructure);
+        #   (b) no Mcp-Session-Id — the sentinel "not-provided" covers both a
+        #       missing header and an invalid id that the affinity check reset.
+        # Placed after server-id validation and RBAC so bogus server IDs still
+        # 404 and unauthorized callers still 403 before we advertise the
+        # endpoint via the Allow header.
+        if method == "GET" and (not settings.use_stateful_sessions or mcp_session_id == "not-provided"):
+            if not settings.use_stateful_sessions:
+                detail = "Stateful sessions disabled on this gateway; passive SSE stream is not available."
+            else:
+                detail = "Passive SSE stream requires an Mcp-Session-Id from a prior initialize."
+            logger.info(
+                "Rejecting GET %s with 405 (stateful=%s, session_id_present=%s)",
+                path,
+                settings.use_stateful_sessions,
+                mcp_session_id != "not-provided",
+            )
+            response = ORJSONResponse(
+                {"detail": detail},
+                status_code=405,
+                headers={"Allow": "POST, DELETE"},
+            )
+            await response(scope, receive, send)
+            return
+
         if is_internally_forwarded:
             logger.debug("[HTTP_AFFINITY_FORWARDED] Received forwarded request | Method: %s | Session: %s", method, mcp_session_id)
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -72,7 +72,7 @@ from mcpgateway.observability import create_span
 from mcpgateway.services.completion_service import CompletionService
 from mcpgateway.services.http_client_service import get_http_client, get_http_limits
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.metrics import mcp_auth_cache_events_counter, oauth_verify_events_counter
+from mcpgateway.services.metrics import mcp_auth_cache_events_counter, oauth_verify_events_counter, transport_get_rejected_counter
 from mcpgateway.services.oauth_manager import OAuthEnforcementUnavailableError, OAuthRequiredError
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.prompt_service import PromptService
@@ -2939,7 +2939,17 @@ class SessionManagerWrapper:
                 if not MCPSessionPool.is_valid_mcp_session_id(mcp_session_id):
                     logger.debug("Invalid MCP session id on Streamable HTTP request, skipping affinity")
                     mcp_session_id = "not-provided"
-            except Exception:
+            except Exception as exc:
+                # A real failure here (pool import broken, DB/Redis timeout in
+                # a future validator) would otherwise be silently rendered as
+                # the #4205 405 with no log line. Warn at least once per
+                # request so ops can correlate a 405 storm with the root
+                # cause; we still fall through to treat the session as
+                # unprovided (the safe behaviour) rather than 5xx'ing.
+                logger.warning(
+                    "Session id validation failed; treating request as session-less: %s",
+                    exc,
+                )
                 mcp_session_id = "not-provided"
 
         # Log session manager ID for debugging
@@ -2977,20 +2987,35 @@ class SessionManagerWrapper:
         #   (a) stateful sessions disabled globally (no session infrastructure);
         #   (b) no Mcp-Session-Id — the sentinel "not-provided" covers both a
         #       missing header and an invalid id that the affinity check reset.
+        # Why 405 rather than 404/400: the `/mcp` path exists and the GET is
+        # syntactically valid; 405 + `Allow: POST, DELETE` tells the client the
+        # resource is real and which verbs it supports, which is exactly what
+        # the MCP Streamable HTTP spec (2025-03-26 rev.) sanctions here.
         # Placed after server-id validation and RBAC so bogus server IDs still
         # 404 and unauthorized callers still 403 before we advertise the
         # endpoint via the Allow header.
         if method == "GET" and (not settings.use_stateful_sessions or mcp_session_id == "not-provided"):
             if not settings.use_stateful_sessions:
                 detail = "Stateful sessions disabled on this gateway; passive SSE stream is not available."
+                reject_outcome = "stateful_disabled"
             else:
                 detail = "Passive SSE stream requires an Mcp-Session-Id from a prior initialize."
-            logger.info(
-                "Rejecting GET %s with 405 (stateful=%s, session_id_present=%s)",
-                path,
-                settings.use_stateful_sessions,
-                mcp_session_id != "not-provided",
-            )
+                reject_outcome = "no_session_id"
+            transport_get_rejected_counter.labels(outcome=reject_outcome).inc()
+            # Log level split by reason: stateful-disabled is an operator-facing
+            # config condition (warn); missing session id is routine probing
+            # from strict MCP clients before `initialize` and would flood
+            # info-level logs (debug).
+            if reject_outcome == "stateful_disabled":
+                logger.warning(
+                    "Rejecting GET %s with 405 — stateful sessions disabled",
+                    path,
+                )
+            else:
+                logger.debug(
+                    "Rejecting GET %s with 405 — no session id presented",
+                    path,
+                )
             response = ORJSONResponse(
                 {"detail": detail},
                 status_code=405,

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -6517,16 +6517,26 @@ class _CountingSessionManager:
 
 
 @pytest.mark.asyncio
-async def test_handle_streamable_http_get_returns_405_when_stateless(monkeypatch):
-    """GET on /mcp 405s with branch-specific detail when stateful sessions are disabled (#4205)."""
+async def test_handle_streamable_http_get_returns_405_when_stateless(monkeypatch, caplog):
+    """GET on /mcp 405s with branch-specific detail when stateful sessions are disabled (#4205).
+
+    Also asserts the Prometheus counter ticks with the `stateful_disabled`
+    outcome label and that the operator-facing WARNING log is emitted — if a
+    future refactor deletes either, this test fails rather than silently
+    dropping ops visibility on a deployment-config condition.
+    """
     sdk = _CountingSessionManager()
     monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", False)
 
+    counter = tr.transport_get_rejected_counter.labels(outcome="stateful_disabled")
+    before = counter._value.get()
+
     wrapper = SessionManagerWrapper()
     await wrapper.initialize()
     send, messages = _make_send_collector()
-    await wrapper.handle_streamable_http(_make_scope("/mcp", method="GET"), _make_receive(b""), send)
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        await wrapper.handle_streamable_http(_make_scope("/mcp", method="GET"), _make_receive(b""), send)
     await wrapper.shutdown()
 
     assert not sdk.called
@@ -6535,19 +6545,30 @@ async def test_handle_streamable_http_get_returns_405_when_stateless(monkeypatch
     assert _allow_header(starts[0]) == "POST, DELETE"
     body = next(m for m in messages if m["type"] == "http.response.body")
     assert b"Stateful sessions disabled" in body["body"]
+    assert counter._value.get() == before + 1
+    assert "stateful sessions disabled" in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_handle_streamable_http_get_returns_405_when_no_session_id(monkeypatch):
-    """GET on /mcp in stateful mode 405s when no Mcp-Session-Id is presented (#4205)."""
+async def test_handle_streamable_http_get_returns_405_when_no_session_id(monkeypatch, caplog):
+    """GET on /mcp in stateful mode 405s when no Mcp-Session-Id is presented (#4205).
+
+    Also asserts the Prometheus counter ticks with the `no_session_id` outcome
+    label and that the DEBUG log (intentionally quieter than the stateful-
+    disabled branch — this one fires on every strict-client probe) is emitted.
+    """
     sdk = _CountingSessionManager()
     monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
 
+    counter = tr.transport_get_rejected_counter.labels(outcome="no_session_id")
+    before = counter._value.get()
+
     wrapper = SessionManagerWrapper()
     await wrapper.initialize()
     send, messages = _make_send_collector()
-    await wrapper.handle_streamable_http(_make_scope("/mcp", method="GET"), _make_receive(b""), send)
+    with caplog.at_level("DEBUG", logger="mcpgateway.transports.streamablehttp_transport"):
+        await wrapper.handle_streamable_http(_make_scope("/mcp", method="GET"), _make_receive(b""), send)
     await wrapper.shutdown()
 
     assert not sdk.called
@@ -6556,6 +6577,8 @@ async def test_handle_streamable_http_get_returns_405_when_no_session_id(monkeyp
     assert _allow_header(starts[0]) == "POST, DELETE"
     body = next(m for m in messages if m["type"] == "http.response.body")
     assert b"Mcp-Session-Id" in body["body"]
+    assert counter._value.get() == before + 1
+    assert "no session id presented" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -6615,6 +6638,11 @@ async def test_handle_streamable_http_get_nonexistent_server_returns_404_not_405
     assert not sdk.called
     starts = [m for m in messages if m["type"] == "http.response.start"]
     assert starts and starts[0]["status"] == 404
+    # A 404 must not leak an `Allow` header — that header is exclusive to the
+    # 405 branch and advertises endpoint existence. If it appeared here, a
+    # client probing for valid server IDs would learn "the server doesn't
+    # exist, but POST/DELETE are allowed," which is a small enumeration leak.
+    assert _allow_header(starts[0]) is None
 
 
 # ---------------------------------------------------------------------------
@@ -10589,6 +10617,60 @@ async def test_handle_streamable_http_server_scope_requires_servers_use(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_handle_streamable_http_server_scope_rbac_forbidden_on_get(monkeypatch):
+    """#4205 regression guard: GET without RBAC permission must 403, not 405.
+
+    The 405 block at #4205 runs AFTER the RBAC gate, so an unauthorized caller
+    issuing a GET must see 403 — not a 405 that leaks endpoint existence via
+    `Allow: POST, DELETE`. A future refactor that moves the 405 above RBAC
+    would silently pass every existing 405 test while breaking this invariant.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import SessionManagerWrapper, user_context_var
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    dummy_manager = DummySessionManager()
+    dummy_manager.handle_request = AsyncMock()
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.StreamableHTTPSessionManager", lambda **kwargs: dummy_manager)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    # Stateless mode ensures the 405 would fire if RBAC were bypassed.
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", False)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    token = user_context_var.set({"email": "dev@example.com", "teams": ["team-1"], "is_admin": False, "is_authenticated": True})
+    try:
+        monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._check_streamable_permission", AsyncMock(return_value=False))
+
+        scope = _make_scope("/servers/abc-123-def/mcp", method="GET", headers=[])
+        receive = _make_receive(orjson.dumps({}))
+        send, messages = _make_send_collector()
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        starts = [m for m in messages if m["type"] == "http.response.start"]
+        assert starts and starts[0]["status"] == tr.HTTP_403_FORBIDDEN
+        # No Allow header — 403 must not advertise endpoint affordances.
+        assert _allow_header(starts[0]) is None
+        dummy_manager.handle_request.assert_not_awaited()
+    finally:
+        user_context_var.reset(token)
+        await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_handle_streamable_http_server_scope_checks_any_team_for_team_api_token(monkeypatch):
     """Server-scoped MCP requests should check RBAC across token teams for API tokens."""
     # Third-Party
@@ -11525,6 +11607,44 @@ async def test_streamable_http_auth_rejects_unauthenticated_oauth_server(monkeyp
     www_auth = dict(called[0].get("headers", [])).get(b"www-authenticate", b"").decode()
     assert "resource_metadata=" in www_auth
     assert "abc123def" in www_auth
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_auth_rejects_unauthenticated_oauth_server_on_get(monkeypatch):
+    """#4205 parity guard: GET to an oauth_enabled server must 401, not 405.
+
+    Without this guard, a future change that moved the 405 shortcut in front
+    of the OAuth layer would silently expose oauth_enabled servers via 405
+    + `Allow: POST, DELETE` to unauthenticated callers, even with
+    `MCP_REQUIRE_AUTH=false`.
+    """
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_require_auth", False)
+
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _make_fake_get_db(mock_db))
+
+    scope = _make_scope("/servers/abc123def/mcp", method="GET")
+    called = []
+
+    async def send(msg):
+        called.append(msg)
+
+    token = tr._oauth_checked_var.set(False)
+    try:
+        result = await streamable_http_auth(scope, None, send)
+    finally:
+        tr._oauth_checked_var.reset(token)
+    assert result is False
+    assert called and called[0]["status"] == 401
+    # Must not leak an `Allow: POST, DELETE` header here — that would only be
+    # emitted by the 405 branch, which must never run before OAuth enforcement.
+    hdrs = dict(called[0].get("headers", []))
+    assert b"allow" not in {k.lower() if isinstance(k, (bytes, bytearray)) else k for k in hdrs}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -6359,9 +6359,11 @@ async def test_handle_streamable_http_non_tuple_header_skipped(monkeypatch):
     await wrapper.initialize()
 
     send, messages = _make_send_collector()
+    # POST so the request bypasses the GET 405 guard (#4205) and actually
+    # exercises the malformed-header branch this test targets.
     scope = {
         "type": "http",
-        "method": "GET",
+        "method": "POST",
         "path": "/mcp",
         "modified_path": "/mcp",
         "query_string": b"",
@@ -6372,7 +6374,10 @@ async def test_handle_streamable_http_non_tuple_header_skipped(monkeypatch):
     }
     await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
     await wrapper.shutdown()
-    assert any(m["type"] == "http.response.start" for m in messages)
+    # 200 from the SDK confirms we reached handle_request (i.e. got past the
+    # header-parsing loop without raising on the malformed entry).
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 200
 
 
 @pytest.mark.asyncio
@@ -6393,9 +6398,11 @@ async def test_handle_streamable_http_non_bytes_header_skipped(monkeypatch):
     await wrapper.initialize()
 
     send, messages = _make_send_collector()
+    # POST so the request bypasses the GET 405 guard (#4205) and actually
+    # exercises the non-bytes-header branch this test targets.
     scope = {
         "type": "http",
-        "method": "GET",
+        "method": "POST",
         "path": "/mcp",
         "modified_path": "/mcp",
         "query_string": b"",
@@ -6406,7 +6413,8 @@ async def test_handle_streamable_http_non_bytes_header_skipped(monkeypatch):
     }
     await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
     await wrapper.shutdown()
-    assert any(m["type"] == "http.response.start" for m in messages)
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 200
 
 
 # ---------------------------------------------------------------------------
@@ -6476,6 +6484,137 @@ async def test_handle_streamable_http_session_validation_exception(monkeypatch):
 
     await wrapper.shutdown()
     assert any(m["type"] == "http.response.start" for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Issue #4205: GET passive SSE stream 405 fallback
+# ---------------------------------------------------------------------------
+
+
+def _allow_header(start_message):
+    """Return the Allow header value from an ASGI http.response.start message."""
+    for k, v in start_message.get("headers", []):
+        if k.lower() == b"allow":
+            return v.decode("latin-1")
+    return None
+
+
+class _CountingSessionManager:
+    """Test double for StreamableHTTPSessionManager that records whether it was called."""
+
+    def __init__(self):
+        self._server_instances = {}
+        self.called = False
+
+    @asynccontextmanager
+    async def run(self):
+        yield self
+
+    async def handle_request(self, scope, receive, send_func):
+        self.called = True
+        await send_func({"type": "http.response.start", "status": 200, "headers": []})
+        await send_func({"type": "http.response.body", "body": b"ok"})
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_returns_405_when_stateless(monkeypatch):
+    """GET on /mcp 405s with branch-specific detail when stateful sessions are disabled (#4205)."""
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", False)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    await wrapper.handle_streamable_http(_make_scope("/mcp", method="GET"), _make_receive(b""), send)
+    await wrapper.shutdown()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 405
+    assert _allow_header(starts[0]) == "POST, DELETE"
+    body = next(m for m in messages if m["type"] == "http.response.body")
+    assert b"Stateful sessions disabled" in body["body"]
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_returns_405_when_no_session_id(monkeypatch):
+    """GET on /mcp in stateful mode 405s when no Mcp-Session-Id is presented (#4205)."""
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    await wrapper.handle_streamable_http(_make_scope("/mcp", method="GET"), _make_receive(b""), send)
+    await wrapper.shutdown()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 405
+    assert _allow_header(starts[0]) == "POST, DELETE"
+    body = next(m for m in messages if m["type"] == "http.response.body")
+    assert b"Mcp-Session-Id" in body["body"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("header_name", [b"mcp-session-id", b"x-mcp-session-id"])
+async def test_handle_streamable_http_get_passes_through_with_session(monkeypatch, header_name):
+    """GET on /mcp with either Mcp-Session-Id alias reaches the SDK in stateful mode (#4205)."""
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="GET", headers=[(header_name, b"abc-123-valid-session")])
+    await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    await wrapper.shutdown()
+
+    assert sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_server_scoped_405_after_validation(monkeypatch):
+    """Server-scoped GET /servers/{id}/mcp 405s only after server-id validates successfully (#4205)."""
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", False)
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    await wrapper.handle_streamable_http(_make_scope("/servers/abc/mcp", method="GET"), _make_receive(b""), send)
+    await wrapper.shutdown()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 405
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_nonexistent_server_returns_404_not_405(monkeypatch):
+    """GET /servers/{bogus}/mcp still 404s — 405 must not mask server-id validation (#4205)."""
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", False)
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=False))
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    await wrapper.handle_streamable_http(_make_scope("/servers/bogus/mcp", method="GET"), _make_receive(b""), send)
+    await wrapper.shutdown()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the downstream symptom of #4205: strict MCP clients (e.g. FastMCP's `streamable_http` client) open a passive GET SSE stream right after `initialize` to listen for server-initiated messages, and time out on `Failed to initialize server session` when the gateway neither rejects the GET nor emits any events.

Both the Python gateway and the Rust MCP runtime now return **405 Method Not Allowed** on GET `/mcp` when a passive SSE stream cannot be served — either because stateful sessions / session-core are disabled, or because no `Mcp-Session-Id` was presented. This is spec-sanctioned per MCP Streamable HTTP (2025-03-26 and 2025-11-25) and lets strict clients skip the passive stream without the timeout cascade.

## Changes

**Python** (`mcpgateway/transports/streamablehttp_transport.py`)
- 405 returned for GET when `use_stateful_sessions=False` or no session id is presented.
- Placed after `_validate_server_id()` and the RBAC gate — bogus server IDs still 404, unauthorized callers still 403.
- Branch-specific detail (`"Stateful sessions disabled…"` vs `"Passive SSE stream requires an Mcp-Session-Id…"`) so clients don't retry in a loop.
- `logger.info` on rejection with path + flags for ops visibility.

**Rust** (`crates/mcp_runtime/src/lib.rs`)
- 405 returned in `forward_transport_request` for GET when `session_core_enabled` is false or no session id is in header / `session_id` query param. Critically, this runs before the live-stream relay commits to a `text/event-stream` response that would otherwise emit nothing.
- Capability headers and a new `RuntimeStats.transport.get_rejected_no_session` counter keep parity with other terminal responses in the function.
- `tracing::info!` on rejection.

**Tests**
- Python: 3 new parametrized tests (stateless / no-session-id / pass-through × `mcp-session-id` + `x-mcp-session-id`) plus a server-scoped 405 test and a regression guard that server-id validation still 404s before 405. Also un-hollows two pre-existing header-parsing tests (`test_handle_streamable_http_non_tuple_header_skipped`, `..._non_bytes_header_skipped`) that would otherwise have been silently short-circuited by the new 405 path.
- Rust: 3 new tests — 405 without session id, 405 when session_core disabled even if a header is present (bypass regression guard), and live-stream branch still reached when session id is validated.
- One pre-existing Rust test (`server_scoped_transport_wrappers_inject_server_header`) updated to provide a session id + record so it still exercises the server-id header injection path.

**Drive-by** (`a2a-agents/go/a2a-echo-agent/Dockerfile`)
- Added `wget` to the runtime-stage `apt-get install` so the compose healthcheck (`wget -qO- http://localhost:9100/health`) can actually run. The container was reporting unhealthy despite the agent listening correctly.

## Out of scope

The original #4205 reproducer (stateful counter leaking state between downstream clients because ContextForge shares one pooled upstream session across them) is an **upstream** per-client session-isolation problem. This PR only fixes the **downstream** GET-SSE cascade from the comment thread. The upstream work — replacing the user-identity-keyed session pool with a per-downstream-session `UpstreamSessionRegistry` — will land on a follow-up branch referencing the same issue.

Closes: none yet; #4205 stays open pending the upstream-isolation follow-up.