### PR TITLE
feat(plugins): runtime plugin management — global toggle, per-plugin mode, cross-instance propagation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-19T08:51:02Z",
+  "generated_at": "2026-04-19T16:27:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4170,7 +4170,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4184,
+        "line_number": 4187,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4178,7 +4178,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4785,
+        "line_number": 4788,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4186,7 +4186,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4787,
+        "line_number": 4790,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4194,7 +4194,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15113,
+        "line_number": 15116,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -58,7 +58,7 @@ mcpContextForge:
         include_user_info: false
       plugins:
         - name: "PIIFilterPlugin"
-          kind: "plugins.pii_filter.pii_filter.PIIFilterPlugin"
+          kind: "cpex_pii_filter.PIIFilterPlugin"
           description: "Detects and masks Personally Identifiable Information"
           version: "0.1.0"
           author: "Mihai Criveti"
@@ -85,7 +85,7 @@ mcpContextForge:
               - "test@example.com"
               - "555-555-5555"
         - name: "RateLimiterPlugin"
-          kind: "plugins.rate_limiter.rate_limiter.RateLimiterPlugin"
+          kind: "cpex_rate_limiter.RateLimiterPlugin"
           description: "Per-user/tenant/tool rate limits"
           version: "0.1.0"
           author: "Mihai Criveti"
@@ -103,7 +103,7 @@ mcpContextForge:
             by_tenant: "3000/m"
             by_tool: {}
         - name: "RetryWithBackoffPlugin"
-          kind: "plugins.retry_with_backoff.retry_with_backoff.RetryWithBackoffPlugin"
+          kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
           description: "Detects transient failures and asks the gateway to re-invoke the tool after a jittered exponential backoff delay"
           version: "0.1.0"
           author: "Mihai Criveti"
@@ -136,7 +136,7 @@ mcpContextForge:
             strategy: "truncate"
             ellipsis: "…"
         - name: "SecretsDetection"
-          kind: "plugins.secrets_detection.secrets_detection.SecretsDetectionPlugin"
+          kind: "cpex_secrets_detection.SecretsDetectionPlugin"
           description: "Detects keys/tokens/secrets in inputs/outputs; optional redaction/blocking"
           version: "0.1.0"
           author: "ContextForge"
@@ -160,7 +160,7 @@ mcpContextForge:
             block_on_detection: true
             min_findings_to_block: 1
         - name: "EncodedExfilDetector"
-          kind: "plugins.encoded_exfil_detection.encoded_exfil_detector.EncodedExfilDetectorPlugin"
+          kind: "cpex_encoded_exfil_detection.EncodedExfilDetectorPlugin"
           description: "Detects suspicious encoded exfiltration patterns in prompt args and tool outputs"
           version: "0.1.0"
           author: "Mihai Criveti"

--- a/docs/docs/api/plugin-bindings-api.md
+++ b/docs/docs/api/plugin-bindings-api.md
@@ -579,7 +579,7 @@ curl -s -X POST \
 2. `GatewayTenantPluginManagerFactory.get_config_from_db()` fetches all DB bindings for the `(team_id, tool_name)` pair, including any wildcard `*` bindings.
 3. For each binding, the DB `mode` and `config` are merged over the global `config.yaml` values (`_merge_tenant_config`). DB values always win.
 4. A **`TenantPluginManager`** is instantiated with the merged config and cached in memory, keyed by context ID.
-5. On upsert or delete, the cache entry is invalidated on the worker that handled the API request. Other workers and pods pick up the change when the cached manager expires (default TTL: 30 seconds). For wildcard bindings (`tool_name="*"`), all cached contexts for the team are evicted.
+5. On upsert or delete, the handling worker invalidates its local cache entry and broadcasts a `binding_change` frame on the `plugin:invalidation` Redis pub/sub channel, so peer workers evict within milliseconds. If pub/sub delivery fails, the cache TTL (default 30 seconds) bounds the worst-case drift. For wildcard bindings (`tool_name="*"`), every cached context for the team is evicted on the handling worker.
 
 ### Priority execution order
 

--- a/docs/docs/api/plugin-bindings-api.md
+++ b/docs/docs/api/plugin-bindings-api.md
@@ -579,7 +579,7 @@ curl -s -X POST \
 2. `GatewayTenantPluginManagerFactory.get_config_from_db()` fetches all DB bindings for the `(team_id, tool_name)` pair, including any wildcard `*` bindings.
 3. For each binding, the DB `mode` and `config` are merged over the global `config.yaml` values (`_merge_tenant_config`). DB values always win.
 4. A **`TenantPluginManager`** is instantiated with the merged config and cached in memory, keyed by context ID.
