### PR TITLE
feat: Remove plugin enum, plugin config schema validation and fix tool binding key lookup

### DIFF
--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6715,10 +6715,10 @@ class ToolPluginBinding(Base):
     UniqueConstraint).  A POST with an existing triple performs an upsert
     (updates the existing row's config/mode/priority).
 
-    Supported plugin_id values:
-        - ``OUTPUT_LENGTH_GUARD`` — truncate/block responses exceeding a char limit.
-        - ``RATE_LIMITER``        — per-user / per-tenant / per-tool rate gating.
-        - ``SECRETS_DETECTION``   — redact or block secret patterns in output.
+    Supported plugin_id values (plugin class names):
+        - ``OutputLengthGuardPlugin`` — truncate/block responses exceeding a char limit.
+        - ``RateLimiterPlugin``        — per-user / per-tenant / per-tool rate gating.
+        - ``SecretsDetection``         — redact or block secret patterns in output.
 
     Attributes:
         id (str): UUID primary key.
@@ -6738,14 +6738,14 @@ class ToolPluginBinding(Base):
         >>> binding = ToolPluginBinding(
         ...     team_id="abc123",
         ...     tool_name="*",
-        ...     plugin_id="OUTPUT_LENGTH_GUARD",
+        ...     plugin_id="OutputLengthGuardPlugin",
         ...     mode="enforce",
         ...     priority=10,
         ...     config={"max_chars": 2000, "strategy": "truncate", "ellipsis": "..."},
         ...     created_by="admin@example.com",
         ... )
         >>> binding.plugin_id
-        'OUTPUT_LENGTH_GUARD'
+        'OutputLengthGuardPlugin'
         >>> binding.mode
         'enforce'
     """

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6715,11 +6715,6 @@ class ToolPluginBinding(Base):
     UniqueConstraint).  A POST with an existing triple performs an upsert
     (updates the existing row's config/mode/priority).
 
-    Supported plugin_id values (plugin class names):
-        - ``OutputLengthGuardPlugin`` — truncate/block responses exceeding a char limit.
-        - ``RateLimiterPlugin``        — per-user / per-tenant / per-tool rate gating.
-        - ``SecretsDetection``         — redact or block secret patterns in output.
-
     Attributes:
         id (str): UUID primary key.
         team_id (str): FK to ``email_teams.id``.

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -23,7 +23,6 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
 from mcpgateway.plugins.framework.models import PluginConfigOverride, PluginMode
-from mcpgateway.schemas import PLUGIN_ID_TO_NAME
 from mcpgateway.services.tool_plugin_binding_service import get_bindings_for_tool
 
 logger = logging.getLogger(__name__)
@@ -42,8 +41,9 @@ class GatewayTenantPluginManagerFactory(TenantPluginManagerFactory):
     * Wildcard bindings (``tool_name == "*"``) provide team-wide defaults.
     * Exact ``tool_name`` bindings override wildcards for the same plugin_id
       (last-write-wins by ``updated_at``).
-    * Bindings whose ``plugin_id`` is not in :data:`~mcpgateway.schemas.PLUGIN_ID_TO_NAME`
-      are silently skipped (forward-compatibility guard).
+    * The ``plugin_id`` column stores the plugin class name directly
+      (e.g. ``"OutputLengthGuardPlugin"``); unknown names are passed through
+      to the framework, which is responsible for ignoring unrecognised plugins.
     * Returns ``None`` (not an empty list) when no bindings are found so the
       framework falls back to the unmodified base YAML config.
     """
@@ -103,15 +103,7 @@ class GatewayTenantPluginManagerFactory(TenantPluginManagerFactory):
 
         overrides: list[PluginConfigOverride] = []
         for binding in bindings:
-            plugin_name = PLUGIN_ID_TO_NAME.get(binding.plugin_id)
-            if plugin_name is None:
-                logger.warning(
-                    "get_config_from_db: unknown plugin_id %r for binding %s, skipping",
-                    binding.plugin_id,
-                    binding.id,
-                )
-                continue
-
+            plugin_name = binding.plugin_id
             mode: Optional[PluginMode] = PluginMode(binding.mode) if binding.mode else None
             overrides.append(
                 PluginConfigOverride(

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import logging
 import re
-from typing import Any, Callable, Dict, List, Literal, Optional, Pattern, Self, Union
+from typing import Any, Dict, List, Literal, Optional, Pattern, Self, Union
 from urllib.parse import urlparse
 
 # Third-Party
@@ -8216,182 +8216,12 @@ class PerformanceHistoryResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-# Registry mapping plugin names (stored in DB) to their config schema classes.
-# New plugins self-register by decorating their config class with
-# ``@register_plugin_config("PluginClassName")``.
-_PLUGIN_CONFIG_REGISTRY: dict[str, type[BaseModel]] = {}
-
-
-def register_plugin_config(plugin_name: str) -> Callable[[type], type]:
-    """Class decorator — register *cls* as the config schema for *plugin_name*.
-
-    Args:
-        plugin_name: The plugin class name exactly as returned by the
-            plugin framework (e.g. ``"OutputLengthGuardPlugin"``).
-
-    Returns:
-        The unmodified config class, so the decorator is transparent.
-    """
-
-    def decorator(cls: type) -> type:
-        _PLUGIN_CONFIG_REGISTRY[plugin_name] = cls
-        return cls
-
-    return decorator
-
-
 class PluginBindingMode(str, Enum):
     """Plugin execution mode for tool plugin bindings."""
 
     ENFORCE = "enforce"
     PERMISSIVE = "permissive"
     DISABLED = "disabled"
-
-
-# --- Plugin-specific config schemas ---
-
-
-@register_plugin_config("OutputLengthGuardPlugin")
-class OutputLengthGuardConfig(BaseModel):
-    """Config schema for OUTPUT_LENGTH_GUARD plugin.
-
-    Attributes:
-        min_chars: Minimum character count (>= 0).
-        max_chars: Maximum character count. None disables the check.
-        min_tokens: Minimum token count (0 disables).
-        max_tokens: Maximum token count. None disables the check.
-        chars_per_token: Characters per token ratio for estimation (1-10).
-        limit_mode: Enforcement mode — 'character' or 'token'.
-        strategy: What to do when limit is exceeded.
-        ellipsis: Suffix appended when truncating.
-        word_boundary: Truncate at word boundaries to avoid mid-word cuts.
-        max_text_length: Maximum text size to process (bytes). Prevents memory exhaustion.
-        max_structure_size: Maximum items in list/dict. Prevents DoS attacks.
-        max_recursion_depth: Maximum nesting depth. Prevents stack overflow.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    min_chars: int = Field(default=0, ge=0, description="Minimum character count, must be >= 0")
-    max_chars: Optional[int] = Field(default=None, description="Maximum character count; None or 0 disables the check")
-    min_tokens: int = Field(default=0, ge=0, description="Minimum token count; 0 disables")
-    max_tokens: Optional[int] = Field(default=None, description="Maximum token count; None or 0 disables")
-    chars_per_token: int = Field(default=4, ge=1, le=10, description="Characters per token ratio for estimation")
-    limit_mode: Literal["character", "token"] = Field(default="character", description="Enforcement mode: 'character' or 'token'")
-    strategy: Literal["truncate", "block"] = Field(default="truncate", description="Action when limit exceeded")
-    ellipsis: str = Field(default="\u2026", description="Suffix appended on truncation")
-    word_boundary: bool = Field(default=False, description="Truncate at word boundaries to avoid mid-word cuts")
-    max_text_length: int = Field(default=1_000_000, ge=1, description="Maximum text size to process; prevents memory exhaustion")
-    max_structure_size: int = Field(default=10_000, ge=1, description="Maximum items in list/dict; prevents DoS")
-    max_recursion_depth: int = Field(default=100, ge=1, description="Maximum nesting depth; prevents stack overflow")
-
-    @model_validator(mode="after")
-    def min_less_than_max(self) -> "OutputLengthGuardConfig":
-        """Validate min < max for both chars and tokens when the max is set.
-
-        Returns:
-            self after validation.
-
-        Raises:
-            ValueError: If min_chars >= max_chars or min_tokens >= max_tokens.
-        """
-        if self.max_chars is not None and self.max_chars > 0 and self.min_chars >= self.max_chars:
-            raise ValueError("min_chars must be less than max_chars")
-        if self.max_tokens is not None and self.max_tokens > 0 and self.min_tokens >= self.max_tokens:
-            raise ValueError("min_tokens must be less than max_tokens")
-        return self
-
-
-@register_plugin_config("RateLimiterPlugin")
-class RateLimiterConfig(BaseModel):
-    """Config schema for RATE_LIMITER plugin.
-
-    Rate strings use the format ``<count>/<period>`` where period is
-    ``s`` (second) or ``m`` (minute), e.g. ``60/m``, ``10/s``.
-
-    Attributes:
-        by_user: Rate limit per user.
-        by_tenant: Rate limit per tenant.
-        by_tool: Per-tool rate limits as a dict of tool_name to rate string.
-        algorithm: Counting algorithm.
-        backend: Storage backend.
-        redis_url: Redis connection URL (required when backend='redis').
-        redis_key_prefix: Prefix for all Redis keys.
-        redis_fallback: Fall back to memory if Redis is unavailable.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    by_user: Optional[str] = Field(default=None, description="Rate limit per user, e.g. '60/m' or '10/s'; null disables")
-    by_tenant: Optional[str] = Field(default=None, description="Rate limit per tenant, e.g. '600/m'; null disables")
-    by_tool: Optional[Dict[str, str]] = Field(default=None, description="Per-tool rate limits, e.g. {'search': '10/m'}; null disables")
-    algorithm: Literal["fixed_window", "sliding_window", "token_bucket"] = Field(default="fixed_window", description="Counting algorithm")
-    backend: Literal["memory", "redis"] = Field(default="memory", description="Storage backend")
-    redis_url: Optional[str] = Field(default=None, description="Redis URL, e.g. 'redis://localhost:6379/0'; required when backend='redis', null otherwise")
-    redis_key_prefix: str = Field(default="rl", description="Prefix for all Redis keys")
-    redis_fallback: bool = Field(default=True, description="Fall back to memory if Redis is unavailable")
-
-    @field_validator("by_user", "by_tenant", mode="before")
-    @classmethod
-    def validate_rate_string(cls, v: Optional[str]) -> Optional[str]:
-        """Validate rate string format <count>/<s|m>.
-
-        Args:
-            v: Rate string to validate.
-
-        Returns:
-            Validated rate string or None.
-
-        Raises:
-            ValueError: If format is invalid.
-        """
-        if v is None:
-            return v
-        if not re.match(r"^\d+/[sm]$", v):
-            raise ValueError(f"Rate string '{v}' is invalid. Use format '<count>/s' or '<count>/m'")
-        return v
-
-    @field_validator("by_tool", mode="before")
-    @classmethod
-    def validate_by_tool_rate_strings(cls, v: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
-        """Validate each per-tool rate string.
-
-        Args:
-            v: Dict of tool_name to rate string.
-
-        Returns:
-            Validated dict or None.
-
-        Raises:
-            ValueError: If any rate string is invalid.
-        """
-        if v is None:
-            return v
-        for tool_name, rate in v.items():
-            if not re.match(r"^\d+/[sm]$", rate):
-                raise ValueError(f"Rate string '{rate}' for tool '{tool_name}' is invalid. Use format '<count>/s' or '<count>/m'")
-        return v
-
-
-@register_plugin_config("SecretsDetection")
-class SecretsDetectionConfig(BaseModel):
-    """Config schema for SECRETS_DETECTION plugin.
-
-    Attributes:
-        enabled: Map of pattern names to whether they are active.
-        redact: Whether to redact detected secrets from output.
-        redaction_text: Text used to replace redacted secrets.
-        block_on_detection: Whether to block the response when secrets are found.
-        min_findings_to_block: Minimum number of findings required to trigger a block.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    enabled: Dict[str, bool] = Field(default_factory=dict, description="Map of pattern names to enabled flag, e.g. {'aws_key': true}")
-    redact: bool = Field(default=True, description="Whether to redact detected secrets")
-    redaction_text: str = Field(default="[REDACTED]", max_length=50, description="Text to replace secrets with when redacting")
-    block_on_detection: bool = Field(default=False, description="Whether to block the response when secrets are detected")
-    min_findings_to_block: int = Field(default=1, ge=1, description="Minimum number of findings required to block")
 
 
 # --- Policy item (one plugin, one or more tools) ---
@@ -8416,7 +8246,7 @@ class PluginPolicyItem(BaseModel):
     priority: int = Field(50, ge=1, le=1000, description="Execution priority; lower numbers run first")
     config: Dict[str, Any] = Field(
         ...,
-        description="Plugin-specific configuration. All schema fields for the selected plugin must be provided — partial configs are rejected at validation time. On upsert the entire config is fully replaced; there is no merge with the previously stored config.",
+        description="Plugin-specific configuration. On upsert the entire config is fully replaced; there is no merge with the previously stored config.",
     )
     binding_reference_id: Optional[str] = Field(
         None,
@@ -8424,28 +8254,6 @@ class PluginPolicyItem(BaseModel):
         pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$",
         description="Optional external reference ID for correlating this binding with an upstream system",
     )
-
-    @model_validator(mode="after")
-    def validate_config_for_plugin(self) -> "PluginPolicyItem":
-        """Reject plugin_id values that are not registered in the gateway.
-
-        Field-level config validation is intentionally left to the plugin itself
-        at execution time.  CF only guards against typos in the plugin name so
-        errors are caught at binding creation rather than first invocation.
-
-        Returns:
-            self after validation.
-
-        Raises:
-            ValueError: If plugin_id is not a known registered plugin name.
-        """
-        known = set(_PLUGIN_CONFIG_REGISTRY.keys())
-        if known and self.plugin_id not in known:
-            raise ValueError(
-                f"Unknown plugin_id {self.plugin_id!r}. "
-                f"Known plugins: {sorted(known)}"
-            )
-        return self
 
 
 # --- Per-team policies wrapper ---

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import logging
 import re
-from typing import Any, Dict, List, Literal, Optional, Pattern, Self, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Pattern, Self, Union
 from urllib.parse import urlparse
 
 # Third-Party
@@ -8216,21 +8216,28 @@ class PerformanceHistoryResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class PluginId(str, Enum):
-    """Supported plugin identifiers for tool plugin bindings."""
-
-    OUTPUT_LENGTH_GUARD = "OUTPUT_LENGTH_GUARD"
-    RATE_LIMITER = "RATE_LIMITER"
-    SECRETS_DETECTION = "SECRETS_DETECTION"
+# Registry mapping plugin names (stored in DB) to their config schema classes.
+# New plugins self-register by decorating their config class with
+# ``@register_plugin_config("PluginClassName")``.
+_PLUGIN_CONFIG_REGISTRY: dict[str, type[BaseModel]] = {}
 
 
-# Maps PluginId enum values (stored in DB) to plugin class names used by the
-# plugin framework's PluginConfigOverride.name field.
-PLUGIN_ID_TO_NAME: dict[str, str] = {
-    PluginId.OUTPUT_LENGTH_GUARD: "OutputLengthGuardPlugin",
-    PluginId.RATE_LIMITER: "RateLimiterPlugin",
-    PluginId.SECRETS_DETECTION: "SecretsDetection",
-}
+def register_plugin_config(plugin_name: str) -> Callable[[type], type]:
+    """Class decorator — register *cls* as the config schema for *plugin_name*.
+
+    Args:
+        plugin_name: The plugin class name exactly as returned by the
+            plugin framework (e.g. ``"OutputLengthGuardPlugin"``).
+
+    Returns:
+        The unmodified config class, so the decorator is transparent.
+    """
+
+    def decorator(cls: type) -> type:
+        _PLUGIN_CONFIG_REGISTRY[plugin_name] = cls
+        return cls
+
+    return decorator
 
 
 class PluginBindingMode(str, Enum):
@@ -8244,6 +8251,7 @@ class PluginBindingMode(str, Enum):
 # --- Plugin-specific config schemas ---
 
 
+@register_plugin_config("OutputLengthGuardPlugin")
 class OutputLengthGuardConfig(BaseModel):
     """Config schema for OUTPUT_LENGTH_GUARD plugin.
 
@@ -8271,7 +8279,7 @@ class OutputLengthGuardConfig(BaseModel):
     chars_per_token: int = Field(default=4, ge=1, le=10, description="Characters per token ratio for estimation")
     limit_mode: Literal["character", "token"] = Field(default="character", description="Enforcement mode: 'character' or 'token'")
     strategy: Literal["truncate", "block"] = Field(default="truncate", description="Action when limit exceeded")
-    ellipsis: str = Field(default="\u2026", max_length=20, description="Suffix appended on truncation")
+    ellipsis: str = Field(default="\u2026", description="Suffix appended on truncation")
     word_boundary: bool = Field(default=False, description="Truncate at word boundaries to avoid mid-word cuts")
     max_text_length: int = Field(default=1_000_000, ge=1, description="Maximum text size to process; prevents memory exhaustion")
     max_structure_size: int = Field(default=10_000, ge=1, description="Maximum items in list/dict; prevents DoS")
@@ -8294,6 +8302,7 @@ class OutputLengthGuardConfig(BaseModel):
         return self
 
 
+@register_plugin_config("RateLimiterPlugin")
 class RateLimiterConfig(BaseModel):
     """Config schema for RATE_LIMITER plugin.
 
@@ -8364,6 +8373,7 @@ class RateLimiterConfig(BaseModel):
         return v
 
 
+@register_plugin_config("SecretsDetection")
 class SecretsDetectionConfig(BaseModel):
     """Config schema for SECRETS_DETECTION plugin.
 
@@ -8384,14 +8394,6 @@ class SecretsDetectionConfig(BaseModel):
     min_findings_to_block: int = Field(default=1, ge=1, description="Minimum number of findings required to block")
 
 
-# Map of plugin_id → config schema class for validation
-_PLUGIN_CONFIG_MAP: Dict[str, type] = {
-    PluginId.OUTPUT_LENGTH_GUARD: OutputLengthGuardConfig,
-    PluginId.RATE_LIMITER: RateLimiterConfig,
-    PluginId.SECRETS_DETECTION: SecretsDetectionConfig,
-}
-
-
 # --- Policy item (one plugin, one or more tools) ---
 
 
@@ -8409,7 +8411,7 @@ class PluginPolicyItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tool_names: List[str] = Field(..., min_length=1, description="Tool names to apply the policy to; use ['*'] for all tools in the team")
-    plugin_id: PluginId = Field(..., description="Plugin to bind")
+    plugin_id: str = Field(..., description="Plugin class name to bind, e.g. 'OutputLengthGuardPlugin'")
     mode: PluginBindingMode = Field(PluginBindingMode.ENFORCE, description="Execution mode: enforce, permissive, or disabled")
     priority: int = Field(50, ge=1, le=1000, description="Execution priority; lower numbers run first")
     config: Dict[str, Any] = Field(
@@ -8425,29 +8427,24 @@ class PluginPolicyItem(BaseModel):
 
     @model_validator(mode="after")
     def validate_config_for_plugin(self) -> "PluginPolicyItem":
-        """Validate config against the schema for the selected plugin_id.
+        """Reject plugin_id values that are not registered in the gateway.
+
+        Field-level config validation is intentionally left to the plugin itself
+        at execution time.  CF only guards against typos in the plugin name so
+        errors are caught at binding creation rather than first invocation.
 
         Returns:
             self after validation.
 
         Raises:
-            ValueError: If config is invalid for the chosen plugin.
+            ValueError: If plugin_id is not a known registered plugin name.
         """
-        config_cls = _PLUGIN_CONFIG_MAP.get(self.plugin_id)
-        if config_cls:
-            expected = set(config_cls.model_fields.keys())
-            provided = set(self.config.keys())
-            missing = expected - provided
-            if missing:
-                raise ValueError(f"Missing config fields for {self.plugin_id.value}: {sorted(missing)}")
-            try:
-                config_cls(**self.config)
-            except ValidationError as exc:
-                parts = []
-                for e in exc.errors():
-                    loc = ".".join(str(p) for p in e["loc"])
-                    parts.append(f"{loc}: {e['msg']}" if loc else e["msg"])
-                raise ValueError(f"Invalid {self.plugin_id.value} config: [{', '.join(parts)}]") from exc
+        known = set(_PLUGIN_CONFIG_REGISTRY.keys())
+        if known and self.plugin_id not in known:
+            raise ValueError(
+                f"Unknown plugin_id {self.plugin_id!r}. "
+                f"Known plugins: {sorted(known)}"
+            )
         return self
 
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -30,7 +30,7 @@ from urllib.parse import urlparse
 
 # Third-Party
 import orjson
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, EmailStr, Field, field_serializer, field_validator, model_serializer, model_validator, SecretStr, ValidationError, ValidationInfo
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, EmailStr, Field, field_serializer, field_validator, model_serializer, model_validator, SecretStr, ValidationInfo
 
 # First-Party
 from mcpgateway.common.models import Annotations, ImageContent

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -162,11 +162,11 @@ class ToolPluginBindingService:
             for policy in team_policies.policies:
                 # Build the authoritative tool-name set for stale pruning.
                 if policy.binding_reference_id:
-                    key = (policy.binding_reference_id, policy.plugin_id.value)
+                    key = (policy.binding_reference_id, policy.plugin_id)
                     ref_plugin_tool_names.setdefault(key, set()).update(policy.tool_names)
 
                 for tool_name in policy.tool_names:
-                    existing = existing_map.get((team_id, tool_name, policy.plugin_id.value))
+                    existing = existing_map.get((team_id, tool_name, policy.plugin_id))
 
                     if existing:
                         # Warn if binding_reference_id ownership is changing — this means two
@@ -184,7 +184,7 @@ class ToolPluginBindingService:
                                 "DELETE by old_ref will now be a no-op",
                                 team_id,
                                 tool_name,
-                                policy.plugin_id.value,
+                                policy.plugin_id,
                                 existing.binding_reference_id,
                                 policy.binding_reference_id,
                             )
@@ -201,14 +201,14 @@ class ToolPluginBindingService:
                             existing.id,
                             team_id,
                             tool_name,
-                            policy.plugin_id.value,
+                            policy.plugin_id,
                         )
                     else:
                         new_binding = ToolPluginBinding(
                             id=uuid.uuid4().hex,
                             team_id=team_id,
                             tool_name=tool_name,
-                            plugin_id=policy.plugin_id.value,
+                            plugin_id=policy.plugin_id,
                             mode=policy.mode.value,
                             priority=policy.priority,
                             config=policy.config,
@@ -225,7 +225,7 @@ class ToolPluginBindingService:
                             new_binding.id,
                             team_id,
                             tool_name,
-                            policy.plugin_id.value,
+                            policy.plugin_id,
                         )
 
         # Prune stale tool bindings for any (binding_reference_id, plugin_id)

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3695,7 +3695,11 @@ class ToolService(BaseService):
         from mcpgateway.plugins.gateway_plugin_manager import make_context_id  # pylint: disable=import-outside-toplevel
 
         _tool_team_id = tool_payload.get("team_id")
-        _binding_tool_name = tool_payload.get("original_name") or name
+        # Use name (the gateway-scoped unique identifier, e.g. "mac-fs-read-file") as the binding key.
+        # original_name (e.g. "read_file") is only unique per gateway, so two gateways in the same
+        # team can share the same original_name — making it ambiguous as a binding key.
+        # name is enforced unique per team by DB constraint uq_team_owner_email_name_tool.
+        _binding_tool_name = tool_payload.get("name") or name
         plugin_context_id = make_context_id(str(_tool_team_id), _binding_tool_name) if _tool_team_id else server_id
         plugin_manager = await self._get_plugin_manager(plugin_context_id)
         has_pre_invoke = plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE)
@@ -4457,10 +4461,11 @@ class ToolService(BaseService):
         from mcpgateway.plugins.gateway_plugin_manager import make_context_id  # pylint: disable=import-outside-toplevel
 
         _tool_team_id = tool_payload.get("team_id")
-        # Use original_name (the MCP server's tool name, e.g. "echo_text") as the binding key,
-        # not the gateway-prefixed display name (e.g. "plugin-tools-echo_text").
-        # Users create bindings against the original name they see in the MCP server.
-        _binding_tool_name = tool_payload.get("original_name") or name
+        # Use name (the gateway-scoped unique identifier, e.g. "mac-fs-read-file") as the binding key.
+        # original_name (e.g. "read_file") is only unique per gateway, so two gateways in the same
+        # team can share the same original_name — making it ambiguous as a binding key.
+        # name is enforced unique per team by DB constraint uq_team_owner_email_name_tool.
+        _binding_tool_name = tool_payload.get("name") or name
         plugin_context_id = make_context_id(str(_tool_team_id), _binding_tool_name) if _tool_team_id else server_id
         plugin_manager = await self._get_plugin_manager(plugin_context_id)
         logger.debug("invoke_tool: plugin_context_id=%r plugin_manager=%r", plugin_context_id, plugin_manager)

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -11,8 +11,7 @@ Tests cover:
     - get_config_from_db: unrecognised format returns None
     - get_config_from_db: unknown team / no bindings returns None
     - get_config_from_db: bindings translated to PluginConfigOverride list
-    - get_config_from_db: unknown plugin_id is skipped (forward-compat guard)
-    - get_config_from_db: all bindings have unknown plugin_ids → returns None
+    - get_config_from_db: unknown plugin_id is passed through to the framework
     - reload_plugin_context: no-op when plugins disabled or factory is None
     - reload_plugin_context: delegates to factory.reload_tenant when factory exists
 """
@@ -38,7 +37,6 @@ from mcpgateway.plugins.gateway_plugin_manager import (
 from mcpgateway.plugins.framework.models import PluginMode
 from mcpgateway.schemas import (
     PluginBindingMode,
-    PluginId,
     PluginPolicyItem,
     TeamPolicies,
     ToolPluginBindingRequest,
@@ -148,7 +146,7 @@ class TestGetConfigFromDb:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["my_tool"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.ENFORCE,
                             priority=42,
                             config={**_OLG, "max_chars": 500},
@@ -171,12 +169,17 @@ class TestGetConfigFromDb:
         assert o.config == {**_OLG, "max_chars": 500}
 
     @pytest.mark.asyncio
-    async def test_unknown_plugin_id_is_skipped(self, db_session):
-        """A binding with an unknown plugin_id is silently skipped (forward-compat)."""
+    async def test_unknown_plugin_id_passed_through(self, db_session):
+        """A binding with an unrecognised plugin_id is passed to the framework as-is.
+
+        CF no longer skips unknown plugin names — the framework decides what to
+        do with them.  This allows new plugins added to cpex to be used without
+        a CF code change.
+        """
         from mcpgateway.db import ToolPluginBinding, utc_now
         import uuid
 
-        # Insert a row with a plugin_id not present in PLUGIN_ID_TO_NAME
+        # Insert a row with a plugin_id not in the registry (simulates a future plugin)
         row = ToolPluginBinding(
             id=uuid.uuid4().hex,
             team_id="team-x",
@@ -195,8 +198,10 @@ class TestGetConfigFromDb:
 
         factory = _make_factory(db_session)
         result = await factory.get_config_from_db(make_context_id("team-x", "t"))
-        # The unknown plugin is skipped and no known plugins remain → None
-        assert result is None
+        # Unknown plugin is passed through — framework will ignore it if unrecognised
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "FUTURE_PLUGIN_NOT_YET_KNOWN"
 
     @pytest.mark.asyncio
     async def test_wildcard_binding_returned(self, db_session):
@@ -208,7 +213,7 @@ class TestGetConfigFromDb:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["*"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=5,
                             config={**_RL, "by_user": "60/m", "by_tenant": "600/m"},

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -39,7 +39,6 @@ from mcpgateway.routers.tool_plugin_bindings import (
 )
 from mcpgateway.schemas import (
     PluginBindingMode,
-    PluginId,
     PluginPolicyItem,
     TeamPolicies,
     ToolPluginBindingListResponse,
@@ -123,7 +122,7 @@ def _simple_request() -> ToolPluginBindingRequest:
                 policies=[
                     PluginPolicyItem(
                         tool_names=["tool_x"],
-                        plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                        plugin_id="OutputLengthGuardPlugin",
                         mode=PluginBindingMode.ENFORCE,
                         priority=50,
                         config=dict(_OLG),
@@ -142,7 +141,7 @@ def _two_team_request() -> ToolPluginBindingRequest:
                 policies=[
                     PluginPolicyItem(
                         tool_names=["tool_x"],
-                        plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                        plugin_id="OutputLengthGuardPlugin",
                         mode=PluginBindingMode.ENFORCE,
                         priority=50,
                         config=dict(_OLG),
@@ -153,7 +152,7 @@ def _two_team_request() -> ToolPluginBindingRequest:
                 policies=[
                     PluginPolicyItem(
                         tool_names=["tool_y"],
-                        plugin_id=PluginId.RATE_LIMITER,
+                        plugin_id="RateLimiterPlugin",
                         mode=PluginBindingMode.PERMISSIVE,
                         priority=30,
                         config={**_RL, "by_user": "60/m", "by_tenant": "600/m"},
@@ -197,7 +196,7 @@ class TestToolPluginBindingsRouter:
         binding = result.bindings[0]
         assert binding.team_id == "team-a"
         assert binding.tool_name == "tool_x"
-        assert binding.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert binding.plugin_id == "OutputLengthGuardPlugin"
         assert binding.mode == "enforce"
         assert binding.priority == 50
         assert binding.created_by == "admin@example.com"
@@ -216,7 +215,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=99,
                             config={**_OLG, "max_chars": 500, "strategy": "block"},
@@ -362,7 +361,7 @@ class TestToolPluginBindingsRouter:
 
         team_a = by_team["team-a"]
         assert team_a.tool_name == "tool_x"
-        assert team_a.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert team_a.plugin_id == "OutputLengthGuardPlugin"
         assert team_a.mode == "enforce"
         assert team_a.priority == 50
         assert team_a.config == _OLG
@@ -370,7 +369,7 @@ class TestToolPluginBindingsRouter:
 
         team_b = by_team["team-b"]
         assert team_b.tool_name == "tool_y"
-        assert team_b.plugin_id == "RATE_LIMITER"
+        assert team_b.plugin_id == "RateLimiterPlugin"
         assert team_b.mode == "permissive"
         assert team_b.priority == 30
         assert team_b.config == {**_RL, "by_user": "60/m", "by_tenant": "600/m"}
@@ -399,7 +398,7 @@ class TestToolPluginBindingsRouter:
         binding = result.bindings[0]
         assert binding.team_id == "team-a"
         assert binding.tool_name == "tool_x"
-        assert binding.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert binding.plugin_id == "OutputLengthGuardPlugin"
         assert binding.mode == "enforce"
         assert binding.priority == 50
         assert binding.config == _OLG
@@ -560,7 +559,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x", "tool_y"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ext-ref-001",
                         )
@@ -611,7 +610,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-alpha",
                         )
@@ -625,7 +624,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_y"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-beta",
                         )
@@ -661,7 +660,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x", "tool_y"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-cache-test",
                         )
@@ -697,7 +696,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-001",
                         )
@@ -711,7 +710,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_y"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-002",
                         )
@@ -741,7 +740,7 @@ class TestToolPluginBindingsRouter:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="cross-team-ref",
                         )

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -30,13 +30,13 @@ from mcpgateway.db import Base, ToolPluginBinding
 from mcpgateway.schemas import (
     OutputLengthGuardConfig,
     PluginBindingMode,
-    PluginId,
     PluginPolicyItem,
     RateLimiterConfig,
     SecretsDetectionConfig,
     TeamPolicies,
     ToolPluginBindingRequest,
     ToolPluginBindingResponse,
+    _PLUGIN_CONFIG_REGISTRY,
 )
 from mcpgateway.services.tool_plugin_binding_service import (
     ToolPluginBindingNotFoundError,
@@ -97,7 +97,7 @@ def _make_binding(
     id_="binding-001",
     team_id="team-a",
     tool_name="tool_x",
-    plugin_id="OUTPUT_LENGTH_GUARD",
+    plugin_id="OutputLengthGuardPlugin",
     mode="enforce",
     priority=50,
     config=None,
@@ -160,7 +160,7 @@ def simple_request():
                 policies=[
                     PluginPolicyItem(
                         tool_names=["tool_x"],
-                        plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                        plugin_id="OutputLengthGuardPlugin",
                         mode=PluginBindingMode.ENFORCE,
                         priority=50,
                         config=dict(_OLG),
@@ -215,7 +215,7 @@ class TestUpsertBindings:
         r = results[0]
         assert r.team_id == "team-a"
         assert r.tool_name == "tool_x"
-        assert r.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert r.plugin_id == "OutputLengthGuardPlugin"
         assert r.mode == "enforce"
         assert r.priority == 50
         assert r.config == dict(_OLG)
@@ -238,7 +238,7 @@ class TestUpsertBindings:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=10,
                             config=cfg_v1,
@@ -256,7 +256,7 @@ class TestUpsertBindings:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.ENFORCE,
                             priority=50,
                             config=cfg_v2,
@@ -285,7 +285,7 @@ class TestUpsertBindings:
         r1 = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=cfg_v1)]
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=cfg_v1)]
                 )
             }
         )
@@ -294,7 +294,7 @@ class TestUpsertBindings:
         r2 = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=cfg_v2)]
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=cfg_v2)]
                 )
             }
         )
@@ -312,7 +312,7 @@ class TestUpsertBindings:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a", "tool_b"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=20,
                             config=cfg,
@@ -331,14 +331,14 @@ class TestUpsertBindings:
 
         tool_a = by_tool["tool_a"]
         assert tool_a.team_id == "team-a"
-        assert tool_a.plugin_id == "RATE_LIMITER"
+        assert tool_a.plugin_id == "RateLimiterPlugin"
         assert tool_a.mode == "permissive"
         assert tool_a.priority == 20
         assert tool_a.config == cfg
 
         tool_b = by_tool["tool_b"]
         assert tool_b.team_id == "team-a"
-        assert tool_b.plugin_id == "RATE_LIMITER"
+        assert tool_b.plugin_id == "RateLimiterPlugin"
         assert tool_b.mode == "permissive"
         assert tool_b.priority == 20
         assert tool_b.config == cfg
@@ -349,10 +349,10 @@ class TestUpsertBindings:
         request = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, config=cfg_olg)]
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="OutputLengthGuardPlugin", config=cfg_olg)]
                 ),
                 "team-b": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config=dict(_SD))]
+                    policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id="SecretsDetection", config=dict(_SD))]
                 ),
             }
         )
@@ -366,12 +366,12 @@ class TestUpsertBindings:
 
         team_a = by_team["team-a"]
         assert team_a.tool_name == "tool_x"