-5. On upsert or delete, the cache entry is invalidated immediately so the next call picks up the new config.
+5. On upsert or delete, the cache entry is invalidated on the worker that handled the API request. Other workers and pods pick up the change when the cached manager expires (default TTL: 30 seconds). For wildcard bindings (`tool_name="*"`), all cached contexts for the team are evicted.
 
 ### Priority execution order
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -104,7 +104,11 @@ from mcpgateway.schemas import (
     PaginationMeta,
     PluginDetail,
     PluginListResponse,
+    PluginModeUpdateRequest,
+    PluginModeUpdateResponse,
     PluginStatsResponse,
+    PluginToggleRequest,
+    PluginToggleResponse,
     PromptCreate,
     PromptMetrics,
     PromptRead,
@@ -2028,11 +2032,10 @@ async def get_overview_partial(
         resources_total = db.query(func.count(DbResource.id)).scalar() or 0  # pylint: disable=not-callable
         resources_active = db.query(func.count(DbResource.id)).filter(DbResource.enabled.is_(True)).scalar() or 0  # pylint: disable=not-callable
 
-        # Plugin stats
+        # Plugin stats — self-heal the cache so the overview reflects the live
+        # shared toggle even on a process that booted with plugins disabled.
         overview_plugin_service = get_plugin_service()
-        plugin_manager = getattr(request.app.state, "plugin_manager", None)
-        if plugin_manager:
-            overview_plugin_service.set_plugin_manager(plugin_manager)
+        await _sync_plugin_service_from_runtime(request, overview_plugin_service)
         plugin_stats = await overview_plugin_service.get_plugin_statistics()
 
         # Infrastructure status (database, cache, uptime)
@@ -16535,6 +16538,41 @@ async def get_gateways_section(
 ####################
 
 
+async def _sync_plugin_service_from_runtime(request: Request, plugin_service) -> None:
+    """Self-heal the admin plugin cache from the live framework state.
+
+    The framework's ``get_plugin_manager`` is the single source of truth — it
+    reads the shared toggle (TTL-cached, so this is a cheap call) and returns
+    ``None`` when plugins are globally disabled, even when the disable came
+    from a *remote* node via the Redis toggle.
+
+    Every admin read mirrors that answer back into ``app.state.plugin_manager``
+    and the ``PluginService`` singleton. This closes three gaps:
+
+    1. Processes that booted with plugins disabled never had ``app.state`` set,
+       so admin views returned empty until restart even after the shared
+       toggle was flipped on.
+    2. If ``toggle_plugins_global`` swallowed an admin-cache sync failure, the
+       stale cache would persist forever — now the next GET repairs it.
+    3. A remote disable (``PUT /admin/plugins {"enabled": false}`` on another
+       worker) would leave this worker's ``app.state.plugin_manager``
+       populated from a prior enable, making admin views serve plugin
+       metadata the cluster had already turned off.
+
+    Best-effort: a failure logs a WARNING and leaves ``app.state`` alone. It
+    never raises, so it can't turn a read into a 500.
+    """
+    try:
+        # pylint: disable=import-outside-toplevel
+        from mcpgateway.plugins.framework import get_plugin_manager
+
+        plugin_manager = await get_plugin_manager()
+        request.app.state.plugin_manager = plugin_manager
+        plugin_service.set_plugin_manager(plugin_manager)
+    except Exception as sync_exc:
+        LOGGER.warning("Admin plugin-cache self-heal failed (%s) — view may render stale/empty", sync_exc)
+
+
 @admin_router.get("/plugins/partial")
 @require_permission("admin.plugins", allow_admin_bypass=False)
 async def get_plugins_partial(request: Request, db: Session = Depends(get_db), user=Depends(get_current_user_with_permissions)) -> HTMLResponse:  # pylint: disable=unused-argument
@@ -16558,17 +16596,15 @@ async def get_plugins_partial(request: Request, db: Session = Depends(get_db), u
         # Get plugin service and check if plugins are enabled
         plugin_service = get_plugin_service()
 
-        # Check if plugin manager is available in app state
-        plugin_manager = getattr(request.app.state, "plugin_manager", None)
-        if plugin_manager:
-            plugin_service.set_plugin_manager(plugin_manager)
+        # Self-heal the cache so the partial reflects the live shared toggle.
+        await _sync_plugin_service_from_runtime(request, plugin_service)
 
         # Get plugin data
         plugins = plugin_service.get_all_plugins()
         stats = await plugin_service.get_plugin_statistics()
 
         # Prepare context for template
-        context = {"request": request, "plugins": plugins, "stats": stats, "plugins_enabled": plugin_manager is not None, "root_path": _resolve_root_path(request)}
+        context = {"request": request, "plugins": plugins, "stats": stats, "plugins_enabled": plugin_service.get_plugin_manager() is not None, "root_path": _resolve_root_path(request)}
 
         # Render the partial template
         return request.app.state.templates.TemplateResponse(request, "plugins_partial.html", context)
@@ -16620,10 +16656,8 @@ async def list_plugins(
         # Get plugin service
         plugin_service = get_plugin_service()
 
-        # Check if plugin manager is available
-        plugin_manager = getattr(request.app.state, "plugin_manager", None)
-        if plugin_manager:
-            plugin_service.set_plugin_manager(plugin_manager)
+        # Self-heal the cache from the live framework state.
+        await _sync_plugin_service_from_runtime(request, plugin_service)
 
         # Get filtered plugins
         if any([search, mode, hook, tag]):
@@ -16666,49 +16700,61 @@ async def list_plugins(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@admin_router.put("/plugins")
+@admin_router.put("/plugins", response_model=PluginToggleResponse)
 @require_permission("admin.plugins", allow_admin_bypass=False)
 async def toggle_plugins_global(
+    payload: PluginToggleRequest,
     request: Request,
     user=Depends(get_current_user_with_permissions),
-) -> dict:
-    """Enable or disable the plugin subsystem globally.
+) -> PluginToggleResponse:
+    """Enable or disable the plugin subsystem globally and broadcast the change."""
+    # pylint: disable=import-outside-toplevel
+    from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins_shared, get_plugin_manager
 
-    Expects JSON body: {"enabled": true} or {"enabled": false}.
-    Writes to Redis so all workers and pods pick up the change.
-    Falls back to in-memory toggle if Redis is unavailable.
+    redis_persisted = await enable_plugins_shared(payload.enabled)
 
-    Args:
-        request: FastAPI request object containing JSON body.
-        user: Authenticated admin user.
+    # Sync the admin-side cache so ``GET /admin/plugins`` and
+    # ``GET /admin/plugins/{name}`` reflect the toggle on a process that
+    # started with plugins disabled (``app.state.plugin_manager`` stayed unset
+    # and ``PluginService`` was never wired). Without this, enabling plugins
+    # at runtime leaves the admin surfaces reading stale/empty metadata until
+    # the next restart; disabling likewise keeps the old manager visible.
+    #
+    # Treat the sync as best-effort: the shared toggle above already committed,
+    # so an exception here (e.g. factory build failure on a degraded node) must
+    # not turn into a 500 for a toggle that actually took effect. The admin
+    # surfaces will self-correct on the next request that re-reads the manager.
+    try:
+        plugin_service = get_plugin_service()
+        if payload.enabled:
+            plugin_manager = await get_plugin_manager()
+            if plugin_manager is not None:
+                plugin_service.set_plugin_manager(plugin_manager)
+                request.app.state.plugin_manager = plugin_manager
+        else:
+            plugin_service.set_plugin_manager(None)
+            request.app.state.plugin_manager = None
+    except Exception as sync_exc:
+        LOGGER.warning(
+            "Plugin global toggle applied (enabled=%s) but admin-cache sync failed (%s) — admin views will refresh on next request",
+            payload.enabled,
+            sync_exc,
+        )
 
-    Returns:
-        dict with current plugins_enabled state.
-    """
-    from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins_shared  # pylint: disable=import-outside-toplevel
-
-    body = await request.json()
-    enabled = body.get("enabled")
-    if enabled is None:
-        raise HTTPException(status_code=400, detail="Missing 'enabled' field in request body")
-    if not isinstance(enabled, bool):
-        raise HTTPException(status_code=400, detail="'enabled' must be a boolean")
-
-    await enable_plugins_shared(enabled)
-    LOGGER.info(f"Plugins globally {'enabled' if enabled else 'disabled'} by {get_user_email(user)}")
+    LOGGER.info(f"Plugins globally {'enabled' if payload.enabled else 'disabled'} by {get_user_email(user)}")
     structured_logger = get_structured_logger()
     structured_logger.info(
-        f"Plugin subsystem globally {'enabled' if enabled else 'disabled'}",
+        f"Plugin subsystem globally {'enabled' if payload.enabled else 'disabled'}",
         user_id=get_user_id(user),
         user_email=get_user_email(user),
         component="plugin_runtime",
         category="security",
         resource_type="plugin_global_toggle",
         resource_action="update",
-        custom_fields={"enabled": enabled},
+        custom_fields={"enabled": payload.enabled, "redis_persisted": redis_persisted},
     )
 
-    return {"plugins_enabled": await are_plugins_enabled_shared()}
+    return PluginToggleResponse(plugins_enabled=await are_plugins_enabled_shared(), redis_persisted=redis_persisted)
 
 
 @admin_router.get("/plugins/stats", response_model=PluginStatsResponse)
@@ -16734,10 +16780,8 @@ async def get_plugin_stats(request: Request, db: Session = Depends(get_db), user
         # Get plugin service
         plugin_service = get_plugin_service()
 
-        # Check if plugin manager is available
-        plugin_manager = getattr(request.app.state, "plugin_manager", None)
-        if plugin_manager:
-            plugin_service.set_plugin_manager(plugin_manager)
+        # Self-heal the cache from the live framework state.
+        await _sync_plugin_service_from_runtime(request, plugin_service)
 
         # Get statistics
         stats = await plugin_service.get_plugin_statistics()
@@ -16796,10 +16840,8 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
         # Get plugin service
         plugin_service = get_plugin_service()
 
-        # Check if plugin manager is available
-        plugin_manager = getattr(request.app.state, "plugin_manager", None)
-        if plugin_manager:
-            plugin_service.set_plugin_manager(plugin_manager)
+        # Self-heal the cache from the live framework state.
+        await _sync_plugin_service_from_runtime(request, plugin_service)
 
         # Get plugin details
         plugin = plugin_service.get_plugin_by_name(name)
@@ -16853,79 +16895,67 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@admin_router.put("/plugins/{name}")
+@admin_router.put("/plugins/{name}", response_model=PluginModeUpdateResponse)
 @require_permission("admin.plugins", allow_admin_bypass=False)
 async def update_plugin_mode(
     name: str,
-    request: Request,
-    db: Session = Depends(get_db),  # pylint: disable=unused-argument
+    payload: PluginModeUpdateRequest,
+    _db: Session = Depends(get_db),  # required by rbac decorator's session lookup
     user=Depends(get_current_user_with_permissions),
-) -> dict:
-    """Change a plugin's mode at runtime (enforce/permissive/disabled).
+) -> PluginModeUpdateResponse:
+    """Persist a per-plugin mode override in Redis and invalidate cached managers."""
+    # pylint: disable=import-outside-toplevel
+    from mcpgateway.plugins.framework import invalidate_all_plugin_managers, list_configured_plugin_names, publish_plugin_mode_change
 
-    Stores the mode override in Redis so all workers and pods pick up the
-    change. The override takes precedence over the YAML config until the
-    gateway is restarted or the override is removed.
+    mode = payload.mode
 
-    Args:
-        name: Plugin name (e.g. "RateLimiterPlugin").
-        request: FastAPI request object containing JSON body with "mode" field.
-        db: Database session.
-        user: Authenticated admin user.
-
-    Returns:
-        dict with plugin name and new mode.
-    """
-    body = await request.json()
-    mode = body.get("mode")
-    valid_modes = ("enforce", "permissive", "disabled")
-    if mode not in valid_modes:
-        raise HTTPException(status_code=400, detail=f"'mode' must be one of: {', '.join(valid_modes)}")
-
-    # Verify plugin exists by checking the plugin list
-    plugin_service = get_plugin_service()
-    plugin_manager = getattr(request.app.state, "plugin_manager", None)
-    if plugin_manager:
-        plugin_service.set_plugin_manager(plugin_manager)
-    all_plugins = plugin_service.get_all_plugins()
-    plugin_names = [p["name"] for p in all_plugins]
+    # Validate against the *configured* plugin set, not the live manager. On a
+    # process that booted with plugins globally disabled, no manager is wired
+    # and ``PluginService.get_all_plugins()`` returns ``[]``; without this the
+    # handler 404s for every valid name and blocks operators from pre-staging
+    # a per-plugin mode before turning the subsystem on.
+    plugin_names = list_configured_plugin_names()
     if name not in plugin_names:
         raise HTTPException(status_code=404, detail=f"Plugin '{name}' not found. Available: {', '.join(plugin_names[:10])}")
 
-    # Store mode override in Redis and invalidate cached managers
+    # publish_plugin_mode_change always updates the in-process override map
+    # (so single-node-no-Redis deployments still work) and additionally
+    # attempts a Redis SET + publish. The Redis outcome is surfaced back to
+    # the caller as redis_persisted so they know whether the change reached
+    # other workers.
+    redis_persisted = await publish_plugin_mode_change(name, mode)
+    # The override is already stored (in-process map and/or Redis) by the line
+    # above. Treat the cache sweep as best-effort — if it raises, a background
+    # TTL refresh still reaches the new mode, and the operator must not see a
+    # 500 for an override that actually took effect.
     try:
-        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
-        from mcpgateway.plugins.framework import invalidate_all_plugin_managers  # pylint: disable=import-outside-toplevel
-
-        client = await get_redis_client()
-        redis_persisted = False
-        if client:
-            await client.set(f"plugin:{name}:mode", mode, ex=86400)  # 24h TTL — stale overrides expire
-            redis_persisted = True
-            LOGGER.info(f"Plugin '{name}' mode changed to '{mode}' by {get_user_email(user)} (stored in Redis, 24h TTL)")
-        else:
-            LOGGER.warning(f"Redis unavailable — plugin '{name}' mode change to '{mode}' is local only")
-
-        # Invalidate all cached managers so they rebuild with the new mode
         await invalidate_all_plugin_managers()
-
-        structured_logger = get_structured_logger()
-        structured_logger.info(
-            f"Plugin '{name}' mode changed to '{mode}'",
-            user_id=get_user_id(user),
-            user_email=get_user_email(user),
-            component="plugin_runtime",
-            category="security",
-            resource_type="plugin_mode",
-            resource_id=name,
-            resource_action="update",
-            custom_fields={"plugin_name": name, "new_mode": mode},
+    except Exception as invalidate_exc:
+        LOGGER.warning(
+            "Plugin '%s' mode override stored but cache invalidation failed (%s) — fresh managers will rebuild on next TTL expiry",
+            name,
+            invalidate_exc,
         )
-    except Exception as exc:
-        LOGGER.warning(f"Failed to write plugin mode to Redis: {exc}")
-        redis_persisted = False
 
-    return {"plugin": name, "mode": mode, "redis_persisted": redis_persisted}
+    if redis_persisted:
+        LOGGER.info(f"Plugin '{name}' mode changed to '{mode}' by {get_user_email(user)} (Redis persisted, 24h TTL)")
+    else:
+        LOGGER.warning(f"Plugin '{name}' mode changed to '{mode}' by {get_user_email(user)} (this worker only — Redis unavailable)")
+
+    structured_logger = get_structured_logger()
+    structured_logger.info(
+        f"Plugin '{name}' mode changed to '{mode}'",
+        user_id=get_user_id(user),
+        user_email=get_user_email(user),
+        component="plugin_runtime",
+        category="security",
+        resource_type="plugin_mode",
+        resource_id=name,
+        resource_action="update",
+        custom_fields={"plugin_name": name, "new_mode": mode, "redis_persisted": redis_persisted},
+    )
+
+    return PluginModeUpdateResponse(plugin=name, mode=mode, redis_persisted=redis_persisted)
 
 
 ##################################################

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -16656,12 +16656,59 @@ async def list_plugins(
             },
         )
 
-        return PluginListResponse(plugins=plugins, total=len(plugins), enabled_count=enabled_count, disabled_count=disabled_count)
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared  # pylint: disable=import-outside-toplevel
+
+        return PluginListResponse(plugins_globally_enabled=await are_plugins_enabled_shared(), plugins=plugins, total=len(plugins), enabled_count=enabled_count, disabled_count=disabled_count)
 
     except Exception as e:
         LOGGER.error(f"Error listing plugins: {e}")
         structured_logger.error("Failed to list plugins in marketplace", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@admin_router.put("/plugins")
+@require_permission("admin.plugins", allow_admin_bypass=False)
+async def toggle_plugins_global(
+    request: Request,
+    user=Depends(get_current_user_with_permissions),
+) -> dict:
+    """Enable or disable the plugin subsystem globally.
+
+    Expects JSON body: {"enabled": true} or {"enabled": false}.
+    Writes to Redis so all workers and pods pick up the change.
+    Falls back to in-memory toggle if Redis is unavailable.
+
+    Args:
+        request: FastAPI request object containing JSON body.
+        user: Authenticated admin user.
+
+    Returns:
+        dict with current plugins_enabled state.
+    """
+    from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins_shared  # pylint: disable=import-outside-toplevel
+
+    body = await request.json()
+    enabled = body.get("enabled")
+    if enabled is None:
+        raise HTTPException(status_code=400, detail="Missing 'enabled' field in request body")
+    if not isinstance(enabled, bool):
+        raise HTTPException(status_code=400, detail="'enabled' must be a boolean")
+
+    await enable_plugins_shared(enabled)
+    LOGGER.info(f"Plugins globally {'enabled' if enabled else 'disabled'} by {get_user_email(user)}")
+    structured_logger = get_structured_logger()
+    structured_logger.info(
+        f"Plugin subsystem globally {'enabled' if enabled else 'disabled'}",
+        user_id=get_user_id(user),
+        user_email=get_user_email(user),
+        component="plugin_runtime",
+        category="security",
+        resource_type="plugin_global_toggle",
+        resource_action="update",
+        custom_fields={"enabled": enabled},
+    )
+
+    return {"plugins_enabled": await are_plugins_enabled_shared()}
 
 
 @admin_router.get("/plugins/stats", response_model=PluginStatsResponse)
@@ -16804,6 +16851,81 @@ async def get_plugin_details(name: str, request: Request, db: Session = Depends(
             f"Failed to get plugin details: '{name}'", user_id=get_user_id(user), user_email=get_user_email(user), error=e, component="plugin_marketplace", category="business_logic"
         )
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@admin_router.put("/plugins/{name}")
+@require_permission("admin.plugins", allow_admin_bypass=False)
+async def update_plugin_mode(
+    name: str,
+    request: Request,
+    db: Session = Depends(get_db),  # pylint: disable=unused-argument
+    user=Depends(get_current_user_with_permissions),
+) -> dict:
+    """Change a plugin's mode at runtime (enforce/permissive/disabled).
+
+    Stores the mode override in Redis so all workers and pods pick up the
+    change. The override takes precedence over the YAML config until the
+    gateway is restarted or the override is removed.
+
+    Args:
+        name: Plugin name (e.g. "RateLimiterPlugin").
+        request: FastAPI request object containing JSON body with "mode" field.
+        db: Database session.
+        user: Authenticated admin user.
+
+    Returns:
+        dict with plugin name and new mode.
+    """
+    body = await request.json()
+    mode = body.get("mode")
+    valid_modes = ("enforce", "permissive", "disabled")
+    if mode not in valid_modes:
+        raise HTTPException(status_code=400, detail=f"'mode' must be one of: {', '.join(valid_modes)}")
+
+    # Verify plugin exists by checking the plugin list
+    plugin_service = get_plugin_service()
+    plugin_manager = getattr(request.app.state, "plugin_manager", None)
+    if plugin_manager:
+        plugin_service.set_plugin_manager(plugin_manager)
+    all_plugins = plugin_service.get_all_plugins()
+    plugin_names = [p["name"] for p in all_plugins]
+    if name not in plugin_names:
+        raise HTTPException(status_code=404, detail=f"Plugin '{name}' not found. Available: {', '.join(plugin_names[:10])}")
+
+    # Store mode override in Redis and invalidate cached managers
+    try:
+        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+        from mcpgateway.plugins.framework import invalidate_all_plugin_managers  # pylint: disable=import-outside-toplevel
+
+        client = await get_redis_client()
+        redis_persisted = False
+        if client:
+            await client.set(f"plugin:{name}:mode", mode, ex=86400)  # 24h TTL — stale overrides expire
+            redis_persisted = True
+            LOGGER.info(f"Plugin '{name}' mode changed to '{mode}' by {get_user_email(user)} (stored in Redis, 24h TTL)")
+        else:
+            LOGGER.warning(f"Redis unavailable — plugin '{name}' mode change to '{mode}' is local only")
+
+        # Invalidate all cached managers so they rebuild with the new mode
+        await invalidate_all_plugin_managers()
+
+        structured_logger = get_structured_logger()
+        structured_logger.info(
+            f"Plugin '{name}' mode changed to '{mode}'",
+            user_id=get_user_id(user),
+            user_email=get_user_email(user),
+            component="plugin_runtime",
+            category="security",
+            resource_type="plugin_mode",
+            resource_id=name,
+            resource_action="update",
+            custom_fields={"plugin_name": name, "new_mode": mode},
+        )
+    except Exception as exc:
+        LOGGER.warning(f"Failed to write plugin mode to Redis: {exc}")
+        redis_persisted = False
+
+    return {"plugin": name, "mode": mode, "redis_persisted": redis_persisted}
 
 
 ##################################################

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -106,6 +106,8 @@ from mcpgateway.plugins.framework import (
     PromptHookType,
     ResourceHookType,
     shutdown_plugin_manager_factory,
+    start_plugin_invalidation_listener,
+    stop_plugin_invalidation_listener,
 )
 from mcpgateway.plugins.framework.constants import PLUGIN_VIOLATION_CODE_MAPPING, PluginViolationCode, VALID_HTTP_STATUS_CODES
 from mcpgateway.routers.server_well_known import router as server_well_known_router
@@ -1621,6 +1623,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Initialize Redis client early (shared pool for all services)
     await get_redis_client()
 
+    # Register the Redis provider with the plugin framework so framework
+    # modules can reach Redis without importing mcpgateway.utils directly
+    # (isolation enforced by scripts/pre-commit/check_framework_imports.py).
+    # First-Party
+    from mcpgateway.plugins.framework._redis import set_shared_redis_provider  # pylint: disable=import-outside-toplevel
+
+    set_shared_redis_provider(get_redis_client)
+
     # Initialize shared HTTP client (connection pool for all outbound requests)
     # First-Party
     from mcpgateway.services.http_client_service import SharedHttpClient  # pylint: disable=import-outside-toplevel
@@ -1668,11 +1678,17 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # Validate security configuration
         validate_security_configuration()
 
-        # Initialize plugin manager factory if plugins are enabled
-        if settings.plugins.enabled:
-            # First-Party
-            from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # pylint: disable=import-outside-toplevel
+        # Initialize the plugin manager factory whenever the YAML config is
+        # available. We used to gate this on ``settings.plugins.enabled`` but
+        # that broke runtime enable-from-disabled: a node that boots with the
+        # flag off would never create the factory, so a later shared-toggle
+        # flip to "enabled" from a peer worker left this node unable to run
+        # plugins until restart. Keep initialisation unconditional; gate
+        # *execution* on the shared toggle in ``get_plugin_manager``.
+        # First-Party
+        from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # pylint: disable=import-outside-toplevel
 
+        try:
             init_plugin_manager_factory(
                 yaml_path=settings.plugins.config_file,
                 timeout=settings.plugins.plugin_timeout,
@@ -1681,6 +1697,28 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 db_factory=SessionLocal,
             )
             logger.info("Plugin manager factory initialized")
+        except Exception as init_exc:
+            if settings.plugins.enabled:
+                # Operator asked for plugins — a failed init (bad YAML, missing
+                # plugin module, validation error) must be a hard boot failure
+                # rather than a silent no-op. Preserve the original loud-crash
+                # semantics; the outer lifespan handler logs and re-raises.
+                logger.error("Plugin manager factory initialization failed: %s", init_exc, exc_info=True)
+                raise
+            # Plugins disabled locally; we init opportunistically so a later
+            # shared-toggle flip from a peer worker can turn the subsystem on
+            # without restarting this node. If that opportunistic init fails,
+            # the gateway still boots — but mark the node degraded so
+            # ``get_plugin_manager`` emits an ERROR the first time the shared
+            # toggle asks us to serve plugins we can't actually run.
+            logger.warning(
+                "Plugin manager factory init failed (%s); runtime-enable from a peer worker will require this node to restart",
+                init_exc,
+            )
+            # First-Party
+            from mcpgateway.plugins.framework import mark_factory_init_degraded  # pylint: disable=import-outside-toplevel
+
+            mark_factory_init_degraded()
 
         try:
             plugin_manager = await get_plugin_manager()
@@ -1697,6 +1735,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         except Exception as diag_exc:
             logger.error(f"Plugin manager initialization failed: {diag_exc}", exc_info=True)
             raise
+
+        # Always start the invalidation listener when a factory is live, even
+        # if the local ``plugins.enabled`` setting is false. The listener
+        # early-exits when no Redis provider is registered, so single-node
+        # deployments don't spin.
+        await start_plugin_invalidation_listener()
+        logger.info("Plugin invalidation listener started")
 
         # Wire observability adapter to plugin manager if observability is enabled
         if settings.observability_enabled and _service is not None:  # pylint: disable=possibly-used-before-assignment
@@ -1899,6 +1944,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 task.cancel()
                 with suppress(asyncio.CancelledError):
                     await task
+
+        # Stop the plugin invalidation listener before the factory so in-flight
+        # messages don't race with a half-torn-down cache.
+        try:
+            await stop_plugin_invalidation_listener()
+        except Exception as e:
+            logger.debug(f"Error stopping plugin invalidation listener: {e}")
 
         # Shutdown global plugin manager factory (no-op when plugins were never initialised)
         try:

--- a/mcpgateway/plugins/framework/__init__.py
+++ b/mcpgateway/plugins/framework/__init__.py
@@ -15,7 +15,15 @@ Exposes core ContextForge plugin components:
 
 # Standard
 import asyncio
-from typing import Callable, Optional
+import json
+import logging
+import random
+import time
+from typing import Any, Callable, Literal, Optional, Union
+
+# Third-Party
+from pydantic import BaseModel, TypeAdapter
+from pydantic import ValidationError as _ValidationError
 
 # First-Party
 from mcpgateway.plugins.framework.base import Plugin
@@ -47,6 +55,8 @@ from mcpgateway.plugins.framework.hooks.resources import ResourceHookType, Resou
 from mcpgateway.plugins.framework.hooks.tools import ToolHookType, ToolPostInvokePayload, ToolPostInvokeResult, ToolPreInvokePayload, ToolPreInvokeResult
 from mcpgateway.plugins.framework.loader.config import ConfigLoader
 from mcpgateway.plugins.framework.loader.plugin import PluginLoader
+from mcpgateway.plugins.framework import _state
+from mcpgateway.plugins.framework._redis import get_shared_redis_client as _redis
 from mcpgateway.plugins.framework.manager import PluginManager, TenantPluginManager, TenantPluginManagerFactory
 from mcpgateway.plugins.framework.models import (
     GlobalContext,
@@ -70,87 +80,253 @@ _plugin_manager_factory: Optional[TenantPluginManagerFactory] = None
 _observability_service: Optional[ObservabilityProvider] = None
 DEFAULT_SERVER_ID = "__global__"
 
-# Redis key for cross-worker/cross-pod global plugin toggle
+# Redis keys / channel for cross-worker/cross-pod runtime coordination.
 _REDIS_PLUGINS_ENABLED_KEY = "plugin:global:enabled"
 _REDIS_INVALIDATION_CHANNEL = "plugin:invalidation"
+_PLUGIN_MODE_TTL_SECONDS = 86400  # 24 h — aligned with the Redis key ``ex=`` value.
 _pubsub_task: Optional["asyncio.Task[None]"] = None
+# Guards the check-then-create-task pattern in start_plugin_invalidation_listener
+# so two concurrent callers can't both reach ``asyncio.create_task`` and leak
+# a second Redis subscription.
+_pubsub_start_lock = asyncio.Lock()
+
+# Short-lived local cache for the shared "plugins enabled" flag. get_plugin_manager
+# is called on every authenticated request; without this each call would cost a
+# Redis round-trip. The pub/sub listener invalidates the cache on global_toggle
+# messages, so the TTL only bounds the worst case when pub/sub is down.
+_SHARED_ENABLED_CACHE_TTL = 2.0
+_shared_enabled_cache: Optional[tuple[bool, float]] = None
+_shared_enabled_cache_lock = asyncio.Lock()
+
+# Per-plugin mode-override state and the degraded-boot flag live in ``_state``
+# (a leaf submodule) so ``framework.manager`` can read them without importing
+# ``framework/__init__.py`` — otherwise we'd have a static ``framework ->
+# framework.manager -> framework`` import cycle that pylint R0401 flags.
+# Writers in this module go through ``_state.set_local_mode_override`` /
+# ``_state.clear_local_mode_overrides``; no alias is held so the single
+# write seam is genuinely single.
+
+_logger = logging.getLogger(__name__)
+
+
+class _GlobalToggleMsg(BaseModel):
+    """Pub/sub frame announcing a plugin subsystem enable/disable."""
+
+    type: Literal["global_toggle"]
+    enabled: bool
+
+
+class _ModeChangeMsg(BaseModel):
+    """Pub/sub frame announcing a per-plugin mode override change.
+
+    ``ttl_seconds`` carries the Redis-key TTL from the publisher so every peer
+    stamps the same absolute deadline on its local override copy. Defaults to
+    the canonical 24 h constant for back-compat with older publishers.
+    """
+
+    type: Literal["mode_change"]
+    plugin: str
+    mode: Literal["enforce", "enforce_ignore_error", "permissive", "disabled"]
+    ttl_seconds: int = _PLUGIN_MODE_TTL_SECONDS
+
+
+class _BindingChangeMsg(BaseModel):
+    """Pub/sub frame announcing a ToolPluginBinding change for a single context."""
+
+    type: Literal["binding_change"]
+    context_id: str
+
+
+class _TeamBindingChangeMsg(BaseModel):
+    """Pub/sub frame announcing a wildcard binding change — every cached context for the team must be evicted."""
+
+    type: Literal["team_binding_change"]
+    team_id: str
+
+
+# Discriminated union shared by producer and consumer. A typo in the ``type``
+# field on the producer fails Pydantic validation on the listener instead of
+# silently no-oping.
+_InvalidationMsg = Union[_GlobalToggleMsg, _ModeChangeMsg, _BindingChangeMsg, _TeamBindingChangeMsg]
+_invalidation_adapter: TypeAdapter[_InvalidationMsg] = TypeAdapter(_InvalidationMsg)
 
 
 def are_plugins_enabled() -> bool:
-    """Return whether the plugin subsystem is currently enabled.
-
-    Returns the in-memory flag. For cross-worker consistency,
-    use ``are_plugins_enabled_shared()`` which reads from Redis.
-    """
+    """Return the in-memory plugin-subsystem flag."""
     return _PLUGINS_ENABLED
+
+
+async def _read_shared_enabled() -> bool:
+    """Fetch the shared toggle from Redis or fall back to the in-memory flag."""
+    try:
+        client = await _redis()
+    except Exception as exc:
+        _logger.warning("Plugin shared toggle read failed (%s), using in-memory flag", exc)
+        return _PLUGINS_ENABLED
+
+    if client is None:
+        return _PLUGINS_ENABLED
+
+    try:
+        val = await client.get(_REDIS_PLUGINS_ENABLED_KEY)
+    except Exception as exc:
+        _logger.warning("Plugin shared toggle Redis GET failed (%s), using in-memory flag", exc)
+        return _PLUGINS_ENABLED
+
+    if val is None:
+        return _PLUGINS_ENABLED
+    return val.decode() == "true" if isinstance(val, bytes) else str(val) == "true"
 
 
 async def are_plugins_enabled_shared() -> bool:
-    """Check the global plugin toggle from Redis (shared across all workers/pods).
+    """Return the shared plugin-subsystem toggle, cached briefly to stay off the hot path."""
+    global _shared_enabled_cache
+    async with _shared_enabled_cache_lock:
+        cache = _shared_enabled_cache
+        now = asyncio.get_event_loop().time()
+        if cache is not None and (now - cache[1]) < _SHARED_ENABLED_CACHE_TTL:
+            return cache[0]
 
-    Falls back to the in-memory ``_PLUGINS_ENABLED`` flag if Redis is unavailable.
+        value = await _read_shared_enabled()
+        _shared_enabled_cache = (value, now)
+        return value
+
+
+def _invalidate_shared_enabled_cache() -> None:
+    """Drop the local memoization so the next read goes to Redis.
+
+    Called by the pub/sub listener when a global_toggle broadcast arrives.
     """
-    import logging as _logging  # pylint: disable=import-outside-toplevel
-
-    _log = _logging.getLogger(__name__)
-    try:
-        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
-
-        client = await get_redis_client()
-        if client:
-            val = await client.get(_REDIS_PLUGINS_ENABLED_KEY)
-            if val is not None:
-                result = val.decode() == "true" if isinstance(val, bytes) else str(val) == "true"
-                return result
-            # Key not set in Redis — fall through to in-memory
-        else:
-            _log.debug("are_plugins_enabled_shared: Redis client is None, using in-memory flag")
-    except Exception as exc:
-        _log.debug("are_plugins_enabled_shared: Redis read failed (%s), using in-memory flag", exc)
-    return _PLUGINS_ENABLED
+    global _shared_enabled_cache
+    _shared_enabled_cache = None
 
 
 def enable_plugins(toggle: bool) -> None:
-    """Enable or disable the plugin subsystem globally (in-memory only).
+    """Toggle the in-memory flag. Use ``enable_plugins_shared`` for cross-worker reach."""
+    global _PLUGINS_ENABLED
+    _PLUGINS_ENABLED = toggle
+    _invalidate_shared_enabled_cache()
 
-    For cross-worker/cross-pod propagation, use ``enable_plugins_shared()``.
 
-    Args:
-        toggle: Pass ``True`` to activate plugins, ``False`` to deactivate.
+async def enable_plugins_shared(toggle: bool) -> bool:
+    """Persist the global toggle to Redis (no TTL — operator kill-switch persists) and broadcast the change.
+
+    Returns True when Redis accepted the write. Falls back to the in-memory flag
+    on Redis failure so the current worker still honors the operator intent.
     """
     global _PLUGINS_ENABLED
     _PLUGINS_ENABLED = toggle
+    _invalidate_shared_enabled_cache()
 
-
-async def enable_plugins_shared(toggle: bool) -> None:
-    """Enable or disable the plugin subsystem globally via Redis.
-
-    Writes to Redis so all workers and pods pick up the change.
-    Also updates the local in-memory flag.
-
-    Args:
-        toggle: Pass ``True`` to activate plugins, ``False`` to deactivate.
-    """
-    global _PLUGINS_ENABLED
-    _PLUGINS_ENABLED = toggle
     try:
-        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
-        import json as _json  # pylint: disable=import-outside-toplevel
+        client = await _redis()
+    except Exception as exc:
+        _logger.warning("Failed to obtain Redis client for plugin toggle (%s) — change is local only", exc)
+        return False
+    if client is None:
+        _logger.warning("Redis unavailable — plugin toggle change is local only")
+        return False
 
-        client = await get_redis_client()
-        if client:
-            await client.set(_REDIS_PLUGINS_ENABLED_KEY, "true" if toggle else "false")
-            try:
-                await client.publish(
-                    _REDIS_INVALIDATION_CHANNEL,
-                    _json.dumps({"type": "global_toggle", "enabled": toggle}),
-                )
-            except Exception:
-                pass  # Publish failure is non-critical — TTL fallback covers it
-    except Exception:
-        import logging  # pylint: disable=import-outside-toplevel
+    try:
+        await client.set(_REDIS_PLUGINS_ENABLED_KEY, "true" if toggle else "false")
+    except Exception as exc:
+        _logger.warning("Failed to write plugin toggle to Redis (%s) — change is local only", exc)
+        return False
 
-        logging.getLogger(__name__).warning("Failed to write plugin toggle to Redis — change is local only")
+    published = await _publish_invalidation({"type": "global_toggle", "enabled": toggle})
+    if not published:
+        # Partial write: SET persisted, broadcast didn't. Peers will converge
+        # on the next cache-TTL read (a few seconds) rather than instantly —
+        # surface this at ERROR so it reaches on-call, not just DEBUG logs.
+        _logger.error("Plugin global toggle persisted to Redis but broadcast failed — peer workers will lag until next cache refresh")
+    return True
+
+
+async def _publish_invalidation(message: dict[str, Any]) -> bool:
+    """Best-effort publish to the invalidation channel; logs but does not raise.
+
+    Listeners also evict on their own TTL, so a publish miss only widens the
+    propagation window — it does not corrupt state.
+    """
+    try:
+        client = await _redis()
+    except Exception as exc:
+        _logger.warning("Plugin invalidation publish skipped — Redis client error (%s)", exc)
+        return False
+    if client is None:
+        return False
+
+    try:
+        await client.publish(_REDIS_INVALIDATION_CHANNEL, json.dumps(message))
+        return True
+    except Exception as exc:
+        _logger.warning("Plugin invalidation publish failed for %s (%s)", message.get("type"), exc)
+        return False
+
+
+def get_local_mode_overrides() -> dict[str, str]:
+    """Return a snapshot of the in-process per-plugin mode override map.
+
+    Prunes expired entries from the backing map before the snapshot so the
+    dict doesn't leak an entry per plugin name ever overridden on workers
+    that never otherwise trigger a prune.
+    """
+    now = time.monotonic()
+    _state.prune_expired_local_overrides(now)
+    return _state.active_local_mode_overrides(now)
+
+
+async def publish_plugin_mode_change(plugin_name: str, mode: str) -> bool:
+    """Persist a per-plugin mode override locally and attempt to broadcast it.
+
+    Always updates the in-process override map so the change takes effect on
+    this worker even when Redis is unavailable (single-node deployments).
+    Returns True only when Redis accepted the write — the caller uses this
+    signal to distinguish "cluster-wide" from "this worker only".
+
+    When the Redis SET succeeds, the local entry carries an expiry aligned
+    with the Redis 24 h TTL so both copies clear together. When the Redis
+    SET fails, the local entry is durable (no expiry) because the operator
+    never got confirmation that a timer had started.
+    """
+    try:
+        client = await _redis()
+    except Exception as exc:
+        _logger.warning("Plugin mode Redis write skipped — client error (%s)", exc)
+        _state.set_local_mode_override(plugin_name, mode, None)
+        return False
+    if client is None:
+        _state.set_local_mode_override(plugin_name, mode, None)
+        return False
+
+    try:
+        await client.set(f"plugin:{plugin_name}:mode", mode, ex=_PLUGIN_MODE_TTL_SECONDS)
+    except Exception as exc:
+        _logger.warning("Plugin mode Redis SET failed for %s (%s)", plugin_name, exc)
+        _state.set_local_mode_override(plugin_name, mode, None)
+        return False
+
+    _state.set_local_mode_override(plugin_name, mode, time.monotonic() + _PLUGIN_MODE_TTL_SECONDS)
+    # Peers use ttl_seconds to stamp their local copy with the same absolute
+    # deadline — without it each worker would anchor expiry to its own
+    # reception time and drift past the Redis key.
+    published = await _publish_invalidation({"type": "mode_change", "plugin": plugin_name, "mode": mode, "ttl_seconds": _PLUGIN_MODE_TTL_SECONDS})
+    if not published:
+        _logger.error(
+            "Plugin mode override persisted to Redis for %s but broadcast failed — peer workers will lag until next cache refresh",
+            plugin_name,
+        )
+    return True
+
+
+async def publish_binding_change(context_id: str) -> bool:
+    """Broadcast a per-context binding change so remote workers evict the cached manager."""
+    return await _publish_invalidation({"type": "binding_change", "context_id": context_id})
+
+
+async def publish_team_binding_change(team_id: str) -> bool:
+    """Broadcast a wildcard binding change — every worker evicts every cached context for the team."""
+    return await _publish_invalidation({"type": "team_binding_change", "team_id": team_id})
 
 
 def init_plugin_manager_factory(
@@ -185,6 +361,7 @@ def init_plugin_manager_factory(
     if db_factory is not None:
         # Lazy import to avoid circular dependency:
         # framework/__init__ → gateway_plugin_manager → services → base_service → framework/__init__
+        # First-Party
         from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory  # pylint: disable=import-outside-toplevel
 
         _plugin_manager_factory = GatewayTenantPluginManagerFactory(
@@ -204,26 +381,42 @@ def init_plugin_manager_factory(
 
 
 async def get_plugin_manager(server_id: str = DEFAULT_SERVER_ID) -> Optional[TenantPluginManager]:
-    """Return a context-scoped plugin manager from the global async factory.
-
-    Checks the shared (Redis) plugin toggle on every call so that runtime
-    enable/disable propagates across all workers and pods without restart.
-    Falls back to the in-memory flag if Redis is unavailable.
-
-    Args:
-        server_id: Context identifier used to resolve a specific manager instance.
-
-    Returns:
-        Optional[TenantPluginManager]: Context-specific manager when plugins are
-            enabled and the factory is initialized, otherwise ``None``.
-    """
+    """Return the context-scoped manager, reading the shared toggle so runtime enable/disable propagates."""
     if not await are_plugins_enabled_shared():
         return None
-
     if _plugin_manager_factory is None:
+        _warn_factory_init_degraded_once()
         return None
-
     return await _plugin_manager_factory.get_manager(server_id)
+
+
+def mark_factory_init_degraded() -> None:
+    """Record that opportunistic factory init failed on this node.
+
+    Called from ``main.py`` lifespan when ``plugins.enabled=false`` AND the
+    factory-init probe raised. On its own this is not an error — the operator
+    opted out of plugins locally. It becomes an error later if the shared
+    toggle flips the subsystem on and this node cannot honour it; the first
+    such ``get_plugin_manager`` call emits one ERROR.
+    """
+    _state.mark_factory_init_degraded()
+
+
+def _reset_factory_init_degraded_for_tests() -> None:
+    """Clear the degraded-boot flag so test isolation is clean."""
+    _state._reset_factory_init_degraded_for_tests()  # pylint: disable=protected-access
+
+
+def _warn_factory_init_degraded_once() -> None:
+    """Emit one ERROR the first time a shared-toggle request hits a degraded node."""
+    if not _state.is_factory_init_degraded() or _state.is_factory_init_degraded_logged():
+        return
+    _state.mark_factory_init_degraded_logged()
+    _logger.error(
+        "Plugin subsystem asked to serve plugins (shared toggle=true) but factory init failed during startup on this node; "
+        "restart after fixing %s to participate. Until then, plugin hooks on this worker will no-op.",
+        "settings.plugins.config_file",
+    )
 
 
 def set_global_observability(observability: ObservabilityProvider) -> None:
@@ -239,17 +432,15 @@ def set_global_observability(observability: ObservabilityProvider) -> None:
 
 
 async def shutdown_plugin_manager_factory() -> None:
-    """Shutdown and reset the global plugin manager factory.
+    """Tear the factory down whenever one exists.
 
-    Calls :meth:`TenantPluginManagerFactory.shutdown` on the singleton factory (if one has
-    been initialised) and then clears the reference so the next call to
-    :func:`get_plugin_manager` will create a fresh factory.  Primarily used during
-    application lifespan teardown.
+    Must not gate on ``_PLUGINS_ENABLED``: an operator can runtime-disable plugins
+    via ``PUT /admin/plugins {"enabled": false}`` and then stop the gateway. The
+    factory and any in-flight build tasks still need cleanup even though the
+    in-memory flag is ``False`` by the time lifespan teardown runs.
     """
     global _plugin_manager_factory  # pylint: disable=global-statement
 
-    if not _PLUGINS_ENABLED:
-        return
     factory = _plugin_manager_factory
     _plugin_manager_factory = None
     if factory is not None:
@@ -262,158 +453,214 @@ def reset_plugin_manager_factory() -> None:
     _plugin_manager_factory = None
 
 
-async def get_plugin_mode_override(plugin_name: str) -> Optional[str]:
-    """Get a plugin's runtime mode override from Redis.
+def get_plugin_manager_factory() -> Optional[TenantPluginManagerFactory]:
+    """Return the active factory without leaking the private module binding.
 
-    Returns None if no override exists (use YAML default).
+    Router code that needs to call ``invalidate_team`` / ``iter_context_ids``
+    goes through this accessor instead of importing ``_plugin_manager_factory``
+    so the factory can be swapped (tests, future per-request scoping) without
+    hunting for every private import.
+    """
+    return _plugin_manager_factory
+
+
+def list_configured_plugin_names() -> list[str]:
+    """Return the plugin names from the loaded YAML config, regardless of runtime state.
+
+    Admin validation (e.g. ``PUT /admin/plugins/{name}``) must not gate on the
+    live manager: on a process that booted with plugins globally disabled the
+    manager is never wired, so ``PluginService.get_all_plugins()`` returns
+    ``[]`` and every valid plugin name 404s. The factory's ``_base_config``
+    is populated at startup from ``PLUGINS_CONFIG_FILE`` even when the shared
+    toggle is off, so it's the authoritative source for "names an operator
+    may pre-stage an override for".
+    """
+    if _plugin_manager_factory is None:
+        return []
+    config = _plugin_manager_factory._base_config  # pylint: disable=protected-access
+    if not config or not config.plugins:
+        return []
+    return [plugin.name for plugin in config.plugins]
+
+
+async def get_plugin_mode_override(plugin_name: str) -> Optional[str]:
+    """Return the per-plugin Redis mode override, or ``None`` when the key is unset.
+
+    Raises on Redis transport errors so callers can distinguish "no override"
+    from "Redis unreachable" instead of silently accepting the YAML default.
+
+    Raises:
+        RuntimeError: If the Redis client errors while fetching the override.
     """
     try:
-        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
-
-        client = await get_redis_client()
-        if client:
-            val = await client.get(f"plugin:{plugin_name}:mode")
-            if val is not None:
-                return val.decode() if isinstance(val, bytes) else str(val)
-    except Exception:
-        pass
-    return None
+        client = await _redis()
+    except Exception as exc:
+        raise RuntimeError(f"Redis client unavailable for plugin mode lookup: {exc}") from exc
+    if client is None:
+        return None
+    try:
+        val = await client.get(f"plugin:{plugin_name}:mode")
+    except Exception as exc:
+        raise RuntimeError(f"Redis GET failed for plugin {plugin_name}: {exc}") from exc
+    if val is None:
+        return None
+    return val.decode() if isinstance(val, bytes) else str(val)
 
 
 async def invalidate_all_plugin_managers() -> None:
-    """Evict all cached plugin managers so they rebuild with fresh config.
-
-    Call this after a global plugin mode change so all contexts
-    pick up the new mode on their next request.
-    """
-    if _plugin_manager_factory is None:
+    """Reload every cached plugin manager; delegates to the factory's public method."""
+    factory = _plugin_manager_factory
+    if factory is None:
         return
-    async with _plugin_manager_factory._lock:
-        contexts = list(_plugin_manager_factory._managers.keys())
-    for ctx_id in contexts:
-        await _plugin_manager_factory.reload_tenant(ctx_id)
+    await factory.invalidate_all()
 
 
 async def reload_plugin_context(context_id: str) -> None:
-    """Invalidate and rebuild the cached plugin manager for *context_id*.
+    """Evict and rebuild the cached manager for ``context_id``.
 
-    No-op when plugins are disabled or the factory is not initialised.
-    Call this after persisting a ToolPluginBinding change so the next tool
-    invocation picks up the updated DB overrides.
-
-    Args:
-        context_id: Context key to evict and rebuild (e.g. ``"<team_id>::<tool_name>"``).
+    Eviction is safe when plugins are disabled — we only skip the work when
+    the factory itself has not been initialised.
     """
-    if not _PLUGINS_ENABLED or _plugin_manager_factory is None:
+    if _plugin_manager_factory is None:
         return
     await _plugin_manager_factory.reload_tenant(context_id)
 
 
-async def _handle_invalidation_message(message: dict) -> None:
-    """Handle a single pub/sub invalidation message.
-
-    Called by the background subscriber task when a message arrives
-    on the ``plugin:invalidation`` channel.
+async def _handle_invalidation_message(message: dict[str, Any]) -> None:
+    """Dispatch one pub/sub frame to the matching invalidation handler.
 
     Args:
-        message: Redis pub/sub message dict with 'type' and 'data' keys.
+        message: Raw redis-py pub/sub frame with ``type`` and ``data`` keys.
     """
-    import json as _json  # pylint: disable=import-outside-toplevel
-    import logging as _logging  # pylint: disable=import-outside-toplevel
-
-    _log = _logging.getLogger(__name__)
-
     if message.get("type") != "message":
-        return  # Ignore subscribe/unsubscribe notifications
+        return  # subscribe/unsubscribe notifications — not an invalidation event
 
     try:
-        data = _json.loads(message["data"])
-    except (ValueError, KeyError, TypeError):
-        _log.debug("Ignoring malformed invalidation message")
+        data = json.loads(message["data"])
+    except (ValueError, KeyError, TypeError) as exc:
+        _logger.warning("Ignoring malformed plugin invalidation message (%s)", exc)
         return
 
-    msg_type = data.get("type")
+    try:
+        frame = _invalidation_adapter.validate_python(data)
+    except _ValidationError as exc:
+        _logger.warning("Ignoring unrecognised plugin invalidation frame %r (%s)", data, exc)
+        return
 
-    if msg_type == "global_toggle":
-        global _PLUGINS_ENABLED
-        _PLUGINS_ENABLED = data.get("enabled", True)
-        _log.debug("Pub/sub: global toggle set to %s", _PLUGINS_ENABLED)
+    match frame:
+        case _GlobalToggleMsg(enabled=enabled):
+            global _PLUGINS_ENABLED
+            _PLUGINS_ENABLED = enabled
+            _invalidate_shared_enabled_cache()
+            _logger.debug("Pub/sub: global toggle set to %s", _PLUGINS_ENABLED)
 
-    elif msg_type == "mode_change":
-        await invalidate_all_plugin_managers()
-        _log.debug("Pub/sub: mode change for %s, all managers invalidated", data.get("plugin"))
+        case _ModeChangeMsg(plugin=plugin, mode=mode, ttl_seconds=ttl_seconds):
+            # Mirror the broadcast into the local override map so this worker's
+            # rebuild uses the new mode even if the Redis MGET on rebuild races
+            # with the key's 24 h TTL. ``ttl_seconds`` arrives from the publisher
+            # so every peer uses the same absolute deadline regardless of when
+            # the broadcast lands locally.
+            _state.set_local_mode_override(plugin, mode, time.monotonic() + ttl_seconds)
+            await invalidate_all_plugin_managers()
+            _logger.debug("Pub/sub: mode change for %s, all managers invalidated", plugin)
 
-    elif msg_type == "binding_change":
-        context_id = data.get("context_id")
-        if context_id and _plugin_manager_factory is not None:
+        case _TeamBindingChangeMsg(team_id=team_id) if _plugin_manager_factory is not None:
+            try:
+                await _plugin_manager_factory.invalidate_team(team_id)
+                _logger.debug("Pub/sub: team_binding_change, invalidated team %s", team_id)
+            except Exception as exc:
+                _logger.warning("Pub/sub team_binding_change failed for %s (%s)", team_id, exc)
+
+        case _BindingChangeMsg(context_id=context_id) if _plugin_manager_factory is not None:
             try:
                 await _plugin_manager_factory.reload_tenant(context_id)
-                _log.debug("Pub/sub: binding change, reloaded context %s", context_id)
-            except Exception:
-                _log.debug("Pub/sub: failed to reload context %s", context_id)
+                _logger.debug("Pub/sub: binding change, reloaded context %s", context_id)
+            except Exception as exc:
+                _logger.warning("Pub/sub binding_change reload failed for %s (%s)", context_id, exc)
 
 
 async def _plugin_invalidation_listener() -> None:
-    """Background task that subscribes to Redis pub/sub for instant cache invalidation.
+    """Subscribe to the invalidation channel and dispatch messages until cancelled.
 
-    Listens on the ``plugin:invalidation`` channel and processes messages
-    to evict stale plugin managers. Automatically reconnects on Redis disconnect.
-    The TTL-based cache refresh serves as fallback if this listener is down.
+    Reconnects on transport errors with exponential backoff plus jitter; the
+    TTL-based cache refresh bounds staleness if this listener stays down.
     """
-    import logging as _logging  # pylint: disable=import-outside-toplevel
-
-    _log = _logging.getLogger(__name__)
+    backoff = 1.0
+    max_backoff = 30.0
+    consecutive_failures = 0
 
     while True:
         try:
-            from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
-
-            client = await get_redis_client()
+            client = await _redis()
             if not client:
-                _log.debug("Plugin invalidation listener: Redis not available, retrying in 10s")
+                _logger.debug("Plugin invalidation listener: Redis unavailable, retrying in 10s")
                 await asyncio.sleep(10)
                 continue
 
             pubsub = client.pubsub()
             await pubsub.subscribe(_REDIS_INVALIDATION_CHANNEL)
-            _log.info("Plugin invalidation listener started on channel: %s", _REDIS_INVALIDATION_CHANNEL)
+            _logger.info("Plugin invalidation listener subscribed to %s", _REDIS_INVALIDATION_CHANNEL)
+            backoff = 1.0
+            consecutive_failures = 0
 
             async for message in pubsub.listen():
                 await _handle_invalidation_message(message)
 
         except asyncio.CancelledError:
-            _log.info("Plugin invalidation listener cancelled")
+            _logger.info("Plugin invalidation listener cancelled")
             break
         except Exception as exc:
-            _log.warning("Plugin invalidation listener error (%s), reconnecting in 5s", exc)
-            await asyncio.sleep(5)
+            consecutive_failures += 1
+            level = logging.ERROR if consecutive_failures >= 5 else logging.WARNING
+            jitter = random.uniform(0, backoff / 2)
+            delay = min(max_backoff, backoff + jitter)
+            _logger.log(
+                level,
+                "Plugin invalidation listener error (%s, failure #%d), reconnecting in %.1fs",
+                exc,
+                consecutive_failures,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            backoff = min(max_backoff, backoff * 2)
 
 
 async def start_plugin_invalidation_listener() -> None:
-    """Start the background pub/sub listener task.
+    """Start the pub/sub listener if a Redis provider is wired and the task is not already running.
 
-    Safe to call multiple times — only starts one listener.
-    Called during gateway lifespan startup.
+    Single-node deployments without Redis would otherwise spin the listener's
+    10-second retry loop indefinitely. Skip the task entirely in that case —
+    operators can register a provider later and call this function again.
+    Concurrent callers are serialized via ``_pubsub_start_lock`` so only one
+    task is ever created.
     """
     global _pubsub_task
-    if _pubsub_task is not None and not _pubsub_task.done():
-        return  # Already running
-    _pubsub_task = asyncio.create_task(_plugin_invalidation_listener())
+    async with _pubsub_start_lock:
+        if _pubsub_task is not None and not _pubsub_task.done():
+            return
+        try:
+            client = await _redis()
+        except Exception as exc:  # noqa: BLE001 — probe failure; log and bail
+            _logger.warning("Plugin invalidation listener probe failed (%s); listener not started", exc)
+            return
+        if client is None:
+            _logger.info("Plugin invalidation listener not started — no Redis provider registered")
+            return
+        _pubsub_task = asyncio.create_task(_plugin_invalidation_listener())
 
 
 async def stop_plugin_invalidation_listener() -> None:
-    """Stop the background pub/sub listener task.
-
-    Called during gateway lifespan shutdown.
-    """
+    """Cancel the pub/sub listener and await its teardown."""
     global _pubsub_task
-    if _pubsub_task is not None and not _pubsub_task.done():
-        _pubsub_task.cancel()
-        try:
-            await _pubsub_task
-        except asyncio.CancelledError:
-            pass
+    task = _pubsub_task
     _pubsub_task = None
+    if task is None or task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 __all__ = [
@@ -426,8 +673,15 @@ __all__ = [
     "are_plugins_enabled_shared",
     "enable_plugins",
     "enable_plugins_shared",
+    "get_plugin_manager_factory",
     "get_plugin_mode_override",
+    "list_configured_plugin_names",
     "invalidate_all_plugin_managers",
+    "mark_factory_init_degraded",
+    "get_local_mode_overrides",
+    "publish_binding_change",
+    "publish_plugin_mode_change",
+    "publish_team_binding_change",
     "start_plugin_invalidation_listener",
     "stop_plugin_invalidation_listener",
     "init_plugin_manager_factory",

--- a/mcpgateway/plugins/framework/__init__.py
+++ b/mcpgateway/plugins/framework/__init__.py
@@ -14,6 +14,7 @@ Exposes core ContextForge plugin components:
 """
 
 # Standard
+import asyncio
 from typing import Callable, Optional
 
 # First-Party
@@ -69,15 +70,87 @@ _plugin_manager_factory: Optional[TenantPluginManagerFactory] = None
 _observability_service: Optional[ObservabilityProvider] = None
 DEFAULT_SERVER_ID = "__global__"
 
+# Redis key for cross-worker/cross-pod global plugin toggle
+_REDIS_PLUGINS_ENABLED_KEY = "plugin:global:enabled"
+_REDIS_INVALIDATION_CHANNEL = "plugin:invalidation"
+_pubsub_task: Optional["asyncio.Task[None]"] = None
+
+
+def are_plugins_enabled() -> bool:
+    """Return whether the plugin subsystem is currently enabled.
+
+    Returns the in-memory flag. For cross-worker consistency,
+    use ``are_plugins_enabled_shared()`` which reads from Redis.
+    """
+    return _PLUGINS_ENABLED
+
+
+async def are_plugins_enabled_shared() -> bool:
+    """Check the global plugin toggle from Redis (shared across all workers/pods).
+
+    Falls back to the in-memory ``_PLUGINS_ENABLED`` flag if Redis is unavailable.
+    """
+    import logging as _logging  # pylint: disable=import-outside-toplevel
+
+    _log = _logging.getLogger(__name__)
+    try:
+        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+        client = await get_redis_client()
+        if client:
+            val = await client.get(_REDIS_PLUGINS_ENABLED_KEY)
+            if val is not None:
+                result = val.decode() == "true" if isinstance(val, bytes) else str(val) == "true"
+                return result
+            # Key not set in Redis — fall through to in-memory
+        else:
+            _log.debug("are_plugins_enabled_shared: Redis client is None, using in-memory flag")
+    except Exception as exc:
+        _log.debug("are_plugins_enabled_shared: Redis read failed (%s), using in-memory flag", exc)
+    return _PLUGINS_ENABLED
+
 
 def enable_plugins(toggle: bool) -> None:
-    """Enable or disable the plugin subsystem globally.
+    """Enable or disable the plugin subsystem globally (in-memory only).
+
+    For cross-worker/cross-pod propagation, use ``enable_plugins_shared()``.
 
     Args:
         toggle: Pass ``True`` to activate plugins, ``False`` to deactivate.
     """
     global _PLUGINS_ENABLED
     _PLUGINS_ENABLED = toggle
+
+
+async def enable_plugins_shared(toggle: bool) -> None:
+    """Enable or disable the plugin subsystem globally via Redis.
+
+    Writes to Redis so all workers and pods pick up the change.
+    Also updates the local in-memory flag.
+
+    Args:
+        toggle: Pass ``True`` to activate plugins, ``False`` to deactivate.
+    """
+    global _PLUGINS_ENABLED
+    _PLUGINS_ENABLED = toggle
+    try:
+        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+        import json as _json  # pylint: disable=import-outside-toplevel
+
+        client = await get_redis_client()
+        if client:
+            await client.set(_REDIS_PLUGINS_ENABLED_KEY, "true" if toggle else "false")
+            try:
+                await client.publish(
+                    _REDIS_INVALIDATION_CHANNEL,
+                    _json.dumps({"type": "global_toggle", "enabled": toggle}),
+                )
+            except Exception:
+                pass  # Publish failure is non-critical — TTL fallback covers it
+    except Exception:
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logging.getLogger(__name__).warning("Failed to write plugin toggle to Redis — change is local only")
 
 
 def init_plugin_manager_factory(
@@ -133,6 +206,10 @@ def init_plugin_manager_factory(
 async def get_plugin_manager(server_id: str = DEFAULT_SERVER_ID) -> Optional[TenantPluginManager]:
     """Return a context-scoped plugin manager from the global async factory.
 
+    Checks the shared (Redis) plugin toggle on every call so that runtime
+    enable/disable propagates across all workers and pods without restart.
+    Falls back to the in-memory flag if Redis is unavailable.
+
     Args:
         server_id: Context identifier used to resolve a specific manager instance.
 
@@ -140,7 +217,7 @@ async def get_plugin_manager(server_id: str = DEFAULT_SERVER_ID) -> Optional[Ten
         Optional[TenantPluginManager]: Context-specific manager when plugins are
             enabled and the factory is initialized, otherwise ``None``.
     """
-    if not _PLUGINS_ENABLED:
+    if not await are_plugins_enabled_shared():
         return None
 
     if _plugin_manager_factory is None:
@@ -185,6 +262,38 @@ def reset_plugin_manager_factory() -> None:
     _plugin_manager_factory = None
 
 
+async def get_plugin_mode_override(plugin_name: str) -> Optional[str]:
+    """Get a plugin's runtime mode override from Redis.
+
+    Returns None if no override exists (use YAML default).
+    """
+    try:
+        from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+        client = await get_redis_client()
+        if client:
+            val = await client.get(f"plugin:{plugin_name}:mode")
+            if val is not None:
+                return val.decode() if isinstance(val, bytes) else str(val)
+    except Exception:
+        pass
+    return None
+
+
+async def invalidate_all_plugin_managers() -> None:
+    """Evict all cached plugin managers so they rebuild with fresh config.
+
+    Call this after a global plugin mode change so all contexts
+    pick up the new mode on their next request.
+    """
+    if _plugin_manager_factory is None:
+        return
+    async with _plugin_manager_factory._lock:
+        contexts = list(_plugin_manager_factory._managers.keys())
+    for ctx_id in contexts:
+        await _plugin_manager_factory.reload_tenant(ctx_id)
+
+
 async def reload_plugin_context(context_id: str) -> None:
     """Invalidate and rebuild the cached plugin manager for *context_id*.
 
@@ -200,13 +309,127 @@ async def reload_plugin_context(context_id: str) -> None:
     await _plugin_manager_factory.reload_tenant(context_id)
 
 
+async def _handle_invalidation_message(message: dict) -> None:
+    """Handle a single pub/sub invalidation message.
+
+    Called by the background subscriber task when a message arrives
+    on the ``plugin:invalidation`` channel.
+
+    Args:
+        message: Redis pub/sub message dict with 'type' and 'data' keys.
+    """
+    import json as _json  # pylint: disable=import-outside-toplevel
+    import logging as _logging  # pylint: disable=import-outside-toplevel
+
+    _log = _logging.getLogger(__name__)
+
+    if message.get("type") != "message":
+        return  # Ignore subscribe/unsubscribe notifications
+
+    try:
+        data = _json.loads(message["data"])
+    except (ValueError, KeyError, TypeError):
+        _log.debug("Ignoring malformed invalidation message")
+        return
+
+    msg_type = data.get("type")
+
+    if msg_type == "global_toggle":
+        global _PLUGINS_ENABLED
+        _PLUGINS_ENABLED = data.get("enabled", True)
+        _log.debug("Pub/sub: global toggle set to %s", _PLUGINS_ENABLED)
+
+    elif msg_type == "mode_change":
+        await invalidate_all_plugin_managers()
+        _log.debug("Pub/sub: mode change for %s, all managers invalidated", data.get("plugin"))
+
+    elif msg_type == "binding_change":
+        context_id = data.get("context_id")
+        if context_id and _plugin_manager_factory is not None:
+            try:
+                await _plugin_manager_factory.reload_tenant(context_id)
+                _log.debug("Pub/sub: binding change, reloaded context %s", context_id)
+            except Exception:
+                _log.debug("Pub/sub: failed to reload context %s", context_id)
+
+
+async def _plugin_invalidation_listener() -> None:
+    """Background task that subscribes to Redis pub/sub for instant cache invalidation.
+
+    Listens on the ``plugin:invalidation`` channel and processes messages
+    to evict stale plugin managers. Automatically reconnects on Redis disconnect.
+    The TTL-based cache refresh serves as fallback if this listener is down.
+    """
+    import logging as _logging  # pylint: disable=import-outside-toplevel
+
+    _log = _logging.getLogger(__name__)
+
+    while True:
+        try:
+            from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+            client = await get_redis_client()
+            if not client:
+                _log.debug("Plugin invalidation listener: Redis not available, retrying in 10s")
+                await asyncio.sleep(10)
+                continue
+
+            pubsub = client.pubsub()
+            await pubsub.subscribe(_REDIS_INVALIDATION_CHANNEL)
+            _log.info("Plugin invalidation listener started on channel: %s", _REDIS_INVALIDATION_CHANNEL)
+
+            async for message in pubsub.listen():
+                await _handle_invalidation_message(message)
+
+        except asyncio.CancelledError:
+            _log.info("Plugin invalidation listener cancelled")
+            break
+        except Exception as exc:
+            _log.warning("Plugin invalidation listener error (%s), reconnecting in 5s", exc)
+            await asyncio.sleep(5)
+
+
+async def start_plugin_invalidation_listener() -> None:
+    """Start the background pub/sub listener task.
+
+    Safe to call multiple times — only starts one listener.
+    Called during gateway lifespan startup.
+    """
+    global _pubsub_task
+    if _pubsub_task is not None and not _pubsub_task.done():
+        return  # Already running
+    _pubsub_task = asyncio.create_task(_plugin_invalidation_listener())
+
+
+async def stop_plugin_invalidation_listener() -> None:
+    """Stop the background pub/sub listener task.
+
+    Called during gateway lifespan shutdown.
+    """
+    global _pubsub_task
+    if _pubsub_task is not None and not _pubsub_task.done():
+        _pubsub_task.cancel()
+        try:
+            await _pubsub_task
+        except asyncio.CancelledError:
+            pass
+    _pubsub_task = None
+
+
 __all__ = [
     "AgentHookType",
     "AgentPostInvokePayload",
     "AgentPostInvokeResult",
     "AgentPreInvokePayload",
     "AgentPreInvokeResult",
+    "are_plugins_enabled",
+    "are_plugins_enabled_shared",
     "enable_plugins",
+    "enable_plugins_shared",
+    "get_plugin_mode_override",
+    "invalidate_all_plugin_managers",
+    "start_plugin_invalidation_listener",
+    "stop_plugin_invalidation_listener",
     "init_plugin_manager_factory",
     "set_global_observability",
     "ConfigLoader",

--- a/mcpgateway/plugins/framework/_redis.py
+++ b/mcpgateway/plugins/framework/_redis.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/plugins/framework/_redis.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Dependency-inversion shim for Redis access inside the plugin framework.
+
+The framework package must not import from ``mcpgateway.utils`` directly
+(enforced by ``scripts/pre-commit/check_framework_imports.py``). Instead, the
+gateway registers a Redis client provider at startup via
+``set_shared_redis_provider``; framework modules call
+``get_shared_redis_client()`` to retrieve a client without naming the
+gateway util.
+
+When the provider is unset (tests, framework-only deployments, or before
+lifespan startup runs), ``get_shared_redis_client`` returns ``None`` and
+the caller's Redis-unavailable fallback paths engage.
+"""
+
+from typing import Any, Awaitable, Callable, Optional
+
+RedisProvider = Callable[[], Awaitable[Optional[Any]]]
+
+_provider: Optional[RedisProvider] = None
+
+
+def set_shared_redis_provider(provider: Optional[RedisProvider]) -> None:
+    """Register (or clear) the gateway's Redis client factory.
+
+    Call with ``None`` to unregister — useful for test isolation.
+    """
+    global _provider
+    _provider = provider
+
+
+async def get_shared_redis_client() -> Optional[Any]:
+    """Return the shared Redis client from the registered provider, or ``None``.
+
+    ``None`` is returned when no provider has been registered, when the
+    provider yields ``None`` (e.g. Redis disabled in config), or when the
+    provider raises — callers treat all three cases as "Redis unavailable".
+    """
+    provider = _provider
+    if provider is None:
+        return None
+    return await provider()

--- a/mcpgateway/plugins/framework/_state.py
+++ b/mcpgateway/plugins/framework/_state.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/plugins/framework/_state.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Module-local runtime state for the plugin framework.
+
+Keeping this state in a leaf module (rather than in ``framework/__init__.py``)
+breaks what would otherwise be a ``framework -> framework.manager -> framework``
+import cycle: ``manager.py`` needs the in-process override map to resolve the
+Redis MGET fallback, and importing it from ``__init__.py`` would close the loop.
+See ``scripts/pre-commit/check_framework_imports.py`` for the isolation-hook
+context that motivates keeping framework internals free of upward dependencies.
+"""
+
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Per-plugin mode override map
+# ---------------------------------------------------------------------------
+# Each entry is ``(mode, expires_at)`` where ``expires_at`` is a monotonic
+# clock deadline or ``None`` to mean "no expiry". Redis-synced entries carry
+# an expiry that matches the Redis 24 h TTL so the local copy clears at the
+# same time the Redis key does — otherwise a worker with a stale in-memory
+# entry would keep applying an override the cluster has let expire. Local-only
+# entries (Redis write failed, or no Redis provider registered) carry ``None``
+# so single-node deployments don't lose the override at 24 h.
+_local_mode_overrides: dict[str, tuple[str, Optional[float]]] = {}
+
+
+def set_local_mode_override(plugin_name: str, mode: str, expires_at: Optional[float]) -> None:
+    """Write a local-override entry; ``expires_at=None`` means durable."""
+    _local_mode_overrides[plugin_name] = (mode, expires_at)
+
+
+def clear_local_mode_overrides() -> None:
+    """Test-only reset hook."""
+    _local_mode_overrides.clear()
+
+
+def prune_expired_local_overrides(now: float) -> None:
+    """Drop entries whose monotonic deadline has passed.
+
+    Callers pass ``time.monotonic()`` so the pruning condition stays monotonic
+    across calls (wall-clock would skew under NTP adjustments). Entries with
+    ``expires_at is None`` are durable and never pruned.
+    """
+    expired = [name for name, (_, exp) in _local_mode_overrides.items() if exp is not None and now >= exp]
+    for name in expired:
+        _local_mode_overrides.pop(name, None)
+
+
+def active_local_mode_overrides(now: float) -> dict[str, str]:
+    """Return a ``{name: mode}`` snapshot of non-expired entries.
+
+    Pure read — callers that also want the dict cleaned should call
+    ``prune_expired_local_overrides(now)`` first. Snapshot semantics decouple
+    ``manager.py``'s rebuild hot path from mutation races with the pub/sub
+    listener that concurrently writes via ``set_local_mode_override``.
+    """
+    return {name: mode for name, (mode, exp) in _local_mode_overrides.items() if exp is None or exp > now}
+
+
+def get_local_mode_overrides_live() -> dict[str, tuple[str, Optional[float]]]:
+    """Return the live backing dict for in-module reads (tests, helpers).
+
+    Previously named ``get_local_mode_overrides_raw``; renamed to ``_live`` to
+    admit what the return value really is. Production writers MUST go through
+    ``set_local_mode_override`` / ``clear_local_mode_overrides``, not mutate
+    the returned dict — the helper APIs are the module's single write seam.
+    """
+    return _local_mode_overrides
+
+
+# ---------------------------------------------------------------------------
+# Degraded-boot flag
+# ---------------------------------------------------------------------------
+# Two bools encode three reachable states: healthy (False, False),
+# degraded-not-yet-logged (True, False), degraded-logged (True, True). The
+# fourth combination is unreachable by construction — the logged bool is only
+# flipped after the degraded bool. A future refactor that flips either flag
+# independently must preserve "logged implies degraded".
+_FACTORY_INIT_DEGRADED = False
+_FACTORY_INIT_DEGRADED_LOGGED = False
+
+
+def mark_factory_init_degraded() -> None:
+    """Record that opportunistic factory init failed on this node."""
+    global _FACTORY_INIT_DEGRADED
+    _FACTORY_INIT_DEGRADED = True
+
+
+def is_factory_init_degraded() -> bool:
+    """Return True when the node booted with a failed opportunistic factory init."""
+    return _FACTORY_INIT_DEGRADED
+
+
+def mark_factory_init_degraded_logged() -> None:
+    """Record that the one-shot ERROR has already been emitted."""
+    global _FACTORY_INIT_DEGRADED_LOGGED
+    _FACTORY_INIT_DEGRADED_LOGGED = True
+
+
+def is_factory_init_degraded_logged() -> bool:
+    """Return True once the one-shot ERROR has fired."""
+    return _FACTORY_INIT_DEGRADED_LOGGED
+
+
+def _reset_factory_init_degraded_for_tests() -> None:
+    """Test-only reset hook (underscore-prefixed so production callers can't suppress the one-shot ERROR)."""
+    global _FACTORY_INIT_DEGRADED, _FACTORY_INIT_DEGRADED_LOGGED
+    _FACTORY_INIT_DEGRADED = False
+    _FACTORY_INIT_DEGRADED_LOGGED = False

--- a/mcpgateway/plugins/framework/manager.py
+++ b/mcpgateway/plugins/framework/manager.py
@@ -30,13 +30,14 @@ Examples:
 # Standard
 import asyncio
 import copy
+from dataclasses import dataclass
 import logging
 import threading
 import time
 from typing import Any, Optional, Union
 
 # Third-Party
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, RootModel, ValidationError
 
 # First-Party
 from mcpgateway.observability import create_span
@@ -1034,6 +1035,22 @@ class TenantPluginManager(PluginManager):
         self._async_lock: asyncio.Lock | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _CachedManager:
+    """A cached tenant manager paired with the monotonic timestamp of its build.
+
+    The frozen dataclass replaces an ad-hoc ``(manager, created_at)`` tuple so
+    every access site uses ``is_expired`` instead of destructuring the pair.
+    """
+
+    manager: "TenantPluginManager"
+    created_at: float
+
+    def is_expired(self, ttl: float) -> bool:
+        """Return True when ``ttl > 0`` and the entry is older than ``ttl`` seconds."""
+        return ttl > 0 and (time.monotonic() - self.created_at) > ttl
+
+
 class TenantPluginManagerFactory:
     """
     Factory for context-scoped TenantPluginManager instances.
@@ -1043,8 +1060,13 @@ class TenantPluginManagerFactory:
     organization, or any other identifier requiring isolated plugin configuration.
     """
 
-    # Default TTL for cached managers (seconds). Set to 0 to disable TTL.
+    # Bounds cross-pod drift after a DB upsert without a broadcast. The listener
+    # invalidates faster; this is the safety net.
     DEFAULT_CACHE_TTL = 30
+    # Default team/tool separator used by context IDs. Subclasses (e.g. the
+    # gateway factory) keep this constant so invalidation broadcasts don't
+    # need to carry the separator on the wire.
+    CONTEXT_ID_SEPARATOR = "::"
 
     def __init__(
         self,
@@ -1068,7 +1090,7 @@ class TenantPluginManagerFactory:
         self._timeout = timeout
         self._observability = observability
         self._hook_policies = hook_policies
-        self._managers: dict[str, tuple[TenantPluginManager, float]] = {}  # (manager, created_at)
+        self._managers: dict[str, _CachedManager] = {}
         self._inflight: dict[str, asyncio.Task[TenantPluginManager]] = {}
         self._lock = asyncio.Lock()
         self._cache_ttl = cache_ttl if cache_ttl is not None else self.DEFAULT_CACHE_TTL
@@ -1092,11 +1114,7 @@ class TenantPluginManagerFactory:
         self._observability = value
 
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
-        """Get or create a TenantPluginManager for the given context.
-
-        If the cached manager is older than ``cache_ttl`` seconds, it is
-        evicted and rebuilt from the DB so that configuration changes
-        propagate across all workers and pods without explicit invalidation.
+        """Return the cached manager for ``context_id``, rebuilding when expired.
 
         Args:
             context_id: Context identifier (server, tenant, etc.). Defaults to __global__.
@@ -1109,13 +1127,11 @@ class TenantPluginManagerFactory:
         async with self._lock:
             entry = self._managers.get(context_id)
             if entry is not None:
-                manager, created_at = entry
-                # Check TTL — evict if expired
-                if self._cache_ttl > 0 and (time.monotonic() - created_at) > self._cache_ttl:
+                if entry.is_expired(self._cache_ttl):
                     self._managers.pop(context_id, None)
                     logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
                 else:
-                    return manager
+                    return entry.manager
 
             inflight = self._inflight.get(context_id)
             if inflight is None:
@@ -1125,26 +1141,20 @@ class TenantPluginManagerFactory:
         try:
             manager = await inflight
 
-            # Re-check cache under the lock: reload_tenant may have evicted
-            # and replaced the entry between the await completing and here.
-            # Returning a shut-down manager (the pre-eviction one) would be
-            # incorrect, so always prefer whatever is currently in the cache.
+            # reload_tenant may have evicted and replaced the entry between the
+            # await finishing and re-entering the lock. Always prefer the current
+            # cache entry so we don't hand out a shut-down manager.
             async with self._lock:
                 entry = self._managers.get(context_id)
-                return entry[0] if entry is not None else manager
+                return entry.manager if entry is not None else manager
 
         finally:
-            # Cleanup only - no return to avoid suppressing exceptions
             async with self._lock:
                 if self._inflight.get(context_id) is inflight:
                     self._inflight.pop(context_id, None)
 
     async def _build_manager(self, context_id: str) -> TenantPluginManager:
-        """Build, initialise, and cache a TenantPluginManager for the given context.
-
-        Fetches any DB overrides for ``context_id``, merges them with the base
-        config, constructs a :class:`TenantPluginManager`, and stores it in the
-        cache.  Shuts down any previously cached manager for the same context.
+        """Build, initialise, and cache a TenantPluginManager for ``context_id``.
 
         Args:
             context_id: Identifier for the tenant/server context.
@@ -1172,9 +1182,9 @@ class TenantPluginManagerFactory:
 
             async with self._lock:
                 old_entry = self._managers.get(context_id)
-                self._managers[context_id] = (manager, time.monotonic())
+                self._managers[context_id] = _CachedManager(manager=manager, created_at=time.monotonic())
 
-            old = old_entry[0] if old_entry is not None else None
+            old = old_entry.manager if old_entry is not None else None
             if old is not None and old is not manager:
                 try:
                     await old.shutdown()
@@ -1199,51 +1209,108 @@ class TenantPluginManagerFactory:
             raise
 
     async def _apply_redis_mode_overrides(self, config: Config) -> Config:
-        """Apply per-plugin mode overrides from Redis to the merged config.
+        """Apply per-plugin mode overrides. Redis is authoritative; the in-process map is the fallback."""
+        # pylint: disable=import-outside-toplevel
+        # First-Party
+        from mcpgateway.plugins.framework._redis import get_shared_redis_client
+        from mcpgateway.plugins.framework._state import active_local_mode_overrides, prune_expired_local_overrides
 
-        Uses a single MGET call to fetch all plugin mode overrides at once,
-        then applies any that exist. This allows runtime mode changes via
-        the ``PUT /admin/plugins/{name}`` API to take effect on manager rebuild.
+        if not config.plugins:
+            return config
 
-        Args:
-            config: The merged config (base YAML + DB overrides).
+        # Prune expired entries from the backing dict (so workers that never hit
+        # the admin GET /plugins path don't accumulate one entry per plugin name
+        # ever overridden), then snapshot the still-active {name: mode} map.
+        now = time.monotonic()
+        prune_expired_local_overrides(now)
+        local_overrides = active_local_mode_overrides(now)
 
-        Returns:
-            Config with Redis mode overrides applied.
-        """
+        redis_values: list[Optional[Any]] = [None] * len(config.plugins)
         try:
-            from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+            client = await get_shared_redis_client()
+        except Exception as exc:
+            logger.warning("Redis mode overrides skipped — client error (%s)", exc, exc_info=True)
+            client = None
 
-            if not config.plugins:
-                return config
-
-            client = await get_redis_client()
-            if not client:
-                return config
-
-            # Single MGET for all plugins instead of N individual GETs
+        if client is not None:
             keys = [f"plugin:{p.name}:mode" for p in config.plugins]
-            values = await client.mget(keys)
+            try:
+                redis_values = list(await client.mget(keys))
+            except Exception as exc:
+                logger.warning("Redis MGET for plugin modes failed (%s)", exc, exc_info=True)
+                redis_values = [None] * len(config.plugins)
 
-            modified = False
-            updated_plugins = []
-            for plugin, override_mode in zip(config.plugins, values):
-                if override_mode is not None:
-                    from mcpgateway.plugins.framework.models import PluginMode  # pylint: disable=import-outside-toplevel
+        modified = False
+        updated_plugins = []
+        for plugin, redis_raw in zip(config.plugins, redis_values):
+            # Build an ordered candidate list: Redis first (cluster-authoritative),
+            # local map second (fallback when Redis is quiet or the Redis value
+            # is corrupt). A corrupt Redis entry must not shadow a valid local
+            # override — previously the loop fell straight to the YAML default.
+            candidates: list[tuple[str, str]] = []
+            if redis_raw is not None:
+                redis_str = redis_raw.decode() if isinstance(redis_raw, bytes) else str(redis_raw)
+                candidates.append(("redis", redis_str))
+            if plugin.name in local_overrides:
+                candidates.append(("local", local_overrides[plugin.name]))
 
-                    mode_str = override_mode.decode() if isinstance(override_mode, bytes) else str(override_mode)
-                    updated_plugins.append(
-                        plugin.model_copy(update={"mode": PluginMode(mode_str)})
+            applied = False
+            for source, mode_str in candidates:
+                try:
+                    mode = PluginMode(mode_str)
+                except ValueError:
+                    logger.warning(
+                        "Ignoring invalid %s mode override %r for plugin %s — value not in PluginMode",
+                        source,
+                        mode_str,
+                        plugin.name,
                     )
+                    continue
+                try:
+                    updated_plugins.append(plugin.model_copy(update={"mode": mode}))
                     modified = True
-                else:
-                    updated_plugins.append(plugin)
+                    applied = True
+                    break
+                except ValidationError as exc:
+                    logger.warning(
+                        "Ignoring %s mode override for plugin %s — validation failed (%s)",
+                        source,
+                        plugin.name,
+                        exc,
+                    )
 
-            if modified:
-                return config.model_copy(update={"plugins": updated_plugins}, deep=True)
-        except Exception:
-            logger.debug("Failed to apply Redis mode overrides, using config as-is")
+            if not applied:
+                updated_plugins.append(plugin)
+
+        if modified:
+            return config.model_copy(update={"plugins": updated_plugins}, deep=True)
         return config
+
+    async def invalidate_all(self) -> None:
+        """Reload every cached manager, logging failures instead of aborting the sweep."""
+        async with self._lock:
+            context_ids = list(self._managers.keys())
+        for ctx_id in context_ids:
+            try:
+                await self.reload_tenant(ctx_id)
+            except Exception as exc:
+                logger.warning("invalidate_all: reload failed for context_id=%s (%s)", ctx_id, exc)
+
+    async def invalidate_team(self, team_id: str, separator: Optional[str] = None) -> None:
+        """Reload every cached manager whose ``context_id`` starts with ``team_id`` plus the class separator."""
+        sep = separator if separator is not None else self.CONTEXT_ID_SEPARATOR
+        prefix = f"{team_id}{sep}"
+        async with self._lock:
+            context_ids = [cid for cid in self._managers if cid.startswith(prefix)]
+        for ctx_id in context_ids:
+            try:
+                await self.reload_tenant(ctx_id)
+            except Exception as exc:
+                logger.warning("invalidate_team: reload failed for context_id=%s (%s)", ctx_id, exc)
+
+    def iter_context_ids(self) -> list[str]:
+        """Return a snapshot of the cached context IDs; safe to iterate without the lock."""
+        return list(self._managers.keys())
 
     def _merge_tenant_config(self, tenant_cfg_override: Optional[list[PluginConfigOverride]]) -> Config:
         """Merge context-specific plugin configuration overrides with base configuration.
@@ -1279,10 +1346,7 @@ class TenantPluginManagerFactory:
         return self._base_config.model_copy(update={"plugins": merged_plugins}, deep=True)
 
     async def reload_tenant(self, context_id: str) -> TenantPluginManager:
-        """Evict and rebuild the cached manager for the given context.
-
-        Removes the existing manager from the cache, triggers a fresh build,
-        and shuts down the old instance once the new one is ready.
+        """Evict and rebuild the cached manager for ``context_id``.
 
         Args:
             context_id: Identifier for the tenant/server context to reload.
@@ -1293,16 +1357,15 @@ class TenantPluginManagerFactory:
         async with self._lock:
             old_entry = self._managers.pop(context_id, None)
 
-            # Cancel any existing inflight task to force fresh DB fetch
-            inflight = self._inflight.get(context_id)
-            if inflight is not None:
-                inflight.cancel()
+            existing = self._inflight.get(context_id)
+            if existing is not None:
+                existing.cancel()
                 self._inflight.pop(context_id, None)
 
             inflight = asyncio.create_task(self._build_manager(context_id))
             self._inflight[context_id] = inflight
 
-        old = old_entry[0] if old_entry is not None else None
+        old = old_entry.manager if old_entry is not None else None
         if old is not None:
             try:
                 await old.shutdown()
@@ -1319,7 +1382,7 @@ class TenantPluginManagerFactory:
     async def shutdown(self) -> None:
         """Shut down all cached managers and cancel any in-flight build tasks."""
         async with self._lock:
-            managers = list(self._managers.values())
+            entries = list(self._managers.values())
             inflight = list(self._inflight.values())
             self._managers.clear()
             self._inflight.clear()
@@ -1330,10 +1393,9 @@ class TenantPluginManagerFactory:
         if inflight:
             await asyncio.gather(*inflight, return_exceptions=True)
 
-        for entry in managers:
-            manager = entry[0] if isinstance(entry, tuple) else entry
+        for entry in entries:
             try:
-                await manager.shutdown()
+                await entry.manager.shutdown()
             except Exception:
                 logger.exception("Failed to shutdown plugin manager")
 

--- a/mcpgateway/plugins/framework/manager.py
+++ b/mcpgateway/plugins/framework/manager.py
@@ -32,6 +32,7 @@ import asyncio
 import copy
 import logging
 import threading
+import time
 from typing import Any, Optional, Union
 
 # Third-Party
@@ -1042,12 +1043,16 @@ class TenantPluginManagerFactory:
     organization, or any other identifier requiring isolated plugin configuration.
     """
 
+    # Default TTL for cached managers (seconds). Set to 0 to disable TTL.
+    DEFAULT_CACHE_TTL = 30
+
     def __init__(
         self,
         yaml_path: str,
         timeout: int = DEFAULT_PLUGIN_TIMEOUT,
         observability: Optional[ObservabilityProvider] = None,
         hook_policies: Optional[dict[str, HookPayloadPolicy]] = None,
+        cache_ttl: Optional[int] = None,
     ):
         """Initialize the TenantPluginManagerFactory.
 
@@ -1056,14 +1061,17 @@ class TenantPluginManagerFactory:
             timeout: Per-plugin call timeout in seconds.
             observability: Optional observability provider.
             hook_policies: Optional hook payload policy map.
+            cache_ttl: TTL in seconds for cached managers. Defaults to DEFAULT_CACHE_TTL.
+                Set to 0 to disable TTL (cache forever until explicit eviction).
         """
         self._base_config = ConfigLoader.load_config(yaml_path)
         self._timeout = timeout
         self._observability = observability
         self._hook_policies = hook_policies
-        self._managers: dict[str, TenantPluginManager] = {}
+        self._managers: dict[str, tuple[TenantPluginManager, float]] = {}  # (manager, created_at)
         self._inflight: dict[str, asyncio.Task[TenantPluginManager]] = {}
         self._lock = asyncio.Lock()
+        self._cache_ttl = cache_ttl if cache_ttl is not None else self.DEFAULT_CACHE_TTL
 
     @property
     def observability(self) -> Optional[ObservabilityProvider]:
@@ -1086,6 +1094,10 @@ class TenantPluginManagerFactory:
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
         """Get or create a TenantPluginManager for the given context.
 
+        If the cached manager is older than ``cache_ttl`` seconds, it is
+        evicted and rebuilt from the DB so that configuration changes
+        propagate across all workers and pods without explicit invalidation.
+
         Args:
             context_id: Context identifier (server, tenant, etc.). Defaults to __global__.
 
@@ -1095,9 +1107,15 @@ class TenantPluginManagerFactory:
         context_id = context_id or _DEFAULT_CONTEXT_ID
 
         async with self._lock:
-            existing = self._managers.get(context_id)
-            if existing is not None:
-                return existing
+            entry = self._managers.get(context_id)
+            if entry is not None:
+                manager, created_at = entry
+                # Check TTL — evict if expired
+                if self._cache_ttl > 0 and (time.monotonic() - created_at) > self._cache_ttl:
+                    self._managers.pop(context_id, None)
+                    logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
+                else:
+                    return manager
 
             inflight = self._inflight.get(context_id)
             if inflight is None:
@@ -1112,7 +1130,8 @@ class TenantPluginManagerFactory:
             # Returning a shut-down manager (the pre-eviction one) would be
             # incorrect, so always prefer whatever is currently in the cache.
             async with self._lock:
-                return self._managers.get(context_id, manager)
+                entry = self._managers.get(context_id)
+                return entry[0] if entry is not None else manager
 
         finally:
             # Cleanup only - no return to avoid suppressing exceptions
@@ -1141,6 +1160,7 @@ class TenantPluginManagerFactory:
         try:
             new_config = await self.get_config_from_db(context_id)
             config = self._merge_tenant_config(new_config)
+            config = await self._apply_redis_mode_overrides(config)
 
             manager = TenantPluginManager(
                 config=config,
@@ -1151,9 +1171,10 @@ class TenantPluginManagerFactory:
             await manager.initialize()
 
             async with self._lock:
-                old = self._managers.get(context_id)
-                self._managers[context_id] = manager
+                old_entry = self._managers.get(context_id)
+                self._managers[context_id] = (manager, time.monotonic())
 
+            old = old_entry[0] if old_entry is not None else None
             if old is not None and old is not manager:
                 try:
                     await old.shutdown()
@@ -1176,6 +1197,53 @@ class TenantPluginManagerFactory:
                 except Exception:
                     logger.warning("Failed to shutdown manager after error for context_id=%s", context_id)
             raise
+
+    async def _apply_redis_mode_overrides(self, config: Config) -> Config:
+        """Apply per-plugin mode overrides from Redis to the merged config.
+
+        Uses a single MGET call to fetch all plugin mode overrides at once,
+        then applies any that exist. This allows runtime mode changes via
+        the ``PUT /admin/plugins/{name}`` API to take effect on manager rebuild.
+
+        Args:
+            config: The merged config (base YAML + DB overrides).
+
+        Returns:
+            Config with Redis mode overrides applied.
+        """
+        try:
+            from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+            if not config.plugins:
+                return config
+
+            client = await get_redis_client()
+            if not client:
+                return config
+
+            # Single MGET for all plugins instead of N individual GETs
+            keys = [f"plugin:{p.name}:mode" for p in config.plugins]
+            values = await client.mget(keys)
+
+            modified = False
+            updated_plugins = []
+            for plugin, override_mode in zip(config.plugins, values):
+                if override_mode is not None:
+                    from mcpgateway.plugins.framework.models import PluginMode  # pylint: disable=import-outside-toplevel
+
+                    mode_str = override_mode.decode() if isinstance(override_mode, bytes) else str(override_mode)
+                    updated_plugins.append(
+                        plugin.model_copy(update={"mode": PluginMode(mode_str)})
+                    )
+                    modified = True
+                else:
+                    updated_plugins.append(plugin)
+
+            if modified:
+                return config.model_copy(update={"plugins": updated_plugins}, deep=True)
+        except Exception:
+            logger.debug("Failed to apply Redis mode overrides, using config as-is")
+        return config
 
     def _merge_tenant_config(self, tenant_cfg_override: Optional[list[PluginConfigOverride]]) -> Config:
         """Merge context-specific plugin configuration overrides with base configuration.
@@ -1223,7 +1291,7 @@ class TenantPluginManagerFactory:
             TenantPluginManager: Rebuilt manager for ``context_id``.
         """
         async with self._lock:
-            old = self._managers.pop(context_id, None)
+            old_entry = self._managers.pop(context_id, None)
 
             # Cancel any existing inflight task to force fresh DB fetch
             inflight = self._inflight.get(context_id)
@@ -1234,6 +1302,7 @@ class TenantPluginManagerFactory:
             inflight = asyncio.create_task(self._build_manager(context_id))
             self._inflight[context_id] = inflight
 
+        old = old_entry[0] if old_entry is not None else None
         if old is not None:
             try:
                 await old.shutdown()
@@ -1261,7 +1330,8 @@ class TenantPluginManagerFactory:
         if inflight:
             await asyncio.gather(*inflight, return_exceptions=True)
 
-        for manager in managers:
+        for entry in managers:
+            manager = entry[0] if isinstance(entry, tuple) else entry
             try:
                 await manager.shutdown()
             except Exception:

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -78,13 +78,21 @@ class GatewayTenantPluginManagerFactory(TenantPluginManagerFactory):
 
         team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
 
-        db: Session = self._db_factory()
         try:
-            bindings = get_bindings_for_tool(db, team_id, tool_name)
-        finally:
-            db.close()
+            db: Session = self._db_factory()
+            try:
+                bindings = get_bindings_for_tool(db, team_id, tool_name)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.warning(
+                "get_config_from_db: DB error for context_id=%s (%s), falling back to base config",
+                context_id, exc,
+            )
+            return None
 
         if not bindings:
+            logger.debug("get_config_from_db: no bindings found for context_id=%s", context_id)
             return None
 
         overrides: list[PluginConfigOverride] = []

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -84,12 +84,18 @@ class GatewayTenantPluginManagerFactory(TenantPluginManagerFactory):
                 bindings = get_bindings_for_tool(db, team_id, tool_name)
             finally:
                 db.close()
-        except Exception as exc:
-            logger.warning(
-                "get_config_from_db: DB error for context_id=%s (%s), falling back to base config",
-                context_id, exc,
+        except Exception:
+            # Previously this swallowed the error and returned None, which made
+            # the factory rebuild the manager with base YAML config — silently
+            # dropping any per-team/per-tool overrides (including enforce-mode
+            # security plugins). Fail loudly so the rebuild bubbles up; the
+            # caller retries on the next request or cache TTL expiry.
+            logger.error(
+                "get_config_from_db: DB error for context_id=%s — failing rebuild to avoid dropping bindings",
+                context_id,
+                exc_info=True,
             )
-            return None
+            raise
 
         if not bindings:
             logger.debug("get_config_from_db: no bindings found for context_id=%s", context_id)

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
-from mcpgateway.plugins.framework import reload_plugin_context
+from mcpgateway.plugins.framework import get_plugin_manager_factory, publish_binding_change, publish_team_binding_change, reload_plugin_context
 from mcpgateway.plugins.gateway_plugin_manager import CONTEXT_ID_SEPARATOR, make_context_id
 from mcpgateway.schemas import ToolPluginBindingListResponse, ToolPluginBindingRequest, ToolPluginBindingResponse
 from mcpgateway.services.logging_service import LoggingService
@@ -37,6 +37,30 @@ logger = logging_service.get_logger(__name__)
 router = APIRouter(prefix="/v1/tools/plugin_bindings", tags=["Tool Plugin Bindings"])
 
 _service = ToolPluginBindingService()
+
+
+async def _invalidate_and_broadcast(bindings: List[ToolPluginBindingResponse]) -> None:
+    """Evict local caches and broadcast pub/sub frames for a batch of bindings.
+
+    Wildcard bindings (``tool_name == "*"``) affect every cached context for
+    the team, so they go through the team-wide channel; specific bindings only
+    evict the one context. Factory may be ``None`` on nodes where opportunistic
+    init failed — we still publish so healthy peers converge.
+    """
+    wildcard_teams = {b.team_id for b in bindings if b.tool_name == "*"}
+    specific_ctx_ids = {make_context_id(b.team_id, b.tool_name) for b in bindings if b.tool_name != "*"}
+
+    for ctx_id in specific_ctx_ids:
+        await reload_plugin_context(ctx_id)
+        await publish_binding_change(ctx_id)
+
+    if wildcard_teams:
+        factory = get_plugin_manager_factory()
+        if factory is not None:
+            for team_id in wildcard_teams:
+                await factory.invalidate_team(team_id, CONTEXT_ID_SEPARATOR)
+        for team_id in wildcard_teams:
+            await publish_team_binding_change(team_id)
 
 
 # ---------------------------------------------------------------------------
@@ -93,22 +117,7 @@ async def upsert_tool_plugin_bindings(
         # reads committed data. The get_db() cleanup commit is then a safe no-op.
         db.commit()
 
-        # Invalidate affected contexts. For wildcard bindings (tool_name="*"),
-        # evict ALL cached contexts for the team since they all inherit the wildcard.
-        wildcard_teams = {b.team_id for b in bindings if b.tool_name == "*"}
-        for ctx_id in {make_context_id(b.team_id, b.tool_name) for b in bindings}:
-            await reload_plugin_context(ctx_id)
-        # Evict all cached contexts matching wildcard teams
-        if wildcard_teams:
-            from mcpgateway.plugins.framework import _plugin_manager_factory  # pylint: disable=import-outside-toplevel
-
-            if _plugin_manager_factory is not None:
-                async with _plugin_manager_factory._lock:
-                    all_contexts = list(_plugin_manager_factory._managers.keys())
-                for ctx in all_contexts:
-                    team_part = ctx.split(CONTEXT_ID_SEPARATOR)[0] if CONTEXT_ID_SEPARATOR in ctx else None
-                    if team_part in wildcard_teams:
-                        await reload_plugin_context(ctx)
+        await _invalidate_and_broadcast(bindings)
         return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
     except ValueError as exc:
         logger.error("Failed to upsert tool plugin bindings: %s", exc)
@@ -214,9 +223,7 @@ async def delete_tool_plugin_bindings_by_reference(
     """
     deleted: List[ToolPluginBindingResponse] = _service.delete_bindings_by_reference(db, binding_reference_id)
     db.commit()
-    # Invalidate cache for every affected (team_id, tool_name) pair.
-    for ctx_id in {make_context_id(b.team_id, b.tool_name) for b in deleted}:
-        await reload_plugin_context(ctx_id)
+    await _invalidate_and_broadcast(deleted)
     return ToolPluginBindingListResponse(bindings=deleted, total=len(deleted))
 
 
@@ -256,7 +263,7 @@ async def delete_tool_plugin_binding(
     try:
         deleted = _service.delete_binding(db, binding_id)
         db.commit()
-        await reload_plugin_context(make_context_id(deleted.team_id, deleted.tool_name))
+        await _invalidate_and_broadcast([deleted])
         return deleted
     except ToolPluginBindingNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.plugins.framework import reload_plugin_context
-from mcpgateway.plugins.gateway_plugin_manager import make_context_id
+from mcpgateway.plugins.gateway_plugin_manager import CONTEXT_ID_SEPARATOR, make_context_id
 from mcpgateway.schemas import ToolPluginBindingListResponse, ToolPluginBindingRequest, ToolPluginBindingResponse
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError, ToolPluginBindingService
@@ -92,8 +92,23 @@ async def upsert_tool_plugin_bindings(
         # Commit before invalidating cache so the new session opened by reload
         # reads committed data. The get_db() cleanup commit is then a safe no-op.
         db.commit()
+
+        # Invalidate affected contexts. For wildcard bindings (tool_name="*"),
+        # evict ALL cached contexts for the team since they all inherit the wildcard.
+        wildcard_teams = {b.team_id for b in bindings if b.tool_name == "*"}
         for ctx_id in {make_context_id(b.team_id, b.tool_name) for b in bindings}:
             await reload_plugin_context(ctx_id)
+        # Evict all cached contexts matching wildcard teams
+        if wildcard_teams:
+            from mcpgateway.plugins.framework import _plugin_manager_factory  # pylint: disable=import-outside-toplevel
+
+            if _plugin_manager_factory is not None:
+                async with _plugin_manager_factory._lock:
+                    all_contexts = list(_plugin_manager_factory._managers.keys())
+                for ctx in all_contexts:
+                    team_part = ctx.split(CONTEXT_ID_SEPARATOR)[0] if CONTEXT_ID_SEPARATOR in ctx else None
+                    if team_part in wildcard_teams:
+                        await reload_plugin_context(ctx)
         return ToolPluginBindingListResponse(bindings=bindings, total=len(bindings))
     except ValueError as exc:
         logger.error("Failed to upsert tool plugin bindings: %s", exc)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7537,6 +7537,35 @@ class PluginListResponse(BaseModel):
     disabled_count: int = Field(0, description="Number of disabled plugins")
 
 
+class PluginToggleRequest(BaseModel):
+    """Request body for ``PUT /admin/plugins`` — toggles the plugin subsystem globally."""
+
+    enabled: bool = Field(..., description="Activate plugins when true, deactivate when false")
+
+
+class PluginToggleResponse(BaseModel):
+    """Response body for the global plugin toggle endpoint."""
+
+    plugins_enabled: bool = Field(..., description="Effective plugin subsystem state after the toggle")
+    redis_persisted: bool = Field(..., description="True when the shared Redis toggle accepted the write")
+
+
+class PluginModeUpdateRequest(BaseModel):
+    """Request body for ``PUT /admin/plugins/{name}`` — drives the Pydantic enum validation."""
+
+    # Mirrors PluginMode.value; importing the enum here would create a cycle
+    # (schemas -> plugins.framework -> services -> schemas), so use a Literal.
+    mode: Literal["enforce", "enforce_ignore_error", "permissive", "disabled"] = Field(..., description="Plugin mode: enforce, enforce_ignore_error, permissive, disabled")
+
+
+class PluginModeUpdateResponse(BaseModel):
+    """Response body for the per-plugin mode update endpoint."""
+
+    plugin: str = Field(..., description="Plugin name whose mode was updated")
+    mode: str = Field(..., description="New plugin mode")
+    redis_persisted: bool = Field(..., description="True when the shared Redis override accepted the write")
+
+
 class PluginStatsResponse(BaseModel):
     """Response for plugin statistics endpoint."""
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7530,6 +7530,7 @@ class PluginDetail(PluginSummary):
 class PluginListResponse(BaseModel):
     """Response for plugin list endpoint."""
 
+    plugins_globally_enabled: bool = Field(True, description="Whether the plugin subsystem is globally enabled at runtime")
     plugins: List[PluginSummary] = Field(..., description="List of plugins")
     total: int = Field(..., description="Total number of plugins")
     enabled_count: int = Field(0, description="Number of enabled plugins")

--- a/mcpgateway/services/plugin_service.py
+++ b/mcpgateway/services/plugin_service.py
@@ -59,11 +59,15 @@ class PluginService:
         """
         return self._plugin_manager
 
-    def set_plugin_manager(self, manager: PluginManager) -> None:
-        """Set the plugin manager instance.
+    def set_plugin_manager(self, manager: Optional[PluginManager]) -> None:
+        """Set or clear the plugin manager instance.
+
+        ``None`` is accepted so the admin runtime-toggle handler can detach the
+        cached manager when the subsystem is disabled at runtime (otherwise the
+        admin surfaces keep reading a now-stale manager until restart).
 
         Args:
-            manager: The PluginManager instance to use.
+            manager: The PluginManager instance to attach, or ``None`` to clear.
         """
         self._plugin_manager = manager
 

--- a/tests/integration/test_plugin_runtime_management.py
+++ b/tests/integration/test_plugin_runtime_management.py
@@ -79,8 +79,16 @@ def auth_headers():
 
 @pytest.fixture(autouse=True)
 def ensure_plugins_enabled(auth_headers):
-    """Ensure plugins are enabled before and after each test."""
-    # Enable before test
+    """Ensure plugins are enabled before and after each test.
+
+    Unconditional PUT + sleep. An earlier attempt probed state first and
+    skipped the sleep when it looked like plugins were already enabled, but
+    the probe goes through the same NGINX that caches GET responses for
+    ``NGINX_CACHE_TTL`` seconds — so a previous test's disable could still
+    be cached as ``enabled=True`` at probe time, causing this fixture to
+    skip the re-enable and leave the next test running against disabled
+    plugins. The ~6 s wall-clock cost is worth the correctness guarantee.
+    """
     requests.put(
         f"{GATEWAY_URL}/admin/plugins",
         json={"enabled": True},
@@ -89,7 +97,7 @@ def ensure_plugins_enabled(auth_headers):
     )
     time.sleep(NGINX_CACHE_TTL)
     yield
-    # Re-enable after test
+    # Re-enable after test in case it left them off.
     requests.put(
         f"{GATEWAY_URL}/admin/plugins",
         json={"enabled": True},
@@ -321,7 +329,14 @@ class TestPutAdminPluginsNameMode:
 
 
 class TestCrossReplicaPropagation:
-    """Tests that plugin state changes propagate via Redis."""
+    """Tests that plugin state changes propagate via Redis.
+
+    TODO(#4300): these assertions assume NGINX round-robins across replicas
+    but don't actually verify different replicas responded. Sticky sessions or
+    source-IP hashing would let every sampled request hit the same backend and
+    the test would still pass. Gate the assertions on a ``Server-Name`` (or
+    equivalent) response header so we can assert ``len(set(replicas_seen)) >= 2``.
+    """
 
     def test_disable_propagates_across_requests(self, auth_headers):
         """After disabling, multiple requests all see disabled state.
@@ -394,6 +409,10 @@ class TestMultiInstanceGlobalToggle:
 
     These tests send multiple requests through NGINX load balancer
     to verify state consistency across all gateway replicas.
+
+    TODO(#4300): same replica-identity gap as ``TestCrossReplicaPropagation`` —
+    requests are assumed to spread across replicas but never verified. Close by
+    asserting distinct replica identities in the response set.
     """
 
     def test_toggle_cycle_consistent(self, auth_headers):
@@ -420,9 +439,7 @@ class TestMultiInstanceGlobalToggle:
                 if resp.status_code == 200:
                     results.append(resp.json().get("plugins_globally_enabled"))
 
-            assert all(r is enabled for r in results), (
-                f"State mismatch after setting enabled={enabled}: {results}"
-            )
+            assert all(r is enabled for r in results), f"State mismatch after setting enabled={enabled}: {results}"
 
     def test_rapid_toggle_converges(self, auth_headers):
         """Rapid toggling eventually converges to the last state."""
@@ -521,9 +538,7 @@ class TestPubSubInstantPropagation:
                 results.append(resp.json().get("plugins_globally_enabled"))
 
         assert len(results) > 0, "No successful responses"
-        assert all(r is False for r in results), (
-            f"Not all replicas see disabled state within {PUBSUB_PROPAGATION_WAIT}s: {results}"
-        )
+        assert all(r is False for r in results), f"Not all replicas see disabled state within {PUBSUB_PROPAGATION_WAIT}s: {results}"
 
     def test_global_enable_instant_propagation(self, auth_headers):
         """Global re-enable propagates to all replicas within 2 seconds."""
@@ -560,9 +575,7 @@ class TestPubSubInstantPropagation:
                 results.append(resp.json().get("plugins_globally_enabled"))
 
         assert len(results) > 0
-        assert all(r is True for r in results), (
-            f"Not all replicas see enabled state within {PUBSUB_PROPAGATION_WAIT}s: {results}"
-        )
+        assert all(r is True for r in results), f"Not all replicas see enabled state within {PUBSUB_PROPAGATION_WAIT}s: {results}"
 
     def test_rapid_toggle_instant_convergence(self, auth_headers):
         """Rapid toggling converges instantly via pub/sub (no 30s TTL wait)."""
@@ -590,6 +603,4 @@ class TestPubSubInstantPropagation:
             if resp.status_code == 200:
                 results.append(resp.json().get("plugins_globally_enabled"))
 
-        assert all(r is True for r in results), (
-            f"Replicas didn't converge within {PUBSUB_PROPAGATION_WAIT}s: {results}"
-        )
+        assert all(r is True for r in results), f"Replicas didn't converge within {PUBSUB_PROPAGATION_WAIT}s: {results}"

--- a/tests/integration/test_plugin_runtime_management.py
+++ b/tests/integration/test_plugin_runtime_management.py
@@ -1,0 +1,595 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for plugin runtime management — multi-instance.
+
+Tests against a live gateway via HTTP endpoints (docker-compose with 3 replicas).
+For CI-compatible Redis tests, see test_plugin_runtime_redis.py.
+
+Requirements:
+    - Running gateway (docker-compose)
+    - Redis available
+    - NGINX load balancer on port 8080
+
+Usage:
+    pytest tests/integration/test_plugin_runtime_management.py -v --with-integration
+
+Environment variables:
+    GATEWAY_URL: Gateway base URL (default: http://localhost:8080)
+    GATEWAY_EMAIL: Admin email (default: admin@example.com)
+    GATEWAY_PASSWORD: Admin password (default: changeme)
+"""
+
+# Standard
+import os
+import time
+
+# Third-Party
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8080")
+GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
+GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
+
+# NGINX cache TTL — wait this long after changes for cache to expire
+NGINX_CACHE_TTL = 6
+
+
+def _get_session_token() -> str:
+    """Login and return a session token."""
+    resp = requests.post(
+        f"{GATEWAY_URL}/auth/login",
+        json={"email": GATEWAY_EMAIL, "password": GATEWAY_PASSWORD},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def _fresh_headers() -> dict:
+    """Get fresh auth headers (handles short-lived session tokens)."""
+    return {"Authorization": f"Bearer {_get_session_token()}"}
+
+
+def _is_gateway_running() -> bool:
+    """Check if the gateway is reachable."""
+    try:
+        resp = requests.get(f"{GATEWAY_URL}/health", timeout=5)
+        return resp.status_code == 200
+    except requests.ConnectionError:
+        return False
+
+
+# Skip all tests if gateway is not running
+pytestmark = pytest.mark.skipif(
+    not _is_gateway_running(),
+    reason=f"Gateway not running at {GATEWAY_URL}",
+)
+
+
+@pytest.fixture
+def auth_headers():
+    """Get fresh authentication headers for each test."""
+    token = _get_session_token()
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def ensure_plugins_enabled(auth_headers):
+    """Ensure plugins are enabled before and after each test."""
+    # Enable before test
+    requests.put(
+        f"{GATEWAY_URL}/admin/plugins",
+        json={"enabled": True},
+        headers=auth_headers,
+        timeout=10,
+    )
+    time.sleep(NGINX_CACHE_TTL)
+    yield
+    # Re-enable after test
+    requests.put(
+        f"{GATEWAY_URL}/admin/plugins",
+        json={"enabled": True},
+        headers=auth_headers,
+        timeout=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Single-instance HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestPluginsGloballyEnabledField:
+    """GET /admin/plugins includes plugins_globally_enabled field."""
+
+    def test_field_present_in_response(self, auth_headers):
+        """Response includes the plugins_globally_enabled field."""
+        resp = requests.get(
+            f"{GATEWAY_URL}/admin/plugins",
+            headers=_fresh_headers(),
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "plugins_globally_enabled" in data
+
+    def test_field_is_boolean(self, auth_headers):
+        """plugins_globally_enabled is a boolean value."""
+        resp = requests.get(
+            f"{GATEWAY_URL}/admin/plugins",
+            headers=_fresh_headers(),
+            timeout=10,
+        )
+        data = resp.json()
+        assert isinstance(data["plugins_globally_enabled"], bool)
+
+
+class TestPutAdminPluginsDisable:
+    """PUT /admin/plugins {"enabled": false} disables plugins globally."""
+
+    def test_disable_returns_false(self, auth_headers):
+        """PUT returns plugins_enabled: false."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["plugins_enabled"] is False
+
+    def test_get_reflects_disabled_state(self, auth_headers):
+        """After disabling, GET shows plugins_globally_enabled: false."""
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=auth_headers,
+            timeout=10,
+        )
+        time.sleep(NGINX_CACHE_TTL)
+
+        # Fresh token after sleep (session tokens may expire)
+        fresh_headers = {"Authorization": f"Bearer {_get_session_token()}"}
+        resp = requests.get(
+            f"{GATEWAY_URL}/admin/plugins",
+            headers=fresh_headers,
+            timeout=10,
+        )
+        data = resp.json()
+        assert data["plugins_globally_enabled"] is False
+
+
+class TestPutAdminPluginsEnable:
+    """PUT /admin/plugins {"enabled": true} enables plugins globally."""
+
+    def test_enable_returns_true(self, auth_headers):
+        """PUT returns plugins_enabled: true."""
+        # First disable
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=auth_headers,
+            timeout=10,
+        )
+        # Then enable
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": True},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["plugins_enabled"] is True
+
+    def test_get_reflects_enabled_state(self, auth_headers):
+        """After re-enabling, GET shows plugins_globally_enabled: true."""
+        # Disable then re-enable
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=auth_headers,
+            timeout=10,
+        )
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": True},
+            headers=auth_headers,
+            timeout=10,
+        )
+        time.sleep(NGINX_CACHE_TTL)
+
+        resp = requests.get(
+            f"{GATEWAY_URL}/admin/plugins",
+            headers=_fresh_headers(),
+            timeout=10,
+        )
+        data = resp.json()
+        assert data["plugins_globally_enabled"] is True
+
+
+class TestPutAdminPluginsValidation:
+    """PUT /admin/plugins input validation."""
+
+    def test_missing_enabled_field(self, auth_headers):
+        """Missing 'enabled' field returns 400."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"foo": "bar"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 400
+
+    def test_non_boolean_enabled(self, auth_headers):
+        """Non-boolean 'enabled' returns 400."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": "yes"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 400
+
+    def test_unauthenticated_request(self):
+        """Request without auth returns 401/403."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            timeout=10,
+        )
+        assert resp.status_code in (401, 403)
+
+
+class TestPutAdminPluginsNameMode:
+    """PUT /admin/plugins/{name} changes per-plugin mode."""
+
+    def test_change_mode_to_enforce(self, auth_headers):
+        """Change plugin mode to enforce."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
+            json={"mode": "enforce"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["plugin"] == "RetryWithBackoffPlugin"
+        assert data["mode"] == "enforce"
+        assert "redis_persisted" in data
+
+    def test_change_mode_to_permissive(self, auth_headers):
+        """Change plugin mode to permissive."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
+            json={"mode": "permissive"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "permissive"
+
+    def test_change_mode_to_disabled(self, auth_headers):
+        """Change plugin mode to disabled."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
+            json={"mode": "disabled"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "disabled"
+
+    def test_invalid_mode_returns_400(self, auth_headers):
+        """Invalid mode returns 400."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
+            json={"mode": "turbo"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 400
+
+    def test_nonexistent_plugin_returns_404(self, auth_headers):
+        """Non-existent plugin returns 404."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/NonExistentPlugin",
+            json={"mode": "enforce"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 404
+
+    def test_404_includes_available_plugins(self, auth_headers):
+        """404 response lists available plugin names."""
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/FakePlugin",
+            json={"mode": "enforce"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 404
+        assert "Available:" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Redis state propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCrossReplicaPropagation:
+    """Tests that plugin state changes propagate via Redis."""
+
+    def test_disable_propagates_across_requests(self, auth_headers):
+        """After disabling, multiple requests all see disabled state.
+
+        With NGINX round-robining across replicas, this verifies
+        Redis propagation (not just local in-memory state).
+        """
+        # Disable
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=auth_headers,
+            timeout=10,
+        )
+        time.sleep(NGINX_CACHE_TTL)
+
+        # Hit the endpoint multiple times — round-robin across replicas
+        results = []
+        for _ in range(5):
+            resp = requests.get(
+                f"{GATEWAY_URL}/admin/plugins",
+                headers=auth_headers,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                results.append(resp.json().get("plugins_globally_enabled"))
+
+        # All responses should show False (propagated via Redis)
+        assert len(results) > 0, "No successful responses"
+        assert all(r is False for r in results), f"Not all replicas see disabled state: {results}"
+
+    def test_enable_propagates_across_requests(self, auth_headers):
+        """After enabling, multiple requests all see enabled state."""
+        # First disable then re-enable
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=auth_headers,
+            timeout=10,
+        )
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": True},
+            headers=auth_headers,
+            timeout=10,
+        )
+        time.sleep(NGINX_CACHE_TTL)
+
+        results = []
+        for _ in range(5):
+            resp = requests.get(
+                f"{GATEWAY_URL}/admin/plugins",
+                headers=auth_headers,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                results.append(resp.json().get("plugins_globally_enabled"))
+
+        assert len(results) > 0
+        assert all(r is True for r in results), f"Not all replicas see enabled state: {results}"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Multi-instance tests (3 gateway replicas via NGINX)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiInstanceGlobalToggle:
+    """Multi-instance tests for global plugin toggle.
+
+    These tests send multiple requests through NGINX load balancer
+    to verify state consistency across all gateway replicas.
+    """
+
+    def test_toggle_cycle_consistent(self, auth_headers):
+        """Full enable-disable-enable cycle is consistent across replicas."""
+        for enabled in [False, True, False, True]:
+            headers = _fresh_headers()
+            requests.put(
+                f"{GATEWAY_URL}/admin/plugins",
+                json={"enabled": enabled},
+                headers=headers,
+                timeout=10,
+            )
+            time.sleep(NGINX_CACHE_TTL)
+
+            # Sample 6 requests to hit all 3 replicas at least twice
+            fresh = _fresh_headers()
+            results = []
+            for _ in range(6):
+                resp = requests.get(
+                    f"{GATEWAY_URL}/admin/plugins",
+                    headers=fresh,
+                    timeout=10,
+                )
+                if resp.status_code == 200:
+                    results.append(resp.json().get("plugins_globally_enabled"))
+
+            assert all(r is enabled for r in results), (
+                f"State mismatch after setting enabled={enabled}: {results}"
+            )
+
+    def test_rapid_toggle_converges(self, auth_headers):
+        """Rapid toggling eventually converges to the last state."""
+        # Rapid toggles
+        for enabled in [False, True, False, True, True]:
+            requests.put(
+                f"{GATEWAY_URL}/admin/plugins",
+                json={"enabled": enabled},
+                headers=auth_headers,
+                timeout=10,
+            )
+
+        # Wait for propagation
+        time.sleep(NGINX_CACHE_TTL)
+
+        # All replicas should converge to True (last toggle)
+        results = []
+        for _ in range(6):
+            resp = requests.get(
+                f"{GATEWAY_URL}/admin/plugins",
+                headers=auth_headers,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                results.append(resp.json().get("plugins_globally_enabled"))
+
+        assert all(r is True for r in results), f"Replicas didn't converge: {results}"
+
+
+class TestMultiInstancePluginMode:
+    """Multi-instance tests for per-plugin mode changes."""
+
+    def test_mode_change_visible_across_replicas(self, auth_headers):
+        """Per-plugin mode change stored in Redis is visible from any replica."""
+        # Change mode
+        resp = requests.put(
+            f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
+            json={"mode": "enforce"},
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+
+        # The mode is stored in Redis — verify the PUT response
+        assert resp.json()["mode"] == "enforce"
+
+        # Restore
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
+            json={"mode": "permissive"},
+            headers=auth_headers,
+            timeout=10,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Pub/Sub instant propagation tests
+# ---------------------------------------------------------------------------
+
+# Shorter wait for pub/sub — should propagate within 2s, not 30s TTL
+PUBSUB_PROPAGATION_WAIT = 2
+
+
+class TestPubSubInstantPropagation:
+    """Tests that plugin state changes propagate instantly via Redis pub/sub.
+
+    These tests verify sub-second propagation across replicas. If pub/sub
+    is not implemented, these tests will fail because PUBSUB_PROPAGATION_WAIT (2s)
+    is shorter than the TTL (30s).
+    """
+
+    def test_global_toggle_instant_propagation(self, auth_headers):
+        """Global toggle propagates to all replicas within 2 seconds."""
+        # Disable
+        headers = _fresh_headers()
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=headers,
+            timeout=10,
+        )
+
+        # Wait only 2s — pub/sub should propagate instantly
+        time.sleep(PUBSUB_PROPAGATION_WAIT)
+
+        # Check across replicas
+        results = []
+        fresh = _fresh_headers()
+        for _ in range(6):
+            resp = requests.get(
+                f"{GATEWAY_URL}/admin/plugins",
+                headers=fresh,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                results.append(resp.json().get("plugins_globally_enabled"))
+
+        assert len(results) > 0, "No successful responses"
+        assert all(r is False for r in results), (
+            f"Not all replicas see disabled state within {PUBSUB_PROPAGATION_WAIT}s: {results}"
+        )
+
+    def test_global_enable_instant_propagation(self, auth_headers):
+        """Global re-enable propagates to all replicas within 2 seconds."""
+        headers = _fresh_headers()
+        # Disable first
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": False},
+            headers=headers,
+            timeout=10,
+        )
+        time.sleep(PUBSUB_PROPAGATION_WAIT)
+
+        # Re-enable
+        headers = _fresh_headers()
+        requests.put(
+            f"{GATEWAY_URL}/admin/plugins",
+            json={"enabled": True},
+            headers=headers,
+            timeout=10,
+        )
+
+        time.sleep(PUBSUB_PROPAGATION_WAIT)
+
+        results = []
+        fresh = _fresh_headers()
+        for _ in range(6):
+            resp = requests.get(
+                f"{GATEWAY_URL}/admin/plugins",
+                headers=fresh,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                results.append(resp.json().get("plugins_globally_enabled"))
+
+        assert len(results) > 0
+        assert all(r is True for r in results), (
+            f"Not all replicas see enabled state within {PUBSUB_PROPAGATION_WAIT}s: {results}"
+        )
+
+    def test_rapid_toggle_instant_convergence(self, auth_headers):
+        """Rapid toggling converges instantly via pub/sub (no 30s TTL wait)."""
+        headers = _fresh_headers()
+        for enabled in [False, True, False, True]:
+            requests.put(
+                f"{GATEWAY_URL}/admin/plugins",
+                json={"enabled": enabled},
+                headers=headers,
+                timeout=10,
+            )
+
+        # Only wait 2s — not the full TTL
+        time.sleep(PUBSUB_PROPAGATION_WAIT)
+
+        # All replicas should show True (last toggle)
+        results = []
+        fresh = _fresh_headers()
+        for _ in range(6):
+            resp = requests.get(
+                f"{GATEWAY_URL}/admin/plugins",
+                headers=fresh,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                results.append(resp.json().get("plugins_globally_enabled"))
+
+        assert all(r is True for r in results), (
+            f"Replicas didn't converge within {PUBSUB_PROPAGATION_WAIT}s: {results}"
+        )

--- a/tests/integration/test_plugin_runtime_redis.py
+++ b/tests/integration/test_plugin_runtime_redis.py
@@ -1,0 +1,523 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for plugin runtime management with real Redis.
+
+Tests the Redis read/write/publish path directly — not via HTTP endpoints.
+Validates that the plugin framework correctly interacts with Redis for
+global toggle, per-plugin mode overrides, and pub/sub invalidation.
+
+Auto-starts a Redis Docker container if one isn't running locally.
+Skips if neither local Redis nor Docker is available.
+
+Usage:
+    uv run pytest tests/integration/test_plugin_runtime_redis.py -v --with-integration
+"""
+
+# Standard
+import asyncio
+import json
+import socket
+import subprocess
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Redis fixture (same pattern as test_rate_limiter.py)
+# ---------------------------------------------------------------------------
+
+
+def _redis_port_open(host: str = "127.0.0.1", port: int = 6379, timeout: float = 0.2) -> bool:
+    """Return True if a TCP connection to host:port succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+def redis_url():
+    """Yield a Redis URL pointing at a real Redis instance.
+
+    Tries localhost:6379 first. If not reachable, attempts to start a
+    temporary Docker container. Skips if neither works.
+    """
+    try:
+        import redis.asyncio  # noqa: F401
+    except Exception:
+        pytest.skip("redis.asyncio package not installed")
+
+    host, port = "127.0.0.1", 6379
+    container_id = None
+
+    if not _redis_port_open(host, port):
+        try:
+            res = subprocess.run(
+                ["docker", "run", "-d", "--rm", "-p", f"{port}:6379", "--name", "pytest-plugin-redis", "redis:7"],
+                check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            container_id = res.stdout.strip()
+        except Exception as exc:
+            pytest.skip(f"Redis unavailable and docker start failed: {exc}")
+
+        for _ in range(50):
+            if _redis_port_open(host, port):
+                break
+            time.sleep(0.1)
+        else:
+            if container_id:
+                subprocess.run(["docker", "stop", container_id], check=False)
+            pytest.skip("Redis did not start in time")
+
+    yield f"redis://{host}:{port}/14"  # DB 14 — isolated
+
+    if container_id:
+        subprocess.run(["docker", "stop", container_id], check=False)
+
+
+@pytest.fixture
+def sync_redis(redis_url):
+    """Return a synchronous Redis client for test verification."""
+    import redis
+
+    r = redis.from_url(redis_url, decode_responses=True)
+    r.flushdb()
+    yield r
+    r.flushdb()
+    r.close()
+
+
+@pytest.fixture
+def async_redis(redis_url):
+    """Set up the gateway's async Redis client to use the test Redis instance."""
+    import redis.asyncio as aioredis
+    import mcpgateway.utils.redis_client as rc
+
+    original_client = rc._client
+    original_initialized = rc._initialized
+
+    rc._client = aioredis.from_url(redis_url, decode_responses=True)
+    rc._initialized = True
+
+    yield rc._client
+
+    # Restore
+    rc._client = original_client
+    rc._initialized = original_initialized
+
+
+# ---------------------------------------------------------------------------
+# Global toggle tests — real Redis
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalToggleRedis:
+    """Test global plugin toggle with real Redis."""
+
+    @pytest.mark.asyncio
+    async def test_enable_plugins_shared_writes_true(self, async_redis, sync_redis):
+        """enable_plugins_shared(True) writes 'true' to real Redis."""
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        await enable_plugins_shared(True)
+
+        val = sync_redis.get("plugin:global:enabled")
+        assert val == "true"
+
+    @pytest.mark.asyncio
+    async def test_enable_plugins_shared_writes_false(self, async_redis, sync_redis):
+        """enable_plugins_shared(False) writes 'false' to real Redis."""
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        await enable_plugins_shared(False)
+
+        val = sync_redis.get("plugin:global:enabled")
+        assert val == "false"
+
+    @pytest.mark.asyncio
+    async def test_are_plugins_enabled_shared_reads_true(self, async_redis, sync_redis):
+        """are_plugins_enabled_shared() reads 'true' from real Redis."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared
+
+        sync_redis.set("plugin:global:enabled", "true")
+
+        result = await are_plugins_enabled_shared()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_are_plugins_enabled_shared_reads_false(self, async_redis, sync_redis):
+        """are_plugins_enabled_shared() reads 'false' from real Redis."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared
+
+        sync_redis.set("plugin:global:enabled", "false")
+
+        result = await are_plugins_enabled_shared()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_toggle(self, async_redis, sync_redis):
+        """Write via enable_plugins_shared, read via are_plugins_enabled_shared."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins_shared
+
+        await enable_plugins_shared(False)
+        assert await are_plugins_enabled_shared() is False
+
+        await enable_plugins_shared(True)
+        assert await are_plugins_enabled_shared() is True
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_key_missing(self, async_redis, sync_redis):
+        """Falls back to in-memory flag when Redis key doesn't exist."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins
+
+        sync_redis.delete("plugin:global:enabled")
+        enable_plugins(True)
+
+        result = await are_plugins_enabled_shared()
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Per-plugin mode override tests — real Redis
+# ---------------------------------------------------------------------------
+
+
+class TestPluginModeOverrideRedis:
+    """Test per-plugin mode overrides with real Redis."""
+
+    @pytest.mark.asyncio
+    async def test_get_plugin_mode_override_reads_value(self, async_redis, sync_redis):
+        """get_plugin_mode_override reads mode from real Redis."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        sync_redis.set("plugin:RateLimiterPlugin:mode", "enforce")
+
+        result = await get_plugin_mode_override("RateLimiterPlugin")
+        assert result == "enforce"
+
+    @pytest.mark.asyncio
+    async def test_get_plugin_mode_override_returns_none_when_missing(self, async_redis, sync_redis):
+        """Returns None when no Redis key exists."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        sync_redis.delete("plugin:RateLimiterPlugin:mode")
+
+        result = await get_plugin_mode_override("RateLimiterPlugin")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_plugin_modes(self, async_redis, sync_redis):
+        """Multiple plugins can have independent mode overrides."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        sync_redis.set("plugin:RateLimiterPlugin:mode", "enforce")
+        sync_redis.set("plugin:SecretsDetection:mode", "disabled")
+
+        assert await get_plugin_mode_override("RateLimiterPlugin") == "enforce"
+        assert await get_plugin_mode_override("SecretsDetection") == "disabled"
+        assert await get_plugin_mode_override("PIIFilterPlugin") is None  # Not set
+
+
+# ---------------------------------------------------------------------------
+# Pub/sub tests — real Redis
+# ---------------------------------------------------------------------------
+
+
+class TestPubSubRedis:
+    """Test pub/sub invalidation messages with real Redis."""
+
+    @pytest.mark.asyncio
+    async def test_toggle_publishes_invalidation_message(self, async_redis, sync_redis):
+        """enable_plugins_shared publishes a message on the invalidation channel."""
+        import redis as sync_redis_lib
+
+        # Subscribe with sync client
+        pubsub = sync_redis.pubsub()
+        pubsub.subscribe("plugin:invalidation")
+        # Consume subscribe confirmation
+        pubsub.get_message(timeout=1)
+
+        # Toggle
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        await enable_plugins_shared(False)
+
+        # Check for message
+        msg = pubsub.get_message(timeout=2)
+        assert msg is not None, "No pub/sub message received"
+        assert msg["type"] == "message"
+        data = json.loads(msg["data"])
+        assert data["type"] == "global_toggle"
+        assert data["enabled"] is False
+
+        pubsub.unsubscribe()
+        pubsub.close()
+
+    @pytest.mark.asyncio
+    async def test_handler_updates_flag_on_global_toggle(self, async_redis):
+        """_handle_invalidation_message updates in-memory flag."""
+        from mcpgateway.plugins.framework import _handle_invalidation_message, are_plugins_enabled, enable_plugins
+
+        enable_plugins(True)
+        assert are_plugins_enabled() is True
+
+        message = {
+            "type": "message",
+            "data": json.dumps({"type": "global_toggle", "enabled": False}),
+        }
+        await _handle_invalidation_message(message)
+
+        assert are_plugins_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_handler_ignores_subscribe_messages(self, async_redis):
+        """Handler ignores non-message types."""
+        from mcpgateway.plugins.framework import _handle_invalidation_message, are_plugins_enabled, enable_plugins
+
+        enable_plugins(True)
+        message = {"type": "subscribe", "data": None}
+        await _handle_invalidation_message(message)
+        assert are_plugins_enabled() is True  # Unchanged
+
+    @pytest.mark.asyncio
+    async def test_handler_handles_malformed_json(self, async_redis):
+        """Handler doesn't crash on malformed JSON."""
+        from mcpgateway.plugins.framework import _handle_invalidation_message, are_plugins_enabled, enable_plugins
+
+        enable_plugins(True)
+        message = {"type": "message", "data": "not valid json {{{"}
+        await _handle_invalidation_message(message)
+        assert are_plugins_enabled() is True  # Unchanged, no crash
+
+
+# ---------------------------------------------------------------------------
+# Global toggle blocks/enables get_plugin_manager — real Redis (#9, #10)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPluginManagerRedis:
+    """Test that global toggle actually controls get_plugin_manager via Redis."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_toggle_returns_none(self, async_redis, sync_redis):
+        """When Redis has global toggle = false, get_plugin_manager returns None."""
+        from mcpgateway.plugins.framework import get_plugin_manager, enable_plugins_shared
+
+        await enable_plugins_shared(False)
+
+        result = await get_plugin_manager()
+        assert result is None, "get_plugin_manager should return None when plugins disabled via Redis"
+
+    @pytest.mark.asyncio
+    async def test_enabled_toggle_returns_manager_or_none_no_factory(self, async_redis, sync_redis):
+        """When Redis has global toggle = true but no factory, returns None (no crash)."""
+        from mcpgateway.plugins.framework import get_plugin_manager, enable_plugins_shared
+        import mcpgateway.plugins.framework as framework
+
+        await enable_plugins_shared(True)
+
+        # With no factory initialized, should return None (not crash)
+        original = framework._plugin_manager_factory
+        framework._plugin_manager_factory = None
+        try:
+            result = await get_plugin_manager()
+            assert result is None
+        finally:
+            framework._plugin_manager_factory = original
+
+    @pytest.mark.asyncio
+    async def test_toggle_cycle_via_redis(self, async_redis, sync_redis):
+        """Toggle disable → enable via Redis, verify get_plugin_manager responds correctly."""
+        from mcpgateway.plugins.framework import get_plugin_manager, enable_plugins_shared
+
+        # Disable
+        await enable_plugins_shared(False)
+        assert await get_plugin_manager() is None
+
+        # Re-enable (still None because no factory, but shouldn't crash)
+        await enable_plugins_shared(True)
+        # Not None check — depends on factory state, but should not raise
+        # The key point: it doesn't return None due to the toggle anymore
+
+
+# ---------------------------------------------------------------------------
+# TTL cache expiry — real Redis (#1)
+# ---------------------------------------------------------------------------
+
+
+class TestTTLCacheExpiryRedis:
+    """Test TTL-based cache expiry with real Redis and real timer."""
+
+    @pytest.mark.asyncio
+    async def test_cache_expires_after_ttl(self, async_redis, sync_redis):
+        """Manager cache entry expires after TTL and triggers rebuild."""
+        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+
+        # Create a factory with very short TTL (1 second)
+        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
+        factory._managers = {}
+        factory._inflight = {}
+        factory._lock = asyncio.Lock()
+        factory._cache_ttl = 1  # 1 second TTL
+        factory._base_config = MagicMock()
+        factory._base_config.plugins = []
+        factory._timeout = 30
+        factory._observability = None
+        factory._hook_policies = None
+
+        # Manually cache a manager with current timestamp
+        mock_manager = MagicMock()
+        mock_manager.shutdown = AsyncMock()
+        factory._managers["test::tool"] = (mock_manager, time.monotonic())
+
+        # Immediately — should return cached manager
+        async with factory._lock:
+            entry = factory._managers.get("test::tool")
+            assert entry is not None
+            mgr, created_at = entry
+            assert (time.monotonic() - created_at) < factory._cache_ttl
+
+        # Wait for TTL to expire
+        await asyncio.sleep(1.5)
+
+        # Now the entry should be considered expired
+        async with factory._lock:
+            entry = factory._managers.get("test::tool")
+            if entry is not None:
+                _, created_at = entry
+                assert (time.monotonic() - created_at) > factory._cache_ttl, "Cache should be expired"
+
+
+# ---------------------------------------------------------------------------
+# Pub/sub handler triggers manager eviction (#7, #8)
+# ---------------------------------------------------------------------------
+
+
+class TestPubSubEvictionRedis:
+    """Test that pub/sub messages trigger actual cache eviction."""
+
+    @pytest.mark.asyncio
+    async def test_mode_change_message_evicts_all_managers(self, async_redis, sync_redis):
+        """mode_change message evicts all cached managers."""
+        import mcpgateway.plugins.framework as framework
+
+        mock_factory = AsyncMock()
+        mock_factory._lock = asyncio.Lock()
+        mock_factory._managers = {
+            "team_a::tool_1": (MagicMock(), time.monotonic()),
+            "team_a::tool_2": (MagicMock(), time.monotonic()),
+        }
+        mock_factory.reload_tenant = AsyncMock()
+
+        original = framework._plugin_manager_factory
+        framework._plugin_manager_factory = mock_factory
+        try:
+            message = {
+                "type": "message",
+                "data": json.dumps({"type": "mode_change", "plugin": "RateLimiterPlugin", "mode": "enforce"}),
+            }
+            await framework._handle_invalidation_message(message)
+
+            # All managers should be reloaded
+            assert mock_factory.reload_tenant.call_count == 2
+            mock_factory.reload_tenant.assert_any_call("team_a::tool_1")
+            mock_factory.reload_tenant.assert_any_call("team_a::tool_2")
+        finally:
+            framework._plugin_manager_factory = original
+
+    @pytest.mark.asyncio
+    async def test_binding_change_message_evicts_specific_context(self, async_redis, sync_redis):
+        """binding_change message evicts only the specified context."""
+        import mcpgateway.plugins.framework as framework
+
+        mock_factory = AsyncMock()
+        mock_factory._lock = asyncio.Lock()
+        mock_factory._managers = {
+            "team_a::tool_1": (MagicMock(), time.monotonic()),
+            "team_a::tool_2": (MagicMock(), time.monotonic()),
+            "team_b::tool_1": (MagicMock(), time.monotonic()),
+        }
+        mock_factory.reload_tenant = AsyncMock()
+
+        original = framework._plugin_manager_factory
+        framework._plugin_manager_factory = mock_factory
+        try:
+            message = {
+                "type": "message",
+                "data": json.dumps({"type": "binding_change", "context_id": "team_a::tool_1"}),
+            }
+            await framework._handle_invalidation_message(message)
+
+            # Only the specific context should be reloaded
+            mock_factory.reload_tenant.assert_called_once_with("team_a::tool_1")
+        finally:
+            framework._plugin_manager_factory = original
+
+    @pytest.mark.asyncio
+    async def test_pubsub_roundtrip_with_real_redis(self, async_redis, sync_redis):
+        """Full pub/sub roundtrip: publish via enable_plugins_shared, receive via subscriber."""
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        # Subscribe
+        pubsub = sync_redis.pubsub()
+        pubsub.subscribe("plugin:invalidation")
+        pubsub.get_message(timeout=1)  # Consume subscribe confirmation
+
+        # Publish by toggling
+        await enable_plugins_shared(True)
+
+        # Receive
+        msg = pubsub.get_message(timeout=2)
+        assert msg is not None
+        data = json.loads(msg["data"])
+        assert data["type"] == "global_toggle"
+        assert data["enabled"] is True
+
+        # Toggle again
+        await enable_plugins_shared(False)
+        msg = pubsub.get_message(timeout=2)
+        assert msg is not None
+        data = json.loads(msg["data"])
+        assert data["enabled"] is False
+
+        pubsub.unsubscribe()
+        pubsub.close()
+
+
+# ---------------------------------------------------------------------------
+# DB error fallback — real Redis (#4)
+# ---------------------------------------------------------------------------
+
+
+class TestDBErrorFallbackRedis:
+    """Test DB error fallback with real Redis."""
+
+    @pytest.mark.asyncio
+    async def test_db_error_returns_none_uses_base_config(self, async_redis):
+        """When DB raises an error, get_config_from_db returns None (base config used)."""
+        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
+
+        factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
+        factory._db_factory = MagicMock(side_effect=Exception("connection refused"))
+
+        result = await factory.get_config_from_db("team_a::my_tool")
+        assert result is None, "Should fall back to None (base config) on DB error"
+
+    @pytest.mark.asyncio
+    async def test_db_error_does_not_affect_redis_toggle(self, async_redis, sync_redis):
+        """Redis global toggle still works even when DB is broken."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins_shared
+
+        # Set toggle via Redis
+        await enable_plugins_shared(False)
+
+        # DB being broken doesn't affect Redis toggle read
+        result = await are_plugins_enabled_shared()
+        assert result is False, "Redis toggle should work independently of DB"
+
+        await enable_plugins_shared(True)
+        result = await are_plugins_enabled_shared()
+        assert result is True

--- a/tests/loadtest/locustfile_plugin_dynamic_config.py
+++ b/tests/loadtest/locustfile_plugin_dynamic_config.py
@@ -1,0 +1,519 @@
+# -*- coding: utf-8 -*-
+"""Dynamic plugin configuration load test.
+
+Tests that runtime plugin config changes propagate correctly across all
+gateway instances under concurrent load. Validates the full path:
+  Admin API → Redis → pub/sub → cache eviction → tool invocation
+
+Scenarios tested:
+  1. Global toggle: disable/enable plugins, verify tool calls reflect state
+  2. Per-plugin mode: switch RateLimiter enforce/disabled, verify enforcement
+  3. Per-tool binding: bind rate limiter to tool A only, verify tool B unaffected
+  4. Per-user isolation: verify rate limits apply independently per user
+
+Usage:
+    # Docker-compose (3 replicas)
+    locust -f tests/loadtest/locustfile_plugin_dynamic_config.py \\
+        --host=http://localhost:8080 --headless --users=10 --spawn-rate=5 --run-time=5m
+
+    # OCP
+    locust -f tests/loadtest/locustfile_plugin_dynamic_config.py \\
+        --host=http://<nginx-service>:80 --headless --users=10 --spawn-rate=5 --run-time=5m
+
+Environment Variables:
+    JWT_SECRET_KEY:    JWT signing key (default: my-test-key-but-now-longer-than-32-bytes)
+    MCP_SERVER_ID:     Virtual server UUID (auto-detected if empty)
+    PROPAGATION_WAIT:  Seconds to wait after admin change (default: 3)
+"""
+
+# Standard
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+# Third-Party
+from locust import FastHttpUser, between, constant_throughput, events, task
+from locust.runners import WorkerRunner
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+_ENV = {}
+_env_file = os.path.join(os.path.dirname(__file__), "../../.env")
+if os.path.isfile(_env_file):
+    with open(_env_file) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                _ENV[k.strip()] = v.strip().strip('"').strip("'")
+
+
+def _cfg(key, default=""):
+    return os.environ.get(key) or _ENV.get(key) or default
+
+
+JWT_SECRET_KEY = _cfg("JWT_SECRET_KEY", "my-test-key-but-now-longer-than-32-bytes")
+JWT_ALGORITHM = _cfg("JWT_ALGORITHM", "HS256")
+JWT_AUDIENCE = _cfg("JWT_AUDIENCE", "mcpgateway-api")
+JWT_ISSUER = _cfg("JWT_ISSUER", "mcpgateway")
+ADMIN_EMAIL = _cfg("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+MCP_SERVER_ID = _cfg("MCP_SERVER_ID", "")
+PROPAGATION_WAIT = float(_cfg("PROPAGATION_WAIT", "7"))
+
+logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Shared state
+# =============================================================================
+
+_server_id: str = ""
+_tool_names: list[str] = []
+_detect_done = False
+
+# Track current expected state for verification
+_plugins_enabled = True
+_rate_limiter_mode = "enforce"  # or "disabled"
+_scenario_phase = "warmup"
+
+
+# =============================================================================
+# JWT token
+# =============================================================================
+
+
+def _make_token(email: str = ADMIN_EMAIL) -> str:
+    """Generate a JWT for the given user."""
+    import jwt  # pylint: disable=import-outside-toplevel
+
+    payload = {
+        "sub": email,
+        "exp": datetime.now(timezone.utc) + timedelta(hours=8760),
+        "iat": datetime.now(timezone.utc),
+        "aud": JWT_AUDIENCE,
+        "iss": JWT_ISSUER,
+        "jti": str(uuid.uuid4()),
+        "token_use": "session",
+        "user": {
+            "email": email,
+            "full_name": f"Load Test User {email}",
+            "is_admin": True,
+            "auth_provider": "local",
+        },
+    }
+    return jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+
+_admin_token: str = ""
+
+
+def _get_admin_token() -> str:
+    global _admin_token  # pylint: disable=global-statement
+    if not _admin_token:
+        _admin_token = _make_token()
+    return _admin_token
+
+
+# =============================================================================
+# Auto-detect server and tools
+# =============================================================================
+
+
+def _auto_detect(host: str) -> None:
+    global _server_id, _tool_names, _detect_done  # pylint: disable=global-statement
+    if _detect_done:
+        return
+    _detect_done = True
+
+    import requests  # pylint: disable=import-outside-toplevel
+
+    headers = {"Authorization": f"Bearer {_get_admin_token()}", "Accept": "application/json"}
+
+    if MCP_SERVER_ID:
+        _server_id = MCP_SERVER_ID
+    else:
+        try:
+            resp = requests.get(f"{host}/servers", headers=headers, timeout=10)
+            servers = resp.json() if resp.status_code == 200 else []
+            if isinstance(servers, list) and servers:
+                _server_id = servers[0].get("id", "")
+        except Exception as exc:
+            logger.warning("Server auto-detect failed: %s", exc)
+
+    if _server_id:
+        try:
+            payload = {"jsonrpc": "2.0", "id": "1", "method": "tools/list", "params": {}}
+            resp = requests.post(
+                f"{host}/servers/{_server_id}/mcp",
+                json=payload,
+                headers={**headers, "Content-Type": "application/json"},
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                result = resp.json().get("result", {})
+                _tool_names = [t["name"] for t in result.get("tools", [])]
+        except Exception as exc:
+            logger.warning("Tool auto-detect failed: %s", exc)
+
+    logger.error("Dynamic config test: server=%s  tools=%s", _server_id, _tool_names)
+
+
+# =============================================================================
+# JSON-RPC helper
+# =============================================================================
+
+
+def _jsonrpc(method: str, params: dict | None = None) -> dict:
+    body: dict = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+# =============================================================================
+# Event handlers
+# =============================================================================
+
+
+@events.init_command_line_parser.add_listener
+def set_defaults(parser):
+    parser.set_defaults(users=10, spawn_rate=5, run_time="300s")
+
+
+@events.test_start.add_listener
+def on_test_start(environment, **kwargs):
+    host = environment.host or "http://localhost:8080"
+    _auto_detect(host)
+    if isinstance(environment.runner, WorkerRunner):
+        return
+
+    logger.error("=" * 70)
+    logger.error("DYNAMIC PLUGIN CONFIGURATION TEST")
+    logger.error("=" * 70)
+    logger.error("  Host:              %s", host)
+    logger.error("  Server:            %s", _server_id)
+    logger.error("  Tools:             %s", ", ".join(_tool_names[:5]) or "(none)")
+    logger.error("  Propagation wait:  %.0fs", PROPAGATION_WAIT)
+    logger.error("")
+    logger.error("  Scenarios:")
+    logger.error("    1. Global toggle (disable/enable)")
+    logger.error("    2. Per-plugin mode (enforce/disabled)")
+    logger.error("    3. Per-tool binding (tool A limited, tool B not)")
+    logger.error("    4. Per-user isolation (independent limits)")
+    logger.error("=" * 70)
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    if isinstance(environment.runner, WorkerRunner):
+        return
+
+    stats = environment.stats
+    total = stats.total.num_requests
+    failures = stats.total.num_failures
+    logger.error("=" * 70)
+    logger.error("RESULTS")
+    logger.error("=" * 70)
+    logger.error("  Total requests: %d", total)
+    logger.error("  Total failures: %d (%.2f%%)", failures, (failures / total * 100) if total else 0)
+    logger.error("")
+
+    for name in sorted(stats.entries.keys()):
+        entry = stats.entries[name]
+        if entry.num_requests > 0:
+            logger.error(
+                "  %-50s %6d reqs  %3d fails  avg %6.0fms",
+                entry.name, entry.num_requests, entry.num_failures,
+                entry.avg_response_time or 0,
+            )
+    logger.error("=" * 70)
+
+
+# =============================================================================
+# AdminUser — orchestrates plugin config changes
+# =============================================================================
+
+
+class AdminUser(FastHttpUser):
+    """Admin user that toggles plugin configuration at runtime.
+
+    Runs through scenarios sequentially, waiting for propagation after each change.
+    Only 1 instance of this user should run.
+    """
+
+    weight = 1
+    wait_time = between(1, 2)
+    connection_timeout = 30.0
+    network_timeout = 30.0
+
+    def _admin_headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {_get_admin_token()}",
+        }
+
+    def _put_global_toggle(self, enabled: bool) -> bool:
+        """Toggle global plugin state."""
+        global _plugins_enabled  # pylint: disable=global-statement
+        with self.client.put(
+            "/admin/plugins",
+            data=json.dumps({"enabled": enabled}),
+            headers=self._admin_headers(),
+            name="Admin: global toggle",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                _plugins_enabled = enabled
+                resp.success()
+                return True
+            resp.failure(f"HTTP {resp.status_code}")
+            return False
+
+    def _put_plugin_mode(self, plugin: str, mode: str) -> bool:
+        """Change a plugin's mode."""
+        global _rate_limiter_mode  # pylint: disable=global-statement
+        with self.client.put(
+            f"/admin/plugins/{plugin}",
+            data=json.dumps({"mode": mode}),
+            headers=self._admin_headers(),
+            name=f"Admin: {plugin} mode={mode}",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                if "RateLimiter" in plugin:
+                    _rate_limiter_mode = mode
+                resp.success()
+                return True
+            resp.failure(f"HTTP {resp.status_code}")
+            return False
+
+    def _verify_state(self) -> None:
+        """Verify GET /admin/plugins reflects current expected state."""
+        with self.client.get(
+            "/admin/plugins",
+            headers=self._admin_headers(),
+            name="Admin: verify state",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                data = resp.json()
+                actual = data.get("plugins_globally_enabled")
+                if actual == _plugins_enabled:
+                    resp.success()
+                else:
+                    resp.failure(f"State mismatch: expected={_plugins_enabled} actual={actual}")
+            else:
+                resp.failure(f"HTTP {resp.status_code}")
+
+    @task
+    def run_scenarios(self) -> None:
+        """Execute all test scenarios sequentially."""
+        global _scenario_phase  # pylint: disable=global-statement
+
+        # --- Scenario 1: Global toggle ---
+        _scenario_phase = "global_toggle_disable"
+        self._put_global_toggle(False)
+        time.sleep(PROPAGATION_WAIT)
+        self._verify_state()
+
+        _scenario_phase = "global_toggle_enable"
+        self._put_global_toggle(True)
+        time.sleep(PROPAGATION_WAIT)
+        self._verify_state()
+
+        # --- Scenario 2: Per-plugin mode toggle ---
+        _scenario_phase = "mode_disable"
+        self._put_plugin_mode("RateLimiterPlugin", "disabled")
+        time.sleep(PROPAGATION_WAIT)
+
+        _scenario_phase = "mode_enforce"
+        self._put_plugin_mode("RateLimiterPlugin", "enforce")
+        time.sleep(PROPAGATION_WAIT)
+
+        # --- Scenario 3: Verify state consistency across replicas ---
+        _scenario_phase = "verify_consistency"
+        for _ in range(6):  # Hit all 3 replicas twice
+            self._verify_state()
+
+        # Brief pause before next cycle
+        _scenario_phase = "idle"
+        time.sleep(5)
+
+
+# =============================================================================
+# ToolUser — continuously calls tools, tags results based on expected state
+# =============================================================================
+
+
+class ToolUser(FastHttpUser):
+    """Tool user that continuously calls MCP tools.
+
+    Tags each request based on whether it was rate-limited or allowed,
+    and whether that matches the expected state (plugins enabled/disabled,
+    rate limiter mode).
+    """
+
+    weight = 10
+    wait_time = constant_throughput(2)  # 2 req/s per user
+    connection_timeout = 30.0
+    network_timeout = 30.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mcp_session_id: str | None = None
+        self._initialized = False
+        self._user_token = _make_token(ADMIN_EMAIL)
+
+    def _headers(self) -> dict[str, str]:
+        h = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self._user_token}",
+        }
+        if self._mcp_session_id:
+            h["Mcp-Session-Id"] = self._mcp_session_id
+        return h
+
+    def _mcp_post(self, method: str, params: dict | None, name: str) -> dict | None:
+        if not _server_id:
+            return None
+        try:
+            with self.client.post(
+                f"/servers/{_server_id}/mcp",
+                data=json.dumps(_jsonrpc(method, params)),
+                headers=self._headers(),
+                name=name,
+                catch_response=True,
+            ) as response:
+                sid = response.headers.get("Mcp-Session-Id") if response.headers else None
+                if sid:
+                    self._mcp_session_id = sid
+
+                if response.status_code in (502, 503, 504):
+                    response.failure(f"Infrastructure error: {response.status_code}")
+                    return None
+                if response.status_code == 429:
+                    response.request_meta["name"] = f"{name} [rate-limited]"
+                    response.success()
+                    return {"_rate_limited": True}
+                if response.status_code != 200:
+                    response.failure(f"HTTP {response.status_code}")
+                    return None
+                try:
+                    data = response.json()
+                except Exception:
+                    response.failure("Invalid JSON")
+                    return None
+
+                # Check for MCP-level rate limit (isError in result)
+                result = data.get("result", {})
+                if isinstance(result, dict) and result.get("isError"):
+                    content = result.get("content", [])
+                    if any("rate" in str(c).lower() or "limit" in str(c).lower() for c in content):
+                        response.request_meta["name"] = f"{name} [rate-limited]"
+                        response.success()
+                        return {"_rate_limited": True}
+
+                response.success()
+                return result
+        except Exception as exc:
+            logger.warning("Request failed (%s): %s", name, exc)
+            return None
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized or not _server_id:
+            return
+        result = self._mcp_post(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "locust-dynamic-config-test", "version": "1.0.0"},
+            },
+            "MCP initialize",
+        )
+        if result is not None:
+            self._initialized = True
+
+    def on_start(self) -> None:
+        self._ensure_initialized()
+
+    @task(3)
+    def call_primary_tool(self) -> None:
+        """Call the first tool (typically fast-time-get-system-time)."""
+        if not _tool_names:
+            return
+        tool = _tool_names[0]
+        self._mcp_post(
+            "tools/call",
+            {"name": tool, "arguments": {}},
+            f"tools/call [{tool}]",
+        )
+
+    @task(1)
+    def call_secondary_tool(self) -> None:
+        """Call the second tool (typically fast-time-convert-time).
+
+        Used to verify per-tool binding isolation — if rate limiter is
+        bound only to the primary tool, this tool should never be limited.
+        """
+        if len(_tool_names) < 2:
+            return
+        tool = _tool_names[1]
+        self._mcp_post(
+            "tools/call",
+            {"name": tool, "arguments": {"source_timezone": "UTC", "target_timezone": "US/Eastern"}},
+            f"tools/call [{tool}]",
+        )
+
+
+# =============================================================================
+# VerifierUser — polls state consistency across replicas
+# =============================================================================
+
+
+class VerifierUser(FastHttpUser):
+    """Verifier user that periodically checks plugin state across replicas.
+
+    Sends GET /admin/plugins through the load balancer to hit different
+    replicas and verifies they all report the same state.
+    """
+
+    weight = 1
+    wait_time = between(2, 4)
+    connection_timeout = 30.0
+    network_timeout = 30.0
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {_get_admin_token()}",
+        }
+
+    @task
+    def verify_state_consistency(self) -> None:
+        """Check that the current replica matches expected global state."""
+        with self.client.get(
+            "/admin/plugins",
+            headers=self._headers(),
+            name=f"Verify: plugins_enabled={_plugins_enabled}",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                data = resp.json()
+                actual = data.get("plugins_globally_enabled")
+                if actual == _plugins_enabled:
+                    resp.success()
+                else:
+                    resp.failure(
+                        f"Inconsistency: expected={_plugins_enabled} actual={actual} "
+                        f"phase={_scenario_phase}"
+                    )
+            else:
+                resp.failure(f"HTTP {resp.status_code}")

--- a/tests/unit/mcpgateway/conftest.py
+++ b/tests/unit/mcpgateway/conftest.py
@@ -70,6 +70,30 @@ def clear_plugins_settings_cache():
 
 
 @pytest.fixture(autouse=True)
+def _reset_plugin_framework_redis_provider():
+    """Clear the plugin framework's shared Redis provider between tests.
+
+    ``main.py`` lifespan registers ``get_redis_client`` as the framework's
+    Redis provider. Lifespan-exercising tests monkeypatch
+    ``main_mod.get_redis_client`` to an ``AsyncMock`` so their lifespan run
+    registers that mock as the provider — but ``set_shared_redis_provider``
+    is module-level state that ``monkeypatch`` doesn't roll back, so the
+    mock bleeds into subsequent tests. ``_read_shared_enabled`` then treats
+    the mock's return value as a truthy-but-non-string Redis reply, which
+    decodes to ``False`` and makes ``get_plugin_manager`` return ``None``.
+
+    Resetting the provider to ``None`` before and after every test keeps
+    that state out of the hot path; plugin-suite tests (which have their
+    own conftest) re-install a real dynamic provider after this runs.
+    """
+    from mcpgateway.plugins.framework._redis import set_shared_redis_provider  # pylint: disable=import-outside-toplevel
+
+    set_shared_redis_provider(None)
+    yield
+    set_shared_redis_provider(None)
+
+
+@pytest.fixture(autouse=True)
 def reset_app_root_path(monkeypatch):
     """Reset app_root_path to empty string for all tests.
 

--- a/tests/unit/mcpgateway/plugins/conftest.py
+++ b/tests/unit/mcpgateway/plugins/conftest.py
@@ -14,21 +14,30 @@ import pytest
 import mcpgateway.plugins.framework as fw
 from mcpgateway.plugins.framework import PluginManager
 from mcpgateway.plugins.framework.settings import settings
+from tests.utils.plugin_redis_helper import install_dynamic_redis_provider
+
+
+@pytest.fixture(autouse=True)
+def _install_redis_provider():
+    """Route the framework's Redis shim to the real ``get_redis_client`` for the duration of each test."""
+    with install_dynamic_redis_provider():
+        yield
 
 
 @pytest.fixture(autouse=True)
 def reset_plugin_manager_state():
-    """Reset PluginManager Borg state before and after each test.
-
-    This ensures each test starts with a fresh PluginManager instance,
-    preventing state leakage between tests when using the Borg pattern.
-    Also resets the module-level singleton cached by get_plugin_manager().
-    """
+    """Reset PluginManager Borg state, the shared-toggle cache, and the factory singleton before/after each test."""
     PluginManager.reset()
-    fw._plugin_manager = None
+    fw.reset_plugin_manager_factory()
+    fw._invalidate_shared_enabled_cache()
+    fw._state.clear_local_mode_overrides()
+    fw._reset_factory_init_degraded_for_tests()
     yield
     PluginManager.reset()
-    fw._plugin_manager = None
+    fw.reset_plugin_manager_factory()
+    fw._invalidate_shared_enabled_cache()
+    fw._state.clear_local_mode_overrides()
+    fw._reset_factory_init_degraded_for_tests()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/mcpgateway/plugins/framework/test_observability.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_observability.py
@@ -558,7 +558,13 @@ def test_reset_plugin_manager_factory_clears_reference():
 
 @pytest.mark.asyncio
 async def test_shutdown_plugin_manager_factory_when_disabled():
-    """shutdown_plugin_manager_factory is a no-op when _PLUGINS_ENABLED is False (line 145)."""
+    """Shutdown must tear the factory down even when the in-memory flag is False.
+
+    Runtime-disabling plugins flips ``_PLUGINS_ENABLED`` to False, but gateway
+    shutdown must still call ``factory.shutdown()`` — otherwise in-flight build
+    tasks leak. Pins the fix that removed the ``if not _PLUGINS_ENABLED``
+    early-return.
+    """
     # Standard
     from unittest.mock import AsyncMock, MagicMock
 
@@ -570,12 +576,12 @@ async def test_shutdown_plugin_manager_factory_when_disabled():
     fw._plugin_manager_factory = mock_factory
     fw.enable_plugins(False)
 
-    await fw.shutdown_plugin_manager_factory()
-
-    mock_factory.shutdown.assert_not_awaited()
-    # factory reference unchanged since we returned early
-    assert fw._plugin_manager_factory is mock_factory
-    fw.reset_plugin_manager_factory()
+    try:
+        await fw.shutdown_plugin_manager_factory()
+        mock_factory.shutdown.assert_awaited_once()
+        assert fw._plugin_manager_factory is None
+    finally:
+        fw._plugin_manager_factory = None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
@@ -21,6 +21,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def _make_bare_factory(**attrs):
+    """Return a bare ``TenantPluginManagerFactory`` that skips heavy ``__init__``.
+
+    Tests use this to exercise individual methods without loading YAML,
+    creating plugin instances, or touching the DB. Pass keyword overrides to
+    pre-set attributes (``_managers``, ``_cache_ttl``, etc.); sensible defaults
+    are applied for the ones tests usually don't care about.
+    """
+    from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+
+    factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
+    factory._managers = attrs.get("_managers", {})
+    factory._inflight = attrs.get("_inflight", {})
+    factory._lock = attrs.get("_lock", asyncio.Lock())
+    factory._cache_ttl = attrs.get("_cache_ttl", 30)
+    factory._base_config = attrs.get("_base_config", MagicMock())
+    factory._timeout = attrs.get("_timeout", 30)
+    factory._observability = attrs.get("_observability", None)
+    factory._hook_policies = attrs.get("_hook_policies", None)
+    return factory
+
+
 # ---------------------------------------------------------------------------
 # Layer 1: Global enable/disable (Redis-backed)
 # ---------------------------------------------------------------------------
@@ -197,13 +219,13 @@ class TestGetPluginModeOverride:
             assert result is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_on_redis_exception(self):
-        """Returns None when Redis raises an exception."""
+    async def test_raises_runtime_error_on_redis_exception(self):
+        """Redis transport errors surface as RuntimeError so callers can distinguish them from 'no override'."""
         from mcpgateway.plugins.framework import get_plugin_mode_override
 
         with patch("mcpgateway.utils.redis_client.get_redis_client", side_effect=Exception("timeout")):
-            result = await get_plugin_mode_override("RateLimiterPlugin")
-            assert result is None
+            with pytest.raises(RuntimeError, match="Redis client unavailable"):
+                await get_plugin_mode_override("RateLimiterPlugin")
 
 
 # ---------------------------------------------------------------------------
@@ -217,41 +239,26 @@ class TestTTLCacheExpiry:
     @pytest.mark.asyncio
     async def test_cache_returns_manager_within_ttl(self):
         """Cached manager is returned when within TTL."""
-        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+        from mcpgateway.plugins.framework.manager import _CachedManager
 
-        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
-        factory._managers = {"test::tool": (MagicMock(), time.monotonic())}
-        factory._inflight = {}
-        factory._lock = asyncio.Lock()
-        factory._cache_ttl = 30
+        cached = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
+        factory = _make_bare_factory(_managers={"test::tool": cached})
 
         manager = await factory.get_manager("test::tool")
-        assert manager is not None
+        assert manager is cached.manager
 
     @pytest.mark.asyncio
     async def test_cache_evicts_after_ttl(self):
-        """Cached manager is evicted when TTL expires."""
-        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+        """Cached manager is reported as expired once the TTL window has passed."""
+        from mcpgateway.plugins.framework.manager import _CachedManager
 
-        mock_manager = MagicMock()
-        # Set created_at to 60 seconds ago (TTL is 5s)
-        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
-        factory._managers = {"test::tool": (mock_manager, time.monotonic() - 60)}
-        factory._inflight = {}
-        factory._lock = asyncio.Lock()
-        factory._cache_ttl = 5
-        factory._base_config = MagicMock()
-        factory._timeout = 30
-        factory._observability = None
-        factory._hook_policies = None
+        expired = _CachedManager(manager=MagicMock(), created_at=time.monotonic() - 60)
+        factory = _make_bare_factory(_managers={"test::tool": expired}, _cache_ttl=5)
 
-        # get_manager should evict the stale entry and try to rebuild
-        # Since we can't easily mock _build_manager, verify eviction happened
         async with factory._lock:
             entry = factory._managers.get("test::tool")
-            assert entry is not None  # Still there before get_manager
-            _, created_at = entry
-            assert (time.monotonic() - created_at) > factory._cache_ttl  # Confirms it's expired
+            assert entry is not None
+            assert entry.is_expired(factory._cache_ttl)
 
     def test_cache_ttl_default(self):
         """Default TTL is 30 seconds."""
@@ -260,13 +267,230 @@ class TestTTLCacheExpiry:
         assert TenantPluginManagerFactory.DEFAULT_CACHE_TTL == 30
 
     def test_cache_ttl_zero_disables(self):
-        """TTL of 0 means no automatic expiry."""
-        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+        """TTL of 0 short-circuits the expiry check so entries never auto-evict."""
+        from mcpgateway.plugins.framework.manager import _CachedManager
 
-        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
-        factory._cache_ttl = 0
-        # TTL check: self._cache_ttl > 0 — when 0, the check is skipped
-        assert factory._cache_ttl == 0
+        entry = _CachedManager(manager=MagicMock(), created_at=time.monotonic() - 10_000)
+        assert entry.is_expired(0) is False
+        assert entry.is_expired(5) is True
+
+
+class TestApplyRedisModeOverrides:
+    """Direct coverage of ``_apply_redis_mode_overrides`` — the merge into ``Config``."""
+
+    def _make_factory(self):
+        # Delegate to the module-level helper so every test in the file
+        # bypasses TenantPluginManagerFactory.__init__ the same way.
+        return _make_bare_factory()
+
+    def _build_config(self, plugin_names):
+        """Return a lightweight stub config compatible with ``_apply_redis_mode_overrides``."""
+        # Each plugin is a MagicMock that records ``model_copy`` updates.
+        plugins = []
+        for name in plugin_names:
+            plugin = MagicMock()
+            plugin.name = name
+            plugin.model_copy = MagicMock(side_effect=lambda update, _name=name: SimpleNamespacePlugin(name=_name, mode=update["mode"]))
+            plugins.append(plugin)
+        config = MagicMock()
+        config.plugins = plugins
+        config.model_copy = MagicMock(side_effect=lambda update, deep: MagicMock(plugins=update["plugins"]))
+        return config
+
+    @pytest.mark.asyncio
+    async def test_no_plugins_short_circuits(self):
+        factory = self._make_factory()
+        config = MagicMock()
+        config.plugins = []
+        result = await factory._apply_redis_mode_overrides(config)
+        assert result is config
+
+    @pytest.mark.asyncio
+    async def test_returns_config_unchanged_when_no_overrides_in_redis(self):
+        factory = self._make_factory()
+        config = self._build_config(["A", "B"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[None, None])
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await factory._apply_redis_mode_overrides(config)
+
+        assert result is config
+        config.model_copy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_applies_per_plugin_override(self):
+        factory = self._make_factory()
+        config = self._build_config(["A", "B"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[b"disabled", None])
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await factory._apply_redis_mode_overrides(config)
+
+        # A had its mode swapped; B was preserved as-is.
+        new_plugins = result.plugins
+        assert new_plugins[0].mode.value == "disabled"
+        assert new_plugins[1] is config.plugins[1]
+
+    @pytest.mark.asyncio
+    async def test_corrupt_redis_falls_through_to_local_override(self):
+        """A corrupt Redis value must not shadow a valid local override — both candidates are tried in priority order."""
+        from mcpgateway.plugins import framework
+
+        factory = self._make_factory()
+        config = self._build_config(["A"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[b"garbage_mode"])
+
+        framework._state.set_local_mode_override("A", "permissive", None)
+        try:
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+                result = await factory._apply_redis_mode_overrides(config)
+        finally:
+            framework._state.clear_local_mode_overrides()
+
+        # Previously the corrupt Redis value was logged then the loop fell
+        # through to YAML; now it falls through to the local override.
+        assert result.plugins[0].mode.value == "permissive"
+
+    @pytest.mark.asyncio
+    async def test_invalid_mode_value_skipped_not_batch_aborted(self, caplog):
+        """One bad Redis value must not drop valid overrides for the rest of the batch."""
+        import logging as _logging
+
+        factory = self._make_factory()
+        config = self._build_config(["A", "B"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[b"not_a_mode", b"enforce"])
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework.manager"):
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+                result = await factory._apply_redis_mode_overrides(config)
+
+        # A was left alone (invalid); B was swapped — batch is NOT aborted.
+        new_plugins = result.plugins
+        assert new_plugins[0] is config.plugins[0]
+        assert new_plugins[1].mode.value == "enforce"
+        assert any("invalid Redis mode override" in rec.message.lower() or "invalid redis mode override" in rec.message.lower() for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_local_override_applied_when_redis_has_nothing(self):
+        """Redis-less deployments: the in-process override map drives the rebuild."""
+        from mcpgateway.plugins import framework
+
+        factory = self._make_factory()
+        config = self._build_config(["A", "B"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[None, None])
+
+        # Durable local-only entry — no expiry (Redis SET was not possible).
+        framework._state.set_local_mode_override("A", "disabled", None)
+        try:
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+                result = await factory._apply_redis_mode_overrides(config)
+        finally:
+            framework._state.clear_local_mode_overrides()
+
+        assert result.plugins[0].mode.value == "disabled"
+        assert result.plugins[1] is config.plugins[1]
+
+    @pytest.mark.asyncio
+    async def test_redis_value_beats_local_override(self):
+        """When both Redis and the local map hold a value, Redis wins — cluster coordination beats local drift."""
+        from mcpgateway.plugins import framework
+
+        factory = self._make_factory()
+        config = self._build_config(["A"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[b"enforce"])
+
+        framework._state.set_local_mode_override("A", "disabled", None)
+        try:
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+                result = await factory._apply_redis_mode_overrides(config)
+        finally:
+            framework._state.clear_local_mode_overrides()
+
+        assert result.plugins[0].mode.value == "enforce"
+
+    @pytest.mark.asyncio
+    async def test_local_override_applied_when_redis_client_none(self):
+        """No Redis provider at all: the in-process map is the sole source."""
+        from mcpgateway.plugins import framework
+
+        factory = self._make_factory()
+        config = self._build_config(["A"])
+
+        framework._state.set_local_mode_override("A", "permissive", None)
+        try:
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+                result = await factory._apply_redis_mode_overrides(config)
+        finally:
+            framework._state.clear_local_mode_overrides()
+
+        assert result.plugins[0].mode.value == "permissive"
+
+    @pytest.mark.asyncio
+    async def test_expired_redis_synced_local_override_is_pruned(self):
+        """Regression pin for the "stuck past 24 h" bug: a Redis-synced entry whose TTL has elapsed must not apply."""
+        from mcpgateway.plugins import framework
+
+        factory = self._make_factory()
+        config = self._build_config(["A", "B"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[None, None])
+
+        # Entry was written when Redis was healthy (so it carries an expiry) —
+        # but the expiry has already passed, matching a 24 h+ stale override.
+        framework._state.set_local_mode_override("A", "disabled", time.monotonic() - 1.0)
+        # Sibling durable entry that must NOT be pruned.
+        framework._state.set_local_mode_override("B", "permissive", None)
+        try:
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+                result = await factory._apply_redis_mode_overrides(config)
+        finally:
+            framework._state.clear_local_mode_overrides()
+
+        # A expired → no override applied (YAML/config default preserved).
+        assert result.plugins[0] is config.plugins[0]
+        # B is durable → still applied.
+        assert result.plugins[1].mode.value == "permissive"
+
+    @pytest.mark.asyncio
+    async def test_mget_failure_warns_and_returns_input(self, caplog):
+        """Redis transport failures surface as WARNING — not silent DEBUG — so operators see them."""
+        import logging as _logging
+
+        factory = self._make_factory()
+        config = self._build_config(["A"])
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(side_effect=Exception("EPIPE"))
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework.manager"):
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+                result = await factory._apply_redis_mode_overrides(config)
+
+        assert result is config
+        assert any(rec.levelno == _logging.WARNING for rec in caplog.records)
+
+
+class SimpleNamespacePlugin:
+    """Tiny stand-in plugin with a mode-carrying enum attribute."""
+
+    def __init__(self, name, mode):
+        from mcpgateway.plugins.framework.models import PluginMode
+
+        self.name = name
+        self.mode = mode if isinstance(mode, PluginMode) else PluginMode(mode)
 
 
 # ---------------------------------------------------------------------------
@@ -278,15 +502,15 @@ class TestDBErrorFallback:
     """Tests for get_config_from_db graceful fallback on DB errors."""
 
     @pytest.mark.asyncio
-    async def test_returns_none_on_db_error(self):
-        """When DB raises an exception, returns None (uses base config)."""
+    async def test_raises_on_db_error(self):
+        """DB failures must raise so the rebuild fails loudly — silently falling back to YAML drops security-relevant overrides."""
         from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
 
         factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
         factory._db_factory = MagicMock(side_effect=Exception("connection refused"))
 
-        result = await factory.get_config_from_db("team_a::my_tool")
-        assert result is None
+        with pytest.raises(Exception, match="connection refused"):
+            await factory.get_config_from_db("team_a::my_tool")
 
     @pytest.mark.asyncio
     async def test_returns_none_for_invalid_context_id(self):
@@ -321,32 +545,26 @@ class TestInvalidateAllPluginManagers:
     """Tests for invalidate_all_plugin_managers()."""
 
     @pytest.mark.asyncio
-    async def test_evicts_all_cached_contexts(self):
-        """All cached manager contexts are evicted and rebuilt."""
-        from mcpgateway.plugins.framework import invalidate_all_plugin_managers, _plugin_manager_factory
-        import mcpgateway.plugins.framework as framework
+    async def test_delegates_to_factory_invalidate_all(self):
+        """Module helper routes through ``factory.invalidate_all()`` rather than reaching into private state."""
+        from mcpgateway.plugins.framework import invalidate_all_plugin_managers
+        from mcpgateway.plugins import framework
 
         mock_factory = AsyncMock()
-        mock_factory._lock = asyncio.Lock()
-        mock_factory._managers = {
-            "team_a::tool_1": (MagicMock(), time.monotonic()),
-            "team_a::tool_2": (MagicMock(), time.monotonic()),
-            "team_b::tool_1": (MagicMock(), time.monotonic()),
-        }
-        mock_factory.reload_tenant = AsyncMock()
+        mock_factory.invalidate_all = AsyncMock()
 
         original_factory = framework._plugin_manager_factory
         framework._plugin_manager_factory = mock_factory
         try:
             await invalidate_all_plugin_managers()
-            assert mock_factory.reload_tenant.call_count == 3
+            mock_factory.invalidate_all.assert_awaited_once()
         finally:
             framework._plugin_manager_factory = original_factory
 
     @pytest.mark.asyncio
     async def test_noop_when_factory_is_none(self):
         """No error when factory is not initialized."""
-        import mcpgateway.plugins.framework as framework
+        from mcpgateway.plugins import framework
 
         original_factory = framework._plugin_manager_factory
         framework._plugin_manager_factory = None
@@ -382,6 +600,7 @@ class TestPubSubPublisher:
             assert call_args[0][0] == "plugin:invalidation"
             # Verify message contains toggle info
             import json
+
             msg = json.loads(call_args[0][1])
             assert msg["type"] == "global_toggle"
             assert msg["enabled"] is False
@@ -415,25 +634,24 @@ class TestPubSubSubscriber:
         await _handle_invalidation_message(message)
 
         from mcpgateway.plugins.framework import are_plugins_enabled
+
         assert are_plugins_enabled() is False
 
     @pytest.mark.asyncio
     async def test_subscriber_evicts_managers_on_mode_change(self):
-        """Subscriber evicts all cached managers when receiving mode_change message."""
-        import mcpgateway.plugins.framework as framework
+        """Subscriber triggers factory-wide invalidation when a mode_change frame arrives."""
+        from mcpgateway.plugins import framework
         import json
 
         mock_factory = AsyncMock()
-        mock_factory._lock = asyncio.Lock()
-        mock_factory._managers = {"ctx1": (MagicMock(), time.monotonic())}
-        mock_factory.reload_tenant = AsyncMock()
+        mock_factory.invalidate_all = AsyncMock()
 
         original_factory = framework._plugin_manager_factory
         framework._plugin_manager_factory = mock_factory
         try:
             message = {"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "RateLimiterPlugin", "mode": "enforce"})}
             await framework._handle_invalidation_message(message)
-            mock_factory.reload_tenant.assert_called()
+            mock_factory.invalidate_all.assert_awaited()
         finally:
             framework._plugin_manager_factory = original_factory
 
@@ -458,18 +676,275 @@ class TestPubSubSubscriber:
         await _handle_invalidation_message(message)
         assert are_plugins_enabled() is True  # Unchanged, no crash
 
+
+class TestPublishHelpers:
+    """Tests that the publish helpers emit correctly-shaped invalidation messages."""
+
+    @pytest.mark.asyncio
+    async def test_publish_plugin_mode_change_sends_mode_change_message(self):
+        """publish_plugin_mode_change must SET the key AND publish a mode_change frame."""
+        import json
+        from mcpgateway.plugins.framework import publish_plugin_mode_change
+
+        client = AsyncMock()
+        client.set = AsyncMock()
+        client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+
+        assert ok is True
+        # SET carries the 24h TTL
+        set_call = client.set.call_args
+        assert set_call.args[:2] == ("plugin:RateLimiterPlugin:mode", "enforce")
+        assert set_call.kwargs.get("ex") == 86400
+        # PUBLISH hits the right channel with the right discriminator, plus
+        # ttl_seconds so every peer stamps the same absolute deadline.
+        pub_call = client.publish.call_args
+        assert pub_call.args[0] == "plugin:invalidation"
+        msg = json.loads(pub_call.args[1])
+        assert msg == {"type": "mode_change", "plugin": "RateLimiterPlugin", "mode": "enforce", "ttl_seconds": 86400}
+
+    @pytest.mark.asyncio
+    async def test_publish_plugin_mode_change_returns_false_on_set_failure(self):
+        """A SET transport failure must surface as False so the caller signals the outage."""
+        from mcpgateway.plugins.framework import publish_plugin_mode_change
+
+        client = AsyncMock()
+        client.set = AsyncMock(side_effect=Exception("ECONNREFUSED"))
+        client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+
+        assert ok is False
+        client.publish.assert_not_awaited()  # No half-state broadcast
+
+    @pytest.mark.asyncio
+    async def test_local_entry_expiry_aligns_with_redis_ttl_on_success(self):
+        """Redis-synced local entries must carry a ~24 h monotonic expiry — otherwise they'd outlive the Redis key."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import publish_plugin_mode_change
+
+        client = AsyncMock()
+        client.set = AsyncMock()
+        client.publish = AsyncMock()
+
+        before = time.monotonic()
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+        after = time.monotonic()
+
+        assert ok is True
+        entry = framework._state.get_local_mode_overrides_live()["RateLimiterPlugin"]
+        mode, expires_at = entry
+        assert mode == "enforce"
+        assert expires_at is not None
+        # Tolerance accounts for the monotonic tick between before/after.
+        assert before + 86400 <= expires_at <= after + 86400
+
+    @pytest.mark.asyncio
+    async def test_local_entry_has_no_expiry_when_redis_set_fails(self):
+        """Local-only entries (Redis SET failed) must be durable — the operator never got confirmation the timer started."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import publish_plugin_mode_change
+
+        client = AsyncMock()
+        client.set = AsyncMock(side_effect=Exception("ECONNREFUSED"))
+        client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+
+        assert ok is False
+        entry = framework._state.get_local_mode_overrides_live()["RateLimiterPlugin"]
+        mode, expires_at = entry
+        assert mode == "enforce"
+        assert expires_at is None
+
+    @pytest.mark.asyncio
+    async def test_publish_binding_change_sends_binding_change_message(self):
+        """publish_binding_change must emit a binding_change frame with the context id."""
+        import json
+        from mcpgateway.plugins.framework import publish_binding_change
+
+        client = AsyncMock()
+        client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+            ok = await publish_binding_change("team_a::my_tool")
+
+        assert ok is True
+        pub_call = client.publish.call_args
+        assert pub_call.args[0] == "plugin:invalidation"
+        msg = json.loads(pub_call.args[1])
+        assert msg == {"type": "binding_change", "context_id": "team_a::my_tool"}
+
+
+class TestPublishToListenerRoundTrip:
+    """End-to-end: one side publishes; the handler on another worker dispatches."""
+
+    @pytest.mark.asyncio
+    async def test_mode_change_publish_triggers_factory_invalidate(self):
+        """Publishing a mode_change must cause the listener handler to trigger cluster-wide invalidation."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import _handle_invalidation_message, publish_plugin_mode_change
+
+        # Simulate the local factory on the *listener* side. Module helper routes
+        # through ``factory.invalidate_all()``, so we just assert that was awaited.
+        mock_factory = AsyncMock()
+        mock_factory.invalidate_all = AsyncMock()
+
+        # Capture the published frame; feed it back into _handle_invalidation_message
+        # to mimic the Redis pub/sub round-trip on a peer worker.
+        published = {}
+
+        async def _fake_publish(channel, payload):
+            published["channel"] = channel
+            published["payload"] = payload
+
+        client = AsyncMock()
+        client.set = AsyncMock()
+        client.publish = AsyncMock(side_effect=_fake_publish)
+
+        original_factory = framework._plugin_manager_factory
+        framework._plugin_manager_factory = mock_factory
+        try:
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+                await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+
+            assert published["channel"] == "plugin:invalidation"
+            frame = {"type": "message", "data": published["payload"]}
+            await _handle_invalidation_message(frame)
+
+            # Listener-side handler delegates to the factory's public invalidate_all.
+            mock_factory.invalidate_all.assert_awaited_once()
+        finally:
+            framework._plugin_manager_factory = original_factory
+
+    @pytest.mark.asyncio
+    async def test_global_toggle_pubsub_invalidates_local_cache(self):
+        """A global_toggle broadcast must drop the short-lived local cache, not just update the flag."""
+        import json
+        from mcpgateway.plugins.framework import _handle_invalidation_message, are_plugins_enabled_shared, enable_plugins
+
+        enable_plugins(True)
+        # Prime the local cache with True.
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            assert await are_plugins_enabled_shared() is True
+
+        # Broadcast flips the toggle OFF.
+        await _handle_invalidation_message({"type": "message", "data": json.dumps({"type": "global_toggle", "enabled": False})})
+
+        # Next read must NOT serve the cached True — it must reflect the new state.
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            assert await are_plugins_enabled_shared() is False
+
+
+class TestFactoryInvalidateTeam:
+    """Public ``invalidate_team`` replaces tool_plugin_bindings reaching into private state."""
+
+    @pytest.mark.asyncio
+    async def test_invalidates_only_matching_team(self):
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory(
+            _managers={
+                "team_a::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                "team_a::tool_2": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                "team_b::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                "__global__": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+            }
+        )
+        factory.reload_tenant = AsyncMock()
+
+        await factory.invalidate_team("team_a", "::")
+
+        # Only the two team_a entries should have been reloaded.
+        calls = [c.args[0] for c in factory.reload_tenant.call_args_list]
+        assert set(calls) == {"team_a::tool_1", "team_a::tool_2"}
+
+    @pytest.mark.asyncio
+    async def test_uses_class_separator_when_not_specified(self):
+        """Default separator is ``CONTEXT_ID_SEPARATOR`` — saves the listener from knowing it on the wire."""
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory(
+            _managers={
+                "team_a::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                "team_a-other::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+            }
+        )
+        factory.reload_tenant = AsyncMock()
+
+        await factory.invalidate_team("team_a")  # no separator arg → uses CONTEXT_ID_SEPARATOR
+
+        calls = [c.args[0] for c in factory.reload_tenant.call_args_list]
+        # Only the context that starts with "team_a::" — not "team_a-other::".
+        assert set(calls) == {"team_a::tool_1"}
+
+
+class TestTeamBindingChangeRoundTrip:
+    """Regression pin: wildcard bindings must evict every per-tool cache in the cluster, not just ``team::*``."""
+
+    @pytest.mark.asyncio
+    async def test_publish_team_binding_change_emits_correct_frame(self):
+        import json
+
+        from mcpgateway.plugins.framework import publish_team_binding_change
+
+        client = AsyncMock()
+        client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+            ok = await publish_team_binding_change("team_a")
+
+        assert ok is True
+        pub_call = client.publish.call_args
+        assert pub_call.args[0] == "plugin:invalidation"
+        msg = json.loads(pub_call.args[1])
+        assert msg == {"type": "team_binding_change", "team_id": "team_a"}
+
+    @pytest.mark.asyncio
+    async def test_handler_evicts_every_per_tool_context_for_team(self):
+        """A team_binding_change frame on a remote worker must reload every ``team_a::*`` cache entry."""
+        import json
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import _handle_invalidation_message
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory(
+            _managers={
+                "team_a::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                "team_a::tool_2": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                "team_b::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+            }
+        )
+        factory.reload_tenant = AsyncMock()
+
+        original_factory = framework._plugin_manager_factory
+        framework._plugin_manager_factory = factory
+        try:
+            frame = {"type": "message", "data": json.dumps({"type": "team_binding_change", "team_id": "team_a"})}
+            await _handle_invalidation_message(frame)
+        finally:
+            framework._plugin_manager_factory = original_factory
+
+        calls = [c.args[0] for c in factory.reload_tenant.call_args_list]
+        assert set(calls) == {"team_a::tool_1", "team_a::tool_2"}  # team_b left alone
+
+
+class TestSubscriberHandlesBindingChange:
+    """Lift of the original binding_change test (kept for backwards compatibility after the refactor)."""
+
     @pytest.mark.asyncio
     async def test_subscriber_handles_binding_change(self):
         """Subscriber evicts specific context on binding_change message."""
-        import mcpgateway.plugins.framework as framework
+        from mcpgateway.plugins import framework
         import json
 
         mock_factory = AsyncMock()
-        mock_factory._lock = asyncio.Lock()
-        mock_factory._managers = {
-            "team_a::tool_1": (MagicMock(), time.monotonic()),
-            "team_b::tool_1": (MagicMock(), time.monotonic()),
-        }
         mock_factory.reload_tenant = AsyncMock()
 
         original_factory = framework._plugin_manager_factory
@@ -480,3 +955,316 @@ class TestPubSubSubscriber:
             mock_factory.reload_tenant.assert_called_once_with("team_a::tool_1")
         finally:
             framework._plugin_manager_factory = original_factory
+
+
+class TestListenerLocalMirror:
+    """Pin the side-effect: mode_change broadcasts must populate the local override map."""
+
+    @pytest.mark.asyncio
+    async def test_mode_change_populates_local_map_with_broadcast_ttl(self):
+        """The handler stamps ``(mode, monotonic + ttl_seconds)`` using the publisher's TTL, not a local constant."""
+        import json
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import _handle_invalidation_message
+
+        # No factory needed for this assertion; invalidate_all is a no-op.
+        framework._state.clear_local_mode_overrides()
+        before = time.monotonic()
+        await _handle_invalidation_message({"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "Foo", "mode": "enforce", "ttl_seconds": 600})})
+        after = time.monotonic()
+
+        entry = framework._state.get_local_mode_overrides_live()["Foo"]
+        mode, expires_at = entry
+        assert mode == "enforce"
+        assert expires_at is not None
+        # Peer uses the broadcast's ttl_seconds, not the 24h local constant.
+        assert before + 600 <= expires_at <= after + 600
+
+    @pytest.mark.asyncio
+    async def test_mode_change_falls_back_to_default_ttl_without_field(self):
+        """Older publishers that omit ``ttl_seconds`` fall back to the 24 h default."""
+        import json
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import _handle_invalidation_message
+
+        framework._state.clear_local_mode_overrides()
+        before = time.monotonic()
+        await _handle_invalidation_message({"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "Foo", "mode": "enforce"})})
+        after = time.monotonic()
+
+        _, expires_at = framework._state.get_local_mode_overrides_live()["Foo"]
+        assert expires_at is not None
+        assert before + 86400 <= expires_at <= after + 86400
+
+    def test_backing_dict_identity_is_stable(self):
+        """Regression pin: writers and readers must share one dict object — introducing a copy would split the listener from the manager."""
+        from mcpgateway.plugins.framework import _state
+
+        first = _state.get_local_mode_overrides_live()
+        _state.set_local_mode_override("Identity", "enforce", None)
+        assert _state.get_local_mode_overrides_live() is first
+
+
+class TestListenerStartup:
+    """Regression pins for ``start_plugin_invalidation_listener`` — TOCTOU lock and skip-when-no-provider."""
+
+    @pytest.mark.asyncio
+    async def test_skips_start_when_no_redis_provider(self, caplog):
+        """Single-node deployments without a Redis provider must not create the listener task."""
+        import logging as _logging
+
+        from mcpgateway.plugins.framework import start_plugin_invalidation_listener, stop_plugin_invalidation_listener
+        from mcpgateway.plugins.framework._redis import set_shared_redis_provider
+
+        set_shared_redis_provider(None)
+        from mcpgateway.plugins import framework
+
+        framework._pubsub_task = None
+
+        with caplog.at_level(_logging.INFO, logger="mcpgateway.plugins.framework"):
+            await start_plugin_invalidation_listener()
+
+        assert framework._pubsub_task is None
+        assert any("no Redis provider" in rec.message for rec in caplog.records)
+        await stop_plugin_invalidation_listener()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_starts_only_create_one_task(self, monkeypatch):
+        """Two racing callers must not both reach ``asyncio.create_task`` (TOCTOU guard)."""
+        from mcpgateway.plugins.framework import start_plugin_invalidation_listener, stop_plugin_invalidation_listener
+        from mcpgateway.plugins import framework
+
+        framework._pubsub_task = None
+
+        # _redis() returns a dummy non-None client. The listener task itself
+        # will raise almost immediately when it tries pubsub() on the dummy,
+        # but that happens inside the task — start_plugin_invalidation_listener
+        # only cares about the create-task path.
+        dummy_client = MagicMock()
+        monkeypatch.setattr(framework, "_redis", AsyncMock(return_value=dummy_client))
+
+        await asyncio.gather(
+            start_plugin_invalidation_listener(),
+            start_plugin_invalidation_listener(),
+            start_plugin_invalidation_listener(),
+        )
+
+        assert framework._pubsub_task is not None
+        await stop_plugin_invalidation_listener()
+        assert framework._pubsub_task is None
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_does_not_start_and_logs(self, monkeypatch, caplog):
+        """If the Redis probe raises, the listener must not start and the failure must log at WARNING."""
+        import logging as _logging
+
+        from mcpgateway.plugins.framework import start_plugin_invalidation_listener, stop_plugin_invalidation_listener
+        from mcpgateway.plugins import framework
+
+        framework._pubsub_task = None
+        monkeypatch.setattr(framework, "_redis", AsyncMock(side_effect=RuntimeError("probe blew up")))
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework"):
+            await start_plugin_invalidation_listener()
+
+        assert framework._pubsub_task is None
+        assert any("probe failed" in rec.message for rec in caplog.records)
+        await stop_plugin_invalidation_listener()
+
+
+class TestPublishPartialWriteSignaling:
+    """When Redis SET succeeded but the broadcast failed, operators see an ERROR log."""
+
+    @pytest.mark.asyncio
+    async def test_enable_plugins_shared_errors_on_publish_failure(self, caplog):
+        import logging as _logging
+
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        client = AsyncMock()
+        client.set = AsyncMock()
+        client.publish = AsyncMock(side_effect=Exception("broker down"))
+
+        with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins.framework"):
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+                await enable_plugins_shared(True)
+
+        assert any("broadcast failed" in rec.message and rec.levelno == _logging.ERROR for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_publish_plugin_mode_change_errors_on_publish_failure(self, caplog):
+        import logging as _logging
+
+        from mcpgateway.plugins.framework import publish_plugin_mode_change
+
+        client = AsyncMock()
+        client.set = AsyncMock()
+        client.publish = AsyncMock(side_effect=Exception("broker down"))
+
+        with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins.framework"):
+            with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=client):
+                await publish_plugin_mode_change("Foo", "enforce")
+
+        assert any("broadcast failed" in rec.message and rec.levelno == _logging.ERROR for rec in caplog.records)
+
+
+class TestFactoryInitFailureSurface:
+    """``init_plugin_manager_factory`` must surface config errors so the lifespan can decide to hard-crash.
+
+    Pins the contract that ``main.py`` relies on: if the YAML load or Pydantic
+    validation fails, the exception propagates. A refactor that silently
+    absorbs it would re-introduce the "gateway boots with plugins silently
+    dead" bug that prompted commit ``268915089``.
+
+    Note: missing-file is deliberately swallowed by ``ConfigLoader.load_config``
+    (minimal-environment fallback), so we pin only the cases the lifespan
+    actually needs to see — malformed YAML and invalid config shape.
+    """
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        from mcpgateway.plugins.framework import init_plugin_manager_factory
+
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("plugins: [this is not a valid plugin list:::")
+
+        with pytest.raises(Exception):
+            init_plugin_manager_factory(
+                yaml_path=str(bad),
+                timeout=30,
+                hook_policies={},
+                observability=None,
+                db_factory=None,
+            )
+
+    def test_invalid_config_shape_raises(self, tmp_path):
+        from mcpgateway.plugins.framework import init_plugin_manager_factory
+
+        bad = tmp_path / "bad.yaml"
+        # plugin_settings.plugin_timeout must be an int per the Config schema.
+        bad.write_text("plugin_settings:\n  plugin_timeout: not-a-number\nplugins: []\n")
+
+        with pytest.raises(Exception):
+            init_plugin_manager_factory(
+                yaml_path=str(bad),
+                timeout=30,
+                hook_policies={},
+                observability=None,
+                db_factory=None,
+            )
+
+
+class TestFactoryInitDegradedSignal:
+    """When plugins.enabled=false + init fails, the node must log once when the toggle later asks it to serve."""
+
+    @pytest.mark.asyncio
+    async def test_get_plugin_manager_emits_error_once_on_degraded_node(self, caplog):
+        import logging as _logging
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import (
+            _reset_factory_init_degraded_for_tests,
+            enable_plugins,
+            get_plugin_manager,
+            mark_factory_init_degraded,
+        )
+
+        _reset_factory_init_degraded_for_tests()
+        framework._plugin_manager_factory = None
+        enable_plugins(True)  # Seed in-memory flag so are_plugins_enabled_shared() returns True.
+        mark_factory_init_degraded()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins.framework"):
+                assert await get_plugin_manager() is None
+                assert await get_plugin_manager() is None
+
+        degraded_errors = [rec for rec in caplog.records if rec.levelno == _logging.ERROR and "factory init failed" in rec.message]
+        # One ERROR, not one per request.
+        assert len(degraded_errors) == 1, f"expected 1 ERROR, got {len(degraded_errors)}: {[r.message for r in degraded_errors]}"
+
+    @pytest.mark.asyncio
+    async def test_no_error_when_factory_is_initialized(self, caplog):
+        """A healthy node never emits the degraded-boot ERROR."""
+        import logging as _logging
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import enable_plugins, get_plugin_manager
+
+        mock_factory = AsyncMock()
+        mock_factory.get_manager = AsyncMock(return_value=MagicMock())
+        framework._plugin_manager_factory = mock_factory
+        enable_plugins(True)
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins.framework"):
+                await get_plugin_manager()
+
+        assert not any("factory init failed" in rec.message for rec in caplog.records)
+        framework._plugin_manager_factory = None
+
+    @pytest.mark.asyncio
+    async def test_no_error_when_toggle_is_off(self, caplog):
+        """Degraded node with the shared toggle off must stay quiet — the opt-out is doing its job."""
+        import logging as _logging
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import (
+            enable_plugins,
+            get_plugin_manager,
+            mark_factory_init_degraded,
+        )
+
+        framework._plugin_manager_factory = None
+        enable_plugins(False)  # toggle off
+        mark_factory_init_degraded()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins.framework"):
+                await get_plugin_manager()
+
+        assert not any("factory init failed" in rec.message for rec in caplog.records)
+
+
+class TestListenerBackoff:
+    """Regression pins for ``_plugin_invalidation_listener`` reconnect loop."""
+
+    @pytest.mark.asyncio
+    async def test_escalates_to_error_after_five_consecutive_failures(self, monkeypatch, caplog):
+        """Exponential backoff plus ERROR log after 5 failures keeps ops visibility when Redis is flaky."""
+        import logging as _logging
+
+        from mcpgateway.plugins import framework
+
+        # Force every subscribe attempt to raise, so the backoff loop cycles.
+        async def _always_raises():
+            raise RuntimeError("redis broker unavailable")
+
+        monkeypatch.setattr(framework, "_redis", _always_raises)
+
+        # Neutralise actual sleeping — just count calls and cap iterations.
+        sleeps: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+            if len(sleeps) >= 6:
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr(framework.asyncio, "sleep", _fake_sleep)
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework"):
+            try:
+                await framework._plugin_invalidation_listener()
+            except asyncio.CancelledError:
+                pass
+
+        # First 4 failures at WARNING; failure #5 onward at ERROR.
+        warnings = [r for r in caplog.records if r.levelno == _logging.WARNING and "reconnecting" in r.message]
+        errors = [r for r in caplog.records if r.levelno == _logging.ERROR and "reconnecting" in r.message]
+        assert len(warnings) == 4, f"expected 4 WARNING-level failures before escalation, got {len(warnings)}"
+        assert len(errors) >= 1, "expected ERROR-level logs after the 5th consecutive failure"
+
+        # Backoff must be non-decreasing up to the 30 s cap.
+        assert all(d <= 30.0 + 1e-6 for d in sleeps), f"backoff exceeded 30s cap: {sleeps}"
+        assert sleeps[-1] >= sleeps[0], f"backoff must grow, not shrink: {sleeps}"

--- a/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
@@ -1268,3 +1268,424 @@ class TestListenerBackoff:
         # Backoff must be non-decreasing up to the 30 s cap.
         assert all(d <= 30.0 + 1e-6 for d in sleeps), f"backoff exceeded 30s cap: {sleeps}"
         assert sleeps[-1] >= sleeps[0], f"backoff must grow, not shrink: {sleeps}"
+
+
+class TestFactoryGetManagerBranches:
+    """Narrow pins on the ``TenantPluginManagerFactory.get_manager`` caching branches."""
+
+    @pytest.mark.asyncio
+    async def test_cache_ttl_expiry_evicts_and_rebuilds(self):
+        """An expired cache entry must be popped and re-built, not served stale."""
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory(_cache_ttl=0.001)
+        stale = MagicMock(name="stale_manager")
+        factory._managers["ctx-1"] = _CachedManager(manager=stale, created_at=time.monotonic() - 10)
+
+        fresh = MagicMock(name="fresh_manager")
+        build_calls: list[str] = []
+
+        async def _fake_build(ctx):
+            build_calls.append(ctx)
+            return fresh
+
+        factory._build_manager = _fake_build
+        result = await factory.get_manager("ctx-1")
+        # Expired entry forced a rebuild (covers the TTL-eviction branch).
+        assert build_calls == ["ctx-1"]
+        assert result is fresh, "expected the rebuilt manager, got the stale cached one"
+
+    @pytest.mark.asyncio
+    async def test_apply_redis_mode_overrides_handles_client_exception(self, caplog):
+        """A client-factory exception logs a WARNING and falls through to YAML defaults (no override applied)."""
+        import logging as _logging
+
+        factory = _make_bare_factory()
+        # Build a minimal Config-like object with a single plugin.
+        plugin = MagicMock()
+        plugin.name = "A"
+        plugin.mode = MagicMock()
+        plugin.model_copy = MagicMock(side_effect=AssertionError("must not be called — no override to apply"))
+        config = MagicMock()
+        config.plugins = [plugin]
+
+        with patch("mcpgateway.plugins.framework._redis.get_shared_redis_client", side_effect=RuntimeError("no client")):
+            with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework.manager"):
+                result = await factory._apply_redis_mode_overrides(config)
+
+        # Config is returned unchanged (no model_copy invoked).
+        assert result is config
+        assert any("client error" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_apply_redis_mode_overrides_skips_override_on_validation_error(self, caplog):
+        """``plugin.model_copy`` raising ``ValidationError`` logs a WARNING and leaves the plugin untouched."""
+        import logging as _logging
+
+        from pydantic import ValidationError as _PydValidationError
+        from mcpgateway.plugins.framework import PluginMode
+
+        factory = _make_bare_factory()
+        plugin = MagicMock()
+        plugin.name = "A"
+        plugin.mode = PluginMode.ENFORCE
+
+        def _raise_validation(*_a, **_k):
+            raise _PydValidationError.from_exception_data("bad", [])
+
+        plugin.model_copy = MagicMock(side_effect=_raise_validation)
+        config = MagicMock()
+        config.plugins = [plugin]
+
+        mock_client = AsyncMock()
+        mock_client.mget = AsyncMock(return_value=[b"permissive"])
+
+        with patch("mcpgateway.plugins.framework._redis.get_shared_redis_client", return_value=mock_client):
+            with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework.manager"):
+                result = await factory._apply_redis_mode_overrides(config)
+
+        # Config is returned unchanged because the one override failed validation.
+        assert result is config
+        assert any("validation failed" in rec.message for rec in caplog.records)
+
+
+class TestInvalidateHelpers:
+    """Pins for ``invalidate_all``/``invalidate_team`` swallow-and-log semantics and ``iter_context_ids``."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_all_logs_when_reload_raises(self, caplog):
+        """One reload failure must not abort the sweep — it logs and moves on."""
+        import logging as _logging
+
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory()
+        factory._managers["ctx-a"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
+        factory.reload_tenant = AsyncMock(side_effect=RuntimeError("reload blew up"))
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework.manager"):
+            await factory.invalidate_all()
+
+        assert any("invalidate_all: reload failed" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_invalidate_team_logs_when_reload_raises(self, caplog):
+        """Same guarantee on the team-scoped sweep."""
+        import logging as _logging
+
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory()
+        factory.CONTEXT_ID_SEPARATOR = "::"
+        factory._managers["team-a::tool-1"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
+        factory.reload_tenant = AsyncMock(side_effect=RuntimeError("reload blew up"))
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework.manager"):
+            await factory.invalidate_team("team-a")
+
+        assert any("invalidate_team: reload failed" in rec.message for rec in caplog.records)
+
+    def test_iter_context_ids_returns_snapshot_list(self):
+        """``iter_context_ids`` copies the cache keys so callers iterating without the lock are safe."""
+        from mcpgateway.plugins.framework.manager import _CachedManager
+
+        factory = _make_bare_factory()
+        factory._managers["ctx-a"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
+        factory._managers["ctx-b"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
+
+        snapshot = factory.iter_context_ids()
+        # Snapshot, not a live view — mutating the cache afterwards shouldn't touch the prior read.
+        factory._managers["ctx-c"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
+        assert set(snapshot) == {"ctx-a", "ctx-b"}
+
+
+class TestRedisExceptionBranches:
+    """Narrow tests for the Redis-transport failure branches."""
+
+    @pytest.mark.asyncio
+    async def test_read_shared_enabled_falls_back_on_client_get_exception(self):
+        """When ``client.get`` raises, ``_read_shared_enabled`` falls back to the in-memory flag."""
+        from mcpgateway.plugins.framework import _read_shared_enabled, enable_plugins
+
+        enable_plugins(True)
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=RuntimeError("broken pipe"))
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await _read_shared_enabled()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_enable_plugins_shared_returns_false_on_set_exception(self):
+        """A Redis SET that raises is downgraded to a local-only toggle change."""
+        from mcpgateway.plugins.framework import enable_plugins_shared, are_plugins_enabled
+
+        mock_client = AsyncMock()
+        mock_client.set = AsyncMock(side_effect=RuntimeError("ECONNRESET"))
+        mock_client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            ok = await enable_plugins_shared(True)
+
+        assert ok is False
+        # In-memory flag is still updated even when the Redis write blew up.
+        assert are_plugins_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_publish_invalidation_returns_false_on_client_error(self, monkeypatch):
+        """When the Redis client factory itself raises, publish bails at False."""
+        from mcpgateway.plugins import framework
+
+        async def _always_raises():
+            raise RuntimeError("no redis")
+
+        monkeypatch.setattr(framework, "_redis", _always_raises)
+        # pylint: disable=protected-access
+        result = await framework._publish_invalidation({"type": "global_toggle", "enabled": True})
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_publish_plugin_mode_change_redis_client_exception(self, monkeypatch):
+        """``_redis()`` failure still stamps the local override so the worker honours the change."""
+        from mcpgateway.plugins import framework
+
+        async def _always_raises():
+            raise RuntimeError("no redis")
+
+        monkeypatch.setattr(framework, "_redis", _always_raises)
+        framework._state.clear_local_mode_overrides()
+
+        ok = await framework.publish_plugin_mode_change("Foo", "enforce")
+        assert ok is False
+        mode, expires_at = framework._state.get_local_mode_overrides_live()["Foo"]
+        assert mode == "enforce"
+        # Local-only entries are durable (no expiry) — the operator never saw
+        # confirmation that the 24h TTL clock started.
+        assert expires_at is None
+        framework._state.clear_local_mode_overrides()
+
+    @pytest.mark.asyncio
+    async def test_get_plugin_mode_override_raises_on_client_get_exception(self):
+        """``client.get`` blowing up surfaces as ``RuntimeError`` so callers see "Redis unreachable"."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            with pytest.raises(RuntimeError, match="Redis GET failed"):
+                await get_plugin_mode_override("Foo")
+
+
+class TestFactoryAccessors:
+    """Pins on accessors whose non-trivial branches weren't otherwise exercised."""
+
+    def test_get_plugin_manager_factory_returns_live_factory(self):
+        """When a factory is set, the accessor returns it rather than ``None``."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import get_plugin_manager_factory, reset_plugin_manager_factory
+
+        sentinel = MagicMock(name="sentinel-factory")
+        framework._plugin_manager_factory = sentinel
+        try:
+            assert get_plugin_manager_factory() is sentinel
+        finally:
+            reset_plugin_manager_factory()
+
+    def test_list_configured_plugin_names_returns_config_names(self):
+        """With a live factory whose ``_base_config`` has plugins, the helper returns their names."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import list_configured_plugin_names, reset_plugin_manager_factory
+
+        fake_factory = MagicMock()
+        fake_factory._base_config = MagicMock()
+        fake_factory._base_config.plugins = [MagicMock(name="P1"), MagicMock(name="P2")]
+        fake_factory._base_config.plugins[0].name = "PluginOne"
+        fake_factory._base_config.plugins[1].name = "PluginTwo"
+
+        framework._plugin_manager_factory = fake_factory
+        try:
+            assert list_configured_plugin_names() == ["PluginOne", "PluginTwo"]
+        finally:
+            reset_plugin_manager_factory()
+
+    def test_list_configured_plugin_names_empty_without_factory(self):
+        """No factory yet → empty list (covers the early-return branch)."""
+        from mcpgateway.plugins.framework import list_configured_plugin_names, reset_plugin_manager_factory
+
+        reset_plugin_manager_factory()
+        assert list_configured_plugin_names() == []
+
+    def test_list_configured_plugin_names_empty_when_config_has_no_plugins(self):
+        """Factory present but empty ``plugins`` → empty list (guards the ``not config.plugins`` branch)."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import list_configured_plugin_names, reset_plugin_manager_factory
+
+        fake_factory = MagicMock()
+        fake_factory._base_config = MagicMock()
+        fake_factory._base_config.plugins = []
+
+        framework._plugin_manager_factory = fake_factory
+        try:
+            assert list_configured_plugin_names() == []
+        finally:
+            reset_plugin_manager_factory()
+
+
+class TestInitPluginManagerFactory:
+    """Cover the ``db_factory``-branch in ``init_plugin_manager_factory``."""
+
+    def test_uses_gateway_factory_when_db_factory_provided(self, monkeypatch):
+        """Passing a ``db_factory`` must route through ``GatewayTenantPluginManagerFactory``."""
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import init_plugin_manager_factory, reset_plugin_manager_factory
+
+        captured_kwargs: dict = {}
+
+        class _FakeGatewayFactory:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+        # Patch the lazy import site so the constructor call is our spy.
+        monkeypatch.setattr(
+            "mcpgateway.plugins.gateway_plugin_manager.GatewayTenantPluginManagerFactory",
+            _FakeGatewayFactory,
+        )
+
+        def _fake_session_local():
+            return MagicMock(name="Session")
+
+        reset_plugin_manager_factory()
+        try:
+            init_plugin_manager_factory(
+                yaml_path="does/not/matter.yaml",
+                timeout=30.0,
+                hook_policies={},
+                observability=None,
+                db_factory=_fake_session_local,
+            )
+            assert isinstance(framework._plugin_manager_factory, _FakeGatewayFactory)
+            assert captured_kwargs["yaml_path"] == "does/not/matter.yaml"
+            assert captured_kwargs["db_factory"] is _fake_session_local
+        finally:
+            reset_plugin_manager_factory()
+
+
+class TestListenerMessageValidation:
+    """Listener robustness: malformed/unknown frames must be dropped without crashing the loop."""
+
+    @pytest.mark.asyncio
+    async def test_handle_invalidation_message_drops_unknown_frame(self, caplog):
+        """A frame whose ``type`` doesn't match any discriminator is logged and ignored."""
+        import logging as _logging
+        import json as _json
+
+        from mcpgateway.plugins.framework import _handle_invalidation_message
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework"):
+            await _handle_invalidation_message({"type": "message", "data": _json.dumps({"type": "bogus_event", "payload": 1})})
+
+        assert any("unrecognised plugin invalidation frame" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_handle_invalidation_team_binding_logs_when_invalidate_team_raises(self, monkeypatch, caplog):
+        """Invalidate-team failure during pub/sub must be logged (not raised) so the listener loop survives."""
+        import logging as _logging
+        import json as _json
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import _handle_invalidation_message
+
+        fake_factory = MagicMock()
+        fake_factory.invalidate_team = AsyncMock(side_effect=RuntimeError("cache busted"))
+        monkeypatch.setattr(framework, "_plugin_manager_factory", fake_factory)
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework"):
+            await _handle_invalidation_message({"type": "message", "data": _json.dumps({"type": "team_binding_change", "team_id": "team-a"})})
+
+        assert any("team_binding_change failed" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_handle_invalidation_binding_change_logs_when_reload_raises(self, monkeypatch, caplog):
+        """Reload-tenant failure during pub/sub must be logged (not raised)."""
+        import logging as _logging
+        import json as _json
+
+        from mcpgateway.plugins import framework
+        from mcpgateway.plugins.framework import _handle_invalidation_message
+
+        fake_factory = MagicMock()
+        fake_factory.reload_tenant = AsyncMock(side_effect=RuntimeError("cache busted"))
+        monkeypatch.setattr(framework, "_plugin_manager_factory", fake_factory)
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.framework"):
+            await _handle_invalidation_message({"type": "message", "data": _json.dumps({"type": "binding_change", "context_id": "ctx-a"})})
+
+        assert any("binding_change reload failed" in rec.message for rec in caplog.records)
+
+
+class TestListenerLoopBranches:
+    """Cover the happy subscribe/listen path and the Redis-unavailable polling path."""
+
+    @pytest.mark.asyncio
+    async def test_listener_polls_when_redis_client_is_none(self, monkeypatch):
+        """When ``_redis()`` returns None, the listener sleeps and retries instead of spinning.
+
+        The listener's ``except asyncio.CancelledError`` branch breaks out of
+        the loop cleanly, so the coroutine returns rather than propagating —
+        we verify the polling sleep was hit at least once.
+        """
+        from mcpgateway.plugins import framework
+
+        monkeypatch.setattr(framework, "_redis", AsyncMock(return_value=None))
+
+        slept: list[float] = []
+
+        async def _fake_sleep(delay):
+            slept.append(delay)
+            # Let the first iteration hit ``continue`` and loop back through
+            # the while-True. Cancel on the second sleep so we've observed
+            # both branches (polling + re-enter) before bailing.
+            if len(slept) >= 2:
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr(framework.asyncio, "sleep", _fake_sleep)
+
+        await framework._plugin_invalidation_listener()
+        # Both polls use the 10 s debug-path wait.
+        assert slept == [10, 10]
+
+    @pytest.mark.asyncio
+    async def test_listener_subscribes_and_dispatches_one_message_then_cancels(self, monkeypatch):
+        """The happy subscribe → listen → dispatch → cancel path runs to completion."""
+        from mcpgateway.plugins import framework
+
+        seen: list[dict] = []
+
+        async def _fake_handle(msg):
+            seen.append(msg)
+            # End the listener via its ``except asyncio.CancelledError`` branch.
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(framework, "_handle_invalidation_message", _fake_handle)
+
+        pubsub = MagicMock()
+        pubsub.subscribe = AsyncMock()
+
+        class _Listen:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return {"type": "message", "data": "{}"}
+
+        pubsub.listen = MagicMock(return_value=_Listen())
+
+        client = MagicMock()
+        client.pubsub = MagicMock(return_value=pubsub)
+        monkeypatch.setattr(framework, "_redis", AsyncMock(return_value=client))
+
+        await framework._plugin_invalidation_listener()
+
+        pubsub.subscribe.assert_awaited_once()
+        assert len(seen) == 1

--- a/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
@@ -1,0 +1,482 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for plugin runtime management.
+
+Tests cover:
+    - Global plugin enable/disable via Redis (shared state)
+    - Per-plugin mode override via Redis
+    - Cache invalidation helpers
+    - TTL-based cache expiry in TenantPluginManagerFactory
+    - DB error fallback in get_config_from_db
+    - Wildcard binding cache invalidation
+
+All Redis interactions are mocked — no real Redis needed.
+"""
+
+# Standard
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Global enable/disable (Redis-backed)
+# ---------------------------------------------------------------------------
+
+
+class TestArePluginsEnabledShared:
+    """Tests for are_plugins_enabled_shared() — reads global toggle from Redis."""
+
+    @pytest.mark.asyncio
+    async def test_reads_true_from_redis(self):
+        """When Redis has 'true', returns True."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value="true")
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await are_plugins_enabled_shared()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_reads_false_from_redis(self):
+        """When Redis has 'false', returns False."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value="false")
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await are_plugins_enabled_shared()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_reads_bytes_from_redis(self):
+        """When Redis returns bytes (decode_responses=False), handles correctly."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=b"true")
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await are_plugins_enabled_shared()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_in_memory_when_redis_unavailable(self):
+        """When Redis client is None, falls back to in-memory _PLUGINS_ENABLED."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins
+
+        enable_plugins(True)
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            result = await are_plugins_enabled_shared()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_in_memory_when_redis_key_missing(self):
+        """When Redis key doesn't exist, falls back to in-memory flag."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins
+
+        enable_plugins(False)
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await are_plugins_enabled_shared()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_redis_exception(self):
+        """When Redis raises an exception, falls back to in-memory flag."""
+        from mcpgateway.plugins.framework import are_plugins_enabled_shared, enable_plugins
+
+        enable_plugins(True)
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", side_effect=Exception("connection refused")):
+            result = await are_plugins_enabled_shared()
+            assert result is True
+
+
+class TestEnablePluginsShared:
+    """Tests for enable_plugins_shared() — writes global toggle to Redis."""
+
+    @pytest.mark.asyncio
+    async def test_writes_true_to_redis(self):
+        """enable_plugins_shared(True) writes 'true' to Redis."""
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        mock_client = AsyncMock()
+        mock_client.set = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            await enable_plugins_shared(True)
+            mock_client.set.assert_called_once_with("plugin:global:enabled", "true")
+
+    @pytest.mark.asyncio
+    async def test_writes_false_to_redis(self):
+        """enable_plugins_shared(False) writes 'false' to Redis."""
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        mock_client = AsyncMock()
+        mock_client.set = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            await enable_plugins_shared(False)
+            mock_client.set.assert_called_once_with("plugin:global:enabled", "false")
+
+    @pytest.mark.asyncio
+    async def test_updates_in_memory_flag(self):
+        """enable_plugins_shared also updates the in-memory _PLUGINS_ENABLED flag."""
+        from mcpgateway.plugins.framework import are_plugins_enabled, enable_plugins, enable_plugins_shared
+
+        enable_plugins(True)
+        assert are_plugins_enabled() is True
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            await enable_plugins_shared(False)
+            assert are_plugins_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_survives_redis_failure(self):
+        """When Redis write fails, in-memory flag is still updated."""
+        from mcpgateway.plugins.framework import are_plugins_enabled, enable_plugins, enable_plugins_shared
+
+        enable_plugins(True)
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", side_effect=Exception("connection refused")):
+            await enable_plugins_shared(False)
+            # In-memory flag should still be updated
+            assert are_plugins_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Per-plugin mode override
+# ---------------------------------------------------------------------------
+
+
+class TestGetPluginModeOverride:
+    """Tests for get_plugin_mode_override() — reads per-plugin mode from Redis."""
+
+    @pytest.mark.asyncio
+    async def test_reads_mode_from_redis(self):
+        """Returns the mode string stored in Redis."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value="enforce")
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await get_plugin_mode_override("RateLimiterPlugin")
+            assert result == "enforce"
+            mock_client.get.assert_called_once_with("plugin:RateLimiterPlugin:mode")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_override(self):
+        """Returns None when no Redis key exists (use YAML default)."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            result = await get_plugin_mode_override("RateLimiterPlugin")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_redis_unavailable(self):
+        """Returns None when Redis client is None."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=None):
+            result = await get_plugin_mode_override("RateLimiterPlugin")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_redis_exception(self):
+        """Returns None when Redis raises an exception."""
+        from mcpgateway.plugins.framework import get_plugin_mode_override
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", side_effect=Exception("timeout")):
+            result = await get_plugin_mode_override("RateLimiterPlugin")
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: TTL cache expiry
+# ---------------------------------------------------------------------------
+
+
+class TestTTLCacheExpiry:
+    """Tests for TTL-based cache expiry in TenantPluginManagerFactory."""
+
+    @pytest.mark.asyncio
+    async def test_cache_returns_manager_within_ttl(self):
+        """Cached manager is returned when within TTL."""
+        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+
+        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
+        factory._managers = {"test::tool": (MagicMock(), time.monotonic())}
+        factory._inflight = {}
+        factory._lock = asyncio.Lock()
+        factory._cache_ttl = 30
+
+        manager = await factory.get_manager("test::tool")
+        assert manager is not None
+
+    @pytest.mark.asyncio
+    async def test_cache_evicts_after_ttl(self):
+        """Cached manager is evicted when TTL expires."""
+        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+
+        mock_manager = MagicMock()
+        # Set created_at to 60 seconds ago (TTL is 5s)
+        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
+        factory._managers = {"test::tool": (mock_manager, time.monotonic() - 60)}
+        factory._inflight = {}
+        factory._lock = asyncio.Lock()
+        factory._cache_ttl = 5
+        factory._base_config = MagicMock()
+        factory._timeout = 30
+        factory._observability = None
+        factory._hook_policies = None
+
+        # get_manager should evict the stale entry and try to rebuild
+        # Since we can't easily mock _build_manager, verify eviction happened
+        async with factory._lock:
+            entry = factory._managers.get("test::tool")
+            assert entry is not None  # Still there before get_manager
+            _, created_at = entry
+            assert (time.monotonic() - created_at) > factory._cache_ttl  # Confirms it's expired
+
+    def test_cache_ttl_default(self):
+        """Default TTL is 30 seconds."""
+        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+
+        assert TenantPluginManagerFactory.DEFAULT_CACHE_TTL == 30
+
+    def test_cache_ttl_zero_disables(self):
+        """TTL of 0 means no automatic expiry."""
+        from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory
+
+        factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
+        factory._cache_ttl = 0
+        # TTL check: self._cache_ttl > 0 — when 0, the check is skipped
+        assert factory._cache_ttl == 0
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: DB error fallback
+# ---------------------------------------------------------------------------
+
+
+class TestDBErrorFallback:
+    """Tests for get_config_from_db graceful fallback on DB errors."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_db_error(self):
+        """When DB raises an exception, returns None (uses base config)."""
+        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
+
+        factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
+        factory._db_factory = MagicMock(side_effect=Exception("connection refused"))
+
+        result = await factory.get_config_from_db("team_a::my_tool")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_invalid_context_id(self):
+        """When context_id has no separator, returns None."""
+        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
+
+        factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
+
+        result = await factory.get_config_from_db("invalid_context_id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_empty_bindings(self):
+        """When no bindings found, returns None."""
+        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
+
+        mock_session = MagicMock()
+        factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
+        factory._db_factory = MagicMock(return_value=mock_session)
+
+        with patch("mcpgateway.plugins.gateway_plugin_manager.get_bindings_for_tool", return_value=[]):
+            result = await factory.get_config_from_db("team_a::my_tool")
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Invalidation helpers
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateAllPluginManagers:
+    """Tests for invalidate_all_plugin_managers()."""
+
+    @pytest.mark.asyncio
+    async def test_evicts_all_cached_contexts(self):
+        """All cached manager contexts are evicted and rebuilt."""
+        from mcpgateway.plugins.framework import invalidate_all_plugin_managers, _plugin_manager_factory
+        import mcpgateway.plugins.framework as framework
+
+        mock_factory = AsyncMock()
+        mock_factory._lock = asyncio.Lock()
+        mock_factory._managers = {
+            "team_a::tool_1": (MagicMock(), time.monotonic()),
+            "team_a::tool_2": (MagicMock(), time.monotonic()),
+            "team_b::tool_1": (MagicMock(), time.monotonic()),
+        }
+        mock_factory.reload_tenant = AsyncMock()
+
+        original_factory = framework._plugin_manager_factory
+        framework._plugin_manager_factory = mock_factory
+        try:
+            await invalidate_all_plugin_managers()
+            assert mock_factory.reload_tenant.call_count == 3
+        finally:
+            framework._plugin_manager_factory = original_factory
+
+    @pytest.mark.asyncio
+    async def test_noop_when_factory_is_none(self):
+        """No error when factory is not initialized."""
+        import mcpgateway.plugins.framework as framework
+
+        original_factory = framework._plugin_manager_factory
+        framework._plugin_manager_factory = None
+        try:
+            await framework.invalidate_all_plugin_managers()
+            # Should not raise
+        finally:
+            framework._plugin_manager_factory = original_factory
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Pub/Sub publisher tests
+# ---------------------------------------------------------------------------
+
+
+class TestPubSubPublisher:
+    """Tests that state changes publish invalidation messages to Redis."""
+
+    @pytest.mark.asyncio
+    async def test_global_toggle_publishes_message(self):
+        """enable_plugins_shared publishes an invalidation message."""
+        from mcpgateway.plugins.framework import enable_plugins_shared
+
+        mock_client = AsyncMock()
+        mock_client.set = AsyncMock()
+        mock_client.publish = AsyncMock()
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            await enable_plugins_shared(False)
+            mock_client.publish.assert_called_once()
+            # Verify channel name
+            call_args = mock_client.publish.call_args
+            assert call_args[0][0] == "plugin:invalidation"
+            # Verify message contains toggle info
+            import json
+            msg = json.loads(call_args[0][1])
+            assert msg["type"] == "global_toggle"
+            assert msg["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_global_toggle_publish_failure_doesnt_crash(self):
+        """If publish fails, the toggle still succeeds."""
+        from mcpgateway.plugins.framework import enable_plugins_shared, are_plugins_enabled
+
+        mock_client = AsyncMock()
+        mock_client.set = AsyncMock()
+        mock_client.publish = AsyncMock(side_effect=Exception("publish failed"))
+
+        with patch("mcpgateway.utils.redis_client.get_redis_client", return_value=mock_client):
+            await enable_plugins_shared(True)
+            # Should not crash — in-memory flag updated
+            assert are_plugins_enabled() is True
+
+
+class TestPubSubSubscriber:
+    """Tests for the pub/sub invalidation listener."""
+
+    @pytest.mark.asyncio
+    async def test_subscriber_updates_flag_on_global_toggle(self):
+        """Subscriber updates in-memory flag when receiving global_toggle message."""
+        from mcpgateway.plugins.framework import _handle_invalidation_message, enable_plugins
+        import json
+
+        enable_plugins(True)
+        message = {"type": "message", "data": json.dumps({"type": "global_toggle", "enabled": False})}
+        await _handle_invalidation_message(message)
+
+        from mcpgateway.plugins.framework import are_plugins_enabled
+        assert are_plugins_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_subscriber_evicts_managers_on_mode_change(self):
+        """Subscriber evicts all cached managers when receiving mode_change message."""
+        import mcpgateway.plugins.framework as framework
+        import json
+
+        mock_factory = AsyncMock()
+        mock_factory._lock = asyncio.Lock()
+        mock_factory._managers = {"ctx1": (MagicMock(), time.monotonic())}
+        mock_factory.reload_tenant = AsyncMock()
+
+        original_factory = framework._plugin_manager_factory
+        framework._plugin_manager_factory = mock_factory
+        try:
+            message = {"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "RateLimiterPlugin", "mode": "enforce"})}
+            await framework._handle_invalidation_message(message)
+            mock_factory.reload_tenant.assert_called()
+        finally:
+            framework._plugin_manager_factory = original_factory
+
+    @pytest.mark.asyncio
+    async def test_subscriber_ignores_non_message_types(self):
+        """Subscriber ignores subscribe/unsubscribe messages."""
+        from mcpgateway.plugins.framework import _handle_invalidation_message, enable_plugins, are_plugins_enabled
+
+        enable_plugins(True)
+        # "subscribe" type messages should be ignored
+        message = {"type": "subscribe", "data": None}
+        await _handle_invalidation_message(message)
+        assert are_plugins_enabled() is True  # Unchanged
+
+    @pytest.mark.asyncio
+    async def test_subscriber_handles_malformed_message(self):
+        """Subscriber doesn't crash on malformed JSON."""
+        from mcpgateway.plugins.framework import _handle_invalidation_message, enable_plugins, are_plugins_enabled
+
+        enable_plugins(True)
+        message = {"type": "message", "data": "not valid json {{{"}
+        await _handle_invalidation_message(message)
+        assert are_plugins_enabled() is True  # Unchanged, no crash
+
+    @pytest.mark.asyncio
+    async def test_subscriber_handles_binding_change(self):
+        """Subscriber evicts specific context on binding_change message."""
+        import mcpgateway.plugins.framework as framework
+        import json
+
+        mock_factory = AsyncMock()
+        mock_factory._lock = asyncio.Lock()
+        mock_factory._managers = {
+            "team_a::tool_1": (MagicMock(), time.monotonic()),
+            "team_b::tool_1": (MagicMock(), time.monotonic()),
+        }
+        mock_factory.reload_tenant = AsyncMock()
+
+        original_factory = framework._plugin_manager_factory
+        framework._plugin_manager_factory = mock_factory
+        try:
+            message = {"type": "message", "data": json.dumps({"type": "binding_change", "context_id": "team_a::tool_1"})}
+            await framework._handle_invalidation_message(message)
+            mock_factory.reload_tenant.assert_called_once_with("team_a::tool_1")
+        finally:
+            framework._plugin_manager_factory = original_factory

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -19,7 +19,7 @@ Tests cover:
 
 # Standard
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException, status
@@ -49,7 +49,6 @@ from mcpgateway.schemas import (
 from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError
 
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -91,15 +90,28 @@ def user_ctx(db_session):
 # ---------------------------------------------------------------------------
 
 _OLG: dict = {
-    "min_chars": 0, "max_chars": 2000, "min_tokens": 0, "max_tokens": None,
-    "chars_per_token": 4, "limit_mode": "character", "strategy": "truncate",
-    "ellipsis": "\u2026", "word_boundary": False, "max_text_length": 1_000_000,
-    "max_structure_size": 10_000, "max_recursion_depth": 100,
+    "min_chars": 0,
+    "max_chars": 2000,
+    "min_tokens": 0,
+    "max_tokens": None,
+    "chars_per_token": 4,
+    "limit_mode": "character",
+    "strategy": "truncate",
+    "ellipsis": "\u2026",
+    "word_boundary": False,
+    "max_text_length": 1_000_000,
+    "max_structure_size": 10_000,
+    "max_recursion_depth": 100,
 }
 _RL: dict = {
-    "by_user": None, "by_tenant": None, "by_tool": None,
-    "algorithm": "fixed_window", "backend": "memory",
-    "redis_url": None, "redis_key_prefix": "rl", "redis_fallback": True,
+    "by_user": None,
+    "by_tenant": None,
+    "by_tool": None,
+    "algorithm": "fixed_window",
+    "backend": "memory",
+    "redis_url": None,
+    "redis_key_prefix": "rl",
+    "redis_fallback": True,
 }
 
 
@@ -657,9 +669,7 @@ class TestToolPluginBindingsRouter:
                 )
             }
         )
-        await upsert_tool_plugin_bindings(
-            request=ref_request, current_user_ctx=user_ctx, db=db_session
-        )
+        await upsert_tool_plugin_bindings(request=ref_request, current_user_ctx=user_ctx, db=db_session)
 
         with patch(
             "mcpgateway.routers.tool_plugin_bindings.reload_plugin_context",
@@ -753,3 +763,63 @@ class TestToolPluginBindingsRouter:
         assert result.total == 1
         assert result.bindings[0].team_id == "team-a"
         assert result.bindings[0].binding_reference_id == "cross-team-ref"
+
+
+class TestWildcardInvalidation:
+    """Regression pin on the wildcard branch of ``_invalidate_and_broadcast``.
+
+    When a binding's ``tool_name == "*"`` the router must sweep every cached
+    context for that team and emit a team-scoped pub/sub frame rather than a
+    per-context one — otherwise peers converge only for contexts they've
+    already built, and the new tenant-wide policy never applies to
+    not-yet-requested tools.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wildcard_binding_invalidates_team_and_broadcasts(self):
+        from mcpgateway.routers.tool_plugin_bindings import _invalidate_and_broadcast
+
+        mock_factory = MagicMock()
+        mock_factory.invalidate_team = AsyncMock()
+
+        wildcard = MagicMock()
+        wildcard.tool_name = "*"
+        wildcard.team_id = "team-a"
+        specific = MagicMock()
+        specific.tool_name = "search"
+        specific.team_id = "team-b"
+
+        with (
+            patch("mcpgateway.routers.tool_plugin_bindings.get_plugin_manager_factory", return_value=mock_factory),
+            patch("mcpgateway.routers.tool_plugin_bindings.reload_plugin_context", new_callable=AsyncMock) as mock_reload,
+            patch("mcpgateway.routers.tool_plugin_bindings.publish_binding_change", new_callable=AsyncMock) as mock_pub_ctx,
+            patch("mcpgateway.routers.tool_plugin_bindings.publish_team_binding_change", new_callable=AsyncMock) as mock_pub_team,
+        ):
+            await _invalidate_and_broadcast([wildcard, specific])
+
+        # Specific context path: reload + per-context publish.
+        mock_reload.assert_awaited_once()
+        mock_pub_ctx.assert_awaited_once()
+        # Wildcard path: factory.invalidate_team + team-scoped publish.
+        mock_factory.invalidate_team.assert_awaited_once()
+        team_arg, sep_arg = mock_factory.invalidate_team.call_args.args
+        assert team_arg == "team-a"
+        assert sep_arg  # CONTEXT_ID_SEPARATOR passed through
+        mock_pub_team.assert_awaited_once_with("team-a")
+
+    @pytest.mark.asyncio
+    async def test_wildcard_still_broadcasts_when_factory_is_none(self):
+        """Nodes where opportunistic factory init failed must still publish so healthy peers converge."""
+        from mcpgateway.routers.tool_plugin_bindings import _invalidate_and_broadcast
+
+        wildcard = MagicMock()
+        wildcard.tool_name = "*"
+        wildcard.team_id = "team-a"
+
+        with (
+            patch("mcpgateway.routers.tool_plugin_bindings.get_plugin_manager_factory", return_value=None),
+            patch("mcpgateway.routers.tool_plugin_bindings.publish_team_binding_change", new_callable=AsyncMock) as mock_pub_team,
+        ):
+            await _invalidate_and_broadcast([wildcard])
+
+        mock_pub_team.assert_awaited_once_with("team-a")

--- a/tests/unit/mcpgateway/test_admin_plugin_runtime.py
+++ b/tests/unit/mcpgateway/test_admin_plugin_runtime.py
@@ -15,9 +15,8 @@ pattern used by ``tests/unit/mcpgateway/routers/test_runtime_admin_router.py``.
 
 # Standard
 from contextlib import contextmanager
-import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException
@@ -32,30 +31,38 @@ from mcpgateway.schemas import PluginModeUpdateRequest, PluginToggleRequest
 
 @contextmanager
 def _capture_admin_logger_records():
-    """Attach a temporary handler to the ``mcpgateway.admin`` logger and yield captured records.
+    """Intercept ``admin_module.LOGGER`` calls directly and yield record-like sentinels.
 
-    We deliberately avoid ``caplog``: under ``pytest-xdist`` an earlier test in
-    the same worker may have triggered the app's lifespan, which calls
-    ``root_logger.handlers.clear()`` and wipes ``caplog``'s root-attached
-    handler. Attaching directly to the named logger is immune to that, and
-    bypasses the root level gate too (the handler's own level is NOTSET).
+    Earlier attempts attached a handler to ``logging.getLogger("mcpgateway.admin")``
+    (and before that, used ``caplog``). Both routes go through the standard
+    logging chain, which CI configurations sometimes mute via root-handler
+    clearing during lifespan, ``logger.disabled`` flips, propagation toggles,
+    or LOG_LEVEL gates. Replacing ``LOGGER`` with a spy bypasses all of that —
+    the test asserts on what the production code actually called, not on what
+    the logging machinery happened to forward.
     """
-    captured: list[logging.LogRecord] = []
+    captured: list[SimpleNamespace] = []
+    spy = MagicMock()
 
-    class _ListHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record)
+    def _record(level: str):
+        def _impl(msg, *args, **_kwargs):
+            try:
+                formatted = msg % args if args else str(msg)
+            except Exception:
+                formatted = str(msg)
+            captured.append(SimpleNamespace(level=level, message=formatted, getMessage=lambda f=formatted: f))
 
-    logger = logging.getLogger("mcpgateway.admin")
-    handler = _ListHandler(level=logging.DEBUG)
-    prior_level = logger.level
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
-    try:
+        return _impl
+
+    spy.debug.side_effect = _record("debug")
+    spy.info.side_effect = _record("info")
+    spy.warning.side_effect = _record("warning")
+    spy.error.side_effect = _record("error")
+    spy.critical.side_effect = _record("critical")
+    spy.exception.side_effect = _record("error")
+
+    with patch.object(admin_module, "LOGGER", spy):
         yield captured
-    finally:
-        logger.removeHandler(handler)
-        logger.setLevel(prior_level)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/mcpgateway/test_admin_plugin_runtime.py
+++ b/tests/unit/mcpgateway/test_admin_plugin_runtime.py
@@ -226,28 +226,27 @@ class TestToggleGlobalPluginsAdminCacheSync:
         mock_plugin_service.set_plugin_manager.assert_called_once_with(fake_manager)
 
     @pytest.mark.asyncio
-    async def test_sync_failure_does_not_mask_successful_toggle(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch, caplog):
+    async def test_sync_failure_does_not_mask_successful_toggle(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
         """The shared toggle has already committed; a failed admin-cache sync must not turn into a 500.
 
         Regression pin: before the try/except, an exception inside the sync
         block (e.g. ``set_plugin_manager`` raising on a degraded node) propagated
         up and the handler 500'd even though the global toggle was already
-        persisted.
+        persisted. We verify the handler still returns normally and that the
+        sync attempt was made (which raised internally and was swallowed).
         """
-        import logging as _logging
-
         monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
         # Force the sync step to fail mid-way. The shared toggle has already
         # been written by ``enable_plugins_shared`` at this point.
         mock_plugin_service.set_plugin_manager.side_effect = RuntimeError("cache unavailable")
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.admin"):
-            response = await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=False), request=mock_request, user=admin_user)
+        # Must not raise — the swallow-and-warn path is what makes this safe.
+        response = await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=False), request=mock_request, user=admin_user)
 
-        # Toggle itself succeeded — that's what the caller sees. The failed
-        # sync surfaces only as a WARNING.
         assert response.redis_persisted is False
-        assert any("admin-cache sync failed" in record.message for record in caplog.records)
+        # The sync path was entered (mock raised), confirming the try/except
+        # actually ran rather than the branch being skipped.
+        mock_plugin_service.set_plugin_manager.assert_called_once_with(None)
 
     @pytest.mark.asyncio
     async def test_disabling_clears_admin_cache(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
@@ -320,25 +319,31 @@ class TestAdminCacheSelfHeal:
         plugin_service.set_plugin_manager.assert_called_once_with(None)
 
     @pytest.mark.asyncio
-    async def test_sync_helper_swallows_errors_and_never_raises(self, monkeypatch, caplog):
-        """A failure inside the helper must not turn a read into a 500 — it just logs."""
-        import logging as _logging
-
+    async def test_sync_helper_swallows_errors_and_never_raises(self, monkeypatch):
+        """A failure inside the helper must not turn a read into a 500."""
         req = MagicMock()
         req.app = MagicMock()
         req.app.state = SimpleNamespace()
 
         plugin_service = MagicMock()
+        called = {"exploding": False}
 
         async def exploding(*_, **__):
+            called["exploding"] = True
             raise RuntimeError("factory unavailable")
 
         monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", exploding)
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.admin"):
-            await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
+        # Must return without raising — the try/except around the helper body
+        # is what stops a framework failure from turning into a 500.
+        await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
 
-        assert any("self-heal failed" in record.message for record in caplog.records)
+        # The exploding framework call was reached (proves we exercised the
+        # failure path rather than short-circuiting before the raise) and no
+        # state was written to either the ``app.state`` cache or the service.
+        assert called["exploding"] is True
+        assert not hasattr(req.app.state, "plugin_manager") or req.app.state.plugin_manager is None
+        plugin_service.set_plugin_manager.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_admin_plugin_runtime.py
+++ b/tests/unit/mcpgateway/test_admin_plugin_runtime.py
@@ -1,0 +1,489 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the plugin runtime admin endpoints in ``mcpgateway.admin``.
+
+Covers the deny paths CLAUDE.md requires for security-sensitive changes:
+    * missing ``admin.plugins`` permission → 403
+    * ``allow_admin_bypass=False`` branch (regression pin)
+    * Pydantic request-body validation (422 for bad payloads)
+    * unknown plugin (404)
+    * Redis-persisted flag reflects the underlying Redis outcome
+
+The endpoints are called directly so the suite runs without docker-compose
+or NGINX. ``PermissionService`` is patched via ``monkeypatch`` — the same
+pattern used by ``tests/unit/mcpgateway/routers/test_runtime_admin_router.py``.
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+from pydantic import ValidationError
+import pytest
+
+# First-Party
+import mcpgateway.admin as admin_module
+import mcpgateway.plugins.framework as fw
+from mcpgateway.schemas import PluginModeUpdateRequest, PluginToggleRequest
+
+
+@pytest.fixture(autouse=True)
+def _reset_framework_state():
+    """Clear the shared-toggle cache and wire the Redis shim for each test."""
+    # First-Party
+    from tests.utils.plugin_redis_helper import install_dynamic_redis_provider
+
+    with install_dynamic_redis_provider():
+        fw._invalidate_shared_enabled_cache()
+        fw._state.clear_local_mode_overrides()
+        yield
+        fw._invalidate_shared_enabled_cache()
+        fw._state.clear_local_mode_overrides()
+
+
+@pytest.fixture
+def admin_user():
+    return {"email": "admin@example.com", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "tests", "db": None}
+
+
+@pytest.fixture
+def non_admin_user():
+    return {"email": "user@example.com", "is_admin": False, "ip_address": "127.0.0.1", "user_agent": "tests", "db": None}
+
+
+@pytest.fixture
+def allow_admin(monkeypatch: pytest.MonkeyPatch):
+    class AllowAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return True
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", AllowAll)
+
+
+@pytest.fixture
+def deny_all(monkeypatch: pytest.MonkeyPatch):
+    class DenyAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return False
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DenyAll)
+
+
+@pytest.fixture
+def admin_bypass_denied(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so it denies only when ``allow_admin_bypass`` is False.
+
+    Pins the regression where a future contributor flips ``allow_admin_bypass=True`` —
+    admin users would then pass this deny path and the test would start failing.
+    """
+
+    class BypassSensitive:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **kwargs):
+            return bool(kwargs.get("allow_admin_bypass"))
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", BypassSensitive)
+
+
+@pytest.fixture
+def mock_request():
+    """Minimal Request stand-in whose ``app.state`` holds no plugin_manager."""
+    req = MagicMock()
+    req.app = MagicMock()
+    req.app.state = SimpleNamespace(plugin_manager=None)
+    req.headers = {}
+    return req
+
+
+@pytest.fixture
+def mock_redis_client():
+    """Return an AsyncMock Redis client that accepts ``set``/``publish`` successfully."""
+    client = AsyncMock()
+    client.set = AsyncMock()
+    client.publish = AsyncMock()
+    client.get = AsyncMock(return_value=b"false")
+    return client
+
+
+@pytest.fixture
+def mock_plugin_service(monkeypatch: pytest.MonkeyPatch):
+    """Return a mock plugin service with two known plugins and wire the configured-names helper."""
+    service = MagicMock()
+    service.set_plugin_manager = MagicMock()
+    service.get_all_plugins = MagicMock(return_value=[{"name": "RateLimiterPlugin"}, {"name": "OtherPlugin"}])
+    monkeypatch.setattr(admin_module, "get_plugin_service", lambda: service)
+    # ``update_plugin_mode`` validates against the configured plugin set rather
+    # than the live manager so freshly-disabled nodes can still pre-stage per-
+    # plugin overrides. Stub the helper here so tests exercise the real path.
+    monkeypatch.setattr("mcpgateway.plugins.framework.list_configured_plugin_names", lambda: ["RateLimiterPlugin", "OtherPlugin"])
+    return service
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/plugins — toggle_plugins_global
+# ---------------------------------------------------------------------------
+
+
+class TestToggleGlobalPluginsRBAC:
+    """Deny-path coverage for ``PUT /admin/plugins``."""
+
+    @pytest.mark.asyncio
+    async def test_denies_when_permission_service_rejects(self, deny_all, admin_user, mock_request, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginToggleRequest(enabled=True)
+        with pytest.raises(HTTPException) as exc:
+            await admin_module.toggle_plugins_global(payload=payload, request=mock_request, user=admin_user)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_denies_admin_when_bypass_disabled(self, admin_bypass_denied, admin_user, mock_request, monkeypatch):
+        """``allow_admin_bypass=False`` must not let an admin through — pins the decorator argument."""
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginToggleRequest(enabled=True)
+        with pytest.raises(HTTPException) as exc:
+            await admin_module.toggle_plugins_global(payload=payload, request=mock_request, user=admin_user)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_denies_non_admin_user(self, deny_all, non_admin_user, mock_request, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginToggleRequest(enabled=False)
+        with pytest.raises(HTTPException) as exc:
+            await admin_module.toggle_plugins_global(payload=payload, request=mock_request, user=non_admin_user)
+        assert exc.value.status_code == 403
+
+
+class TestToggleGlobalPluginsValidation:
+    """Pydantic request-body validation runs before the route handler executes."""
+
+    def test_missing_enabled_rejected(self):
+        with pytest.raises(ValidationError):
+            PluginToggleRequest()  # type: ignore[call-arg]
+
+    def test_non_bool_enabled_rejected(self):
+        # Pydantic coerces "yes"/"no" strings to bool by default; use an
+        # uncoercible value so the test pins against a future schema change.
+        with pytest.raises(ValidationError):
+            PluginToggleRequest(enabled=["bad"])  # type: ignore[arg-type]
+
+
+class TestToggleGlobalPluginsHappyPath:
+    """Verifies the endpoint surfaces the real Redis outcome to the caller."""
+
+    @pytest.mark.asyncio
+    async def test_returns_redis_persisted_true_when_redis_ok(self, allow_admin, admin_user, mock_request, mock_redis_client, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=mock_redis_client))
+        payload = PluginToggleRequest(enabled=True)
+        response = await admin_module.toggle_plugins_global(payload=payload, request=mock_request, user=admin_user)
+        assert response.redis_persisted is True
+        mock_redis_client.set.assert_awaited_once()
+        mock_redis_client.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_redis_persisted_false_when_redis_unavailable(self, allow_admin, admin_user, mock_request, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginToggleRequest(enabled=True)
+        response = await admin_module.toggle_plugins_global(payload=payload, request=mock_request, user=admin_user)
+        assert response.redis_persisted is False
+
+
+class TestToggleGlobalPluginsAdminCacheSync:
+    """Regression pins: toggling the subsystem must refresh the admin-side caches.
+
+    On a node that started with plugins disabled, ``app.state.plugin_manager``
+    stays unset and ``PluginService`` is never wired. Without this sync the
+    runtime starts serving plugins but ``/admin/plugins`` and
+    ``/admin/plugins/{name}`` read empty/stale state until restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_enabling_wires_admin_cache(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        fake_manager = MagicMock(name="fake_plugin_manager")
+        # RBAC decorator also calls ``get_plugin_manager`` and would try to
+        # invoke the permission-check hook on whatever comes back. Flip
+        # ``has_hooks_for`` off so the decorator skips it and we only exercise
+        # the admin-cache sync path here.
+        fake_manager.has_hooks_for = MagicMock(return_value=False)
+
+        async def fake_get_plugin_manager(*_, **__):
+            return fake_manager
+
+        monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", fake_get_plugin_manager)
+
+        await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=True), request=mock_request, user=admin_user)
+
+        assert mock_request.app.state.plugin_manager is fake_manager
+        mock_plugin_service.set_plugin_manager.assert_called_once_with(fake_manager)
+
+    @pytest.mark.asyncio
+    async def test_sync_failure_does_not_mask_successful_toggle(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch, caplog):
+        """The shared toggle has already committed; a failed admin-cache sync must not turn into a 500.
+
+        Regression pin: before the try/except, an exception inside the sync
+        block (e.g. ``set_plugin_manager`` raising on a degraded node) propagated
+        up and the handler 500'd even though the global toggle was already
+        persisted.
+        """
+        import logging as _logging
+
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        # Force the sync step to fail mid-way. The shared toggle has already
+        # been written by ``enable_plugins_shared`` at this point.
+        mock_plugin_service.set_plugin_manager.side_effect = RuntimeError("cache unavailable")
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.admin"):
+            response = await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=False), request=mock_request, user=admin_user)
+
+        # Toggle itself succeeded — that's what the caller sees. The failed
+        # sync surfaces only as a WARNING.
+        assert response.redis_persisted is False
+        assert any("admin-cache sync failed" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_disabling_clears_admin_cache(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        """The inverse path: disabling must detach the manager so stale metadata doesn't keep serving."""
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        # Pre-populate with something so we can assert it gets cleared.
+        mock_request.app.state.plugin_manager = MagicMock(name="stale_manager")
+
+        await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=False), request=mock_request, user=admin_user)
+
+        assert mock_request.app.state.plugin_manager is None
+        mock_plugin_service.set_plugin_manager.assert_called_once_with(None)
+
+
+class TestAdminCacheSelfHeal:
+    """Regression pin for ``_sync_plugin_service_from_runtime`` — admin reads must self-heal.
+
+    If ``toggle_plugins_global`` ever swallowed a sync failure (degraded factory,
+    transient error) and left ``app.state.plugin_manager`` unset, the admin GETs
+    would render stale/empty forever without this fallback. Pinning it here
+    prevents a future refactor from silently deleting the helper.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sync_helper_populates_from_framework_when_app_state_missing(self, monkeypatch):
+        """The helper must hydrate ``app.state`` and ``plugin_service`` from ``get_plugin_manager`` when ``app.state`` is empty."""
+        req = MagicMock()
+        req.app = MagicMock()
+        req.app.state = SimpleNamespace()  # deliberately no ``plugin_manager`` attr
+
+        plugin_service = MagicMock()
+        plugin_service.set_plugin_manager = MagicMock()
+
+        fake_manager = MagicMock(name="live_manager")
+
+        async def fake_get_plugin_manager(*_, **__):
+            return fake_manager
+
+        monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", fake_get_plugin_manager)
+
+        await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
+
+        assert req.app.state.plugin_manager is fake_manager
+        plugin_service.set_plugin_manager.assert_called_once_with(fake_manager)
+
+    @pytest.mark.asyncio
+    async def test_sync_helper_clears_cache_on_remote_global_disable(self, monkeypatch):
+        """Remote-disable regression pin: if another node flipped the shared toggle off, this node must drop its stale cache.
+
+        Before the fix, the helper only hydrated ``app.state`` when it was
+        empty, so a prior enable left a live-looking manager there and admin
+        reads kept serving plugin metadata the cluster had turned off.
+        """
+        req = MagicMock()
+        req.app = MagicMock()
+        # Simulate a prior enable: cache populated with a now-stale manager.
+        req.app.state = SimpleNamespace(plugin_manager=MagicMock(name="stale_manager"))
+
+        plugin_service = MagicMock()
+
+        async def fake_get_plugin_manager(*_, **__):
+            # Framework returns None because the shared toggle is now ``false``.
+            return None
+
+        monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", fake_get_plugin_manager)
+
+        await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
+
+        assert req.app.state.plugin_manager is None
+        plugin_service.set_plugin_manager.assert_called_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_sync_helper_swallows_errors_and_never_raises(self, monkeypatch, caplog):
+        """A failure inside the helper must not turn a read into a 500 — it just logs."""
+        import logging as _logging
+
+        req = MagicMock()
+        req.app = MagicMock()
+        req.app.state = SimpleNamespace()
+
+        plugin_service = MagicMock()
+
+        async def exploding(*_, **__):
+            raise RuntimeError("factory unavailable")
+
+        monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", exploding)
+
+        with caplog.at_level(_logging.WARNING, logger="mcpgateway.admin"):
+            await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
+
+        assert any("self-heal failed" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/plugins/{name} — update_plugin_mode
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePluginModeRBAC:
+    """Deny-path coverage for ``PUT /admin/plugins/{name}``."""
+
+    @pytest.mark.asyncio
+    async def test_denies_without_permission(self, deny_all, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginModeUpdateRequest(mode="enforce")
+        with pytest.raises(HTTPException) as exc:
+            await admin_module.update_plugin_mode(
+                name="RateLimiterPlugin",
+                payload=payload,
+                user=admin_user,
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_denies_admin_when_bypass_disabled(self, admin_bypass_denied, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginModeUpdateRequest(mode="enforce")
+        with pytest.raises(HTTPException) as exc:
+            await admin_module.update_plugin_mode(
+                name="RateLimiterPlugin",
+                payload=payload,
+                user=admin_user,
+            )
+        assert exc.value.status_code == 403
+
+
+class TestUpdatePluginModeValidation:
+    """Pydantic rejects unsupported mode values before the handler runs."""
+
+    @pytest.mark.parametrize("bad_mode", ["off", "PERMISSIVE", "", None, 123])
+    def test_invalid_mode_rejected(self, bad_mode):
+        with pytest.raises(ValidationError):
+            PluginModeUpdateRequest(mode=bad_mode)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("good_mode", ["enforce", "enforce_ignore_error", "permissive", "disabled"])
+    def test_valid_modes_accepted(self, good_mode):
+        body = PluginModeUpdateRequest(mode=good_mode)
+        assert body.mode == good_mode
+
+
+class TestUpdatePluginModeConfiguredValidation:
+    """Regression pin: validation reads the configured plugin set, not the live manager.
+
+    On a node that booted with plugins globally disabled, ``PluginService`` has
+    no wired manager and ``get_all_plugins()`` returns ``[]``. Before this fix
+    that made the endpoint 404 for every valid plugin name, blocking operators
+    from pre-staging a mode override before turning the subsystem on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_accepts_configured_plugin_when_manager_unwired(self, allow_admin, admin_user, mock_request, mock_redis_client, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=mock_redis_client))
+
+        # Simulate a freshly disabled node: no live manager, so the plugin
+        # service returns an empty list — but the factory still loaded the
+        # YAML config at startup, so the configured names helper is populated.
+        stub_service = MagicMock()
+        stub_service.get_all_plugins = MagicMock(return_value=[])
+        monkeypatch.setattr(admin_module, "get_plugin_service", lambda: stub_service)
+        monkeypatch.setattr("mcpgateway.plugins.framework.list_configured_plugin_names", lambda: ["PreStagePlugin"])
+
+        response = await admin_module.update_plugin_mode(
+            name="PreStagePlugin",
+            payload=PluginModeUpdateRequest(mode="permissive"),
+            user=admin_user,
+        )
+        assert response.plugin == "PreStagePlugin"
+        assert response.mode == "permissive"
+
+
+class TestUpdatePluginModeHandler:
+    """End-to-end behaviour of the handler when RBAC allows."""
+
+    @pytest.mark.asyncio
+    async def test_404_on_unknown_plugin(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginModeUpdateRequest(mode="enforce")
+        with pytest.raises(HTTPException) as exc:
+            await admin_module.update_plugin_mode(
+                name="NotARealPlugin",
+                payload=payload,
+                user=admin_user,
+            )
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_reports_redis_persisted_true(self, allow_admin, admin_user, mock_request, mock_plugin_service, mock_redis_client, monkeypatch):
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=mock_redis_client))
+        payload = PluginModeUpdateRequest(mode="permissive")
+        response = await admin_module.update_plugin_mode(
+            name="RateLimiterPlugin",
+            payload=payload,
+            user=admin_user,
+        )
+        assert response.plugin == "RateLimiterPlugin"
+        assert response.mode == "permissive"
+        assert response.redis_persisted is True
+        # Redis SET carries the 24h TTL — regression pin so a refactor can't drop ``ex=``.
+        call = mock_redis_client.set.call_args
+        assert call.kwargs.get("ex") == 86400 or (len(call.args) >= 3 and call.args[2] == 86400)
+        mock_redis_client.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_single_node_no_redis_applies_override_locally(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        """On Redis-less deployments the override lands in the in-process map; response signals redis_persisted=False."""
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+        payload = PluginModeUpdateRequest(mode="disabled")
+        response = await admin_module.update_plugin_mode(
+            name="RateLimiterPlugin",
+            payload=payload,
+            user=admin_user,
+        )
+        assert response.redis_persisted is False
+        assert response.mode == "disabled"
+        # The local override map now holds the change — this is what makes the
+        # "local fallback" real: _apply_redis_mode_overrides will pick it up on
+        # the next manager rebuild.
+        assert fw.get_local_mode_overrides()["RateLimiterPlugin"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_redis_set_failure_still_applies_locally(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
+        """A Redis SET transport failure still lands the override locally; publish must not run."""
+        failing_client = AsyncMock()
+        failing_client.set = AsyncMock(side_effect=Exception("ECONNREFUSED"))
+        failing_client.publish = AsyncMock()
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=failing_client))
+
+        payload = PluginModeUpdateRequest(mode="enforce")
+        response = await admin_module.update_plugin_mode(
+            name="RateLimiterPlugin",
+            payload=payload,
+            user=admin_user,
+        )
+        assert response.redis_persisted is False
+        assert response.mode == "enforce"
+        assert fw.get_local_mode_overrides()["RateLimiterPlugin"] == "enforce"
+        # Publish must not run when the SET itself failed — prevents broadcasting
+        # an override that isn't in Redis yet.
+        failing_client.publish.assert_not_awaited()

--- a/tests/unit/mcpgateway/test_admin_plugin_runtime.py
+++ b/tests/unit/mcpgateway/test_admin_plugin_runtime.py
@@ -14,6 +14,8 @@ pattern used by ``tests/unit/mcpgateway/routers/test_runtime_admin_router.py``.
 """
 
 # Standard
+from contextlib import contextmanager
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -26,6 +28,34 @@ import pytest
 import mcpgateway.admin as admin_module
 import mcpgateway.plugins.framework as fw
 from mcpgateway.schemas import PluginModeUpdateRequest, PluginToggleRequest
+
+
+@contextmanager
+def _capture_admin_logger_records():
+    """Attach a temporary handler to the ``mcpgateway.admin`` logger and yield captured records.
+
+    We deliberately avoid ``caplog``: under ``pytest-xdist`` an earlier test in
+    the same worker may have triggered the app's lifespan, which calls
+    ``root_logger.handlers.clear()`` and wipes ``caplog``'s root-attached
+    handler. Attaching directly to the named logger is immune to that, and
+    bypasses the root level gate too (the handler's own level is NOTSET).
+    """
+    captured: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    logger = logging.getLogger("mcpgateway.admin")
+    handler = _ListHandler(level=logging.DEBUG)
+    prior_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield captured
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prior_level)
 
 
 @pytest.fixture(autouse=True)
@@ -232,21 +262,25 @@ class TestToggleGlobalPluginsAdminCacheSync:
         Regression pin: before the try/except, an exception inside the sync
         block (e.g. ``set_plugin_manager`` raising on a degraded node) propagated
         up and the handler 500'd even though the global toggle was already
-        persisted. We verify the handler still returns normally and that the
-        sync attempt was made (which raised internally and was swallowed).
+        persisted. We also pin the swallow-and-warn log path so a future
+        refactor that drops the log can't silently strand operators.
         """
         monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
         # Force the sync step to fail mid-way. The shared toggle has already
         # been written by ``enable_plugins_shared`` at this point.
         mock_plugin_service.set_plugin_manager.side_effect = RuntimeError("cache unavailable")
 
-        # Must not raise — the swallow-and-warn path is what makes this safe.
-        response = await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=False), request=mock_request, user=admin_user)
+        # Attach directly to the admin module's LOGGER — pytest's ``caplog``
+        # lives on root and is lost if any earlier test's lifespan ran
+        # ``root_logger.handlers.clear()``. A logger-local handler survives.
+        with _capture_admin_logger_records() as records:
+            response = await admin_module.toggle_plugins_global(payload=PluginToggleRequest(enabled=False), request=mock_request, user=admin_user)
 
         assert response.redis_persisted is False
-        # The sync path was entered (mock raised), confirming the try/except
-        # actually ran rather than the branch being skipped.
+        # The sync path was entered (mock raised), and the swallow path logged
+        # the admin-cache-sync failure warning.
         mock_plugin_service.set_plugin_manager.assert_called_once_with(None)
+        assert any("admin-cache sync failed" in record.getMessage() for record in records)
 
     @pytest.mark.asyncio
     async def test_disabling_clears_admin_cache(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
@@ -320,7 +354,7 @@ class TestAdminCacheSelfHeal:
 
     @pytest.mark.asyncio
     async def test_sync_helper_swallows_errors_and_never_raises(self, monkeypatch):
-        """A failure inside the helper must not turn a read into a 500."""
+        """A failure inside the helper must not turn a read into a 500 — and must log."""
         req = MagicMock()
         req.app = MagicMock()
         req.app.state = SimpleNamespace()
@@ -335,15 +369,16 @@ class TestAdminCacheSelfHeal:
         monkeypatch.setattr("mcpgateway.plugins.framework.get_plugin_manager", exploding)
 
         # Must return without raising — the try/except around the helper body
-        # is what stops a framework failure from turning into a 500.
-        await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
+        # is what stops a framework failure from turning into a 500. We also
+        # pin the warning log (via a logger-local handler, see note above)
+        # so the operator signal isn't quietly dropped.
+        with _capture_admin_logger_records() as records:
+            await admin_module._sync_plugin_service_from_runtime(req, plugin_service)
 
-        # The exploding framework call was reached (proves we exercised the
-        # failure path rather than short-circuiting before the raise) and no
-        # state was written to either the ``app.state`` cache or the service.
         assert called["exploding"] is True
         assert not hasattr(req.app.state, "plugin_manager") or req.app.state.plugin_manager is None
         plugin_service.set_plugin_manager.assert_not_called()
+        assert any("self-heal failed" in record.getMessage() for record in records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_admin_plugin_runtime.py
+++ b/tests/unit/mcpgateway/test_admin_plugin_runtime.py
@@ -491,6 +491,31 @@ class TestUpdatePluginModeHandler:
         mock_redis_client.publish.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_invalidate_failure_logged_not_raised(self, allow_admin, admin_user, mock_request, mock_plugin_service, mock_redis_client, monkeypatch):
+        """``invalidate_all_plugin_managers`` raising must become a WARNING, not a 500.
+
+        The override is already stored by ``publish_plugin_mode_change`` at this
+        point — a cache-sweep failure would strand operators without this pin.
+        """
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=mock_redis_client))
+
+        async def _fail_invalidate():
+            raise RuntimeError("cache sweep blew up")
+
+        monkeypatch.setattr("mcpgateway.plugins.framework.invalidate_all_plugin_managers", _fail_invalidate)
+
+        with _capture_admin_logger_records() as records:
+            response = await admin_module.update_plugin_mode(
+                name="RateLimiterPlugin",
+                payload=PluginModeUpdateRequest(mode="permissive"),
+                user=admin_user,
+            )
+
+        assert response.plugin == "RateLimiterPlugin"
+        assert response.mode == "permissive"
+        assert any("cache invalidation failed" in record.getMessage() for record in records)
+
+    @pytest.mark.asyncio
     async def test_single_node_no_redis_applies_override_locally(self, allow_admin, admin_user, mock_request, mock_plugin_service, monkeypatch):
         """On Redis-less deployments the override lands in the in-process map; response signals redis_persisted=False."""
         monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -4856,6 +4856,130 @@ class TestLifespanAdvanced:
 
         assert excinfo.value.code == 1
 
+    async def _prepare_lifespan_stubs(self, monkeypatch, *, plugins_enabled: bool) -> None:
+        """Install the minimal set of stubs needed for ``lifespan`` to reach the plugin-init try/except."""
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        def make_service():  # noqa: ANN001
+            service = MagicMock()
+            service.initialize = AsyncMock()
+            service.shutdown = AsyncMock()
+            return service
+
+        for flag, value in (
+            ("mcpgateway_session_affinity_enabled", False),
+            ("enable_header_passthrough", False),
+            ("mcpgateway_tool_cancellation_enabled", False),
+            ("mcpgateway_elicitation_enabled", False),
+            ("metrics_buffer_enabled", False),
+            ("metrics_cleanup_enabled", False),
+            ("metrics_rollup_enabled", False),
+            ("sso_enabled", False),
+            ("metrics_aggregation_enabled", False),
+        ):
+            monkeypatch.setattr(main_mod.settings, flag, value)
+        # ``settings.plugins.enabled`` is a property that reads ``PLUGINS_ENABLED``
+        # as the authoritative override — set it directly rather than patching.
+        monkeypatch.setenv("PLUGINS_ENABLED", "true" if plugins_enabled else "false")
+
+        logging_service = make_service()
+        logging_service.configure_uvicorn_after_startup = MagicMock()
+        monkeypatch.setattr(main_mod, "logging_service", logging_service)
+
+        for attr in (
+            "tool_service",
+            "resource_service",
+            "prompt_service",
+            "gateway_service",
+            "root_service",
+            "completion_service",
+            "sampling_handler",
+            "resource_cache",
+            "streamable_http_session",
+            "session_registry",
+            "export_service",
+            "import_service",
+        ):
+            monkeypatch.setattr(main_mod, attr, make_service())
+        monkeypatch.setattr(main_mod, "a2a_service", None)
+
+        monkeypatch.setattr(main_mod, "get_redis_client", AsyncMock())
+        monkeypatch.setattr(main_mod, "close_redis_client", AsyncMock())
+        monkeypatch.setattr("mcpgateway.routers.llmchat_router.init_redis", AsyncMock())
+        monkeypatch.setattr(main_mod, "init_telemetry", MagicMock())
+        monkeypatch.setattr(main_mod, "validate_security_configuration", MagicMock())
+        monkeypatch.setattr("mcpgateway.services.http_client_service.SharedHttpClient.get_instance", AsyncMock())
+        monkeypatch.setattr("mcpgateway.services.http_client_service.SharedHttpClient.shutdown", AsyncMock())
+
+        subscriber = MagicMock()
+        subscriber.start = AsyncMock()
+        subscriber.stop = AsyncMock()
+        # First-Party
+        import mcpgateway.cache.registry_cache as registry_cache_mod
+
+        monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
+        monkeypatch.setattr(main_mod, "get_plugin_manager", AsyncMock(return_value=None))
+        monkeypatch.setattr(main_mod, "shutdown_plugin_manager_factory", AsyncMock())
+        monkeypatch.setattr(main_mod, "start_plugin_invalidation_listener", AsyncMock())
+        monkeypatch.setattr(main_mod, "stop_plugin_invalidation_listener", AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_lifespan_raises_when_init_factory_fails_and_plugins_enabled(self, monkeypatch):
+        """Plugins explicitly enabled + factory init failure must loud-crash, not silently degrade."""
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        await self._prepare_lifespan_stubs(monkeypatch, plugins_enabled=True)
+        # The lifespan's outer handler converts errors whose message contains
+        # "Plugin initialization failed" to a clean ``SystemExit(1)``; matching
+        # that phrasing pins the "operator-meaningful crash" path.
+        monkeypatch.setattr(
+            main_mod,
+            "init_plugin_manager_factory",
+            MagicMock(side_effect=RuntimeError("Plugin initialization failed: bad YAML")),
+        )
+
+        with pytest.raises(SystemExit):
+            async with main_mod.lifespan(main_mod.app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_lifespan_marks_degraded_when_init_factory_fails_and_plugins_disabled(self, monkeypatch):
+        """Plugins disabled but opportunistic init fails → gateway still boots, node is marked degraded."""
+        # First-Party
+        import mcpgateway.main as main_mod
+        from mcpgateway.plugins.framework import _state as plugin_state
+
+        await self._prepare_lifespan_stubs(monkeypatch, plugins_enabled=False)
+        monkeypatch.setattr(main_mod, "init_plugin_manager_factory", MagicMock(side_effect=RuntimeError("bad YAML")))
+
+        # pylint: disable=protected-access
+        plugin_state._reset_factory_init_degraded_for_tests()
+
+        async with main_mod.lifespan(main_mod.app):
+            pass
+
+        # The degraded flag must now be set so ``get_plugin_manager`` will emit
+        # its one-shot ERROR when a shared-toggle flip asks for plugins.
+        assert plugin_state.is_factory_init_degraded() is True
+        plugin_state._reset_factory_init_degraded_for_tests()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_swallows_stop_listener_exception(self, monkeypatch):
+        """``stop_plugin_invalidation_listener`` raising during shutdown must not crash lifespan teardown."""
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        await self._prepare_lifespan_stubs(monkeypatch, plugins_enabled=False)
+        # Keep startup clean so we actually reach the shutdown block.
+        monkeypatch.setattr(main_mod, "init_plugin_manager_factory", MagicMock())
+        monkeypatch.setattr(main_mod, "stop_plugin_invalidation_listener", AsyncMock(side_effect=RuntimeError("stop blew up")))
+
+        # Must not raise — the shutdown block swallows and DEBUG-logs.
+        async with main_mod.lifespan(main_mod.app):
+            pass
+
     @pytest.mark.asyncio
     async def test_shutdown_services_continues_on_exception(self):
         """Cover shutdown_services exception logging branch."""

--- a/tests/utils/plugin_redis_helper.py
+++ b/tests/utils/plugin_redis_helper.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Test-only helper that wires the framework's Redis shim to the real provider.
+
+Production sets up ``mcpgateway.plugins.framework._redis`` during FastAPI
+lifespan. Unit tests don't run lifespan, so without explicit wiring every
+``_redis()`` call in the framework returns ``None`` and mocked Redis clients
+never get reached. This helper installs a dynamic provider that re-reads
+``get_redis_client`` from ``mcpgateway.utils.redis_client`` on every call —
+capturing the reference at registration time would bind the pre-patch
+function and defeat ``monkeypatch``/``patch`` in tests.
+
+Usage:
+    from tests.unit.mcpgateway.plugins._redis_test_helper import install_dynamic_redis_provider
+
+    with install_dynamic_redis_provider():
+        ...  # test body, can monkeypatch ``mcpgateway.utils.redis_client.get_redis_client``
+"""
+
+from contextlib import contextmanager
+
+from mcpgateway.plugins.framework._redis import set_shared_redis_provider
+
+
+async def _dynamic_get_redis_client():
+    # First-Party — import on every call so monkeypatch of the module attr works.
+    from mcpgateway.utils import redis_client as _rc  # pylint: disable=import-outside-toplevel
+
+    return await _rc.get_redis_client()
+
+
+@contextmanager
+def install_dynamic_redis_provider():
+    """Register the test provider for the duration of the context."""
+    set_shared_redis_provider(_dynamic_get_redis_client)
+    try:
+        yield
+    finally:
+        set_shared_redis_provider(None)


### PR DESCRIPTION
## Summary

Adds runtime plugin management capabilities to ContextForge — enabling global plugin enable/disable, per-plugin mode changes, and cross-worker/cross-pod state propagation via Redis pub/sub. Previously, plugin configuration was static (YAML loaded at startup) and changes required pod restarts.

The dynamic plugin configuration and per-tool bindings added in #4068 / #4143 built the data layer and single-worker runtime. This PR closes the multi-instance gaps by adding Redis-backed shared state, pub/sub-driven instant invalidation, TTL-based cache refresh as a safety net, and the missing API endpoints.

New endpoints:
- `PUT /admin/plugins` — global enable/disable (writes to Redis, broadcasts via pub/sub)
- `PUT /admin/plugins/{name}` — per-plugin mode change (enforce/enforce_ignore_error/permissive/disabled)
- `GET /admin/plugins` — now includes `plugins_globally_enabled` field from runtime state

Both endpoints use Pydantic request/response models (`PluginToggleRequest`, `PluginModeUpdateResponse`, etc.) for typed validation instead of raw dict parsing.

Related issues: #4276 (gap analysis), #4230 (testing plan)

---

## Gaps closed

### HIGH — Multi-instance propagation and missing features

**Gap 1 (HIGH)** — Cache invalidation per-worker only: `reload_plugin_context()` evicted cache in one Gunicorn worker only. Other workers in the same pod and all workers in other pods kept stale config indefinitely. Fixed with Redis pub/sub for instant cross-worker/cross-pod cache eviction, with TTL-based cache refresh (default 30s) as a safety net if pub/sub messages are missed.

**Gap 2 (HIGH)** — Wildcard binding invalidation mismatch: Upsert of `tool_name="*"` created context_id `"team::*"` but tools requested `"team::my_tool"`. Eviction was a no-op — team-wide policies never propagated. Fixed with `factory.invalidate_team()` that evicts ALL cached contexts for the team locally, plus a `team_binding_change` pub/sub message that triggers the same eviction on all remote workers.

**Gap 3 (HIGH)** — No cross-pod state propagation: Pods were completely isolated. A binding change on pod A was invisible to pods B and C forever. Fixed with Redis pub/sub channel `plugin:invalidation` carrying four typed message types (`global_toggle`, `mode_change`, `binding_change`, `team_binding_change`). The pub/sub listener is wired into the FastAPI lifespan with exponential backoff + jitter on reconnect.

**Gap 4 (HIGH)** — No global plugin toggle in shared store: `_PLUGINS_ENABLED` was a per-process Python global. Fixed with `PUT /admin/plugins` that writes to Redis (`plugin:global:enabled`). Workers check a 2-second in-memory cache (invalidated instantly by pub/sub) instead of hitting Redis per request.

**Gap 5 (HIGH)** — No per-plugin mode change via API: Could not switch a plugin from `permissive` to `enforce` globally at runtime. Fixed with `PUT /admin/plugins/{name}` that stores mode in Redis (`plugin:{name}:mode`, 24h TTL), broadcasts a `mode_change` pub/sub message, and maintains an in-process `_local_mode_overrides` dict so single-node deployments work without Redis.

**Gap 6 (HIGH)** — `GET /admin/plugins` didn't reflect runtime state: Returned YAML boot-time config. Fixed by reading `plugins_globally_enabled` from Redis. The response now shows actual runtime state.

**Gap 7 (HIGH)** — No TTL on plugin manager cache: `self._managers` dict had no expiry — stale config was permanent until worker restart. Fixed with configurable TTL (default 30s) on `TenantPluginManagerFactory`. Managers older than TTL are automatically evicted and rebuilt from DB. Cache entries use a frozen `_CachedManager` dataclass with an `.is_expired()` method.

### MEDIUM — Resilience and observability

**Gap 8 (MEDIUM)** — DB error kills manager build: If Postgres was briefly unavailable during `get_config_from_db()`, the exception propagated and tool invocations failed. Fixed by re-raising the error so the build fails loudly — this prevents silently dropping per-team security plugin bindings (rate limiter, PII filter) that would otherwise fall back to the permissive YAML defaults. The caller retries on the next request or cache TTL expiry.

**Gap 9 (MEDIUM)** — `_PLUGINS_ENABLED` not checked per-request: Once a manager was cached, the global flag wasn't rechecked. Fixed by checking a 2-second in-memory cache of the shared toggle on every `get_plugin_manager()` call. The cache is invalidated instantly by pub/sub, so the 2s TTL is only the worst-case bound when pub/sub is down.

**Gap 10 (MEDIUM)** — Concurrent upserts race on reload: Mitigated via TTL — even if invalidation is missed due to a race, the stale manager is rebuilt within 30s.

**Gap 11 (MEDIUM)** — `__global__` context never reloaded: Default context for HTTP middleware hooks was cached once. Now auto-refreshes via TTL, and `invalidate_all_plugin_managers()` includes it in the eviction sweep.

### LOW — Documentation and observability

**Gap 12 (LOW)** — No audit trail for runtime changes: Added structured logging for global toggle and per-plugin mode changes (user, action, timestamp, `redis_persisted` status).

**Gap 13 (LOW)** — No multi-instance caveats in docs: Updated `plugin-bindings-api.md` — cache invalidation is pub/sub-driven (instant) with TTL fallback (30s default), wildcard eviction behaviour documented.

**Gap 14 (LOW)** — No logging for missing team/tool bindings: Added `logger.debug` for empty binding lookups and `logger.error` (with `exc_info`) for DB errors.

---

## Architecture

### Before: per-process plugin state (no shared state)

```text
┌──────────────────────────────────────────────────────────────────────┐
│  Pod A                                                                │
│                                                                       │
│  ┌─────────────────────┐  ┌─────────────────────┐                    │
│  │  Gunicorn Worker 1   │  │  Gunicorn Worker 2   │                    │
│  │                      │  │                      │                    │
│  │  _PLUGINS_ENABLED    │  │  _PLUGINS_ENABLED    │                    │
│  │  = True (in-memory)  │  │  = True (in-memory)  │                    │
│  │                      │  │                      │                    │
│  │  _managers: {        │  │  _managers: {        │                    │
│  │    "team::tool": mgr │  │    "team::tool": mgr │  ← separate copy  │
│  │  }  (no TTL)         │  │  }  (no TTL)         │                    │
│  └──────────┬───────────┘  └──────────────────────┘                    │
│             │ API call lands here                                      │
│             ▼                                                          │
│  PUT /v1/tools/plugin_bindings                                        │
│    1. Write binding to DB            ✓                                │
│    2. reload_plugin_context()        ✓ (Worker 1 only)                │
│    3. Worker 2 notified?             ✗ (stale forever)                │
│                                                                       │
└──────────────────────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────────────────────┐
│  Pod B                                                                │
│                                                                       │
│  ┌─────────────────────┐  ┌─────────────────────┐                    │
│  │  Gunicorn Worker 1   │  │  Gunicorn Worker 2   │                    │
│  │                      │  │                      │                    │
│  │  _managers: {        │  │  _managers: {        │                    │
│  │    "team::tool": mgr │  │    "team::tool": mgr │  ← stale forever  │
│  │  }                   │  │  }                   │                    │
│  └──────────────────────┘  └──────────────────────┘                    │
│                                                                       │
│  Pod B has no knowledge of binding changes on Pod A.                  │
│  No IPC, no shared cache, no pub/sub.                                 │
│                                                                       │
└──────────────────────────────────────────────────────────────────────┘

Problems:
  ✗ Binding change only affects 1 of N workers in 1 of M pods
  ✗ Wildcard binding ("*") evicts "team::*" but tools use "team::my_tool" — no-op
  ✗ No global enable/disable API
  ✗ No TTL — stale managers cached permanently
  ✗ GET /admin/plugins shows YAML boot-time config, not runtime state
```

### After: Redis-backed shared state with pub/sub + TTL fallback

```text
┌──────────────────────────────────────────────────────────────────────┐
│  Pod A                                                                │
│                                                                       │
│  ┌──────────────────────────┐  ┌──────────────────────────┐          │
│  │  Gunicorn Worker 1        │  │  Gunicorn Worker 2        │          │
│  │                           │  │                           │          │
│  │  ┌─ Pub/sub listener ──┐ │  │  ┌─ Pub/sub listener ──┐ │          │
│  │  │  SUBSCRIBE           │ │  │  │  SUBSCRIBE           │ │          │
│  │  │  plugin:invalidation │ │  │  │  plugin:invalidation │ │          │
│  │  │  (lifespan-managed)  │ │  │  │  (lifespan-managed)  │ │          │
│  │  │  Reconnect: exp.     │ │  │  │  Reconnect: exp.     │ │          │
│  │  │  backoff + jitter    │ │  │  │  backoff + jitter    │ │          │
│  │  │  On message:         │ │  │  │  On message:         │ │          │
│  │  │   → evict cache      │ │  │  │   → evict cache      │ │          │
│  │  │   → update flag      │ │  │  │   → update flag      │ │          │
│  │  │   → mirror to local  │ │  │  │   → mirror to local  │ │          │
│  │  │     overrides dict   │ │  │  │     overrides dict   │ │          │
│  │  └──────────────────────┘ │  │  └──────────────────────┘ │          │
│  │                           │  │                           │          │
│  │  get_plugin_manager       │  │  get_plugin_manager       │          │
│  │    │                      │  │    │                      │          │
│  │    ├─ 2s cached toggle    │  │    ├─ 2s cached toggle    │          │
│  │    │  (invalidated by     │  │    │  (invalidated by     │          │
│  │    │   pub/sub instantly) │  │    │   pub/sub instantly) │          │
│  │    │                      │  │    │                      │          │
│  │    └─ Check TTL on cache  │  │    └─ Check TTL on cache  │          │
│  │       (30s safety net)    │  │       (30s safety net)    │          │
│  │                           │  │                           │          │
│  │  _local_mode_overrides    │  │  _local_mode_overrides    │          │
│  │    (in-process fallback   │  │    (in-process fallback   │          │
│  │     for no-Redis deploy)  │  │     for no-Redis deploy)  │          │
│  └──────────┬────────────────┘  └───────────────────────────┘          │
│             │                                                          │
│             ▼                                                          │
│  PUT /admin/plugins {"enabled": false}                                │
│    1. Write to Redis: plugin:global:enabled = "false"            ✓   │
│    2. PUBLISH {type: global_toggle, enabled: false}              ✓   │
│    3. All workers receive pub/sub → update flag + drop cache     ✓   │
│    4. 2s cached toggle ensures no Redis call per request         ✓   │
│                                                                       │
│  PUT /admin/plugins/RateLimiterPlugin {"mode": "enforce"}             │
│    1. Update _local_mode_overrides (instant, this worker)        ✓   │
│    2. Write to Redis: plugin:RateLimiterPlugin:mode (24h TTL)    ✓   │
│    3. PUBLISH {type: mode_change, plugin, mode, ttl_seconds}     ✓   │
│    4. All workers receive pub/sub → mirror to local overrides    ✓   │
│    5. Invalidate all cached managers → rebuild with new mode     ✓   │
│    6. If Redis is down: local override still works (this worker) ✓   │
│                                                                       │
│  PUT/DELETE /v1/tools/plugin_bindings                                 │
│    All three handlers (upsert, delete-by-ref, delete-by-UUID)        │
│    funnel through _invalidate_and_broadcast(bindings):                │
│                                                                       │
│    Wildcard (tool_name="*"):                                          │
│      1. Write to DB                                              ✓   │
│      2. factory.invalidate_team(team_id) — all team contexts     ✓   │
│      3. PUBLISH {type: team_binding_change, team_id}             ✓   │
│                                                                       │
│    Specific tool:                                                     │
│      1. Write to DB                                              ✓   │
│      2. reload_plugin_context(ctx_id) — this context only        ✓   │
│      3. PUBLISH {type: binding_change, context_id}               ✓   │
│                                                                       │
└────────────────────────────────┬─────────────────────────────────────┘
                                 │
                   ┌─────────────┴──────────────────┐
                   │                                │
                   ▼                                ▼
┌──────────────────────────────────┐  ┌──────────────────────────────┐
│  framework/ isolation modules    │  │  Redis (shared state)        │
│                                  │  │                              │
│  _redis.py (DI shim):            │  │  Keys:                      │
│    framework/ can't import from  │  │   plugin:global:enabled     │
│    mcpgateway.utils (pre-commit  │  │     = "true"/"false"        │
│    hook enforced).               │  │     (no TTL — kill-switch)  │
│    set_shared_redis_provider(fn) │  │                              │
│      → registered at lifespan    │  │   plugin:{name}:mode        │
│    get_shared_redis_client()     │  │     = "enforce"             │
│      → returns client or None    │  │     (24h TTL — auto-expire) │
│                                  │  │                              │
│  _state.py (shared mutable):     │  │  Pub/sub channel:           │
│    Breaks __init__ → manager →   │  │   plugin:invalidation       │
│    __init__ import cycle.        │  │    → global_toggle          │
│    _local_mode_overrides dict    │  │    → mode_change            │
│    set/prune/active helpers      │  │    → binding_change         │
│    Degraded-boot flag + logged   │  │    → team_binding_change    │
│      (two bools, three states)   │  │                              │
│                                  │  │  Messages are Pydantic      │
└──────────────────────────────────┘  │  discriminated union —       │
                                      │  match/case dispatch on      │
                                      │  the listener side           │
                                      └──────────────────────────────┘
                                                   │
                                                   ▼
┌──────────────────────────────────────────────────────────────────────┐
│  Pod B                                                                │
│                                                                       │
│  ┌──────────────────────────┐  ┌──────────────────────────┐          │
│  │  Gunicorn Worker 1        │  │  Gunicorn Worker 2        │          │
│  │                           │  │                           │          │
│  │  ┌─ Pub/sub listener ──┐ │  │  ┌─ Pub/sub listener ──┐ │          │
│  │  │  Receives messages   │ │  │  │  Receives messages   │ │          │
│  │  │  from Pod A instantly │ │  │  │  from Pod A instantly │ │          │
│  │  │  → evicts cache      │ │  │  │  → evicts cache      │ │          │
│  │  │  → updates flag      │ │  │  │  → updates flag      │ │          │
│  │  │  → mirrors overrides │ │  │  │  → mirrors overrides │ │          │
│  │  └──────────────────────┘ │  │  └──────────────────────┘ │          │
│  │                           │  │                           │          │
│  │  get_plugin_manager       │  │  get_plugin_manager       │          │
│  │    │                      │  │    │                      │          │
│  │    ├─ 2s cached toggle    │  │    ├─ 2s cached toggle    │          │
│  │    │                      │  │    │                      │          │
│  │    └─ TTL expired?        │  │    └─ TTL expired?        │          │
│  │       (safety net only    │  │       (safety net only    │          │
│  │        — pub/sub already  │  │        — pub/sub already  │          │
│  │        evicted the cache) │  │        evicted the cache) │          │
│  └───────────────────────────┘  └───────────────────────────┘          │
│                                                                       │
│  Three layers of propagation (fastest wins):                          │
│    Layer 1: Pub/sub     → instant (~0ms)                             │
│    Layer 2: TTL expiry  → 0-30s (catches missed pub/sub)             │
│    Layer 3: Redis read  → 2s cached (global toggle only)             │
│                                                                       │
│  Pod B sees all changes from Pod A:                                   │
│    ✓ Global toggle    — instant (pub/sub invalidates 2s cache)       │
│    ✓ Per-plugin mode  — instant (pub/sub evicts + mirrors to local)  │
│    ✓ Per-tool bindings — instant (pub/sub evicts, rebuild reads DB)  │
│    ✓ Wildcard bindings — instant (team_binding_change evicts all)    │
│    ✓ Fallback         — 30s max if pub/sub missed the message        │
│                                                                       │
└──────────────────────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────────────────────┐
│  PostgreSQL (binding storage)                                         │
│                                                                       │
│  tool_plugin_bindings table:                                          │
│    (team_id, tool_name, plugin_id, mode, config, priority)           │
│                                                                       │
│  ← Written by /v1/tools/plugin_bindings API                         │
│  ← Read by get_config_from_db() on manager rebuild                   │
│  ← DB errors re-raise to prevent silent security-binding drops       │
│    (caller retries on next request or TTL expiry)                    │
│                                                                       │
└──────────────────────────────────────────────────────────────────────┘
```

### Request flow: tool invocation with plugin checks

```text
  Client request (tool/call)
         │
         ▼
  ┌──────────────────────────────────────────────────────────────┐
  │  Gateway (any worker)                                         │
  │                                                               │
  │  Background: pub/sub listener running (lifespan-managed)     │
  │    SUBSCRIBE plugin:invalidation                              │
  │    Pydantic discriminated union validates each frame          │
  │    On message → evict cache / update flag / mirror overrides  │
  │    (already done before this request arrives)                 │
  │                                                               │
  │  1. get_plugin_manager()                                      │
  │     │                                                         │
  │     ├── are_plugins_enabled_shared()                          │
  │     │   2s in-memory cache (pub/sub invalidates instantly)    │
  │     │   Falls back to Redis GET on miss, then in-memory flag │
  │     │         │                                               │
  │     │    No → return None (skip all plugins)                  │
  │     │    Yes ↓                                                │
  │     │                                                         │
  │     ├── _plugin_manager_factory is None?                      │
  │     │     │                                                   │
  │     │   Yes → _warn_factory_init_degraded_once()             │
  │     │         (one ERROR if node booted with failed init)     │
  │     │         return None                                     │
  │     │     │                                                   │
  │     │   No ↓                                                  │
  │     │                                                         │
  │     ├── Check _managers cache for context_id                  │
  │     │     │                                                   │
  │     │   Found?                                                │
  │     │     │                                                   │
  │     │   Yes → _CachedManager.is_expired(ttl)?                │
  │     │         No  → return cached manager                     │
  │     │         Yes → evict, fall through to build              │
  │     │                                                         │
  │     │   No (evicted by pub/sub or TTL) ↓                     │
  │     │                                                         │
  │     ├── _build_manager()                                      │
  │     │   │                                                     │
  │     │   ├─ DB: get_config_from_db()                          │
  │     │   │  (read bindings; re-raises on DB error to prevent  │
  │     │   │   silent security-binding drops)                    │
  │     │   │                                                     │
  │     │   ├─ _merge_tenant_config()                            │
  │     │   │  (DB overrides win over YAML)                      │
  │     │   │                                                     │
  │     │   ├─ _apply_redis_mode_overrides()                     │
  │     │   │  Priority: Redis MGET > _state.py overrides > YAML │
  │     │   │  Invalid values are skipped (logged), not fatal     │
  │     │   │  If Redis is down, _state.py overrides still apply │
  │     │   │                                                     │
  │     │   └─ Cache as _CachedManager (TTL = 30s safety net)    │
  │     │                                                         │
  │     └── Return manager                                        │
  │                                                               │
  │  2. manager.execute_hook                                      │
  │     (run plugins in priority order)                           │
  │                                                               │
  │  Admin: PUT /admin/plugins/{name} {"mode": "enforce"}        │
  │     Plugin name validated against factory._base_config        │
  │     (not the live manager — works even when plugins disabled, │
  │      allowing operators to pre-stage overrides before enable) │
  │                                                               │
  └──────────────────────────────────────────────────────────────┘
```

### Key design decisions

1. **Three-layer propagation** — pub/sub for instant notification (~0ms), TTL cache expiry as fallback (30s), cached Redis key read as confirmation (2s cache for global toggle). Fastest layer wins. Industry-standard pattern used by Kong, Envoy, and Consul.

2. **Pub/sub is notification, Redis keys are truth** — pub/sub tells workers "something changed, evict your cache." Workers then read the actual new state from Redis keys (global toggle, per-plugin mode) or DB (bindings) on the next request. If a pub/sub message is lost, TTL ensures the cache is rebuilt within 30s anyway.

3. **Dual-store fallback for mode overrides** — Redis is authoritative when available. An in-process `_local_mode_overrides` dict provides fallback for single-node/no-Redis deployments and write-through for the local worker. Redis-synced entries carry a TTL-aligned expiry (matching the Redis 24h key TTL) so both copies clear together. Local-only entries (Redis write failed) carry no expiry — the operator never got confirmation a timer started.

4. **Isolation modules for import-cycle prevention** — the plugin `framework/` package cannot import from `mcpgateway.utils` (enforced by a pre-commit hook). Two leaf modules break what would otherwise be circular dependencies:
   - `_redis.py` — dependency-inversion shim for Redis access. The gateway registers its Redis client provider at lifespan startup via `set_shared_redis_provider()`; framework modules call `get_shared_redis_client()` without naming the gateway util. When no provider is registered (tests, framework-only deployments), Redis-unavailable fallback paths engage automatically.
   - `_state.py` — shared mutable state (per-plugin mode overrides, degraded-boot flags). Breaks the `__init__` → `manager.py` → `__init__` import cycle: `manager.py` needs the local override map during rebuild, and importing it from `__init__.py` would close the loop. Exposes `set_local_mode_override()` / `prune_expired_local_overrides()` / `active_local_mode_overrides()` helpers so all mutation flows through a single seam.

5. **Factory init unconditional** — the plugin manager factory is initialized regardless of the local `plugins.enabled` setting. This allows a peer worker to runtime-enable plugins via `PUT /admin/plugins` without requiring a restart of nodes that booted with plugins disabled. If init fails and `plugins.enabled=true`, the gateway crashes (loud failure). If init fails and `plugins.enabled=false`, the gateway boots with a warning — runtime-enable from a peer will require a restart.

6. **MGET batched reads** — per-plugin mode overrides are fetched in a single Redis MGET call during manager rebuild, not N individual GETs. One round-trip regardless of plugin count.

7. **Typed pub/sub messages** — pub/sub frames are Pydantic `BaseModel` subclasses in a discriminated union (`_GlobalToggleMsg`, `_ModeChangeMsg`, `_BindingChangeMsg`, `_TeamBindingChangeMsg`). A typo in the `type` field on the producer fails Pydantic validation on the listener instead of silently no-oping.

8. **24h TTL on mode override keys** — stale overrides auto-expire. Prevents forgotten overrides from persisting indefinitely across gateway restarts.

9. **DB errors re-raise, not swallow** — `get_config_from_db()` re-raises on DB errors instead of returning `None`. This prevents silently dropping per-team security plugin bindings (rate limiter, PII filter) that would otherwise fall back to the permissive YAML defaults. The caller retries on the next request or cache TTL expiry.

10. **Degraded-boot signal** — when a node boots with `plugins.enabled=false` and the opportunistic factory init fails, `mark_factory_init_degraded()` is called. If a peer later flips the shared toggle to enabled, `get_plugin_manager()` emits one ERROR explaining that this node can't serve plugins and requires a restart. Prevents silent drift where a node appears healthy but silently ignores runtime-enable.

11. **Resilient invalidation on mode change** — `update_plugin_mode` wraps the post-write `invalidate_all_plugin_managers()` in try/except. The override is already stored in Redis + the local map before invalidation runs; a cache-refresh glitch must not turn an already-applied change into a 500. On failure the operator sees a WARNING and the TTL refresh reaches the new mode within 30s.

12. **Mode pre-staging on disabled nodes** — `PUT /admin/plugins/{name}` validates plugin names against `factory._base_config` (the YAML config loaded at startup), not against the live manager. This means operators can pre-stage mode overrides on a node with plugins disabled — the override takes effect when the shared toggle is flipped on, without requiring a second API call.

---

## Additional improvements

- **Plugin bindings API docs** — updated `docs/docs/api/plugin-bindings-api.md` with multi-instance cache propagation caveats.

- **`_invalidate_and_broadcast()` helper** — the wildcard-vs-specific invalidation split was copy-pasted across three binding handlers (upsert, delete-by-reference, delete-by-UUID). Extracted into a shared helper in `tool_plugin_bindings.py` so future changes land in one place.

- **`match/case` dispatch** — `_handle_invalidation_message` replaced four `isinstance(frame, X)` branches with structural pattern matching on the discriminated union. Makes union closure explicit and drops redundant return statements.

- **Test isolation** — autouse fixture in `tests/unit/mcpgateway/conftest.py` resets the framework's shared Redis provider between tests. Prevents lifespan-exercising tests from leaking a mock provider into subsequent tests via module-level state.

---

## Test results

<details>
<summary>Unit tests — plugin runtime management (65 tests)</summary>

```
tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py

TestArePluginsEnabledShared (6):
  test_reads_true_from_redis                             PASSED
  test_reads_false_from_redis                            PASSED
  test_reads_bytes_from_redis                            PASSED
  test_falls_back_to_in_memory_when_redis_unavailable    PASSED
  test_falls_back_to_in_memory_when_redis_key_missing    PASSED
  test_falls_back_on_redis_exception                     PASSED

TestEnablePluginsShared (4):
  test_writes_true_to_redis                              PASSED
  test_writes_false_to_redis                             PASSED
  test_updates_in_memory_flag                            PASSED
  test_survives_redis_failure                             PASSED

TestGetPluginModeOverride (4):
  test_reads_mode_from_redis                             PASSED
  test_returns_none_when_no_override                     PASSED
  test_returns_none_when_redis_unavailable               PASSED
  test_raises_runtime_error_on_redis_exception           PASSED

TestTTLCacheExpiry (4):
  test_cache_returns_manager_within_ttl                  PASSED
  test_cache_evicts_after_ttl                            PASSED
  test_cache_ttl_default                                 PASSED
  test_cache_ttl_zero_disables                           PASSED

TestApplyRedisModeOverrides (10):
  test_no_plugins_short_circuits                         PASSED
  test_returns_config_unchanged_when_no_overrides        PASSED
  test_applies_per_plugin_override                       PASSED
  test_corrupt_redis_falls_through_to_local_override     PASSED
  test_invalid_mode_value_skipped_not_batch_aborted      PASSED
  test_local_override_applied_when_redis_has_nothing     PASSED
  test_redis_value_beats_local_override                  PASSED
  test_local_override_applied_when_redis_client_none     PASSED
  test_expired_redis_synced_local_override_is_pruned     PASSED
  test_mget_failure_warns_and_returns_input              PASSED

TestDBErrorFallback (3):
  test_raises_on_db_error                                PASSED
  test_returns_none_for_invalid_context_id               PASSED
  test_returns_none_for_empty_bindings                   PASSED

TestInvalidateAllPluginManagers (2):
  test_delegates_to_factory_invalidate_all               PASSED
  test_noop_when_factory_is_none                         PASSED

TestPubSubPublisher (2):
  test_global_toggle_publishes_message                   PASSED
  test_global_toggle_publish_failure_doesnt_crash        PASSED

TestPubSubSubscriber (4):
  test_subscriber_updates_flag_on_global_toggle          PASSED
  test_subscriber_evicts_managers_on_mode_change         PASSED
  test_subscriber_ignores_non_message_types              PASSED
  test_subscriber_handles_malformed_message              PASSED

TestPublishHelpers (5):
  test_publish_plugin_mode_change_sends_message          PASSED
  test_publish_plugin_mode_change_returns_false_on_fail  PASSED
  test_local_entry_expiry_aligns_with_redis_ttl          PASSED
  test_local_entry_has_no_expiry_when_redis_set_fails    PASSED
  test_publish_binding_change_sends_message              PASSED

TestPublishToListenerRoundTrip (2):
  test_mode_change_publish_triggers_factory_invalidate   PASSED
  test_global_toggle_pubsub_invalidates_local_cache      PASSED

TestFactoryInvalidateTeam (2):
  test_invalidates_only_matching_team                    PASSED
  test_uses_class_separator_when_not_specified           PASSED

TestTeamBindingChangeRoundTrip (2):
  test_publish_team_binding_change_emits_correct_frame   PASSED
  test_handler_evicts_every_per_tool_context_for_team    PASSED

TestSubscriberHandlesBindingChange (1):
  test_subscriber_handles_binding_change                 PASSED

TestListenerLocalMirror (3):
  test_mode_change_populates_local_map_with_ttl          PASSED
  test_mode_change_falls_back_to_default_ttl             PASSED
  test_backing_dict_identity_is_stable                   PASSED

TestListenerStartup (3):
  test_skips_start_when_no_redis_provider                PASSED
  test_concurrent_starts_only_create_one_task            PASSED
  test_probe_failure_does_not_start_and_logs             PASSED

TestPublishPartialWriteSignaling (2):
  test_enable_plugins_shared_errors_on_publish_failure   PASSED
  test_publish_plugin_mode_change_errors_on_publish_fail PASSED

TestFactoryInitFailureSurface (2):
  test_malformed_yaml_raises                             PASSED
  test_invalid_config_shape_raises                       PASSED

TestFactoryInitDegradedSignal (3):
  test_get_plugin_manager_emits_error_once_on_degraded   PASSED
  test_no_error_when_factory_is_initialized              PASSED
  test_no_error_when_toggle_is_off                       PASSED

TestListenerBackoff (1):
  test_escalates_to_error_after_five_consecutive_fails   PASSED

65 passed
```

All tests use mocked Redis — no external dependencies. Runs in CI.

</details>

<details>
<summary>Unit tests — admin plugin runtime endpoints (22 tests)</summary>

```
tests/unit/mcpgateway/test_admin_plugin_runtime.py

TestToggleGlobalPluginsRBAC (3):
  test_denies_when_permission_service_rejects            PASSED
  test_denies_admin_when_bypass_disabled                 PASSED
  test_denies_non_admin_user                             PASSED

TestToggleGlobalPluginsValidation (2):
  test_missing_enabled_rejected                          PASSED
  test_non_bool_enabled_rejected                         PASSED

TestToggleGlobalPluginsHappyPath (2):
  test_returns_redis_persisted_true_when_redis_ok        PASSED
  test_returns_redis_persisted_false_when_redis_down     PASSED

TestUpdatePluginModeRBAC (2):
  test_denies_without_permission                         PASSED
  test_denies_admin_when_bypass_disabled                 PASSED

TestUpdatePluginModeValidation (2):
  test_invalid_mode_rejected                             PASSED
  test_valid_modes_accepted                              PASSED

TestUpdatePluginModeHandler (4):
  test_404_on_unknown_plugin                             PASSED
  test_reports_redis_persisted_true                      PASSED
  test_single_node_no_redis_applies_override_locally     PASSED
  test_redis_set_failure_still_applies_locally           PASSED

+ additional tests for invalidation error handling,
  structured logging verification, and edge cases

22 passed
```

Tests cover RBAC enforcement, Pydantic validation, Redis/no-Redis paths,
and invalidation failure resilience.

</details>

<details>
<summary>Integration tests — Redis plugin runtime (22 tests)</summary>

```
tests/integration/test_plugin_runtime_redis.py

TestGlobalToggleRedis (6):
  test_write_true / test_write_false / test_read_true
  test_read_false / test_roundtrip / test_fallback

TestPluginModeOverrideRedis (3):
  test_read_value / test_missing_key / test_multiple_plugins

TestPubSubRedis (4):
  test_publish_message / test_handler_updates_flag
  test_ignore_subscribe / test_malformed_json

TestGetPluginManagerRedis (3):
  test_disabled_returns_none / test_no_factory / test_toggle_cycle

TestTTLCacheExpiryRedis (1):
  test_cache_expires_after_ttl

TestPubSubEvictionRedis (3):
  test_mode_change_evicts_all / test_binding_change_evicts_specific
  test_pubsub_roundtrip

TestDBErrorFallbackRedis (2):
  test_db_error_returns_none / test_redis_toggle_independent

22 passed
```

Tests use real Redis (auto-starts Docker container if not running).

</details>

<details>
<summary>Integration tests — docker-compose multi-replica (23 tests)</summary>

```
tests/integration/test_plugin_runtime_management.py

TestPluginsGloballyEnabledField (2)
TestPutAdminPluginsDisable (2)
TestPutAdminPluginsEnable (2)
TestPutAdminPluginsValidation (3)
TestPutAdminPluginsNameMode (5)
TestCrossReplicaPropagation (2)
TestMultiInstanceGlobalToggle (2)
TestMultiInstancePluginMode (1)
+ additional tests for endpoint validation and consistency

23 passed
```

Tests run against a live gateway (docker-compose with 3 replicas + NGINX).

</details>

---

## Limitations

1. **Plugin config stored in Postgres, not Redis** — full plugin config (rate limits, detection rules, etc.) is stored in Postgres and read on cache rebuild. For sub-second config propagation, a write-behind pattern (Redis-first with async Postgres replication) would be needed. Not required at current scale (4 plugins, infrequent config changes).

2. **Redis required for cross-instance consistency** — without Redis, the global toggle falls back to the per-process in-memory flag. Per-plugin mode overrides fall back to the `_local_mode_overrides` dict (so mode changes work on the local worker, but don't propagate to other workers/pods). The system degrades to single-instance behavior rather than failing.

3. **DB errors fail the manager rebuild** — a transient Postgres outage causes individual tool invocations to fail (no cached manager available) rather than silently falling back to YAML defaults. This is a deliberate trade-off: for security-critical plugins (rate limiter, PII filter), silently dropping per-team bindings is worse than a transient failure. The caller retries on the next request or cache TTL expiry.

4. **No integration tests in CI** — the 22 Redis integration tests and 23 docker-compose tests run locally. The 87 unit tests (65 + 22) run in CI. CI-compatible integration tests using TestClient + auto-started Redis are planned.

---

## Future work

### Write-behind caching for plugin config

The current architecture writes plugin config to Postgres first, then workers read it on cache rebuild. For use cases requiring sub-second config propagation at scale, a **write-behind** pattern could be adopted:

```text
  Config update arrives
         │
         ├──1. Write to Redis (instant, 0.1ms)
         │     → API returns success immediately
         │     → All workers see new config via pub/sub
         │
         └──2. Background task: replicate to Postgres (async)
                → Picks up pending writes from Redis
                → Writes to Postgres for durability
                → Marks as "synced" in Redis
                → Retries with backoff on failure
```

This is standard in high-throughput systems (Shopify uses it for cart/inventory, Discord for presence, AWS ElastiCache best practices recommend it). The benefit is that the API call returns in 0.1ms instead of ~5ms, and config changes propagate instantly via pub/sub.

**Trade-off:** Eventual consistency between Redis and Postgres — if Redis dies before the async Postgres write completes, the config update is lost. Mitigation: reconciliation on startup (compare Redis state vs Postgres and resolve differences).

Not needed for the current scale (4 plugins, infrequent config changes), but a natural evolution if ContextForge grows to handle thousands of per-tool config updates per minute.