-        assert team_a.plugin_id == "OUTPUT_LENGTH_GUARD"
+        assert team_a.plugin_id == "OutputLengthGuardPlugin"
         assert team_a.config == cfg_olg
 
         team_b = by_team["team-b"]
         assert team_b.tool_name == "tool_y"
-        assert team_b.plugin_id == "SECRETS_DETECTION"
+        assert team_b.plugin_id == "SecretsDetection"
         assert team_b.config == dict(_SD)
 
     def test_caller_email_stored_in_audit_fields(self, service, db_session, simple_request):
@@ -389,7 +389,7 @@ class TestUpsertBindings:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="test-bind-001",
                         )
@@ -413,7 +413,7 @@ class TestUpsertBindings:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="test-bind-old",
                         )
@@ -429,7 +429,7 @@ class TestUpsertBindings:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="test-bind-new",
                         )
@@ -459,8 +459,8 @@ class TestListBindings:
         """Insert two bindings for different teams before each test."""
         request = ToolPluginBindingRequest(
             teams={
-                "team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=dict(_RL))]),
-                "team-b": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id=PluginId.SECRETS_DETECTION, config=dict(_SD))]),
+                "team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=dict(_RL))]),
+                "team-b": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id="SecretsDetection", config=dict(_SD))]),
             }
         )
         service.upsert_bindings(db_session, request, caller_email="seeder@example.com")
@@ -483,7 +483,7 @@ class TestListBindings:
         r = ToolPluginBindingRequest(
             teams={
                 "team-a": TeamPolicies(
-                    policies=[PluginPolicyItem(tool_names=["tool_z"], plugin_id=PluginId.OUTPUT_LENGTH_GUARD, priority=10, config={**_OLG, "max_chars": 500, "strategy": "block"})]
+                    policies=[PluginPolicyItem(tool_names=["tool_z"], plugin_id="OutputLengthGuardPlugin", priority=10, config={**_OLG, "max_chars": 500, "strategy": "block"})]
                 )
             }
         )
@@ -511,7 +511,7 @@ class TestDeleteBinding:
     def test_delete_success(self, service, db_session):
         """delete_binding returns the deleted record's details and removes it from the DB."""
         r = ToolPluginBindingRequest(
-            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id=PluginId.RATE_LIMITER, config=dict(_RL))])}
+            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=dict(_RL))])}
         )
         inserted = service.upsert_bindings(db_session, r, caller_email="admin@example.com")
         binding_id = inserted[0].id
@@ -521,7 +521,7 @@ class TestDeleteBinding:
         assert deleted.id == binding_id
         assert deleted.team_id == "team-a"
         assert deleted.tool_name == "tool_x"
-        assert deleted.plugin_id == "RATE_LIMITER"
+        assert deleted.plugin_id == "RateLimiterPlugin"
         assert deleted.config == dict(_RL)
         # Confirm the row is gone from the DB
         assert db_session.query(ToolPluginBinding).filter_by(id=binding_id).first() is None
@@ -625,11 +625,6 @@ class TestOutputLengthGuardConfig:
         """Strategy values other than 'truncate' or 'block' are rejected."""
         with pytest.raises(ValidationError, match=r"(?s)strategy.*'truncate' or 'block'"):
             OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="drop", ellipsis="...")
-
-    def test_ellipsis_too_long(self):
-        """ellipsis longer than 20 characters is rejected."""
-        with pytest.raises(ValidationError, match=r"(?s)ellipsis.*at most 20 characters"):
-            OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="truncate", ellipsis="x" * 21)
 
     def test_extra_fields_forbidden(self):
         """Unknown fields are rejected (extra='forbid')."""
@@ -774,90 +769,63 @@ class TestPluginPolicyItemValidation:
         """PluginPolicyItem defaults for mode and priority; RATE_LIMITER full config is accepted."""
         item = PluginPolicyItem(
             tool_names=["tool_x"],
-            plugin_id=PluginId.RATE_LIMITER,
+            plugin_id="RateLimiterPlugin",
             config=dict(_RL),
         )
         assert item.mode == PluginBindingMode.ENFORCE
         assert item.priority == 50
 
     def test_output_length_guard_valid_config(self):
-        """OUTPUT_LENGTH_GUARD with all fields passes cross-validation."""
+        """OUTPUT_LENGTH_GUARD with all fields is accepted by PluginPolicyItem."""
         item = PluginPolicyItem(
             tool_names=["tool_x"],
-            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+            plugin_id="OutputLengthGuardPlugin",
             config={**_OLG, "max_chars": 500, "strategy": "block"},
         )
-        assert item.plugin_id == PluginId.OUTPUT_LENGTH_GUARD
+        assert item.plugin_id == "OutputLengthGuardPlugin"
 
-    def test_output_length_guard_invalid_config_rejected(self):
-        """OUTPUT_LENGTH_GUARD with min >= max is caught by PluginPolicyItem validator."""
-        with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
-            PluginPolicyItem(
-                tool_names=["tool_x"],
-                plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
-                config={**_OLG, "min_chars": 5000, "max_chars": 3000},
-            )
-
-    def test_output_length_guard_rejects_empty_config(self):
-        """OUTPUT_LENGTH_GUARD with {} is rejected — all four fields are required."""
-        with pytest.raises(ValidationError, match="Missing config fields for OUTPUT_LENGTH_GUARD"):
-            PluginPolicyItem(
-                tool_names=["tool_x"],
-                plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
-                config={},
-            )
+    def test_output_length_guard_empty_config_accepted(self):
+        """OUTPUT_LENGTH_GUARD with {} is accepted — CF does not validate config fields."""
+        item = PluginPolicyItem(
+            tool_names=["tool_x"],
+            plugin_id="OutputLengthGuardPlugin",
+            config={},
+        )
+        assert item.plugin_id == "OutputLengthGuardPlugin"
 
     def test_rate_limiter_valid_config(self):
-        """RATE_LIMITER with full config passes cross-validation."""
+        """RATE_LIMITER with full config is accepted by PluginPolicyItem."""
         item = PluginPolicyItem(
             tool_names=["tool_y"],
-            plugin_id=PluginId.RATE_LIMITER,
+            plugin_id="RateLimiterPlugin",
             config={**_RL, "by_user": "60/m", "by_tenant": "600/m"},
         )
-        assert item.plugin_id == PluginId.RATE_LIMITER
-
-    def test_rate_limiter_invalid_config_rejected(self):
-        """RATE_LIMITER with invalid rate string format is caught by PluginPolicyItem validator."""
-        with pytest.raises(ValidationError, match=r"Rate string '60/h' is invalid"):
-            PluginPolicyItem(
-                tool_names=["tool_y"],
-                plugin_id=PluginId.RATE_LIMITER,
-                config={**_RL, "by_user": "60/h"},  # /h not allowed
-            )
+        assert item.plugin_id == "RateLimiterPlugin"
 
     def test_secrets_detection_valid_config(self):
-        """SECRETS_DETECTION with all required fields passes cross-validation."""
+        """SECRETS_DETECTION with all required fields is accepted by PluginPolicyItem."""
         item = PluginPolicyItem(
             tool_names=["tool_z"],
-            plugin_id=PluginId.SECRETS_DETECTION,
+            plugin_id="SecretsDetection",
             config={"enabled": {"aws_key": True}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": True, "min_findings_to_block": 2},
         )
-        assert item.plugin_id == PluginId.SECRETS_DETECTION
+        assert item.plugin_id == "SecretsDetection"
 
-    def test_secrets_detection_invalid_config_rejected(self):
-        """SECRETS_DETECTION with min_findings_to_block=0 is caught by PluginPolicyItem validator."""
-        with pytest.raises(ValidationError, match=r"(?s)min_findings_to_block.*greater than or equal to 1"):
-            PluginPolicyItem(
-                tool_names=["tool_z"],
-                plugin_id=PluginId.SECRETS_DETECTION,
-                config={"enabled": {}, "redact": True, "redaction_text": "[REDACTED]", "block_on_detection": False, "min_findings_to_block": 0},
-            )
-
-    def test_secrets_detection_rejects_empty_config(self):
-        """SECRETS_DETECTION with {} is rejected — all five fields are required."""
-        with pytest.raises(ValidationError, match="Missing config fields for SECRETS_DETECTION"):
-            PluginPolicyItem(
-                tool_names=["tool_z"],
-                plugin_id=PluginId.SECRETS_DETECTION,
-                config={},
-            )
+    def test_secrets_detection_empty_config_accepted(self):
+        """SECRETS_DETECTION with {} is accepted — CF does not validate config fields."""
+        item = PluginPolicyItem(
+            tool_names=["tool_z"],
+            plugin_id="SecretsDetection",
+            config={},
+        )
+        assert item.plugin_id == "SecretsDetection"
 
     def test_empty_tool_names_rejected(self):
         """tool_names=[] is rejected (min_length=1)."""
         with pytest.raises(ValidationError, match=r"(?s)tool_names.*at least 1 item"):
             PluginPolicyItem(
                 tool_names=[],
-                plugin_id=PluginId.RATE_LIMITER,
+                plugin_id="RateLimiterPlugin",
                 config={"by_user": None, "by_tenant": None, "by_tool": None},
             )
 
@@ -866,7 +834,7 @@ class TestPluginPolicyItemValidation:
         with pytest.raises(ValidationError, match=r"(?s)priority.*greater than or equal to 1"):
             PluginPolicyItem(
                 tool_names=["tool_x"],
-                plugin_id=PluginId.RATE_LIMITER,
+                plugin_id="RateLimiterPlugin",
                 priority=0,
                 config=dict(_RL),
             )
@@ -876,7 +844,7 @@ class TestPluginPolicyItemValidation:
         with pytest.raises(ValidationError, match=r"(?s)priority.*less than or equal to 1000"):
             PluginPolicyItem(
                 tool_names=["tool_x"],
-                plugin_id=PluginId.RATE_LIMITER,
+                plugin_id="RateLimiterPlugin",
                 priority=1001,
                 config=dict(_RL),
             )
@@ -885,7 +853,7 @@ class TestPluginPolicyItemValidation:
         """binding_reference_id is optional and stored when provided."""
         item = PluginPolicyItem(
             tool_names=["tool_x"],
-            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+            plugin_id="OutputLengthGuardPlugin",
             config=dict(_OLG),
             binding_reference_id="test-bind-001",
         )
@@ -895,7 +863,7 @@ class TestPluginPolicyItemValidation:
         """binding_reference_id is None when not specified."""
         item = PluginPolicyItem(
             tool_names=["tool_x"],
-            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+            plugin_id="OutputLengthGuardPlugin",
             config=dict(_OLG),
         )
         assert item.binding_reference_id is None
@@ -905,17 +873,17 @@ class TestPluginPolicyItemValidation:
         with pytest.raises(ValidationError):
             PluginPolicyItem(
                 tool_names=["tool_x"],
-                plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                plugin_id="OutputLengthGuardPlugin",
                 config=dict(_OLG),
                 binding_reference_id="a" * 256,
             )
 
-    def test_invalid_plugin_id_rejected(self):
-        """An unrecognised plugin_id string is rejected by the PluginId enum."""
-        with pytest.raises(ValidationError, match=r"(?s)plugin_id.*Input should be"):
+    def test_unknown_plugin_id_rejected(self):
+        """An unrecognised plugin_id is rejected — guards against typos at binding creation."""
+        with pytest.raises(ValidationError, match=r"Unknown plugin_id"):
             PluginPolicyItem(
                 tool_names=["tool_x"],
-                plugin_id="UNKNOWN_PLUGIN",  # type: ignore[arg-type]
+                plugin_id="FuturePlugin",
                 config={},
             )
 
@@ -924,7 +892,7 @@ class TestPluginPolicyItemValidation:
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             PluginPolicyItem(
                 tool_names=["tool_x"],
-                plugin_id=PluginId.RATE_LIMITER,
+                plugin_id="RateLimiterPlugin",
                 config={"by_user": None, "by_tenant": None, "by_tool": None},
                 unknown_key="bad",
             )
@@ -934,10 +902,9 @@ class TestPluginPolicyItemValidation:
         with pytest.raises(ValidationError, match=r"(?s)config.*Field required"):
             PluginPolicyItem(
                 tool_names=["tool_x"],
-                plugin_id=PluginId.RATE_LIMITER,
+                plugin_id="RateLimiterPlugin",
                 # config intentionally omitted
             )
-
 
 # ---------------------------------------------------------------------------
 # Schema validation tests — top-level request/enum invariants
@@ -957,61 +924,17 @@ class TestTopLevelSchemas:
         with pytest.raises(ValidationError, match=r"(?s)policies.*at least 1 item"):
             TeamPolicies(policies=[])
 
-    def test_plugin_id_enum_values(self):
-        """PluginId enum covers all expected plugin identifiers."""
-        assert PluginId.OUTPUT_LENGTH_GUARD == "OUTPUT_LENGTH_GUARD"
-        assert PluginId.RATE_LIMITER == "RATE_LIMITER"
-        assert PluginId.SECRETS_DETECTION == "SECRETS_DETECTION"
+    def test_plugin_config_registry_contains_expected_plugins(self):
+        """_PLUGIN_CONFIG_REGISTRY maps each plugin class name to its config schema."""
+        assert _PLUGIN_CONFIG_REGISTRY["OutputLengthGuardPlugin"] is OutputLengthGuardConfig
+        assert _PLUGIN_CONFIG_REGISTRY["RateLimiterPlugin"] is RateLimiterConfig
+        assert _PLUGIN_CONFIG_REGISTRY["SecretsDetection"] is SecretsDetectionConfig
 
     def test_plugin_binding_mode_enum_values(self):
         """PluginBindingMode enum covers all expected execution modes."""
         assert PluginBindingMode.ENFORCE == "enforce"
         assert PluginBindingMode.PERMISSIVE == "permissive"
         assert PluginBindingMode.DISABLED == "disabled"
-
-    def test_all_plugin_errors_collected_across_list(self):
-        """When multiple PluginPolicyItems are invalid, all their errors appear in one ValidationError.
-
-        Previously, a ValidationError escaping from the model_validator would short-circuit
-        list validation and hide errors from subsequent items. After the fix, each item's
-        errors are wrapped as ValueError so Pydantic can collect every item.
-
-        NOTE: items must be passed as raw dicts so that Pydantic constructs each
-        PluginPolicyItem internally — if you pre-construct them with PluginPolicyItem(...),
-        Python evaluates each call before TeamPolicies() is reached, raising immediately.
-        """
-        with pytest.raises(ValidationError) as exc_info:
-            ToolPluginBindingRequest.model_validate(
-                {
-                    "teams": {
-                        "team-a": {
-                            "policies": [
-                                # item 0: OLG with full config but invalid strategy value
-                                {
-                                    "tool_names": ["tool_x"],
-                                    "plugin_id": "OUTPUT_LENGTH_GUARD",
-                                    "config": {**_OLG, "strategy": "drop"},
-                                },
-                                # item 1: RATE_LIMITER with empty config — triggers "Missing config fields"
-                                {"tool_names": ["tool_y"], "plugin_id": "RATE_LIMITER", "config": {}},
-                            ]
-                        }
-                    }
-                }
-            )
-        errors = exc_info.value.errors()
-        assert len(errors) == 2, f"Expected 2 errors, got {len(errors)}: {errors}"
-
-        # Sort by the integer index in the loc tuple so assertions are deterministic regardless of collection order
-        errors_by_index = sorted(errors, key=lambda e: next(x for x in e["loc"] if isinstance(x, int)))
-
-        # item 0: OLG — strategy field rejected
-        assert errors_by_index[0]["loc"] == ("teams", "team-a", "policies", 0)
-        assert errors_by_index[0]["msg"] == "Value error, Invalid OUTPUT_LENGTH_GUARD config: [strategy: Input should be 'truncate' or 'block']"
-
-        # item 1: RATE_LIMITER — all 8 fields are missing (sorted alphabetically in the error)
-        assert errors_by_index[1]["loc"] == ("teams", "team-a", "policies", 1)
-        assert errors_by_index[1]["msg"] == "Value error, Missing config fields for RATE_LIMITER: ['algorithm', 'backend', 'by_tenant', 'by_tool', 'by_user', 'redis_fallback', 'redis_key_prefix', 'redis_url']"
 
 
 # ---------------------------------------------------------------------------
@@ -1035,7 +958,7 @@ class TestGetBindingsForTool:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.ENFORCE,
                             priority=50,
                             config=dict(_OLG),
@@ -1053,7 +976,7 @@ class TestGetBindingsForTool:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["*"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=10,
                             config={**_RL, "by_user": "100/m", "by_tenant": "1000/m"},
@@ -1068,13 +991,13 @@ class TestGetBindingsForTool:
         """get_bindings_for_tool returns both the exact tool_name match and the '*' wildcard."""
         results = get_bindings_for_tool(self._db, "team-a", "tool_x")
         plugin_ids = {b.plugin_id for b in results}
-        assert plugin_ids == {"OUTPUT_LENGTH_GUARD", "RATE_LIMITER"}
+        assert plugin_ids == {"OutputLengthGuardPlugin", "RateLimiterPlugin"}
 
     def test_returns_only_wildcard_for_unknown_tool(self):
         """A tool with no exact binding still gets the wildcard binding."""
         results = get_bindings_for_tool(self._db, "team-a", "other_tool")
         assert len(results) == 1
-        assert results[0].plugin_id == "RATE_LIMITER"
+        assert results[0].plugin_id == "RateLimiterPlugin"
 
     def test_returns_empty_for_unknown_team(self):
         """An unknown team has no bindings."""
@@ -1091,7 +1014,7 @@ class TestGetBindingsForTool:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["*"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.PERMISSIVE,
                             priority=1,
                             config={**_OLG, "max_chars": 100},
@@ -1109,7 +1032,7 @@ class TestGetBindingsForTool:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_z"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             mode=PluginBindingMode.ENFORCE,
                             priority=99,
                             config={**_OLG, "max_chars": 9999},
@@ -1122,7 +1045,7 @@ class TestGetBindingsForTool:
 
         results = get_bindings_for_tool(db_session, "team-b", "tool_z")
         # Specificity wins: exact tool_name binding always beats the '*' wildcard
-        olg_results = [b for b in results if b.plugin_id == "OUTPUT_LENGTH_GUARD"]
+        olg_results = [b for b in results if b.plugin_id == "OutputLengthGuardPlugin"]
         assert len(olg_results) == 1
         # The exact binding (priority=99, max_chars=9999) wins — not the wildcard (priority=1, max_chars=100)
         assert olg_results[0].priority == 99
@@ -1155,7 +1078,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a", "tool_b", "tool_c"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-001",
                         )
@@ -1173,7 +1096,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a", "tool_b"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-001",
                         )
@@ -1196,7 +1119,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a", "tool_b"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-002",
                         )
@@ -1219,7 +1142,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a", "tool_b"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             # intentionally no binding_reference_id
                         )
@@ -1236,7 +1159,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                         )
                     ]
@@ -1257,7 +1180,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a", "tool_b"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-A",
                         )
@@ -1274,7 +1197,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_c"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             config=dict(_RL),
                             binding_reference_id="ref-B",
                         )
@@ -1293,7 +1216,7 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_a"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-A",
                         )
@@ -1318,13 +1241,13 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_1", "tool_2"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-X",
                         ),
                         PluginPolicyItem(
                             tool_names=["tool_3", "tool_4"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             config=dict(_RL),
                             binding_reference_id="ref-Y",
                         ),
@@ -1342,13 +1265,13 @@ class TestStalePruning:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_1"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-X",
                         ),
                         PluginPolicyItem(
                             tool_names=["tool_3"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             config=dict(_RL),
                             binding_reference_id="ref-Y",
                         ),
@@ -1379,7 +1302,7 @@ class TestListBindingsByReference:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="ref-filter-001",
                         )
@@ -1389,7 +1312,7 @@ class TestListBindingsByReference:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_y"],
-                            plugin_id=PluginId.RATE_LIMITER,
+                            plugin_id="RateLimiterPlugin",
                             config=dict(_RL),
                             binding_reference_id="ref-filter-002",
                         )
@@ -1412,7 +1335,7 @@ class TestListBindingsByReference:
                     policies=[
                         PluginPolicyItem(
                             tool_names=["tool_x"],
-                            plugin_id=PluginId.OUTPUT_LENGTH_GUARD,
+                            plugin_id="OutputLengthGuardPlugin",
                             config=dict(_OLG),
                             binding_reference_id="unique-ref",
                         )
@@ -1439,4 +1362,70 @@ class TestListBindingsByReference:
     def test_filter_by_reference_id_no_match_returns_empty(self, service, db_session):
         """list_bindings with a non-existent binding_reference_id returns an empty list."""
         results = service.list_bindings(db_session, binding_reference_id="does-not-exist")
+        assert results == []
+
+
+class TestGetBindingsForToolUsesName:
+    """get_bindings_for_tool must match on tool name (team-scoped unique identifier),
+    not original_name (which is only unique per gateway).
+
+    Two gateways in the same team can each expose a tool with the same original_name
+    (e.g. "fetch_data"). The DB-level unique identifier for a tool is its `name` column,
+    enforced by constraint uq_team_owner_email_name_tool. Bindings must therefore be
+    keyed on `name` (e.g. "alpha-gw-fetch-data") to remain unambiguous.
+    """
+
+    def test_binding_stored_with_name_is_found_by_name(self, db_session):
+        """A binding stored with tool_name='alpha-gw-fetch-data' is retrieved when
+        queried with that exact name, and every stored field is returned intact."""
+        db_session.add(
+            ToolPluginBinding(
+                id="b-001",
+                team_id="team-abc",
+                tool_name="alpha-gw-fetch-data",
+                plugin_id="OutputLengthGuardPlugin",
+                mode="enforce",
+                priority=50,
+                config=dict(_OLG),
+                created_by="admin@example.com",
+                updated_by="admin@example.com",
+            )
+        )
+        db_session.commit()
+
+        results = get_bindings_for_tool(db_session, "team-abc", "alpha-gw-fetch-data")
+        assert len(results) == 1
+        row = results[0]
+        assert row.id == "b-001"
+        assert row.team_id == "team-abc"
+        assert row.tool_name == "alpha-gw-fetch-data"
+        assert row.plugin_id == "OutputLengthGuardPlugin"
+        assert row.mode == "enforce"
+        assert row.priority == 50
+        assert row.config == dict(_OLG)
+        assert row.created_by == "admin@example.com"
+        assert row.updated_by == "admin@example.com"
+
+    def test_binding_stored_with_name_is_not_found_by_original_name(self, db_session):
+        """A binding stored with tool_name='alpha-gw-fetch-data' is NOT returned when
+        queried with original_name='fetch_data'. The two are different keys; using
+        original_name as the lookup key would silently miss the binding."""
+        db_session.add(
+            ToolPluginBinding(
+                id="b-002",
+                team_id="team-abc",
+                tool_name="alpha-gw-fetch-data",
+                plugin_id="OutputLengthGuardPlugin",
+                mode="enforce",
+                priority=50,
+                config=dict(_OLG),
+                created_by="admin@example.com",
+                updated_by="admin@example.com",
+            )
+        )
+        db_session.commit()
+
+        # Querying by the bare original_name must return nothing — the team-scoped
+        # name ("alpha-gw-fetch-data") is the only valid binding key.
+        results = get_bindings_for_tool(db_session, "team-abc", "fetch_data")
         assert results == []

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -28,15 +28,11 @@ from sqlalchemy.pool import StaticPool
 # First-Party
 from mcpgateway.db import Base, ToolPluginBinding
 from mcpgateway.schemas import (
-    OutputLengthGuardConfig,
     PluginBindingMode,
     PluginPolicyItem,
-    RateLimiterConfig,
-    SecretsDetectionConfig,
     TeamPolicies,
     ToolPluginBindingRequest,
     ToolPluginBindingResponse,
-    _PLUGIN_CONFIG_REGISTRY,
 )
 from mcpgateway.services.tool_plugin_binding_service import (
     ToolPluginBindingNotFoundError,
@@ -533,231 +529,6 @@ class TestDeleteBinding:
 
 
 # ---------------------------------------------------------------------------
-# Schema validation tests — OutputLengthGuardConfig
-# ---------------------------------------------------------------------------
-
-
-class TestOutputLengthGuardConfig:
-    """Pydantic validation for OutputLengthGuardConfig."""
-
-    def test_valid_defaults(self):
-        """Default construction succeeds with all new field defaults."""
-        cfg = OutputLengthGuardConfig()
-        assert cfg.min_chars == 0
-        assert cfg.max_chars is None        # disabled by default
-        assert cfg.min_tokens == 0
-        assert cfg.max_tokens is None       # disabled by default
-        assert cfg.chars_per_token == 4
-        assert cfg.limit_mode == "character"
-        assert cfg.strategy == "truncate"
-        assert cfg.ellipsis == "…"          # Unicode ellipsis
-        assert cfg.word_boundary is False
-        assert cfg.max_text_length == 1_000_000
-        assert cfg.max_structure_size == 10_000
-        assert cfg.max_recursion_depth == 100
-
-    def test_valid_explicit(self):
-        """Explicit valid values are accepted."""
-        cfg = OutputLengthGuardConfig(min_chars=100, max_chars=500, strategy="block", ellipsis="[cut]")
-        assert cfg.min_chars == 100
-        assert cfg.max_chars == 500
-        assert cfg.strategy == "block"
-        assert cfg.ellipsis == "[cut]"
-
-    def test_min_equal_to_max_rejected(self):
-        """min_chars == max_chars is rejected by the cross-validator."""
-        with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
-            OutputLengthGuardConfig(min_chars=500, max_chars=500, strategy="truncate", ellipsis="...")
-
-    def test_min_greater_than_max_rejected(self):
-        """min_chars > max_chars is rejected by the cross-validator."""
-        with pytest.raises(ValidationError, match="min_chars must be less than max_chars"):
-            OutputLengthGuardConfig(min_chars=1000, max_chars=100, strategy="truncate", ellipsis="...")
-
-    def test_max_chars_none_disables_check(self):
-        """max_chars=None is valid — explicitly disables the character limit."""
-        cfg = OutputLengthGuardConfig(max_chars=None)
-        assert cfg.max_chars is None
-
-    def test_max_tokens_none_disables_check(self):
-        """max_tokens=None is valid — explicitly disables the token limit."""
-        cfg = OutputLengthGuardConfig(max_tokens=None)
-        assert cfg.max_tokens is None
-
-    def test_limit_mode_token_accepted(self):
-        """limit_mode='token' is a valid choice."""
-        cfg = OutputLengthGuardConfig(limit_mode="token", max_tokens=500)
-        assert cfg.limit_mode == "token"
-
-    def test_word_boundary_true_accepted(self):
-        """word_boundary=True is accepted."""
-        cfg = OutputLengthGuardConfig(word_boundary=True)
-        assert cfg.word_boundary is True
-
-    def test_min_tokens_equal_to_max_tokens_rejected(self):
-        """min_tokens == max_tokens is rejected by the cross-validator."""
-        with pytest.raises(ValidationError, match="min_tokens must be less than max_tokens"):
-            OutputLengthGuardConfig(min_tokens=100, max_tokens=100)
-
-    def test_min_tokens_greater_than_max_tokens_rejected(self):
-        """min_tokens > max_tokens is rejected by the cross-validator."""
-        with pytest.raises(ValidationError, match="min_tokens must be less than max_tokens"):
-            OutputLengthGuardConfig(min_tokens=500, max_tokens=100)
-
-    def test_max_tokens_zero_skips_token_validator(self):
-        """max_tokens=0 disables the check — min_tokens can be higher without error."""
-        cfg = OutputLengthGuardConfig(min_tokens=100, max_tokens=0)
-        assert cfg.min_tokens == 100
-
-    def test_chars_per_token_out_of_range_rejected(self):
-        """chars_per_token must be between 1 and 10."""
-        with pytest.raises(ValidationError):
-            OutputLengthGuardConfig(chars_per_token=0)
-        with pytest.raises(ValidationError):
-            OutputLengthGuardConfig(chars_per_token=11)
-
-    def test_min_chars_must_be_non_negative(self):
-        """min_chars=-1 is rejected (must be >= 0)."""
-        with pytest.raises(ValidationError, match=r"(?s)min_chars.*greater than or equal to 0"):
-            OutputLengthGuardConfig(min_chars=-1, max_chars=100, strategy="truncate", ellipsis="...")
-
-    def test_invalid_strategy(self):
-        """Strategy values other than 'truncate' or 'block' are rejected."""
-        with pytest.raises(ValidationError, match=r"(?s)strategy.*'truncate' or 'block'"):
-            OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="drop", ellipsis="...")
-
-    def test_extra_fields_forbidden(self):
-        """Unknown fields are rejected (extra='forbid')."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-            OutputLengthGuardConfig(min_chars=0, max_chars=2000, strategy="truncate", ellipsis="...", unknown_field="bad")
-
-
-# ---------------------------------------------------------------------------
-# Schema validation tests — RateLimiterConfig
-# ---------------------------------------------------------------------------
-
-
-class TestRateLimiterConfig:
-    """Pydantic validation for RateLimiterConfig."""
-
-    def test_all_none_is_valid(self):
-        """All-None construction is valid (no limits configured)."""
-        cfg = RateLimiterConfig()
-        assert cfg.by_user is None
-        assert cfg.by_tenant is None
-        assert cfg.by_tool is None
-
-    def test_valid_per_minute(self):
-        """Rate strings ending in /m are accepted for all rate fields."""
-        cfg = RateLimiterConfig(by_user="60/m", by_tenant="600/m", by_tool={"search": "10/m"})
-        assert cfg.by_user == "60/m"
-        assert cfg.by_tenant == "600/m"
-        assert cfg.by_tool == {"search": "10/m"}
-
-    def test_valid_per_second(self):
-        """Rate strings ending in /s are accepted."""
-        cfg = RateLimiterConfig(by_user="10/s")
-        assert cfg.by_user == "10/s"
-
-    def test_invalid_period_h(self):
-        """Period /h is not accepted."""
-        with pytest.raises(ValidationError, match=r"Rate string '60/h' is invalid"):
-            RateLimiterConfig(by_user="60/h")
-
-    def test_invalid_no_slash(self):
-        """Rate strings without a slash inside by_tool dict values are rejected."""
-        with pytest.raises(ValidationError, match=r"Rate string '100' for tool 'search' is invalid"):
-            RateLimiterConfig(by_tool={"search": "100"})
-
-    def test_invalid_missing_count(self):
-        """Rate strings missing the numeric count are rejected."""
-        with pytest.raises(ValidationError, match=r"Rate string '/m' is invalid"):
-            RateLimiterConfig(by_tenant="/m")
-
-    def test_invalid_non_numeric_count(self):
-        """Non-numeric count is rejected."""
-        with pytest.raises(ValidationError, match=r"Rate string 'fast/m' is invalid"):
-            RateLimiterConfig(by_user="fast/m")
-
-    def test_by_tool_dict_individual_value_invalid(self):
-        """A dict value with invalid period in by_tool is rejected."""
-        with pytest.raises(ValidationError, match=r"Rate string '60/h' for tool 'search' is invalid"):
-            RateLimiterConfig(by_tool={"search": "60/h"})
-
-    def test_algorithm_values_accepted(self):
-        """All three algorithm values are accepted."""
-        for algo in ("fixed_window", "sliding_window", "token_bucket"):
-            cfg = RateLimiterConfig(algorithm=algo)
-            assert cfg.algorithm == algo
-
-    def test_invalid_algorithm_rejected(self):
-        """An unknown algorithm is rejected."""
-        with pytest.raises(ValidationError):
-            RateLimiterConfig(algorithm="round_robin")
-
-    def test_backend_redis_with_redis_url(self):
-        """backend='redis' with a redis_url is accepted."""
-        cfg = RateLimiterConfig(backend="redis", redis_url="redis://localhost:6379/0")
-        assert cfg.backend == "redis"
-        assert cfg.redis_url == "redis://localhost:6379/0"
-
-    def test_invalid_backend_rejected(self):
-        """An unknown backend is rejected."""
-        with pytest.raises(ValidationError):
-            RateLimiterConfig(backend="postgres")
-
-    def test_redis_fallback_false(self):
-        """redis_fallback=False is accepted."""
-        cfg = RateLimiterConfig(redis_fallback=False)
-        assert cfg.redis_fallback is False
-
-
-# ---------------------------------------------------------------------------
-# Schema validation tests — SecretsDetectionConfig
-# ---------------------------------------------------------------------------
-
-
-class TestSecretsDetectionConfig:
-    """Pydantic validation for SecretsDetectionConfig."""
-
-    def test_valid_defaults(self):
-        """Default construction succeeds — schema defaults remain available for internal/plugin-manager use."""
-        cfg = SecretsDetectionConfig()
-        assert cfg.redact is True
-        assert cfg.redaction_text == "[REDACTED]"
-        assert cfg.block_on_detection is False
-        assert cfg.min_findings_to_block == 1
-        assert cfg.enabled == {}
-
-    def test_valid_explicit(self):
-        """Explicit valid values are accepted."""
-        cfg = SecretsDetectionConfig(
-            enabled={"aws_key": True, "github_token": False},
-            redact=True,
-            redaction_text="***",
-            block_on_detection=True,
-            min_findings_to_block=3,
-        )
-        assert cfg.enabled == {"aws_key": True, "github_token": False}
-        assert cfg.min_findings_to_block == 3
-
-    def test_min_findings_must_be_at_least_one(self):
-        """min_findings_to_block=0 is rejected (must be >= 1)."""
-        with pytest.raises(ValidationError, match=r"(?s)min_findings_to_block.*greater than or equal to 1"):
-            SecretsDetectionConfig(enabled={}, redact=True, redaction_text="[REDACTED]", block_on_detection=False, min_findings_to_block=0)
-
-    def test_redaction_text_too_long(self):
-        """redaction_text longer than 50 characters is rejected."""
-        with pytest.raises(ValidationError, match=r"(?s)redaction_text.*at most 50 characters"):
-            SecretsDetectionConfig(enabled={}, redact=True, redaction_text="x" * 51, block_on_detection=False, min_findings_to_block=1)
-
-    def test_extra_fields_forbidden(self):
-        """Unknown fields are rejected (extra='forbid')."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-            SecretsDetectionConfig(enabled={}, redact=True, redaction_text="[REDACTED]", block_on_detection=False, min_findings_to_block=1, scan_mode="deep")
-
-
-# ---------------------------------------------------------------------------
 # Schema validation tests — PluginPolicyItem cross-validation
 # ---------------------------------------------------------------------------
 
@@ -878,15 +649,6 @@ class TestPluginPolicyItemValidation:
                 binding_reference_id="a" * 256,
             )
 
-    def test_unknown_plugin_id_rejected(self):
-        """An unrecognised plugin_id is rejected — guards against typos at binding creation."""
-        with pytest.raises(ValidationError, match=r"Unknown plugin_id"):
-            PluginPolicyItem(
-                tool_names=["tool_x"],
-                plugin_id="FuturePlugin",
-                config={},
-            )
-
     def test_extra_fields_forbidden(self):
         """Unknown fields on PluginPolicyItem are rejected (extra='forbid')."""
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
@@ -923,12 +685,6 @@ class TestTopLevelSchemas:
         """TeamPolicies with an empty policies list is rejected."""
         with pytest.raises(ValidationError, match=r"(?s)policies.*at least 1 item"):
             TeamPolicies(policies=[])
-
-    def test_plugin_config_registry_contains_expected_plugins(self):
-        """_PLUGIN_CONFIG_REGISTRY maps each plugin class name to its config schema."""
-        assert _PLUGIN_CONFIG_REGISTRY["OutputLengthGuardPlugin"] is OutputLengthGuardConfig
-        assert _PLUGIN_CONFIG_REGISTRY["RateLimiterPlugin"] is RateLimiterConfig
-        assert _PLUGIN_CONFIG_REGISTRY["SecretsDetection"] is SecretsDetectionConfig
 
     def test_plugin_binding_mode_enum_values(self):
         """PluginBindingMode enum covers all expected execution modes."""


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4289 #4253

---

## 📝 Summary

This PR fixes a correctness bug in plugin binding resolution and removes architectural coupling between CF and the plugin framework.

**Bug fix — binding key was wrong**

When a tool was invoked, CF looked up plugin bindings using `original_name` (e.g. `read_file`) as the key. The problem is that `original_name` is only unique per gateway — two gateways in the same team can both expose a tool named `read_file`. This meant a binding intended for one tool could match the wrong tool depending on which gateway was invoked first. The fix uses `name` (e.g. `mac-fs-read-file`), which is the gateway-prefixed identifier enforced unique per team by DB constraint `uq_team_owner_email_name_tool`. This applies to both `prepare_rust_mcp_tool_execution` and `invoke_tool`.

**Refactor — CF does not own plugin contracts**

The original design had CF maintaining a `PluginId` enum (`OUTPUT_LENGTH_GUARD`, `RATE_LIMITER`, `SECRETS_DETECTION`), a mapping from those enum values to plugin class names, full Pydantic config schemas for each plugin (`OutputLengthGuardConfig`, `RateLimiterConfig`, `SecretsDetectionConfig`), and a validator that checked every config field against those schemas at binding creation time.

This was wrong for three reasons:
1. Plugins live in a separate repo (cpex). Every new plugin required a CF PR just to be stored and routed — before it could even be used.
2. Config schemas in CF would drift from the authoritative definitions in cpex over time.
3. Field-level config validation belongs in the plugin at execution time, not in the gateway at binding creation time.

The refactor removes all of this in stages. First, the `PluginId` enum is replaced with plain strings — plugin class names are stored directly in the DB as-is. Then the config schema classes and registry machinery are removed entirely. Finally, even the simplified name allowlist (`_KNOWN_PLUGIN_NAMES` frozenset) is removed, because CF has no business knowing which plugins exist at all.

The end state: `plugin_id` is a plain stored string. CF persists whatever WXO sends verbatim. The plugin framework in cpex resolves it at execution time and ignores names it doesn't recognise. New plugins in cpex require zero CF changes.

A regression guard test (`test_unknown_plugin_id_passed_through` in `test_gateway_plugin_manager.py`) is retained to ensure CF never accidentally re-introduces filtering of unknown plugin names.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅     |
| Unit tests                | `make test`     | ✅     |
| Coverage ≥ 80%            | `make coverage` | ✅     |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes
